### PR TITLE
LocalCopyPropagation pass -- copyprop and elim vars within a function.

### DIFF
--- a/ir/Makefile.am
+++ b/ir/Makefile.am
@@ -1,32 +1,33 @@
 ir_SOURCES += \
 	ir/base.cpp \
+	ir/configuration.h \
 	ir/dbprint.cpp \
 	ir/dbprint-expression.cpp \
 	ir/dbprint.h \
 	ir/dbprint-p4.cpp \
 	ir/dump.cpp \
 	ir/expression.cpp \
-	ir/v1.cpp \
-	ir/ir.h \
 	ir/id.h \
+	ir/ir.cpp \
 	ir/ir-generated.cpp \
+	ir/ir.h \
 	ir/ir-inline.h \
 	ir/namemap.h \
 	ir/node.cpp \
 	ir/node.h \
+	ir/parameterSubstitution.h \
 	ir/pass_manager.cpp \
 	ir/pass_manager.h \
-	ir/ir.cpp \
+	ir/substitution.cpp \
+	ir/substitution.h \
+	ir/substitutionVisitor.cpp \
+	ir/substitutionVisitor.h \
 	ir/type.cpp \
+	ir/v1.cpp \
 	ir/vector.h \
 	ir/visitor.cpp \
 	ir/visitor.h \
-	ir/substitution.h \
-	ir/substitution.cpp \
-	ir/substitutionVisitor.h \
-	ir/substitutionVisitor.cpp \
-	ir/parameterSubstitution.h \
-	ir/configuration.h
+	ir/write_context.cpp
 
 ir_DEF_FILES += \
     $(srcdir)/ir/base.def \

--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -38,6 +38,32 @@ void IR::ActionFunction::dbprint(std::ostream &out) const {
   out << unindent << " }";
 }
 
+void IR::P4Action::dbprint(std::ostream &out) const {
+  out << "action " << name << "(";
+  const char *sep = "";
+  for (auto &arg : parameters->parameters) {
+    out << sep << arg.second->direction << ' ' << arg.second->type << ' ' << arg.first;
+    sep = ", "; }
+  out << ") {" << indent;
+  if (body)
+    for (auto &p : *body)
+      out << endl << p;
+  out << unindent << " }";
+}
+
+void IR::BlockStatement::dbprint(std::ostream &out) const {
+  out << "{" << indent;
+  if (components) {
+    bool first = true;
+    for (auto &p : *components) {
+      if (first) {
+        out << ' ' << p;
+        first = false;
+      } else {
+        out << endl << p; } } }
+  out << unindent << " }";
+}
+
 void IR::ActionProfile::dbprint(std::ostream &out) const { out << "IR::ActionProfile"; }
 void IR::ActionSelector::dbprint(std::ostream &out) const { out << "IR::ActionSelector"; }
 void IR::V1Table::dbprint(std::ostream &out) const { out << "IR::V1Table " << name; }

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -116,7 +116,6 @@ class P4Action : Declaration, IGeneralNamespace, IAnnotated {
     { return body->only<IDeclaration>(); }
     const Annotations* getAnnotations() const override { return annotations; }
 #end
-#nodbprint
     validate{ body->check_null(); }
 }
 
