### PR TITLE
Visitor additions to clean up custom visitor routines a bit.

### DIFF
--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -244,7 +244,7 @@ bool CodeGenInspector::preorder(const IR::AssignmentStatement* a) {
 bool CodeGenInspector::preorder(const IR::BlockStatement* s) {
     builder->blockStart();
     setVecSep("\n", "\n");
-    s->components.visit_children(*this);
+    visit(s->components, "components");
     doneVec();
     builder->blockEnd(false);
     return false;

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -56,7 +56,7 @@ bool StateTranslationVisitor::preorder(const IR::ParserState* parserState) {
     builder->blockStart();
 
     setVecSep("\n", "\n");
-    parserState->components.visit_children(*this);
+    visit(parserState->components, "components");
     doneVec();
 
     if (parserState->selectExpression == nullptr) {

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -603,7 +603,7 @@ bool ComputeWriteSet::preorder(const IR::SelectExpression* expression) {
 }
 
 bool ComputeWriteSet::preorder(const IR::ListExpression* expression) {
-    expression->components.visit_children(*this);
+    visit(expression->components, "components");
     auto l = LocationSet::empty;
     for (auto c : expression->components) {
         auto cl = get(c);
@@ -776,7 +776,7 @@ bool ComputeWriteSet::preorder(const IR::IfStatement* statement) {
 }
 
 bool ComputeWriteSet::preorder(const IR::BlockStatement* statement) {
-    statement->components.visit_children(*this);
+    visit(statement->components, "components");
     return setDefinitions(currentDefinitions);
 }
 

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -115,7 +115,7 @@ class FindUninitialized : public Inspector {
         LOG1("FU Visiting " << dbp(state));
         context = ProgramPoint(state);
         currentPoint = ProgramPoint(state);  // point before the first statement
-        state->components.visit_children(*this);
+        visit(state->components, "components");
         if (state->selectExpression != nullptr)
             visit(state->selectExpression);
         context = ProgramPoint();
@@ -164,7 +164,7 @@ class FindUninitialized : public Inspector {
 
     bool preorder(const IR::P4Parser* parser) override {
         LOG1("FU Visiting " << dbp(parser));
-        parser->states.visit_children(*this);
+        visit(parser->states, "states");
         auto accept = ProgramPoint(parser->getDeclByName(IR::ParserState::accept)->getNode());
         auto acceptdefs = definitions->get(accept, true);
         if (!acceptdefs->empty())
@@ -198,7 +198,7 @@ class FindUninitialized : public Inspector {
 
     bool preorder(const IR::BlockStatement* statement) override {
         LOG1("FU Visiting " << dbp(statement));
-        statement->components.visit_children(*this);
+        visit(statement->components, "components");
         return setCurrent(statement);
     }
 

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -799,10 +799,10 @@ const IR::Node* TypeInference::preorder(IR::Declaration_Instance* decl) {
     // the declaration, and then typecheck the initializer if present.
     if (done())
         return decl;
-    visit(decl->type);
-    visit(decl->arguments);
-    visit(decl->annotations);
-    decl->properties.visit_children(*this);
+    visit(decl->type, "type");
+    visit(decl->arguments, "arguments");
+    visit(decl->annotations, "annotations");
+    visit(decl->properties, "properties");
 
     auto type = getTypeType(decl->type);
     if (type == nullptr) {

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -49,7 +49,7 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Control* cont) {
         return nullptr;
     }
 
-    cont->controlLocals.visit_children(*this);
+    visit(cont->controlLocals, "controlLocals");
     visit(cont->body);
     prune();
     return cont;
@@ -62,8 +62,8 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Parser* cont) {
         return nullptr;
     }
 
-    cont->parserLocals.visit_children(*this);
-    cont->states.visit_children(*this);
+    visit(cont->parserLocals, "parserLocals");
+    visit(cont->states, "states");
     prune();
     return cont;
 }

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -307,7 +307,7 @@ class SelectExpression : Expression {
     inline Vector<SelectCase> selectCases;
     visit_children {
         v.visit(select, "select");
-        selectCases.parallel_visit_children(v); }
+        v.parallel_visit(selectCases, "selectCases"); }
 }
 
 class MethodCallExpression : Expression {

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -457,7 +457,7 @@ class SwitchStatement : Statement {
     inline Vector<SwitchCase> cases;
     visit_children {
         v.visit(expression, "expression");
-        cases.parallel_visit_children(v); }
+        v.parallel_visit(cases, "cases"); }
 }
 
 class Function : Declaration {

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -374,7 +374,7 @@ class ActionFunction {
                 return a;
         return nullptr; }
     visit_children {
-        action.visit_children(v);
+        v.visit(action, "action");
         // DANGER -- visiting action first so type inferencing will push types to
         // DANGER -- action args based on use.  This is immoral.
         for (auto &a : args) v.visit(a, "arg");

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -92,6 +92,38 @@ class Visitor {
     void visit(IR::CLASS *&, const char * = 0, int = 0) { BUG("Can't visit non-const pointer"); }
     IRNODE_ALL_SUBCLASSES(DECLARE_VISIT_FUNCTIONS)
 #undef DECLARE_VISIT_FUNCTIONS
+    void visit(IR::Node &n, const char *name = 0) {
+        if (name && ctxt) ctxt->child_name = name;
+        n.visit_children(*this); }
+    void visit(const IR::Node &n, const char *name = 0) {
+        if (name && ctxt) ctxt->child_name = name;
+        n.visit_children(*this); }
+    void visit(IR::Node &n, const char *name, int cidx) {
+        if (ctxt) {
+            ctxt->child_name = name;
+            ctxt->child_index = cidx; }
+        n.visit_children(*this); }
+    void visit(const IR::Node &n, const char *name, int cidx) {
+        if (ctxt) {
+            ctxt->child_name = name;
+            ctxt->child_index = cidx; }
+        n.visit_children(*this); }
+    template<class T> void parallel_visit(IR::Vector<T> &v, const char *name = 0) {
+        if (name && ctxt) ctxt->child_name = name;
+        v.parallel_visit_children(*this); }
+    template<class T> void parallel_visit(const IR::Vector<T> &v, const char *name = 0) {
+        if (name && ctxt) ctxt->child_name = name;
+        v.parallel_visit_children(*this); }
+    template<class T> void parallel_visit(IR::Vector<T> &v, const char *name, int cidx) {
+        if (ctxt) {
+            ctxt->child_name = name;
+            ctxt->child_index = cidx; }
+        v.parallel_visit_children(*this); }
+    template<class T> void parallel_visit(const IR::Vector<T> &v, const char *name, int cidx) {
+        if (ctxt) {
+            ctxt->child_name = name;
+            ctxt->child_index = cidx; }
+        v.parallel_visit_children(*this); }
 
     // Functions for IR visit_children to call for ControlFlowVisitors.
     virtual Visitor &flow_clone() { return *this; }

--- a/midend/inlining.cpp
+++ b/midend/inlining.cpp
@@ -138,7 +138,7 @@ class FindLocationSets : public Inspector {
     }
 
     bool preorder(const IR::ListExpression* expression) {
-        expression->components.visit_children(*this);
+        visit(expression->components, "components");
         auto l = LocationSet::empty;
         for (auto c : expression->components) {
             auto cl = get(c);
@@ -444,7 +444,7 @@ bool DiscoverInlining::preorder(const IR::ParserBlock* block) {
         inlineList->addInstantiation(parent->container, callee, instance);
     }
     visit_all(block);
-    block->container->states.visit_children(*this);
+    visit(block->container->states, "states");
     return false;
 }
 
@@ -681,7 +681,7 @@ class RenameStates : public Transform {
         return path;
     }
     const IR::Node* preorder(IR::SelectExpression* expression) override {
-        expression->selectCases.parallel_visit_children(*this);
+        parallel_visit(expression->selectCases, "selectCases", 1);
         prune();
         return expression;
     }
@@ -704,7 +704,7 @@ class RenameStates : public Transform {
         return state;
     }
     const IR::Node* preorder(IR::P4Parser* parser) override {
-        parser->states.visit_children(*this);
+        visit(parser->states, "states");
         prune();
         return parser;
     }
@@ -871,7 +871,7 @@ const IR::Node* GeneralInliner::preorder(IR::P4Parser* caller) {
         }
     }
 
-    caller->states.visit_children(*this);
+    visit(caller->states, "states");
     caller->parserLocals = locals;
     list->replace(orig, caller);
     workToDo = nullptr;

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -312,7 +312,7 @@ IR::P4Control *DoLocalCopyPropagation::preorder(IR::P4Control *ctrl) {
     BUG_CHECK(!working && available.empty(), "corrupt internal data struct");
     visit(ctrl->type, "type");
     visit(ctrl->constructorParams, "constructorParams");
-    ctrl->controlLocals.visit_children(*this);
+    visit(ctrl->controlLocals, "controlLocals");
     if (working || !available.empty()) BUG("corrupt internal data struct");
     working = true;
     LOG2("DoLocalCopyPropagation working on control " << ctrl->name);

--- a/midend/moveConstructors.cpp
+++ b/midend/moveConstructors.cpp
@@ -49,9 +49,9 @@ class MoveConstructorsImpl : public Transform {
     const IR::Node* preorder(IR::P4Parser* parser) override {
         cmap.clear();
         convert = Region::InParserStateful;
-        parser->parserLocals.visit_children(*this);
+        visit(parser->parserLocals, "parserLocals");
         convert = Region::InBody;
-        parser->states.visit_children(*this);
+        visit(parser->states, "states");
         convert = Region::Outside;
         prune();
         return parser;

--- a/midend/removeReturns.cpp
+++ b/midend/removeReturns.cpp
@@ -71,7 +71,7 @@ const IR::Node* DoRemoveReturns::preorder(IR::P4Action* action) {
 }
 
 const IR::Node* DoRemoveReturns::preorder(IR::P4Control* control) {
-    control->controlLocals.visit_children(*this);
+    visit(control->controlLocals, "controlLocals");
 
     HasExits he;
     (void)control->body->apply(he);
@@ -168,7 +168,7 @@ const IR::Node* DoRemoveReturns::preorder(IR::IfStatement* statement) {
 const IR::Node* DoRemoveReturns::preorder(IR::SwitchStatement* statement) {
     auto r = Returns::No;
     push();
-    statement->cases.visit_children(*this);
+    parallel_visit(statement->cases, "cases", 1);
     if (hasReturned() != Returns::No)
         // this is conservative: we don't check if we cover all labels.
         r = Returns::Maybe;
@@ -262,7 +262,7 @@ const IR::Node* DoRemoveExits::preorder(IR::P4Control* control) {
 
     cstring var = refMap->newName(variableName);
     returnVar = IR::ID(var, nullptr);
-    control->controlLocals.visit_children(*this);
+    visit(control->controlLocals, "controlLocals");
 
     BUG_CHECK(stack.empty(), "Non-empty stack");
     push();


### PR DESCRIPTION
I'm of mixed feelings about whether this makes things easier, or more obscure.

The change adds overloads to Visitor so that visit_children routines need only call `visit` (or `parallel_visit`) for each field, rather than calling `visit` for non-inline fields and `visit_children` for inline fields.  It simplifies things in that you don't have to think as much about whether a field is inline or not but is a little more obscure in that you may not notice when a field is inline.  When you have an inline field, you never actually visit the field object instance at all -- that's the whole point of inline: a level of indirection goes away and all the children act as if they were direct children of the containing object.