### PR TITLE
typo fix

### DIFF
--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -128,7 +128,7 @@ control Ingress<H, M>(inout H hdr,
 control Egress<H, M>(inout H hdr,
                      inout M meta,
                      inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr,
+control ComputeChecksum<H, M>(inout H hdr,
                               inout M meta,
                               inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
@@ -137,7 +137,7 @@ package V1Switch<H, M>(Parser<H, M> p,
                        VerifyChecksum<H, M> vr,
                        Ingress<H, M> ig,
                        Egress<H, M> eg,
-                       ComputeCkecksum<H, M> ck,
+                       ComputeChecksum<H, M> ck,
                        Deparser<H> dep
                        );
 

--- a/testdata/p4_14_samples_outputs/01-BigMatch-first.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1>    drop;
     bit<8>    egress_port;

--- a/testdata/p4_14_samples_outputs/01-BigMatch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1>    drop;
     bit<8>    egress_port;

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1-first.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<32> f1;
 }

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<32> f1;
 }

--- a/testdata/p4_14_samples_outputs/01-FullPHV-first.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/01-FullPHV-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/01-JustEthernet-first.p4
+++ b/testdata/p4_14_samples_outputs/01-JustEthernet-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/01-JustEthernet-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-JustEthernet-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/01-NoDeps-first.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1> drop;
     bit<8> egress_port;

--- a/testdata/p4_14_samples_outputs/01-NoDeps-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1> drop;
     bit<8> egress_port;

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-first.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1> drop;
     bit<8> egress_port;

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1> drop;
     bit<8> egress_port;

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2-first.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<32> f1;
 }

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<32> f1;
 }

--- a/testdata/p4_14_samples_outputs/02-FullPHV1-first.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/02-FullPHV1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet-first.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header len_or_type_t {
     bit<48> value;
 }

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header len_or_type_t {
     bit<48> value;
 }

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3-first.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/03-FullPHV2-first.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/03-FullPHV2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/03-Gateway-first.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1>  drop;
     bit<8>  egress_port;

