### PR TITLE
Specialize NameMap::visit_children for ordered_map so that order is …

### DIFF
--- a/ir/namemap.h
+++ b/ir/namemap.h
@@ -5,7 +5,7 @@ namespace IR {
 
 template<class T, template<class K, class V, class COMP, class ALLOC> class MAP = std::map,
          class COMP = std::less<cstring>,
-         class ALLOC = std::allocator<std::pair<cstring, const T*>>>
+         class ALLOC = std::allocator<std::pair<const cstring, const T*>>>
 class NameMap : public Node {
     typedef MAP<cstring, const T *, COMP, ALLOC>        map_t;
     map_t       symbols;

--- a/lib/ordered_map.h
+++ b/lib/ordered_map.h
@@ -130,13 +130,6 @@ public:
         if (it == data.end()) throw std::out_of_range("ordered_map");
         return it->second; }
 
-    std::pair<iterator, bool> insert(const value_type &v) {
-        auto it = find(v.first);
-        if (it == data.end()) {
-            it = data.insert(data.end(), v);
-            data_map.emplace(&it->first, it);
-            return std::make_pair(it, true); }
-        return std::make_pair(it, false); }
     std::pair<iterator, bool> emplace(K &&k, V &&v) {
         auto it = find(k);
         if (it == data.end()) {
@@ -144,8 +137,36 @@ public:
             data_map.emplace(&it->first, it);
             return std::make_pair(it, true); }
         return std::make_pair(it, false); }
+    std::pair<iterator, bool> emplace_hint(iterator pos, K &&k, V &&v) {
+        /* should be const_iterator pos, but glibc++ std::list is broken */
+        auto it = find(k);
+        if (it == data.end()) {
+            it = data.emplace(pos, std::move(k), std::move(v));
+            data_map.emplace(&it->first, it);
+            return std::make_pair(it, true); }
+        return std::make_pair(it, false); }
+
+    std::pair<iterator, bool> insert(const value_type &v) {
+        auto it = find(v.first);
+        if (it == data.end()) {
+            it = data.insert(data.end(), v);
+            data_map.emplace(&it->first, it);
+            return std::make_pair(it, true); }
+        return std::make_pair(it, false); }
+    std::pair<iterator, bool> insert(iterator pos, const value_type &v) {
+        /* should be const_iterator pos, but glibc++ std::list is broken */
+        auto it = find(v.first);
+        if (it == data.end()) {
+            it = data.insert(pos, v);
+            data_map.emplace(&it->first, it);
+            return std::make_pair(it, true); }
+        return std::make_pair(it, false); }
     template<class InputIterator> void insert(InputIterator b, InputIterator e) {
         while (b != e) insert(*b++); }
+    template<class InputIterator>
+    void insert(iterator pos, InputIterator b, InputIterator e) {
+        /* should be const_iterator pos, but glibc++ std::list is broken */
+        while (b != e) insert(pos, *b++); }
 
     /* should be erase(const_iterator), but glibc++ std::list::erase is broken */
     iterator erase(iterator pos) {

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,7 +1,8 @@
 # Unit tests
 
 check_PROGRAMS = exception_test format_test source_file_test path_test \
-                 enumerator_test default_test unittest_transform1 json_test
+		 enumerator_test default_test unittest_transform1 json_test \
+		 namemap_order_test
 
 default_test_SOURCES = test/unittests/default_test.cpp
 default_test_LDADD = libp4ctoolkit.a
@@ -19,6 +20,8 @@ json_test_SOURCES = test/unittests/json_test.cpp
 json_test_LDADD = libp4ctoolkit.a
 unittest_transform1_SOURCES = $(ir_SOURCES) test/unittests/transform1.cpp
 unittest_transform1_LDADD = libp4ctoolkit.a
+namemap_order_test_SOURCES = $(ir_SOURCES) test/unittests/namemap_order_test.cpp
+namemap_order_test_LDADD = libp4ctoolkit.a
 
 # Compiler tests
 

--- a/test/unittests/namemap_order_test.cpp
+++ b/test/unittests/namemap_order_test.cpp
@@ -1,0 +1,34 @@
+#include "ir/ir.h"
+#include "ir/visitor.h"
+#include <assert.h>
+
+class TestTrans : public Transform {
+    IR::Node *preorder(IR::TableProperty *a) override {
+        if (!a->isConstant)
+            a->name = "$new$";
+        return a;
+    }
+    IR::Node *postorder(IR::TableProperties *p) override {
+        int count = 0;
+        for (auto &prop : p->properties) {
+            if (prop.first == "$new$")
+                assert(count == 0);
+            else
+                assert(count == 1);
+            ++count; }
+        return p;
+    }
+};
+
+int main() {
+    auto tp = new IR::TableProperties();
+    tp->properties.add("a", new IR::TableProperty(Util::SourceInfo(), "a",
+        new IR::Annotations(new IR::Vector<IR::Annotation>()),
+        new IR::Key(Util::SourceInfo(), new IR::Vector<IR::KeyElement>()),
+        false));
+    tp->properties.add("b", new IR::TableProperty(Util::SourceInfo(), "b",
+        new IR::Annotations(new IR::Vector<IR::Annotation>()),
+        new IR::Key(Util::SourceInfo(), new IR::Vector<IR::KeyElement>()),
+        true));
+    tp->apply(TestTrans());
+}


### PR DESCRIPTION
…preserved when nodes change names or split or whatever.
