### PR TITLE
Fix for issue #220

### DIFF
--- a/backends/ebpf/midend.cpp
+++ b/backends/ebpf/midend.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include "midend/simplifySelect.h"
 #include "midend/validateProperties.h"
 #include "midend/eliminateTuples.h"
+#include "midend/noMatch.h"
 #include "frontends/p4/uniqueNames.h"
 #include "frontends/p4/moveDeclarations.h"
 #include "frontends/p4/typeMap.h"
@@ -86,6 +87,7 @@ const IR::ToplevelBlock* MidEnd::run(EbpfOptions& options, const IR::P4Program* 
         new P4::RemoveExits(&refMap, &typeMap),
         new P4::ConstantFolding(&refMap, &typeMap),
         new P4::SimplifySelect(&refMap, &typeMap, false),  // accept non-constant keysets
+        new P4::HandleNoMatch(&refMap),
         new P4::SimplifyParsers(&refMap),
         new P4::StrengthReduction(),
         new P4::EliminateTuples(&refMap, &typeMap),

--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -31,6 +31,7 @@ limitations under the License.
 #include "midend/nestedStructs.h"
 #include "midend/copyStructures.h"
 #include "midend/predication.h"
+#include "midend/noMatch.h"
 #include "frontends/p4/simplifyParsers.h"
 #include "frontends/p4/typeMap.h"
 #include "frontends/p4/evaluator/evaluator.h"
@@ -83,6 +84,7 @@ MidEnd::MidEnd(CompilerOptions& options) {
         new P4::RemoveExits(&refMap, &typeMap),
         new P4::ConstantFolding(&refMap, &typeMap),
         new P4::SimplifySelect(&refMap, &typeMap, false),  // non-constant keysets
+        new P4::HandleNoMatch(&refMap),
         new P4::SimplifyParsers(&refMap),
         new P4::StrengthReduction(),
         new P4::Predication(&refMap),

--- a/backends/p4test/run-p4-sample.py
+++ b/backends/p4test/run-p4-sample.py
@@ -186,7 +186,7 @@ def process_file(options, argv):
     # We rely on the fact that these keys are in alphabetical order.
     rename = { "FrontEnd_11_SimplifyControlFlow": "first",
                "FrontEnd_25_FrontEndLast": "frontend",
-               "MidEnd_31_Evaluator": "midend" }
+               "MidEnd_32_Evaluator": "midend" }
 
     if options.verbose:
         print("Writing temporary files into ", tmpdir)

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -758,8 +758,6 @@ const IR::Node* DoConstantFolding::postorder(IR::SelectExpression* expression) {
 
     if (changes) {
         if (cases.size() == 0 && result == expression && warnings)
-            // TODO: this is the same as verify(false, error.NoMatch),
-            // but we cannot replace the selectExpression with a method call.
             ::warning("%1%: no case matches", expression);
         expression->selectCases = std::move(cases);
     }

--- a/frontends/p4/coreLibrary.h
+++ b/frontends/p4/coreLibrary.h
@@ -26,8 +26,7 @@ enum class StandardExceptions {
     NoError,
     PacketTooShort,
     NoMatch,
-    EmptyStack,
-    FullStack,
+    StackOutOfBounds,
     OverwritingHeader,
     HeaderTooShort,
     ParserTimeout,
@@ -45,11 +44,8 @@ inline std::ostream& operator<<(std::ostream &out, P4::StandardExceptions e) {
         case P4::StandardExceptions::NoMatch:
             out << "NoMatch";
             break;
-        case P4::StandardExceptions::EmptyStack:
-            out << "EmptyStack";
-            break;
-        case P4::StandardExceptions::FullStack:
-            out << "FullStack";
+        case P4::StandardExceptions::StackOutOfBounds:
+            out << "StackOutOfBounds";
             break;
         case P4::StandardExceptions::OverwritingHeader:
             out << "OverwritingHeader";
@@ -105,8 +101,8 @@ class P4CoreLibrary : public ::Model::Model {
             ternaryMatch("ternary"), lpmMatch("lpm"), packetIn(PacketIn()),
             packetOut(PacketOut()), noError(StandardExceptions::NoError),
             packetTooShort(StandardExceptions::PacketTooShort),
-            noMatch(StandardExceptions::NoMatch), emptyStack(StandardExceptions::EmptyStack),
-            fullStack(StandardExceptions::FullStack),
+            noMatch(StandardExceptions::NoMatch),
+            stackOutOfBounds(StandardExceptions::StackOutOfBounds),
             overwritingHeader(StandardExceptions::OverwritingHeader),
             headerTooShort(StandardExceptions::HeaderTooShort) {}
 
@@ -124,8 +120,7 @@ class P4CoreLibrary : public ::Model::Model {
     P4Exception_Model noError;
     P4Exception_Model packetTooShort;
     P4Exception_Model noMatch;
-    P4Exception_Model emptyStack;
-    P4Exception_Model fullStack;
+    P4Exception_Model stackOutOfBounds;
     P4Exception_Model overwritingHeader;
     P4Exception_Model headerTooShort;
 };

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -172,6 +172,7 @@ class LocationSet : public IHasDbPrint {
 class StorageMap {
     std::map<const IR::IDeclaration*, StorageLocation*> storage;
     StorageFactory factory;
+
  public:
     ReferenceMap*  refMap;
     TypeMap*       typeMap;
@@ -238,13 +239,6 @@ class ProgramPoint : public IHasDbPrint {
     { return stack.empty(); }
 };
 }  // namespace P4
-
-#if 0
-// hash and comparator for ProgramPoint
-inline bool operator==(const P4::ProgramPoint& left, const P4::ProgramPoint& right) {
-    return left.operator==(right);
-}
-#endif
 
 // inject hash into std namespace so it is picked up by std::unordered_set
 namespace std {
@@ -326,6 +320,7 @@ class AllDefinitions : public IHasDbPrint {
     // However, for ProgramPoints representing P4Control, P4Action, and P4Table
     // the definitions are BEFORE the ProgramPoint.
     std::unordered_map<ProgramPoint, Definitions*> atPoint;
+
  public:
     StorageMap* storageMap;
     AllDefinitions(ReferenceMap* refMap, TypeMap* typeMap) :

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1348,12 +1348,6 @@ const IR::Node* TypeInference::postorder(IR::ArrayIndex* expression) {
         return expression;
     }
 
-#if 0
-    auto parser = findContext<IR::P4Parser>();
-    if (parser != nullptr)
-        typeError("%1%: Explicit stack indexing cannot be used in a parser", expression);
-#endif
-
     auto hst = ltype->to<IR::Type_Stack>();
     if (isLeftValue(expression->left)) {
         setLeftValue(expression);

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -82,7 +82,8 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::Declaration_Variable* dec
 const IR::Node* RemoveUnusedDeclarations::process(const IR::IDeclaration* decl) {
     LOG1("Visiting " << decl);
     auto ctx = getContext();
-    if (decl->getName().name == IR::P4Program::main &&
+    if ((decl->getName().name == IR::P4Program::main ||
+        decl->getName().name == IR::ParserState::verify) &&
         ctx->parent->node->is<IR::P4Program>())
         return decl->getNode();
     if (refMap->isUsed(getOriginal<IR::IDeclaration>()))

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -28,6 +28,7 @@ const cstring TableProperties::keyPropertyName = "key";
 const cstring TableProperties::defaultActionPropertyName = "default_action";
 const cstring IApply::applyMethodName = "apply";
 const cstring P4Program::main = "main";
+const cstring Type_Error::error = "error";
 
 int IR::Declaration::nextId = 0;
 

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -32,7 +32,7 @@
 
 class ParserState : ISimpleNamespace, Declaration, IAnnotated {
     Annotations               annotations;
-    IndexedVector<StatOrDecl> components;  // only some statements allowed
+    IndexedVector<StatOrDecl> components;
     // selectExpression can be a SelectExpression, or a PathExpression representing a state
     NullOK Expression         selectExpression;
 
@@ -47,15 +47,12 @@ class ParserState : ISimpleNamespace, Declaration, IAnnotated {
     static const cstring start;
     static const cstring verify;
     bool isBuiltin() const { return name == ParserState::accept || name == ParserState::reject; }
-    /* Relaxing constraints on parser control-flow
     validate{
-        for (auto e : *components) {
-            CHECK_NULL(e);
-            if (e->is<IR::Statement>())
-                BUG_CHECK(e->is<IR::AssignmentStatement>() || e->is<IR::MethodCallStatement>(),
-                          "%1%: unexpected statement in parser", e);
-        }
-    } */
+        if (selectExpression != nullptr)
+            BUG_CHECK(selectExpression->is<IR::PathExpression>() ||
+                      selectExpression->is<IR::SelectExpression>(),
+                      "%1%: unexpected select expression", selectExpression);
+    }
 }
 
 // A parser that contains all states (unlike the P4 v1.0 parser, which is really just a state)
@@ -121,6 +118,7 @@ class P4Action : Declaration, ISimpleNamespace, IAnnotated {
 }
 
 class Type_Error : ISimpleNamespace, Type_Declaration {
+    static const cstring error;
     IndexedVector<Declaration_ID> members;
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
         return members->getDeclarations(); }

--- a/midend/Makefile.am
+++ b/midend/Makefile.am
@@ -33,7 +33,8 @@ midend_UNIFIED = \
 	midend/removeLeftSlices.cpp \
 	midend/simplifyKey.cpp \
 	midend/simplifySelect.cpp \
-	midend/validateProperties.cpp
+	midend/validateProperties.cpp \
+	midend/noMatch.cpp
 
 noinst_HEADERS += \
 	midend/actionsInlining.h \
@@ -57,6 +58,7 @@ noinst_HEADERS += \
 	midend/removeReturns.h \
 	midend/simplifyKey.h \
 	midend/simplifySelect.h \
-	midend/validateProperties.h
+	midend/validateProperties.h \
+	midend/noMatch.h
 
 cpplint_FILES += $(midend_UNIFIED) $(midend_NONUNIFIED)

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -414,7 +414,7 @@ SymbolicValue* SymbolicArray::next(const IR::Node* node) {
         if (!v->valid->value)
             return v;
     }
-    return new SymbolicException(node, P4::StandardExceptions::FullStack);
+    return new SymbolicException(node, P4::StandardExceptions::StackOutOfBounds);
 }
 
 SymbolicValue* SymbolicArray::last(const IR::Node* node) {
@@ -426,7 +426,7 @@ SymbolicValue* SymbolicArray::last(const IR::Node* node) {
         if (v->valid->value)
             return v;
     }
-    return new SymbolicException(node, P4::StandardExceptions::EmptyStack);
+    return new SymbolicException(node, P4::StandardExceptions::StackOutOfBounds);
 }
 
 void SymbolicArray::setAllUnknown() {

--- a/midend/noMatch.cpp
+++ b/midend/noMatch.cpp
@@ -1,0 +1,59 @@
+/*
+Copyright 2016 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "noMatch.h"
+#include "frontends/p4/coreLibrary.h"
+
+namespace P4 {
+
+const IR::Node* DoHandleNoMatch::postorder(IR::SelectExpression* expression) {
+    for (auto c : expression->selectCases) {
+        if (c->keyset->is<IR::DefaultExpression>())
+            return expression;
+    }
+    CHECK_NULL(noMatch);
+    auto sc = new IR::SelectCase(
+        new IR::DefaultExpression(), new IR::PathExpression(noMatch->getName()));
+    expression->selectCases.push_back(sc);
+    return expression;
+}
+
+const IR::Node* DoHandleNoMatch::preorder(IR::P4Parser* parser) {
+    P4CoreLibrary& lib = P4CoreLibrary::instance;
+
+    cstring name = nameGen->newName("noMatch");
+    LOG2("Inserting " << name << " state");
+    auto vec = new IR::IndexedVector<IR::StatOrDecl>();
+    auto args = new IR::Vector<IR::Expression>();
+    args->push_back(new IR::BoolLiteral(false));
+    args->push_back(new IR::Member(
+        Util::SourceInfo(),
+        new IR::TypeNameExpression(IR::Type_Error::error),
+        lib.noMatch.Id()));
+    auto verify = new IR::MethodCallExpression(
+        Util::SourceInfo(), new IR::PathExpression(IR::ID(IR::ParserState::verify)),
+        new IR::Vector<IR::Type>(), args);
+    vec->push_back(new IR::MethodCallStatement(verify));
+    noMatch = new IR::ParserState(Util::SourceInfo(), IR::ID(name),
+                                  IR::Annotations::empty, vec,
+                                  new IR::PathExpression(IR::ID(IR::ParserState::reject)));
+    auto comp = new IR::IndexedVector<IR::ParserState>(*parser->states);
+    comp->push_back(noMatch);
+    parser->states = comp;
+    return parser;
+}
+
+}  // namespace P4

--- a/midend/predication.cpp
+++ b/midend/predication.cpp
@@ -42,7 +42,7 @@ const IR::Node* Predication::preorder(IR::IfStatement* statement) {
     // A vector for a new BlockStatement.
     auto blockVec = new IR::IndexedVector<IR::StatOrDecl>();
 
-    const IR::Expression* previousPredicate = predicate(); // This may be nullptr
+    const IR::Expression* previousPredicate = predicate();  // This may be nullptr
     // a new name for the new predicate
     cstring newPredName = generator->newName("pred");
     predicateName.push_back(newPredName);

--- a/midend/predication.h
+++ b/midend/predication.h
@@ -68,6 +68,7 @@ class Predication final : public Transform {
             ::error("%1%: Predication cannot be applied", statement);
         return statement;
     }
+
  public:
     explicit Predication(NameGenerator* generator) : generator(generator),
             inside_action(false), ifNestingLevel(0)

--- a/p4include/core.p4
+++ b/p4include/core.p4
@@ -23,8 +23,7 @@ error {
     NoError,           // no error
     PacketTooShort,    // not enough bits in packet for extract
     NoMatch,           // match expression has no matches
-    EmptyStack,        // reference to .last in an empty header stack
-    FullStack,         // reference to .next in a full header stack
+    StackOutOfBounds,  // reference to invalid element of a header stack
     OverwritingHeader, // one header is extracted twice
     HeaderTooShort,    // extracting too many bits in a varbit field
     ParserTimeout      // parser execution time limit exceeded
@@ -46,6 +45,7 @@ extern packet_in {
 
 extern packet_out {
     void emit<T>(in T hdr);
+    void emit<T>(in bool condition, in T data);
 }
 
 // TODO: remove from this file, convert to built-in

--- a/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
@@ -119,10 +119,15 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
             (8w0x0 &&& 8w0x0, 8w0x1 &&& 8w0xff): parse_ipv4_option_NOP;
             (8w0x0 &&& 8w0x0, 8w0x82 &&& 8w0xff): parse_ipv4_option_security;
             (8w0x0 &&& 8w0x0, 8w0x44 &&& 8w0xff): parse_ipv4_option_timestamp;
+            default: noMatch;
         }
     }
     @header_ordering("ethernet", "ipv4_base", "ipv4_option_security", "ipv4_option_NOP", "ipv4_option_timestamp", "ipv4_option_EOL") @name("start") state start {
         transition parse_ethernet;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -1004,6 +1004,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition select(hdr.int_val.last.bos) {
             1w0: parse_int_val;
             1w1: parse_inner_ethernet;
+            default: noMatch;
         }
     }
     @name("parse_ipv4") state parse_ipv4 {
@@ -1187,6 +1188,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name("start") state start {
         transition parse_ethernet;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/triv_ipv4-midend.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-midend.p4
@@ -37,6 +37,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.ethertype) {
             16w0x800: ipv4;
+            default: noMatch;
         }
     }
     @name("ipv4") state ipv4 {
@@ -45,6 +46,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name("start") state start {
         transition ethernet;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
     }
 }
 

--- a/testdata/p4_16_samples/functors.p4
+++ b/testdata/p4_16_samples/functors.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser p()(bit b, bit c)
 {
    state start {

--- a/testdata/p4_16_samples/functors1.p4
+++ b/testdata/p4_16_samples/functors1.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser p00()
 {
     state start {

--- a/testdata/p4_16_samples/functors2.p4
+++ b/testdata/p4_16_samples/functors2.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser p1(out bit<2> z1)(bit<2> a) {
     state start {
         z1 = a;

--- a/testdata/p4_16_samples/functors3.p4
+++ b/testdata/p4_16_samples/functors3.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser p1(out bit z1)(bit b1) {
     state start {
         z1 = b1;

--- a/testdata/p4_16_samples/functors4.p4
+++ b/testdata/p4_16_samples/functors4.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser p1(out bit z1)(bit b1) {
     state start {
         z1 = b1;

--- a/testdata/p4_16_samples/functors5.p4
+++ b/testdata/p4_16_samples/functors5.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser p1(out bit<2> w)(bit<2> a) {
     state start {
         w = 2;

--- a/testdata/p4_16_samples/functors6.p4
+++ b/testdata/p4_16_samples/functors6.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser p1<T>(in T a) {
     state start {
         T w = a;

--- a/testdata/p4_16_samples/functors7.p4
+++ b/testdata/p4_16_samples/functors7.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser p1<T>(in T a) {
     state start {
         T w = a;

--- a/testdata/p4_16_samples/functors8.p4
+++ b/testdata/p4_16_samples/functors8.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 extern e<T> {
     e();
     T get();

--- a/testdata/p4_16_samples/functors9.p4
+++ b/testdata/p4_16_samples/functors9.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 extern e<T> {
     e();
     T get();

--- a/testdata/p4_16_samples/highorder.p4
+++ b/testdata/p4_16_samples/highorder.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser parse<H>(out H headers);
 
 package ebpfFilter<H>(parse<H> prs);

--- a/testdata/p4_16_samples/interface.p4
+++ b/testdata/p4_16_samples/interface.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-extern Crc16 <T> 
-{        
+#include <core.p4>
+
+extern Crc16 <T>
+{
         Crc16();
         Crc16(in int<32> x);
         void initialize<U>(in U input_data);
@@ -40,5 +42,3 @@ control empty();
 package m(empty e);
 
 m(p()) main;
-
-

--- a/testdata/p4_16_samples/interface1.p4
+++ b/testdata/p4_16_samples/interface1.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 extern X<T> { X(); }
 extern Y    { Y(); }
 

--- a/testdata/p4_16_samples/interface2.p4
+++ b/testdata/p4_16_samples/interface2.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 extern X { X(); }
 
 control p()

--- a/testdata/p4_16_samples/issue210.p4
+++ b/testdata/p4_16_samples/issue210.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 control Ing(out bit<32> a) {
     bool b;
 

--- a/testdata/p4_16_samples/noMatch.p4
+++ b/testdata/p4_16_samples/noMatch.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 VMware, Inc.
+Copyright 2017 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,31 +15,18 @@ limitations under the License.
 */
 
 #include <core.p4>
+#include <v1model.p4>
 
-extern Fake {
-    Fake();
-    void call(in bit<32> data);
-}
-
-parser P() {
-    bit<32> x = 0;
-    Fake() fake;
+parser p() {
     state start {
-        fake.call(x);
-        transition accept;
+        bit<32> x;
+        transition select(x) {
+            0: reject;
+        }
     }
 }
 
-control C() {
-    bit<32> x = 0;
-    bit<32> y = x + 1;
-    Fake() fake;
-    apply {
-        fake.call(y);
-    }
-}
+parser e();
+package top(e e);
 
-parser SimpleParser();
-control SimpleControl();
-package top(SimpleParser prs, SimpleControl ctrl);
-top(P(), C()) main;
+top(p()) main;

--- a/testdata/p4_16_samples/parser-arg.p4
+++ b/testdata/p4_16_samples/parser-arg.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser Parser();
 package Package(Parser p1, Parser p2);
 

--- a/testdata/p4_16_samples/parser-conditional.p4
+++ b/testdata/p4_16_samples/parser-conditional.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser p(out bit<32> b) {
     bit<32> a = 1;
     state start {

--- a/testdata/p4_16_samples/parser-locals.p4
+++ b/testdata/p4_16_samples/parser-locals.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+#include <core.p4>
 
 header H {
     bit<32> a;

--- a/testdata/p4_16_samples/pipe.p4
+++ b/testdata/p4_16_samples/pipe.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 match_kind {
     ternary,
     exact
@@ -46,8 +48,6 @@ struct QArg2 {
 
 extern bs {}
 struct Packet_data {}
-
-action NoAction() {}
 
 control P_pipe(inout TArg1 pArg1, inout TArg2 pArg2)(bit<32> t2Size) {
     // free-floating action: defined like a type

--- a/testdata/p4_16_samples/reject.p4
+++ b/testdata/p4_16_samples/reject.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 parser f() {
     state start {
         // implicit transition to reject: warning

--- a/testdata/p4_16_samples/stack.p4
+++ b/testdata/p4_16_samples/stack.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <core.p4>
+
 header h {}
 
 parser p()

--- a/testdata/p4_16_samples/states.p4
+++ b/testdata/p4_16_samples/states.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,9 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-extern packet_in {
-    void extract<T>(out T hdr);
-}
+#include <core.p4>
 
 parser parse<H>(packet_in packet, out H headers);
 package ebpfFilter<H>(parse<H> prs);

--- a/testdata/p4_16_samples_outputs/chain1-midend.p4
+++ b/testdata/p4_16_samples_outputs/chain1-midend.p4
@@ -10,6 +10,7 @@ parser p1(packet_in p, out Header h) {
         transition select(x) {
             1w0: chain1;
             1w1: chain2;
+            default: noMatch;
         }
     }
     state chain1 {
@@ -22,6 +23,10 @@ parser p1(packet_in p, out Header h) {
     }
     state endchain {
         transition accept;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/default-midend.p4
+++ b/testdata/p4_16_samples_outputs/default-midend.p4
@@ -12,6 +12,7 @@ parser p0(packet_in p, out Header h) {
         transition select(h.data, b) {
             (default, true): next;
             (default, default): reject;
+            default: noMatch;
         }
     }
     state next {
@@ -21,6 +22,10 @@ parser p0(packet_in p, out Header h) {
             (default, default): reject;
             default: reject;
         }
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/noMatch-first.p4
+++ b/testdata/p4_16_samples_outputs/noMatch-first.p4
@@ -1,0 +1,15 @@
+#include <core.p4>
+#include <v1model.p4>
+
+parser p() {
+    state start {
+        bit<32> x;
+        transition select(x) {
+            32w0: reject;
+        }
+    }
+}
+
+parser e();
+package top(e e);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/noMatch-frontend.p4
+++ b/testdata/p4_16_samples_outputs/noMatch-frontend.p4
@@ -1,0 +1,15 @@
+#include <core.p4>
+#include <v1model.p4>
+
+parser p() {
+    bit<32> x_0;
+    state start {
+        transition select(x_0) {
+            32w0: reject;
+        }
+    }
+}
+
+parser e();
+package top(e e);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/noMatch-midend.p4
+++ b/testdata/p4_16_samples_outputs/noMatch-midend.p4
@@ -1,0 +1,20 @@
+#include <core.p4>
+#include <v1model.p4>
+
+parser p() {
+    bit<32> x;
+    state start {
+        transition select(x) {
+            32w0: reject;
+            default: noMatch;
+        }
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
+    }
+}
+
+parser e();
+package top(e e);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/noMatch.p4
+++ b/testdata/p4_16_samples_outputs/noMatch.p4
@@ -1,0 +1,15 @@
+#include <core.p4>
+#include <v1model.p4>
+
+parser p() {
+    state start {
+        bit<32> x;
+        transition select(x) {
+            0: reject;
+        }
+    }
+}
+
+parser e();
+package top(e e);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/noMatch.p4-stderr
+++ b/testdata/p4_16_samples_outputs/noMatch.p4-stderr
@@ -1,0 +1,9 @@
+../testdata/p4_16_samples/noMatch.p4(20): warning: accept state in parser p is unreachable
+parser p() {
+       ^
+../testdata/p4_16_samples/noMatch.p4(23): warning: x may be uninitialized
+        transition select(x) {
+                          ^
+../testdata/p4_16_samples/noMatch.p4(20): warning: accept state in parser p is unreachable
+parser p() {
+       ^

--- a/testdata/p4_16_samples_outputs/parser-conditional-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-conditional-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p(out bit<32> b) {
     bit<32> a = 32w1;
     state start {

--- a/testdata/p4_16_samples_outputs/parser-conditional-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-conditional-frontend.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p(out bit<32> b) {
     bit<32> a_0;
     bool tmp;

--- a/testdata/p4_16_samples_outputs/parser-conditional-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-conditional-midend.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p(out bit<32> b) {
     bit<32> a;
     bool tmp_9;
@@ -16,6 +18,7 @@ parser p(out bit<32> b) {
         transition select(tmp_9) {
             true: start_true;
             false: start_false;
+            default: noMatch;
         }
     }
     state start_true {
@@ -34,6 +37,7 @@ parser p(out bit<32> b) {
         transition select(tmp_12) {
             true: start_true_0;
             false: start_false_0;
+            default: noMatch;
         }
     }
     state start_true_0 {
@@ -41,6 +45,7 @@ parser p(out bit<32> b) {
         transition select(tmp_14) {
             true: start_true_0_true;
             false: start_true_0_false;
+            default: noMatch;
         }
     }
     state start_true_0_true {
@@ -65,6 +70,10 @@ parser p(out bit<32> b) {
     state start_join_0 {
         b = tmp_13;
         transition accept;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/parser-conditional.p4
+++ b/testdata/p4_16_samples_outputs/parser-conditional.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p(out bit<32> b) {
     bit<32> a = 1;
     state start {

--- a/testdata/p4_16_samples_outputs/pipe-first.p4
+++ b/testdata/p4_16_samples_outputs/pipe-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 match_kind {
     ternary,
     exact
@@ -33,8 +35,6 @@ extern bs {
 struct Packet_data {
 }
 
-action NoAction() {
-}
 control P_pipe(inout TArg1 pArg1, inout TArg2 pArg2)(bit<32> t2Size) {
     action B_action(out bit<9> barg, BParamType bData) {
         barg = (bit<9>)bData;

--- a/testdata/p4_16_samples_outputs/pipe-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pipe-frontend.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 match_kind {
     ternary,
     exact
@@ -32,8 +34,6 @@ extern bs {
 struct Packet_data {
 }
 
-action NoAction() {
-}
 control P_pipe_0(inout TArg1 pArg1, inout TArg2 pArg2) {
     TArg1 tmp;
     TArg2 tmp_0;

--- a/testdata/p4_16_samples_outputs/pipe-midend.p4
+++ b/testdata/p4_16_samples_outputs/pipe-midend.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 match_kind {
     ternary,
     exact

--- a/testdata/p4_16_samples_outputs/pipe.p4
+++ b/testdata/p4_16_samples_outputs/pipe.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 match_kind {
     ternary,
     exact
@@ -33,8 +35,6 @@ extern bs {
 struct Packet_data {
 }
 
-action NoAction() {
-}
 control P_pipe(inout TArg1 pArg1, inout TArg2 pArg2)(bit<32> t2Size) {
     action B_action(out bit<9> barg, BParamType bData) {
         barg = (bit<9>)bData;

--- a/testdata/p4_16_samples_outputs/states-first.p4
+++ b/testdata/p4_16_samples_outputs/states-first.p4
@@ -1,6 +1,4 @@
-extern packet_in {
-    void extract<T>(out T hdr);
-}
+#include <core.p4>
 
 parser parse<H>(packet_in packet, out H headers);
 package ebpfFilter<H>(parse<H> prs);

--- a/testdata/p4_16_samples_outputs/states-frontend.p4
+++ b/testdata/p4_16_samples_outputs/states-frontend.p4
@@ -1,6 +1,4 @@
-extern packet_in {
-    void extract<T>(out T hdr);
-}
+#include <core.p4>
 
 parser parse<H>(packet_in packet, out H headers);
 package ebpfFilter<H>(parse<H> prs);

--- a/testdata/p4_16_samples_outputs/states-midend.p4
+++ b/testdata/p4_16_samples_outputs/states-midend.p4
@@ -1,6 +1,4 @@
-extern packet_in {
-    void extract<T>(out T hdr);
-}
+#include <core.p4>
 
 parser parse<H>(packet_in packet, out H headers);
 package ebpfFilter<H>(parse<H> prs);

--- a/testdata/p4_16_samples_outputs/states.p4
+++ b/testdata/p4_16_samples_outputs/states.p4
@@ -1,6 +1,4 @@
-extern packet_in {
-    void extract<T>(out T hdr);
-}
+#include <core.p4>
 
 parser parse<H>(packet_in packet, out H headers);
 package ebpfFilter<H>(parse<H> prs);

--- a/testdata/p4_16_samples_outputs/uninit-midend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-midend.p4
@@ -33,6 +33,7 @@ parser p1(packet_in p, out Header h) {
         transition select(h.isValid()) {
             true: next1;
             false: next2;
+            default: noMatch;
         }
     }
     state next1 {
@@ -46,6 +47,10 @@ parser p1(packet_in p, out Header h) {
     }
     state next3 {
         transition accept;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/value-sets-midend.p4
+++ b/testdata/p4_16_samples_outputs/value-sets-midend.p4
@@ -34,6 +34,7 @@ parser TopParser(packet_in b, out Parsed_packet p) {
         transition select(setIndex) {
             8w1: parse_trill;
             8w2: parse_vlan_tag;
+            default: noMatch;
         }
     }
     state parse_ipv4 {
@@ -50,6 +51,10 @@ parser TopParser(packet_in b, out Parsed_packet p) {
     }
     state parse_vlan_tag {
         transition accept;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/vss-example-midend.p4
+++ b/testdata/p4_16_samples_outputs/vss-example-midend.p4
@@ -64,6 +64,7 @@ parser TopParser(packet_in b, out Parsed_packet p) {
         b.extract<Ethernet_h>(p.ethernet);
         transition select(p.ethernet.etherType) {
             16w0x800: parse_ipv4;
+            default: noMatch;
         }
     }
     state parse_ipv4 {
@@ -79,6 +80,10 @@ parser TopParser(packet_in b, out Parsed_packet p) {
         tmp_14 = tmp_13;
         verify(tmp_14, error.IPv4ChecksumError);
         transition accept;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/vss-example.p4-stderr
+++ b/testdata/p4_16_samples_outputs/vss-example.p4-stderr
@@ -1,0 +1,6 @@
+../testdata/p4_16_samples/vss-example.p4(123): warning: out parameter nextHop may be uninitialized when ipv4_match terminates
+     table ipv4_match(out IPv4Address nextHop) {
+                                      ^^^^^^^
+../testdata/p4_16_samples/vss-example.p4(123)
+     table ipv4_match(out IPv4Address nextHop) {
+           ^^^^^^^^^^


### PR DESCRIPTION
As a consequence of this change, if a program does not include <core.p4> it may get undefined symbol errors at compilation, since this pass synthesizes code that refers to declarations in core.p4. Maybe we should arrange for the compiler to always load core.p4, even if the user does not specify it.
