### PR TITLE
Add version information to bmv2 JSON

### DIFF
--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1778,6 +1778,18 @@ void JsonConverter::padScalars() {
     }
 }
 
+void JsonConverter::addMetaInformation() {
+  auto meta = new Util::JsonObject();
+
+  static constexpr int version_major = 2;
+  static constexpr int version_minor = 0;
+  auto version = mkArrayField(meta, "version");
+  version->append(version_major);
+  version->append(version_minor);
+
+  toplevel.emplace("__meta__", meta);
+}
+
 void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
                             IR::ToplevelBlock* toplevelBlock) {
     this->toplevelBlock = toplevelBlock;
@@ -1813,6 +1825,7 @@ void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
         return;
     }
     toplevel.emplace("program", options.file);
+    addMetaInformation();
 
     headerTypes = mkArrayField(&toplevel, "header_types");
     headerInstances = mkArrayField(&toplevel, "headers");

--- a/backends/bmv2/jsonconverter.h
+++ b/backends/bmv2/jsonconverter.h
@@ -135,6 +135,9 @@ class JsonConverter final {
                      mpz_class& value, mpz_class& mask) const;
     void buildCfg(IR::P4Control* cont);
 
+    // Adds meta information (such as version) to the json
+    void addMetaInformation();
+
  public:
     explicit JsonConverter(const CompilerOptions& options);
     void convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap, IR::ToplevelBlock *toplevel);


### PR DESCRIPTION
The bmv2 JSON now includes a __meta__ entry, which for now only includes
version information (version number for JSON format). This commit makes
sure the bmv2 backend includes this entry in the JSON, as some tools
consumming the JSON may start performing a version check.