### PR TITLE
Speed up compilation of ir-generated.cpp

### DIFF
--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -86,7 +86,7 @@ void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &i
     out << "#include <map>\n"
         << "#include <functional>\n" << std::endl
         << "class JSONLoader;\n"
-        << "typedef std::function<IR::Node*(JSONLoader&)> NodeFactoryFn;\n"
+        << "using NodeFactoryFn = IR::Node*(*)(JSONLoader&);\n"
         << std::endl
         << "namespace IR {\n"
         << "extern std::map<cstring, NodeFactoryFn> unpacker_table;\n"


### PR DESCRIPTION
One of the main bottlenecks in compilation performance for p4c is compilation of ir-generated.cpp; it takes 30 seconds on my machine.

It turns out that fully 33% of that time is spent generating specializations for std::function for IR::unpacker_table. The values in that table wrap the various IR fromJSON() methods, which return concrete IR types, with a std::function that implicitly casts the result to an IR::Node*.

If the fromJSON() methods returned an IR::Node*, then instead of storing std::function values in this table, we could simply store raw function pointers. The fromJSON() methods are never called in a situation where the caller expects a concrete node type, so there's no loss in making this change. It's straightforward to update `irgenerator` so that fromJSON() methods (i.e., FACTORY methods) return an IR::Node*.

One minor complication is that `irgenerator` can generate fromJSON() methods for nested classes, which aren't necessarily subclasses of IR::Node. This is only an issue in one case: `CalculatedField::update_or_verify`. I dealt with the situation by continuing to return the concrete type from fromJSON() methods in nested classes. Those classes don't appear in IR::unpacker_table, so this doesn't interfere with the optimization this PR is trying to accomplish.

With this change, ir-generated.cpp drops from taking 30 seconds to compile on my machine to taking 20 seconds -- a 33% reduction!