### PR TITLE
use followlinks instead of symlinks in tools/gen-unified-makefile.py

### DIFF
--- a/tools/gen-unified-makefile.py
+++ b/tools/gen-unified-makefile.py
@@ -73,7 +73,7 @@ import sys
 
 def find_automake_files():
     files = []
-    for root, _, filenames in os.walk('.', symlinks=True):
+    for root, _, filenames in os.walk('.', followlinks=True):
         for filename in fnmatch.filter(filenames, '*.am'):
             files.append(os.path.join(root, filename))
     return files


### PR DESCRIPTION
Python does not have argument "symlinks" in os.walk(), should be "followlinks"