### PR TITLE
Fix json for header stack ref in push/pop primitives

### DIFF
--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -604,7 +604,8 @@ class ExpressionConverter : public Inspector {
                 f->append(converter->scalarsName);
                 f->append(var->name);
             } else if (type->is<IR::Type_Stack>()) {
-                // handled specially elsewhere
+                result->emplace("type", "header_stack");
+                result->emplace("value", var->name);
             } else {
                 BUG("%1%: type not yet handled", type);
             }


### PR DESCRIPTION
Fairly trivial fix -- the only part I'm unsure of is removing the comment which just seemed to be generally wrong.  While other places may handle Type_Stack specially elsewhere, they then don't look at the result of the PathExpression conversion, or prune in the preorder to avoid it completely.