### PR TITLE
Add support for enums in bmv2 backend

### DIFF
--- a/backends/bmv2/bmv2.cpp
+++ b/backends/bmv2/bmv2.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *const argv[]) {
         return 1;
 
     BMV2::JsonConverter converter(options);
-    converter.convert(&midEnd.refMap, &midEnd.typeMap, toplevel);
+    converter.convert(&midEnd.refMap, &midEnd.typeMap, toplevel, &midEnd.enumMap);
     if (::errorCount() > 0)
         return 1;
 

--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1833,12 +1833,15 @@ void JsonConverter::addMetaInformation() {
 }
 
 void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
-                            IR::ToplevelBlock* toplevelBlock) {
+                            IR::ToplevelBlock* toplevelBlock,
+                            P4::ConvertEnums::EnumMapping* enumMap) {
     this->toplevelBlock = toplevelBlock;
     this->refMap = refMap;
     this->typeMap = typeMap;
+    this->enumMap = enumMap;
     CHECK_NULL(typeMap);
     CHECK_NULL(refMap);
+    CHECK_NULL(enumMap);
 
     auto package = toplevelBlock->getMain();
     if (package == nullptr) {
@@ -1899,6 +1902,8 @@ void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
     ErrorCodesVisitor errorCodesVisitor(this);
     toplevelBlock->getProgram()->apply(errorCodesVisitor);
     addErrors();
+
+    addEnums();
 
     auto prsrs = mkArrayField(&toplevel, "parsers");
     auto parserJson = toJson(parser);
@@ -2478,6 +2483,23 @@ JsonConverter::ErrorValue JsonConverter::retrieveErrorValue(const IR::Expression
     BUG_CHECK(type->is<IR::Type_Error>(), "Not an error constant");
     auto decl = type->to<IR::Type_Error>()->getDeclByName(mem->member.name);
     return errorCodesMap.at(decl);
+}
+
+void JsonConverter::addEnums() {
+    CHECK_NULL(enumMap);
+    auto enums = mkArrayField(&toplevel, "enums");
+    for (const auto &pEnum : *enumMap) {
+        auto enumName = pEnum.first->getName().name.c_str();
+        auto enumObj = new Util::JsonObject();
+        enumObj->emplace("name", enumName);
+        auto entries = mkArrayField(enumObj, "entries");
+        for (const auto &pEntry : *pEnum.second) {
+            auto entry = pushNewArray(entries);
+            entry->append(pEntry.first);
+            entry->append(pEntry.second);
+        }
+        enums->append(enumObj);
+    }
 }
 
 }  // namespace BMV2

--- a/backends/bmv2/jsonconverter.h
+++ b/backends/bmv2/jsonconverter.h
@@ -79,6 +79,7 @@ class JsonConverter final {
     using ErrorValue = unsigned int;
     using ErrorCodesMap = std::unordered_map<const IR::IDeclaration *, ErrorValue>;
     ErrorCodesMap errorCodesMap{};
+    P4::ConvertEnums::EnumMapping* enumMap;
 
  private:
     Util::JsonArray *headerTypes;
@@ -150,9 +151,13 @@ class JsonConverter final {
     // Retrieve assigned numerical value for given error constant (expr must be IR::Member)
     ErrorValue retrieveErrorValue(const IR::Expression* expr) const;
 
+    // Adds declared enums to json
+    void addEnums();
+
  public:
     explicit JsonConverter(const CompilerOptions& options);
-    void convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap, IR::ToplevelBlock *toplevel);
+    void convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap, IR::ToplevelBlock *toplevel,
+                 P4::ConvertEnums::EnumMapping* enumMap);
     void serialize(std::ostream& out) const
     { toplevel.serialize(out); }
 };

--- a/backends/bmv2/midend.cpp
+++ b/backends/bmv2/midend.cpp
@@ -88,9 +88,10 @@ class EnumOn32Bits : public P4::ChooseEnumRepresentation {
 void MidEnd::setup_for_P4_16(CompilerOptions&) {
     // we may come through this path even if the program is actually a P4 v1.0 program
     auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
+    auto convertEnums = new P4::ConvertEnums(&refMap, &typeMap, new EnumOn32Bits());
     addPasses({
-        new P4::ConvertEnums(&refMap, &typeMap,
-                             new EnumOn32Bits()),
+        convertEnums,
+        new VisitFunctor([this, convertEnums]() { enumMap = convertEnums->getEnumMapping(); }),
         new P4::RemoveReturns(&refMap),
         new P4::MoveConstructors(&refMap),
         new P4::RemoveAllUnusedDeclarations(&refMap),

--- a/backends/bmv2/midend.h
+++ b/backends/bmv2/midend.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "frontends/p4/evaluator/evaluator.h"
 #include "midend/actionsInlining.h"
 #include "midend/inlining.h"
+#include "midend/convertEnums.h"
 
 namespace BMV2 {
 
@@ -35,9 +36,10 @@ class MidEnd : public PassManager {
 
  public:
     // These will be accurate when the mid-end completes evaluation
-    P4::ReferenceMap    refMap;
-    P4::TypeMap         typeMap;
-    IR::ToplevelBlock   *toplevel = nullptr;  // Should this be const?
+    P4::ReferenceMap refMap;
+    P4::TypeMap typeMap;
+    IR::ToplevelBlock *toplevel = nullptr;  // Should this be const?
+    P4::ConvertEnums::EnumMapping enumMap;
 
     explicit MidEnd(CompilerOptions& options);
     IR::ToplevelBlock* process(const IR::P4Program *&program) {


### PR DESCRIPTION
Starting with version 2.3, the bmv2 JSON supports declaring enums. See
https://github.com/p4lang/behavioral-model/pull/270 for more
information.

The bmv2 backend was already converting enums to integers (under certain
conditions). In this PR, we simply reteieve the mapping enums -> int and
dump it to the JSON file. In order to do this, the ConvertEnums midend
pass had to be slightly modified to give the backend access to the
produced mapping.