--- a/testdata/p4_14_samples_outputs/03-Gateway-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1>  drop;
     bit<8>  egress_port;

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-first.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header len_or_type_t {
     bit<48> value;
 }

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header len_or_type_t {
     bit<48> value;
 }

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-first.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<8>  drop;
     bit<8>  egress_port;

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-frontend.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<8>  drop;
     bit<8>  egress_port;

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan-first.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan-frontend.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-first.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<8>  f1;
     bit<16> f2;

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<8>  f1;
     bit<16> f2;

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-first.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1-first.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-first.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack-first.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack-frontend.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-first.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1> drop;
     bit<8> egress_port;

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1> drop;
     bit<8> egress_port;

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-first.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-first.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct m_t {
     bit<8>  field_8_01;
     bit<8>  field_8_02;

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-first.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1> drop;
     bit<8> egress_port;

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1> drop;
     bit<8> egress_port;

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-first.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities-first.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities-frontend.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/11-MultiTags-first.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/11-MultiTags-frontend.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/12-Counters-first.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/12-Counters-frontend.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-first.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-frontend.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-first.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-first.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-frontend.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/14-Counter-first.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/14-Counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-first.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-frontend.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-first.p4
+++ b/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header cfi_t {
     bit<1> cfi;
 }

--- a/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-frontend.p4
+++ b/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header cfi_t {
     bit<1> cfi;
 }

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-first.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1> drop;
     bit<8> egress_port;

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-frontend.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<1> drop;
     bit<8> egress_port;

--- a/testdata/p4_14_samples_outputs/16-NoHeaders-first.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata {
 }
 

--- a/testdata/p4_14_samples_outputs/16-NoHeaders-frontend.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata {
 }
 

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-first.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-frontend.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/17-Minimal-first.p4
+++ b/testdata/p4_14_samples_outputs/17-Minimal-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata {
 }
 

--- a/testdata/p4_14_samples_outputs/17-Minimal-frontend.p4
+++ b/testdata/p4_14_samples_outputs/17-Minimal-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata {
 }
 

--- a/testdata/p4_14_samples_outputs/18-EmptyPipelines-first.p4
+++ b/testdata/p4_14_samples_outputs/18-EmptyPipelines-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/18-EmptyPipelines-frontend.p4
+++ b/testdata/p4_14_samples_outputs/18-EmptyPipelines-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/acl1-first.p4
+++ b/testdata/p4_14_samples_outputs/acl1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct acl_metadata_t {
     bit<1>  acl_deny;
     bit<1>  racl_deny;

--- a/testdata/p4_14_samples_outputs/acl1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct acl_metadata_t {
     bit<1>  acl_deny;
     bit<1>  racl_deny;

--- a/testdata/p4_14_samples_outputs/action_bus1-first.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1_1;
     bit<32> f1_2;

--- a/testdata/p4_14_samples_outputs/action_bus1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1_1;
     bit<32> f1_2;

--- a/testdata/p4_14_samples_outputs/action_chain1-first.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/action_chain1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/action_inline-first.p4
+++ b/testdata/p4_14_samples_outputs/action_inline-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ht {
     bit<1> b;
 }

--- a/testdata/p4_14_samples_outputs/action_inline-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ht {
     bit<1> b;
 }

--- a/testdata/p4_14_samples_outputs/action_inline1-first.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/action_inline1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/action_inline2-first.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/axon-first.p4
+++ b/testdata/p4_14_samples_outputs/axon-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct my_metadata_t {
     bit<8>  fwdHopCount;
     bit<8>  revHopCount;

--- a/testdata/p4_14_samples_outputs/axon-frontend.p4
+++ b/testdata/p4_14_samples_outputs/axon-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct my_metadata_t {
     bit<8>  fwdHopCount;
     bit<8>  revHopCount;

--- a/testdata/p4_14_samples_outputs/basic_routing-first.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<12> vrf;
     bit<16> bd;

--- a/testdata/p4_14_samples_outputs/basic_routing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<12> vrf;
     bit<16> bd;

--- a/testdata/p4_14_samples_outputs/bridge1-first.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata_t {
     bit<8> val;
 }

--- a/testdata/p4_14_samples_outputs/bridge1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata_t {
     bit<8> val;
 }

--- a/testdata/p4_14_samples_outputs/checksum1-first.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/checksum1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
@@ -112,9 +112,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/counter-first.p4
+++ b/testdata/p4_14_samples_outputs/counter-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/counter1-first.p4
+++ b/testdata/p4_14_samples_outputs/counter1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
 }

--- a/testdata/p4_14_samples_outputs/counter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
 }

--- a/testdata/p4_14_samples_outputs/counter2-first.p4
+++ b/testdata/p4_14_samples_outputs/counter2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
 }

--- a/testdata/p4_14_samples_outputs/counter2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
 }

--- a/testdata/p4_14_samples_outputs/counter3-first.p4
+++ b/testdata/p4_14_samples_outputs/counter3-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
 }

--- a/testdata/p4_14_samples_outputs/counter3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter3-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
 }

--- a/testdata/p4_14_samples_outputs/counter4-first.p4
+++ b/testdata/p4_14_samples_outputs/counter4-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
 }

--- a/testdata/p4_14_samples_outputs/counter4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
 }

--- a/testdata/p4_14_samples_outputs/counter5-first.p4
+++ b/testdata/p4_14_samples_outputs/counter5-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
 }

--- a/testdata/p4_14_samples_outputs/counter5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
 }

--- a/testdata/p4_14_samples_outputs/do_nothing-first.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/do_nothing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/exact_match1-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match2-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match3-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match4-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<128> f4;
     bit<8>   b1;

--- a/testdata/p4_14_samples_outputs/exact_match4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<128> f4;
     bit<8>   b1;

