### PR TITLE
P4_14 extern features fixes

### DIFF
--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -447,14 +447,18 @@ bool ResolveReferences::preorder(const IR::Property *prop) {
     if (auto attr = dynamic_cast<const IR::Attribute *>(context->
                     resolveUnique(prop->name, ResolutionType::Any, false))) {
         if (attr->locals)
-            // FIXME Property with local names -- skip is at it will break otherwise
-            return false;
+            addToContext(attr->locals);
         if (attr->type->is<IR::Type::String>())
             // Attribute is arbitray string -- need not match anything
             return false; }
     return true;
 }
-void ResolveReferences::postorder(const IR::Property *) {
+void ResolveReferences::postorder(const IR::Property *prop) {
+    if (auto attr = dynamic_cast<const IR::Attribute *>(context->
+                    resolveUnique(prop->name, ResolutionType::Any, false))) {
+        if (attr->locals)
+            removeFromContext(attr->locals);
+    }
 }
 
 #undef PROCESS_NAMESPACE

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -138,6 +138,13 @@ ResolutionContext::resolveUnique(IR::ID name,
     return decls->at(0);
 }
 
+const IR::Type *
+ResolutionContext::resolveType(const IR::Type *type) const {
+    if (auto tname = type->to<IR::Type_Name>())
+        return resolveUnique(tname->path->name, ResolutionType::Type, false)->to<IR::Type>();
+    return type;
+}
+
 void ResolutionContext::dbprint(std::ostream& out) const {
     out << "Context stack[" << stack.size() << "]" << std::endl;
     for (auto it = stack.begin(); it != stack.end(); it++) {
@@ -422,6 +429,8 @@ void ResolveReferences::postorder(const IR::BlockStatement *b)
 
 bool ResolveReferences::preorder(const IR::Declaration_Instance *decl) {
     refMap->usedName(decl->name.name);
+    if (auto ext = context->resolveType(decl->type)->to<IR::Type_Extern>())
+        addToContext(ext);
     if (decl->initializer != nullptr)
         addToContext(decl->initializer);
     return true;
@@ -430,6 +439,22 @@ bool ResolveReferences::preorder(const IR::Declaration_Instance *decl) {
 void ResolveReferences::postorder(const IR::Declaration_Instance *decl) {
     if (decl->initializer != nullptr)
         removeFromContext(decl->initializer);
+    if (auto ext = context->resolveType(decl->type)->to<IR::Type_Extern>())
+        removeFromContext(ext);
+}
+
+bool ResolveReferences::preorder(const IR::Property *prop) {
+    if (auto attr = dynamic_cast<const IR::Attribute *>(context->
+                    resolveUnique(prop->name, ResolutionType::Any, false))) {
+        if (attr->locals)
+            // FIXME Property with local names -- skip is at it will break otherwise
+            return false;
+        if (attr->type->is<IR::Type::String>())
+            // Attribute is arbitray string -- need not match anything
+            return false; }
+    return true;
+}
+void ResolveReferences::postorder(const IR::Property *) {
 }
 
 #undef PROCESS_NAMESPACE

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -66,6 +66,9 @@ class ResolutionContext : public IHasDbPrint {
     // Resolve a reference for the specified name; expect a single result
     const IR::IDeclaration*
     resolveUnique(IR::ID name, ResolutionType type, bool previousOnly) const;
+
+    // Resolve a Type_Name to a concrete type
+    const IR::Type *resolveType(const IR::Type *type) const;
 };
 
 // No prerequisites, but it usually must be run over the whole program.
@@ -118,6 +121,7 @@ class ResolveReferences : public Inspector {
     DECLARE(Type_StructLike)
     DECLARE(BlockStatement)
     DECLARE(Declaration_Instance)
+    DECLARE(Property)
 #undef DECLARE
 
     bool preorder(const IR::Declaration_MatchKind* d) override;

--- a/frontends/p4-14/p4-14-parse.ypp
+++ b/frontends/p4-14/p4-14-parse.ypp
@@ -66,6 +66,8 @@ static const IR::Annotations *getPragmas() {
     IR::Annotations             *Annotations;
     IR::Apply                   *Apply;
     IR::Attribute               *Attribute;
+    IR::AttribLocal             *AttribLocal;
+    IR::AttribLocals            *AttribLocals;
     IR::CalculatedField         *CalculatedField;
     IR::CaseEntry               *CaseEntry;
     IR::Vector<IR::CaseEntry>   *CaseEntryList;
@@ -139,6 +141,8 @@ static const IR::Annotations *getPragmas() {
 %type<Annotations>      blackbox_method
 %type<Apply>            apply_case_list
 %type<Attribute>        blackbox_attribute
+%type<AttribLocal>      local_var
+%type<AttribLocals>     locals_list opt_locals_list
 %type<BBox>             blackbox_config
 %type<BBoxType>         blackbox_body
 %type<CalculatedField>  update_verify_spec_list
@@ -730,7 +734,7 @@ blackbox_body: /* epsilon */ {
 
 blackbox_attribute: /* epsilon */ { $$ = new IR::Attribute(@-1, $<str>-1); }
     | blackbox_attribute TYPE ':' type ';' { ($$=$1)->type = $4; }
-    | blackbox_attribute EXPRESSION_LOCAL_VARIABLES '{' opt_name_list '}'
+    | blackbox_attribute EXPRESSION_LOCAL_VARIABLES '{' opt_locals_list '}'
         { ($$=$1)->locals = $4; }
     | blackbox_attribute OPTIONAL ';'
         { ($$=$1)->optional = true; }
@@ -763,6 +767,16 @@ argument:
 ;
 
 inout: IN { $$ = IR::Direction::In; } | OUT { $$ = IR::Direction::Out; } ;
+
+opt_locals_list: { $$ = nullptr; } | locals_list ;
+locals_list:
+      local_var  { ($$ = new IR::AttribLocals())->locals[$1->name] = $1; }
+    | locals_list ',' local_var  { ($$ = $1)->locals[$3->name] = $3; }
+;
+local_var:
+      name              { $$ = new IR::AttribLocal(@1, $1); }
+    | type name         { $$ = new IR::AttribLocal(@1+@2, $1, $2); }
+;
 
 blackbox_instantiation:
       BLACKBOX name name ';'

--- a/frontends/p4-14/typecheck.cpp
+++ b/frontends/p4-14/typecheck.cpp
@@ -98,9 +98,8 @@ class TypeCheck::Pass1 : public Transform {
             if (auto bbox = prop_ctxt->parent->node->to<IR::Declaration_Instance>()) {
                 auto bbox_type = bbox->type->to<IR::Type_Extern>();
                 auto attr = bbox_type->attributes.get<IR::Attribute>(prop->name);
-                if (attr->locals && contains(attr->locals->names, ref->path->name)) {
-                    /* ref to local of property -- do something with it? */
-                    return ref; } } }
+                if (attr->locals && attr->locals->locals.count(ref->path->name)) {
+                    return attr->locals->locals.at(ref->path->name); } } }
         IR::Node *new_node = ref;
         if (auto hdr = global->get<IR::HeaderOrMetadata>(ref->path->name)) {
             visit(hdr);

--- a/frontends/p4-14/typecheck.cpp
+++ b/frontends/p4-14/typecheck.cpp
@@ -81,6 +81,16 @@ class TypeCheck::Pass1 : public Transform {
                 fl->fields.push_back(new IR::PathExpression(name));
                 fl->srcInfo += name.srcInfo; } }
         return flc; }
+    const IR::Node *preorder(IR::Property *prop) override {
+        if (auto di = findContext<IR::Declaration_Instance>()) {
+            auto ext = di->type->to<IR::Type_Extern>();
+            BUG_CHECK(ext, "%s is not an extern", di);
+            if (auto attr = ext->attributes[prop->name]) {
+                if (attr->type->is<IR::Type::String>())
+                    prune();
+            } else {
+                error("No property name %s in extern %s", prop->name, ext->name); } }
+        return prop; }
     const IR::Node *postorder(IR::PathExpression *ref) override {
         if (!global) return ref;
         const Visitor::Context *prop_ctxt = nullptr;

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -228,10 +228,20 @@ void ProgramStructure::createStructures() {
 void ProgramStructure::createExterns() {
     for (auto it : extern_types) {
         auto type = it.first;
+        IR::Type_Extern *modified_type = nullptr;
         if (type->name != it.second) {
             auto annos = addNameAnnotation(type->name.name, type->annotations);
-            type = new IR::Type_Extern(type->srcInfo, it.second, type->methods,
-                                       type->attributes, annos); }
+            type = modified_type = new IR::Type_Extern(type->srcInfo, it.second, type->methods,
+                                                       type->attributes, annos); }
+        // FIXME -- should create ctors based on attributes?  For now just create a
+        // FIXME -- 0-arg one if needed
+        if (!type->lookupMethod(type->name, 0)) {
+            if (!modified_type)
+                type = modified_type = type->clone();
+            auto methods = type->methods->clone();
+            modified_type->methods = methods;
+            methods->push_back(new IR::Method(type->name, new IR::Type_Method(
+                                                new IR::ParameterList()))); }
         declarations->push_back(type);
     }
 }
@@ -1447,6 +1457,17 @@ ProgramStructure::convert(const IR::CounterOrMeter* cm, cstring newName) {
 }
 
 const IR::Declaration_Instance*
+ProgramStructure::convertExtern(const IR::Declaration_Instance *ext, cstring newName) {
+    LOG1("Synthesizing " << ext);
+    auto *rv = ext->clone();
+    auto *et = rv->type->to<IR::Type_Extern>();
+    BUG_CHECK(et, "Extern %s is not extern type, but %s", ext, ext->type);
+    rv->name = newName;
+    rv->type = new IR::Type_Name(new IR::Path(extern_types.get(et)));
+    return rv;
+}
+
+const IR::Declaration_Instance*
 ProgramStructure::convertDirectMeter(const IR::Meter* m, cstring newName) {
     LOG1("Synthesizing " << m);
     auto meterOutput = m->result;
@@ -1565,7 +1586,7 @@ ProgramStructure::convertControl(const IR::V1Control* control, cstring newName) 
 
     for (auto c : externsToDo) {
         auto ext = externs.get(c);
-        // auto e = convert(ext, externs.get(ext));  -- no conversion needed?
+        ext = convertExtern(ext, externs.get(ext));
         stateful->push_back(ext);
     }
 

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -1464,7 +1464,7 @@ ProgramStructure::convertExtern(const IR::Declaration_Instance *ext, cstring new
     BUG_CHECK(et, "Extern %s is not extern type, but %s", ext, ext->type);
     rv->name = newName;
     rv->type = new IR::Type_Name(new IR::Path(extern_types.get(et)));
-    return rv;
+    return rv->apply(TypeConverter(this))->to<IR::Declaration_Instance>();;
 }
 
 const IR::Declaration_Instance*

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -163,6 +163,7 @@ class ProgramStructure {
     const IR::Declaration_Instance* convertDirectMeter(const IR::Meter* m, cstring newName);
     const IR::Declaration_Instance* convert(const IR::CounterOrMeter* cm, cstring newName);
     const IR::Declaration_Instance* convert(const IR::Register* reg, cstring newName);
+    const IR::Declaration_Instance* convertExtern(const IR::Declaration_Instance *ext, cstring newName);
     const IR::P4Table*
     convertTable(const IR::V1Table* table, cstring newName,
                  IR::IndexedVector<IR::Declaration>* stateful);

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -796,6 +796,7 @@ const IR::Node* TypeInference::preorder(IR::Declaration_Instance* decl) {
     visit(decl->type);
     visit(decl->arguments);
     visit(decl->annotations);
+    decl->properties.visit_children(*this);
 
     auto type = getTypeType(decl->type);
     if (type == nullptr) {

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -2402,6 +2402,12 @@ const IR::Node* TypeInference::postorder(IR::SelectExpression* expression) {
     return expression;
 }
 
+const IR::Node* TypeInference::postorder(IR::AttribLocal* local) {
+    setType(local, local->type);
+    setType(getOriginal(), local->type);
+    return local;
+}
+
 ///////////////////////////////////////// Statements et al.
 
 const IR::Node* TypeInference::postorder(IR::IfStatement* conditional) {

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -241,6 +241,7 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::SelectExpression* expression) override;
     const IR::Node* postorder(IR::DefaultExpression* expression) override;
     const IR::Node* postorder(IR::This* expression) override;
+    const IR::Node* postorder(IR::AttribLocal* local) override;
 
     const IR::Node* postorder(IR::ReturnStatement* stat) override;
     const IR::Node* postorder(IR::IfStatement* stat) override;

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -53,7 +53,7 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
         }
     }
 
-    if (dest->parameters->size() != src->arguments->size()) {
+    if (dest->parameters->size() < src->arguments->size()) {
         if (reportErrors)
             ::error("%1%: Passing %2% arguments when %3% expected",
                     errorPosition, src->arguments->size(), dest->parameters->size());
@@ -62,20 +62,28 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
 
     auto sit = src->arguments->begin();
     for (auto dit : *dest->parameters->getEnumerator()) {
+        bool optarg = dit->annotations->getSingle("optional") != nullptr;
+        if (sit == src->arguments->end()) {
+            if (optarg) continue;
+            if (reportErrors)
+                ::error("%1%: Not enough arguments for call", errorPosition);
+            return false; }
         auto arg = *sit;
         if ((dit->direction == IR::Direction::Out || dit->direction == IR::Direction::InOut) &&
             (!arg->leftValue)) {
+            if (optarg) continue;
             if (reportErrors)
                 ::error("%1%: Read-only value used for out/inout parameter %2%", arg->srcInfo, dit);
             return false;
         } else if (dit->direction == IR::Direction::None && !arg->compileTimeConstant) {
+            if (optarg) continue;
             if (reportErrors)
                 ::error("%1%: not a compile-time constant when binding to %2%", arg->srcInfo, dit);
             return false;
         }
 
-        if (dit->direction != IR::Direction::None &&
-            dit->type->is<IR::Type_Extern>()) {
+        if (dit->direction != IR::Direction::None && dit->type->is<IR::Type_Extern>()) {
+            if (optarg) continue;
             ::error("%1%: extern values cannot be passed in/out/inout", dit);
             return false;
         }

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -91,6 +91,10 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
         constraints->addEqualityConstraint(dit->type, arg->type);
         ++sit;
     }
+    if (sit != src->arguments->end()) {
+        if (reportErrors)
+            ::error("%1%: Too many arguments for call", errorPosition);
+        return false; }
 
     return true;
 }

--- a/ir/base.def
+++ b/ir/base.def
@@ -13,6 +13,7 @@ abstract Type {
     typedef Type_Unknown        Unknown;
     typedef Type_Boolean        Boolean;
     typedef Type_Bits           Bits;
+    typedef Type_String         String;
     typedef Type_Varbits        Varbits;
     typedef Type_Void           Void;
 #end

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -94,7 +94,8 @@ const Method* Type_Extern::lookupMethod(cstring name, int paramCount) const {
 
     bool reported = false;
     for (auto m : *methods) {
-        if (m->name == name && m->getParameterCount() == upc) {
+        if (m->name == name && m->minParameterCount() <= upc && m->maxParameterCount() >= upc) {
+
             if (result == nullptr) {
                 result = m;
             } else {

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -124,6 +124,14 @@ bool Type_ActionEnum::contains(cstring name) const {
     return false;
 }
 
+size_t Type_MethodBase::minParameterCount() const {
+    size_t rv = 0;
+    for (auto p : *parameters)
+        if (!p->annotations->getSingle("optional"))
+            ++rv;
+    return rv;
+}
+
 const Type* Type_Specialized::getP4Type() const {
     auto args = new IR::Vector<Type>();
     for (auto a : *arguments) {

--- a/ir/type.def
+++ b/ir/type.def
@@ -133,6 +133,10 @@ class ParameterList : ISimpleNamespace {
         }
         return result;
     }
+#emit
+    decltype(parameters->begin()) begin() const { return parameters->begin(); }
+    decltype(parameters->end()) end() const { return parameters->end(); }
+#end
 }
 
 // Represents a type variable written by the user
@@ -405,7 +409,8 @@ abstract Type_MethodBase : Type, IMayBeGenericType {
     // nullptr for constructors or functors; nullptr is not void
     ParameterList parameters;
 
-    size_t getParameterCount() const { return parameters->size(); }
+    size_t maxParameterCount() const { return parameters->size(); }
+    size_t minParameterCount() const;
     virtual TypeParameters getTypeParameters() const override { return typeParameters; }
     void dbprint(std::ostream& out) const override;
     toString {
@@ -457,7 +462,8 @@ class Method : Declaration {
     Type_Method type;
     optional bool isAbstract = false;
     optional Annotations annotations = Annotations::empty;
-    size_t getParameterCount() const { return type->getParameterCount(); }
+    size_t maxParameterCount() const { return type->maxParameterCount(); }
+    size_t minParameterCount() const { return type->minParameterCount(); }
     void setAbstract() { isAbstract = true; }
 }
 

--- a/ir/type.def
+++ b/ir/type.def
@@ -476,7 +476,8 @@ class Type_Extern : Type_Declaration, IGeneralNamespace, IMayBeGenericType {
     optional Annotations annotations = Annotations::empty;
 
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return methods->getEnumerator()->as<const IDeclaration*>(); }
+        return methods->getEnumerator()->as<const IDeclaration*>()
+            ->concat(attributes.valueEnumerator()->as<const IDeclaration*>()); }
     virtual TypeParameters getTypeParameters() const override { return typeParameters; }
     Method lookupMethod(cstring name, int argCount) const;
     validate{ methods->check_null(); }

--- a/ir/v1.cpp
+++ b/ir/v1.cpp
@@ -137,5 +137,7 @@ const IR::Type *IR::Primitive::inferOperandType(int operand) const {
                 if (tbl->instance_count > 0) {
                     int width = ceil_log2(tbl->instance_count);
                     return IR::Type::Bits::get(width); } } } }
+    if (name.startsWith("execute_stateful") && operand == 1) {
+            return IR::Type::Bits::get(32); }
     return IR::Type::Unknown::get();
 }

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -431,9 +431,23 @@ class V1Control {
     toString { return node_type_name() + " " + name; }
 }
 
+class AttribLocal : Expression, IDeclaration {
+    ID  name;
+#nodbprint
+    ID getName() const override { return name; }
+}
+
+class AttribLocals : ISimpleNamespace {
+    inline NameMap<AttribLocal> locals = {};
+#nodbprint
+    Util::Enumerator<IDeclaration> *getDeclarations() const override {
+        return locals.valueEnumerator()->as<const IDeclaration *>(); }
+    IDeclaration getDeclByName(cstring name) const override { return locals[name]; }
+}
+
 class Attribute : Declaration {
     NullOK Type type = nullptr;
-    NullOK NameList locals = nullptr;
+    NullOK AttribLocals locals = nullptr;
     bool optional = false;
 #nodbprint
 }

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -343,3 +343,22 @@ bool ControlFlowVisitor::join_flows(const IR::Node *n) {
             return true; } }
     return false;
 }
+
+void Inspector::check_clone(const Visitor *v) {
+    auto *t = dynamic_cast<const Inspector *>(v);
+    BUG_CHECK(t && t->visited == visited, "Clone failed to copy base object");
+}
+void Modifier::check_clone(const Visitor *v) {
+    auto *t = dynamic_cast<const Modifier *>(v);
+    BUG_CHECK(t && t->visited == visited, "Clone failed to copy base object");
+}
+void Transform::check_clone(const Visitor *v) {
+    auto *t = dynamic_cast<const Transform *>(v);
+    BUG_CHECK(t && t->visited == visited, "Clone failed to copy base object");
+}
+
+ControlFlowVisitor &ControlFlowVisitor::flow_clone() {
+    auto *rv = clone();
+    rv->check_clone(this);
+    return *rv;
+}


### PR DESCRIPTION
This fixes a bunch of issues that come up with P4_14 code that use more complex extern objects when translating to P4_16.  Part of the issue is that P4_14 externs may be more capable that P4_16 externs; I'm not completely sure.  The code does not currently try to convert P4_14 extern attributes to constructor arguments, as that seems tough in general, and has difficulty with optional attributes.