### PR TITLE
Support functions for TableProperties

### DIFF
--- a/frontends/p4-14/typecheck.cpp
+++ b/frontends/p4-14/typecheck.cpp
@@ -86,7 +86,8 @@ class TypeCheck::Pass1 : public Transform {
             auto fl = new IR::FieldList();
             for (auto &name : flc->input->names) {
                 fl->fields.push_back(new IR::PathExpression(name));
-                fl->srcInfo += name.srcInfo; } }
+                fl->srcInfo += name.srcInfo; }
+            flc->input_fields = fl; }
         return flc; }
     const IR::Node *preorder(IR::Property *prop) override {
         if (auto di = findContext<IR::Declaration_Instance>()) {

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -357,13 +357,8 @@ class DiscoverStructure : public Inspector {
     { structure->calculated_fields.push_back(cf); }
     void postorder(const IR::Meter* m) override
     { structure->meters.emplace(m); }
-    void postorder(const IR::ActionSelector* as) override {
-        structure->action_selectors.emplace(as);
-        if (!as->type.name.isNullOrEmpty())
-            ::warning("%1%: Action selector attribute ignored", as->type);
-        if (!as->mode.name.isNullOrEmpty())
-            ::warning("%1%: Action selector attribute ignored", as->mode);
-    }
+    void postorder(const IR::ActionSelector* as) override
+    { structure->action_selectors.emplace(as); }
     void postorder(const IR::Type_Extern *ext) override
     { structure->extern_types.emplace(ext); }
     void postorder(const IR::Declaration_Instance *ext) override

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -743,6 +743,10 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
         auto constructor = new IR::ConstructorCallExpression(Util::SourceInfo(), type, args);
         auto propvalue = new IR::ExpressionValue(Util::SourceInfo(), constructor);
         auto annos = addNameAnnotation(action_profile->name);
+        if (action_selector->mode)
+            annos = annos->addAnnotation("mode", new IR::StringLiteral(action_selector->mode));
+        if (action_selector->type)
+            annos = annos->addAnnotation("type", new IR::StringLiteral(action_selector->mode));
         auto prop = new IR::Property(
             Util::SourceInfo(), IR::ID(v1model.tableAttributes.tableImplementation.Id()),
             annos, propvalue, false);
@@ -1750,6 +1754,7 @@ ProgramStructure::checksumUnit(const IR::FieldListCalculation* flc) {
 // if a FieldListCalculation contains multiple field lists concatenate them all
 // into a temporary field list
 const IR::FieldList* ProgramStructure::getFieldLists(const IR::FieldListCalculation* flc) {
+    // FIXME -- this duplicates P4_14::TypeCheck.  Why not just use flc->input_fields?
     if (flc->input->names.size() == 0)
         ::error("%1%: field_list_calculation with zero inputs", flc);
     if (flc->input->names.size() == 1) {

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -178,6 +178,25 @@ class KeyElement {
     Annotations     annotations;
     Expression      expression;
     PathExpression  matchType;
+
+    const IR::Node *transform_visit(Transform &v) {
+        // call this from Transform::preorder(KeyElement) if the transform might split
+        // the expression into a Vector<Expression>
+        v.visit(annotations, "annotations");
+        auto exp = v.apply_visitor(expression, "expression");
+        v.visit(matchType, "matchType");
+        v.prune();
+        if (exp == expression) {
+        } else if (auto vec = exp->to<Vector<Expression>>()) {
+            auto *rv = new Vector<KeyElement>();
+            for (auto el : *vec) {
+                auto *kel = clone();
+                kel->expression = el;
+                rv->push_back(kel); }
+            return rv;
+        } else {
+            expression = exp->to<IR::Expression>(); }
+        return this; }
 }
 
 // Value of a table key property
@@ -243,6 +262,13 @@ class P4Table : Declaration, IAnnotated, IApply {
             ::error("%1% must be an expression", d);
             return nullptr; }
         return d->value->to<IR::ExpressionValue>()->expression; }
+    Constant getConstantProperty(cstring name) const {
+        if (auto d = properties->getProperty(name)) {
+            if (auto ev = d->value->to<IR::ExpressionValue>()) {
+                if (auto k = ev->expression->to<IR::Constant>()) {
+                    return k; } }
+            error("%1% must be a constant expression", d); }
+        return nullptr; }
 }
 
 class Declaration_Variable : Declaration, IAnnotated {

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -228,10 +228,10 @@ class Transform : public virtual Visitor {
     IRNODE_ALL_SUBCLASSES(DECLARE_VISIT_FUNCTIONS)
 #undef DECLARE_VISIT_FUNCTIONS
     void revisit_visited();
+    // can only be called usefully from a 'preorder' function (directly or indirectly)
+    void prune() { prune_flag = true; }
 
  protected:
-    // can only be called usefully from 'preorder' function
-    void prune() { prune_flag = true; }
     const IR::Node *transform_child(const IR::Node *child) {
         auto *rv = apply_visitor(child);
         prune_flag = true;

--- a/testdata/p4_14_samples_outputs/selector0-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector0-frontend.p4
@@ -44,7 +44,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1_0.apply();

--- a/testdata/p4_14_samples_outputs/selector0-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector0-midend.p4
@@ -46,7 +46,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction_0();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1.apply();

--- a/testdata/p4_14_samples_outputs/selector0.p4
+++ b/testdata/p4_14_samples_outputs/selector0.p4
@@ -44,7 +44,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1.apply();

--- a/testdata/p4_14_samples_outputs/selector1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector1-frontend.p4
@@ -48,7 +48,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1_0.apply();

--- a/testdata/p4_14_samples_outputs/selector1-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector1-midend.p4
@@ -50,7 +50,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction_0();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1.apply();

--- a/testdata/p4_14_samples_outputs/selector1.p4
+++ b/testdata/p4_14_samples_outputs/selector1.p4
@@ -48,7 +48,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1.apply();

--- a/testdata/p4_14_samples_outputs/selector2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector2-frontend.p4
@@ -48,7 +48,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1_0.apply();

--- a/testdata/p4_14_samples_outputs/selector2-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector2-midend.p4
@@ -50,7 +50,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction_0();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1.apply();

--- a/testdata/p4_14_samples_outputs/selector2.p4
+++ b/testdata/p4_14_samples_outputs/selector2.p4
@@ -48,7 +48,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1.apply();

--- a/testdata/p4_14_samples_outputs/selector3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector3-frontend.p4
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1_0.apply();

--- a/testdata/p4_14_samples_outputs/selector3-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector3-midend.p4
@@ -57,7 +57,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction_0();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1.apply();

--- a/testdata/p4_14_samples_outputs/selector3.p4
+++ b/testdata/p4_14_samples_outputs/selector3.p4
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction();
-        @name("sel_profile") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
+        @name("sel_profile") @mode("fair") implementation = action_selector(HashAlgorithm.crc16, 32w16384, 32w14);
     }
     apply {
         test1.apply();

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -4502,7 +4502,7 @@ control process_nexthop(inout headers hdr, inout metadata meta, inout standard_m
         }
         size = 1024;
         default_action = NoAction();
-        @name("ecmp_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+        @name("ecmp_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
     }
     @name("nexthop") table nexthop_0() {
         actions = {
@@ -4572,7 +4572,7 @@ control process_lag(inout headers hdr, inout metadata meta, inout standard_metad
         }
         size = 1024;
         default_action = NoAction();
-        @name("lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     apply {
         lag_group_0.apply();
@@ -4632,7 +4632,7 @@ control process_fabric_lag(inout headers hdr, inout metadata meta, inout standar
             meta.hash_metadata.hash2       : selector @name("meta.hash_metadata.hash2") ;
         }
         default_action = NoAction();
-        @name("fabric_lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("fabric_lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     apply {
         fabric_lag_0.apply();

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -4610,7 +4610,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction_160();
-        @name("ecmp_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+        @name("ecmp_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
     }
     @name("process_nexthop.nexthop") table process_nexthop_nexthop_0() {
         actions = {
@@ -4665,7 +4665,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction_163();
-        @name("lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     @name("process_mac_learning.nop") action process_mac_learning_nop() {
     }
@@ -4706,7 +4706,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             meta.hash_metadata.hash2       : selector @name("meta.hash_metadata.hash2") ;
         }
         default_action = NoAction_165();
-        @name("fabric_lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("fabric_lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     @name("process_system_acl.drop_stats") counter(32w1024, CounterType.packets) process_system_acl_drop_stats_2;
     @name("process_system_acl.drop_stats_2") counter(32w1024, CounterType.packets) process_system_acl_drop_stats_3;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
@@ -4630,7 +4630,7 @@ control process_nexthop(inout headers hdr, inout metadata meta, inout standard_m
         }
         size = 1024;
         default_action = NoAction();
-        @name("ecmp_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+        @name("ecmp_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
     }
     @name("nexthop") table nexthop() {
         actions = {
@@ -4702,7 +4702,7 @@ control process_lag(inout headers hdr, inout metadata meta, inout standard_metad
         }
         size = 1024;
         default_action = NoAction();
-        @name("lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     apply {
         lag_group.apply();
@@ -4763,7 +4763,7 @@ control process_fabric_lag(inout headers hdr, inout metadata meta, inout standar
             meta.hash_metadata.hash2       : selector;
         }
         default_action = NoAction();
-        @name("fabric_lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("fabric_lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     apply {
         fabric_lag.apply();

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -5451,7 +5451,7 @@ control process_nexthop(inout headers hdr, inout metadata meta, inout standard_m
         }
         size = 1024;
         default_action = NoAction();
-        @name("ecmp_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+        @name("ecmp_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
     }
     @name("nexthop") table nexthop_0() {
         actions = {
@@ -5521,7 +5521,7 @@ control process_lag(inout headers hdr, inout metadata meta, inout standard_metad
         }
         size = 1024;
         default_action = NoAction();
-        @name("lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     apply {
         lag_group_0.apply();
@@ -5581,7 +5581,7 @@ control process_fabric_lag(inout headers hdr, inout metadata meta, inout standar
             meta.hash_metadata.hash2       : selector @name("meta.hash_metadata.hash2") ;
         }
         default_action = NoAction();
-        @name("fabric_lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("fabric_lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     apply {
         fabric_lag_0.apply();

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -5488,7 +5488,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction_218();
-        @name("ecmp_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+        @name("ecmp_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
     }
     @name("process_nexthop.nexthop") table process_nexthop_nexthop_0() {
         actions = {
@@ -5543,7 +5543,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         size = 1024;
         default_action = NoAction_221();
-        @name("lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     @name("process_mac_learning.nop") action process_mac_learning_nop() {
     }
@@ -5584,7 +5584,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             meta.hash_metadata.hash2       : selector @name("meta.hash_metadata.hash2") ;
         }
         default_action = NoAction_223();
-        @name("fabric_lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("fabric_lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     @name("process_system_acl.drop_stats") counter(32w1024, CounterType.packets) process_system_acl_drop_stats_2;
     @name("process_system_acl.drop_stats_2") counter(32w1024, CounterType.packets) process_system_acl_drop_stats_3;

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -5596,7 +5596,7 @@ control process_nexthop(inout headers hdr, inout metadata meta, inout standard_m
         }
         size = 1024;
         default_action = NoAction();
-        @name("ecmp_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+        @name("ecmp_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
     }
     @name("nexthop") table nexthop() {
         actions = {
@@ -5668,7 +5668,7 @@ control process_lag(inout headers hdr, inout metadata meta, inout standard_metad
         }
         size = 1024;
         default_action = NoAction();
-        @name("lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     apply {
         lag_group.apply();
@@ -5729,7 +5729,7 @@ control process_fabric_lag(inout headers hdr, inout metadata meta, inout standar
             meta.hash_metadata.hash2       : selector;
         }
         default_action = NoAction();
-        @name("fabric_lag_action_profile") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
+        @name("fabric_lag_action_profile") @mode("fair") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w8);
     }
     apply {
         fabric_lag.apply();


### PR DESCRIPTION
- IR::P4Table::getConstProp to get a constant property
- IR::KeyElement::transform_visit to visit a KeyElement and possibly
  split it into multiple KeyElements.

These are useful utility functions for backends that need to do things with Table Properties.