--- a/testdata/p4_14_samples_outputs/exact_match5-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<128> f4;
     bit<8>   b1;

--- a/testdata/p4_14_samples_outputs/exact_match5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<128> f4;
     bit<8>   b1;

--- a/testdata/p4_14_samples_outputs/exact_match6-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct meta_t {
     bit<32> sum;
 }

--- a/testdata/p4_14_samples_outputs/exact_match6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct meta_t {
     bit<32> sum;
 }

--- a/testdata/p4_14_samples_outputs/exact_match7-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<3>  x1;
     bit<7>  f1;

--- a/testdata/p4_14_samples_outputs/exact_match7-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<3>  x1;
     bit<7>  f1;

--- a/testdata/p4_14_samples_outputs/exact_match8-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match8-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match9-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match9-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<32> flow_ipg;
     bit<13> flowlet_map_index;

--- a/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
@@ -107,9 +107,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<32> flow_ipg;
     bit<13> flowlet_map_index;

--- a/testdata/p4_14_samples_outputs/gateway1-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway2-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway3-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway4-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway5-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway6-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway7-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/gateway7-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/hit-first.p4
+++ b/testdata/p4_14_samples_outputs/hit-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/hit-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hit-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/hitmiss-first.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/hitmiss-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/inline-first.p4
+++ b/testdata/p4_14_samples_outputs/inline-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct h {
     bit<1> b;
 }

--- a/testdata/p4_14_samples_outputs/inline-frontend.p4
+++ b/testdata/p4_14_samples_outputs/inline-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct h {
     bit<1> b;
 }

