### PR TITLE
Mark BMV2 JSON scalars as 'pi_omit' so they won't be exposed in PI

### DIFF
--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1761,6 +1761,7 @@ void JsonConverter::addLocals() {
     json->emplace("id", nextId("headers"));
     json->emplace("header_type", scalarsName);
     json->emplace("metadata", true);
+    json->emplace("pi_omit", true);  // Don't expose scalars in PI.
     headerInstances->append(json);
 }
 


### PR DESCRIPTION
This patch marks the scalars header instance that we synthesize in the BMV2 JSON converter as "pi_omit". The plan is to not expose the scalars in PI, since they're an implementation detail and it doesn't really make sense to interact with them via PI directly.