### PR TITLE
Mark Node::getNode() final

### DIFF
--- a/ir/node.h
+++ b/ir/node.h
@@ -90,8 +90,8 @@ class Node : public virtual INode {
     virtual Node *clone() const = 0;
     void dbprint(std::ostream &out) const override;
     virtual void dump_fields(std::ostream &) const { }
-    const Node* getNode() const override { return this; }
-    Node* getNode() override { return this; }
+    const Node* getNode() const override final { return this; }
+    Node* getNode() override final { return this; }
     Util::SourceInfo getSourceInfo() const override { return srcInfo; }
     cstring node_type_name() const override { return "Node"; }
     static cstring static_type_name() { return "Node"; }


### PR DESCRIPTION
There are no overrides for Node::getNode(), and it seems to me that it would have rather unintuitive results if there were, so unless we have a specific reason to support this, let's mark getNode() final. This has the side benefit of helping the compiler devirtualize the call.