--- a/testdata/p4_14_samples_outputs/instruct1-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/instruct1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/instruct2-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/instruct2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/instruct3-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct3-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/instruct3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct3-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/instruct4-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct4-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/instruct4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct4-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/instruct5-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/instruct5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/mac_rewrite-first.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct egress_metadata_t {
     bit<16> payload_length;
     bit<9>  smac_idx;

--- a/testdata/p4_14_samples_outputs/mac_rewrite-frontend.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct egress_metadata_t {
     bit<16> payload_length;
     bit<9>  smac_idx;

--- a/testdata/p4_14_samples_outputs/meter-first.p4
+++ b/testdata/p4_14_samples_outputs/meter-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/meter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/meter1-first.p4
+++ b/testdata/p4_14_samples_outputs/meter1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/meter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/miss-first.p4
+++ b/testdata/p4_14_samples_outputs/miss-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/miss-frontend.p4
+++ b/testdata/p4_14_samples_outputs/miss-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/overflow-first.p4
+++ b/testdata/p4_14_samples_outputs/overflow-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata_t {
     bit<1> field_1_1_1;
     bit<1> field_2_1_1;

--- a/testdata/p4_14_samples_outputs/overflow-frontend.p4
+++ b/testdata/p4_14_samples_outputs/overflow-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata_t {
     bit<1> field_1_1_1;
     bit<1> field_2_1_1;

--- a/testdata/p4_14_samples_outputs/packet_redirect-first.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
@@ -113,9 +113,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/parser1-first.p4
+++ b/testdata/p4_14_samples_outputs/parser1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/parser1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/parser2-first.p4
+++ b/testdata/p4_14_samples_outputs/parser2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/parser2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/parser3-first.p4
+++ b/testdata/p4_14_samples_outputs/parser3-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data1_t {
     bit<32> f1;
     bit<2>  x1;

--- a/testdata/p4_14_samples_outputs/parser3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser3-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data1_t {
     bit<32> f1;
     bit<2>  x1;

--- a/testdata/p4_14_samples_outputs/parser4-first.p4
+++ b/testdata/p4_14_samples_outputs/parser4-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/parser4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser4-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;

--- a/testdata/p4_14_samples_outputs/parser_dc_full-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header arp_rarp_t {
     bit<16> hwType;
     bit<16> protoType;

--- a/testdata/p4_14_samples_outputs/parser_dc_full-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header arp_rarp_t {
     bit<16> hwType;
     bit<16> protoType;

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-first.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<3>   lkp_pkt_type;
     bit<48>  lkp_mac_sa;

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-frontend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<3>   lkp_pkt_type;
     bit<48>  lkp_mac_sa;

--- a/testdata/p4_14_samples_outputs/queueing-first.p4
+++ b/testdata/p4_14_samples_outputs/queueing-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 @name("queueing_metadata_t") struct queueing_metadata_t_0 {
     bit<48> enq_timestamp;
     bit<24> enq_qdepth;

--- a/testdata/p4_14_samples_outputs/queueing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 @name("queueing_metadata_t") struct queueing_metadata_t_0 {
     bit<48> enq_timestamp;
     bit<24> enq_qdepth;

--- a/testdata/p4_14_samples_outputs/register-first.p4
+++ b/testdata/p4_14_samples_outputs/register-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/register-frontend.p4
+++ b/testdata/p4_14_samples_outputs/register-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/resubmit-first.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/resubmit-frontend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/sai_p4-first.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct egress_metadata_t {
     bit<16> mirror_port;
 }

--- a/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
@@ -107,9 +107,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct egress_metadata_t {
     bit<16> mirror_port;
 }

--- a/testdata/p4_14_samples_outputs/selector0-first.p4
+++ b/testdata/p4_14_samples_outputs/selector0-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/selector0-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector0-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/selector1-first.p4
+++ b/testdata/p4_14_samples_outputs/selector1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/selector1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/selector2-first.p4
+++ b/testdata/p4_14_samples_outputs/selector2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/selector2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/selector3-first.p4
+++ b/testdata/p4_14_samples_outputs/selector3-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/selector3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector3-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/simple_nat-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
@@ -112,9 +112,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;

--- a/testdata/p4_14_samples_outputs/simple_router-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct routing_metadata_t {
     bit<32> nhop_ipv4;
 }

--- a/testdata/p4_14_samples_outputs/simple_router-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct routing_metadata_t {
     bit<32> nhop_ipv4;
 }

--- a/testdata/p4_14_samples_outputs/source_routing-first.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header easyroute_head_t {
     bit<64> preamble;
     bit<32> num_valid;

--- a/testdata/p4_14_samples_outputs/source_routing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-frontend.p4
@@ -106,9 +106,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header easyroute_head_t {
     bit<64> preamble;
     bit<32> num_valid;

--- a/testdata/p4_14_samples_outputs/swap_1-first.p4
+++ b/testdata/p4_14_samples_outputs/swap_1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr1_t {
     bit<8> f1;
     bit<8> f2;

--- a/testdata/p4_14_samples_outputs/swap_1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/swap_1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr1_t {
     bit<8> f1;
     bit<8> f2;

--- a/testdata/p4_14_samples_outputs/swap_2-first.p4
+++ b/testdata/p4_14_samples_outputs/swap_2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr2_t {
     bit<8>  f1;
     bit<8>  f2;

--- a/testdata/p4_14_samples_outputs/swap_2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/swap_2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr2_t {
     bit<8>  f1;
     bit<8>  f2;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct acl_metadata_t {
     bit<1>  acl_deny;
     bit<1>  racl_deny;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -114,9 +114,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct acl_metadata_t {
     bit<1>  acl_deny;
     bit<1>  racl_deny;

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct acl_metadata_t {
     bit<1>  acl_deny;
     bit<1>  acl_copy;

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -115,9 +115,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct acl_metadata_t {
     bit<1>  acl_deny;
     bit<1>  acl_copy;

--- a/testdata/p4_14_samples_outputs/ternary_match0-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/ternary_match0-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/ternary_match1-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/ternary_match1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/ternary_match2-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/ternary_match2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/ternary_match3-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/ternary_match3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/ternary_match4-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/ternary_match4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-first.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<16> bd;
     bit<12> vrf;

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<16> bd;
     bit<12> vrf;

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-first.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header pkt_t {
     bit<32> field_a_32;
     int<32> field_b_32;

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header pkt_t {
     bit<32> field_a_32;
     int<32> field_b_32;

--- a/testdata/p4_14_samples_outputs/testgw-first.p4
+++ b/testdata/p4_14_samples_outputs/testgw-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/testgw-frontend.p4
+++ b/testdata/p4_14_samples_outputs/testgw-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/tp2a-first.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/tp2a-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/tp2b-first.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/tp2b-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/tp2c-first.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/tp2c-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/tp3a-first.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/tp3a-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_14_samples_outputs/triv_eth-first.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dst_addr;
     bit<48> src_addr;

--- a/testdata/p4_14_samples_outputs/triv_eth-frontend.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dst_addr;
     bit<48> src_addr;

--- a/testdata/p4_14_samples_outputs/triv_ipv4-first.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dst_addr;
     bit<48> src_addr;

--- a/testdata/p4_14_samples_outputs/triv_ipv4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header ethernet_t {
     bit<48> dst_addr;
     bit<48> src_addr;

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet-first.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<3>  lkp_pkt_type;
     bit<48> lkp_mac_sa;

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet-frontend.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<3>  lkp_pkt_type;
     bit<48> lkp_mac_sa;

--- a/testdata/p4_14_samples_outputs/wide_action1-first.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata_t {
     bit<32> m0;
     bit<32> m1;

--- a/testdata/p4_14_samples_outputs/wide_action1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata_t {
     bit<32> m0;
     bit<32> m1;

--- a/testdata/p4_14_samples_outputs/wide_action2-first.p4
+++ b/testdata/p4_14_samples_outputs/wide_action2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<16> bd;
     bit<12> vrf;

--- a/testdata/p4_14_samples_outputs/wide_action2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct ingress_metadata_t {
     bit<16> bd;
     bit<12> vrf;

--- a/testdata/p4_14_samples_outputs/wide_action3-first.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata_t {
     bit<32> m0;
     bit<32> m1;

--- a/testdata/p4_14_samples_outputs/wide_action3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 struct metadata_t {
     bit<32> m0;
     bit<32> m1;

--- a/testdata/p4_16_samples_outputs/arith-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/arith-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith-bmv2-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/arith1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     int<32> a;
     int<32> b;

--- a/testdata/p4_16_samples_outputs/arith1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     int<32> a;
     int<32> b;

--- a/testdata/p4_16_samples_outputs/arith2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/arith2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/arith3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<8>  b;

--- a/testdata/p4_16_samples_outputs/arith3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<8>  b;

--- a/testdata/p4_16_samples_outputs/arith4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<8>  b;

--- a/testdata/p4_16_samples_outputs/arith4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<8>  b;

--- a/testdata/p4_16_samples_outputs/arith5-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     int<32> a;
     bit<8>  b;

--- a/testdata/p4_16_samples_outputs/arith5-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     int<32> a;
     bit<8>  b;

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/enum-bmv-first.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/enum-bmv-frontend.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/key-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/key-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2-frontend.p4
@@ -105,9 +105,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header hdr {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-first.p4
@@ -121,9 +121,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_h {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-frontend.p4
@@ -103,9 +103,9 @@ parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta, inout standard_m
 control VerifyChecksum<H, M>(in H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
-control ComputeCkecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
 control Deparser<H>(packet_out b, in H hdr);
-package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeCkecksum<H, M> ck, Deparser<H> dep);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg, ComputeChecksum<H, M> ck, Deparser<H> dep);
 header data_h {
     bit<32> f1;
     bit<32> f2;


### PR DESCRIPTION
v1model.p4 has a typo: 'Ckecksum' should be 'Checksum'. The same typo also occurs in many of the testdata files.
