### PR TITLE
P4_14 support for extern

### DIFF
--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1079,7 +1079,7 @@ Util::IJson* JsonConverter::convertIf(const CFG::IfNode* node, cstring) {
     return result;
 }
 
-bool JsonConverter::handleTableImplementation(const IR::TableProperty* implementation,
+bool JsonConverter::handleTableImplementation(const IR::Property* implementation,
                                               const IR::Key* key,
                                               Util::JsonObject* table) {
     if (implementation == nullptr) {

--- a/backends/bmv2/jsonconverter.h
+++ b/backends/bmv2/jsonconverter.h
@@ -108,7 +108,7 @@ class JsonConverter final {
                           Util::JsonArray* force_list) const;
     cstring convertHashAlgorithm(cstring algorithm) const;
     // Return 'true' if the table is 'simple'
-    bool handleTableImplementation(const IR::TableProperty* implementation,
+    bool handleTableImplementation(const IR::Property* implementation,
                                    const IR::Key* key,
                                    Util::JsonObject* table);
     void addToFieldList(const IR::Expression* expr, Util::JsonArray* fl);

--- a/frontends/p4-14/p4-14-lex.l
+++ b/frontends/p4-14/p4-14-lex.l
@@ -64,6 +64,7 @@ static bool pragmaLine = false;  // FIXME -- use a flex state (and state stack?)
 "bit"           { yylval.str = yytext; BEGIN(NORMAL); return BIT; }
 "blackbox"      { yylval.str = yytext; BEGIN(NORMAL); return BLACKBOX; }
 "blackbox_type" { yylval.str = yytext; BEGIN(NORMAL); return BLACKBOX_TYPE; }
+"block"         { yylval.str = yytext; BEGIN(NORMAL); return BLOCK; }
 "calculated_field" {
                   yylval.str = yytext; BEGIN(NORMAL); return CALCULATED_FIELD; }
 "control"       { yylval.str = yytext; BEGIN(NORMAL); return CONTROL; }
@@ -77,6 +78,12 @@ static bool pragmaLine = false;  // FIXME -- use a flex state (and state stack?)
                   yylval.str = yytext; BEGIN(NORMAL);
                   return DYNAMIC_ACTION_SELECTION; }
 "else"          { yylval.str = yytext; BEGIN(NORMAL); return ELSE; }
+"extern"        { yylval.str = yytext; BEGIN(NORMAL); return BLACKBOX; }
+"extern_type"   { yylval.str = yytext; BEGIN(NORMAL); return BLACKBOX_TYPE; }
+"expression"    { yylval.str = yytext; BEGIN(NORMAL); return EXPRESSION; }
+"expression_local_variables" {
+                  yylval.str = yytext; BEGIN(NORMAL);
+                  return EXPRESSION_LOCAL_VARIABLES; }
 "extract"       { yylval.str = yytext; BEGIN(NORMAL); return EXTRACT; }
 "false"         { yylval.str = yytext; BEGIN(NORMAL); return FALSE; }
 "field_list"    { yylval.str = yytext; BEGIN(NORMAL); return FIELD_LIST; }
@@ -90,6 +97,7 @@ static bool pragmaLine = false;  // FIXME -- use a flex state (and state stack?)
 "implementation" {yylval.str = yytext; BEGIN(NORMAL); return IMPLEMENTATION; }
 "input"         { yylval.str = yytext; BEGIN(NORMAL); return INPUT; }
 "instance_count" {yylval.str = yytext; BEGIN(NORMAL); return INSTANCE_COUNT; }
+"in"            { yylval.str = yytext; BEGIN(NORMAL); return IN; }
 "int"           { yylval.str = yytext; BEGIN(NORMAL); return INT; }
 "latest"        { yylval.str = yytext; BEGIN(NORMAL); return LATEST; }
 "layout"        { yylval.str = yytext; BEGIN(NORMAL); return LAYOUT; }
@@ -105,6 +113,8 @@ static bool pragmaLine = false;  // FIXME -- use a flex state (and state stack?)
 "min_width"     { yylval.str = yytext; BEGIN(NORMAL); return MIN_WIDTH; }
 "not"           { yylval.str = yytext; BEGIN(NORMAL); return NOT; }
 "or"            { yylval.str = yytext; BEGIN(NORMAL); return OR; }
+"optional"      { yylval.str = yytext; BEGIN(NORMAL); return OPTIONAL; }
+"out"           { yylval.str = yytext; BEGIN(NORMAL); return OUT; }
 "output_width"  { yylval.str = yytext; BEGIN(NORMAL); return OUTPUT_WIDTH; }
 "parse_error"   { yylval.str = yytext; BEGIN(NORMAL); return PARSE_ERROR; }
 "parser"        { yylval.str = yytext; BEGIN(NORMAL); return PARSER; }
@@ -127,6 +137,7 @@ static bool pragmaLine = false;  // FIXME -- use a flex state (and state stack?)
 "signed"        { yylval.str = yytext; BEGIN(NORMAL); return SIGNED; }
 "size"          { yylval.str = yytext; BEGIN(NORMAL); return SIZE; }
 "static"        { yylval.str = yytext; BEGIN(NORMAL); return STATIC; }
+"string"        { yylval.str = yytext; BEGIN(NORMAL); return STRING; }
 "true"          { yylval.str = yytext; BEGIN(NORMAL); return TRUE; }
 "table"         { yylval.str = yytext; BEGIN(NORMAL); return TABLE; }
 "type"          { yylval.str = yytext; BEGIN(NORMAL); return TYPE; }

--- a/frontends/p4-14/p4-14-parse.ypp
+++ b/frontends/p4-14/p4-14-parse.ypp
@@ -37,6 +37,7 @@ static map<int, std::pair<std::string, int>> line_file_map;
 static IR::V1Program *global;
 static void yyerror(const char *fmt);
 static IR::Constant *constantFold(IR::Expression *);
+static IR::Vector<IR::Expression> make_expr_list(const IR::NameList *);
 
 #define YYLTYPE Util::SourceInfo
 #define YYLLOC_DEFAULT(Cur, Rhs, N)                                     \
@@ -62,12 +63,16 @@ static const IR::Annotations *getPragmas() {
     IR::ActionFunction          *ActionFunction;
     IR::ActionProfile           *ActionProfile;
     IR::ActionSelector          *ActionSelector;
+    IR::Annotations             *Annotations;
     IR::Apply                   *Apply;
+    IR::Attribute               *Attribute;
     IR::CalculatedField         *CalculatedField;
     IR::CaseEntry               *CaseEntry;
     IR::Vector<IR::CaseEntry>   *CaseEntryList;
     IR::Constant                *Constant;
     IR::Counter                 *Counter;
+    IR::Declaration_Instance    *BBox;
+    IR::Direction               Direction;
     IR::Expression              *Expression;
     IR::Vector<IR::Expression>  *ExpressionList;
     IR::FieldList               *FieldList;
@@ -75,6 +80,9 @@ static const IR::Annotations *getPragmas() {
     IR::NameList                *NameList;
     IR::Member                  *Member;
     IR::Meter                   *Meter;
+    IR::Parameter               *Parameter;
+    IR::ParameterList           *ParameterList;
+    IR::IndexedVector<IR::Parameter> *ParameterVector;
     IR::V1Parser                *Parser;
     IR::Register                *Register;
     IR::V1Table                 *Table;
@@ -83,21 +91,26 @@ static const IR::Annotations *getPragmas() {
         IR::Vector<IR::Annotation>      *annotations;
         IR::IndexedVector<IR::StructField> *fields;
     }                           HeaderType;
+    struct {
+        IR::Vector<IR::Method>                  *methods;
+        IR::NameMap<IR::Attribute, ordered_map> *attribs;
+    }                           BBoxType;
 }
 
 %token<str> ACTION ACTIONS ACTION_PROFILE ACTION_SELECTOR ALGORITHM APPLY
-            ATTRIBUTE ATTRIBUTES BIT BLACKBOX BLACKBOX_TYPE
+            ATTRIBUTE ATTRIBUTES BIT BLACKBOX BLACKBOX_TYPE BLOCK
             CALCULATED_FIELD CONTROL COUNTER CURRENT DEFAULT DEFAULT_ACTION
-            DIRECT DROP DYNAMIC_ACTION_SELECTION ELSE EXTRACT FALSE
+            DIRECT DROP DYNAMIC_ACTION_SELECTION ELSE EXTRACT EXPRESSION
+            EXPRESSION_LOCAL_VARIABLES FALSE
             FIELD_LIST FIELD_LIST_CALCULATION FIELDS HEADER HEADER_TYPE
-            IF IMPLEMENTATION INPUT INSTANCE_COUNT INT LATEST LAYOUT LENGTH MASK
+            IF IMPLEMENTATION IN INPUT INSTANCE_COUNT INT LATEST LAYOUT LENGTH MASK
             MAX_LENGTH MAX_SIZE MAX_WIDTH METADATA METER METHOD MIN_SIZE MIN_WIDTH NOT
-            OUTPUT_WIDTH PARSE_ERROR PARSER PARSER_EXCEPTION PAYLOAD PRAGMA PREFIX
-            PRE_COLOR PRIMITIVE_ACTION READS REGISTER RESULT RETURN SATURATING
+            OPTIONAL OUT OUTPUT_WIDTH PARSE_ERROR PARSER PARSER_EXCEPTION PAYLOAD PRAGMA
+            PREFIX PRE_COLOR PRIMITIVE_ACTION READS REGISTER RESULT RETURN SATURATING
             SELECT SELECTION_KEY SELECTION_MODE SELECTION_TYPE SET_METADATA
-            SIGNED SIZE STATIC TABLE TRUE TYPE UPDATE VALID VERIFY WIDTH WRITES
+            SIGNED SIZE STATIC STRING TABLE TRUE TYPE UPDATE VALID VERIFY WIDTH WRITES
 
-%token<str> IDENTIFIER STRING
+%token<str> IDENTIFIER STRING_LITERAL
 %token<Constant> INTEGER
 
 %printer { fprintf(yyoutput, "\"%s\"", $$.c_str()); } <str>
@@ -123,12 +136,17 @@ static const IR::Annotations *getPragmas() {
 %type<ActionFunction>   action_function_body action_statement_list
 %type<ActionProfile>    action_profile_body
 %type<ActionSelector>   action_selector_body
+%type<Annotations>      blackbox_method
 %type<Apply>            apply_case_list
+%type<Attribute>        blackbox_attribute
+%type<BBox>             blackbox_config
+%type<BBoxType>         blackbox_body
 %type<CalculatedField>  update_verify_spec_list
 %type<CaseEntry>        case_value_list
 %type<CaseEntryList>    case_entry_list
 %type<Constant>         const_expression
 %type<Counter>          counter_spec_list
+%type<Direction>        inout
 %type<Expression>       expression header_ref header_or_field_ref field_or_masked_ref opt_condition
                         pragma_operand
 %type<ExpressionList>   expression_list opt_expression_list control_statement_list opt_else
@@ -139,6 +157,9 @@ static const IR::Annotations *getPragmas() {
 %type<HeaderType>       header_dec_body field_declarations
 %type<NameList>         action_list name_list opt_name_list field_list_list
 %type<Meter>            meter_spec_list
+%type<Parameter>        argument
+%type<ParameterList>    opt_argument_list
+%type<ParameterVector>  argument_list
 %type<Parser>           parser_statement_list
 %type<Register>         register_spec_list
 %type<Table>            table_body
@@ -239,14 +260,24 @@ opt_max_length: /* epsilon */
               IR::Vector<IR::Expression>($3)); }
     ;
 
-type: INT '<' INTEGER '>'
-      { if (!$3->fitsInt())
-            BUG("%1$: Value too large", @3);
-        $$ = IR::Type::Bits::get(@3, $3->asInt()); }
+type: BIT { $$ = IR::Type::Bits::get(@1, 1); }
     | BIT '<' INTEGER '>'
       { if (!$3->fitsInt())
             BUG("%1$: Value too large", @3);
         $$ = IR::Type::Bits::get(@3, $3->asInt()); }
+    | BLOCK { $$ = IR::Type_Block::get(); }
+    | COUNTER { $$ = IR::Type_Counter::get(); }
+    | EXPRESSION { $$ = IR::Type_Expression::get(); }
+    | FIELD_LIST_CALCULATION { $$ = IR::Type_FieldListCalculation::get(); }
+    | INT { $$ = new IR::Type_InfInt; }
+    | INT '<' INTEGER '>'
+      { if (!$3->fitsInt())
+            BUG("%1$: Value too large", @3);
+        $$ = IR::Type::Bits::get(@3, $3->asInt(), true); }
+    | METER { $$ = IR::Type_Meter::get(); }
+    | STRING { $$ = IR::Type_String::get(); }
+    | REGISTER { $$ = IR::Type_Register::get(); }
+    | TABLE { $$ = IR::Type_AnyTable::get(); }
 ;
 
 /************************************/
@@ -603,7 +634,7 @@ table_body: /* epsilon */ { $$ = new IR::V1Table(getPragmas()); }
         $$->default_action_args = $6; }
     | table_body IDENTIFIER ':' expression ';'
       { auto exp = new IR::ExpressionValue(@4, $4);
-        auto prop = new IR::TableProperty(@2, IR::ID(@2, $2), IR::Annotations::empty, exp, false);
+        auto prop = new IR::Property(@2, IR::ID(@2, $2), IR::Annotations::empty, exp, false);
         $1->addProperty(prop);
         $$ = $1; }
     | table_body error ';' { $$=$1; }
@@ -679,47 +710,83 @@ apply_case_list: /* epsilon */ { $$ = new IR::Apply; }
 /************/
 
 blackbox_type_declaration: BLACKBOX_TYPE name '{' blackbox_body '}'
-        { current_pragmas.clear(); }
+      { global->add($2, new IR::Type_Extern(@1+@5, IR::ID(@2, $2), $4.methods,
+                                            *$4.attribs, getPragmas())); }
 ;
 
-blackbox_body: /* epsilon */
+blackbox_body: /* epsilon */ {
+            $$.methods = new IR::Vector<IR::Method>;
+            $$.attribs = new IR::NameMap<IR::Attribute, ordered_map>; }
     | blackbox_body ATTRIBUTE name '{' blackbox_attribute '}'
+          { ($$=$1).attribs->addUnique($3, $5); }
     | blackbox_body METHOD name '(' opt_argument_list ')' ';'
+          { ($$=$1).methods->push_back(new IR::Method(@2+@3, $3,
+                new IR::Type_Method(@4+@6, IR::Type::Void::get(), $5))); }
     | blackbox_body METHOD name '(' opt_argument_list ')' '{' blackbox_method '}'
+          { ($$=$1).methods->push_back(new IR::Method(@2+@3, $3,
+                new IR::Type_Method(@4+@6, IR::Type::Void::get(), $5), $8)); }
     | blackbox_body error
 ;
 
-blackbox_attribute: /* epsilon */
-    | blackbox_attribute name ':' name ';'
-    | blackbox_attribute name ':' type ';'
-    | blackbox_attribute name '{' opt_name_list '}'
-    | blackbox_attribute name ';'
+blackbox_attribute: /* epsilon */ { $$ = new IR::Attribute(@-1, $<str>-1); }
+    | blackbox_attribute TYPE ':' type ';' { ($$=$1)->type = $4; }
+    | blackbox_attribute EXPRESSION_LOCAL_VARIABLES '{' opt_name_list '}'
+        { ($$=$1)->locals = $4; }
+    | blackbox_attribute OPTIONAL ';'
+        { ($$=$1)->optional = true; }
     | blackbox_attribute error ';'
     | blackbox_attribute error
 ;
 
-blackbox_method: /* epsilon */
+blackbox_method: { $$ = new IR::Annotations; }
     | blackbox_method READS '{' opt_name_list '}'
+        { ($$=$1)->add(new IR::Annotation(@2, $2, make_expr_list($4))); }
     | blackbox_method WRITES '{' opt_name_list '}'
+        { ($$=$1)->add(new IR::Annotation(@2, $2, make_expr_list($4))); }
 ;
 
-opt_argument_list: /* epsilon */ | argument_list ;
+opt_argument_list:
+      /* epsilon */ { $$ = new IR::ParameterList(new IR::IndexedVector<IR::Parameter>); }
+    | argument_list { $$ = new IR::ParameterList($1); }
+;
 
-argument_list: argument | argument_list ',' argument ;
+argument_list:
+      argument                          { $$ = new IR::IndexedVector<IR::Parameter>($1); }
+    | argument_list ',' argument        { ($$=$1)->push_back($3); }
+;
 
-argument: name | type | argument name | argument type;
+argument:
+      inout type name
+        { $$ = new IR::Parameter(@3, $3, $1, $2); }
+    | OPTIONAL argument
+        { ($$ = $2)->annotations = $2->annotations->add(new IR::Annotation(@1, $1, {})); }
+;
+
+inout: IN { $$ = IR::Direction::In; } | OUT { $$ = IR::Direction::Out; } ;
 
 blackbox_instantiation:
       BLACKBOX name name ';'
-        { current_pragmas.clear(); }
-    | BLACKBOX name name '{' blackbox_config '}'
-        { current_pragmas.clear(); }
+        { global->add($3, new IR::Declaration_Instance(@3, $3, getPragmas(),
+                            new IR::Type_Name($2), new IR::Vector<IR::Expression>)); }
+    | BLACKBOX name name '{'
+        { $<BBox>$ = new IR::Declaration_Instance(@3, $3, getPragmas(),
+                            new IR::Type_Name($2), new IR::Vector<IR::Expression>); }
+      blackbox_config '}'
+        { global->add($3, $6); }
 ;
 
-blackbox_config: /* epsilon */
+blackbox_config: /* epsilon */ { $$ = $<BBox>0; }
     | blackbox_config name ':' expressions ';'
+          { const IR::PropertyValue *pv;
+            if ($4->size() == 1)
+                pv = new IR::ExpressionValue($4->front());
+            else
+                pv = new IR::ExpressionListValue(std::move(*$4));
+            ($$=$1)->properties.add($2, new IR::Property(@2+@4, $2, pv, false)); }
     | blackbox_config name '{' expressions '}'
-;
+          { auto *pv = new IR::ExpressionListValue(std::move(*$4));
+            ($$=$1)->properties.add($2, new IR::Property(@2+@4, $2, pv, false)); }
+    ;
 
 expressions: /* epsilon */
       { $$ = new IR::Vector<IR::Expression>; }
@@ -739,9 +806,9 @@ pragma_operands: /* epsilon */
 
 pragma_operand:
       INTEGER { $$ = $1; }
-    | STRING { $$ = new IR::StringLiteral($1); }
-    | name { $$ = new IR::StringLiteral($1); }
-    | name '.' name { $$ = new IR::StringLiteral($1 + '.' + $3); }
+    | STRING_LITERAL { $$ = new IR::StringLiteral(@1, $1); }
+    | name { $$ = new IR::StringLiteral(@1, $1); }
+    | name '.' name { $$ = new IR::StringLiteral(@1+@3, $1 + '.' + $3); }
 ;
 
 /***************/
@@ -813,15 +880,16 @@ opt_expression_list: /* epsilon */ { $$ = nullptr; } | expression_list
 
 name: IDENTIFIER
     | ACTION | ACTIONS | ACTION_PROFILE | ACTION_SELECTOR | ALGORITHM
-    | ATTRIBUTE | ATTRIBUTES | BIT | BLACKBOX | BLACKBOX_TYPE
+    | ATTRIBUTE | ATTRIBUTES | BIT | BLACKBOX | BLACKBOX_TYPE | BLOCK
     | CALCULATED_FIELD | CONTROL | COUNTER | DEFAULT_ACTION
-    | DIRECT | DROP | DYNAMIC_ACTION_SELECTION | EXTRACT | FIELD_LIST
-    | FIELD_LIST_CALCULATION | FIELDS | HEADER | HEADER_TYPE | IMPLEMENTATION
+    | DIRECT | DROP | DYNAMIC_ACTION_SELECTION | EXPRESSION | EXPRESSION_LOCAL_VARIABLES
+    | EXTRACT | FIELD_LIST
+    | FIELD_LIST_CALCULATION | FIELDS | HEADER | HEADER_TYPE | IMPLEMENTATION | IN
     | INPUT | INSTANCE_COUNT | INT | LAYOUT | LENGTH | MASK | MAX_LENGTH | MAX_SIZE
-    | MAX_WIDTH | METADATA | METER | METHOD | MIN_SIZE | MIN_WIDTH | OUTPUT_WIDTH
-    | PARSER | PARSER_EXCEPTION | PRE_COLOR | PRIMITIVE_ACTION | READS
+    | MAX_WIDTH | METADATA | METER | METHOD | MIN_SIZE | MIN_WIDTH | OPTIONAL | OUT
+    | OUTPUT_WIDTH | PARSER | PARSER_EXCEPTION | PRE_COLOR | PRIMITIVE_ACTION | READS
     | REGISTER | RESULT | RETURN | SATURATING | SELECTION_KEY | SELECTION_MODE
-    | SELECTION_TYPE | SET_METADATA | SIGNED | SIZE | STATIC | TABLE | TYPE
+    | SELECTION_TYPE | SET_METADATA | SIGNED | SIZE | STATIC | STRING | TABLE | TYPE
     | UPDATE | VERIFY | WIDTH | WRITES
 ;
 
@@ -866,4 +934,11 @@ static IR::Constant *constantFold(IR::Expression *a) {
     IR::Node *exp(a);
     auto rv = exp->apply(P4::DoConstantFolding(nullptr, nullptr))->to<IR::Constant>();
     return rv ? new IR::Constant(rv->type, rv->value, rv->base) : nullptr;
+}
+
+static IR::Vector<IR::Expression> make_expr_list(const IR::NameList *list) {
+    IR::Vector<IR::Expression> rv;
+    for (auto &name :list->names)
+        rv.push_back(new IR::StringLiteral(name));
+    return rv;
 }

--- a/frontends/p4/createBuiltins.cpp
+++ b/frontends/p4/createBuiltins.cpp
@@ -49,7 +49,7 @@ void CreateBuiltins::postorder(IR::ActionListElement* element) {
 void CreateBuiltins::postorder(IR::ExpressionValue* expression) {
     // convert a default_action = a; into
     // default_action = a();
-    auto prop = findContext<IR::TableProperty>();
+    auto prop = findContext<IR::Property>();
     if (prop != nullptr &&
         prop->name == IR::TableProperties::defaultActionPropertyName &&
         expression->expression->is<IR::PathExpression>())

--- a/frontends/p4/evaluator/evaluator.cpp
+++ b/frontends/p4/evaluator/evaluator.cpp
@@ -252,7 +252,7 @@ bool Evaluator::preorder(const IR::P4Table* table) {
     return false;
 }
 
-bool Evaluator::preorder(const IR::TableProperty* prop) {
+bool Evaluator::preorder(const IR::Property* prop) {
     LOG1("Evaluating " << prop);
     visit(prop->value);
     auto value = getValue(prop->value);

--- a/frontends/p4/evaluator/evaluator.h
+++ b/frontends/p4/evaluator/evaluator.h
@@ -61,7 +61,7 @@ class Evaluator final : public Inspector, public IHasBlock {
     bool preorder(const IR::Declaration_Instance* inst) override;
     bool preorder(const IR::ConstructorCallExpression* inst) override;
     bool preorder(const IR::PathExpression* expression) override;
-    bool preorder(const IR::TableProperty* prop) override;
+    bool preorder(const IR::Property* prop) override;
     bool preorder(const IR::Member* expression) override;
     bool preorder(const IR::Constant* expression) override
     { setValue(expression, expression); return false; }

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -572,7 +572,7 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
     ExpressionConverter conv(this);
 
     auto params = new IR::ParameterList();
-    auto propvec = new IR::IndexedVector<IR::TableProperty>(*table->properties.properties);
+    auto propvec = new IR::IndexedVector<IR::Property>(*table->properties.properties);
 
     auto actVect = new IR::IndexedVector<IR::ActionListElement>();
     auto actionList = new IR::ActionList(Util::SourceInfo(), actVect);
@@ -610,7 +610,7 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
     auto nop = new IR::ActionListElement(Util::SourceInfo(), IR::Annotations::empty,
                                          new IR::PathExpression(p4lib.noAction.Id()));
     actVect->push_back(nop);
-    propvec->push_back(new IR::TableProperty(Util::SourceInfo(),
+    propvec->push_back(new IR::Property(Util::SourceInfo(),
                                              IR::ID(IR::TableProperties::actionsPropertyName),
                                              IR::Annotations::empty,
                                              actionList, false));
@@ -648,26 +648,26 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
             }
         }
 
-        propvec->push_back(new IR::TableProperty(Util::SourceInfo(),
+        propvec->push_back(new IR::Property(Util::SourceInfo(),
                                                  IR::ID(IR::TableProperties::keyPropertyName),
                                                  IR::Annotations::empty,
                                                  key, false));
     }
 
     if (table->size != 0) {
-        auto prop = new IR::TableProperty(
+        auto prop = new IR::Property(
             Util::SourceInfo(), IR::ID("size"), IR::Annotations::empty,
             new IR::ExpressionValue(Util::SourceInfo(), new IR::Constant(table->size)), false);
         propvec->push_back(prop);
     }
     if (table->min_size != 0) {
-        auto prop = new IR::TableProperty(
+        auto prop = new IR::Property(
             Util::SourceInfo(), IR::ID("min_size"), IR::Annotations::empty,
             new IR::ExpressionValue(Util::SourceInfo(), new IR::Constant(table->min_size)), false);
         propvec->push_back(prop);
     }
     if (table->max_size != 0) {
-        auto prop = new IR::TableProperty(
+        auto prop = new IR::Property(
             Util::SourceInfo(), IR::ID("max_size"), IR::Annotations::empty,
             new IR::ExpressionValue(Util::SourceInfo(), new IR::Constant(table->max_size)), false);
         propvec->push_back(prop);
@@ -684,7 +684,7 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
                 table->default_action_args : new IR::Vector<IR::Expression>();
         auto methodCall = new IR::MethodCallExpression(Util::SourceInfo(), act,
                                                        emptyTypeArguments, args);
-        auto prop = new IR::TableProperty(
+        auto prop = new IR::Property(
             Util::SourceInfo(), IR::ID(IR::TableProperties::defaultActionPropertyName),
             IR::Annotations::empty, new IR::ExpressionValue(Util::SourceInfo(), methodCall), false);
         propvec->push_back(prop);
@@ -705,7 +705,7 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
         auto constructor = new IR::ConstructorCallExpression(Util::SourceInfo(), type, args);
         auto propvalue = new IR::ExpressionValue(Util::SourceInfo(), constructor);
         auto annos = addNameAnnotation(action_profile->name);
-        auto prop = new IR::TableProperty(
+        auto prop = new IR::Property(
             Util::SourceInfo(), IR::ID(v1model.tableAttributes.tableImplementation.Id()),
             annos, propvalue, false);
         propvec->push_back(prop);
@@ -717,7 +717,7 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
         auto constructor = new IR::ConstructorCallExpression(Util::SourceInfo(), type, args);
         auto propvalue = new IR::ExpressionValue(Util::SourceInfo(), constructor);
         auto annos = addNameAnnotation(action_profile->name);
-        auto prop = new IR::TableProperty(
+        auto prop = new IR::Property(
             Util::SourceInfo(), IR::ID(v1model.tableAttributes.tableImplementation.Id()),
             annos, propvalue, false);
         propvec->push_back(prop);
@@ -733,7 +733,7 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
         auto constructor = new IR::ConstructorCallExpression(Util::SourceInfo(), type, args);
         auto propvalue = new IR::ExpressionValue(Util::SourceInfo(), constructor);
         auto annos = addNameAnnotation(ctr);
-        auto prop = new IR::TableProperty(
+        auto prop = new IR::Property(
             Util::SourceInfo(), IR::ID(v1model.tableAttributes.directCounter.Id()),
             annos, propvalue, false);
         propvec->push_back(prop);
@@ -742,7 +742,7 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
     if (mtr != nullptr) {
         auto meter = new IR::PathExpression(mtr->name);
         auto propvalue = new IR::ExpressionValue(Util::SourceInfo(), meter);
-        auto prop = new IR::TableProperty(
+        auto prop = new IR::Property(
             Util::SourceInfo(), IR::ID(v1model.tableAttributes.directMeter.Id()),
             IR::Annotations::empty, propvalue, false);
         propvec->push_back(prop);

--- a/frontends/p4/p4-parse.ypp
+++ b/frontends/p4/p4-parse.ypp
@@ -71,7 +71,7 @@ static int yylex();
     IR::IndexedVector<IR::Declaration>    *decls;
     IR::IndexedVector<IR::ParserState>    *parserStates;
     IR::IndexedVector<IR::StructField>    *structFields;
-    IR::IndexedVector<IR::TableProperty>  *properties;
+    IR::IndexedVector<IR::Property>       *properties;
     IR::IndexedVector<IR::Declaration_ID> *ids;
     IR::IndexedVector<IR::ActionListElement> *actions;
     IR::Vector<IR::Annotation>  *annoVec;
@@ -106,7 +106,7 @@ static int yylex();
     IR::StatOrDecl              *StatOrDecl;
     IR::StructField             *StructField;
     IR::SwitchCase              *SwitchCase;
-    IR::TableProperty           *TableProperty;
+    IR::Property                *Property;
     IR::Type_Control            *Type_Control;
     IR::Type_Declaration        *Type_Declaration;
     IR::Type_Name               *Type_Name;
@@ -173,7 +173,7 @@ static int yylex();
 %type<structFields>     structFieldList
 %type<Method>           methodPrototype functionPrototype
 %type<methods>          methodPrototypes
-%type<TableProperty>    tableProperty
+%type<Property>         tableProperty
 %type<properties>       tablePropertyList
 %type<KeyElement>       keyElement
 %type<keyElements>      keyElementList
@@ -768,7 +768,7 @@ tableDeclaration
     ;
 
 tablePropertyList
-    : tableProperty                      { $$ = new IR::IndexedVector<IR::TableProperty>();
+    : tableProperty                      { $$ = new IR::IndexedVector<IR::Property>();
                                            $$->push_back($1); }
     | tablePropertyList tableProperty    { $$ = $1; $$->push_back($2); }
     ;
@@ -776,20 +776,20 @@ tablePropertyList
 tableProperty
     : KEY '=' '{' keyElementList '}'     { auto v = new IR::Key(@4, $4);
                                            auto id = IR::ID(@1, "key");
-                                           $$ = new IR::TableProperty(
+                                           $$ = new IR::Property(
                                                @1 + @5, id, IR::Annotations::empty, v, false); }
     | ACTIONS '=' '{' actionList '}'     { auto v = new IR::ActionList(@4, $4);
                                            auto id = IR::ID(@1, "actions");
-                                           $$ = new IR::TableProperty(
+                                           $$ = new IR::Property(
                                                @1 + @5, id, IR::Annotations::empty, v, false); }
     | optAnnotations CONST IDENTIFIER '=' initializer ';'
                                          { auto v = new IR::ExpressionValue(@5, $5);
                                             auto id = IR::ID(@3, $3);
-                                            $$ = new IR::TableProperty(@3, id, $1, v, true); }
+                                            $$ = new IR::Property(@3, id, $1, v, true); }
     | optAnnotations IDENTIFIER '=' initializer ';'
                                          { auto v = new IR::ExpressionValue(@4, $4);
                                            auto id = IR::ID(@2, $2);
-                                           $$ = new IR::TableProperty(@2, id, $1, v, false); }
+                                           $$ = new IR::Property(@2, id, $1, v, false); }
     ;
 
 keyElementList

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -1158,7 +1158,7 @@ bool ToP4::preorder(const IR::Key* v) {
     return false;
 }
 
-bool ToP4::preorder(const IR::TableProperty* p) {
+bool ToP4::preorder(const IR::Property* p) {
     dump(1);
     visit(p->annotations);
     if (p->isConstant)

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -207,7 +207,7 @@ class ToP4 : public Inspector {
     bool preorder(const IR::ActionListElement* ale) override;
     bool preorder(const IR::ActionList* v) override;
     bool preorder(const IR::Key* v) override;
-    bool preorder(const IR::TableProperty* p) override;
+    bool preorder(const IR::Property* p) override;
     bool preorder(const IR::TableProperties* t) override;
     bool preorder(const IR::P4Table* c) override;
 };

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1783,7 +1783,7 @@ const IR::Node* TypeInference::postorder(IR::PathExpression* expression) {
         //    default_action = a(2);  << a typechecked as specialized in the actions list
         // }
         // This works only if the actions property has already been visited
-        auto prop = findContext<IR::TableProperty>();
+        auto prop = findContext<IR::Property>();
         if (prop != nullptr) {
             auto table = findContext<IR::P4Table>();
             BUG_CHECK(table != nullptr, "%1%: property not within a table?", prop);
@@ -2230,7 +2230,7 @@ const IR::Node* TypeInference::postorder(IR::MethodCallExpression* expression) {
     // with different signatures
     if (methodType->is<IR::Type_Action>()) {
         bool inActionsList = false;
-        auto prop = findContext<IR::TableProperty>();
+        auto prop = findContext<IR::Property>();
         if (prop != nullptr && prop->name == IR::TableProperties::actionsPropertyName)
             inActionsList = true;
         return actionCall(inActionsList, expression);
@@ -2556,7 +2556,7 @@ const IR::Node* TypeInference::postorder(IR::KeyElement* elem) {
     return elem;
 }
 
-const IR::Node* TypeInference::postorder(IR::TableProperty* prop) {
+const IR::Node* TypeInference::postorder(IR::Property* prop) {
     if (prop->name == IR::TableProperties::defaultActionPropertyName) {
         auto pv = prop->value->to<IR::ExpressionValue>();
         if (pv == nullptr) {

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -248,7 +248,7 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::AssignmentStatement* stat) override;
     const IR::Node* postorder(IR::ActionListElement* elem) override;
     const IR::Node* postorder(IR::KeyElement* elem) override;
-    const IR::Node* postorder(IR::TableProperty* elem) override;
+    const IR::Node* postorder(IR::Property* elem) override;
     const IR::Node* postorder(IR::SelectCase* elem) override;
 
     Visitor::profile_t init_apply(const IR::Node* node) override;

--- a/ir/base.def
+++ b/ir/base.def
@@ -14,6 +14,7 @@ abstract Type {
     typedef Type_Boolean        Boolean;
     typedef Type_Bits           Bits;
     typedef Type_Varbits        Varbits;
+    typedef Type_Void           Void;
 #end
     // This is well-defined only for types with fixed width
     virtual int width_bits() const { return 0; }
@@ -167,18 +168,22 @@ class Annotation {
 // FIXME -- get rid of this class -- classes with annotations should have an
 // inline Vector<Annotation> instead (remove useless indirection)
 class Annotations {
-    inline Vector<Annotation> annotations;
+    optional inline Vector<Annotation> annotations;
     Annotations { if (!srcInfo && !annotations.empty()) srcInfo = annotations[0]->srcInfo; }
     static Annotations *empty;  // FIXME -- should be const
     size_t size() const { return annotations.size(); }
     // Get the annotation with the specified name or nullptr.
     // There should be at most one annotation with this name.
     Annotation getSingle(cstring name) const { return get(annotations, name); }
+    Annotations add(Annotation annot) {
+        if (annot->srcInfo) srcInfo += annot->srcInfo;
+        annotations.push_back(annot);
+        return this; }
+    Annotations add(Annotation annot) const { return clone()->add(annot); }
+    Annotations addAnnotation(cstring name, Expression expr) {
+        return add(new Annotation(name, Vector<Expression>(expr))); }
     Annotations addAnnotation(cstring name, Expression expr) const {
-        auto rv = clone();
-        rv->annotations.push_back(new Annotation(name, Vector<Expression>(expr)));
-        return rv;
-    }
+        return add(new Annotation(name, Vector<Expression>(expr))); }
     // Add annotation if another annotation with the same name is not
     // already present.
     Annotations addAnnotationIfNew(cstring name, Expression expr) const {

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -174,6 +174,7 @@ class StringLiteral : Literal {
     cstring value;
     validate{ if (value.isNull()) BUG("null StringLiteral"); }
     toString{ return cstring("\"") + value + "\""; }
+    StringLiteral(ID v) : Literal(v.srcInfo), value(v.name) {}
 }
 
 class PathExpression : Expression {

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -148,6 +148,11 @@ class ExpressionValue : PropertyValue {
     dbprint { out << expression; }
 }
 
+class ExpressionListValue : PropertyValue {
+    inline Vector<Expression> expressions;
+    dbprint { out << expressions; }
+}
+
 // An element in a table actions list
 class ActionListElement : IAnnotated, IDeclaration {
     Annotations annotations;
@@ -183,8 +188,8 @@ class Key : PropertyValue {
     validate { keyElements->check_null(); }
 }
 
-class TableProperty : Declaration, IAnnotated {
-    Annotations   annotations;
+class Property : Declaration, IAnnotated {
+    optional Annotations   annotations = Annotations::empty;
     PropertyValue value;
     bool          isConstant;
     Annotations getAnnotations() const override { return annotations; }
@@ -192,13 +197,13 @@ class TableProperty : Declaration, IAnnotated {
 }
 
 class TableProperties : ISimpleNamespace {
-    IndexedVector<TableProperty> properties;
+    IndexedVector<Property> properties;
     toString{ return "TableProperties(" + Util::toString(properties->size()) + ")"; }
-    TableProperties() { properties = new IndexedVector<TableProperty>(); }
+    TableProperties() { properties = new IndexedVector<Property>(); }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
         return properties->getDeclarations(); }
-    TableProperty getProperty(cstring name) const {
-        return properties->getDeclaration<TableProperty>(name); }
+    Property getProperty(cstring name) const {
+        return properties->getDeclaration<Property>(name); }
     IDeclaration getDeclByName(cstring name) const override {
         return properties->getDeclaration(name); }
 
@@ -266,10 +271,12 @@ class Declaration_Constant : Declaration, IAnnotated {
 // Like a variable, but for a statically allocated instance.
 // The syntax is Contructor(args) name = initializer;
 class Declaration_Instance : Declaration, IAnnotated {
-    Annotations           annotations;
+    optional Annotations  annotations = Annotations::empty;
     Type                  type;         // Either Type_Name or Type_Specialized
     Vector<Expression>    arguments;
-    NullOK BlockStatement initializer;  // experimental only; contains just declarations, no code
+    inline NameMap<Property> properties = {};  // P4_14 externs only, at the moment
+    optional NullOK BlockStatement initializer = nullptr;
+        // experimental only; contains just declarations, no code
 
     Annotations getAnnotations() const override { return annotations; }
     validate{ BUG_CHECK(type->is<Type_Name>() ||

--- a/ir/type.def
+++ b/ir/type.def
@@ -98,7 +98,7 @@ class Type_Varbits : Type_Base {
 }
 
 class Parameter : Declaration, IAnnotated {
-    Annotations         annotations;
+    optional Annotations annotations = Annotations::empty;
     Direction           direction;
     Type                type;
     Annotations getAnnotations() const override { return annotations; }
@@ -449,6 +449,7 @@ class Type_Action : Type_MethodBase {
 class Method : Declaration {
     Type_Method type;
     optional bool isAbstract = false;
+    optional Annotations annotations = Annotations::empty;
     size_t getParameterCount() const { return type->getParameterCount(); }
     void setAbstract() { isAbstract = true; }
 }
@@ -462,8 +463,10 @@ class Type_Typedef : Type_Declaration, IAnnotated {
 
 // An 'extern' black-box (not a function)
 class Type_Extern : Type_Declaration, IGeneralNamespace, IMayBeGenericType {
-    TypeParameters typeParameters;
+    optional TypeParameters typeParameters = new TypeParameters;
     Vector<Method> methods;  // methods can be overloaded, so this is not IndexedVector
+    optional inline NameMap<Attribute, ordered_map> attributes;  // P4_14 only, currently
+    optional Annotations annotations = Annotations::empty;
 
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
         return methods->getEnumerator()->as<const IDeclaration*>(); }

--- a/ir/v1.cpp
+++ b/ir/v1.cpp
@@ -18,6 +18,21 @@ limitations under the License.
 #include "dbprint.h"
 #include "lib/gmputil.h"
 
+#define SINGLETON_TYPE(NAME)                                    \
+const IR::Type_##NAME *IR::Type_##NAME::get() {                 \
+    static const Type_##NAME *singleton;                        \
+    if (!singleton)                                             \
+        singleton = (new Type_##NAME(Util::SourceInfo()));      \
+    return singleton;                                           \
+}
+SINGLETON_TYPE(Block)
+SINGLETON_TYPE(Counter)
+SINGLETON_TYPE(Expression)
+SINGLETON_TYPE(FieldListCalculation)
+SINGLETON_TYPE(Meter)
+SINGLETON_TYPE(Register)
+SINGLETON_TYPE(AnyTable)
+
 cstring IR::NamedCond::unique_name() {
     static int unique_counter = 0;
     char buf[16];

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -39,6 +39,42 @@ inline bool operator>>(cstring s, IR::CounterType &ctr) {
 }
 #end
 
+class Type_Block : Type_Base {
+    toString { return "block"; }
+    static Type_Block get();
+    dbprint { out << "block"; }
+}
+class Type_Counter : Type_Base {
+    toString { return "counter"; }
+    static Type_Counter get();
+    dbprint { out << "counter"; }
+}
+class Type_Expression : Type_Base {
+    toString { return "expression"; }
+    static Type_Expression get();
+    dbprint { out << "expression"; }
+}
+class Type_FieldListCalculation : Type_Base {
+    toString { return "field_list_calculation"; }
+    static Type_FieldListCalculation get();
+    dbprint { out << "field_list_calculation"; }
+}
+class Type_Meter : Type_Base {
+    toString { return "meter"; }
+    static Type_Meter get();
+    dbprint { out << "meter"; }
+}
+class Type_Register : Type_Base {
+    toString { return "register"; }
+    static Type_Register get();
+    dbprint { out << "register"; }
+}
+class Type_AnyTable : Type_Base {
+    toString { return "table"; }
+    static Type_AnyTable get();
+    dbprint { out << "table"; }
+}
+
 abstract HeaderOrMetadata {
     ID                      type_name;
     ID                      name;
@@ -373,8 +409,8 @@ class V1Table {
     optional Annotations        annotations = Annotations::empty;
 
     // inefficient add
-    void addProperty(TableProperty prop) {
-        auto props = new IndexedVector<TableProperty>(*properties.properties);
+    void addProperty(Property prop) {
+        auto props = new IndexedVector<Property>(*properties.properties);
         props->push_back(prop);
         properties = TableProperties(properties.srcInfo, props); }
     toString { return node_type_name() + " " + name; }
@@ -389,6 +425,13 @@ class V1Control {
     V1Control(Util::SourceInfo si, ID n) : Node(si), name(n), code(new Vector<Expression>()) {}
 #apply
     toString { return node_type_name() + " " + name; }
+}
+
+class Attribute : Declaration {
+    NullOK Type type = nullptr;
+    NullOK NameList locals = nullptr;
+    bool optional = false;
+#nodbprint
 }
 
 #emit

--- a/midend/actionSynthesis.cpp
+++ b/midend/actionSynthesis.cpp
@@ -52,7 +52,7 @@ const IR::Node* DoMoveActionsToTables::postorder(IR::MethodCallStatement* statem
     actions->push_back(actinst);
     // Action list property
     auto actlist = new IR::ActionList(Util::SourceInfo(), actions);
-    auto prop = new IR::TableProperty(
+    auto prop = new IR::Property(
         Util::SourceInfo(),
         IR::ID(IR::TableProperties::actionsPropertyName, nullptr),
         IR::Annotations::empty, actlist, false);
@@ -65,12 +65,12 @@ const IR::Node* DoMoveActionsToTables::postorder(IR::MethodCallStatement* statem
     BUG_CHECK(arg == mc->arguments->end(), "%1%: mismatched arguments", mc);
     auto amce = new IR::MethodCallExpression(mc->srcInfo, mc->method, mc->typeArguments, otherArgs);
     auto defactval = new IR::ExpressionValue(Util::SourceInfo(), amce);
-    auto defprop = new IR::TableProperty(
+    auto defprop = new IR::Property(
         Util::SourceInfo(), IR::ID(IR::TableProperties::defaultActionPropertyName, nullptr),
         IR::Annotations::empty, defactval, true);
 
     // List of table properties
-    auto nm = new IR::IndexedVector<IR::TableProperty>();
+    auto nm = new IR::IndexedVector<IR::Property>();
     nm->push_back(prop);
     nm->push_back(defprop);
     auto props = new IR::TableProperties(Util::SourceInfo(), nm);

--- a/midend/validateProperties.cpp
+++ b/midend/validateProperties.cpp
@@ -2,7 +2,7 @@
 
 namespace P4 {
 
-void ValidateTableProperties::postorder(const IR::TableProperty* property) {
+void ValidateTableProperties::postorder(const IR::Property* property) {
     if (legalProperties.find(property->name.name) != legalProperties.end())
         return;
     ::warning("Unknown table property: %1%", property);

--- a/midend/validateProperties.h
+++ b/midend/validateProperties.h
@@ -34,7 +34,7 @@ class ValidateTableProperties : public Inspector {
         for (auto l : legal)
             legalProperties.emplace(l);
     }
-    void postorder(const IR::TableProperty* property) override;
+    void postorder(const IR::Property* property) override;
 };
 
 }  // namespace P4

--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -87,7 +87,7 @@ static IrNamespace *current_namespace = LookupScope().resolve(0);
 %type<constFieldInit>           constFieldInit
 %type<kind>                     kind
 %type<types>                    parentList nonEmptyParentList type_args
-%type<str>                      name expression optInitializer methodName body
+%type<str>                      name expression optInitializer fieldName methodName body
 %type<lookup>                   lookup_scope
 
 %error-verbose
@@ -269,11 +269,11 @@ body: BLOCK
     ;
 
 irField
-    : modifiers type IDENTIFIER optInitializer ';'
+    : modifiers type fieldName optInitializer ';'
           { $$ = new IrField(@3, $2, $3, $4, $1);
             if ($1 & IrElement::Virtual)
                 yyerror("virtual invalid on field %s", $3); }
-    | modifiers CONST nonRefType IDENTIFIER optInitializer ';'
+    | modifiers CONST nonRefType fieldName optInitializer ';'
           { $$ = new IrField(@4, $3, $4, $5, $1 | IrElement::Const);
             if ($1 & IrElement::Virtual)
                 yyerror("virtual invalid on field %s", $4); }
@@ -288,6 +288,8 @@ modifier
     ;
 
 modifiers : { $$ = 0; } | modifiers modifier { $$ = $1 | $2; }
+
+fieldName: IDENTIFIER | OPTIONAL { $$ = "optional"; } ;
 
 optInitializer
     : /* empty */       { $$ = nullptr; }


### PR DESCRIPTION
This adds support in the parser and IR for representing externs from P4_14 code.

I renamed 'TableProperty' as just 'Property' as it is now used for extern properties as well.  The goal is to have as much commonality between P4_14 and P4_16 as possible.