### PR TITLE
Use only two make jobs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ services:
   - docker
 
 install:
-  - docker build -t p4c .
+  - docker build --build-arg MAKEFLAGS=-j2 -t p4c .
 
 script:
-  - docker run -w /p4c/build p4c sh -c 'make check VERBOSE=1 -j8'
-  - docker run -w /p4c/build p4c sh -c 'make cpplint'
+  - docker run -w /p4c/build p4c make check VERBOSE=1
+  - docker run -w /p4c/build p4c make cpplint

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ RUN apt-get update && \
       python-scapy \
       tcpdump
 
+# Default to using 8 make jobs, which is appropriate for local builds. On CI
+# infrastructure it will often be best to override this.
+ARG MAKEFLAGS
+ENV MAKEFLAGS ${MAKEFLAGS:-j8}
+
 # Clone and build behavioral-model, which is needed by some tests.
 ENV BEHAVIORAL_MODEL_REPO https://github.com/sethfowler/behavioral-model.git
 ENV BEHAVIORAL_MODEL_TAG 4f85ec95da24
@@ -29,7 +34,7 @@ RUN git clone --recursive $BEHAVIORAL_MODEL_REPO /behavioral-model && \
     ./install_deps.sh && \
     ./autogen.sh && \
     ./configure && \
-    make -j8 && \
+    make && \
     make install && \
     ldconfig
 
@@ -40,4 +45,4 @@ WORKDIR /p4c/
 # Build.
 RUN ./bootstrap.sh && \
     cd build && \
-    make -j8
+    make


### PR DESCRIPTION
Since we only get two cores on Travis, it makes sense to only use two make jobs. For local builds, IMO we should still default to 8, as that will be the best choice for most developers' machines.

Note that we use `ENV` to persist `MAKEFLAGS` in the Docker image, so the `MAKEFLAGS` value passed to `docker build` will also apply to the `docker run` invocations in `.travis.yml`.

Before merging this, we should verify that it doesn't have a negative effect on our build times on Travis.