### PR TITLE
Run p4c tests that require the behavioral model in Travis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:14.04
 MAINTAINER Seth Fowler <seth.fowler@barefootnetworks.com>
 
 # Install dependencies.
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y \
       automake \
@@ -18,6 +19,19 @@ RUN apt-get update && \
       python-ipaddr \
       python-scapy \
       tcpdump
+
+# Clone and build behavioral-model, which is needed by some tests.
+ENV BEHAVIORAL_MODEL_REPO https://github.com/sethfowler/behavioral-model.git
+ENV BEHAVIORAL_MODEL_TAG 4f85ec95da24
+RUN git clone --recursive $BEHAVIORAL_MODEL_REPO /behavioral-model && \
+    cd /behavioral-model && \
+    git reset --hard $BEHAVIORAL_MODEL_TAG && \
+    ./install_deps.sh && \
+    ./autogen.sh && \
+    ./configure && \
+    make -j8 && \
+    make install && \
+    ldconfig
 
 # Copy entire repository.
 COPY . /p4c/


### PR DESCRIPTION
This PR updates the Dockerfile to include the behavioral model, which enables the full suite of BMV2 tests to run on Travis.

It will be straightforward to change the repo and tag used to clone `behavior-model` from in the future by modifying the appropriate `ENV` variables. I've used my fork for the time being because I discovered some issues on the `behavioral-model` side while setting this up, but once Antonin merges  p4lang/behavioral-model#277 we can switch over to his repo. (Or we can just wait and update the PR; we'll get it taken care of quickly either way.)