### PR TITLE
Fix for issue #249

### DIFF
--- a/backends/bmv2/Makefile.am
+++ b/backends/bmv2/Makefile.am
@@ -23,13 +23,11 @@ p4c_bm2_ss_UNIFIED = \
 	backends/bmv2/bmv2.cpp \
 	backends/bmv2/analyzer.cpp \
 	backends/bmv2/jsonconverter.cpp \
-	backends/bmv2/inlining.cpp \
 	backends/bmv2/midend.cpp \
 	backends/bmv2/lower.cpp
 
 noinst_HEADERS += \
 	backends/bmv2/analyzer.h \
-	backends/bmv2/inlining.h \
 	backends/bmv2/jsonconverter.h \
 	backends/bmv2/lower.h \
 	backends/bmv2/midend.h
@@ -50,4 +48,3 @@ bmv2tests.mk: $(GENTESTS) $(srcdir)/%reldir%/Makefile.am \
 	      $(srcdir)/testdata/p4_14_samples/switch_*/switch.p4 \
 	      $(srcdir)/testdata/p4_16_samples $(srcdir)/testdata/p4_14_samples
 	@$(GENTESTS) $(srcdir) bmv2 $(srcdir)/backends/bmv2/run-bmv2-test.py $^ >$@
-

--- a/backends/bmv2/analyzer.cpp
+++ b/backends/bmv2/analyzer.cpp
@@ -293,7 +293,7 @@ class DiscoverStructure : public Inspector {
 };
 }  // namespace
 
