### PR TITLE
Convert P4_14 pragmas into annotations as strings

### DIFF
--- a/backends/bmv2/analyzer.cpp
+++ b/backends/bmv2/analyzer.cpp
@@ -30,8 +30,8 @@ cstring nameFromAnnotation(const IR::Annotations* annotations,
     CHECK_NULL(annotations); CHECK_NULL(defaultValue);
     auto anno = annotations->getSingle(IR::Annotation::nameAnnotation);
     if (anno != nullptr) {
-        CHECK_NULL(anno->expr);
-        auto str = anno->expr->to<IR::StringLiteral>();
+        BUG_CHECK(anno->expr.size() == 1, "name annotation must be a string");
+        auto str = anno->expr[0]->to<IR::StringLiteral>();
         CHECK_NULL(str);
         return str->value;
     }

--- a/backends/ebpf/ebpfObject.cpp
+++ b/backends/ebpf/ebpfObject.cpp
@@ -28,8 +28,8 @@ cstring nameFromAnnotation(const IR::Annotations* annotations,
     CHECK_NULL(annotations); CHECK_NULL(defaultValue);
     auto anno = annotations->getSingle(IR::Annotation::nameAnnotation);
     if (anno != nullptr) {
-        CHECK_NULL(anno->expr);
-        auto str = anno->expr->to<IR::StringLiteral>();
+        BUG_CHECK(anno->expr.size() == 1, "name annotation must be a string");
+        auto str = anno->expr[0]->to<IR::StringLiteral>();
         CHECK_NULL(str);
         return str->value;
     }

--- a/frontends/p4-14/header_type.cpp
+++ b/frontends/p4-14/header_type.cpp
@@ -18,20 +18,20 @@ limitations under the License.
 
 bool
 HeaderTypeMaxLengthCalculator::preorder(IR::Type_StructLike *hdr_type) {
-    IR::Vector<IR::Annotation> *annot = nullptr;
+    IR::Annotations *annot = nullptr;
     auto *max_length = hdr_type->annotations->getSingle("max_length");
     if (!max_length) {
         unsigned len = 0;
         for (auto field : *hdr_type->fields)
             len += field->type->width_bits();
         max_length = new IR::Annotation("max_length", len);
-        if (!annot) annot = hdr_type->annotations->annotations->clone();
-        annot->push_back(max_length); }
+        if (!annot) annot = hdr_type->annotations->clone();
+        annot->annotations.push_back(max_length); }
     auto *length = hdr_type->annotations->getSingle("length");
     if (!length) {
-        if (!annot) annot = hdr_type->annotations->annotations->clone();
+        if (!annot) annot = hdr_type->annotations->clone();
         length = new IR::Annotation("length", max_length->expr);
-        annot->push_back(length); }
-    if (annot) hdr_type->annotations = new IR::Annotations(annot);
+        annot->annotations.push_back(length); }
+    if (annot) hdr_type->annotations = annot;
     return false;
 }

--- a/frontends/p4-14/p4-14-lex.l
+++ b/frontends/p4-14/p4-14-lex.l
@@ -7,6 +7,7 @@
       yylloc = Util::SourceInfo(tmp, Util::InputSources::instance->getCurrentPosition()); }
 
 static int lineDirectiveLine;
+static bool pragmaLine = false;  // FIXME -- use a flex state (and state stack?)
 
 // shut up warnings about unused functions and variables
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -25,12 +26,12 @@ static int lineDirectiveLine;
 %%
 
 [ \t\r]+                ;
-[\n]            { BEGIN INITIAL; }
+[\n]            { BEGIN INITIAL; if (pragmaLine) { pragmaLine = false; return '\n'; }}
 "//".*                  ;
 "/*"            { BEGIN COMMENT; }
 <COMMENT>"*/"   { BEGIN NORMAL; }
 <COMMENT>.              ;
-<COMMENT>[\n]           ;
+<COMMENT>[\n]         { if (pragmaLine) { pragmaLine = false; return '\n'; } }
 
 <INITIAL>"#line"      { BEGIN(LINE1); }
 <INITIAL>"# "         { BEGIN(LINE1); }
@@ -45,7 +46,10 @@ static int lineDirectiveLine;
 <LINE1,LINE2,LINE3>\n { BEGIN(INITIAL); }
 <LINE1,LINE2,LINE3,COMMENT,NORMAL><<EOF>> { BEGIN(INITIAL); }
 
-"@pragma".*     { yylval.str = StringRef(yytext+7).trim(); return PRAGMA; }
+"@pragma"[ \t]*[A-Za-z_][A-Za-z0-9_]* {
+                  yylval.str = StringRef(yytext+7).trim();
+                  pragmaLine = true;
+                  return PRAGMA; }
 
 "action"        { yylval.str = yytext; BEGIN(NORMAL); return ACTION; }
 "actions"       { yylval.str = yytext; BEGIN(NORMAL); return ACTIONS; }