@@ -265,7 +264,8 @@ class Declaration_Variable : Declaration, IAnnotated {
 #emit
     const Annotations* getAnnotations() const override { return annotations; }
 #end
-#nodbprint
+    dbprint { Declaration::dbprint(out);
+        if (initializer) out << " = " << *initializer; }
 }
 
 class Declaration_Constant : Declaration, IAnnotated {
@@ -339,6 +339,13 @@ class IfStatement : Statement {
     Statement        ifTrue;
     NullOK Statement ifFalse;
 #nodbprint
+    visit_children {
+        v.visit(condition, "condition");
+        auto &clone(v.flow_clone());
+        v.visit(ifTrue, "ifTrue");
+        clone.visit(ifFalse, "ifFalse");
+        v.flow_merge(clone);
+    }
 }
 
 class BlockStatement : Statement, IGeneralNamespace {
@@ -347,7 +354,6 @@ class BlockStatement : Statement, IGeneralNamespace {
     Util::Enumerator<const IDeclaration*>* getDeclarations() const
     { return components->only<IDeclaration>(); }
 #end
-#nodbprint
 }
 
 class MethodCallStatement : Statement {

--- a/ir/type.def
+++ b/ir/type.def
@@ -103,13 +103,9 @@ class ParameterList : ISimpleNamespace {
     const IR::Parameter* getParameter(cstring name) const
     { return parameters.getUnique(name); }
     const IR::Parameter* getParameter(unsigned index) const {
-        BUG_CHECK(index <= size(), "Only %1% parameters; %2% requested", size(), index);
-        unsigned ix = 0;
-        auto it = parameters.begin();
-        for (; ix != index; it++)
-            ++ix;
-        return it->second;
-    }
+        for (auto &param : parameters)
+            if (0 == index--) return param.second;
+        BUG("Only %1% parameters; %2% requested", size(), size()+index); }
     void add(const Parameter* param)
     { parameters.addUnique(param->name, param); }
     const IR::IDeclaration* getDeclByName(cstring name) const

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -250,9 +250,3 @@ const IR::Node *Transform::postorder(IR::CLASS *n) {                            
 
 IRNODE_ALL_SUBCLASSES(DEFINE_VISIT_FUNCTIONS)
 
-bool P4WriteContext::isWrite() {
-    const Context *ctxt = getContext();
-    if (auto *prim = dynamic_cast<const IR::Primitive *>(ctxt->node))
-        return prim->isOutput(ctxt->child_index);
-    return false;
-}

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -189,9 +189,11 @@ class Backtrack : public virtual Visitor {
     virtual bool backtrack(trigger &trig) = 0;
 };
 
+namespace P4 { class TypeMap; }
+
 class P4WriteContext : public virtual Visitor {
  public:
-    bool isWrite();
+    bool isWrite(const P4::TypeMap *typeMap = nullptr);
 };
 
 #endif /* _IR_VISITOR_H_ */

--- a/ir/write_context.cpp
+++ b/ir/write_context.cpp
@@ -1,0 +1,29 @@
+#include "ir.h"
+#include "lib/log.h"
+#include "frontends/common/typeMap.h"
+
+bool P4WriteContext::isWrite(const P4::TypeMap *typeMap) {
+    const Context *ctxt = getContext();
+    if (!ctxt || !ctxt->node)
+        return false;
+    if (auto *prim = ctxt->node->to<IR::Primitive>())
+        return prim->isOutput(ctxt->child_index);
+    if (ctxt->node->is<IR::AssignmentStatement>())
+        return ctxt->child_index == 0;
+    if (ctxt->node->is<IR::Vector<IR::Expression>>()) {
+        if (!ctxt->parent || !ctxt->parent->node)
+            return false;
+        if (auto *mc = ctxt->parent->node->to<IR::MethodCallExpression>()) {
+            auto type = dynamic_cast<const IR::Type_Method *>(
+                typeMap ? typeMap->getType(mc->method) : mc->method->type);
+            if (!type) {
+                /* FIXME -- can't find the type of the method -- should be a BUG? */
+                return true; }
+            auto param = type->parameters->getParameter(ctxt->child_index);
+            return param->direction == IR::Direction::Out ||
+                   param->direction == IR::Direction::InOut; }
+        if (ctxt->parent->node->is<IR::ConstructorCallExpression>()) {
+            /* FIXME -- no constructor types?  assume all arguments are inout? */
+            return true; } }
+    return false;
+}

--- a/midend/Makefile.am
+++ b/midend/Makefile.am
@@ -1,19 +1,21 @@
 # Makefile for mid-ends
 
 midend_SOURCES = \
-	midend/actionsInlining.h \
 	midend/actionsInlining.cpp \
-	midend/inlining.h \
-	midend/inlining.cpp \
-	midend/removeReturns.h \
-	midend/removeReturns.cpp \
-	midend/uniqueNames.h \
-	midend/uniqueNames.cpp \
-	midend/moveDeclarations.h \
-	midend/moveDeclarations.cpp \
-	midend/moveConstructors.h \
-	midend/moveConstructors.cpp \
+	midend/actionsInlining.h \
+	midend/actionSynthesis.cpp \
 	midend/actionSynthesis.h \
-	midend/actionSynthesis.cpp
+	midend/inlining.cpp \
+	midend/inlining.h \
+	midend/local_copyprop.cpp \
+	midend/local_copyprop.h \
+	midend/moveConstructors.cpp \
+	midend/moveConstructors.h \
+	midend/moveDeclarations.cpp \
+	midend/moveDeclarations.h \
+	midend/removeReturns.cpp \
+	midend/removeReturns.h \
+	midend/uniqueNames.cpp \
+	midend/uniqueNames.h
 
 cpplint_FILES += $(midend_SOURCES)

--- a/midend/expr_uses.h
+++ b/midend/expr_uses.h
@@ -1,0 +1,27 @@
+#ifndef MIDEND_EXPR_USES_H_
+#define MIDEND_EXPR_USES_H_
+
+#include "ir/ir.h"
+
+/* Should this be a method on IR::Expression? */
+
+class exprUses : public Inspector {
+    cstring look_for;
+    bool result = false;
+    bool preorder(const IR::Path *p) override { 
+        if (p->name == look_for) result = true;
+        return !result; }
+    bool preorder(const IR::Primitive *p) override { 
+        if (p->name == look_for) result = true;
+        return !result; }
+    bool preorder(const IR::NamedRef *n) override { 
+        if (n->name == look_for) result = true;
+        return !result; }
+    bool preorder(const IR::Expression *) override { return !result; }
+ public:
+    exprUses(const IR::Expression *e, cstring n) : look_for(n) { e->apply(*this); }
+    explicit operator bool () { return result; }
+};
+
+
+#endif /* MIDEND_EXPR_USES_H_ */

--- a/midend/has_side_effects.h
+++ b/midend/has_side_effects.h
@@ -1,0 +1,21 @@
+#ifndef MIDEND_HAS_SIDE_EFFECTS_H_
+#define MIDEND_HAS_SIDE_EFFECTS_H_
+
+#include "ir/ir.h"
+
+/* Should this be a method on IR::Expression? */
+
+class hasSideEffects : public Inspector {
+    bool result = false;
+    bool preorder(const IR::AssignmentStatement *) override { return !(result = true); }
+    /* FIXME -- currently assuming all calls and primitves have side effects */
+    bool preorder(const IR::MethodCallExpression *) override { return !(result = true); }
+    bool preorder(const IR::Primitive *) override { return !(result = true); }
+    bool preorder(const IR::Expression *) override { return !result; }
+ public:
+    explicit hasSideEffects(const IR::Expression *e) { e->apply(*this); }
+    explicit operator bool () { return result; }
+};
+
+
+#endif /* MIDEND_HAS_SIDE_EFFECTS_H_ */

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -1,0 +1,131 @@
+#include "local_copyprop.h"
+#include "has_side_effects.h"
+#include "expr_uses.h"
+
+class P4::LocalCopyPropagation::ElimDead : public Transform {
+    LocalCopyPropagation &self;
+    IR::Declaration_Variable *preorder(IR::Declaration_Variable *var) override {
+        if (auto local = ::getref(self.locals, var->name)) {
+            if (!local->live) {
+                LOG3("  removing dead local " << var->name);
+                return nullptr; }
+        } else {
+            BUG("local %s isn't in locals table", var->name); }
+        return var; }
+    IR::AssignmentStatement *postorder(IR::AssignmentStatement *as) override {
+        if (auto dest = as->left->to<IR::PathExpression>()) {
+            if (auto local = ::getref(self.locals, dest->path->name)) {
+                if (!local->live) {
+                    LOG3("  removing dead assignment to " << dest->path->name);
+                    return nullptr; } } }
+        return as; }
+
+ public:
+    explicit ElimDead(LocalCopyPropagation &self) : self(self) {}
+};
+
+void P4::LocalCopyPropagation::flow_merge(Visitor &a_) {
+    auto &a = dynamic_cast<LocalCopyPropagation &>(a_);
+    BUG_CHECK(in_action == a.in_action, "inconsitent LocalCopyPropagation state on merge");
+    for (auto &local : locals) {
+        if (auto merge = ::getref(a.locals, local.first)) {
+            if (merge->val != local.second.val)
+                local.second.val = nullptr;
+            if (merge->live)
+                local.second.live = true;
+        } else {
+            local.second.val = nullptr; } }
+}
+
+void P4::LocalCopyPropagation::dropLocalsUsing(cstring name) {
+    for (auto &local : locals) {
+        if (local.first == name) {
+            LOG4("   dropping " << name << " as it is being assigned to");
+            local.second.val = nullptr;
+        } else if (local.second.val && exprUses(local.second.val, name)) {
+            LOG4("   dropping " << name << " as it is being used");
+            local.second.val = nullptr; } }
+}
+
+P4::LocalCopyPropagation::LocalCopyPropagation(const P4::TypeMap *typeMap) : typeMap(typeMap) { 
+    visitDagOnce = false;
+}
+
+IR::Declaration_Variable *P4::LocalCopyPropagation::postorder(IR::Declaration_Variable *var) {
+    if (!in_action) return var;
+    if (locals.count(var->name))
+        BUG("duplicate var declaration for %s", var->name);
+    auto &local = locals[var->name];
+    if (var->initializer) {
+        if (!hasSideEffects(var->initializer)) {
+            LOG3("  saving init value for " << var->name);
+            local.val = var->initializer;
+        } else {
+            local.live = true; } }
+    return var;
+}
+
+const IR::Expression *P4::LocalCopyPropagation::postorder(IR::PathExpression *path) {
+    if (auto local = ::getref(locals, path->path->name)) {
+        if (isWrite(typeMap)) {
+            return path;
+        } else if (local->val) {
+            LOG3("  propagating value for " << path->path->name);
+            return local->val; 
+        } else {
+            LOG4("  using " << path->path->name << " with no propagated value");
+            local->live = true; } }
+    return path;
+}
+
+IR::AssignmentStatement *P4::LocalCopyPropagation::postorder(IR::AssignmentStatement *as) {
+    if (as->left == as->right) { // FIXME -- need deep equals here?
+        LOG3("  removing noop assignment " << *as);
+        return nullptr; }
+    if (auto dest = as->left->to<IR::PathExpression>()) {
+        dropLocalsUsing(dest->path->name);
+        if (auto local = ::getref(locals, dest->path->name)) {
+            if (!hasSideEffects(as->right)) {
+                LOG3("  saving value for " << dest->path->name);
+                local->val = as->right; } } }
+    return as;
+}
+
+IR::MethodCallExpression *P4::LocalCopyPropagation::postorder(IR::MethodCallExpression *mc) {
+    if (!in_action) return mc;
+    auto type = typeMap->getType(mc->method)->to<IR::Type_Method>();
+    int idx = 0;
+    for (auto param : Values(type->parameters->parameters)) {
+        if (param->direction == IR::Direction::Out || param->direction == IR::Direction::InOut) {
+            if (auto arg = mc->arguments->at(idx)->to<IR::PathExpression>()) {
+                dropLocalsUsing(arg->path->name); } }
+        ++idx; }
+    return mc;
+}
+
+IR::Primitive *P4::LocalCopyPropagation::postorder(IR::Primitive *prim) {
+    if (!in_action) return prim;
+    for (unsigned idx = 0; idx < prim->operands.size(); ++idx) {
+        if (prim->isOutput(idx+1)) {
+            dropLocalsUsing(prim->operands.at(idx)->toString()); } }
+    return prim;
+}
+
+IR::P4Action *P4::LocalCopyPropagation::preorder(IR::P4Action *act) {
+    in_action = true;
+    if (!locals.empty()) BUG("corrupt internal data struct");
+    LOG2("LocalCopyPropagation working on action " << act->name);
+    LOG4(act);
+    return act;
+}
+
+IR::P4Action *P4::LocalCopyPropagation::postorder(IR::P4Action *act) {
+    LOG5("LocalCopyPropagation before ElimDead " << act->name);
+    LOG5(act);
+    act->body = act->body->apply(ElimDead(*this));
+    in_action = false;
+    locals.clear();
+    LOG3("LocalCopyPropagation finished action " << act->name);
+    LOG4(act);
+    return act;
+}

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -1,0 +1,38 @@
+#ifndef MIDEND_LOCAL_COPYPROP_H_
+#define MIDEND_LOCAL_COPYPROP_H_
+
+#include "ir/ir.h"
+#include "frontends/common/typeMap.h"
+#include "frontends/common/resolveReferences/referenceMap.h"
+
+namespace P4 {
+
+class LocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteContext {
+    const P4::TypeMap           *typeMap;
+    bool                        in_action = false;
+    struct Local {
+        bool                    live = false;
+        const IR::Expression    *val = nullptr;
+    };
+    std::map<cstring, Local>    locals;
+    LocalCopyPropagation *clone() const override { return new LocalCopyPropagation(*this); }
+    void flow_merge(Visitor &) override;
+    void dropLocalsUsing(cstring);
+
+    IR::Declaration_Variable *postorder(IR::Declaration_Variable *) override;
+    const IR::Expression *postorder(IR::PathExpression *) override;
+    IR::AssignmentStatement *postorder(IR::AssignmentStatement *) override;
+    IR::MethodCallExpression *postorder(IR::MethodCallExpression *) override;
+    IR::Primitive *postorder(IR::Primitive *) override;
+    IR::P4Action *preorder(IR::P4Action *) override;
+    IR::P4Action *postorder(IR::P4Action *) override;
+    class ElimDead;
+
+    LocalCopyPropagation(const LocalCopyPropagation &) = default;
+ public:
+    explicit LocalCopyPropagation(const P4::TypeMap *);
+};
+
+}  // namespace P4
+
+#endif /* MIDEND_LOCAL_COPYPROP_H_ */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,9 +19,9 @@ path_test_LDADD = libp4ctoolkit.a
 json_test_SOURCES = test/unittests/json_test.cpp
 json_test_LDADD = libp4ctoolkit.a
 unittest_transform1_SOURCES = $(ir_SOURCES) test/unittests/transform1.cpp
-unittest_transform1_LDADD = libp4ctoolkit.a
+unittest_transform1_LDADD = libfrontend.a libp4ctoolkit.a
 namemap_order_test_SOURCES = $(ir_SOURCES) test/unittests/namemap_order_test.cpp
-namemap_order_test_LDADD = libp4ctoolkit.a
+namemap_order_test_LDADD = libfrontend.a libp4ctoolkit.a
 
 # Compiler tests
 


### PR DESCRIPTION
This additional midend pass currently just works on action bodies, but should be equally applicable (and extensible to) controlflow apply bodies and function bodies.
