### PR TITLE
More general support for errors in bmv2 backend

### DIFF
--- a/backends/bmv2/jsonconverter.h
+++ b/backends/bmv2/jsonconverter.h
@@ -147,8 +147,8 @@ class JsonConverter final {
 
     // Adds declared errors to json
     void addErrors();
-    // Retrieve assigned numerical value for given error constant (expr must be IR::Member)
-    ErrorValue retrieveErrorValue(const IR::Expression* expr) const;
+    // Retrieve assigned numerical value for given error constant
+    ErrorValue retrieveErrorValue(const IR::Member* mem) const;
 
  public:
     explicit JsonConverter(const CompilerOptions& options);

--- a/testdata/p4_16_samples/verify-bmv2.p4
+++ b/testdata/p4_16_samples/verify-bmv2.p4
@@ -26,6 +26,8 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     state start {
         verify(meta.x == 0, error.NewError);
         verify(true, error.NoError);
+        error e = error.NoError;
+        verify(true, e);
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/verify-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2-first.p4
@@ -15,6 +15,8 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     state start {
         verify(meta.x == 8s0, error.NewError);
         verify(true, error.NoError);
+        error e = error.NoError;
+        verify(true, e);
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/verify-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2-frontend.p4
@@ -12,11 +12,14 @@ struct h {
 }
 
 parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t std) {
+    error e_0;
     bool tmp;
     state start {
         tmp = meta.x == 8s0;
         verify(tmp, error.NewError);
         verify(true, error.NoError);
+        e_0 = error.NoError;
+        verify(true, e_0);
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/verify-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2-midend.p4
@@ -12,11 +12,14 @@ struct h {
 }
 
 parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t std) {
+    error e;
     bool tmp_0;
     state start {
         tmp_0 = meta.x == 8s0;
         verify(tmp_0, error.NewError);
         verify(true, error.NoError);
+        e = error.NoError;
+        verify(true, e);
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/verify-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2.p4
@@ -15,6 +15,8 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     state start {
         verify(meta.x == 0, error.NewError);
         verify(true, error.NoError);
+        error e = error.NoError;
+        verify(true, e);
         transition accept;
     }
 }


### PR DESCRIPTION
Added support for error constants in all expressions (not just verify
statements). Also the verify statement in bmv2 now accepts arbitrary
expressions, which enables us to have more general support.