### PR TITLE
Increase test timeouts to fix the Travis build

### DIFF
--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -110,7 +110,7 @@ def run_timeout(options, args, timeout, stderr):
         print("Exit code ", local.process.returncode)
     return local.process.returncode
 
-timeout = 100
+timeout = 10 * 60
 
 class ConcurrentInteger(object):
     # Generates exclusive integers in a range 0-max

--- a/backends/bmv2/run-bmv2-test.py
+++ b/backends/bmv2/run-bmv2-test.py
@@ -158,7 +158,7 @@ def run_timeout(options, args, timeout, stderr):
         print("Exit code ", local.process.returncode)
     return local.process.returncode
 
-timeout = 100
+timeout = 10 * 60
 
 def compare_files(options, produced, expected):
     if options.replace:

--- a/backends/ebpf/run-ebpf-sample.py
+++ b/backends/ebpf/run-ebpf-sample.py
@@ -84,7 +84,7 @@ def run_timeout(options, args, timeout, stderr):
         print("Exit code ", local.process.returncode)
     return local.process.returncode
 
-timeout = 100
+timeout = 10 * 60
 
 def compare_files(options, produced, expected):
     if options.replace:

--- a/backends/p4test/run-p4-sample.py
+++ b/backends/p4test/run-p4-sample.py
@@ -90,7 +90,7 @@ def run_timeout(options, args, timeout, stderr):
         print("Exit code ", local.process.returncode)
     return local.process.returncode
 
-timeout = 300  # seconds
+timeout = 10 * 60
 
 def compare_files(options, produced, expected):
     if options.replace:


### PR DESCRIPTION
The Travis build is failing right now. The cause is that we're running our tests with a timeout, but time behaves strangely in VMs (which is where Travis runs our tests), and so we get timeouts that we don't get locally.

The best bet is to disable the timeouts and rely on Travis's built-in timeout. To make that happen, I've add a `configure` option to disable the test timeouts, updated all of the test running scripts to use it, and added it to the `Dockerfile`.

I tested this in my fork and it fixed the Travis build.