--- a/frontends/p4-14/p4-14-parse.ypp
+++ b/frontends/p4-14/p4-14-parse.ypp
@@ -46,6 +46,13 @@ static IR::Constant *constantFold(IR::Expression *);
 namespace {  // anonymous namespace
 static int yylex();
 
+static IR::Vector<IR::Annotation> current_pragmas;
+static const IR::Annotations *getPragmas() {
+    if (current_pragmas.empty()) return IR::Annotations::empty;
+    auto *rv = new IR::Annotations(current_pragmas);
+    current_pragmas.clear();
+    return rv; }
+
 %}
 
 %union {
@@ -90,8 +97,12 @@ static int yylex();
             SELECT SELECTION_KEY SELECTION_MODE SELECTION_TYPE SET_METADATA
             SIGNED SIZE STATIC TABLE TRUE TYPE UPDATE VALID VERIFY WIDTH WRITES
 
-%token<str> IDENTIFIER
+%token<str> IDENTIFIER STRING
 %token<Constant> INTEGER
+
+%printer { fprintf(yyoutput, "\"%s\"", $$.c_str()); } <str>
+%printer { fprintf(yyoutput, "\%d", $$); } <i>
+%printer { fprintf(yyoutput, "\%s", $$->toString().c_str()); } <Constant>
 
 %left EXPRLIST
 %right '='
@@ -119,8 +130,9 @@ static int yylex();
 %type<Constant>         const_expression
 %type<Counter>          counter_spec_list
 %type<Expression>       expression header_ref header_or_field_ref field_or_masked_ref opt_condition
+                        pragma_operand
 %type<ExpressionList>   expression_list opt_expression_list control_statement_list opt_else
-                        field_match_list expressions
+                        field_match_list expressions pragma_operands
 %type<FieldList>        field_list_entries
 %type<FieldListCalculation>     field_list_calculation_body
 %type<Member>           field_ref
@@ -157,8 +169,10 @@ input: /* epsilon */
     | input control_function_declaration
     | input blackbox_type_declaration
     | input blackbox_instantiation
-    | input PRAGMA
+    | input PRAGMA pragma_operands '\n'
+          { current_pragmas.push_back(new IR::Annotation(@2, $2, *$3)); }
     | input error
+          { current_pragmas.clear(); }
 ;
 
 /********************************/
@@ -166,11 +180,13 @@ input: /* epsilon */
 /********************************/
 
 header_type_declaration: HEADER_TYPE name '{' header_dec_body '}'
-      { global->add($2, new IR::v1HeaderType(@1+@5, $2,
+      { $4.annotations->append(current_pragmas);
+        current_pragmas.clear();
+        global->add($2, new IR::v1HeaderType(@1+@5, $2,
             new IR::Type_Struct(@1+@5, IR::ID(@2, $2),
-                                new IR::Annotations($4.annotations), $4.fields),
+                                new IR::Annotations(*$4.annotations), $4.fields),
             new IR::Type_Header(@1+@5, IR::ID(@2, $2),
-                                new IR::Annotations($4.annotations), $4.fields))); }
+                                new IR::Annotations(*$4.annotations), $4.fields))); }
 ;
 
 header_dec_body: FIELDS '{' field_declarations '}' opt_length opt_max_length
@@ -213,12 +229,14 @@ attrib:
 
 opt_length: /* epsilon */
     | LENGTH ':' expression ';'  /* const_expression or name */
-      { $<HeaderType>-1.annotations->emplace_back(@1+@4, "length", $3); }
+      { $<HeaderType>-1.annotations->emplace_back(@1+@4, "length",
+              IR::Vector<IR::Expression>($3)); }
     ;
 
 opt_max_length: /* epsilon */
     | MAX_LENGTH ':' const_expression ';'
-      { $<HeaderType>-2.annotations->emplace_back(@1+@4, "max_length", $3); }
+      { $<HeaderType>-2.annotations->emplace_back(@1+@4, "max_length",
+              IR::Vector<IR::Expression>($3)); }
     ;
 
 type: INT '<' INTEGER '>'
@@ -237,16 +255,16 @@ type: INT '<' INTEGER '>'
 
 header_instance:
       HEADER name name ';'
-      { global->add($3, new IR::Header(@1+@4, IR::ID(@2, $2), IR::ID(@3, $3))); }
+      { global->add($3, new IR::Header(@1+@4, IR::ID(@2, $2), IR::ID(@3, $3), getPragmas())); }
     | HEADER name name '[' const_expression ']' ';'
