### PR TITLE
Default to building with -O0

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,5 +27,5 @@ cd build
 # TODO: the "prefix" is needed for finding the p4include folder.
 # It should be an absolute path.  This may need to change
 # when we have a proper installation procedure.
-../configure CXXFLAGS="-g -O1" --prefix=$sourcedir $*
+../configure CXXFLAGS="-g -O0" --prefix=$sourcedir $*
 echo "### Configured for building in 'build' folder"


### PR DESCRIPTION
Per our discussion earlier today, building with -O0 is both faster and is necessary to get good debug symbols. Let's change the default in bootstrap.sh.