### PR TITLE
Add .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ build/
 .cproject
 .project
 .settings
+
+# macOS files
+.DS_Store


### PR DESCRIPTION
Let's add .DS_Store files to .gitignore to keep `git status` output clean on macOS.