-      { global->add($3, new IR::HeaderStack(@1+@7, IR::ID(@2, $2), IR::ID(@3, $3),
+      { global->add($3, new IR::HeaderStack(@1+@7, IR::ID(@2, $2), IR::ID(@3, $3), getPragmas(),
                                             $5 ? $5->asLong() : 0));
         $5 = nullptr; }
     ;
 
 metadata_instance:
       METADATA name name opt_metadata_initializer ';'
-      { global->add($3, new IR::Metadata(@1+@5, IR::ID(@2, $2), IR::ID(@3, $3))); }
+      { global->add($3, new IR::Metadata(@1+@5, IR::ID(@2, $2), IR::ID(@3, $3), getPragmas())); }
     ;
 
 opt_metadata_initializer: /* epsilon */
@@ -269,7 +287,7 @@ field_list_declaration:
       /* FIXME -- empty field list? or (unneeded) forward declaration? */
 ;
 
-field_list_entries: /* epsilon */ { $$ = new IR::FieldList; }
+field_list_entries: /* epsilon */ { $$ = new IR::FieldList(getPragmas()); }
     | field_list_entries expression ';'  /* const_expression or field_ref or name */
       { ($$=$1)->fields.push_back($2); }
     | field_list_entries PAYLOAD ';'
@@ -285,7 +303,7 @@ field_list_calculation_declaration:
       { $4->name = IR::ID(@2, $2); $4->srcInfo = @1 + @5; global->add($2, $4); }
 ;
 
-field_list_calculation_body: /* epsilon */ { $$ = new IR::FieldListCalculation; }
+field_list_calculation_body: /* epsilon */ { $$ = new IR::FieldListCalculation(getPragmas()); }
     | field_list_calculation_body INPUT '{' field_list_list '}'
       { if ($1->input)
             error("%s: multiple 'input' in field_list_calculation", @2);
@@ -314,7 +332,7 @@ calculated_field_declaration:
 ;
 
 update_verify_spec_list: /* epsilon */
-      { $$ = new IR::CalculatedField; }
+      { $$ = new IR::CalculatedField(getPragmas()); }
     | update_verify_spec_list UPDATE name opt_condition ';'
       { ($$=$1)->specs.emplace_back(@1+@3, true, IR::ID(@3, $3), $4); }
     | update_verify_spec_list VERIFY name opt_condition ';'
@@ -336,7 +354,7 @@ parser_function_declaration:
       { $4->name = IR::ID(@2, $2); $4->srcInfo = @1 + @5; global->add($2, $4); }
 ;
 
-parser_statement_list: /* epsilon */ { $$ = new IR::V1Parser; }
+parser_statement_list: /* epsilon */ { $$ = new IR::V1Parser(getPragmas()); }
     | parser_statement_list EXTRACT '(' header_ref ')' ';'
       { ($$=$1)->stmts.push_back(new IR::Primitive(@2+@5, $2, $4)); }
     | parser_statement_list SET_METADATA '(' field_ref ',' expression ')' ';'
@@ -382,6 +400,7 @@ case_value:
 
 parser_exception_declaration:
       PARSER_EXCEPTION name '{' parser_statement_list '}'
+        { current_pragmas.clear(); }
 ;
 
 /*****************/
@@ -394,7 +413,7 @@ counter_declaration: COUNTER name '{' counter_spec_list '}'
 
 counter_spec_list:
       TYPE ':' name ';'
-      { ($$ = new IR::Counter)->settype($3); }
+      { ($$ = new IR::Counter(getPragmas()))->settype($3); }
     | counter_spec_list DIRECT ':' name ';'
       { if (($$=$1)->table)
             error("%s: Can't attach counter to two tables", @2+@4);
@@ -427,7 +446,7 @@ meter_declaration : METER name '{' meter_spec_list '}'
 
 meter_spec_list:
       TYPE ':' name ';'
-      { ($$ = new IR::Meter)->settype($3); }
+      { ($$ = new IR::Meter(getPragmas()))->settype($3); }
     | meter_spec_list RESULT ':' field_ref ';'
       { ($$=$1)->result = $4; }
     | meter_spec_list PRE_COLOR ':' field_ref ';'
@@ -460,9 +479,9 @@ register_declaration: REGISTER name '{' register_spec_list '}'
 
 register_spec_list:
       WIDTH ':' const_expression ';'
-      { ($$ = new IR::Register)->width = $3 ? $3->asLong() : 0; $3 = nullptr; }
+      { ($$ = new IR::Register(getPragmas()))->width = $3 ? $3->asLong() : 0; $3 = nullptr; }
     | LAYOUT ':' name ';'
-      { ($$ = new IR::Register)->layout = IR::ID(@3, $3); }
+      { ($$ = new IR::Register(getPragmas()))->layout = IR::ID(@3, $3); }
     | register_spec_list DIRECT ':' name ';'
       { if (($$=$1)->table)
             error("%s: Can't attach register to two tables", @2+@4);
@@ -487,7 +506,7 @@ register_spec_list:
 /**************************/
 
 primitive_action_declaration: PRIMITIVE_ACTION name '(' name_list ')' ';'
-    { $4 = nullptr; }
+    { current_pragmas.clear(); $4 = nullptr; }
 ;
 
 name_list: name { $$ = new IR::NameList(@1, $1); }
@@ -515,7 +534,7 @@ action_function_body:
     | '{' action_statement_list error '}'  { $$ = $2; }
 ;
 
-action_statement_list: /* epsilon */ { $$ = new IR::ActionFunction; }
+action_statement_list: /* epsilon */ { $$ = new IR::ActionFunction(getPragmas()); }
     | action_statement_list name '(' opt_expression_list ')' ';'
       { ($$ = $1)->action.push_back(new IR::Primitive(@2+@5, $2, $4)); }
     | action_statement_list field_ref '=' expression ';'
@@ -534,7 +553,7 @@ action_profile_declaration: ACTION_PROFILE name '{' action_profile_body '}'
       { $4->name = IR::ID(@2, $2); $4->srcInfo = @1 + @5; global->add($2, $4); }
     ;
 
-action_profile_body: /* epsilon */ { $$ = new IR::ActionProfile; }
+action_profile_body: /* epsilon */ { $$ = new IR::ActionProfile(getPragmas()); }
     | action_profile_body ACTIONS '{' action_list '}'
       { ($$=$1)->actions = $4->names; $4 = nullptr; }
     | action_profile_body SIZE ':' const_expression ';'
@@ -547,7 +566,7 @@ action_selector_declaration: ACTION_SELECTOR name '{' action_selector_body '}'
       { $4->name = IR::ID(@2, $2); $4->srcInfo = @1 + @5; global->add($2, $4); }
     ;
 
-action_selector_body: /* epsilon */ { $$ = new IR::ActionSelector; }
+action_selector_body: /* epsilon */ { $$ = new IR::ActionSelector(getPragmas()); }
     | action_selector_body SELECTION_KEY ':' name ';'
       { ($$=$1)->key = IR::ID(@4, $4); }
     | action_selector_body SELECTION_MODE ':' name ';'
@@ -564,7 +583,7 @@ table_declaration: TABLE name '{' table_body '}'
       { $4->name = IR::ID(@2, $2); $4->srcInfo = @1 + @5; global->add($2, $4); }
 ;
 
-table_body: /* epsilon */ { $$ = new IR::V1Table; }
+table_body: /* epsilon */ { $$ = new IR::V1Table(getPragmas()); }
     | table_body READS '{' field_match_list '}'
       { ($$=$1)->reads = $4; }
     | table_body ACTIONS '{' action_list '}'
@@ -623,7 +642,7 @@ action_list: /* epsilon */ { $$ = new IR::NameList(); }
 /*****************************************/
 
 control_function_declaration: CONTROL name '{' control_statement_list '}'
-      { global->add($2, new IR::V1Control(@1+@5, IR::ID(@2, $2), $4)); }
+      { global->add($2, new IR::V1Control(@1+@5, IR::ID(@2, $2), $4, getPragmas())); }
 ;
 
 control_statement_list: /* epsilon */ { $$ = new IR::Vector<IR::Expression>; }
@@ -660,10 +679,12 @@ apply_case_list: /* epsilon */ { $$ = new IR::Apply; }
 /************/
 
 blackbox_type_declaration: BLACKBOX_TYPE name '{' blackbox_body '}'
+        { current_pragmas.clear(); }
 ;
 
 blackbox_body: /* epsilon */
     | blackbox_body ATTRIBUTE name '{' blackbox_attribute '}'
+    | blackbox_body METHOD name '(' opt_argument_list ')' ';'
     | blackbox_body METHOD name '(' opt_argument_list ')' '{' blackbox_method '}'
     | blackbox_body error
 ;
@@ -688,7 +709,11 @@ argument_list: argument | argument_list ',' argument ;
 
 argument: name | type | argument name | argument type;
 
-blackbox_instantiation: BLACKBOX name name '{' blackbox_config '}'
+blackbox_instantiation:
+      BLACKBOX name name ';'
+        { current_pragmas.clear(); }
+    | BLACKBOX name name '{' blackbox_config '}'
+        { current_pragmas.clear(); }
 ;
 
 blackbox_config: /* epsilon */
@@ -700,6 +725,23 @@ expressions: /* epsilon */
       { $$ = new IR::Vector<IR::Expression>; }
     | expressions expression %prec EXPRLIST
       { ($$=$1)->push_back($2); $$->srcInfo += @2; }
+    | expressions ',' expression %prec EXPRLIST
+      { ($$=$1)->push_back($3); $$->srcInfo += @3; }
+;
+
+pragma_operands: /* epsilon */
+      { $$ = new IR::Vector<IR::Expression>; }
+    | pragma_operands pragma_operand
+      { ($$=$1)->push_back($2); $$->srcInfo += @2; }
+    | pragma_operands ',' pragma_operand
+      { ($$=$1)->push_back($3); $$->srcInfo += @3; }
+;
+
+pragma_operand:
+      INTEGER { $$ = $1; }
+    | STRING { $$ = new IR::StringLiteral($1); }
+    | name { $$ = new IR::StringLiteral($1); }
+    | name '.' name { $$ = new IR::StringLiteral($1 + '.' + $3); }
 ;
 
 /***************/
@@ -768,7 +810,6 @@ expression_list:
     ;
 
 opt_expression_list: /* epsilon */ { $$ = nullptr; } | expression_list
-
 
 name: IDENTIFIER
     | ACTION | ACTIONS | ACTION_PROFILE | ACTION_SELECTOR | ALGORITHM

--- a/frontends/p4/p4-parse.ypp
+++ b/frontends/p4/p4-parse.ypp
@@ -267,7 +267,7 @@ name
 
 optAnnotations
     : /* empty */ { $$ = IR::Annotations::empty; }
-    | annotations { $$ = new IR::Annotations(@1, $1); }
+    | annotations { $$ = new IR::Annotations(@1, *$1); }
     ;
 
 annotations
@@ -276,8 +276,8 @@ annotations
     ;
 
 annotation
-    : '@' name                        { $$ = new IR::Annotation(@1, *$2, nullptr); }
-    | '@' name '(' expression ')'     { $$ = new IR::Annotation(@1, *$2, $4); }
+    : '@' name                        { $$ = new IR::Annotation(@1, *$2, {}); }
+    | '@' name '(' expressionList ')' { $$ = new IR::Annotation(@1, *$2, *$4); }
     ;
 
 parameterList
@@ -311,13 +311,13 @@ packageTypeDeclaration
 
 instantiation
       : annotations typeRef '(' argumentList ')' name ';'
-                     { $$ = new IR::Declaration_Instance(@6, *$6, new IR::Annotations($1),
+                     { $$ = new IR::Declaration_Instance(@6, *$6, new IR::Annotations(*$1),
                                                          $2, $4, nullptr); }
       | typeRef '(' argumentList ')' name ';'
                      { $$ = new IR::Declaration_Instance(@5, *$5, IR::Annotations::empty,
                                                          $1, $3, nullptr); }
       | annotations typeRef '(' argumentList ')' name '=' objInitializer ';'
-                     { $$ = new IR::Declaration_Instance(@6, *$6, new IR::Annotations($1),
+                     { $$ = new IR::Declaration_Instance(@6, *$6, new IR::Annotations(*$1),
                                                          $2, $4, $8); }
       | typeRef '(' argumentList ')' name '=' objInitializer ';'
                      { $$ = new IR::Declaration_Instance(@5, *$5, IR::Annotations::empty,
@@ -675,11 +675,11 @@ identifierList
 
 typedefDeclaration
     : annotations TYPEDEF typeRef name   { structure.declareType(*$4);
-          $$ = new IR::Type_Typedef(@4, *$4, new IR::Annotations($1), $3); }
+          $$ = new IR::Type_Typedef(@4, *$4, new IR::Annotations(*$1), $3); }
     | TYPEDEF typeRef name               { structure.declareType(*$3);
           $$ = new IR::Type_Typedef(@3, *$3, IR::Annotations::empty, $2); }
     | annotations TYPEDEF derivedTypeDeclaration name   { structure.declareType(*$4);
-                        $$ = new IR::Type_Typedef(@4, *$4, new IR::Annotations($1), $3); }
+                        $$ = new IR::Type_Typedef(@4, *$4, new IR::Annotations(*$1), $3); }
     | TYPEDEF derivedTypeDeclaration name { structure.declareType(*$3);
                         $$ = new IR::Type_Typedef(@3, *$3, IR::Annotations::empty, $2); }
     ;
@@ -843,7 +843,7 @@ actionDeclaration
 
 variableDeclaration
     : annotations typeRef name optInitializer ';'
-                                     { auto ann = new IR::Annotations(@1, $1);
+                                     { auto ann = new IR::Annotations(@1, *$1);
                                        $$ = new IR::Declaration_Variable(@1+@4, *$3, ann, $2, $4); }
     | typeRef name optInitializer ';'
                                      { $$ = new IR::Declaration_Variable(

--- a/frontends/p4/simplifyParsers.cpp
+++ b/frontends/p4/simplifyParsers.cpp
@@ -91,7 +91,7 @@ class CollapseChains : public Transform {
             auto callers = transitions->getCallers(next);
             if (callers->size() != 1)
                 continue;
-            if (!next->annotations->annotations->empty())
+            if (!next->annotations->annotations.empty())
                 // we are not sure what to do with the annotations
                 continue;
             chain.emplace(node, next);

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -620,15 +620,6 @@ VECTOR_VISIT(IndexedVector, Declaration)
 VECTOR_VISIT(IndexedVector, Node)
 #undef VECTOR_VISIT
 
-bool ToP4::preorder(const IR::Vector<IR::Annotation> *v) {
-    if (v == nullptr) return false;
-    for (auto a : *v) {
-        visit(a);
-        builder.spc();
-    }
-    return false;
-}
-
 ///////////////////////////////////////////
 
 bool ToP4::preorder(const IR::Slice* slice) {
@@ -693,6 +684,11 @@ bool ToP4::preorder(const IR::Member* e) {
     builder.append(".");
     builder.append(e->member);
     expressionPrecedence = prec;
+    return false;
+}
+
+bool ToP4::preorder(const IR::NamedRef* e) {
+    builder.append(e->name);
     return false;
 }
 
@@ -966,11 +962,14 @@ bool ToP4::preorder(const IR::SwitchStatement* s) {
 bool ToP4::preorder(const IR::Annotation * a) {
     builder.append("@");
     builder.append(a->name);
-    if (a->expr != nullptr) {
+    if (!a->expr.empty()) {
         builder.append("(");
-        visit(a->expr);
+        setVecSep(", ");
+        preorder(&a->expr);
+        doneVec();
         builder.append(")");
     }
+    builder.spc();
     return false;
 }
 

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -157,6 +157,7 @@ class ToP4 : public Inspector {
     bool preorder(const IR::Mux* a) override;
     bool preorder(const IR::ConstructorCallExpression* e) override;
     bool preorder(const IR::Member* e) override;
+    bool preorder(const IR::NamedRef* e) override;
     bool preorder(const IR::SelectCase* e) override;
     bool preorder(const IR::SelectExpression* e) override;
     bool preorder(const IR::ListExpression* e) override;
@@ -165,7 +166,6 @@ class ToP4 : public Inspector {
     bool preorder(const IR::This* e) override;
 
     // vectors
-    bool preorder(const IR::Vector<IR::Annotation>* v) override;
     bool preorder(const IR::Vector<IR::Type>* v) override;
     bool preorder(const IR::Vector<IR::Expression>* v) override;
     bool preorder(const IR::Vector<IR::SelectCase>* v) override;

--- a/ir/base.cpp
+++ b/ir/base.cpp
@@ -24,10 +24,10 @@ cstring IDeclaration::externalName() const {
 
     auto anno = to<IAnnotated>()->getAnnotations()->getSingle(IR::Annotation::nameAnnotation);
     if (anno != nullptr) {
-        if (anno->expr == nullptr) {
+        if (anno->expr.size() != 1) {
             ::error("%1% should contain a string", anno);
         } else {
-            auto str = anno->expr->to<IR::StringLiteral>();
+            auto str = anno->expr[0]->to<IR::StringLiteral>();
             if (str == nullptr)
                 ::error("%1% should contain a string", anno);
             else

--- a/ir/base.def
+++ b/ir/base.def
@@ -193,66 +193,60 @@ class Path {
 
 class Annotation {
     ID name;
-    NullOK Expression expr;
+    inline Vector<Expression> expr;
     Annotation { if (!srcInfo) srcInfo = name.srcInfo; }
-    Annotation(cstring n, intmax_t v) : name(n), expr(new IR::Constant(v)) {}
+    Annotation(Util::SourceInfo si, ID n, const std::initializer_list<const IR::Expression *> &a)
+    : Node(si), name(n), expr(a) {}
+    Annotation(ID n, const std::initializer_list<const IR::Expression *> &a) : name(n), expr(a) {}
+    Annotation(ID n, intmax_t v) : name(n) {
+        expr.push_back(new IR::Constant(v)); }
     // Predefined annotations used by the compiler
     static const cstring nameAnnotation;
     toString{ return cstring("@") + name; }
-    dbprint { out << '@' << name; if (expr) out << '(' << expr << ')'; }
+    dbprint { out << '@' << name << expr; }
     validate{ BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name"); }
 }
 
 // There can be several annotations with the same "name", so this is a vector.
+// FIXME -- get rid of this class -- classes with annotations should have an
+// inline Vector<Annotation> instead (remove useless indirection)
 class Annotations {
-    Vector<Annotation> annotations;
-    Annotations { if (!srcInfo && annotations) srcInfo = annotations->srcInfo; }
+    inline Vector<Annotation> annotations;
+    Annotations { if (!srcInfo && !annotations.empty()) srcInfo = annotations[0]->srcInfo; }
     static Annotations *empty;  // FIXME -- should be const
-    size_t size() const { return annotations->size(); }
+    size_t size() const { return annotations.size(); }
     // Get the annotation with the specified name or nullptr.
     // There should be at most one annotation with this name.
     Annotation getSingle(cstring name) const { return get(annotations, name); }
     Annotations addAnnotation(cstring name, Expression expr) const {
-        auto vec = new Vector<Annotation>(*annotations);
-        vec->push_back(new Annotation(name, expr));
-        return new Annotations(vec);
+        auto rv = clone();
+        rv->annotations.push_back(new Annotation(name, Vector<Expression>(expr)));
+        return rv;
     }
     // Add annotation if another annotation with the same name is not
     // already present.
     Annotations addAnnotationIfNew(cstring name, Expression expr) const {
-        if (getSingle(name) != nullptr)
-            return this;
-        return addAnnotation(name, expr);
-    }
+        return getSingle(name) ? this : addAnnotation(name, expr); }
     // If annotations with the same name are already present, remove them.
     // Add this annotation.
     Annotations addOrReplace(cstring name, Expression expr) const {
-        auto vec = new Vector<Annotation>();
-        for (auto a : *annotations) {
-            if (a->name.name != name)
-                vec->push_back(new Annotation(name, expr));
-        }
-        vec->push_back(new Annotation(name, expr));
-        return new Annotations(vec);
-    }
+        auto rv = clone();
+        auto &vec = rv->annotations;
+        vec.resize(std::remove_if(vec.begin(), vec.end(),
+            [name](const Annotation *a)->bool { return a->name == name; }) - vec.begin());
+        vec.push_back(new Annotation(name, Vector<Expression>(expr)));
+        return rv; }
 #emit
     typedef std::function<bool(const IR::Annotation*)> Filter;
 #end
     Annotations where(Filter func) const {
-        auto vec = new Vector<Annotation>();
-        bool changes = false;
-        for (auto a : *annotations) {
-            if (func(a))
-                vec->push_back(a);
-            else
-                changes = true;
-        }
-        if (!changes)
-            return this;
-        return new Annotations(vec);
-    }
-    validate{ annotations->check_null(); }
-    dbprint { for (auto a : *annotations) out << a << ' '; }
+        auto rv = empty->clone();
+        std::copy_if(annotations.begin(), annotations.end(),
+                     std::back_insert_iterator<Vector<Annotation>>(rv->annotations), func);
+        if (rv->annotations.size() == annotations.size()) return this;
+        return rv; }
+    validate{ annotations.check_null(); }
+    dbprint { for (auto a : annotations) out << a << ' '; }
 }
 
 // Implemented by all objects that can have annotations

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -39,7 +39,7 @@ std::map<int, const IR::Type_Bits*> *Type_Bits::unsignedTypes = nullptr;
 int Type_Declaration::nextId = 0;
 int Type_InfInt::nextId = 0;
 
-Annotations* Annotations::empty = new Annotations(new Vector<Annotation>());
+Annotations* Annotations::empty = new Annotations(Vector<Annotation>());
 
 const Type_Bits* Type_Bits::get(int width, bool isSigned) {
     std::map<int, const IR::Type_Bits*> *map;

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -40,27 +40,29 @@ inline bool operator>>(cstring s, IR::CounterType &ctr) {
 #end
 
 abstract HeaderOrMetadata {
-    IR::ID                      type_name;
-    IR::ID                      name;
+    ID                      type_name;
+    ID                      name;
+    Annotations                 annotations;
     NullOK Type_StructLike      type = nullptr;
 
-    HeaderOrMetadata(IR::ID n, Type_StructLike t) : type_name(t->name), name(n), type(t) {}
+    HeaderOrMetadata(ID n, Type_StructLike t)
+    : type_name(t->name), name(n), annotations(Annotations::empty), type(t) {}
     dbprint { out << type_name << ' ' << name; }
 }
 
 class Header : HeaderOrMetadata {
-    Header(IR::ID n, Type_Header t) : HeaderOrMetadata(n, t) {}
+    Header(ID n, Type_Header t) : HeaderOrMetadata(n, t) {}
 #nodbprint
 }
 
 class HeaderStack : HeaderOrMetadata {
     int size;
-    HeaderStack(IR::ID n, Type_Header t, int sz) : HeaderOrMetadata(n, t), size(sz) {}
+    HeaderStack(ID n, Type_Header t, int sz) : HeaderOrMetadata(n, t), size(sz) {}
 #nodbprint
 }
 
 class Metadata : HeaderOrMetadata {
-    Metadata(IR::ID n, Type_StructLike t) : HeaderOrMetadata(n, t) {}
+    Metadata(ID n, Type_StructLike t) : HeaderOrMetadata(n, t) {}
 #nodbprint
 }
 
@@ -181,6 +183,7 @@ class Primitive : Operation {
 class FieldList {
     optional ID                 name;
     bool                        payload = false;
+    optional Annotations        annotations = Annotations::empty;
     inline Vector<Expression>   fields = {};
 }
 
@@ -189,6 +192,7 @@ class FieldListCalculation {
     NullOK NameList     input = nullptr;
     ID                  algorithm = {};
     int                 output_width = 0;
+    Annotations         annotations;
 }
 
 class CalculatedField {
@@ -212,16 +216,20 @@ class CalculatedField {
         }
         fromJSON {
             bool update_temp = false;
-            IR::ID name_temp;
-            const IR::Expression *cond_temp = nullptr;
+            ID name_temp;
+            const Expression *cond_temp = nullptr;
             json.load("update", update_temp);
             json.load("name", name_temp);
             json.load("cond", cond_temp);
-            return new IR::CalculatedField::update_or_verify(update_temp, name_temp, cond_temp);
+            return new CalculatedField::update_or_verify(update_temp, name_temp, cond_temp);
         }
     }
     vector<update_or_verify>    specs = {};
-    visit_children { v.visit(field, "field"); for (auto &s : specs) v.visit(s.cond, s.name.name); }
+    Annotations                 annotations;
+    visit_children {
+        v.visit(field, "field");
+        for (auto &s : specs) v.visit(s.cond, s.name.name);
+        v.visit(annotations, "annotations"); }
 }
 
 class CaseEntry {
@@ -237,18 +245,20 @@ class V1Parser {
     ID                          default_return = {};
     ID                          parse_error = {};
     bool                        drop = false;
+    Annotations                 annotations;
     toString { return node_type_name() + " " + name; }
 }
 
 class ParserException {}
 
 abstract Attached {
-    optional ID     name;
+    optional ID                 name;
+    optional Annotations        annotations = Annotations::empty;
     virtual const char *kind() const = 0;
     virtual bool indexed() const { return false; }
     Attached *clone_rename(const char *ext) const {
         Attached *rv = clone();
-        rv->name = IR::ID(Util::SourceInfo(), rv->name.name + ext);
+        rv->name = ID(Util::SourceInfo(), rv->name.name + ext);
         return rv; }
     dbprint { out << node_type_name() << " " << name; }
     toString { return node_type_name() + " " + name; }
@@ -314,6 +324,7 @@ class ActionFunction {
     optional ID                 name;
     inline Vector<Primitive>    action = {};
     vector<ActionArg>           args = {};
+    optional Annotations        annotations = Annotations::empty;
 
     ActionArg arg(cstring n) const {
         for (auto a : args)
@@ -359,6 +370,7 @@ class V1Table {
     ID                          default_action = {};
     NullOK Vector<Expression>   default_action_args = 0;
     inline TableProperties      properties = {};  // non-standard properties
+    optional Annotations        annotations = Annotations::empty;
 
     // inefficient add
     void addProperty(TableProperty prop) {
@@ -369,8 +381,9 @@ class V1Table {
 }
 
 class V1Control {
-    ID                            name;
-    Vector<Expression>            code;
+    ID                  name;
+    Vector<Expression>  code;
+    Annotations         annotations;
 
     V1Control(ID n) : name(n), code(new Vector<Expression>()) {}
     V1Control(Util::SourceInfo si, ID n) : Node(si), name(n), code(new Vector<Expression>()) {}

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -63,6 +63,7 @@ class Vector : public VectorBase {
         vec.emplace_back(std::move(a)); }
     explicit Vector(const vector<const T *> &a) {
         vec.insert(vec.end(), a.begin(), a.end()); }
+    Vector(const std::initializer_list<const T *> &a) : vec(a) {}
     static Vector<T>* fromJSON(JSONLoader &json);
     typedef typename vector<const T *>::iterator        iterator;
     typedef typename vector<const T *>::const_iterator  const_iterator;
@@ -81,6 +82,7 @@ class Vector : public VectorBase {
     std::reverse_iterator<iterator> rend() { return vec.rend(); }
     std::reverse_iterator<const_iterator> rend() const { return vec.rend(); }
     size_t size() const override { return vec.size(); }
+    void resize(size_t sz) { vec.resize(sz); }
     bool empty() const override { return vec.empty(); }
     const T* const & front() const { return vec.front(); }
     const T*& front() { return vec.front(); }

--- a/lib/stringref.h
+++ b/lib/stringref.h
@@ -90,6 +90,8 @@ struct StringRef {
         return *this; }
     StringRef &operator++() { p++; if (len) len--; else p = 0; return *this; }  // NOLINT
     StringRef operator++(int) { StringRef rv(*this); ++*this; return rv; }
+    StringRef &operator--() { if (len) len--; else p = 0; return *this; }  // NOLINT
+    StringRef operator--(int) { StringRef rv(*this); --*this; return rv; }
     char operator[](size_t i) const { return i < len ? p[i] : 0; }
     char operator*() const { return len ? *p : 0; }
     StringRef operator+(size_t i) const {

--- a/midend/inlining.cpp
+++ b/midend/inlining.cpp
@@ -34,8 +34,8 @@ static cstring nameFromAnnotation(const IR::Annotations* annotations,
     CHECK_NULL(annotations); CHECK_NULL(decl);
     auto anno = annotations->getSingle(IR::Annotation::nameAnnotation);
     if (anno != nullptr) {
-        CHECK_NULL(anno->expr);
-        auto str = anno->expr->to<IR::StringLiteral>();
+        BUG_CHECK(anno->expr.size() == 1, "name annotation needs single expression");
+        auto str = anno->expr[0]->to<IR::StringLiteral>();
         CHECK_NULL(str);
         return str->value;
     }

--- a/midend/localizeActions.cpp
+++ b/midend/localizeActions.cpp
@@ -92,7 +92,7 @@ const IR::Node* LocalizeActions::postorder(IR::PathExpression* expression) {
     if (control == nullptr)
         return expression;
     auto decl = refMap->getDeclaration(expression->path);
-    if (!decl->is<IR::P4Action>())
+    if (!decl || !decl->is<IR::P4Action>())
         return expression;
     auto action = decl->to<IR::P4Action>();
     auto replacement = repl->getReplacement(action, control);

--- a/testdata/p4_14_samples_outputs/acl1-first.p4
+++ b/testdata/p4_14_samples_outputs/acl1-first.p4
@@ -132,7 +132,7 @@ header data_t {
 }
 
 struct metadata {
-    @name("acl_metadata") 
+    @pa_solitary("ingress", "acl_metadata.if_label") @name("acl_metadata") 
     acl_metadata_t      acl_metadata;
     @name("fabric_metadata") 
     fabric_metadata_t   fabric_metadata;

--- a/testdata/p4_14_samples_outputs/acl1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-frontend.p4
@@ -132,7 +132,7 @@ header data_t {
 }
 
 struct metadata {
-    @name("acl_metadata") 
+    @pa_solitary("ingress", "acl_metadata.if_label") @name("acl_metadata") 
     acl_metadata_t      acl_metadata;
     @name("fabric_metadata") 
     fabric_metadata_t   fabric_metadata;

--- a/testdata/p4_14_samples_outputs/acl1-midend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-midend.p4
@@ -132,7 +132,7 @@ header data_t {
 }
 
 struct metadata {
-    @name("acl_metadata") 
+    @pa_solitary("ingress", "acl_metadata.if_label") @name("acl_metadata") 
     acl_metadata_t      acl_metadata;
     @name("fabric_metadata") 
     fabric_metadata_t   fabric_metadata;

--- a/testdata/p4_14_samples_outputs/acl1.p4
+++ b/testdata/p4_14_samples_outputs/acl1.p4
@@ -132,7 +132,7 @@ header data_t {
 }
 
 struct metadata {
-    @name("acl_metadata") 
+    @pa_solitary("ingress", "acl_metadata.if_label") @name("acl_metadata") 
     acl_metadata_t      acl_metadata;
     @name("fabric_metadata") 
     fabric_metadata_t   fabric_metadata;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
@@ -613,7 +613,7 @@ struct metadata {
     egress_metadata_t            egress_metadata;
     @name("fabric_metadata") 
     fabric_metadata_t            fabric_metadata;
-    @name("hash_metadata") 
+    @pa_atomic("ingress", "hash_metadata.hash1") @pa_solitary("ingress", "hash_metadata.hash1") @pa_atomic("ingress", "hash_metadata.hash2") @pa_solitary("ingress", "hash_metadata.hash2") @name("hash_metadata") 
     hash_metadata_t              hash_metadata;
     @name("i2e_metadata") 
     i2e_metadata_t               i2e_metadata;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -613,7 +613,7 @@ struct metadata {
     egress_metadata_t            egress_metadata;
     @name("fabric_metadata") 
     fabric_metadata_t            fabric_metadata;
-    @name("hash_metadata") 
+    @pa_atomic("ingress", "hash_metadata.hash1") @pa_solitary("ingress", "hash_metadata.hash1") @pa_atomic("ingress", "hash_metadata.hash2") @pa_solitary("ingress", "hash_metadata.hash2") @name("hash_metadata") 
     hash_metadata_t              hash_metadata;
     @name("i2e_metadata") 
     i2e_metadata_t               i2e_metadata;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -613,7 +613,7 @@ struct metadata {
     egress_metadata_t            egress_metadata;
     @name("fabric_metadata") 
     fabric_metadata_t            fabric_metadata;
-    @name("hash_metadata") 
+    @pa_atomic("ingress", "hash_metadata.hash1") @pa_solitary("ingress", "hash_metadata.hash1") @pa_atomic("ingress", "hash_metadata.hash2") @pa_solitary("ingress", "hash_metadata.hash2") @name("hash_metadata") 
     hash_metadata_t              hash_metadata;
     @name("i2e_metadata") 
     i2e_metadata_t               i2e_metadata;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
@@ -613,7 +613,7 @@ struct metadata {
     egress_metadata_t            egress_metadata;
     @name("fabric_metadata") 
     fabric_metadata_t            fabric_metadata;
-    @name("hash_metadata") 
+    @pa_atomic("ingress", "hash_metadata.hash1") @pa_solitary("ingress", "hash_metadata.hash1") @pa_atomic("ingress", "hash_metadata.hash2") @pa_solitary("ingress", "hash_metadata.hash2") @name("hash_metadata") 
     hash_metadata_t              hash_metadata;
     @name("i2e_metadata") 
     i2e_metadata_t               i2e_metadata;


### PR DESCRIPTION
An alternate way of converting pragmas to annotations that does not involve changing typechecking, as names get converted into string literals