### PR TITLE
Prevent GMP values in lambdas from outliving their stack frame

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -161,27 +161,27 @@ DoConstantFolding::cast(const IR::Constant* node, unsigned base, const IR::Type_
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Add* e) {
-    return binary(e, [](mpz_class a, mpz_class b) { return a + b; });
+    return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a + b; });
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Sub* e) {
-    return binary(e, [](mpz_class a, mpz_class b) { return a - b; });
+    return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a - b; });
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Mul* e) {
-    return binary(e, [](mpz_class a, mpz_class b) { return a * b; });
+    return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a * b; });
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::BXor* e) {
-    return binary(e, [](mpz_class a, mpz_class b) { return a ^ b; });
+    return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a ^ b; });
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::BAnd* e) {
-    return binary(e, [](mpz_class a, mpz_class b) { return a & b; });
+    return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a & b; });
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::BOr* e) {
-    return binary(e, [](mpz_class a, mpz_class b) { return a | b; });
+    return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a | b; });
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Equ* e) {
@@ -193,23 +193,23 @@ const IR::Node* DoConstantFolding::postorder(IR::Neq* e) {
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Lss* e) {
-    return binary(e, [](mpz_class a, mpz_class b) { return a < b; });
+    return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a < b; });
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Grt* e) {
-    return binary(e, [](mpz_class a, mpz_class b) { return a > b; });
+    return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a > b; });
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Leq* e) {
-    return binary(e, [](mpz_class a, mpz_class b) { return a <= b; });
+    return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a <= b; });
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Geq* e) {
-    return binary(e, [](mpz_class a, mpz_class b) { return a >= b; });
+    return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a >= b; });
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Div* e) {
-    return binary(e, [e](mpz_class a, mpz_class b)->mpz_class {
+    return binary(e, [e](mpz_class a, mpz_class b) -> mpz_class {
             if (sgn(a) < 0 || sgn(b) < 0) {
                 ::error("%1%: Division is not defined for negative numbers", e);
                 return 0;
@@ -223,7 +223,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Div* e) {
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Mod* e) {
-    return binary(e, [e](mpz_class a, mpz_class b)->mpz_class {
+    return binary(e, [e](mpz_class a, mpz_class b) -> mpz_class {
             if (sgn(a) < 0 || sgn(b) < 0) {
                 ::error("%1%: Modulo is not defined for negative numbers", e);
                 return 0;
@@ -265,9 +265,9 @@ DoConstantFolding::compare(const IR::Operation_Binary* e) {
     }
 
     if (eqTest)
-        return binary(e, [](mpz_class a, mpz_class b) { return a == b; });
+        return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a == b; });
     else
-        return binary(e, [](mpz_class a, mpz_class b) { return a != b; });
+        return binary(e, [](mpz_class a, mpz_class b) -> mpz_class { return a != b; });
 }
 
 const IR::Node*


### PR DESCRIPTION
So I recently noticed that while p4c builds on macOS, the tests fail. I investigated a little and tracked down the issue. Here's what's happening:

In constantFolding.cpp, the binary operators are handling by a common method, DoConstantFolding::binary(), which takes a std::function as an argument. The std::function accepts two GMP values (i.e., mpz_class values) and performs the appropriate binary operation, returning a new value. Here's an example:

```
return binary(e, [](mpz_class a, mpz_class b) { return a + b; });
```

The problem here is that the return type of these lambdas are inferred, and the inferred type is *not* mpz_class. For this example, the inferred return type is actually:

```
__gmp_expr<__mpz_struct [1], __gmp_binary_expr<__gmp_expr<mpz_t, mpz_t>, __gmp_expr<mpz_t, mpz_t>, __gmp_binary_plus>> 
```

What's happening here is that operations on mpz_class values build up an expression tree which is then evaluated when it's assigned to another mpz_class value. This didn't get noticed because while binary() accepts a `std::function<mpz_class(mpz_class, mpz_class)>`, std::function will happily store a lambda whose return type is *implicitly convertible* to an mpz_class, which is the case for __gmp_expr.

So, why is this bad? Well, take a look at this code snippet from gmpxx.h:

```
template <class T, class U, class Op>
struct __gmp_binary_expr
{
  typename __gmp_resolve_ref<T>::ref_type val1;
  typename __gmp_resolve_ref<U>::ref_type val2;

  __gmp_binary_expr(const T &v1, const U &v2) : val1(v1), val2(v2) { }
private:
  __gmp_binary_expr();
};
```

As this code implies, __gmp_resolve_ref<T>::ref_type is a *reference*. The lambda is returning a __gmp_expr that contains references to values which are on its stack frame. This is obviously ill-advised. =)

This works in GCC, presumably, because the code it generates doesn't clobber those values before the __gmp_expr is evaluated. Clang users are not so lucky, which means that DoConstantFolding::binary() ends up generating garbage values, causing tests to fail.

This patch adds explicit return types to all the lambdas in constantFolding.cpp that have this issue. This fixes the problem, since the implicit conversion happens before the stack frame gets popped, and with this patch applied all tests pass on macOS.