### PR TITLE
Fix for issue #304

### DIFF
--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1587,9 +1587,13 @@ Util::IJson* JsonConverter::convertControl(const IR::ControlBlock* block, cstrin
     for (auto node : cfg->allNodes) {
         if (node->is<CFG::TableNode>()) {
             auto j = convertTable(node->to<CFG::TableNode>(), counters, action_profiles);
+            if (::errorCount() > 0)
+                return nullptr;
             tables->append(j);
         } else if (node->is<CFG::IfNode>()) {
             auto j = convertIf(node->to<CFG::IfNode>(), cont->name);
+            if (::errorCount() > 0)
+                return nullptr;
             conditionals->append(j);
         }
     }

--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -152,7 +152,7 @@ bool CodeGenInspector::preorder(const IR::BoolLiteral* b) {
 
 bool CodeGenInspector::preorder(const IR::ListExpression* expression) {
     bool first = true;
-    for (auto e: *expression->components) {
+    for (auto e : *expression->components) {
         if (!first)
             builder->append(", ");
         first = false;

--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -30,7 +30,7 @@ bool CodeGenInspector::preorder(const IR::Constant* expression) {
 
 bool CodeGenInspector::preorder(const IR::Declaration_Variable* decl) {
     auto type = EBPFTypeFactory::instance->create(decl->type);
-    type->declare(decl->name.name, false);
+    type->declare(builder, decl->name.name, false);
     if (decl->initializer != nullptr) {
         builder->append(" = ");
         visit(decl->initializer);
@@ -114,7 +114,7 @@ bool CodeGenInspector::preorder(const IR::Cast* c) {
     builder->append("(");
     builder->append("(");
     auto et = EBPFTypeFactory::instance->create(c->destType);
-    et->emit();
+    et->emit(builder);
     builder->append(")");
     visit(c->expr);
     builder->append(")");
@@ -145,7 +145,7 @@ bool CodeGenInspector::preorder(const IR::BoolLiteral* b) {
 bool CodeGenInspector::preorder(const IR::Type_Typedef* type) {
     auto et = EBPFTypeFactory::instance->create(type->type);
     builder->append("typedef ");
-    et->emit();
+    et->emit(builder);
     builder->spc();
     builder->append(type->name);
     builder->endOfStatement();

--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -30,7 +30,7 @@ bool CodeGenInspector::preorder(const IR::Constant* expression) {
 
 bool CodeGenInspector::preorder(const IR::Declaration_Variable* decl) {
     auto type = EBPFTypeFactory::instance->create(decl->type);
-    type->declare(builder, decl->name.name, false);
+    type->declare(decl->name.name, false);
     if (decl->initializer != nullptr) {
         builder->append(" = ");
         visit(decl->initializer);
@@ -114,7 +114,7 @@ bool CodeGenInspector::preorder(const IR::Cast* c) {
     builder->append("(");
     builder->append("(");
     auto et = EBPFTypeFactory::instance->create(c->destType);
-    et->emit(builder);
+    et->emit();
     builder->append(")");
     visit(c->expr);
     builder->append(")");
@@ -145,7 +145,7 @@ bool CodeGenInspector::preorder(const IR::BoolLiteral* b) {
 bool CodeGenInspector::preorder(const IR::Type_Typedef* type) {
     auto et = EBPFTypeFactory::instance->create(type->type);
     builder->append("typedef ");
-    et->emit(builder);
+    et->emit();
     builder->spc();
     builder->append(type->name);
     builder->endOfStatement();

--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "codeGen.h"
 #include "ebpfObject.h"
 #include "ebpfType.h"
+#include "frontends/p4/enumInstance.h"
 
 namespace EBPF {
 
@@ -126,10 +127,13 @@ bool CodeGenInspector::preorder(const IR::Cast* c) {
     return false;
 }
 
-bool CodeGenInspector::preorder(const IR::Member* e) {
-    visit(e->expr);
-    builder->append(".");
-    builder->append(e->member);
+bool CodeGenInspector::preorder(const IR::Member* expression) {
+    auto ei = P4::EnumInstance::resolve(expression, typeMap);
+    if (ei == nullptr) {
+        visit(expression->expr);
+        builder->append(".");
+    }
+    builder->append(expression->member);
     return false;
 }
 

--- a/backends/ebpf/codeGen.h
+++ b/backends/ebpf/codeGen.h
@@ -35,12 +35,16 @@ class CodeBuilder : public Util::SourceCodeBuilder {
 class CodeGenInspector : public Inspector {
  protected:
     CodeBuilder*       builder;
-    const P4::TypeMap* typeMap;
+    P4::ReferenceMap* refMap;
+    P4::TypeMap* typeMap;
     std::map<const IR::Parameter*, const IR::Parameter*> substitution;
 
  public:
-    explicit CodeGenInspector(const P4::TypeMap* typeMap) :
-            builder(nullptr), typeMap(typeMap) { visitDagOnce = false; }
+    CodeGenInspector(P4::ReferenceMap* refMap, P4::TypeMap* typeMap) :
+            builder(nullptr), refMap(refMap), typeMap(typeMap) {
+        CHECK_NULL(refMap); CHECK_NULL(typeMap);
+        visitDagOnce = false;
+    }
 
     void setBuilder(CodeBuilder* builder) {
         CHECK_NULL(builder);
@@ -56,6 +60,8 @@ class CodeGenInspector : public Inspector {
     bool notSupported(const IR::Expression* expression)
     { ::error("%1%: not yet implemented", expression); return false; }
 
+    bool preorder(const IR::Expression* expression) override
+    { return notSupported(expression); }
     bool preorder(const IR::Range* expression) override
     { return notSupported(expression); }
     bool preorder(const IR::Mask* expression) override
@@ -63,6 +69,9 @@ class CodeGenInspector : public Inspector {
     bool preorder(const IR::Slice* expression) override
     { return notSupported(expression); }
 
+    bool preorder(const IR::StringLiteral* expression) override;
+    bool preorder(const IR::ListExpression* expression) override;
+    bool preorder(const IR::PathExpression* expression) override;
     bool preorder(const IR::Constant* expression) override;
     bool preorder(const IR::Declaration_Variable* decl) override;
     bool preorder(const IR::BoolLiteral* b) override;
@@ -72,6 +81,7 @@ class CodeGenInspector : public Inspector {
     bool preorder(const IR::ArrayIndex* a) override;
     bool preorder(const IR::Mux* a) override;
     bool preorder(const IR::Member* e) override;
+    bool preorder(const IR::MethodCallExpression* expression) override;
     bool comparison(const IR::Operation_Relation* comp);
     bool preorder(const IR::Equ* e) override { return comparison(e); }
     bool preorder(const IR::Neq* e) override { return comparison(e); }

--- a/backends/ebpf/ebpfBackend.cpp
+++ b/backends/ebpf/ebpfBackend.cpp
@@ -72,8 +72,8 @@ void run_ebpf_backend(const EbpfOptions& options, const IR::ToplevelBlock* tople
     if (hstream == nullptr)
         return;
 
-    ebpfprog->emitC(&c, hfile);
     ebpfprog->emitH(&h, hfile);
+    ebpfprog->emitC(&c, hfile);
     *cstream << c.toString();
     *hstream << h.toString();
     cstream->flush();

--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -285,7 +285,7 @@ void ControlBodyTranslator::processApply(const P4::ApplyMethod* method) {
     builder->appendLine("/* construct key */");
     builder->emitIndent();
     cstring keyname = "key";
-    builder->appendFormat("struct %s %s", table->keyTypeName, keyname);
+    builder->appendFormat("struct %s %s = {}", table->keyTypeName, keyname);
     builder->endOfStatement(true);
 
     table->emitKey(builder, keyname);

--- a/backends/ebpf/ebpfControl.h
+++ b/backends/ebpf/ebpfControl.h
@@ -33,11 +33,12 @@ class ControlBodyTranslator : public CodeGenInspector {
     explicit ControlBodyTranslator(const EBPFControl* control);
 
     // handle the packet_out.emit method
-    void compileEmitField(const IR::Expression* expr, cstring field,
-                          unsigned alignment, EBPFType* type);
-    void compileEmit(const IR::Vector<IR::Expression>* args);
-    void processMethod(const P4::ExternMethod* method);
-    void processApply(const P4::ApplyMethod* method);
+    virtual void compileEmitField(const IR::Expression* expr, cstring field,
+                                  unsigned alignment, EBPFType* type);
+    virtual void compileEmit(const IR::Vector<IR::Expression>* args);
+    virtual void processMethod(const P4::ExternMethod* method);
+    virtual void processApply(const P4::ApplyMethod* method);
+    virtual void processFunction(const P4::ExternFunction* function);
 
     bool preorder(const IR::PathExpression* expression) override;
     bool preorder(const IR::MethodCallExpression* expression) override;

--- a/backends/ebpf/ebpfObject.h
+++ b/backends/ebpf/ebpfObject.h
@@ -29,10 +29,6 @@ namespace EBPF {
 // Base class for EBPF objects
 class EBPFObject {
  public:
-    CodeBuilder* builder;
-
-    explicit EBPFObject(CodeBuilder* builder) : builder(builder)
-    { CHECK_NULL(builder); }
     virtual ~EBPFObject() {}
     template<typename T> bool is() const { return to<T>() != nullptr; }
     template<typename T> const T* to() const {

--- a/backends/ebpf/ebpfObject.h
+++ b/backends/ebpf/ebpfObject.h
@@ -29,6 +29,10 @@ namespace EBPF {
 // Base class for EBPF objects
 class EBPFObject {
  public:
+    CodeBuilder* builder;
+
+    explicit EBPFObject(CodeBuilder* builder) : builder(builder)
+    { CHECK_NULL(builder); }
     virtual ~EBPFObject() {}
     template<typename T> bool is() const { return to<T>() != nullptr; }
     template<typename T> const T* to() const {

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -154,7 +154,7 @@ StateTranslationVisitor::compileExtractField(
         builder->emitIndent();
         visit(expr);
         builder->appendFormat(".%s = (", field.c_str());
-        type->emit();
+        type->emit(builder);
         builder->appendFormat(")((%s(%s, BYTES(%s))",
                               helper,
                               program->packetStartVar.c_str(),
@@ -165,7 +165,7 @@ StateTranslationVisitor::compileExtractField(
 
         if (widthToExtract != loadSize) {
             builder->append(" & EBPF_MASK(");
-            type->emit();
+            type->emit(builder);
             builder->appendFormat(", %d)", widthToExtract);
         }
 
@@ -190,7 +190,7 @@ StateTranslationVisitor::compileExtractField(
             builder->emitIndent();
             visit(expr);
             builder->appendFormat(".%s[%d] = (", field.c_str(), i);
-            bt->emit();
+            bt->emit(builder);
             builder->appendFormat(")((%s(%s, BYTES(%s) + %d) >> %d)",
                                   helper,
                                   program->packetStartVar.c_str(),
@@ -198,7 +198,7 @@ StateTranslationVisitor::compileExtractField(
 
             if ((i == bytes - 1) && (widthToExtract % 8 != 0)) {
                 builder->append(" & EBPF_MASK(");
-                bt->emit();
+                bt->emit(builder);
                 builder->appendFormat(", %d)", widthToExtract % 8);
             }
 
@@ -334,7 +334,7 @@ EBPFParser::EBPFParser(const EBPFProgram* program, const IR::ParserBlock* block,
 
 void EBPFParser::emit(CodeBuilder* builder) {
     for (auto s : states)
-        s->emit();
+        s->emit(builder);
     builder->newline();
 
     // Create a synthetic reject state
@@ -357,7 +357,7 @@ bool EBPFParser::build() {
     packet = *it; ++it;
     headers = *it;
     for (auto state : *parserBlock->container->states) {
-        auto ps = new EBPFParserState(state, this, builder);
+        auto ps = new EBPFParserState(state, this);
         states.push_back(ps);
     }
 

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -34,7 +34,7 @@ class StateTranslationVisitor : public CodeGenInspector {
 
  public:
     explicit StateTranslationVisitor(const EBPFParserState* state) :
-            CodeGenInspector(state->parser->program->typeMap),
+            CodeGenInspector(state->parser->program->refMap, state->parser->program->typeMap),
             hasDefault(false), p4lib(P4::P4CoreLibrary::instance), state(state) {}
     bool preorder(const IR::ParserState* state) override;
     bool preorder(const IR::SelectCase* selectCase) override;

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -154,7 +154,7 @@ StateTranslationVisitor::compileExtractField(
         builder->emitIndent();
         visit(expr);
         builder->appendFormat(".%s = (", field.c_str());
-        type->emit(builder);
+        type->emit();
         builder->appendFormat(")((%s(%s, BYTES(%s))",
                               helper,
                               program->packetStartVar.c_str(),
@@ -165,7 +165,7 @@ StateTranslationVisitor::compileExtractField(
 
         if (widthToExtract != loadSize) {
             builder->append(" & EBPF_MASK(");
-            type->emit(builder);
+            type->emit();
             builder->appendFormat(", %d)", widthToExtract);
         }
 
@@ -190,7 +190,7 @@ StateTranslationVisitor::compileExtractField(
             builder->emitIndent();
             visit(expr);
             builder->appendFormat(".%s[%d] = (", field.c_str(), i);
-            bt->emit(builder);
+            bt->emit();
             builder->appendFormat(")((%s(%s, BYTES(%s) + %d) >> %d)",
                                   helper,
                                   program->packetStartVar.c_str(),
@@ -198,7 +198,7 @@ StateTranslationVisitor::compileExtractField(
 
             if ((i == bytes - 1) && (widthToExtract % 8 != 0)) {
                 builder->append(" & EBPF_MASK(");
-                bt->emit(builder);
+                bt->emit();
                 builder->appendFormat(", %d)", widthToExtract % 8);
             }
 
@@ -334,7 +334,7 @@ EBPFParser::EBPFParser(const EBPFProgram* program, const IR::ParserBlock* block,
 
 void EBPFParser::emit(CodeBuilder* builder) {
     for (auto s : states)
-        s->emit(builder);
+        s->emit();
     builder->newline();
 
     // Create a synthetic reject state
@@ -357,7 +357,7 @@ bool EBPFParser::build() {
     packet = *it; ++it;
     headers = *it;
     for (auto state : *parserBlock->container->states) {
-        auto ps = new EBPFParserState(state, this);
+        auto ps = new EBPFParserState(state, this, builder);
         states.push_back(ps);
     }
 

--- a/backends/ebpf/ebpfProgram.cpp
+++ b/backends/ebpf/ebpfProgram.cpp
@@ -78,7 +78,7 @@ void EBPFProgram::emitC(CodeBuilder* builder, cstring header) {
     // HACK to force LLVM to put the headers on the stack.
     // This should not be needed, but the llvm bpf back-end seems to be broken.
     builder->emitIndent();
-    builder->append("printk(\"\%p\", ");
+    builder->append("printk(\"%p\", ");
     builder->append(parser->headers->name);
     builder->append(")");
     builder->endOfStatement(true);

--- a/backends/ebpf/ebpfProgram.cpp
+++ b/backends/ebpf/ebpfProgram.cpp
@@ -75,6 +75,14 @@ void EBPFProgram::emitC(CodeBuilder* builder, cstring header) {
     parser->headerType->emitInitializer(builder);
     builder->endOfStatement(true);
 
+    // HACK to force LLVM to put the headers on the stack.
+    // This should not be needed, but the llvm bpf back-end seems to be broken.
+    builder->emitIndent();
+    builder->append("printk(\"\%p\", ");
+    builder->append(parser->headers->name);
+    builder->append(")");
+    builder->endOfStatement(true);
+
     emitLocalVariables(builder);
     builder->newline();
     builder->emitIndent();
@@ -114,6 +122,8 @@ void EBPFProgram::emitH(CodeBuilder* builder, cstring) {
     builder->appendLine("#ifndef _P4_GEN_HEADER_");
     builder->appendLine("#define _P4_GEN_HEADER_");
     builder->target->emitIncludes(builder);
+    builder->appendFormat("#define MAP_PATH \"%s\"", builder->target->sysMapPath().c_str());
+    builder->newline();
     emitTypes(builder);
     control->emitTableTypes(builder);
     builder->appendLine("#if CONTROL_PLANE");

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -74,7 +74,7 @@ EBPFTable::EBPFTable(const EBPFProgram* program, const IR::TableBlock* table,
     actionList = table->container->getActionList();
 }
 
-void EBPFTable::emitKeyType(CodeBuilder* builder) {
+void EBPFTable::emitKeyType() {
     builder->emitIndent();
     builder->appendFormat("struct %s ", keyTypeName);
     builder->blockStart();
@@ -112,7 +112,7 @@ void EBPFTable::emitActionArguments(CodeBuilder* builder,
     for (auto p : *action->parameters->getEnumerator()) {
         builder->emitIndent();
         auto type = EBPFTypeFactory::instance->create(p->type);
-        type->declare(builder, p->name.name, false);
+        type->declare(p->name.name, false);
         builder->endOfStatement(true);
     }
 
@@ -122,7 +122,7 @@ void EBPFTable::emitActionArguments(CodeBuilder* builder,
     builder->endOfStatement(true);
 }
 
-void EBPFTable::emitValueType(CodeBuilder* builder) {
+void EBPFTable::emitValueType() {
     // create an enum with tags for all actions
     builder->emitIndent();
     builder->append("enum ");
@@ -160,7 +160,7 @@ void EBPFTable::emitValueType(CodeBuilder* builder) {
         auto adecl = program->refMap->getDeclaration(a->getPath(), true);
         auto action = adecl->getNode()->to<IR::P4Action>();
         cstring name = action->externalName();
-        emitActionArguments(builder, action, name);
+        emitActionArguments(action, name);
     }
 
     builder->blockEnd(false);
@@ -388,8 +388,7 @@ void EBPFCounterTable::emitInstance(CodeBuilder* builder) {
         EBPFModel::instance.counterValueType, size);
 }
 
-void EBPFCounterTable::emitCounterIncrement(CodeBuilder* builder,
-                                            const IR::MethodCallExpression *expression) {
+void EBPFCounterTable::emitCounterIncrement(const IR::MethodCallExpression *expression) {
     cstring keyName = program->refMap->newName("key");
     cstring valueName = program->refMap->newName("value");
 
@@ -440,9 +439,9 @@ void EBPFCounterTable::emitCounterIncrement(CodeBuilder* builder,
 }
 
 void
-EBPFCounterTable::emitMethodInvocation(CodeBuilder* builder, const P4::ExternMethod* method) {
+EBPFCounterTable::emitMethodInvocation(const P4::ExternMethod* method) {
     if (method->method->name.name == program->model.counterArray.increment.name) {
-        emitCounterIncrement(builder, method->expr);
+        emitCounterIncrement(method->expr);
         return;
     }
     ::error("%1%: Unexpected method for %2%", method->expr, program->model.counterArray.name);

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -74,7 +74,7 @@ EBPFTable::EBPFTable(const EBPFProgram* program, const IR::TableBlock* table,
     actionList = table->container->getActionList();
 }
 
-void EBPFTable::emitKeyType() {
+void EBPFTable::emitKeyType(CodeBuilder* builder) {
     builder->emitIndent();
     builder->appendFormat("struct %s ", keyTypeName);
     builder->blockStart();
@@ -112,7 +112,7 @@ void EBPFTable::emitActionArguments(CodeBuilder* builder,
     for (auto p : *action->parameters->getEnumerator()) {
         builder->emitIndent();
         auto type = EBPFTypeFactory::instance->create(p->type);
-        type->declare(p->name.name, false);
+        type->declare(builder, p->name.name, false);
         builder->endOfStatement(true);
     }
 
@@ -122,7 +122,7 @@ void EBPFTable::emitActionArguments(CodeBuilder* builder,
     builder->endOfStatement(true);
 }
 
-void EBPFTable::emitValueType() {
+void EBPFTable::emitValueType(CodeBuilder* builder) {
     // create an enum with tags for all actions
     builder->emitIndent();
     builder->append("enum ");
@@ -160,7 +160,7 @@ void EBPFTable::emitValueType() {
         auto adecl = program->refMap->getDeclaration(a->getPath(), true);
         auto action = adecl->getNode()->to<IR::P4Action>();
         cstring name = action->externalName();
-        emitActionArguments(action, name);
+        emitActionArguments(builder, action, name);
     }
 
     builder->blockEnd(false);
@@ -388,7 +388,8 @@ void EBPFCounterTable::emitInstance(CodeBuilder* builder) {
         EBPFModel::instance.counterValueType, size);
 }
 
-void EBPFCounterTable::emitCounterIncrement(const IR::MethodCallExpression *expression) {
+void EBPFCounterTable::emitCounterIncrement(CodeBuilder* builder,
+                                            const IR::MethodCallExpression *expression) {
     cstring keyName = program->refMap->newName("key");
     cstring valueName = program->refMap->newName("value");
 
@@ -439,9 +440,9 @@ void EBPFCounterTable::emitCounterIncrement(const IR::MethodCallExpression *expr
 }
 
 void
-EBPFCounterTable::emitMethodInvocation(const P4::ExternMethod* method) {
+EBPFCounterTable::emitMethodInvocation(CodeBuilder* builder, const P4::ExternMethod* method) {
     if (method->method->name.name == program->model.counterArray.increment.name) {
-        emitCounterIncrement(method->expr);
+        emitCounterIncrement(builder, method->expr);
         return;
     }
     ::error("%1%: Unexpected method for %2%", method->expr, program->model.counterArray.name);

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -275,7 +275,7 @@ void EBPFTable::emitKey(CodeBuilder* builder, cstring keyName) {
 
         builder->emitIndent();
         if (memcpy) {
-            builder->appendFormat("&%s.%s, &", keyName.c_str(), fieldName.c_str());
+            builder->appendFormat("memcpy(&%s.%s, &", keyName.c_str(), fieldName.c_str());
             codeGen->visit(c->expression);
             builder->appendFormat(", %d)", scalar->bytesRequired());
         } else {

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -477,10 +477,12 @@ EBPFCounterTable::emitMethodInvocation(CodeBuilder* builder, const P4::ExternMet
 
 void EBPFCounterTable::emitTypes(CodeBuilder* builder) {
     builder->emitIndent();
-    builder->appendFormat("typedef %s %s", EBPFModel::instance.counterIndexType.c_str(), keyTypeName.c_str());
+    builder->appendFormat("typedef %s %s",
+                          EBPFModel::instance.counterIndexType.c_str(), keyTypeName.c_str());
     builder->endOfStatement(true);
     builder->emitIndent();
-    builder->appendFormat("typedef %s %s", EBPFModel::instance.counterValueType.c_str(), valueTypeName.c_str());
+    builder->appendFormat("typedef %s %s",
+                          EBPFModel::instance.counterValueType.c_str(), valueTypeName.c_str());
     builder->endOfStatement(true);
 }
 

--- a/backends/ebpf/ebpfTable.h
+++ b/backends/ebpf/ebpfTable.h
@@ -53,6 +53,8 @@ class EBPFTable final : public EBPFTableBase {
     const IR::TableBlock*    table;
     cstring               defaultActionMapName;
     cstring               actionEnumName;
+    std::map<const IR::KeyElement*, cstring> keyFieldNames;
+    std::map<const IR::KeyElement*, EBPFType*> keyTypes;
 
     EBPFTable(const EBPFProgram* program, const IR::TableBlock* table, CodeGenInspector* codeGen);
     void emitTypes(CodeBuilder* builder);
@@ -71,7 +73,7 @@ class EBPFCounterTable final : public EBPFTableBase {
  public:
     EBPFCounterTable(const EBPFProgram* program, const IR::ExternBlock* block,
                      cstring name, CodeGenInspector* codeGen);
-    void emitTypes(CodeBuilder*) {}
+    void emitTypes(CodeBuilder*);
     void emitInstance(CodeBuilder* builder);
     void emitCounterIncrement(CodeBuilder* builder, const IR::MethodCallExpression* expression);
     void emitMethodInvocation(CodeBuilder* builder, const P4::ExternMethod* method);

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -25,20 +25,20 @@ EBPFType* EBPFTypeFactory::create(const IR::Type* type) {
     CHECK_NULL(typeMap);
     EBPFType* result = nullptr;
     if (type->is<IR::Type_Boolean>()) {
-        result = new EBPFBoolType();
+        result = new EBPFBoolType(builder);
     } else if (type->is<IR::Type_Bits>()) {
-        result = new EBPFScalarType(type->to<IR::Type_Bits>());
+        result = new EBPFScalarType(type->to<IR::Type_Bits>(), builder);
     } else if (type->is<IR::Type_StructLike>()) {
-        result = new EBPFStructType(type->to<IR::Type_StructLike>());
+        result = new EBPFStructType(type->to<IR::Type_StructLike>(), builder);
     } else if (type->is<IR::Type_Typedef>()) {
         auto canon = typeMap->getTypeType(type, true);
         result = create(canon);
         auto path = new IR::Path(type->to<IR::Type_Typedef>()->name);
-        result = new EBPFTypeName(new IR::Type_Name(Util::SourceInfo(), path), result);
+        result = new EBPFTypeName(new IR::Type_Name(Util::SourceInfo(), path), result, builder);
     } else if (type->is<IR::Type_Name>()) {
         auto canon = typeMap->getTypeType(type, true);
         result = create(canon);
-        result = new EBPFTypeName(type->to<IR::Type_Name>(), result);
+        result = new EBPFTypeName(type->to<IR::Type_Name>(), result, builder);
     } else {
         ::error("Type %1% unsupported by EBPF", type);
     }
@@ -47,8 +47,8 @@ EBPFType* EBPFTypeFactory::create(const IR::Type* type) {
 }
 
 void
-EBPFBoolType::declare(CodeBuilder* builder, cstring id, bool asPointer) {
-    emit(builder);
+EBPFBoolType::declare(cstring id, bool asPointer) {
+    emit();
     if (asPointer)
         builder->append("*");
     builder->appendFormat(" %s", id.c_str());
@@ -68,7 +68,7 @@ unsigned EBPFScalarType::alignment() const {
         return 1;
 }
 
-void EBPFScalarType::emit(CodeBuilder* builder) {
+void EBPFScalarType::emit() {
     auto prefix = isSigned ? "i" : "u";
 
     if (width <= 8)
@@ -82,9 +82,9 @@ void EBPFScalarType::emit(CodeBuilder* builder) {
 }
 
 void
-EBPFScalarType::declare(CodeBuilder* builder, cstring id, bool asPointer) {
+EBPFScalarType::declare(cstring id, bool asPointer) {
     if (width <= 32) {
-        emit(builder);
+        emit();
         if (asPointer)
             builder->append("*");
         builder->spc();
@@ -99,8 +99,8 @@ EBPFScalarType::declare(CodeBuilder* builder, cstring id, bool asPointer) {
 
 //////////////////////////////////////////////////////////
 
-EBPFStructType::EBPFStructType(const IR::Type_StructLike* strct) :
-        EBPFType(strct) {
+EBPFStructType::EBPFStructType(const IR::Type_StructLike* strct, CodeBuilder* builder) :
+        EBPFType(strct, builder) {
     if (strct->is<IR::Type_Struct>())
         kind = "struct";
     else if (strct->is<IR::Type_Header>())
@@ -127,7 +127,7 @@ EBPFStructType::EBPFStructType(const IR::Type_StructLike* strct) :
 }
 
 void
-EBPFStructType::declare(CodeBuilder* builder, cstring id, bool asPointer) {
+EBPFStructType::declare(cstring id, bool asPointer) {
     builder->append(kind);
     if (asPointer)
         builder->append("*");
@@ -135,13 +135,13 @@ EBPFStructType::declare(CodeBuilder* builder, cstring id, bool asPointer) {
     builder->appendFormat(" %s %s", n, id.c_str());
 }
 
-void EBPFStructType::emitInitializer(CodeBuilder* builder) {
+void EBPFStructType::emitInitializer() {
     builder->blockStart();
     if (type->is<IR::Type_Struct>() || type->is<IR::Type_Union>()) {
         for (auto f : fields) {
             builder->emitIndent();
             builder->appendFormat(".%s = ", f->field->name.name);
-            f->type->emitInitializer(builder);
+            f->type->emitInitializer();
             builder->append(",");
             builder->newline();
         }
@@ -154,7 +154,7 @@ void EBPFStructType::emitInitializer(CodeBuilder* builder) {
     builder->blockEnd(false);
 }
 
-void EBPFStructType::emit(CodeBuilder* builder) {
+void EBPFStructType::emit() {
     builder->emitIndent();
     builder->append(kind);
     builder->spc();
@@ -166,7 +166,7 @@ void EBPFStructType::emit(CodeBuilder* builder) {
         auto type = f->type;
         builder->emitIndent();
 
-        type->declare(builder, f->field->name, false);
+        type->declare(f->field->name, false);
         builder->append("; ");
         builder->append("/* ");
         builder->append(type->type->toString());
@@ -182,7 +182,7 @@ void EBPFStructType::emit(CodeBuilder* builder) {
         builder->emitIndent();
         auto type = EBPFTypeFactory::instance->create(IR::Type_Boolean::get());
         if (type != nullptr) {
-            type->declare(builder, "ebpf_valid", false);
+            type->declare("ebpf_valid", false);
             builder->endOfStatement(true);
         }
     }
@@ -193,14 +193,14 @@ void EBPFStructType::emit(CodeBuilder* builder) {
 
 ///////////////////////////////////////////////////////////////
 
-void EBPFTypeName::declare(CodeBuilder* builder, cstring id, bool asPointer) {
+void EBPFTypeName::declare(cstring id, bool asPointer) {
     if (canonical != nullptr)
-        canonical->declare(builder, id, asPointer);
+        canonical->declare(id, asPointer);
 }
 
-void EBPFTypeName::emitInitializer(CodeBuilder* builder) {
+void EBPFTypeName::emitInitializer() {
     if (canonical != nullptr)
-        canonical->emitInitializer(builder);
+        canonical->emitInitializer();
 }
 
 unsigned EBPFTypeName::widthInBits() {

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -64,7 +64,7 @@ unsigned EBPFScalarType::alignment() const {
     else if (width <= 32)
         return 4;
     else
-        // compiled as char*
+        // compiled as u8*
         return 1;
 }
 
@@ -78,7 +78,7 @@ void EBPFScalarType::emit(CodeBuilder* builder) {
     else if (width <= 32)
         builder->appendFormat("%s32", prefix);
     else
-        builder->appendFormat("char*");
+        builder->appendFormat("u8*");
 }
 
 void
@@ -91,9 +91,9 @@ EBPFScalarType::declare(CodeBuilder* builder, cstring id, bool asPointer) {
         builder->append(id);
     } else {
         if (asPointer)
-            builder->append("char*");
+            builder->append("u8*");
         else
-            builder->appendFormat("char %s[%d]", id.c_str(), bytesRequired());
+            builder->appendFormat("u8 %s[%d]", id.c_str(), bytesRequired());
     }
 }
 

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -39,7 +39,7 @@ EBPFType* EBPFTypeFactory::create(const IR::Type* type) {
         auto canon = typeMap->getTypeType(type, true);
         result = create(canon);
         result = new EBPFTypeName(type->to<IR::Type_Name>(), result);
-    } else if (type->is<IR::Type_Enum>()){
+    } else if (type->is<IR::Type_Enum>()) {
         return new EBPFEnumType(type->to<IR::Type_Enum>());
     } else {
         ::error("Type %1% not supported", type);

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -39,6 +39,8 @@ EBPFType* EBPFTypeFactory::create(const IR::Type* type) {
         auto canon = typeMap->getTypeType(type, true);
         result = create(canon);
         result = new EBPFTypeName(type->to<IR::Type_Name>(), result);
+    } else if (type->is<IR::Type_Enum>()){
+        return new EBPFEnumType(type->to<IR::Type_Enum>());
     } else {
         ::error("Type %1% not supported", type);
     }
@@ -219,6 +221,29 @@ unsigned EBPFTypeName::implementationWidthInBits() {
         return 0;
     }
     return wt->implementationWidthInBits();
+}
+
+////////////////////////////////////////////////////////////////
+
+void EBPFEnumType::declare(EBPF::CodeBuilder* builder, cstring id, bool asPointer) {
+    builder->append("enum ");
+    builder->append(getType()->name);
+    if (asPointer)
+        builder->append("*");
+    builder->append(" ");
+    builder->append(id);
+}
+
+void EBPFEnumType::emit(EBPF::CodeBuilder* builder) {
+    builder->append("enum ");
+    auto et = getType();
+    builder->append(et->name);
+    builder->blockStart();
+    for (auto m : *et->members) {
+        builder->append(m->name);
+        builder->appendLine(",");
+    }
+    builder->blockEnd(true);
 }
 
 }  // namespace EBPF

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -40,7 +40,7 @@ EBPFType* EBPFTypeFactory::create(const IR::Type* type) {
         result = create(canon);
         result = new EBPFTypeName(type->to<IR::Type_Name>(), result);
     } else {
-        ::error("Type %1% unsupported by EBPF", type);
+        ::error("Type %1% not supported", type);
     }
 
     return result;

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -27,7 +27,8 @@ namespace EBPF {
 // Base class for EBPF types
 class EBPFType : public EBPFObject {
  protected:
-    explicit EBPFType(const IR::Type* type) : type(type) {}
+    explicit EBPFType(const IR::Type* type, CodeBuilder* builder) :
+            EBPFObject(builder), type(type) {}
  public:
     const IR::Type* type;
     virtual void emit(CodeBuilder* builder) = 0;
@@ -56,15 +57,15 @@ class EBPFTypeFactory {
             typeMap(typeMap) { CHECK_NULL(typeMap); }
  public:
     static EBPFTypeFactory* instance;
-    static void createFactory(const P4::TypeMap* typeMap)
-    { EBPFTypeFactory::instance = new EBPFTypeFactory(typeMap); }
+    static void createFactory(const P4::TypeMap* typeMap, CodeBuilder* builder)
+    { EBPFTypeFactory::instance = new EBPFTypeFactory(typeMap, builder); }
     EBPFType* create(const IR::Type* type);
 };
 
 class EBPFBoolType : public EBPFType, public IHasWidth {
  public:
-    EBPFBoolType() : EBPFType(IR::Type_Boolean::get()) {}
-    void emit(CodeBuilder* builder) override
+    EBPFBoolType(CodeBuilder* builder) : EBPFType(IR::Type_Boolean::get(), builder) {}
+    void emit() override
     { builder->append("u8"); }
     void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
     void emitInitializer(CodeBuilder* builder) override
@@ -97,11 +98,11 @@ class EBPFTypeName : public EBPFType, public IHasWidth {
     const IR::Type_Name* type;
     EBPFType* canonical;
  public:
-    EBPFTypeName(const IR::Type_Name* type, EBPFType* canonical) :
-            EBPFType(type), type(type), canonical(canonical) {}
-    void emit(CodeBuilder* builder) override { canonical->emit(builder); }
-    void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
-    void emitInitializer(CodeBuilder* builder) override;
+    EBPFTypeName(const IR::Type_Name* type, EBPFType* canonical, CodeBuilder* builder) :
+            EBPFType(type, builder), type(type), canonical(canonical) {}
+    void emit() override { canonical->emit(); }
+    void declare(cstring id, bool asPointer) override;
+    void emitInitializer() override;
     unsigned widthInBits() override;
     unsigned implementationWidthInBits() override;
 };
@@ -125,12 +126,12 @@ class EBPFStructType : public EBPFType, public IHasWidth {
     unsigned width;
     unsigned implWidth;
 
-    explicit EBPFStructType(const IR::Type_StructLike* strct);
-    void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
-    void emitInitializer(CodeBuilder* builder) override;
+    EBPFStructType(const IR::Type_StructLike* strct, CodeBuilder* builder);
+    void declare(cstring id, bool asPointer) override;
+    void emitInitializer() override;
     unsigned widthInBits() override { return width; }
     unsigned implementationWidthInBits() override { return implWidth; }
-    void emit(CodeBuilder* builder) override;
+    void emit() override;
 };
 
 }  // namespace EBPF

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -1,4 +1,4 @@
-/*
+
 Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,7 @@ namespace EBPF {
 // Base class for EBPF types
 class EBPFType : public EBPFObject {
  protected:
-    explicit EBPFType(const IR::Type* type, CodeBuilder* builder) :
+    EBPFType(const IR::Type* type, CodeBuilder* builder) :
             EBPFObject(builder), type(type) {}
  public:
     const IR::Type* type;
@@ -64,7 +64,7 @@ class EBPFTypeFactory {
 
 class EBPFBoolType : public EBPFType, public IHasWidth {
  public:
-    EBPFBoolType(CodeBuilder* builder) : EBPFType(IR::Type_Boolean::get(), builder) {}
+    explicit EBPFBoolType(CodeBuilder* builder) : EBPFType(IR::Type_Boolean::get(), builder) {}
     void emit() override
     { builder->append("u8"); }
     void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
@@ -78,8 +78,13 @@ class EBPFScalarType : public EBPFType, public IHasWidth {
  public:
     const unsigned width;
     const bool     isSigned;
+<<<<<<< 8f5dfba7b57ef4bde6a5da900a0576bfd47931e1
     explicit EBPFScalarType(const IR::Type_Bits* bits) :
             EBPFType(bits), width(bits->size), isSigned(bits->isSigned) {}
+=======
+    EBPFScalarType(const IR::Type_Bits* bits, CodeBuilder* builder) :
+            EBPFType(bits, builder), width(bits->size), isSigned(bits->isSigned) {}
+>>>>>>> cpplint fix
     unsigned bytesRequired() const { return ROUNDUP(width, 8); }
     unsigned alignment() const;
     void emit(CodeBuilder* builder) override;

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -1,4 +1,4 @@
-
+/*
 Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -50,7 +50,7 @@ class IHasWidth {
 };
 
 class EBPFTypeFactory {
- private:
+ protected:
     const P4::TypeMap* typeMap;
     explicit EBPFTypeFactory(const P4::TypeMap* typeMap) :
             typeMap(typeMap) { CHECK_NULL(typeMap); }
@@ -58,7 +58,7 @@ class EBPFTypeFactory {
     static EBPFTypeFactory* instance;
     static void createFactory(const P4::TypeMap* typeMap)
     { EBPFTypeFactory::instance = new EBPFTypeFactory(typeMap); }
-    EBPFType* create(const IR::Type* type);
+    virtual EBPFType* create(const IR::Type* type);
 };
 
 class EBPFBoolType : public EBPFType, public IHasWidth {

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -133,6 +133,19 @@ class EBPFStructType : public EBPFType, public IHasWidth {
     void emit(CodeBuilder* builder) override;
 };
 
+class EBPFEnumType : public EBPFType, public EBPF::IHasWidth {
+ public:
+    explicit EBPFEnumType(const IR::Type_Enum* type) : EBPFType(type) {}
+    void emit(CodeBuilder* builder) override;
+    void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
+    void emitInitializer(CodeBuilder* builder) override
+    { builder->append("0"); }
+    unsigned widthInBits() override { return 32; }
+    unsigned implementationWidthInBits() override { return 32; }
+
+    const IR::Type_Enum* getType() const { return type->to<IR::Type_Enum>(); }
+};
+
 }  // namespace EBPF
 
 #endif /* _BACKENDS_EBPF_EBPFTYPE_H_ */

--- a/backends/ebpf/target.cpp
+++ b/backends/ebpf/target.cpp
@@ -64,6 +64,12 @@ void KernelSamplesTarget::emitTableUpdate(Util::SourceCodeBuilder* builder, cstr
                           tblName, key, value);
 }
 
+void KernelSamplesTarget::emitUserTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
+                                          cstring key, cstring value) const {
+    builder->appendFormat("bpf_update_elem(%s, &%s, &%s, BPF_ANY);",
+                          tblName, key, value);
+}
+
 void KernelSamplesTarget::emitTableDecl(Util::SourceCodeBuilder* builder,
                                         cstring tblName, bool isHash,
                                         cstring keyType, cstring valueType,
@@ -122,6 +128,12 @@ void BccTarget::emitTableLookup(Util::SourceCodeBuilder* builder, cstring tblNam
 void BccTarget::emitTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
                                 cstring key, cstring value) const {
     builder->appendFormat("%s.update(&%s, &%s);",
+                          tblName, key, value);
+}
+
+void BccTarget::emitUserTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
+                                    cstring key, cstring value) const {
+    builder->appendFormat("bpf_update_elem(%s, &%s, &%s, BPF_ANY);",
                           tblName, key, value);
 }
 

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -26,8 +26,6 @@ limitations under the License.
 
 namespace EBPF {
 
-class EBPFType;
-
 class Target {
  protected:
     explicit Target(cstring name) : name(name) {}

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -42,6 +42,8 @@ class Target {
                                  cstring key, cstring value) const = 0;
     virtual void emitTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
                                  cstring key, cstring value) const = 0;
+    virtual void emitUserTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
+                                     cstring key, cstring value) const = 0;
     virtual void emitTableDecl(Util::SourceCodeBuilder* builder,
                                cstring tblName, bool isHash,
                                cstring keyType, cstring valueType, unsigned size) const = 0;
@@ -53,6 +55,8 @@ class Target {
     virtual cstring forwardReturnCode() const = 0;
     virtual cstring dropReturnCode() const = 0;
     virtual cstring abortReturnCode() const = 0;
+    // Path on /sys filesystem where maps are stored
+    virtual cstring sysMapPath() const = 0;
 };
 
 // Represents a target that is compiled within the kernel
@@ -67,6 +71,8 @@ class KernelSamplesTarget : public Target {
                          cstring key, cstring value) const override;
     void emitTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
                          cstring key, cstring value) const override;
+    void emitUserTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
+                             cstring key, cstring value) const override;
     void emitTableDecl(Util::SourceCodeBuilder* builder,
                        cstring tblName, bool isHash,
                        cstring keyType, cstring valueType, unsigned size) const override;
@@ -79,6 +85,7 @@ class KernelSamplesTarget : public Target {
     cstring forwardReturnCode() const override { return "0"; }
     cstring dropReturnCode() const override { return "1"; }
     cstring abortReturnCode() const override { return "1"; }
+    cstring sysMapPath() const override { return "/sys/fs/bpf"; }
 };
 
 // Represents a target compiled by bcc that uses the TC
@@ -92,6 +99,8 @@ class BccTarget : public Target {
                          cstring key, cstring value) const override;
     void emitTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
                          cstring key, cstring value) const override;
+    void emitUserTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
+                             cstring key, cstring value) const override;
     void emitTableDecl(Util::SourceCodeBuilder* builder,
                        cstring tblName, bool isHash,
                        cstring keyType, cstring valueType, unsigned size) const override;
@@ -104,6 +113,7 @@ class BccTarget : public Target {
     cstring forwardReturnCode() const override { return "0"; }
     cstring dropReturnCode() const override { return "1"; }
     cstring abortReturnCode() const override { return "1"; }
+    cstring sysMapPath() const override { return "/sys/fs/bpf"; }
 };
 
 }  // namespace EBPF

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -26,6 +26,8 @@ limitations under the License.
 
 namespace EBPF {
 
+class EBPFType;
+
 class Target {
  protected:
     explicit Target(cstring name) : name(name) {}

--- a/frontends/common/resolveReferences/referenceMap.cpp
+++ b/frontends/common/resolveReferences/referenceMap.cpp
@@ -50,7 +50,7 @@ void ReferenceMap::setDeclaration(const IR::This* pointer, const IR::IDeclaratio
     auto previous = get(thisToDeclaration, pointer);
     if (previous != nullptr && previous != decl)
         BUG("%1% already resolved to %2% instead of %3%",
-            pointer, previous, decl);
+            dbp(pointer), dbp(previous), dbp(decl));
     thisToDeclaration.emplace(pointer, decl);
 }
 

--- a/frontends/p4/evaluator/substituteParameters.cpp
+++ b/frontends/p4/evaluator/substituteParameters.cpp
@@ -18,6 +18,12 @@ limitations under the License.
 
 namespace P4 {
 
+const IR::Node* SubstituteParameters::postorder(IR::This* t) {
+    auto result = new IR::This(t->srcInfo);
+    LOG1("Cloned " << dbp(t) << " into " << dbp(result));
+    return result;
+}
+
 const IR::Node* SubstituteParameters::postorder(IR::PathExpression* expr) {
     auto decl = refMap->getDeclaration(expr->path, true);
     auto param = decl->to<IR::Parameter>();

--- a/frontends/p4/evaluator/substituteParameters.h
+++ b/frontends/p4/evaluator/substituteParameters.h
@@ -46,6 +46,7 @@ class SubstituteParameters : public TypeVariableSubstitutionVisitor {
     using TypeVariableSubstitutionVisitor::postorder;
     const IR::Node* postorder(IR::PathExpression* expr) override;
     const IR::Node* postorder(IR::Type_Name* type) override;
+    const IR::Node* postorder(IR::This* t) override;
 };
 
 }  // namespace P4

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -2519,6 +2519,8 @@ const IR::Node* TypeInference::postorder(IR::SelectCase* sc) {
 
 const IR::Node* TypeInference::postorder(IR::KeyElement* elem) {
     auto ktype = getType(elem->expression);
+    if (ktype == nullptr)
+        return elem;
     if (!ktype->is<IR::Type_Bits>() && !ktype->is<IR::Type_Enum>() &&
         !ktype->is<IR::Type_Error>() && !ktype->is<IR::Type_Boolean>())
         typeError("Key %1% field type must be a scalar type; it cannot be %2%",

--- a/ir/base.def
+++ b/ir/base.def
@@ -98,6 +98,8 @@ abstract Declaration : StatOrDecl, IDeclaration {
 // A declaration which introduces a type.
 // Two declarations with the same name are not the same declaration
 // That's why declid is used to distinguish them.
+// (We don't use multiple inheritance, so we can't
+// inherit both Type and Declaration.)
 abstract Type_Declaration : Type, IDeclaration {
     ID name;
     int declid = nextId++;

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -269,7 +269,13 @@ class Mux : Operation_Ternary {
 
 class DefaultExpression : Expression {}
 
-class This : Expression {}  // experimental
+// Two different This should not be equal.
+// That's why we use a hidden id field to distinguish them.
+class This : Expression {
+    int id = nextId++;
+ private:
+    static int nextId;
+}  // experimental
 
 class Cast : Operation_Unary {
     Type destType = type;

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -31,6 +31,7 @@ const cstring P4Program::main = "main";
 const cstring Type_Error::error = "error";
 
 int IR::Declaration::nextId = 0;
+int IR::This::nextId = 0;
 
 const Type_Method* P4Control::getConstructorMethodType() const {
     return new Type_Method(Util::SourceInfo(), getTypeParameters(), type, constructorParams);

--- a/testdata/p4_16_errors/issue306.p4
+++ b/testdata/p4_16_errors/issue306.p4
@@ -1,0 +1,103 @@
+/*
+Copyright 2017 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <v1model.p4>
+
+#define STACK_SIZE 4
+
+header instr_h {
+  bit<8> op_code;
+  bit<8> data;
+}
+
+header data_h {
+  bit<8> data;
+}
+
+struct my_packet {
+  instr_h[STACK_SIZE] instr;
+  data_h[STACK_SIZE] data;
+}
+
+struct my_metadata {
+
+}
+
+parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+  state start {
+    transition parse_instr;
+  }
+
+  state parse_instr {
+    b.extract(p.stack.next);
+    transition select(p.stack.last.op_code) {
+      0: parse_data;
+      default: parse_instr;
+    }
+  }
+
+  state parse_data {
+    b.extract(p.stack.next);
+    transition select(p.stack.last.op_code) {
+      0: accept;
+      default: parse_data;
+    }
+  }
+}
+
+control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+  apply { }
+}
+
+
+control MyIngress(inout my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+  action nop() {
+  }
+
+
+
+  table t {
+    key = { p.stack[0].op_code : exact; }
+    actions = { nop; }
+    default_action = nop;
+  }
+
+  apply { t.apply(); }
+}
+
+control MyEgress(inout my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+  apply { }
+}
+
+control MyComputeChecksum(inout my_packet p, inout my_metadata m) {
+  apply { }
+}
+
+control MyDeparser(packet_out b, in my_packet p) {
+  apply {
+    b.emit(p.stack);
+  }
+}
+
+/* Instantiate */
+MyParser() p;
+MyVerifyChecksum() vck;
+MyIngress() i;
+MyEgress() e;
+MyComputeChecksum() cck;
+MyDeparser() dp;
+
+V1Switch(p, vck, i, e, cck, dp) main;

--- a/testdata/p4_16_errors_outputs/issue306.p4
+++ b/testdata/p4_16_errors_outputs/issue306.p4
@@ -1,0 +1,85 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header instr_h {
+    bit<8> op_code;
+    bit<8> data;
+}
+
+header data_h {
+    bit<8> data;
+}
+
+struct my_packet {
+    instr_h[4] instr;
+    data_h[4]  data;
+}
+
+struct my_metadata {
+}
+
+parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+    state start {
+        transition parse_instr;
+    }
+    state parse_instr {
+        b.extract(p.stack.next);
+        transition select(p.stack.last.op_code) {
+            0: parse_data;
+            default: parse_instr;
+        }
+    }
+    state parse_data {
+        b.extract(p.stack.next);
+        transition select(p.stack.last.op_code) {
+            0: accept;
+            default: parse_data;
+        }
+    }
+}
+
+control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+    action nop() {
+    }
+    table t() {
+        key = {
+            p.stack[0].op_code: exact;
+        }
+        actions = {
+            nop;
+        }
+        default_action = nop;
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control MyEgress(inout my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout my_packet p, inout my_metadata m) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out b, in my_packet p) {
+    apply {
+        b.emit(p.stack);
+    }
+}
+
+MyParser() p;
+MyVerifyChecksum() vck;
+MyIngress() i;
+MyEgress() e;
+MyComputeChecksum() cck;
+MyDeparser() dp;
+V1Switch(p, vck, i, e, cck, dp) main;

--- a/testdata/p4_16_errors_outputs/issue306.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue306.p4-stderr
@@ -1,0 +1,84 @@
+../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+struct my_packet {
+       ^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(45)
+    b.extract(p.stack.next);
+                ^^^^^
+../testdata/p4_16_errors/issue306.p4(45): error: Could not find type of p.stack
+    b.extract(p.stack.next);
+              ^^^^^^^
+../testdata/p4_16_errors/issue306.p4(45): error: Could not find type of p.stack.next
+    b.extract(p.stack.next);
+              ^^^^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+struct my_packet {
+       ^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(46)
+    transition select(p.stack.last.op_code) {
+                        ^^^^^
+../testdata/p4_16_errors/issue306.p4(46): error: Could not find type of p.stack
+    transition select(p.stack.last.op_code) {
+                      ^^^^^^^
+../testdata/p4_16_errors/issue306.p4(46): error: Could not find type of p.stack.last
+    transition select(p.stack.last.op_code) {
+                      ^^^^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(46): error: Could not find type of p.stack.last.op_code
+    transition select(p.stack.last.op_code) {
+                      ^^^^^^^^^^^^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(46): error: Could not find type of ListExpression
+    transition select(p.stack.last.op_code) {
+                      ^^^^^^^^^^^^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+struct my_packet {
+       ^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(53)
+    b.extract(p.stack.next);
+                ^^^^^
+../testdata/p4_16_errors/issue306.p4(53): error: Could not find type of p.stack
+    b.extract(p.stack.next);
+              ^^^^^^^
+../testdata/p4_16_errors/issue306.p4(53): error: Could not find type of p.stack.next
+    b.extract(p.stack.next);
+              ^^^^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+struct my_packet {
+       ^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(54)
+    transition select(p.stack.last.op_code) {
+                        ^^^^^
+../testdata/p4_16_errors/issue306.p4(54): error: Could not find type of p.stack
+    transition select(p.stack.last.op_code) {
+                      ^^^^^^^
+../testdata/p4_16_errors/issue306.p4(54): error: Could not find type of p.stack.last
+    transition select(p.stack.last.op_code) {
+                      ^^^^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(54): error: Could not find type of p.stack.last.op_code
+    transition select(p.stack.last.op_code) {
+                      ^^^^^^^^^^^^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(54): error: Could not find type of ListExpression
+    transition select(p.stack.last.op_code) {
+                      ^^^^^^^^^^^^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+struct my_packet {
+       ^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(73)
+    key = { p.stack[0].op_code : exact; }
+              ^^^^^
+../testdata/p4_16_errors/issue306.p4(73): error: Could not find type of p.stack
+    key = { p.stack[0].op_code : exact; }
+            ^^^^^^^
+../testdata/p4_16_errors/issue306.p4(73): error: Could not find type of []
+    key = { p.stack[0].op_code : exact; }
+            ^^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(73): error: Could not find type of [].op_code
+    key = { p.stack[0].op_code : exact; }
+            ^^^^^^^^^^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+struct my_packet {
+       ^^^^^^^^^
+../testdata/p4_16_errors/issue306.p4(91)
+    b.emit(p.stack);
+             ^^^^^
+../testdata/p4_16_errors/issue306.p4(91): error: Could not find type of p.stack
+    b.emit(p.stack);
+           ^^^^^^^

--- a/testdata/p4_16_samples/issue304-1.p4
+++ b/testdata/p4_16_samples/issue304-1.p4
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+extern X {
+    X();
+    bit<32> b();
+    abstract void a(inout bit<32> arg);
+}
+
+control c(inout bit<32> y) {
+    X() x = {
+        void a(inout bit<32> arg) { arg = arg + this.b(); }
+    };
+    apply {
+        x.a(y);
+    }
+}
+
+control t(inout bit<32> b) {
+    c() c1;
+    c() c2;
+
+    apply {
+        c1.apply(b);
+        c2.apply(b);
+    }
+}
+
+control cs(inout bit<32> arg);
+package top(cs _ctrl);
+
+top(t()) main;

--- a/testdata/p4_16_samples/issue304.p4
+++ b/testdata/p4_16_samples/issue304.p4
@@ -1,0 +1,36 @@
+/*
+Copyright 2017 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+control c(inout bit<32> y) {
+    apply {
+        y = y + 1;
+    }
+}
+
+control t(inout bit<32> b) {
+    c() c1;
+    c() c2;
+
+    apply {
+        c1.apply(b);
+        c2.apply(b);
+    }
+}
+
+control cs(inout bit<32> arg);
+package top(cs _ctrl);
+
+top(t()) main;

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2-midend.p4
@@ -43,9 +43,9 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bit<32> tmp_0;
+    bit<32> c_tmp_0;
     @name("c.add") action c_add() {
-        tmp_0 = h.h.a + h.h.b;
+        c_tmp_0 = h.h.a + h.h.b;
         h.h.c = (bit<64>)(h.h.a + h.h.b);
     }
     @name("c.t") table c_t_0() {

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2-midend.p4
@@ -43,7 +43,7 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bool tmp_0;
+    bool c_tmp_0;
     action act() {
         h.h.c = 8w0;
     }
@@ -51,7 +51,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         h.h.c = 8w1;
     }
     action act_1() {
-        tmp_0 = h.h.a < h.h.b;
+        c_tmp_0 = h.h.a < h.h.b;
     }
     action act_2() {
         sm.egress_spec = 9w0;
@@ -82,7 +82,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
     apply {
         tbl_act.apply();
-        if (tmp_0) 
+        if (c_tmp_0) 
             tbl_act_0.apply();
         else 
             tbl_act_1.apply();

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-midend.p4
@@ -42,9 +42,9 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bit<32> tmp_0;
+    bit<32> c_tmp_0;
     @name("c.add") action c_add(bit<32> data) {
-        tmp_0 = h.h.a + data;
+        c_tmp_0 = h.h.a + data;
         h.h.b = h.h.a + data;
     }
     @name("c.t") table c_t_0() {

--- a/testdata/p4_16_samples_outputs/enum-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv2-midend.p4
@@ -48,8 +48,8 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    Choice c_1;
-    bool tmp_0;
+    Choice c_c_0;
+    bool c_tmp_0;
     action act() {
         h.h.c = h.h.a;
     }
@@ -57,8 +57,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         h.h.c = h.h.b;
     }
     action act_1() {
-        c_1 = Choice.First;
-        tmp_0 = c_1 == Choice.Second;
+        c_c_0 = Choice.First;
+        c_tmp_0 = c_c_0 == Choice.Second;
     }
     action act_2() {
         sm.egress_spec = 9w0;
@@ -89,7 +89,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
     apply {
         tbl_act.apply();
-        if (tmp_0) 
+        if (c_tmp_0) 
             tbl_act_0.apply();
         else 
             tbl_act_1.apply();

--- a/testdata/p4_16_samples_outputs/generic1-midend.p4
+++ b/testdata/p4_16_samples_outputs/generic1-midend.p4
@@ -6,15 +6,15 @@ extern Generic<T> {
 
 extern void f<T>(in T arg);
 control caller() {
-    bit<32> b;
-    bit<32> tmp_1;
-    bit<5> tmp_2;
+    bit<32> cinst_b_0;
+    bit<32> cinst_tmp_1;
+    bit<5> cinst_tmp_2;
     @name("cinst.x") Generic<bit<8>>(8w9) cinst_x_0;
     action act() {
-        tmp_1 = cinst_x_0.get<bit<32>>();
-        tmp_2 = cinst_x_0.get1<bit<5>, bit<10>>(10w0, 5w0);
-        b = (bit<32>)tmp_2;
-        f<bit<32>>(b);
+        cinst_tmp_1 = cinst_x_0.get<bit<32>>();
+        cinst_tmp_2 = cinst_x_0.get1<bit<5>, bit<10>>(10w0, 5w0);
+        cinst_b_0 = (bit<32>)cinst_tmp_2;
+        f<bit<32>>(cinst_b_0);
     }
     table tbl_act() {
         actions = {

--- a/testdata/p4_16_samples_outputs/header-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2-midend.p4
@@ -41,12 +41,12 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    hdr tmp_1;
-    bit<32> tmp_2;
+    hdr c_tmp_1;
+    bit<32> c_tmp_2;
     action act() {
-        tmp_2 = h.h.f + 32w1;
-        tmp_1.f = tmp_2;
-        h.h.f = tmp_1.f;
+        c_tmp_2 = h.h.f + 32w1;
+        c_tmp_1.f = c_tmp_2;
+        h.h.f = c_tmp_1.f;
         sm.egress_spec = 9w0;
     }
     table tbl_act() {

--- a/testdata/p4_16_samples_outputs/inline-control-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-control-midend.p4
@@ -4,11 +4,11 @@ extern Y {
 }
 
 control d(out bit<32> x) {
-    bit<32> tmp_0;
+    bit<32> cinst_tmp_0;
     @name("cinst.inst") Y(32w16) cinst_inst_0;
     action act() {
-        tmp_0 = cinst_inst_0.get();
-        x = tmp_0;
+        cinst_tmp_0 = cinst_inst_0.get();
+        x = cinst_tmp_0;
     }
     table tbl_act() {
         actions = {

--- a/testdata/p4_16_samples_outputs/inline-control1-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-control1-midend.p4
@@ -6,14 +6,14 @@ extern Y {
 control d(out bit<32> x) {
     bit<32> y;
     bit<32> x_1;
-    bit<32> tmp_0;
+    bit<32> cinst_tmp_0;
     @name("cinst.inst") Y(32w16) cinst_inst_0;
     action act() {
-        tmp_0 = cinst_inst_0.get();
-        x_1 = tmp_0;
+        cinst_tmp_0 = cinst_inst_0.get();
+        x_1 = cinst_tmp_0;
         x = x_1;
-        tmp_0 = cinst_inst_0.get();
-        x_1 = tmp_0;
+        cinst_tmp_0 = cinst_inst_0.get();
+        x_1 = cinst_tmp_0;
         y = x_1;
     }
     table tbl_act() {

--- a/testdata/p4_16_samples_outputs/inline-switch-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-switch-midend.p4
@@ -1,5 +1,5 @@
 control d(out bit<32> x) {
-    bool hasReturned_0;
+    bool cinst_hasReturned_0;
     @name("cinst.a1") action cinst_a1() {
     }
     @name("cinst.a2") action cinst_a2() {
@@ -12,13 +12,13 @@ control d(out bit<32> x) {
         default_action = cinst_a1();
     }
     action act() {
-        hasReturned_0 = true;
+        cinst_hasReturned_0 = true;
     }
     action act_0() {
-        hasReturned_0 = true;
+        cinst_hasReturned_0 = true;
     }
     action act_1() {
-        hasReturned_0 = false;
+        cinst_hasReturned_0 = false;
     }
     table tbl_act() {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue281-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue281-midend.p4
@@ -39,76 +39,76 @@ struct m {
 }
 
 parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t std) {
-    ethernet_t tmp_4_ether;
-    vlan_t tmp_4_vlan;
-    ipv4_t tmp_4_ipv4;
-    ethernet_t tmp_5_ether;
-    vlan_t tmp_5_vlan;
-    ipv4_t tmp_5_ipv4;
+    ethernet_t tmp_ether;
+    vlan_t tmp_vlan;
+    ipv4_t tmp_ipv4;
+    ethernet_t tmp_0_ether;
+    vlan_t tmp_0_vlan;
+    ipv4_t tmp_0_ipv4;
     ethernet_t hdr_2_ether;
     vlan_t hdr_2_vlan;
     ipv4_t hdr_2_ipv4;
-    ethernet_t tmp_6;
-    ethernet_t ether_1;
+    ethernet_t l2_tmp_0;
+    ethernet_t l2_ether_0;
     ethernet_t hdr_3_ether;
     vlan_t hdr_3_vlan;
     ipv4_t hdr_3_ipv4;
-    bit<16> etherType_1;
-    ipv4_t tmp_7;
-    vlan_t tmp_8;
-    ipv4_t ipv4_1;
-    vlan_t vlan_1;
+    bit<16> l3_etherType_0;
+    ipv4_t l3_tmp_1;
+    vlan_t l3_tmp_2;
+    ipv4_t l3_ipv4_0;
+    vlan_t l3_vlan_0;
     state start {
         hdr_2_ether.setInvalid();
         hdr_2_vlan.setInvalid();
         hdr_2_ipv4.setInvalid();
-        ether_1.setInvalid();
-        b.extract<ethernet_t>(ether_1);
-        tmp_6 = ether_1;
-        hdr_2_ether = tmp_6;
-        tmp_4_ether = hdr_2_ether;
-        tmp_4_vlan = hdr_2_vlan;
-        tmp_4_ipv4 = hdr_2_ipv4;
-        hdr.ether = tmp_4_ether;
-        hdr.vlan = tmp_4_vlan;
-        hdr.ipv4 = tmp_4_ipv4;
-        tmp_5_ether = hdr.ether;
-        tmp_5_vlan = hdr.vlan;
-        tmp_5_ipv4 = hdr.ipv4;
-        hdr_3_ether = tmp_5_ether;
-        hdr_3_vlan = tmp_5_vlan;
-        hdr_3_ipv4 = tmp_5_ipv4;
+        l2_ether_0.setInvalid();
+        b.extract<ethernet_t>(l2_ether_0);
+        l2_tmp_0 = l2_ether_0;
+        hdr_2_ether = l2_tmp_0;
+        tmp_ether = hdr_2_ether;
+        tmp_vlan = hdr_2_vlan;
+        tmp_ipv4 = hdr_2_ipv4;
+        hdr.ether = tmp_ether;
+        hdr.vlan = tmp_vlan;
+        hdr.ipv4 = tmp_ipv4;
+        tmp_0_ether = hdr.ether;
+        tmp_0_vlan = hdr.vlan;
+        tmp_0_ipv4 = hdr.ipv4;
+        hdr_3_ether = tmp_0_ether;
+        hdr_3_vlan = tmp_0_vlan;
+        hdr_3_ipv4 = tmp_0_ipv4;
         transition L3_start;
     }
     state L3_start {
-        etherType_1 = hdr_3_ether.etherType;
-        transition select(etherType_1) {
+        l3_etherType_0 = hdr_3_ether.etherType;
+        transition select(l3_etherType_0) {
             16w0x800: L3_ipv4;
             16w0x8100: L3_vlan;
             default: start_2;
         }
     }
     state L3_ipv4 {
-        ipv4_1.setInvalid();
-        b.extract<ipv4_t>(ipv4_1);
-        tmp_7 = ipv4_1;
-        hdr_3_ipv4 = tmp_7;
+        l3_ipv4_0.setInvalid();
+        b.extract<ipv4_t>(l3_ipv4_0);
+        l3_tmp_1 = l3_ipv4_0;
+        hdr_3_ipv4 = l3_tmp_1;
         transition start_2;
     }
     state L3_vlan {
-        vlan_1.setInvalid();
-        b.extract<vlan_t>(vlan_1);
-        tmp_8 = vlan_1;
-        hdr_3_vlan = tmp_8;
+        l3_vlan_0.setInvalid();
+        b.extract<vlan_t>(l3_vlan_0);
+        l3_tmp_2 = l3_vlan_0;
+        hdr_3_vlan = l3_tmp_2;
         transition L3_start;
     }
     state start_2 {
-        tmp_5_ether = hdr_3_ether;
-        tmp_5_vlan = hdr_3_vlan;
-        tmp_5_ipv4 = hdr_3_ipv4;
-        hdr.ether = tmp_5_ether;
-        hdr.vlan = tmp_5_vlan;
-        hdr.ipv4 = tmp_5_ipv4;
+        tmp_0_ether = hdr_3_ether;
+        tmp_0_vlan = hdr_3_vlan;
+        tmp_0_ipv4 = hdr_3_ipv4;
+        hdr.ether = tmp_0_ether;
+        hdr.vlan = tmp_0_vlan;
+        hdr.ipv4 = tmp_0_ipv4;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue304-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue304-1-frontend.p4
@@ -1,0 +1,32 @@
+extern X {
+    X();
+    bit<32> b();
+    abstract void a(inout bit<32> arg);
+}
+
+control c(inout bit<32> y) {
+    @name("x") X() x_0 = {
+        void a(inout bit<32> arg) {
+            bit<32> tmp;
+            bit<32> tmp_0;
+            tmp = this.b();
+            tmp_0 = arg + tmp;
+        }
+    };
+    apply {
+        x_0.a(y);
+    }
+}
+
+control t(inout bit<32> b) {
+    @name("c1") c() c1_0;
+    @name("c2") c() c2_0;
+    apply {
+        c1_0.apply(b);
+        c2_0.apply(b);
+    }
+}
+
+control cs(inout bit<32> arg);
+package top(cs _ctrl);
+top(t()) main;

--- a/testdata/p4_16_samples_outputs/issue304-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue304-1-midend.p4
@@ -1,0 +1,41 @@
+extern X {
+    X();
+    bit<32> b();
+    abstract void a(inout bit<32> arg);
+}
+
+control t(inout bit<32> b) {
+    @name("c1.x") X() c1_x_0 = {
+        void a(inout bit<32> arg) {
+            @name("c1.tmp") bit<32> c1_tmp_1;
+            @name("c1.tmp_0") bit<32> c1_tmp_2;
+            c1_tmp_1 = this.b();
+            c1_tmp_2 = arg + c1_tmp_1;
+        }
+    };
+    @name("c2.x") X() c2_x_0 = {
+        void a(inout bit<32> arg) {
+            @name("c2.tmp") bit<32> c2_tmp_1;
+            @name("c2.tmp_0") bit<32> c2_tmp_2;
+            c2_tmp_1 = this.b();
+            c2_tmp_2 = arg + c2_tmp_1;
+        }
+    };
+    action act() {
+        c1_x_0.a(b);
+        c2_x_0.a(b);
+    }
+    table tbl_act() {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control cs(inout bit<32> arg);
+package top(cs _ctrl);
+top(t()) main;

--- a/testdata/p4_16_samples_outputs/issue304-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue304-1-midend.p4
@@ -7,16 +7,16 @@ extern X {
 control t(inout bit<32> b) {
     @name("c1.x") X() c1_x_0 = {
         void a(inout bit<32> arg) {
-            @name("c1.tmp") bit<32> c1_tmp_1;
-            @name("c1.tmp_0") bit<32> c1_tmp_2;
+            bit<32> c1_tmp_1;
+            bit<32> c1_tmp_2;
             c1_tmp_1 = this.b();
             c1_tmp_2 = arg + c1_tmp_1;
         }
     };
     @name("c2.x") X() c2_x_0 = {
         void a(inout bit<32> arg) {
-            @name("c2.tmp") bit<32> c2_tmp_1;
-            @name("c2.tmp_0") bit<32> c2_tmp_2;
+            bit<32> c2_tmp_1;
+            bit<32> c2_tmp_2;
             c2_tmp_1 = this.b();
             c2_tmp_2 = arg + c2_tmp_1;
         }

--- a/testdata/p4_16_samples_outputs/issue304-1.p4
+++ b/testdata/p4_16_samples_outputs/issue304-1.p4
@@ -1,0 +1,29 @@
+extern X {
+    X();
+    bit<32> b();
+    abstract void a(inout bit<32> arg);
+}
+
+control c(inout bit<32> y) {
+    X() x = {
+        void a(inout bit<32> arg) {
+            arg = arg + this.b();
+        }
+    };
+    apply {
+        x.a(y);
+    }
+}
+
+control t(inout bit<32> b) {
+    c() c1;
+    c() c2;
+    apply {
+        c1.apply(b);
+        c2.apply(b);
+    }
+}
+
+control cs(inout bit<32> arg);
+package top(cs _ctrl);
+top(t()) main;

--- a/testdata/p4_16_samples_outputs/issue304-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue304-frontend.p4
@@ -1,0 +1,20 @@
+control c(inout bit<32> y) {
+    bit<32> tmp;
+    apply {
+        tmp = y + 32w1;
+        y = tmp;
+    }
+}
+
+control t(inout bit<32> b) {
+    @name("c1") c() c1_0;
+    @name("c2") c() c2_0;
+    apply {
+        c1_0.apply(b);
+        c2_0.apply(b);
+    }
+}
+
+control cs(inout bit<32> arg);
+package top(cs _ctrl);
+top(t()) main;

--- a/testdata/p4_16_samples_outputs/issue304-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue304-midend.p4
@@ -1,6 +1,6 @@
 control t(inout bit<32> b) {
-    @name("c1.tmp") bit<32> c1_tmp_0;
-    @name("c2.tmp") bit<32> c2_tmp_0;
+    bit<32> c1_tmp_0;
+    bit<32> c2_tmp_0;
     action act() {
         c1_tmp_0 = b + 32w1;
         b = c1_tmp_0;

--- a/testdata/p4_16_samples_outputs/issue304-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue304-midend.p4
@@ -1,0 +1,23 @@
+control t(inout bit<32> b) {
+    @name("c1.tmp") bit<32> c1_tmp_0;
+    @name("c2.tmp") bit<32> c2_tmp_0;
+    action act() {
+        c1_tmp_0 = b + 32w1;
+        b = c1_tmp_0;
+        c2_tmp_0 = b + 32w1;
+        b = c2_tmp_0;
+    }
+    table tbl_act() {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control cs(inout bit<32> arg);
+package top(cs _ctrl);
+top(t()) main;

--- a/testdata/p4_16_samples_outputs/issue304.p4
+++ b/testdata/p4_16_samples_outputs/issue304.p4
@@ -1,0 +1,18 @@
+control c(inout bit<32> y) {
+    apply {
+        y = y + 1;
+    }
+}
+
+control t(inout bit<32> b) {
+    c() c1;
+    c() c2;
+    apply {
+        c1.apply(b);
+        c2.apply(b);
+    }
+}
+
+control cs(inout bit<32> arg);
+package top(cs _ctrl);
+top(t()) main;

--- a/testdata/p4_16_samples_outputs/pipe-midend.p4
+++ b/testdata/p4_16_samples_outputs/pipe-midend.p4
@@ -35,12 +35,12 @@ struct Packet_data {
 }
 
 control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
-    TArg1 tmp_5;
-    TArg2 tmp_6;
-    TArg1 tmp_7;
-    TArg2 tmp_8;
-    TArg1 tmp_9;
-    TArg2 tmp_10;
+    TArg1 tmp;
+    TArg2 tmp_0;
+    TArg1 p1_tmp_3;
+    TArg2 p1_tmp_4;
+    TArg1 p1_tmp_5;
+    TArg2 p1_tmp_6;
     TArg1 tArg1_0;
     TArg2 aArg2_0;
     bit<9> barg_0;
@@ -65,11 +65,11 @@ control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
         const default_action = p1_C_action(9w5);
     }
     @name("p1.Drop") action p1_Drop() {
-        tmp_5.drop = true;
+        tmp.drop = true;
     }
     @name("p1.Tinner") table p1_Tinner_0() {
         key = {
-            tmp_5.field1: ternary @name("pArg1.field1") ;
+            tmp.field1: ternary @name("pArg1.field1") ;
         }
         actions = {
             p1_Drop();
@@ -78,38 +78,38 @@ control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
         const default_action = NoAction_0();
     }
     action act() {
-        tmp_5.field1 = qArg1.field1;
-        tmp_5.drop = qArg1.drop;
-        tmp_6.field2 = qArg2.field2;
-        tmp_7.field1 = tmp_5.field1;
-        tmp_7.drop = tmp_5.drop;
-        tmp_8.field2 = tmp_6.field2;
-        tArg1_0.field1 = tmp_7.field1;
-        tArg1_0.drop = tmp_7.drop;
-        aArg2_0.field2 = tmp_8.field2;
+        tmp.field1 = qArg1.field1;
+        tmp.drop = qArg1.drop;
+        tmp_0.field2 = qArg2.field2;
+        p1_tmp_3.field1 = tmp.field1;
+        p1_tmp_3.drop = tmp.drop;
+        p1_tmp_4.field2 = tmp_0.field2;
+        tArg1_0.field1 = p1_tmp_3.field1;
+        tArg1_0.drop = p1_tmp_3.drop;
+        aArg2_0.field2 = p1_tmp_4.field2;
     }
     action act_0() {
-        tmp_7.field1 = tArg1_0.field1;
-        tmp_7.drop = tArg1_0.drop;
-        tmp_5.field1 = tmp_7.field1;
-        tmp_5.drop = tmp_7.drop;
-        tmp_9.field1 = tmp_5.field1;
-        tmp_9.drop = tmp_5.drop;
-        tmp_10.field2 = tmp_6.field2;
-        tArg1_0.field1 = tmp_9.field1;
-        tArg1_0.drop = tmp_9.drop;
-        aArg2_0.field2 = tmp_10.field2;
+        p1_tmp_3.field1 = tArg1_0.field1;
+        p1_tmp_3.drop = tArg1_0.drop;
+        tmp.field1 = p1_tmp_3.field1;
+        tmp.drop = p1_tmp_3.drop;
+        p1_tmp_5.field1 = tmp.field1;
+        p1_tmp_5.drop = tmp.drop;
+        p1_tmp_6.field2 = tmp_0.field2;
+        tArg1_0.field1 = p1_tmp_5.field1;
+        tArg1_0.drop = p1_tmp_5.drop;
+        aArg2_0.field2 = p1_tmp_6.field2;
     }
     action act_1() {
-        tmp_9.field1 = tArg1_0.field1;
-        tmp_9.drop = tArg1_0.drop;
-        tmp_5.field1 = tmp_9.field1;
-        tmp_5.drop = tmp_9.drop;
+        p1_tmp_5.field1 = tArg1_0.field1;
+        p1_tmp_5.drop = tArg1_0.drop;
+        tmp.field1 = p1_tmp_5.field1;
+        tmp.drop = p1_tmp_5.drop;
     }
     action act_2() {
-        qArg1.field1 = tmp_5.field1;
-        qArg1.drop = tmp_5.drop;
-        qArg2.field2 = tmp_6.field2;
+        qArg1.field1 = tmp.field1;
+        qArg1.drop = tmp.drop;
+        qArg2.field2 = tmp_0.field2;
     }
     table tbl_act() {
         actions = {

--- a/testdata/p4_16_samples_outputs/stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2-midend.p4
@@ -41,12 +41,12 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    hdr[1] tmp_1;
-    bit<32> tmp_2;
+    hdr[1] c_tmp_1;
+    bit<32> c_tmp_2;
     action act() {
-        tmp_2 = h.h.f + 32w1;
-        tmp_1[0].f = tmp_2;
-        h.h.f = tmp_1[0].f;
+        c_tmp_2 = h.h.f + 32w1;
+        c_tmp_1[0].f = c_tmp_2;
+        h.h.f = c_tmp_1[0].f;
         sm.egress_spec = 9w0;
     }
     table tbl_act() {


### PR DESCRIPTION
This PR also has some ebpf back-end improvements, e.g., support for enum types.
Issue #304 was caused by omitting to rename local variables when inlining; inlining a block twice would thus generate two variables with the same name in the same scope.
Fixing this problem uncovered another bug: all This objects were always equal (since they had no fields); reference resolution however may need to resolve each This object to point to a different instance. So we used the same trick as for Declarations to make This objects distinct - a hidden unique id field.