-void ProgramParts::analyze(IR::ToplevelBlock* toplevel) {
+void ProgramParts::analyze(const IR::ToplevelBlock* toplevel) {
     DiscoverStructure disc(this);
     toplevel->getProgram()->apply(disc);
 }

--- a/backends/bmv2/analyzer.cpp
+++ b/backends/bmv2/analyzer.cpp
@@ -253,7 +253,7 @@ void CFG::build(const IR::P4Control* cc,
                 P4::ReferenceMap* refMap, P4::TypeMap* typeMap) {
     container = cc;
     entryPoint = makeNode(cc->name + ".entry");
-    exitPoint = makeNode(cc->name + ".exit");
+    exitPoint = makeNode("");  // the only node with an empty name
 
     CFGBuilder builder(this, refMap, typeMap);
     auto startValue = new CFG::EdgeSet(new CFG::Edge(entryPoint));

--- a/backends/bmv2/analyzer.h
+++ b/backends/bmv2/analyzer.h
@@ -185,7 +185,7 @@ class ProgramParts {
     std::vector<const IR::Declaration_Variable*> variables;
 
     ProgramParts() {}
-    void analyze(IR::ToplevelBlock* toplevel);
+    void analyze(const IR::ToplevelBlock* toplevel);
 };
 
 }  // namespace BMV2

--- a/backends/bmv2/analyzer.h
+++ b/backends/bmv2/analyzer.h
@@ -74,13 +74,15 @@ class CFG final : public IHasDbPrint {
         const IR::P4Table* table;
         const IR::Expression*      invocation;
         explicit TableNode(const IR::P4Table* table, const IR::Expression* invocation)
-        : Node(table->externalName()), table(table), invocation(invocation) {}
+        : Node(table->externalName()), table(table), invocation(invocation)
+        { CHECK_NULL(table); CHECK_NULL(invocation); }
     };
 
     class IfNode final : public Node {
      public:
         const IR::IfStatement* statement;
-        explicit IfNode(const IR::IfStatement* statement) : statement(statement) {}
+        explicit IfNode(const IR::IfStatement* statement) : statement(statement)
+        { CHECK_NULL(statement); }
     };
 
     class DummyNode final : public Node {

--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1309,6 +1309,7 @@ JsonConverter::convertTable(const CFG::TableNode* node,
                         auto bim = mi->to<P4::BuiltInMethod>();
                         if (bim->name == IR::Type_Header::isValid) {
                             expr = new IR::Member(bim->appliedTo, "$valid$");
+                            typeMap->setType(expr, IR::Type_Boolean::get());
                         }
                     }
                 }
@@ -1837,7 +1838,7 @@ void JsonConverter::addMetaInformation() {
 }
 
 void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
-                            IR::ToplevelBlock* toplevelBlock,
+                            const IR::ToplevelBlock* toplevelBlock,
                             P4::ConvertEnums::EnumMapping* enumMap) {
     this->toplevelBlock = toplevelBlock;
     this->refMap = refMap;

--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -732,7 +732,7 @@ class ExpressionConverter : public Inspector {
 JsonConverter::JsonConverter(const CompilerOptions& options) :
         options(options), v1model(P4V1::V1Model::instance),
         corelib(P4::P4CoreLibrary::instance),
-        refMap(nullptr), typeMap(nullptr), dropActionId(0), toplevelBlock(nullptr),
+        refMap(nullptr), typeMap(nullptr), toplevelBlock(nullptr),
         conv(new ExpressionConverter(this)),
         headerParameter(nullptr), userMetadataParameter(nullptr), stdMetadataParameter(nullptr)
 {}

--- a/backends/bmv2/jsonconverter.h
+++ b/backends/bmv2/jsonconverter.h
@@ -60,9 +60,7 @@ class JsonConverter final {
     P4::ReferenceMap*      refMap;
     P4::TypeMap*           typeMap;
     ProgramParts           structure;
-    cstring                dropAction = ".drop";
     cstring                scalarsName;  // name of struct in JSON holding all scalars
-    unsigned               dropActionId;
     IR::ToplevelBlock*     toplevelBlock;
     ExpressionConverter*   conv;
     DirectMeterMap         meterMap;

--- a/backends/bmv2/jsonconverter.h
+++ b/backends/bmv2/jsonconverter.h
@@ -61,7 +61,7 @@ class JsonConverter final {
     P4::TypeMap*           typeMap;
     ProgramParts           structure;
     cstring                scalarsName;  // name of struct in JSON holding all scalars
-    IR::ToplevelBlock*     toplevelBlock;
+    const IR::ToplevelBlock* toplevelBlock;
     ExpressionConverter*   conv;
     DirectMeterMap         meterMap;
     const IR::Parameter*   headerParameter;
@@ -154,7 +154,7 @@ class JsonConverter final {
 
  public:
     explicit JsonConverter(const CompilerOptions& options);
-    void convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap, IR::ToplevelBlock *toplevel,
+    void convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap, const IR::ToplevelBlock *toplevel,
                  P4::ConvertEnums::EnumMapping* enumMap);
     void serialize(std::ostream& out) const
     { toplevel.serialize(out); }

--- a/backends/bmv2/lower.cpp
+++ b/backends/bmv2/lower.cpp
@@ -125,4 +125,36 @@ const IR::Node* LowerExpressions::postorder(IR::Concat* expression) {
     return result;
 }
 
+/////////////////////////////////////////////////////////////
+
+const IR::Node* FixupChecksum::preorder(IR::P4Control* control) {
+    if (control->name != *updateBlockName)
+        return control;
+    // Convert
+    // tmp = e;
+    // f = tmp;
+    // into
+    // f = e;
+    auto instrs = control->body->components;
+    if (instrs->size() != 2)
+        return control;
+    if (!instrs->at(0)->is<IR::AssignmentStatement>() || !instrs->at(1)->is<IR::AssignmentStatement>())
+        return control;
+    auto ass0 = instrs->at(0)->to<IR::AssignmentStatement>();
+    auto ass1 = instrs->at(1)->to<IR::AssignmentStatement>();
+    if (!ass0->left->is<IR::PathExpression>() || !ass1->right->is<IR::PathExpression>())
+        return control;
+    auto pe0 = ass0->left->to<IR::PathExpression>();
+    auto pe1 = ass1->right->to<IR::PathExpression>();
+    if (pe0->path->name != pe1->path->name ||
+        pe0->path->absolute != pe1->path->absolute)
+        return control;
+    auto ass = new IR::AssignmentStatement(ass1->srcInfo, ass1->left, ass0->right);
+    auto vec = new IR::IndexedVector<IR::StatOrDecl>();
+    vec->push_back(ass);
+    auto block = new IR::BlockStatement(control->body->srcInfo, control->body->annotations, vec);
+    control->body = block;
+    return control;
+}
+
 }  // namespace BMV2

--- a/backends/bmv2/lower.cpp
+++ b/backends/bmv2/lower.cpp
@@ -138,7 +138,8 @@ const IR::Node* FixupChecksum::preorder(IR::P4Control* control) {
     auto instrs = control->body->components;
     if (instrs->size() != 2)
         return control;
-    if (!instrs->at(0)->is<IR::AssignmentStatement>() || !instrs->at(1)->is<IR::AssignmentStatement>())
+    if (!instrs->at(0)->is<IR::AssignmentStatement>() ||
+        !instrs->at(1)->is<IR::AssignmentStatement>())
         return control;
     auto ass0 = instrs->at(0)->to<IR::AssignmentStatement>();
     auto ass1 = instrs->at(1)->to<IR::AssignmentStatement>();

--- a/backends/bmv2/lower.h
+++ b/backends/bmv2/lower.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "ir/ir.h"
 #include "frontends/p4/typeMap.h"
+#include "frontends/common/resolveReferences/resolveReferences.h"
 
 namespace BMV2 {
 
@@ -43,6 +44,19 @@ class LowerExpressions : public Transform {
     const IR::Node* postorder(IR::Concat* expression) override;
     const IR::Node* preorder(IR::P4Table* table) override
     { prune(); return table; }  // don't simplify expressions in table
+};
+
+// TODO: FIXME
+// This pass is a hack to work around current BMv2 limitations:
+// checksum computations must be expressed in a restricted way, since
+// the JSON code generator uses simple pattern-matching.
+class FixupChecksum : public Transform {
+    const cstring* updateBlockName;
+ public:
+    explicit FixupChecksum(const cstring* updateBlockName) :
+            updateBlockName(updateBlockName)
+    { setName("FixupChecksum"); }
+    const IR::Node* preorder(IR::P4Control* control) override;
 };
 
 }  // namespace BMV2

--- a/backends/bmv2/midend.cpp
+++ b/backends/bmv2/midend.cpp
@@ -90,7 +90,7 @@ class SkipControls : public P4::ActionSynthesisPolicy {
     const std::set<cstring> *skip;
 
  public:
-    SkipControls(const std::set<cstring> *skip) : skip(skip) { CHECK_NULL(skip); }
+    explicit SkipControls(const std::set<cstring> *skip) : skip(skip) { CHECK_NULL(skip); }
     bool convert(const IR::P4Control* control) const {
         if (skip->find(control->name) != skip->end())
             return false;
@@ -114,7 +114,7 @@ MidEnd::MidEnd(CompilerOptions& options) {
         new P4::RemoveAllUnusedDeclarations(&refMap),
         new P4::ClearTypeMap(&typeMap),
         evaluator,
-        new VisitFunctor([this,v1controls,evaluator](const IR::Node *root) -> const IR::Node* {
+        new VisitFunctor([this, v1controls, evaluator](const IR::Node *root) -> const IR::Node* {
             auto toplevel = evaluator->getToplevelBlock();
             auto main = toplevel->getMain();
             if (main == nullptr)

--- a/backends/bmv2/midend.h
+++ b/backends/bmv2/midend.h
@@ -29,20 +29,21 @@ namespace BMV2 {
 class MidEnd : public PassManager {
 #if 0
     void setup_for_P4_14(CompilerOptions& options);
-#endif
     void setup_for_P4_16(CompilerOptions& options);
+#endif
     P4::InlineWorkList controlsToInline;
     P4::ActionsInlineList actionsToInline;
+    cstring updateControlBlockName;
 
  public:
     // These will be accurate when the mid-end completes evaluation
-    P4::ReferenceMap refMap;
-    P4::TypeMap typeMap;
-    IR::ToplevelBlock *toplevel = nullptr;  // Should this be const?
+    P4::ReferenceMap    refMap;
+    P4::TypeMap         typeMap;
+    const IR::ToplevelBlock   *toplevel = nullptr;
     P4::ConvertEnums::EnumMapping enumMap;
 
     explicit MidEnd(CompilerOptions& options);
-    IR::ToplevelBlock* process(const IR::P4Program *&program) {
+    const IR::ToplevelBlock* process(const IR::P4Program *&program) {
         program = program->apply(*this);
         return toplevel; }
 };

--- a/backends/ebpf/Makefile.am
+++ b/backends/ebpf/Makefile.am
@@ -21,7 +21,7 @@ p4c_ebpf_LDADD = libfrontend.a libp4ctoolkit.a
 p4c_ebpf_UNIFIED = \
 	backends/ebpf/p4c-ebpf.cpp \
 	backends/ebpf/ebpfBackend.cpp \
-	backends/ebpf/ebpfObject.cpp \
+	backends/ebpf/ebpfProgram.cpp \
 	backends/ebpf/ebpfTable.cpp \
 	backends/ebpf/ebpfControl.cpp \
 	backends/ebpf/ebpfParser.cpp \
@@ -37,6 +37,7 @@ noinst_HEADERS += \
 	backends/ebpf/ebpfControl.h \
 	backends/ebpf/ebpfModel.h \
 	backends/ebpf/ebpfObject.h \
+	backends/ebpf/ebpfProgram.h \
 	backends/ebpf/ebpfOptions.h \
 	backends/ebpf/ebpfParser.h \
 	backends/ebpf/ebpfTable.h \

--- a/backends/ebpf/ebpfBackend.cpp
+++ b/backends/ebpf/ebpfBackend.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "ebpfBackend.h"
 #include "target.h"
 #include "ebpfType.h"
+#include "ebpfProgram.h"
 
 namespace EBPF {
 

--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -95,8 +95,8 @@ class ControlBodyTranslationVisitor : public CodeGenInspector {
         auto ac = mi->to<P4::ActionCall>();
         if (ac != nullptr) {
             // Action arguments have been eliminated by the mid-end.
-            BUG_CHECK(expression->arguments->size() == 0, "%1%: unexpected arguments for action call",
-                      expression);
+            BUG_CHECK(expression->arguments->size() == 0,
+                      "%1%: unexpected arguments for action call", expression);
             visit(ac->action->body);
             return false;
         }
@@ -127,7 +127,7 @@ class ControlBodyTranslationVisitor : public CodeGenInspector {
             for (unsigned i=0; i < (widthToEmit + 7) / 8; i++) {
                 builder->emitIndent();
                 builder->appendFormat("write_byte(%s, BYTES(%s) + %d, ((u8*)(&",
-                                      builder->target->dataOffset(program->model.CPacketName.str()),
+                                      program->packetStartVar.c_str(),
                                       program->offsetVar.c_str(), i);
                 visit(expr);
                 builder->appendFormat(".%s))[%d]", field.c_str(), i);
@@ -146,15 +146,17 @@ class ControlBodyTranslationVisitor : public CodeGenInspector {
                 builder->emitIndent();
                 builder->appendFormat("WRITE_PARTIAL(%s + BYTES(%s) + %d, %d, %s)",
                                       builder->target->dataOffset(program->model.CPacketName.str()),
-                                      program->offsetVar.c_str(), i, alignment % 8, program->byteVar);
+                                      program->offsetVar.c_str(), i, alignment % 8,
+                                      program->byteVar);
                 builder->endOfStatement(true);
                 left -= alignment % 8;
 
                 if (left > 0) {
                     builder->emitIndent();
-                    builder->appendFormat("write_byte(%s, BYTES(%s) + %d + 1, (%s << %d))",
-                                          builder->target->dataOffset(program->model.CPacketName.str()),
-                                          program->offsetVar.c_str(), i, program->byteVar, 8 - alignment % 8);
+                    builder->appendFormat(
+                        "write_byte(%s, BYTES(%s) + %d + 1, (%s << %d))",
+                        builder->target->dataOffset(program->model.CPacketName.str()),
+                        program->offsetVar.c_str(), i, program->byteVar, 8 - alignment % 8);
                     builder->endOfStatement(true);
                     left -= (8 - alignment % 8);
                 }

--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "ebpfControl.h"
 #include "ebpfType.h"
 #include "ebpfTable.h"
+#include "lib/error.h"
 #include "frontends/p4/tableApply.h"
 #include "frontends/p4/typeMap.h"
 #include "frontends/p4/methodInstance.h"
@@ -29,291 +30,417 @@ class ControlBodyTranslationVisitor : public CodeGenInspector {
     const EBPFControl* control;
     std::set<const IR::Parameter*> toDereference;
     std::vector<cstring> saveAction;
+    P4::P4CoreLibrary& p4lib;
+
+    std::map<const IR::Parameter*, const IR::Parameter*> substitution;
 
  public:
     ControlBodyTranslationVisitor(const EBPFControl* control, CodeBuilder* builder) :
-            CodeGenInspector(builder, control->program->typeMap), control(control) {}
-    using CodeGenInspector::preorder;
-    bool preorder(const IR::PathExpression* expression) override;
-    bool preorder(const IR::SwitchStatement* stat) override;
-    bool preorder(const IR::IfStatement* stat) override;
-    bool preorder(const IR::MethodCallExpression* expression) override;
-    bool preorder(const IR::ReturnStatement* stat) override;
-    bool preorder(const IR::ExitStatement* stat) override;
-    void processMethod(const P4::ExternMethod* method);
-    void processApply(const P4::ApplyMethod* method);
-};
+            CodeGenInspector(builder, control->program->typeMap), control(control),
+            p4lib(P4::P4CoreLibrary::instance) {}
 
-bool ControlBodyTranslationVisitor::preorder(const IR::PathExpression* expression) {
-    auto decl = control->program->refMap->getDeclaration(expression->path, true);
-    auto param = decl->getNode()->to<IR::Parameter>();
-    if (param != nullptr && toDereference.count(param) > 0)
-        builder->append("*");
-    builder->append(expression->path->name);  // each identifier should be unique
-    return false;
-}
-
-bool ControlBodyTranslationVisitor::preorder(const IR::MethodCallExpression* expression) {
-    auto mi = P4::MethodInstance::resolve(expression,
-                                          control->program->refMap,
-                                          control->program->typeMap);
-    auto apply = mi->to<P4::ApplyMethod>();
-    if (apply != nullptr) {
-        processApply(apply);
-        return false;
-    }
-    auto ext = mi->to<P4::ExternMethod>();
-    if (ext != nullptr) {
-        processMethod(ext);
-        return false;
-    }
-    auto bim = mi->to<P4::BuiltInMethod>();
-    if (bim != nullptr && bim->name == IR::Type_Header::isValid) {
-        visit(bim->appliedTo);
-        builder->append(".ebpf_valid");
-        return false;
-    }
-    auto ac = mi->to<P4::ActionCall>();
-    if (ac != nullptr) {
-        // Action arguments have been eliminated by the mid-end.
-        BUG_CHECK(expression->arguments->size() == 0, "%1%: unexpected arguments for action call",
-                  expression);
-        visit(ac->action->body);
+    bool preorder(const IR::PathExpression* expression) override {
+        auto decl = control->program->refMap->getDeclaration(expression->path, true);
+        auto param = decl->getNode()->to<IR::Parameter>();
+        if (param != nullptr) {
+            if (toDereference.count(param) > 0)
+                builder->append("*");
+            auto subst = ::get(substitution, param);
+            if (subst != nullptr) {
+                builder->append(subst->name);
+                return false;
+            }
+        }
+        builder->append(expression->path->name);  // each identifier should be unique
         return false;
     }
 
-    BUG("Unexpected method invocation %1%", expression);
-    return false;
-}
+    void substitute(const IR::Parameter* p, const IR::Parameter* with)
+    { substitution.emplace(p, with); }
 
-void ControlBodyTranslationVisitor::processMethod(const P4::ExternMethod* method) {
-    auto block = control->controlBlock->getValue(method->object->getNode());
-    BUG_CHECK(block != nullptr, "Cannot locate block for %1%", method->object);
-    auto extblock = block->to<IR::ExternBlock>();
-    BUG_CHECK(extblock != nullptr, "Expected external block for %1%", method->object);
+    bool preorder(const IR::MethodCallExpression* expression) override {
+        builder->append("/* ");
+        visit(expression->method);
+        builder->append("(");
+        bool first = true;
+        for (auto a  : *expression->arguments) {
+            if (!first)
+                builder->append(", ");
+            first = false;
+            visit(a);
+        }
+        builder->append(")");
+        builder->append("*/");
+        builder->newline();
 
-    if (extblock->type->name.name != control->program->model.counterArray.name) {
-        ::error("Unknown external block %1%", method->expr);
+        auto mi = P4::MethodInstance::resolve(expression,
+                                              control->program->refMap,
+                                              control->program->typeMap);
+        auto apply = mi->to<P4::ApplyMethod>();
+        if (apply != nullptr) {
+            processApply(apply);
+            return false;
+        }
+        auto ext = mi->to<P4::ExternMethod>();
+        if (ext != nullptr) {
+            processMethod(ext);
+            return false;
+        }
+        auto bim = mi->to<P4::BuiltInMethod>();
+        if (bim != nullptr && bim->name == IR::Type_Header::isValid) {
+            visit(bim->appliedTo);
+            builder->append(".ebpf_valid");
+            return false;
+        }
+        auto ac = mi->to<P4::ActionCall>();
+        if (ac != nullptr) {
+            // Action arguments have been eliminated by the mid-end.
+            BUG_CHECK(expression->arguments->size() == 0, "%1%: unexpected arguments for action call",
+                      expression);
+            visit(ac->action->body);
+            return false;
+        }
+
+        BUG("Unexpected method invocation %1%", expression);
+        return false;
+    }
+
+    void compileEmitField(const IR::Expression* expr, cstring field,
+                          unsigned alignment, EBPFType* type) {
+        unsigned widthToEmit = dynamic_cast<IHasWidth*>(type)->widthInBits();
+        cstring swap = "";
+        if (widthToEmit == 16)
+            swap = "htons";
+        else if (widthToEmit == 32)
+            swap = "htonl";
+        if (!swap.isNullOrEmpty()) {
+            builder->emitIndent();
+            visit(expr);
+            builder->appendFormat(".%s = %s(", field.c_str(), swap);
+            visit(expr);
+            builder->appendFormat(".%s)", field.c_str());
+            builder->endOfStatement(true);
+        }
+        auto program = control->program;
+
+        if (alignment == 0) {
+            for (unsigned i=0; i < (widthToEmit + 7) / 8; i++) {
+                builder->emitIndent();
+                builder->appendFormat("write_byte(%s, BYTES(%s) + %d, ((u8*)(&",
+                                      builder->target->dataOffset(program->model.CPacketName.str()),
+                                      program->offsetVar.c_str(), i);
+                visit(expr);
+                builder->appendFormat(".%s))[%d]", field.c_str(), i);
+                builder->append(")");
+                builder->endOfStatement(true);
+            }
+        } else {
+            unsigned left = widthToEmit;
+            for (unsigned i=0; i < (widthToEmit + 7) / 8; i++) {
+                builder->emitIndent();
+                builder->appendFormat("%s = ((char*)(&", program->byteVar);
+                visit(expr);
+                builder->appendFormat(".%s))[%d]", field.c_str(), i);
+                builder->endOfStatement(true);
+
+                builder->emitIndent();
+                builder->appendFormat("WRITE_PARTIAL(%s + BYTES(%s) + %d, %d, %s)",
+                                      builder->target->dataOffset(program->model.CPacketName.str()),
+                                      program->offsetVar.c_str(), i, alignment % 8, program->byteVar);
+                builder->endOfStatement(true);
+                left -= alignment % 8;
+
+                if (left > 0) {
+                    builder->emitIndent();
+                    builder->appendFormat("write_byte(%s, BYTES(%s) + %d + 1, (%s << %d))",
+                                          builder->target->dataOffset(program->model.CPacketName.str()),
+                                          program->offsetVar.c_str(), i, program->byteVar, 8 - alignment % 8);
+                    builder->endOfStatement(true);
+                    left -= (8 - alignment % 8);
+                }
+            }
+        }
+
+        builder->emitIndent();
+        builder->appendFormat("%s += %d", program->offsetVar.c_str(), widthToEmit);
+        builder->endOfStatement(true);
+    }
+
+    void compileEmit(const IR::Vector<IR::Expression>* args) {
+        BUG_CHECK(args->size() == 1, "%1%: expected 1 argument for emit", args);
+
+        auto expr = args->at(0);
+        auto type = typeMap->getType(expr);
+        auto ht = type->to<IR::Type_Header>();
+        if (ht == nullptr) {
+            ::error("Cannot emit a non-header type %1%", expr);
+            return;
+        }
+
+        auto program = control->program;
+        builder->emitIndent();
+        builder->append("if (");
+        visit(expr);
+        builder->append(".ebpf_valid) ");
+        builder->blockStart();
+
+        unsigned width = ht->width_bits();
+        builder->emitIndent();
+        builder->appendFormat("if (%s < %s + BYTES(%s + %d)) ",
+                              program->packetEndVar.c_str(),
+                              program->packetStartVar.c_str(),
+                              program->offsetVar.c_str(), width);
+        builder->blockStart();
+
+        builder->emitIndent();
+        builder->appendFormat("%s = %s;", program->errorVar.c_str(),
+                              p4lib.packetTooShort.str());
+        builder->newline();
+
+        builder->emitIndent();
+        builder->appendFormat("goto %s;", program->endLabel.c_str());
+        builder->newline();
+        builder->blockEnd(true);
+
+        unsigned alignment = 0;
+        for (auto f : *ht->fields) {
+            auto ftype = typeMap->getType(f);
+            auto etype = EBPFTypeFactory::instance->create(ftype);
+            auto et = dynamic_cast<IHasWidth*>(etype);
+            if (et == nullptr) {
+                ::error("Only headers with fixed widths supported %1%", f);
+                return;
+            }
+            compileEmitField(expr, f->name, alignment, etype);
+            alignment += et->widthInBits();
+            alignment %= 8;
+        }
+
+        builder->blockEnd(true);
         return;
     }
 
-    builder->blockStart();
-    auto decl = extblock->node->to<IR::Declaration_Instance>();
-    cstring name = decl->externalName();
-    auto counterMap = control->getCounter(name);
-    counterMap->emitMethodInvocation(builder, method);
-    builder->blockEnd(true);
-}
+    void processMethod(const P4::ExternMethod* method) {
+        auto decl = method->object;
+        auto declType = method->originalExternType;
 
-void ControlBodyTranslationVisitor::processApply(const P4::ApplyMethod* method) {
-    auto table = control->getTable(method->object->getName().name);
-    BUG_CHECK(table != nullptr, "No table for %1%", method->expr);
+        if (declType->name.name == control->program->model.counterArray.name) {
+            builder->blockStart();
+            cstring name = decl->externalName();
+            auto counterMap = control->getCounter(name);
+            counterMap->emitMethodInvocation(builder, method);
+            builder->blockEnd(true);
+            return;
+        } else if (declType->name.name == p4lib.packetOut.name) {
+            if (method->method->name.name == p4lib.packetOut.emit.name) {
+                compileEmit(method->expr->arguments);
+                return;
+            }
+        }
+        ::error("%1%: Unexpected method call", method->expr);
+    }
 
-    P4::ParameterSubstitution binding;
-    binding.populate(method->getActualParameters(), method->expr->arguments);
-    cstring actionVariableName;
-    if (!saveAction.empty()) {
-        actionVariableName = saveAction.at(saveAction.size() - 1);
+    void processApply(const P4::ApplyMethod* method) {
+        auto table = control->getTable(method->object->getName().name);
+        BUG_CHECK(table != nullptr, "No table for %1%", method->expr);
+
+        P4::ParameterSubstitution binding;
+        binding.populate(method->getActualParameters(), method->expr->arguments);
+        cstring actionVariableName;
+        if (!saveAction.empty()) {
+            actionVariableName = saveAction.at(saveAction.size() - 1);
+            if (!actionVariableName.isNullOrEmpty()) {
+                builder->appendFormat("enum %s %s;\n", table->actionEnumName, actionVariableName);
+                builder->emitIndent();
+            }
+        }
+        builder->blockStart();
+
+        if (!binding.empty()) {
+            builder->emitIndent();
+            builder->appendLine("/* bind parameters */");
+            for (auto p : *method->getActualParameters()->getEnumerator()) {
+                toDereference.emplace(p);
+                auto etype = EBPFTypeFactory::instance->create(p->type);
+                builder->emitIndent();
+
+                bool pointer = p->direction != IR::Direction::In;
+                etype->declare(builder, p->name.name, pointer);
+
+                builder->append(" = ");
+                auto e = binding.lookup(p);
+                if (pointer)
+                    builder->append("&");
+                visit(e);
+                builder->endOfStatement(true);
+            }
+            builder->newline();
+        }
+
+        builder->emitIndent();
+        builder->appendLine("/* construct key */");
+        builder->emitIndent();
+        cstring keyname = "key";
+        builder->appendFormat("struct %s %s", table->keyTypeName, keyname);
+        builder->endOfStatement(true);
+
+        table->createKey(builder, keyname);
+        builder->emitIndent();
+        builder->appendLine("/* value */");
+        builder->emitIndent();
+        cstring valueName = "value";
+        builder->appendFormat("struct %s *%s", table->valueTypeName, valueName);
+        builder->endOfStatement(true);
+
+        builder->emitIndent();
+        builder->appendLine("/* perform lookup */");
+        builder->emitIndent();
+        builder->target->emitTableLookup(builder, table->dataMapName, keyname, valueName);
+        builder->endOfStatement(true);
+
+        builder->emitIndent();
+        builder->appendFormat("if (%s == NULL) ", valueName);
+        builder->blockStart();
+
+        builder->emitIndent();
+        builder->appendLine("/* miss; find default action */");
+        builder->emitIndent();
+        builder->appendFormat("%s = 0", control->hitVariable);
+        builder->endOfStatement(true);
+
+        builder->emitIndent();
+        builder->target->emitTableLookup(builder, table->defaultActionMapName,
+                                         control->program->zeroKey, valueName);
+        builder->endOfStatement(true);
+        builder->blockEnd(false);
+        builder->append(" else ");
+        builder->blockStart();
+        builder->emitIndent();
+        builder->appendFormat("%s = 1", control->hitVariable);
+        builder->endOfStatement(true);
+        builder->blockEnd(true);
+
+        builder->emitIndent();
+        builder->appendFormat("if (%s != NULL) ", valueName);
+        builder->blockStart();
+        builder->emitIndent();
+        builder->appendLine("/* run action */");
+        table->runAction(builder, valueName);
         if (!actionVariableName.isNullOrEmpty()) {
-            builder->appendFormat("enum %s %s;\n", table->actionEnumName, actionVariableName);
+            builder->emitIndent();
+            builder->appendFormat("%s = %s->action;\n", actionVariableName, valueName);
+        }
+        toDereference.clear();
+
+        builder->blockEnd(true);
+        builder->blockEnd(true);
+    }
+
+    bool preorder(const IR::ExitStatement*) override {
+        builder->appendFormat("goto %s;", control->program->endLabel.c_str());
+        return false;
+    }
+
+    bool preorder(const IR::ReturnStatement*) override {
+        builder->appendFormat("goto %s;", control->program->endLabel.c_str());
+        return false;
+    }
+
+    bool preorder(const IR::IfStatement* statement) override {
+        bool isHit = P4::TableApplySolver::isHit(statement->condition, control->program->refMap,
+                                                 control->program->typeMap);
+        if (isHit) {
+            // visit first the table, and then the conditional
+            auto member = statement->condition->to<IR::Member>();
+            CHECK_NULL(member);
+            visit(member->expr);  // table application.  Sets 'hitVariable'
             builder->emitIndent();
         }
-    }
-    builder->blockStart();
 
-    if (!binding.empty()) {
-        builder->emitIndent();
-        builder->appendLine("/* bind parameters */");
-        for (auto p : *method->getActualParameters()->getEnumerator()) {
-            toDereference.emplace(p);
-            auto etype = EBPFTypeFactory::instance->create(p->type);
-            builder->emitIndent();
-
-            bool pointer = p->direction != IR::Direction::In;
-            etype->declare(builder, p->name.name, pointer);
-
-            builder->append(" = ");
-            auto e = binding.lookup(p);
-            if (pointer)
-                builder->append("&");
-            visit(e);
-            builder->endOfStatement(true);
-        }
-        builder->newline();
-    }
-
-    builder->emitIndent();
-    builder->appendLine("/* construct key */");
-    builder->emitIndent();
-    cstring keyname = "key";
-    builder->appendFormat("struct %s %s", table->keyTypeName, keyname);
-    builder->endOfStatement(true);
-
-    table->createKey(builder, keyname);
-    builder->emitIndent();
-    builder->appendLine("/* value */");
-    builder->emitIndent();
-    cstring valueName = "value";
-    builder->appendFormat("struct %s *%s", table->valueTypeName, valueName);
-    builder->endOfStatement(true);
-
-    builder->emitIndent();
-    builder->appendLine("/* perform lookup */");
-    builder->emitIndent();
-    builder->target->emitTableLookup(builder, table->dataMapName, keyname, valueName);
-    builder->endOfStatement(true);
-
-    builder->emitIndent();
-    builder->appendFormat("if (%s == NULL) ", valueName);
-    builder->blockStart();
-
-    builder->emitIndent();
-    builder->appendLine("/* miss; find default action */");
-    builder->emitIndent();
-    builder->appendFormat("%s = 0", control->hitVariable);
-    builder->endOfStatement(true);
-
-    builder->emitIndent();
-    builder->target->emitTableLookup(builder, table->defaultActionMapName,
-                                     control->program->zeroKey, valueName);
-    builder->endOfStatement(true);
-    builder->blockEnd(false);
-    builder->append(" else ");
-    builder->blockStart();
-    builder->emitIndent();
-    builder->appendFormat("%s = 1", control->hitVariable);
-    builder->endOfStatement(true);
-    builder->blockEnd(true);
-
-    builder->emitIndent();
-    builder->appendFormat("if (%s != NULL) ", valueName);
-    builder->blockStart();
-    builder->emitIndent();
-    builder->appendLine("/* run action */");
-    table->runAction(builder, valueName);
-    if (!actionVariableName.isNullOrEmpty()) {
-        builder->emitIndent();
-        builder->appendFormat("%s = %s->action;\n", actionVariableName, valueName);
-    }
-    toDereference.clear();
-
-    builder->blockEnd(true);
-    builder->blockEnd(true);
-}
-
-bool ControlBodyTranslationVisitor::preorder(const IR::ExitStatement*) {
-    builder->appendFormat("goto %s;", control->program->endLabel.c_str());
-    return false;
-}
-
-bool ControlBodyTranslationVisitor::preorder(const IR::ReturnStatement*) {
-    builder->appendFormat("goto %s;", control->program->endLabel.c_str());
-    return false;
-}
-
-bool ControlBodyTranslationVisitor::preorder(const IR::IfStatement* statement) {
-    bool isHit = P4::TableApplySolver::isHit(statement->condition, control->program->refMap,
-                                             control->program->typeMap);
-    if (isHit) {
-        // visit first the table, and then the conditional
-        auto member = statement->condition->to<IR::Member>();
-        CHECK_NULL(member);
-        visit(member->expr);  // table application.  Sets 'hitVariable'
-        builder->emitIndent();
-    }
-
-    // This is almost the same as the base class method
-    builder->append("if (");
-    if (isHit)
-        builder->append(control->hitVariable);
-    else
-        visit(statement->condition);
-    builder->append(") ");
-    if (!statement->ifTrue->is<IR::BlockStatement>()) {
-        builder->increaseIndent();
-        builder->newline();
-        builder->emitIndent();
-    }
-    visit(statement->ifTrue);
-    if (!statement->ifTrue->is<IR::BlockStatement>())
-        builder->decreaseIndent();
-    if (statement->ifFalse != nullptr) {
-        builder->newline();
-        builder->emitIndent();
-        builder->append("else ");
-        if (!statement->ifFalse->is<IR::BlockStatement>()) {
+        // This is almost the same as the base class method
+        builder->append("if (");
+        if (isHit)
+            builder->append(control->hitVariable);
+        else
+            visit(statement->condition);
+        builder->append(") ");
+        if (!statement->ifTrue->is<IR::BlockStatement>()) {
             builder->increaseIndent();
             builder->newline();
             builder->emitIndent();
         }
-        visit(statement->ifFalse);
-        if (!statement->ifFalse->is<IR::BlockStatement>())
+        visit(statement->ifTrue);
+        if (!statement->ifTrue->is<IR::BlockStatement>())
             builder->decreaseIndent();
-    }
-    return false;
-}
-
-bool ControlBodyTranslationVisitor::preorder(const IR::SwitchStatement* statement) {
-    cstring newName = control->program->refMap->newName("action_run");
-    saveAction.push_back(newName);
-    // This must be a table.apply().action_run
-    auto mem = statement->expression->to<IR::Member>();
-    BUG_CHECK(mem != nullptr,
-              "%1%: Unexpected expression in switch statement", statement->expression);
-    visit(mem->expr);
-    saveAction.pop_back();
-    saveAction.push_back(nullptr);
-    builder->emitIndent();
-    builder->append("switch (");
-    builder->append(newName);
-    builder->append(") ");
-    builder->blockStart();
-    for (auto c : statement->cases) {
-        builder->emitIndent();
-        if (c->label->is<IR::DefaultExpression>()) {
-            builder->append("default");
-        } else {
-            builder->append("case ");
-            auto pe = c->label->to<IR::PathExpression>();
-            auto decl = control->program->refMap->getDeclaration(pe->path, true);
-            BUG_CHECK(decl->is<IR::P4Action>(), "%1%: expected an action", pe);
-            auto act = decl->to<IR::P4Action>();
-            cstring name = act->externalName();
-            builder->append(name);
+        if (statement->ifFalse != nullptr) {
+            builder->newline();
+            builder->emitIndent();
+            builder->append("else ");
+            if (!statement->ifFalse->is<IR::BlockStatement>()) {
+                builder->increaseIndent();
+                builder->newline();
+                builder->emitIndent();
+            }
+            visit(statement->ifFalse);
+            if (!statement->ifFalse->is<IR::BlockStatement>())
+                builder->decreaseIndent();
         }
-        builder->append(":");
-        builder->newline();
-        builder->emitIndent();
-        visit(c->statement);
-        builder->newline();
-        builder->emitIndent();
-        builder->appendLine("break;");
+        return false;
     }
-    builder->blockEnd(false);
-    saveAction.pop_back();
-    return false;
-}
+
+    bool preorder(const IR::SwitchStatement* statement) override {
+        cstring newName = control->program->refMap->newName("action_run");
+        saveAction.push_back(newName);
+        // This must be a table.apply().action_run
+        auto mem = statement->expression->to<IR::Member>();
+        BUG_CHECK(mem != nullptr,
+                  "%1%: Unexpected expression in switch statement", statement->expression);
+        visit(mem->expr);
+        saveAction.pop_back();
+        saveAction.push_back(nullptr);
+        builder->emitIndent();
+        builder->append("switch (");
+        builder->append(newName);
+        builder->append(") ");
+        builder->blockStart();
+        for (auto c : statement->cases) {
+            builder->emitIndent();
+            if (c->label->is<IR::DefaultExpression>()) {
+                builder->append("default");
+            } else {
+                builder->append("case ");
+                auto pe = c->label->to<IR::PathExpression>();
+                auto decl = control->program->refMap->getDeclaration(pe->path, true);
+                BUG_CHECK(decl->is<IR::P4Action>(), "%1%: expected an action", pe);
+                auto act = decl->to<IR::P4Action>();
+                cstring name = act->externalName();
+                builder->append(name);
+            }
+            builder->append(":");
+            builder->newline();
+            builder->emitIndent();
+            visit(c->statement);
+            builder->newline();
+            builder->emitIndent();
+            builder->appendLine("break;");
+        }
+        builder->blockEnd(false);
+        saveAction.pop_back();
+        return false;
+    }
+};
+
 }  // namespace
 
 /////////////////////////////////////////////////
 
 EBPFControl::EBPFControl(const EBPFProgram* program,
-                         const IR::ControlBlock* block) :
-        program(program), controlBlock(block), headers(nullptr), accept(nullptr) {}
+                         const IR::ControlBlock* block,
+                         const IR::Parameter* parserHeaders) :
+        program(program), controlBlock(block), headers(nullptr), accept(nullptr),
+        parserHeaders(parserHeaders) {}
 
-bool EBPFControl::build() {
-    hitVariable = program->refMap->newName("hit");
-    auto pl = controlBlock->container->type->applyParams;
-    if (pl->size() != 2) {
-        ::error("Expected control block to have exactly 2 parameters");
-        return false;
-    }
-
-    auto it = pl->parameters->begin();
-    headers = *it;
-    ++it;
-    accept = *it;
-
+void EBPFControl::scanConstants() {
     for (auto c : controlBlock->constantValue) {
         auto b = c.second;
         if (!b->is<IR::Block>()) continue;
@@ -334,7 +461,22 @@ bool EBPFControl::build() {
             ::error("Unexpected block %s nested within control", b->toString());
         }
     }
-    return true;
+}
+
+bool EBPFControl::build() {
+    hitVariable = program->refMap->newName("hit");
+    auto pl = controlBlock->container->type->applyParams;
+    if (pl->size() != 2) {
+        ::error("Expected control block to have exactly 2 parameters");
+        return false;
+    }
+
+    auto it = pl->parameters->begin();
+    headers = *it;
+    ++it;
+    accept = *it;
+    scanConstants();
+    return ::errorCount() == 0;
 }
 
 void EBPFControl::emitDeclaration(const IR::Declaration* decl, CodeBuilder* builder) {
@@ -364,6 +506,7 @@ void EBPFControl::emit(CodeBuilder* builder) {
         emitDeclaration(a, builder);
     builder->emitIndent();
     ControlBodyTranslationVisitor psi(this, builder);
+    psi.substitute(headers, parserHeaders);
     controlBlock->container->body->apply(psi);
     builder->newline();
 }

--- a/backends/ebpf/ebpfControl.h
+++ b/backends/ebpf/ebpfControl.h
@@ -28,18 +28,20 @@ class EBPFControl : public EBPFObject {
     const IR::ControlBlock* controlBlock;
     const IR::Parameter*    headers;
     const IR::Parameter*    accept;
+    const IR::Parameter*    parserHeaders;
+    // replace references to headers with references to parserHeaders
     cstring                 hitVariable;
 
     std::set<const IR::Parameter*> toDereference;
     std::map<cstring, EBPFTable*>  tables;
     std::map<cstring, EBPFCounterTable*>  counters;
 
-    explicit EBPFControl(const EBPFProgram* program, const IR::ControlBlock* block);
-    virtual ~EBPFControl() {}
-    void emit(CodeBuilder* builder);
+    EBPFControl(const EBPFProgram* program, const IR::ControlBlock* block,
+                const IR::Parameter* parserHeaders);
+    virtual void emit(CodeBuilder* builder);
     void emitDeclaration(const IR::Declaration* decl, CodeBuilder *builder);
     void emitTables(CodeBuilder* builder);
-    bool build();
+    virtual bool build();
     EBPFTable* getTable(cstring name) const {
         auto result = get(tables, name);
         BUG_CHECK(result != nullptr, "No table named %1%", name);
@@ -48,6 +50,9 @@ class EBPFControl : public EBPFObject {
         auto result = get(counters, name);
         BUG_CHECK(result != nullptr, "No counter named %1%", name);
         return result; }
+
+ protected:
+    void scanConstants();
 };
 
 }  // namespace EBPF

--- a/backends/ebpf/ebpfObject.h
+++ b/backends/ebpf/ebpfObject.h
@@ -26,12 +26,6 @@ limitations under the License.
 
 namespace EBPF {
 
-class EBPFProgram;
-class EBPFParser;
-class EBPFControl;
-class EBPFTable;
-class EBPFType;
-
 // Base class for EBPF objects
 class EBPFObject {
  public:
@@ -42,54 +36,6 @@ class EBPFObject {
         return dynamic_cast<const T*>(this); }
     template<typename T> T* to() {
         return dynamic_cast<T*>(this); }
-};
-
-class EBPFProgram : public EBPFObject {
- public:
-    const IR::P4Program* program;
-    const IR::ToplevelBlock*  toplevel;
-    P4::ReferenceMap*    refMap;
-    P4::TypeMap*         typeMap;
-    EBPFParser*          parser;
-    EBPFControl*         control;
-    EBPFModel           &model;
-
-    cstring endLabel, offsetVar, lengthVar;
-    cstring zeroKey, functionName, errorVar;
-    cstring packetStartVar, packetEndVar;
-    cstring errorEnum;
-    cstring license = "GPL";  // TODO: this should be a compiler option probably
-    cstring arrayIndexType = "u32";
-
-    // write program as C source code
-    void emit(CodeBuilder *builder) override;
-    bool build();  // return 'true' on success
-
-    EBPFProgram(const IR::P4Program* program, P4::ReferenceMap* refMap,
-                P4::TypeMap* typeMap, const IR::ToplevelBlock* toplevel) :
-            program(program), toplevel(toplevel),
-            refMap(refMap), typeMap(typeMap),
-            parser(nullptr), control(nullptr), model(EBPFModel::instance) {
-        offsetVar = EBPFModel::reserved("packetOffsetInBits");
-        zeroKey = EBPFModel::reserved("zero");
-        functionName = EBPFModel::reserved("filter");
-        errorVar = EBPFModel::reserved("errorCode");
-        packetStartVar = EBPFModel::reserved("packetStart");
-        packetEndVar = EBPFModel::reserved("packetEnd");
-        endLabel = EBPFModel::reserved("end");
-        errorEnum = EBPFModel::reserved("errorCodes");
-    }
-
- private:
-    void emitIncludes(CodeBuilder* builder);
-    void emitPreamble(CodeBuilder* builder);
-    void emitTypes(CodeBuilder* builder);
-    void emitTables(CodeBuilder* builder);
-    void emitHeaderInstances(CodeBuilder* builder);
-    void emitIninitailizeHeaders(CodeBuilder* builder);
-    void createLocalVariables(CodeBuilder* builder);
-    void emitPipeline(CodeBuilder* builder);
-    void emitLicense(CodeBuilder* builder);
 };
 
 }  // namespace EBPF

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -154,7 +154,7 @@ StateTranslationVisitor::compileExtractField(
         type->emit(builder);
         builder->appendFormat(")((%s(%s, BYTES(%s))",
                               helper,
-                              builder->target->dataOffset(program->model.CPacketName.str()),
+                              program->packetStartVar.c_str(),
                               program->offsetVar.c_str());
         if (shift != 0)
             builder->appendFormat(" >> %d", shift);
@@ -190,7 +190,7 @@ StateTranslationVisitor::compileExtractField(
             bt->emit(builder);
             builder->appendFormat(")((%s(%s, BYTES(%s) + %d) >> %d)",
                                   helper,
-                                  builder->target->dataOffset(program->model.CPacketName.str()),
+                                  program->packetStartVar.c_str(),
                                   program->offsetVar.c_str(), i, shift);
 
             if ((i == bytes - 1) && (widthToExtract % 8 != 0)) {

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -282,7 +282,7 @@ bool StateTranslationVisitor::preorder(const IR::MethodCallExpression* expressio
     auto mi = P4::MethodInstance::resolve(expression,
                                           state->parser->program->refMap,
                                           state->parser->program->typeMap);
-    auto extMethod = dynamic_cast<P4::ExternMethod*>(mi);
+    auto extMethod = mi->to<P4::ExternMethod>();
     if (extMethod != nullptr) {
         auto decl = extMethod->object;
         if (decl == state->parser->packet) {

--- a/backends/ebpf/ebpfParser.h
+++ b/backends/ebpf/ebpfParser.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,8 +19,11 @@ limitations under the License.
 
 #include "ir/ir.h"
 #include "ebpfObject.h"
+#include "ebpfProgram.h"
 
 namespace EBPF {
+
+class EBPFParser;
 
 class EBPFParserState : public EBPFObject {
  public:

--- a/backends/ebpf/ebpfProgram.cpp
+++ b/backends/ebpf/ebpfProgram.cpp
@@ -131,8 +131,14 @@ void EBPFProgram::emitPreamble(CodeBuilder* builder) {
     builder->newline();
     builder->appendLine("#define EBPF_MASK(t, w) ((((t)(1)) << (w)) - (t)1)");
     builder->appendLine("#define BYTES(w) ((w + 7) / 8)");
-    builder->appendLine("#define WRITE_PARTIAL(a, s, v) do { u8 mask = EBPF_MASK(u8, s); *((u8*)a) = ((*((u8*)a)) & ~mask) | (((v) >> (8 - (s))) & mask); } while (0)");
-    builder->appendLine("#define write_byte(base, offset, v) do { *(u8*)((base) + (offset)) = (v); } while (0)");
+    builder->appendLine(
+        "#define WRITE_PARTIAL(a, s, v) do "
+        "{ u8 mask = EBPF_MASK(u8, s); "
+        "*((u8*)a) = ((*((u8*)a)) & ~mask) | (((v) >> (8 - (s))) & mask); "
+        "} while (0)");
+    builder->appendLine("#define write_byte(base, offset, v) do { "
+                        "*(u8*)((base) + (offset)) = (v); "
+                        "} while (0)");
     builder->newline();
 }
 

--- a/backends/ebpf/ebpfProgram.h
+++ b/backends/ebpf/ebpfProgram.h
@@ -1,0 +1,82 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _BACKENDS_EBPF_EBPFPROGRAM_H_
+#define _BACKENDS_EBPF_EBPFPROGRAM_H_
+
+#include "target.h"
+#include "ebpfModel.h"
+#include "ir/ir.h"
+#include "frontends/p4/typeMap.h"
+#include "frontends/p4/evaluator/evaluator.h"
+#include "codeGen.h"
+
+namespace EBPF {
+
+class EBPFProgram;
+class EBPFParser;
+class EBPFControl;
+class EBPFTable;
+class EBPFType;
+
+class EBPFProgram : public EBPFObject {
+ public:
+    const IR::P4Program* program;
+    const IR::ToplevelBlock*  toplevel;
+    P4::ReferenceMap*    refMap;
+    P4::TypeMap*         typeMap;
+    EBPFParser*          parser;
+    EBPFControl*         control;
+    EBPFModel           &model;
+
+    cstring endLabel, offsetVar, lengthVar;
+    cstring zeroKey, functionName, errorVar;
+    cstring packetStartVar, packetEndVar, byteVar;
+    cstring errorEnum;
+    cstring license = "GPL";  // TODO: this should be a compiler option probably
+    cstring arrayIndexType = "u32";
+
+    // write program as C source code
+    void emit(CodeBuilder *builder) override;
+    virtual bool build();  // return 'true' on success
+
+    EBPFProgram(const IR::P4Program* program, P4::ReferenceMap* refMap,
+                P4::TypeMap* typeMap, const IR::ToplevelBlock* toplevel) :
+            program(program), toplevel(toplevel),
+            refMap(refMap), typeMap(typeMap),
+            parser(nullptr), control(nullptr), model(EBPFModel::instance) {
+        offsetVar = EBPFModel::reserved("packetOffsetInBits");
+        zeroKey = EBPFModel::reserved("zero");
+        functionName = EBPFModel::reserved("filter");
+        errorVar = EBPFModel::reserved("errorCode");
+        packetStartVar = EBPFModel::reserved("packetStart");
+        packetEndVar = EBPFModel::reserved("packetEnd");
+        byteVar = EBPFModel::reserved("byte");
+        endLabel = EBPFModel::reserved("end");
+        errorEnum = EBPFModel::reserved("errorCodes");
+    }
+
+ protected:
+    virtual void emitPreamble(CodeBuilder* builder);
+    virtual void emitTypes(CodeBuilder* builder);
+    virtual void emitHeaderInstances(CodeBuilder* builder);
+    virtual void createLocalVariables(CodeBuilder* builder);
+    virtual void emitPipeline(CodeBuilder* builder);
+};
+
+}  // namespace EBPF
+
+#endif /* _BACKENDS_EBPF_EBPFPROGRAM_H_ */

--- a/backends/ebpf/ebpfTable.h
+++ b/backends/ebpf/ebpfTable.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define _BACKENDS_EBPF_EBPFTABLE_H_
 
 #include "ebpfObject.h"
+#include "ebpfProgram.h"
 #include "frontends/p4/methodInstance.h"
 
 namespace EBPF {

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -123,7 +123,7 @@ EBPFStructType::EBPFStructType(const IR::Type_StructLike* strct) :
         auto type = EBPFTypeFactory::instance->create(f->type);
         auto wt = dynamic_cast<IHasWidth*>(type);
         if (wt == nullptr) {
-            ::error("EBPF: Unsupported type in struct %s", f->type);
+            ::error("EBPF: Unsupported type in struct: %s", f->type);
         } else {
             width += wt->widthInBits();
             implWidth += wt->implementationWidthInBits();

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ class EBPFTypeFactory {
     EBPFType* create(const IR::Type* type);
 };
 
-class EBPFBoolType : public EBPFType, IHasWidth {
+class EBPFBoolType : public EBPFType, public IHasWidth {
  public:
     EBPFBoolType() : EBPFType(IR::Type_Boolean::get()) {}
     void emit(CodeBuilder* builder) override

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -28,12 +28,13 @@ namespace EBPF {
 
 class Target {
  protected:
-    cstring name;
     explicit Target(cstring name) : name(name) {}
     Target() = delete;
     virtual ~Target() {}
 
  public:
+    const cstring name;
+
     virtual void emitLicense(Util::SourceCodeBuilder* builder, cstring license) const = 0;
     virtual void emitCodeSection(Util::SourceCodeBuilder* builder, cstring sectionName) const = 0;
     virtual void emitIncludes(Util::SourceCodeBuilder* builder) const = 0;
@@ -55,7 +56,7 @@ class Target {
 // source tree samples folder and which attaches to a socket
 class KernelSamplesTarget : public Target {
  public:
-    KernelSamplesTarget() : Target("Linux kernel") {}
+    explicit KernelSamplesTarget(cstring name = "Linux kernel") : Target(name) {}
     void emitLicense(Util::SourceCodeBuilder* builder, cstring license) const override;
     void emitCodeSection(Util::SourceCodeBuilder* builder, cstring sectionName) const override;
     void emitIncludes(Util::SourceCodeBuilder* builder) const override;

--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -51,7 +51,7 @@ class SkipControls : public P4::ActionSynthesisPolicy {
     const std::set<cstring> *skip;
 
  public:
-    SkipControls(const std::set<cstring> *skip) : skip(skip) { CHECK_NULL(skip); }
+    explicit SkipControls(const std::set<cstring> *skip) : skip(skip) { CHECK_NULL(skip); }
     bool convert(const IR::P4Control* control) const override {
         if (skip->find(control->name) != skip->end())
             return false;
@@ -78,7 +78,7 @@ MidEnd::MidEnd(CompilerOptions& options) {
         new P4::RemoveAllUnusedDeclarations(&refMap),
         new P4::ClearTypeMap(&typeMap),
         evaluator,
-            new VisitFunctor([v1controls,evaluator](const IR::Node *root) -> const IR::Node * {
+            new VisitFunctor([v1controls, evaluator](const IR::Node *root) -> const IR::Node * {
             auto toplevel = evaluator->getToplevelBlock();
             auto main = toplevel->getMain();
             if (main == nullptr)

--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -43,14 +43,29 @@ limitations under the License.
 #include "frontends/common/constantFolding.h"
 #include "frontends/p4/strengthReduction.h"
 #include "frontends/p4/uniqueNames.h"
+#include "frontends/p4/fromv1.0/v1model.h"
 
 namespace P4Test {
+
+class SkipControls : public P4::ActionSynthesisPolicy {
+    const std::set<cstring> *skip;
+
+ public:
+    SkipControls(const std::set<cstring> *skip) : skip(skip) { CHECK_NULL(skip); }
+    bool convert(const IR::P4Control* control) const override {
+        if (skip->find(control->name) != skip->end())
+            return false;
+        return true;
+    }
+};
 
 MidEnd::MidEnd(CompilerOptions& options) {
     bool isv1 = options.langVersion == CompilerOptions::FrontendVersion::P4_14;
     refMap.setIsV1(isv1);
     auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
     setName("MidEnd");
+
+    auto v1controls = new std::set<cstring>();
 
     // TODO: parser loop unrolling
     // TODO: improve copy propagation
@@ -63,11 +78,28 @@ MidEnd::MidEnd(CompilerOptions& options) {
         new P4::RemoveAllUnusedDeclarations(&refMap),
         new P4::ClearTypeMap(&typeMap),
         evaluator,
-        new VisitFunctor([evaluator](const IR::Node *root) -> const IR::Node * {
+            new VisitFunctor([v1controls,evaluator](const IR::Node *root) -> const IR::Node * {
             auto toplevel = evaluator->getToplevelBlock();
-            if (toplevel->getMain() == nullptr)
+            auto main = toplevel->getMain();
+            if (main == nullptr)
                 // nothing further to do
                 return nullptr;
+            // Special handling when compiling for v1model.p4
+            if (main->type->name == P4V1::V1Model::instance.sw.name) {
+                if (main->getConstructorParameters()->size() != 6)
+                    return root;
+                auto verify = main->getParameterValue(P4V1::V1Model::instance.sw.verify.name);
+                auto update = main->getParameterValue(P4V1::V1Model::instance.sw.update.name);
+                auto deparser = main->getParameterValue(P4V1::V1Model::instance.sw.deparser.name);
+                if (verify == nullptr || update == nullptr || deparser == nullptr ||
+                    !verify->is<IR::ControlBlock>() || !update->is<IR::ControlBlock>() ||
+                    !deparser->is<IR::ControlBlock>()) {
+                    return root;
+                }
+                v1controls->emplace(verify->to<IR::ControlBlock>()->container->name);
+                v1controls->emplace(update->to<IR::ControlBlock>()->container->name);
+                v1controls->emplace(deparser->to<IR::ControlBlock>()->container->name);
+            }
             return root; }),
         new P4::Inline(&refMap, &typeMap, evaluator),
         new P4::InlineActions(&refMap, &typeMap),
@@ -97,7 +129,7 @@ MidEnd::MidEnd(CompilerOptions& options) {
         new P4::MoveDeclarations(),  // more may have been introduced
         new P4::SimplifyControlFlow(&refMap, &typeMap),
         new P4::CompileTimeOperations(),
-        new P4::SynthesizeActions(&refMap, &typeMap),
+        new P4::SynthesizeActions(&refMap, &typeMap, new SkipControls(v1controls)),
         new P4::MoveActionsToTables(&refMap, &typeMap),
         evaluator,
         new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); })

--- a/midend/copyStructures.cpp
+++ b/midend/copyStructures.cpp
@@ -41,7 +41,8 @@ const IR::Node* DoCopyStructures::postorder(IR::AssignmentStatement* statement) 
                 BUG_CHECK(statement->right->is<IR::PathExpression>() ||
                           statement->right->is<IR::Member>() ||
                           statement->right->is<IR::ArrayIndex>(),
-                          "%1%: Unexpected operation when eliminating struct copying", statement->right);
+                          "%1%: Unexpected operation when eliminating struct copying",
+                          statement->right);
                 auto right = new IR::Member(Util::SourceInfo(), statement->right, f->name);
                 auto left = new IR::Member(Util::SourceInfo(), statement->left, f->name);
                 retval->push_back(new IR::AssignmentStatement(statement->srcInfo, left, right));
@@ -53,8 +54,10 @@ const IR::Node* DoCopyStructures::postorder(IR::AssignmentStatement* statement) 
         auto stack = ltype->to<IR::Type_Stack>();
         for (unsigned i = 0; i < stack->getSize(); i++) {
             auto index = new IR::Constant(i);
-            BUG_CHECK(statement->right->is<IR::PathExpression>() || statement->right->is<IR::Member>(),
-                      "%1%: Unexpected operation when eliminating struct copying", statement->right);
+            BUG_CHECK(statement->right->is<IR::PathExpression>() ||
+                      statement->right->is<IR::Member>(),
+                      "%1%: Unexpected operation when eliminating struct copying",
+                      statement->right);
             auto right = new IR::ArrayIndex(Util::SourceInfo(), statement->right, index);
             auto left = new IR::ArrayIndex(Util::SourceInfo(), statement->left, index->clone());
             retval->push_back(new IR::AssignmentStatement(statement->srcInfo, left, right));

--- a/testdata/p4_14_samples_outputs/basic_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-midend.p4
@@ -215,18 +215,9 @@ struct tuple_0 {
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
-    action act() {
-        mark_to_drop();
-    }
-    table tbl_act() {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
     apply {
         if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
-            tbl_act.apply();
+            mark_to_drop();
     }
 }
 

--- a/testdata/p4_14_samples_outputs/checksum1-midend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-midend.p4
@@ -136,18 +136,9 @@ struct tuple_0 {
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
-    action act() {
-        mark_to_drop();
-    }
-    table tbl_act() {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
     apply {
         if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
-            tbl_act.apply();
+            mark_to_drop();
     }
 }
 

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -264,18 +264,9 @@ struct tuple_2 {
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
-    action act() {
-        mark_to_drop();
-    }
-    table tbl_act() {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
     apply {
         if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
-            tbl_act.apply();
+            mark_to_drop();
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_dc_full-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-midend.p4
@@ -693,29 +693,11 @@ struct tuple_0 {
 control verifyChecksum(in headers hdr, inout metadata meta) {
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
-    action act() {
-        mark_to_drop();
-    }
-    action act_0() {
-        mark_to_drop();
-    }
-    table tbl_act() {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
-    table tbl_act_0() {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
     apply {
         if (hdr.ipv4.isValid() && hdr.inner_ipv4.hdrChecksum == (inner_ipv4_checksum.get<tuple_0>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }))) 
-            tbl_act.apply();
+            mark_to_drop();
         if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
-            tbl_act_0.apply();
+            mark_to_drop();
     }
 }
 

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
@@ -917,29 +917,11 @@ struct tuple_0 {
 control verifyChecksum(in headers hdr, inout metadata meta) {
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
-    action act() {
-        mark_to_drop();
-    }
-    action act_0() {
-        mark_to_drop();
-    }
-    table tbl_act() {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
-    table tbl_act_0() {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
     apply {
         if (hdr.ipv4.isValid() && hdr.inner_ipv4.hdrChecksum == (inner_ipv4_checksum.get<tuple_0>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }))) 
-            tbl_act.apply();
+            mark_to_drop();
         if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
-            tbl_act_0.apply();
+            mark_to_drop();
     }
 }
 

--- a/testdata/p4_14_samples_outputs/sai_p4-midend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-midend.p4
@@ -377,18 +377,9 @@ struct tuple_0 {
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
-    action act() {
-        mark_to_drop();
-    }
-    table tbl_act() {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
     apply {
         if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.checksum == (ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
-            tbl_act.apply();
+            mark_to_drop();
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_nat-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-midend.p4
@@ -337,29 +337,11 @@ struct tuple_2 {
 control verifyChecksum(in headers hdr, inout metadata meta) {
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
     @name("tcp_checksum") Checksum16() tcp_checksum;
-    action act() {
-        mark_to_drop();
-    }
-    action act_0() {
-        mark_to_drop();
-    }
-    table tbl_act() {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
-    table tbl_act_0() {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
     apply {
         if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple_1>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
-            tbl_act.apply();
+            mark_to_drop();
         if (hdr.tcp.isValid() && hdr.tcp.checksum == (tcp_checksum.get<tuple_2>({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }))) 
-            tbl_act_0.apply();
+            mark_to_drop();
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_router-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-midend.p4
@@ -155,18 +155,9 @@ struct tuple_0 {
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
-    action act() {
-        mark_to_drop();
-    }
-    table tbl_act() {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
     apply {
         if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
-            tbl_act.apply();
+            mark_to_drop();
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -5000,29 +5000,11 @@ struct tuple_8 {
 control verifyChecksum(in headers hdr, inout metadata meta) {
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
-    action act() {
-        mark_to_drop();
-    }
-    action act_0() {
-        mark_to_drop();
-    }
-    table tbl_act() {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
-    table tbl_act_0() {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
     apply {
         if (hdr.inner_ipv4.ihl == 4w5 && hdr.inner_ipv4.hdrChecksum == (inner_ipv4_checksum.get<tuple_8>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }))) 
-            tbl_act.apply();
+            mark_to_drop();
         if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple_8>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
-            tbl_act_0.apply();
+            mark_to_drop();
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -5968,29 +5968,11 @@ struct tuple_10 {
 control verifyChecksum(in headers hdr, inout metadata meta) {
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
-    action act() {
-        mark_to_drop();
-    }
-    action act_0() {
-        mark_to_drop();
-    }
-    table tbl_act() {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
-    table tbl_act_0() {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
     apply {
         if (hdr.inner_ipv4.ihl == 4w5 && hdr.inner_ipv4.hdrChecksum == (inner_ipv4_checksum.get<tuple_10>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }))) 
-            tbl_act.apply();
+            mark_to_drop();
         if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple_10>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
-            tbl_act_0.apply();
+            mark_to_drop();
     }
 }
 

--- a/testdata/p4_16_samples/issue249.p4
+++ b/testdata/p4_16_samples/issue249.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct routing_metadata_t {
+    bit<32> nhop_ipv4;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+    routing_metadata_t routing_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {}
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {}
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {}
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
+    apply {
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))
+            mark_to_drop();
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
+    apply {
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -310,47 +310,20 @@ control verifyChecksum(in headers hdr, inout metadata meta) {
     bit<16> tmp_26;
     bool tmp_27;
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
-    action act_0() {
-        mark_to_drop();
-    }
-    action act_1() {
-        tmp_27 = hdr.ipv4.hdrChecksum == tmp_26;
-    }
-    table tbl_act_0() {
-        actions = {
-            act_1();
-        }
-        const default_action = act_1();
-    }
-    table tbl_act_1() {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
     apply {
         tmp_26 = ipv4_checksum.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        tbl_act_0.apply();
+        tmp_27 = hdr.ipv4.hdrChecksum == tmp_26;
         if (tmp_27) 
-            tbl_act_1.apply();
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
     bit<16> tmp_28;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
-    action act_2() {
-        hdr.ipv4.hdrChecksum = tmp_28;
-    }
-    table tbl_act_2() {
-        actions = {
-            act_2();
-        }
-        const default_action = act_2();
-    }
     apply {
         tmp_28 = ipv4_checksum_2.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        tbl_act_2.apply();
+        hdr.ipv4.hdrChecksum = tmp_28;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue249-first.p4
+++ b/testdata/p4_16_samples_outputs/issue249-first.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct routing_metadata_t {
+    bit<32> nhop_ipv4;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+    routing_metadata_t routing_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
+    apply {
+        if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
+    apply {
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue249-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue249-frontend.p4
@@ -1,0 +1,80 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct routing_metadata_t {
+    bit<32> nhop_ipv4;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+    routing_metadata_t routing_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp;
+    bool tmp_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
+    apply {
+        tmp = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_0 = hdr.ipv4.hdrChecksum == tmp;
+        if (tmp_0) 
+            mark_to_drop();
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
+    apply {
+        tmp_1 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_1;
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue249.p4
+++ b/testdata/p4_16_samples_outputs/issue249.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct routing_metadata_t {
+    bit<32> nhop_ipv4;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+    routing_metadata_t routing_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
+    apply {
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
+    apply {
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/lj_example-midend.p4
+++ b/testdata/p4_16_samples_outputs/lj_example-midend.p4
@@ -77,8 +77,17 @@ control LjPipe(inout Parsed_rep p, in error parseError, in InControl inCtrl, out
 }
 
 control LJdeparse(inout Parsed_rep p, packet_out b) {
-    apply {
+    action act_0() {
         b.emit<ARPA_hdr>(p.arpa_pak);
+    }
+    table tbl_act_0() {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    apply {
+        tbl_act_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/unreachable-accept-midend.p4
+++ b/testdata/p4_16_samples_outputs/unreachable-accept-midend.p4
@@ -18,8 +18,17 @@ parser Parser(packet_in pkt_in, out headers_t hdr) {
 }
 
 control Deparser(in headers_t hdr, packet_out pkt_out) {
-    apply {
+    action act() {
         pkt_out.emit<ethernet_h>(hdr.ethernet);
+    }
+    table tbl_act() {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/vss-example-midend.p4
+++ b/testdata/p4_16_samples_outputs/vss-example-midend.p4
@@ -300,18 +300,36 @@ control TopDeparser(inout Parsed_packet p, packet_out b) {
         tmp_20 = ck_2.get();
         p.ip.hdrChecksum = tmp_20;
     }
+    action act_9() {
+        b.emit<Ethernet_h>(p.ethernet);
+    }
+    action act_10() {
+        b.emit<Ipv4_h>(p.ip);
+    }
     table tbl_act_8() {
+        actions = {
+            act_9();
+        }
+        const default_action = act_9();
+    }
+    table tbl_act_9() {
         actions = {
             act_8();
         }
         const default_action = act_8();
     }
-    apply {
-        b.emit<Ethernet_h>(p.ethernet);
-        if (p.ip.isValid()) {
-            tbl_act_8.apply();
+    table tbl_act_10() {
+        actions = {
+            act_10();
         }
-        b.emit<Ipv4_h>(p.ip);
+        const default_action = act_10();
+    }
+    apply {
+        tbl_act_8.apply();
+        if (p.ip.isValid()) {
+            tbl_act_9.apply();
+        }
+        tbl_act_10.apply();
     }
 }
 


### PR DESCRIPTION
I didn't mean to add the previous commit with the exit tables, but I guess I didn't create the branch at the correct time.
The fix has two halves:
- SynthesizeActions now has a more precise policy function, which is used to skip the verify, update and deparser blocks in the bmv2 back-end. (It is also used in the p4test back-end when compiling for the v1model). 
- Undo the effects of the SideEffectOrdering pass only for the update checksum control. This is a hack, but it is no worse than the current code generation for checksums; the proper solution will require the checksum block to be implemented using an extern in BMv2.
@anirudhSK: this is (hopefully) a fix for the issues with the checksum you have reported on the BMv2 repo