### PR TITLE
Work around dynamic_cast bug in clang

### DIFF
--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -315,7 +315,7 @@ class SetupJoinPoints : public Inspector {
 };
 
 void ControlFlowVisitor::init_join_flows(const IR::Node *root) {
-    if (!dynamic_cast<Inspector *>(this))
+    if (!dynamic_cast<Inspector *>(static_cast<Visitor *>(this)))
         BUG("joinFlows only works for Inspector passes currently, not Modifier or Transform");
     if (flow_join_points)
         flow_join_points->clear();


### PR DESCRIPTION
Ran into this one trying to fix another bug.  Visitor is the common (dynamic, virtual) base class of ControlFlowVisitor and Inspector, so this static_cast should be an unnecessary noop, but clang seems to have a bug in its complex inheritance handling.