### PR TITLE
Turn libfrontend.a into a libtool library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,9 +26,10 @@ GEN_UNIFIED_CPP=$(TOOLSDIR)/gen-unified-sources.py
 .l.c:
 	$(LEX.l) $< > $@
 
-# Variables that are appended to in sub-Makefiles
-# Please use += to add values to these variables
-# The first 7 are standard automake variables
+################ Variables populated in subproject Makefiles
+# Please use += to append values to these variables.
+
+# Standard automake variables.
 CLEANFILES =                   # Files to remove on clean
 bin_PROGRAMS =                 # Binaries built
 noinst_LTLIBRARIES =           # Libtool convenience libraries
@@ -37,6 +38,8 @@ noinst_LIBRARIES =             # Static libraries built
 noinst_PROGRAMS =              # Binaries built that are not installed
 BUILT_SOURCES =                # Generated source files
 TESTS =                        # Tests to execute
+
+# Variables specific to our build system.
 XFAIL_TESTS = $(IFAIL_TESTS)   # Tests that are supposed to fail
 IFAIL_TESTS =                  # intermittent failures
 export XFAIL_TESTS
@@ -44,6 +47,8 @@ export IFAIL_TESTS
 cpplint_FILES =                # Files that should be passed to cpplint (and etags)
 ir_DEF_FILES =                 # Files that generate the IR
 extension_frontend_SOURCES =   # Files added to libfrontend by extensions
+
+################ Subproject Makefile inclusions
 
 include $(srcdir)/lib/Makefile.am
 include $(srcdir)/tools/ir-generator/Makefile.am

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,7 @@ GEN_UNIFIED_CPP=$(TOOLSDIR)/gen-unified-sources.py
 # The first 7 are standard automake variables
 CLEANFILES =                   # Files to remove on clean
 bin_PROGRAMS =                 # Binaries built
+noinst_LTLIBRARIES =           # Libtool convenience libraries
 noinst_HEADERS =               # Headers that are not installed
 noinst_LIBRARIES =             # Static libraries built
 noinst_PROGRAMS =              # Binaries built that are not installed
@@ -82,8 +83,8 @@ BUILT_SOURCES += \
 ################
 
 # Front-end library
-noinst_LIBRARIES += libfrontend.a
-libfrontend_a_SOURCES = \
+noinst_LTLIBRARIES += libfrontend.la
+libfrontend_la_SOURCES = \
 	setup.h \
 	setup.cpp \
 	$(frontend_SOURCES) \

--- a/backends/bmv2/Makefile.am
+++ b/backends/bmv2/Makefile.am
@@ -17,7 +17,7 @@
 # To be included in the main P4C compiler makefile
 
 bin_PROGRAMS += p4c-bm2-ss
-p4c_bm2_ss_LDADD = libfrontend.a libp4ctoolkit.a
+p4c_bm2_ss_LDADD = libfrontend.la libp4ctoolkit.a
 
 p4c_bm2_ss_UNIFIED = \
 	backends/bmv2/bmv2.cpp \

--- a/backends/ebpf/Makefile.am
+++ b/backends/ebpf/Makefile.am
@@ -16,7 +16,7 @@
 # To be included in the main P4C compiler makefile
 
 bin_PROGRAMS += p4c-ebpf
-p4c_ebpf_LDADD = libfrontend.a libp4ctoolkit.a
+p4c_ebpf_LDADD = libfrontend.la libp4ctoolkit.a
 
 p4c_ebpf_UNIFIED = \
 	backends/ebpf/p4c-ebpf.cpp \

--- a/backends/p4test/Makefile.am
+++ b/backends/p4test/Makefile.am
@@ -16,7 +16,7 @@
 # To be included in the main P4C compiler makefile
 
 noinst_PROGRAMS += p4test
-p4test_LDADD = libfrontend.a libp4ctoolkit.a
+p4test_LDADD = libfrontend.la libp4ctoolkit.a
 
 p4test_UNIFIED = \
     backends/p4test/p4test.cpp \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -32,14 +32,14 @@ path_test_SOURCES = test/unittests/path_test.cpp
 path_test_LDADD = libp4ctoolkit.a
 json_test_SOURCES = test/unittests/json_test.cpp
 json_test_LDADD = libp4ctoolkit.a
-call_graph_test_SOURCES = $(ir_SOURCES) test/unittests/call_graph_test.cpp
-call_graph_test_LDADD = libp4ctoolkit.a libfrontend.a
-unittest_transform1_SOURCES = $(ir_SOURCES) test/unittests/transform1.cpp
-unittest_transform1_LDADD = libfrontend.a libp4ctoolkit.a
-dumpjson_SOURCES = $(ir_SOURCES) test/unittests/dumpjson.cpp
-dumpjson_LDADD = libfrontend.a libp4ctoolkit.a
-opeq_test_SOURCES = $(ir_SOURCES) test/unittests/opeq_test.cpp
-opeq_test_LDADD = libfrontend.a libp4ctoolkit.a
+call_graph_test_SOURCES = test/unittests/call_graph_test.cpp
+call_graph_test_LDADD = libp4ctoolkit.a libfrontend.la
+unittest_transform1_SOURCES = test/unittests/transform1.cpp
+unittest_transform1_LDADD = libfrontend.la libp4ctoolkit.a
+dumpjson_SOURCES = test/unittests/dumpjson.cpp
+dumpjson_LDADD = libfrontend.la libp4ctoolkit.a
+opeq_test_SOURCES = test/unittests/opeq_test.cpp
+opeq_test_LDADD = libfrontend.la libp4ctoolkit.a
 
 # Compiler tests
 


### PR DESCRIPTION
This PR contains the portion of #239 that involves converting `libfrontend` into a libtool library; see that PR for the motivation.

The version of this patch in #239 was cherry-picked and then backed out because it resulted in `libfrontend` being generated as a dynamic library. It turns out that this is the default behavior for libtool libraries which are installed - that is, this is what happens by default if you use `lib_LTLIBRARIES`. Since this is a convenience library which is only intended to be linked into other libraries or executables, we don't want to install it, and `noinst_LTLIBRARIES` is a better fit. What's nice is that `noinst_LTLIBRARIES` also defaults to generating a static library, so this kills two birds with one stone.