### PR TITLE
Fix bmv2/json generation crashes for p4_16 code converted from p4_14

### DIFF
--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -110,12 +110,11 @@ void DirectMeterMap::setTable(const IR::IDeclaration* meter, const IR::P4Table* 
 static bool checkSame(const IR::Expression* expr0, const IR::Expression* expr1) {
     if (expr0->node_type_name() != expr1->node_type_name())
         return false;
-    if (expr0->is<IR::PathExpression>()) {
-        auto pe0 = expr0->to<IR::PathExpression>();
+    if (auto pe0 = expr0->to<IR::PathExpression>()) {
         auto pe1 = expr1->to<IR::PathExpression>();
-        return pe0->path == pe1->path;
-    } else if (expr0->is<IR::Member>()) {
-        auto mem0 = expr0->to<IR::Member>();
+        return pe0->path->name == pe1->path->name &&
+               IR::equal(pe0->path->prefix, pe1->path->prefix);
+    } else if (auto mem0 = expr0->to<IR::Member>()) {
         auto mem1 = expr1->to<IR::Member>();
         return checkSame(mem0->expr, mem1->expr) && mem0->member == mem1->member;
     }
@@ -132,7 +131,7 @@ void DirectMeterMap::setDestination(const IR::IDeclaration* meter,
     } else {
         bool same = checkSame(destination, info->destinationField);
         if (!same)
-            ::error("On this target all meter operations must write to the same destination ",
+            ::error("On this target all meter operations must write to the same destination "
                     "but %1% and %2% are different", destination, info->destinationField);
     }
 }
@@ -530,8 +529,7 @@ class ExpressionConverter : public Inspector {
     void postorder(const IR::PathExpression* expression) override {
         // This is useful for action bodies mostly
         auto decl = converter->refMap->getDeclaration(expression->path, true);
-        if (decl->is<IR::Parameter>()) {
-            auto param = decl->to<IR::Parameter>();
+        if (auto param = decl->to<IR::Parameter>()) {
             if (param == converter->stdMetadataParameter) {
                 auto result = new Util::JsonObject();
                 result->emplace("type", "header");
@@ -550,13 +548,15 @@ class ExpressionConverter : public Inspector {
             unsigned paramIndex = ::get(converter->structure.index, param);
             result->emplace("value", paramIndex);
             map.emplace(expression, result);
-        } else if (decl->is<IR::Declaration_Variable>()) {
+        } else if (auto var = decl->to<IR::Declaration_Variable>()) {
             auto result = new Util::JsonObject();
-            auto var = decl->to<IR::Declaration_Variable>();
             auto type = converter->typeMap->getType(var, true);
             if (type->is<IR::Type_StructLike>()) {
                 result->emplace("type", "header");
                 result->emplace("value", var->name);
+            } else if (auto tt = type->to<IR::Type_Tuple>()) {
+                result->emplace("type", "header");
+                result->emplace("value", converter->createJsonType(tt));
             } else if (type->is<IR::Type_Bits>() ||
                        (type->is<IR::Type_Boolean>() && leftValue)) {
                 // no convertion d2b when writing (leftValue is true) to a boolean
@@ -986,6 +986,12 @@ Util::JsonArray* JsonConverter::createActions(Util::JsonArray* fieldLists,
         auto control = it.second;
         if (control != nullptr) {
             // It could be nullptr for global actions
+            if (v1model.ingress.standardMetadataParam.index >= control->type->applyParams->size()) {
+                // FIXME -- compute/verifyChecksum don't have a standard_metadata argument and will
+                // fail below if we try to convert their 'action'.  When converting from p4_14,
+                // we don't even call here with them (why?), but when compiling native P4_16
+                // we do.  skipping for now.
+                continue; }
             stdMetadataParameter = control->type->applyParams->getParameter(
                 v1model.ingress.standardMetadataParam.index);
             userMetadataParameter = control->type->applyParams->getParameter(
@@ -1570,9 +1576,7 @@ unsigned JsonConverter::nextId(cstring group) {
     return counters[group]++;
 }
 
-void JsonConverter::addHeaderStacks(const IR::Type_Struct* headersStruct,
-                                    Util::JsonArray* headers, Util::JsonArray* headerTypes,
-                                    Util::JsonArray* stacks, std::set<cstring> &headerTypesDone) {
+void JsonConverter::addHeaderStacks(const IR::Type_Struct* headersStruct) {
     for (auto f : *headersStruct->fields) {
         auto ft = typeMap->getType(f->type, true);
         auto stack = ft->to<IR::Type_Stack>();
@@ -1587,10 +1591,7 @@ void JsonConverter::addHeaderStacks(const IR::Type_Struct* headersStruct,
         auto type = typeMap->getType(stack->elementType, true);
         BUG_CHECK(type->is<IR::Type_Header>(), "%1% not a header type", stack->elementType);
         auto ht = type->to<IR::Type_Header>();
-        if (!headerTypesDone.count(ht->name)) {
-            auto json = typeToJson(ht);
-            headerTypes->append(json);
-        }
+        createJsonType(ht);
 
         cstring header_type = stack->elementType->to<IR::Type_Header>()->name;
         json->emplace("header_type", header_type);
@@ -1605,14 +1606,13 @@ void JsonConverter::addHeaderStacks(const IR::Type_Struct* headersStruct,
             header->emplace("id", id);
             header->emplace("header_type", header_type);
             header->emplace("metadata", false);
-            headers->append(header);
+            headerInstances->append(header);
         }
-        stacks->append(json);
+        headerStacks->append(json);
     }
 }
 
-void JsonConverter::addLocals(Util::JsonArray* headerTypes, Util::JsonArray* instances,
-                              Util::JsonArray* /*stacks*/, std::set<cstring> &headerTypesCreated) {
+void JsonConverter::addLocals() {
     // We synthesize a "header_type" for each local which has a struct type
     // and we pack all the scalar-typed locals into a scalarsStruct
     // TODO: synthesize stacks
@@ -1626,21 +1626,22 @@ void JsonConverter::addLocals(Util::JsonArray* headerTypes, Util::JsonArray* ins
     for (auto v : structure.variables) {
         LOG1("Creating local " << v);
         auto type = typeMap->getType(v, true);
-        if (type->is<IR::Type_StructLike>()) {
-            auto st = type->to<IR::Type_StructLike>();
-
-            if (!headerTypesCreated.count(st->name)) {
-                auto tjson = typeToJson(st);
-                headerTypes->append(tjson);
-                headerTypesCreated.emplace(st->name);
-            }
-
+        if (auto st = type->to<IR::Type_StructLike>()) {
+            auto name = createJsonType(st);
             auto json = new Util::JsonObject();
             json->emplace("name", v->name);
             json->emplace("id", nextId("headers"));
-            json->emplace("header_type", st->name.name);
+            json->emplace("header_type", name);
             json->emplace("metadata", true);
-            instances->append(json);
+            headerInstances->append(json);
+        } else if (auto tt = type->to<IR::Type_Tuple>()) {
+            auto name = createJsonType(tt);
+            auto json = new Util::JsonObject();
+            json->emplace("name", v->name);
+            json->emplace("id", nextId("headers"));
+            json->emplace("header_type", name);
+            json->emplace("metadata", true);
+            headerInstances->append(json);
         } else if (type->is<IR::Type_Bits>()) {
             auto tb = type->to<IR::Type_Bits>();
             auto field = pushNewArray(scalarFields);
@@ -1672,7 +1673,7 @@ void JsonConverter::addLocals(Util::JsonArray* headerTypes, Util::JsonArray* ins
         }
 
         // insert the scalars type
-        headerTypesCreated.emplace(scalarsName);
+        headerTypesCreated[scalarsName] = scalarsName;
         headerTypes->append(scalarsStruct);
 
         // insert the scalars instance
@@ -1681,7 +1682,7 @@ void JsonConverter::addLocals(Util::JsonArray* headerTypes, Util::JsonArray* ins
         json->emplace("id", nextId("headers"));
         json->emplace("header_type", scalarsName);
         json->emplace("metadata", true);
-        instances->append(json);
+        headerInstances->append(json);
     }
 }
 
@@ -1721,16 +1722,17 @@ void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
     }
     toplevel.emplace("program", options.file);
 
-    auto headerTypes = mkArrayField(&toplevel, "header_types");
-    auto headers = mkArrayField(&toplevel, "headers");
-    auto headerStacks = mkArrayField(&toplevel, "header_stacks");
+    headerTypes = mkArrayField(&toplevel, "header_types");
+    headerInstances = mkArrayField(&toplevel, "headers");
+    headerStacks = mkArrayField(&toplevel, "header_stacks");
     auto fieldLists = mkArrayField(&toplevel, "field_lists");
     (void)nextId("field_lists");  // field list IDs must start at 1; 0 is reserved
     (void)nextId("learn_lists");  // idem
 
-    std::set<cstring> headerTypesCreated;
-    addTypesAndInstances(ht, false, headerTypes, headers, headerTypesCreated);
-    addHeaderStacks(ht, headers, headerTypes, headerStacks, headerTypesCreated);
+    headerTypesCreated.clear();
+    tupleTypesCreated.clear();
+    addTypesAndInstances(ht, false);
+    addHeaderStacks(ht);
     if (::errorCount() > 0)
         return;
 
@@ -1744,8 +1746,8 @@ void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
         ::error("Expected metadata %1% to be a struct", mdType);
         return;
     }
-    addTypesAndInstances(mt, true, headerTypes, headers, headerTypesCreated);
-    addLocals(headerTypes, headers, headerStacks, headerTypesCreated);
+    addTypesAndInstances(mt, true);
+    addLocals();
 
     auto prsrs = mkArrayField(&toplevel, "parsers");
     auto parserJson = toJson(parser);
@@ -1805,16 +1807,15 @@ void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
     stdMetadataParameter = ingressControl->container->type->applyParams->getParameter(
         v1model.ingress.standardMetadataParam.index);
     auto stdMetaType = typeMap->getType(stdMetadataParameter, true);
-    auto json = typeToJson(stdMetaType->to<IR::Type_StructLike>());
-    headerTypes->append(json);
+    auto stdMetaName = createJsonType(stdMetaType->to<IR::Type_StructLike>());
 
     {
         auto json = new Util::JsonObject();
         json->emplace("name", v1model.ingress.standardMetadataParam.name);
         json->emplace("id", nextId("headers"));
-        json->emplace("header_type", stdMetaType->to<IR::Type_StructLike>()->name.name);
+        json->emplace("header_type", stdMetaName);
         json->emplace("metadata", true);
-        headers->append(json);
+        headerInstances->append(json);
     }
 
     auto checksums = mkArrayField(&toplevel, "checksums");
@@ -1884,24 +1885,23 @@ void JsonConverter::generateUpdate(const IR::P4Control* updateControl,
                     }
                 }
             }
+        } else if (auto apply = stat->to<IR::MethodCallStatement>()) {
+            BUG_CHECK(apply->methodCall->method->to<IR::Member>()->member == "apply",
+                      "Call of something other than an apply method");
+            // FIXME -- ignore for now
+            continue;
         }
         BUG("%1%: not handled yet", stat);
     }
 }
 
-void JsonConverter::addTypesAndInstances(const IR::Type_StructLike* type, bool meta,
-                                         Util::JsonArray* headerTypes, Util::JsonArray* instances,
-                                         std::set<cstring> &headerTypesCreated) {
+void JsonConverter::addTypesAndInstances(const IR::Type_StructLike* type, bool meta) {
     // TODO: this is wrong if the structs are more deeply nested.
     for (auto f : *type->fields) {
         auto ft = typeMap->getType(f->type, true);
         if (ft->is<IR::Type_StructLike>()) {
             auto st = ft->to<IR::Type_StructLike>();
-            if (headerTypesCreated.count(st->name))
-                continue;
-            auto json = typeToJson(st);
-            headerTypes->append(json);
-            headerTypesCreated.emplace(st->name);
+            createJsonType(st);
         }
     }
 
@@ -1913,7 +1913,7 @@ void JsonConverter::addTypesAndInstances(const IR::Type_StructLike* type, bool m
             json->emplace("id", nextId("headers"));
             json->emplace("header_type", ft->to<IR::Type_StructLike>()->name.name);
             json->emplace("metadata", meta);
-            instances->append(json);
+            headerInstances->append(json);
         } else if (ft->is<IR::Type_Stack>()) {
             // Done elsewhere
             continue;
@@ -1926,20 +1926,22 @@ void JsonConverter::addTypesAndInstances(const IR::Type_StructLike* type, bool m
     }
 }
 
-Util::IJson* JsonConverter::typeToJson(const IR::Type_StructLike* st) {
-    auto result = new Util::JsonObject();
-    result->emplace("name", nameFromAnnotation(st->annotations, st->name.name));
-    result->emplace("id", nextId("header_types"));
-    auto fields = mkArrayField(result, "fields");
+void JsonConverter::pushFields(cstring prefix, const IR::Type_StructLike *st,
+                               Util::JsonArray *fields) {
     for (auto f : *st->fields) {
-        auto field = pushNewArray(fields);
-        field->append(f->name.name);
         auto ftype = typeMap->getType(f->type, true);
-        BUG_CHECK(ftype->is<IR::Type_Bits>(), "%1%: expected a bit<> or int<> type for %2%.%3%",
-                  ftype, st, f->name);
-        auto type = ftype->to<IR::Type_Bits>();
-        field->append(type->size);
-        field->append(type->isSigned);
+        if (auto nested = ftype->to<IR::Type_StructLike>()) {
+            pushFields(prefix + f->name.name + ".", nested, fields);
+        } else if (auto nested = ftype->to<IR::Type_Tuple>()) {
+            pushFields(prefix + f->name.name + ".", nested, fields);
+        } else if (auto type = ftype->to<IR::Type_Bits>()) {
+            auto field = pushNewArray(fields);
+            field->append(prefix + f->name.name);
+            field->append(type->size);
+            field->append(type->isSigned);
+        } else {
+            BUG_CHECK("%1%: unexpected type for %2%.%3%", ftype, st, f->name);
+        }
     }
     // must add padding
     unsigned width = st->width_bits();
@@ -1947,11 +1949,58 @@ Util::IJson* JsonConverter::typeToJson(const IR::Type_StructLike* st) {
     if (padding != 0) {
         cstring name = refMap->newName("_padding");
         auto field = pushNewArray(fields);
-        field->append(name);
+        field->append(prefix + name);
         field->append(8 - padding);
         field->append(false);
     }
-    return result;
+}
+void JsonConverter::pushFields(cstring prefix, const IR::Type_Tuple *tt,
+                               Util::JsonArray *fields) {
+    int idx = 1;
+    for (auto f : *tt->components) {
+        char name[8];
+        snprintf(name, sizeof(name), "_%d", idx);
+        auto ftype = typeMap->getType(f, true);
+        if (auto nested = ftype->to<IR::Type_StructLike>()) {
+            pushFields(prefix + name + ".", nested, fields);
+        } else if (auto nested = ftype->to<IR::Type_Tuple>()) {
+            pushFields(prefix + name + ".", nested, fields);
+        } else if (auto type = ftype->to<IR::Type_Bits>()) {
+            auto field = pushNewArray(fields);
+            field->append(prefix + name);
+            field->append(type->size);
+            field->append(type->isSigned);
+        } else {
+            BUG_CHECK("%1%: unexpected type for %2%.%3%", ftype, tt, idx);
+        }
+        ++idx;
+    }
+}
+
+cstring JsonConverter::createJsonType(const IR::Type_StructLike *st) {
+    if (headerTypesCreated.count(st->name)) return headerTypesCreated[st->name];
+    auto typeJson = new Util::JsonObject();
+    cstring name = nameFromAnnotation(st->annotations, st->name.name);
+    headerTypesCreated[st->name] = name;
+    typeJson->emplace("name", name);
+    typeJson->emplace("id", nextId("header_types"));
+    headerTypes->append(typeJson);
+    auto fields = mkArrayField(typeJson, "fields");
+    pushFields("", st, fields);
+    return name;
+}
+
+cstring JsonConverter::createJsonType(const IR::Type_Tuple *tt) {
+    if (tupleTypesCreated.count(tt)) return tupleTypesCreated[tt];
+    auto typeJson = new Util::JsonObject();
+    cstring name = refMap->newName("_tuple");
+    tupleTypesCreated[tt] = name;
+    typeJson->emplace("name", name);
+    typeJson->emplace("id", nextId("header_types"));
+    headerTypes->append(typeJson);
+    auto fields = mkArrayField(typeJson, "fields");
+    pushFields("", tt, fields);
+    return name;
 }
 
 void JsonConverter::convertDeparserBody(const IR::Vector<IR::StatOrDecl>* body,

--- a/backends/bmv2/jsonconverter.h
+++ b/backends/bmv2/jsonconverter.h
@@ -70,17 +70,23 @@ class JsonConverter final {
     const IR::Parameter*   userMetadataParameter;
     const IR::Parameter*   stdMetadataParameter;
 
+ private:
+    Util::JsonArray *headerTypes;
+    std::map<cstring, cstring> headerTypesCreated;
+    std::map<const IR::Type_Tuple *, cstring> tupleTypesCreated;
+    Util::JsonArray *headerInstances;
+    Util::JsonArray *headerStacks;
+    friend class ExpressionConverter;
+
  protected:
-    Util::IJson* typeToJson(const IR::Type_StructLike* type);
+    void pushFields(cstring prefix, const IR::Type_StructLike *st, Util::JsonArray *fields);
+    void pushFields(cstring prefix, const IR::Type_Tuple *tt, Util::JsonArray *fields);
+    cstring createJsonType(const IR::Type_StructLike *type);
+    cstring createJsonType(const IR::Type_Tuple *type);
     unsigned nextId(cstring group);
-    void addHeaderStacks(const IR::Type_Struct* headersStruct,
-                         Util::JsonArray* headers, Util::JsonArray* headerTypes,
-                         Util::JsonArray* stacks, std::set<cstring> &headerTypesCreated);
-    void addLocals(Util::JsonArray* headerTYpes, Util::JsonArray* instances,
-                   Util::JsonArray* stacks, std::set<cstring> &headerTypesCreated);
-    void addTypesAndInstances(const IR::Type_StructLike* type, bool meta,
-                              Util::JsonArray* headerTypes, Util::JsonArray* instances,
-                              std::set<cstring> &headerTypesCreated);
+    void addHeaderStacks(const IR::Type_Struct* headersStruct);
+    void addLocals();
+    void addTypesAndInstances(const IR::Type_StructLike* type, bool meta);
     void convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                            Util::JsonArray* result, Util::JsonArray* fieldLists,
                            Util::JsonArray* calculations, Util::JsonArray* learn_lists);

--- a/ir/node.h
+++ b/ir/node.h
@@ -115,6 +115,11 @@ cstring dbp(const INode* node);
 template<typename T> bool INode::is() const { return getNode()->is<T>(); }
 template<typename T> const T* INode::to() const { return getNode()->to<T>(); }
 
+inline bool equal(const Node *a, const Node *b) {
+    return a == b || (a && b && *a == *b); }
+inline bool equal(const INode *a, const INode *b) {
+    return a == b || (a && b && *a->getNode() == *b->getNode()); }
+
 /* common things that ALL Node subclasses must define */
 #define IRNODE_SUBCLASS(T)                                              \
  public:                                                                \


### PR DESCRIPTION
- refactor the code, moving repeated arguments into the JsonConverter
  object
- support for Tuple types
- support for nested structs
- skips things related to checksums that were crashing (TODO)
