### PR TITLE
Support direct counters and direct meters in p4RuntimeSerializer

### DIFF
--- a/frontends/Makefile.am
+++ b/frontends/Makefile.am
@@ -32,6 +32,7 @@ p4_frontend_UNIFIED = \
 	frontends/p4/parserControlFlow.cpp \
 	frontends/p4/reservedWords.cpp \
 	frontends/p4/coreLibrary.cpp \
+	frontends/p4/externInstance.cpp \
 	frontends/p4/methodInstance.cpp \
 	frontends/p4/parserCallGraph.cpp \
 	frontends/p4/tableApply.cpp \
@@ -67,6 +68,7 @@ noinst_HEADERS += \
 	frontends/p4/enumInstance.h \
 	frontends/p4/evaluator/evaluator.h \
 	frontends/p4/evaluator/substituteParameters.h \
+	frontends/p4/externInstance.h \
 	frontends/p4/fromv1.0/converters.h \
 	frontends/p4/fromv1.0/programStructure.h \
 	frontends/p4/fromv1.0/v1model.h \

--- a/frontends/p4/externInstance.cpp
+++ b/frontends/p4/externInstance.cpp
@@ -1,0 +1,101 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "externInstance.h"
+
+#include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/p4/methodInstance.h"
+#include "frontends/p4/typeMap.h"
+#include "ir/ir.h"
+
+namespace P4 {
+
+
+boost::optional<ExternInstance>
+ExternInstance::resolve(const IR::Expression* expr,
+                        ReferenceMap* refMap,
+                        TypeMap* typeMap,
+                        const boost::optional<cstring>& defaultName
+                            /* = boost::none */) {
+    CHECK_NULL(expr);
+    CHECK_NULL(refMap);
+    CHECK_NULL(typeMap);
+
+    if (expr->is<IR::PathExpression>()) {
+        return resolve(expr->to<IR::PathExpression>(), refMap, typeMap);
+    } else if (expr->is<IR::ConstructorCallExpression>()) {
+        return resolve(expr->to<IR::ConstructorCallExpression>(),
+                       refMap, typeMap, defaultName);
+    } else {
+        return boost::none;
+    }
+}
+
+boost::optional<ExternInstance>
+ExternInstance::resolve(const IR::PathExpression* path,
+                        ReferenceMap* refMap,
+                        TypeMap* typeMap) {
+    CHECK_NULL(path);
+    CHECK_NULL(refMap);
+    CHECK_NULL(typeMap);
+
+    auto decl = refMap->getDeclaration(path->path, true);
+    if (!decl->is<IR::Declaration_Instance>()) return boost::none;
+
+    auto instance = decl->to<IR::Declaration_Instance>();
+    auto type = typeMap->getType(instance);
+    if (!type) {
+        BUG("Couldn't determine the type of expression: %1%", path);
+        return boost::none;
+    }
+
+    // If this is a type instantiation, extract the underlying generic type.
+    if (type->is<IR::Type_Specialized>()) {
+        type = typeMap->getTypeType(type->to<IR::Type_Specialized>()
+                                        ->baseType, true);
+    } else if (type->is<IR::Type_SpecializedCanonical>()) {
+        type = typeMap->getTypeType(type->to<IR::Type_SpecializedCanonical>()
+                                        ->baseType, true);
+    }
+
+    if (!type->is<IR::Type_Extern>()) return boost::none;
+
+    return ExternInstance{instance->externalName(), path,
+                          type->to<IR::Type_Extern>(),
+                          instance->arguments,
+                          instance->to<IR::IAnnotated>()};
+}
+
+boost::optional<ExternInstance>
+ExternInstance::resolve(const IR::ConstructorCallExpression* constructorCallExpr,
+                        ReferenceMap* refMap,
+                        TypeMap* typeMap,
+                        const boost::optional<cstring>& name /* = boost::none */) {
+    CHECK_NULL(constructorCallExpr);
+    CHECK_NULL(refMap);
+    CHECK_NULL(typeMap);
+
+    auto constructorCall =
+      P4::ConstructorCall::resolve(constructorCallExpr, refMap, typeMap);
+    if (!constructorCall->is<P4::ExternConstructorCall>()) return boost::none;
+
+    auto type = constructorCall->to<P4::ExternConstructorCall>()->type;
+    return ExternInstance{name, constructorCallExpr, type,
+                          constructorCallExpr->arguments,
+                          constructorCallExpr->to<IR::IAnnotated>()};
+}
+
+}  // namespace P4

