### PR TITLE
Make it possible to run ResolveReferences on a V1Program

### DIFF
--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -89,6 +89,8 @@ class ResolveReferences : public Inspector {
     void removeFromContext(const IR::INamespace* ns);
     void addToGlobals(const IR::INamespace* ns);
     void resolvePath(const IR::Path* path, bool isType) const;
+    bool enterRootNamespace(const IR::INamespace* ns);
+    void leaveRootNamespace();
 
  public:
     explicit ResolveReferences(/* out */ P4::ReferenceMap* refMap,
@@ -108,6 +110,7 @@ class ResolveReferences : public Inspector {
     void postorder(const IR::TYPE* t) override; \
 
     DECLARE(P4Program)
+    DECLARE(V1Program)
     DECLARE(P4Control)
     DECLARE(P4Parser)
     DECLARE(P4Action)

--- a/ir/v1.cpp
+++ b/ir/v1.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "ir.h"
 #include "dbprint.h"
+#include "lib/enumerator.h"
 #include "lib/gmputil.h"
 #include "lib/bitops.h"
 
@@ -140,4 +141,30 @@ const IR::Type *IR::Primitive::inferOperandType(int operand) const {
     if (name.startsWith("execute_stateful") && operand == 1) {
             return IR::Type::Bits::get(32); }
     return IR::Type::Unknown::get();
+}
+
+Util::Enumerator<const IR::IDeclaration*>* IR::V1Program::getDeclarations() const {
+    using ScopeVal = decltype(scope)::value_type;
+
+    std::function<const IR::Node*(const ScopeVal&)> toNode =
+      [](const ScopeVal& value) -> const IR::Node* { return value.second; };
+    std::function<const IR::IDeclaration*(const IR::Node* const&)> toIDeclaration =
+      [](const IR::Node* const& node) { return node->to<IR::IDeclaration>(); };
+
+    // Return an enumerator over all Nodes in the scope which are IDeclarations.
+    return Util::Enumerator<ScopeVal>::createEnumerator(scope.begin(), scope.end())
+              ->map(toNode)
+              ->where([](const IR::Node* node) { return node->is<IR::IDeclaration>(); })
+              ->map(toIDeclaration);
+}
+
+const IR::IDeclaration* IR::V1Program::getDeclByName(cstring name) const {
+    auto nodeIter = scope.find(name);
+
+    // Search the scope and return the first IDeclaration we find.
+    while (nodeIter != scope.end() && nodeIter->first == name)
+        if (nodeIter->second->is<IR::IDeclaration>())
+            return nodeIter->second->to<IR::IDeclaration>();
+
+    return nullptr;  // No matching declaration.
 }

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -475,11 +475,13 @@ class AttributeRef : Expression {
 class CompilerOptions;
 #end
 
-class V1Program {
+class V1Program : ISimpleNamespace {
     inline NameMap<Node, std::multimap>         scope;
 
 #noconstructor
     V1Program(const CompilerOptions &options);
+    Util::Enumerator<IDeclaration>* getDeclarations() const override;
+    IDeclaration getDeclByName(cstring name) const override;
 #emit
     template<class T> const T *get(cstring name) const { return scope.get<T>(name); }
 #end


### PR DESCRIPTION
Many (most?) passes can't run on a V1Program because they require a ReferenceMap, and ResolveReferences requires a P4Program. However, there are a number of passes for which this is more or less an artificial limitation - they work fine on either kind of program.

This PR makes ResolveReferences work on V1Programs by making V1Program implement ISimpleNamespace. The ISimpleNamespace methods are implemented using V1Program::scope.

I've kicked the tires on this a little and things seem to work, but I haven't used it for anything complicated yet. I'm planning to start depending on this for parser-related compiler passes that don't depend on the details of either language version, so this code will get exercised more soon.

(By the way, I know that in the long term there's interest in making P4Program symbol lookup work more like V1Program symbol lookup, rather than the other way around. I think this is the most pragmatic way forward until we're ready to do that refactoring, though.)