### PR TITLE
Rework log level caching to avoid the need for per-file static variables

### DIFF
--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *const argv[]) {
 
     compile(options);
 
-    if (options.verbosity > 0)
+    if (Log::verbose())
         std::cerr << "Done." << std::endl;
     return ::errorCount() > 0;
 }

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -82,7 +82,7 @@ int main(int argc, char *const argv[]) {
             }
         }
     }
-    if (verbose)
+    if (Log::verbose())
         std::cerr << "Done." << std::endl;
     return ::errorCount() > 0;
 }

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -66,8 +66,6 @@ class CompilerOptions : public Util::Options {
     // Dump and undump the IR tree
     bool debugJson = false;
 
-    // higher means more verbose
-    unsigned verbosity = 0;
     // Compiler target architecture
     cstring target = nullptr;
     // substrings matched agains pass names

--- a/frontends/common/parseInput.cpp
+++ b/frontends/common/parseInput.cpp
@@ -34,7 +34,7 @@ const IR::P4Program* parseP4File(CompilerOptions& options) {
         // Model is loaded before parsing the input file.
         // In this way the SourceInfo in the model comes first.
         const IR::Node* v1 = parse_P4_14_file(options, in);
-        if (verbose)
+        if (Log::verbose())
             std::cerr << "Converting to P4-16" << std::endl;
         converter.visit(v1);
         if (v1 != nullptr) {

--- a/frontends/p4-14/p4-14-parse.ypp
+++ b/frontends/p4-14/p4-14-parse.ypp
@@ -908,8 +908,7 @@ void yyerror(const char *msg) {
 }
 
 const IR::V1Program *parse_P4_14_file(const CompilerOptions &options, FILE *in) {
-    extern int verbose;
-    if (verbose)
+    if (Log::verbose())
         std::cout << "Parsing P4-14 program " << options.file << std::endl;
 #ifdef YYDEBUG
     if (const char *p = getenv("YYDEBUG"))

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -486,7 +486,7 @@ class Rewriter : public Transform {
     { CHECK_NULL(structure); setName("Rewriter"); }
 
     const IR::Node* preorder(IR::V1Program* global) override {
-        if (verbose > 1)
+        if (Log::verbose())
             dump(global);
         prune();
         return structure->create(global->srcInfo);

--- a/frontends/p4/p4-parse.ypp
+++ b/frontends/p4/p4-parse.ypp
@@ -972,8 +972,7 @@ void yyerror(const char *fmt, ...) {
 }
 
 const IR::P4Program *parse_P4_16_file(const char *name, FILE *in) {
-    extern int verbose;
-    if (verbose)
+    if (Log::verbose())
         std::cout << "Parsing P4-16 program " << name << std::endl;
 
     int errors = 0;


### PR DESCRIPTION
This PR reworks log.h to eliminate the need for per-file static variables. These variables were used as a cache for the log level for each source file, the idea being that the caches eliminate the need to look through the vector of debug specs every time a LOG() macro is called. Because some LOG() statements execute in tight loops, this caching is very important, and we need to maintain a comparable performance level in the new code.

In this PR, a different caching scheme is used. The procedure for checking the log level for a file now involves four steps:

1. Check the maximum log level for any file, globally. This allows us to quick-reject many log statements, especially since the log statements in tight loops are likely to be at higher log levels.

2. Check if the file we're checking is the same file that we most recently checked. We cache the log level for the last file so that if we get another check for the same file, we can return a result immediately.

3. Check for the file in a hash table that maps filenames to log levels. We should hit in this cache virtually all the time.

4. If all else fails, we have to fall back to iterating over the vector of debug specs and doing string comparisons. We should hit this path very rarely.

To make this caching work, we have to invalidate the caches when a new debug spec is added or when the global verbosity level changes. That means that we need a bit more encapsulation than we used to have. To keep things clean, the logging implementation has been moved into the Log namespace, and internal functions/variables that shouldn't be accessed by external code have been moved into the Log::Detail namespace.

I ended up touching most of log.cpp and log.h in this PR, unfortunately. =) Hopefully it won't be necessary to touch them much more any time soon. I've tested the changes locally and everything appears to be working just fine.