--- a/frontends/p4/externInstance.h
+++ b/frontends/p4/externInstance.h
@@ -1,0 +1,91 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _FRONTENDS_P4_EXTERNINSTANCE_H_
+#define _FRONTENDS_P4_EXTERNINSTANCE_H_
+
+#include <boost/optional.hpp>
+#include "lib/cstring.h"
+
+namespace IR {
+class Expression;
+class IAnnotated;
+class Type_Extern;
+class TypeMap;
+template <typename T> class Vector;
+}  // namespace IR
+
+namespace P4 {
+
+class ReferenceMap;
+class TypeMap;
+
+/**
+ * ExternInstance is a utility class that allows you to gather information about
+ * an expression that resolves to an extern instance.
+ *
+ * The name is in analogy to MethodInstance. It provides information about the
+ * name of the extern instance, the underlying extern type, the arguments it was
+ * instantiated with, and the annotations that we applied to it. It can gather
+ * this information from either a reference to a named instance, or from an
+ * expression which constructs an anonymous instance.
+ */
+struct ExternInstance final {
+    const boost::optional<cstring> name;  // The instance's name, if any.
+    const IR::Expression* expression;     // The original expression passed to resolve().
+    const IR::Type_Extern* type;          // The type of the instance.
+    const IR::Vector<IR::Expression>* arguments;  // The instance's constructor arguments.
+    const IR::IAnnotated* annotations;    // If non-null, the instance's annotations.
+
+    /**
+     * @return the extern instance that @expr resolves to, if any, or
+     * boost::none otherwise.
+     *
+     * @expr may either refer to a named extern instance (i.e., it may be a
+     * PathExpression), or it may construct an anonymous instance directly
+     * (i.e., it may be a ConstructorCallExpression). In the latter case, the
+     * instance will not have a name; @defaultName may optionally be used to
+     * specify a default name to return.
+     */
+    static boost::optional<ExternInstance>
+    resolve(const IR::Expression* expr,
+            ReferenceMap* refMap,
+            TypeMap* typeMap,
+            const boost::optional<cstring>& defaultName = boost::none);
+
+    /**
+     * @return the extern instance that @path resolves to, if any, or
+     * boost::none otherwise.
+     */
+    static boost::optional<ExternInstance>
+    resolve(const IR::PathExpression* path, ReferenceMap* refMap, TypeMap* typeMap);
+
+    /**
+     * @return the extern instance that @constructorCallExpr resolves to, if any, or
+     * boost::none otherwise.
+     *
+     * Anonymous instances do not have a name, but the caller may provide one
+     * via @name if it has external information about what the name should be.
+     */
+    static boost::optional<ExternInstance>
+    resolve(const IR::ConstructorCallExpression* constructorCallExpr,
+            ReferenceMap* refMap, TypeMap* typeMap,
+            const boost::optional<cstring>& name = boost::none);
+};
+
+}  // namespace P4
+
+#endif /* _FRONTENDS_P4_EXTERNINSTANCE_H_ */


### PR DESCRIPTION
This PR adds support for direct counters and direct meters in p4RuntimeSerializer and addresses something other existing issues along the way.

455c196 fixes #302 by adding an ExternInstance help class, akin to MethodInstance, which provides information about the extern instance referenced by an expression. It handles both PathExpressions which refer to a Declaration_Instance by name and ConstructorCallExpressions which create an anonymous extern instance. These are the two common cases that we need to support in p4RuntimeSerializer, though it's possible that in the future there would be others which would be useful to add.

3d3ce5c fixes #311 by actually adding support for serializing direct counters and meters in p4RuntimeSerializer. A little bit of metaprogramming is used to make this less repetitive, since the two cases are almost exactly the same.

Finally, a04ad31 is a small additional patch that fixes an issue Mihai noticed in #296: the existing action profile support in p4RuntimeSerializer handles only ConstructorCallExpressions, but we need to support Declaration_Instance references as well. The previous two commits add code that abstracts over the two cases; you can simply pass `getExternInstanceFromProperty()` a table and a property name and it will do the right thing. a04ad31 changes the action profile code to leverage `getExternInstanceFromProperty()`, which both simplifies the code and adds support for the case we previously didn't handle.