### PR TITLE
Make our Docker image inherit from the behavioral-model Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 install:
-  - docker build --build-arg MAKEFLAGS=-j2 -t p4c .
+  - docker build -t p4c .
 
 script:
   - docker run -w /p4c/build p4c make check VERBOSE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,23 @@
-FROM ubuntu:14.04
+FROM p4lang/behavioral-model:latest
 MAINTAINER Seth Fowler <seth.fowler@barefootnetworks.com>
 
-# Install dependencies.
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    apt-get install -y \
-      automake \
-      bison \
-      build-essential \
-      flex \
-      g++ \
-      git \
-      libboost-dev \
-      libgc-dev \
-      libgmp-dev \
-      libtool \
-      python2.7 \
-      python-ipaddr \
-      python-scapy \
-      tcpdump
-
-# Default to using 8 make jobs, which is appropriate for local builds. On CI
-# infrastructure it will often be best to override this.
-ARG MAKEFLAGS
-ENV MAKEFLAGS ${MAKEFLAGS:-j8}
-
-# Clone and build behavioral-model, which is needed by some tests.
-ENV BEHAVIORAL_MODEL_REPO https://github.com/sethfowler/behavioral-model.git
-ENV BEHAVIORAL_MODEL_TAG 4f85ec95da24
-RUN git clone --recursive $BEHAVIORAL_MODEL_REPO /behavioral-model && \
-    cd /behavioral-model && \
-    git reset --hard $BEHAVIORAL_MODEL_TAG && \
-    ./install_deps.sh && \
-    ./autogen.sh && \
-    ./configure && \
-    make && \
-    make install && \
-    ldconfig
-
-# Copy entire repository.
+ENV P4C_DEPS automake \
+             bison \
+             build-essential \
+             flex \
+             g++ \
+             libboost-dev \
+             libgc-dev \
+             libgmp-dev \
+             libtool \
+             python2.7 \
+             python-ipaddr \
+             python-scapy \
+             tcpdump
 COPY . /p4c/
 WORKDIR /p4c/
-
-# Build.
-RUN ./bootstrap.sh && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $P4C_DEPS && \
+    ./bootstrap.sh && \
     cd build && \
     make


### PR DESCRIPTION
This PR makes this repo's Dockerfile inherit from the `behavioral-model` Dockerfile. This should speed up the tests considerably, since `behavioral-model` and its dependencies will no longer have to be built as part of the testing process.

The Dockerfile has also been changed to use a style consistent with that used in the `third-party` and `behavioral-model` repos.