### PR TITLE
Do not visit the 'type' field in IR:Expressions by default

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -350,27 +350,6 @@ const IR::Type* TypeInference::canonicalize(const IR::Type* type) {
 
 ///////////////////////////////////// Visitor methods
 
-// This method is here to avoid visiting the Expression::type field;
-// this field is not used by the P4 v1.2 front-end, but may be populated
-// by the P4 v1.0 front-end.
-const IR::Node* TypeInference::preorder(IR::Type* type) {
-    auto ctx = getContext();
-    if (ctx == nullptr)
-        // This happens when recursively calling the type checker on a new type object
-        return type;
-    if (!ctx->node->is<IR::Expression>())
-        return type;
-    // We do want to visit the type of some nodes...
-    if (ctx->node->is<IR::Constant>())
-        return type;
-    // Expression::type is the 0-th child of an expression
-    if (ctx->child_index != 0)
-        return type;
-    // Don't visit Expression::type
-    prune();
-    return type;
-}
-
 const IR::Node* TypeInference::postorder(IR::Declaration_Errors* decl) {
     if (done())
         return decl;

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -102,7 +102,6 @@ class TypeInference : public Transform {
     using Transform::postorder;
     using Transform::preorder;
 
-    const IR::Node* preorder(IR::Type* type) override;
     // do functions pre-order so we can check the prototype
     // before the returns
     const IR::Node* preorder(IR::Function* function) override;
@@ -197,6 +196,10 @@ class ApplyTypesToExpressions : public Transform {
             if (*orig != *n)
                 typeMap->setType(n, type); }
         return n; }
+    IR::Node *postorder(IR::ConstructorCallExpression *cc) override {
+        // FIXME -- these get 'canonical' types in the typeMap, which can confuse
+        // later passes, so we don't put them into the Expression::type field
+        return postorder(static_cast<IR::Node *>(cc)); }
     IR::Expression *postorder(IR::Expression *e) override {
         const IR::Node *orig = getOriginal();
         if (auto type = typeMap->getType(orig)) {

--- a/frontends/p4v1/typecheck.cpp
+++ b/frontends/p4v1/typecheck.cpp
@@ -128,9 +128,9 @@ class TypeCheck::Pass3 : public Modifier {
         const Context *ctxt = getContext();
         if (auto parent = ctxt->node->to<IR::Expression>()) {
             if (auto p = parent->to<IR::Operation_Relation>()) {
-                if (ctxt->child_index == 1)
+                if (ctxt->child_index == 0)
                     rv = p->right->type;
-                else if (ctxt->child_index == 2)
+                else if (ctxt->child_index == 1)
                     rv = p->left->type;
                 else
                     BUG("Unepxected child index");
@@ -139,10 +139,10 @@ class TypeCheck::Pass3 : public Modifier {
             } else if (!global) {
             } else if (auto prim = parent->to<IR::Primitive>()) {
                 if (auto af = global->get<IR::ActionFunction>(prim->name)) {
-                    if (size_t(ctxt->child_index-1) < af->args.size())
-                        rv = af->args[ctxt->child_index-1]->type;
+                    if (size_t(ctxt->child_index) < af->args.size())
+                        rv = af->args[ctxt->child_index]->type;
                 } else if (auto infer = prim->inferOperandTypes()) {
-                    if ((infer >> (ctxt->child_index-1)) & 1) {
+                    if ((infer >> (ctxt->child_index)) & 1) {
                         for (auto o : prim->operands) {
                             if ((infer & 1) && o->type != rv) {
                                 rv = o->type;
@@ -161,9 +161,9 @@ class TypeCheck::Pass3 : public Modifier {
         const Context *ctxt = getContext();
         if (auto *prim = ctxt->node->to<IR::Primitive>()) {
             if (auto af = global ? global->get<IR::ActionFunction>(prim->name) : nullptr) {
-                if (size_t(ctxt->child_index-1) < af->args.size()) {
-                    if (af->args[ctxt->child_index-1]->write) arg->write = true;
-                    if (af->args[ctxt->child_index-1]->read) arg->read = true; }
+                if (size_t(ctxt->child_index) < af->args.size()) {
+                    if (af->args[ctxt->child_index]->write) arg->write = true;
+                    if (af->args[ctxt->child_index]->read) arg->read = true; }
             } else if (prim->isOutput(ctxt->child_index)) {
                 arg->write = true;
             } else {

--- a/ir/base.def
+++ b/ir/base.def
@@ -136,12 +136,12 @@ abstract Expression {
 #emit
     // No P4 v1.2 front-end passes not use this field.
     // It is used by the P4 v1.0 front-end and by some back-ends.
+    // It is not visited by the visitors by default (can visit explicitly in the preorder)
     const Type* type = Type::Unknown::get();
     Expression() : type(Type::Unknown::get()) {}
     explicit Expression(const Type *t) : type(t) {}
     Expression(Util::SourceInfo srcInfo, const Type *t) : Node(srcInfo), type(t) {}
 #end
-    visit_children { v.visit(type, "type"); }
     operator== { return typeid(*this) == typeid(a) && type == a.type; }
 }
 

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -225,6 +225,7 @@ class Constant : Expression, CompileTimeValue {
     Constant operator-(const Constant &c) const;
 #end
     toString { return Util::toString(&value); }
+    visit_children { v.visit(type, "type"); }
 }
 
 class BoolLiteral : Expression, CompileTimeValue {

--- a/ir/v1.cpp
+++ b/ir/v1.cpp
@@ -73,7 +73,7 @@ void IR::Primitive::typecheck() const {
 
 bool IR::Primitive::isOutput(int operand_index) const {
     if (prim_info.count(name))
-        return (prim_info.at(name).out_operands >> (operand_index-1)) & 1;
+        return (prim_info.at(name).out_operands >> operand_index) & 1;
     return false;
 }
 

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -102,7 +102,7 @@ IR::MethodCallExpression *P4::LocalCopyPropagation::postorder(IR::MethodCallExpr
 IR::Primitive *P4::LocalCopyPropagation::postorder(IR::Primitive *prim) {
     if (!in_action) return prim;
     for (unsigned idx = 0; idx < prim->operands.size(); ++idx) {
-        if (prim->isOutput(idx+1)) {
+        if (prim->isOutput(idx)) {
             dropLocalsUsing(prim->operands.at(idx)->toString()); } }
     return prim;
 }


### PR DESCRIPTION
The main part of this change is actually fixing the various places it was using the child_index (at least one of which was off-by-one and didn't actually need to be changed as a result).

Also had to add an explicit Constant::visit_children that visits the type, as there seem to be a number of places that depend on that.
