### PR TITLE
Add name annotation to NoAction in core.p4

### DIFF
--- a/p4include/core.p4
+++ b/p4include/core.p4
@@ -51,6 +51,7 @@ extern packet_out {
 // TODO: remove from this file, convert to built-in
 extern void verify(in bool check, in error toSignal);
 
+@name("NoAction")
 action NoAction() {}
 
 match_kind {

--- a/testdata/p4_14_samples_outputs/01-BigMatch-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-midend.p4
@@ -43,7 +43,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -63,13 +63,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_5") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_6") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1-midend.p4
@@ -25,7 +25,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("a1") action a1_0() {
         meta.m.f1 = 32w1;

--- a/testdata/p4_14_samples_outputs/01-FullPHV-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV-midend.p4
@@ -257,7 +257,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("a1") action a1_0() {
         meta.m.field_8_01 = 8w1;

--- a/testdata/p4_14_samples_outputs/01-NoDeps-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-midend.p4
@@ -30,7 +30,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -50,9 +50,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_5() {
+    @name("NoAction") action NoAction_5() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-midend.p4
@@ -38,7 +38,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -58,7 +58,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2-midend.p4
@@ -26,7 +26,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("a1") action a1_0() {
         meta.m.f1 = 32w1;

--- a/testdata/p4_14_samples_outputs/02-FullPHV1-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1-midend.p4
@@ -257,15 +257,15 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_6() {
+    @name("NoAction") action NoAction_6() {
     }
-    @name("NoAction_3") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_4") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_5") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
     @name("a1") action a1_0() {
         meta.m.field_8_01 = 8w1;

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet-midend.p4
@@ -44,7 +44,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -64,7 +64,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3-midend.p4
@@ -26,9 +26,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("a1") action a1_0() {
         meta.m.f1 = 32w1;

--- a/testdata/p4_14_samples_outputs/03-FullPHV2-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2-midend.p4
@@ -257,17 +257,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_3") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_4") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_5") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_6") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("a1") action a1_0() {
         meta.m.field_8_01 = 8w1;

--- a/testdata/p4_14_samples_outputs/03-Gateway-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-midend.p4
@@ -44,7 +44,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -64,13 +64,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_5") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_6") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-midend.p4
@@ -35,7 +35,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -55,7 +55,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-midend.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-midend.p4
@@ -34,7 +34,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -54,13 +54,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_5") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_6") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan-midend.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan-midend.p4
@@ -43,7 +43,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -63,7 +63,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-midend.p4
@@ -31,7 +31,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -51,7 +51,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-midend.p4
@@ -310,17 +310,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_3") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_4") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_5") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_6") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("a1") action a1_0() {
         meta.m.field_8_01 = 8w1;

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1-midend.p4
@@ -42,7 +42,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -62,7 +62,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-midend.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-midend.p4
@@ -326,17 +326,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_3") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_4") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_5") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_6") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("a1") action a1_0() {
         meta.m.field_8_01 = 8w1;

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack-midend.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack-midend.p4
@@ -45,7 +45,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -65,7 +65,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-midend.p4
@@ -326,17 +326,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_3") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_4") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_5") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_6") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("a1") action a1_0() {
         meta.m.field_8_01 = 8w1;

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
@@ -150,21 +150,21 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_3") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_4") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
-    @name("NoAction_5") action NoAction_12() {
+    @name("NoAction") action NoAction_12() {
     }
-    @name("NoAction_6") action NoAction_13() {
+    @name("NoAction") action NoAction_13() {
     }
-    @name("NoAction_7") action NoAction_14() {
+    @name("NoAction") action NoAction_14() {
     }
-    @name("NoAction_8") action NoAction_15() {
+    @name("NoAction") action NoAction_15() {
     }
     @name("l2_packet") action l2_packet_0() {
         meta.ing_metadata.packet_type = 4w0;

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-midend.p4
@@ -68,7 +68,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -88,7 +88,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-midend.p4
@@ -496,17 +496,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_3") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_4") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_5") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_6") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("a1") action a1_0() {
         meta.m.field_8_01 = 8w1;

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-midend.p4
@@ -150,11 +150,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_4() {
+    @name("NoAction") action NoAction_4() {
     }
-    @name("NoAction_3") action NoAction_5() {
+    @name("NoAction") action NoAction_5() {
     }
     @name("nop") action nop_0() {
     }

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-midend.p4
@@ -70,7 +70,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -90,7 +90,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
@@ -72,7 +72,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -92,7 +92,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities-midend.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities-midend.p4
@@ -51,7 +51,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -71,7 +71,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/11-MultiTags-midend.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags-midend.p4
@@ -59,7 +59,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -79,7 +79,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/12-Counters-midend.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-midend.p4
@@ -28,9 +28,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("c1") counter(32w1024, CounterType.packets) c1;
     @name("count_c1_1") action count_c1() {

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-midend.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-midend.p4
@@ -57,7 +57,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -77,7 +77,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-midend.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-midend.p4
@@ -28,9 +28,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("c1") counter(32w1024, CounterType.packets) c1;
     @name("count_c1_1") action count_c1() {

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-midend.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-midend.p4
@@ -69,7 +69,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -89,7 +89,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/14-Counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-midend.p4
@@ -28,7 +28,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("c1") counter(32w1024, CounterType.packets) c1;
     @name("count_c1_1") action count_c1() {

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-midend.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-midend.p4
@@ -34,7 +34,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }

--- a/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-midend.p4
+++ b/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-midend.p4
@@ -74,7 +74,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("nop") action nop_0() {
     }
@@ -94,7 +94,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("nop") action nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-midend.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-midend.p4
@@ -78,9 +78,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("nop") action nop_0() {
     }

--- a/testdata/p4_14_samples_outputs/16-NoHeaders-midend.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders-midend.p4
@@ -19,7 +19,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("a1") action a1_0() {
     }

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-midend.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-midend.p4
@@ -28,17 +28,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_3") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_4") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_5") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_6") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("do_b") action do_b_0() {
     }

--- a/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
@@ -132,7 +132,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("format_options_security") action format_options_security_0() {
         hdr.ipv4_option_NOP.pop_front(3);

--- a/testdata/p4_14_samples_outputs/acl1-midend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-midend.p4
@@ -165,9 +165,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("drop_stats") counter(32w256, CounterType.packets) drop_stats;
     @name("drop_stats_2") counter(32w256, CounterType.packets) drop_stats_0;

--- a/testdata/p4_14_samples_outputs/action_bus1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-midend.p4
@@ -60,21 +60,21 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_3") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_4") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
-    @name("NoAction_5") action NoAction_12() {
+    @name("NoAction") action NoAction_12() {
     }
-    @name("NoAction_6") action NoAction_13() {
+    @name("NoAction") action NoAction_13() {
     }
-    @name("NoAction_7") action NoAction_14() {
+    @name("NoAction") action NoAction_14() {
     }
-    @name("NoAction_8") action NoAction_15() {
+    @name("NoAction") action NoAction_15() {
     }
     @name("set1") action set1_0(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
         hdr.data.f1_1 = v1;

--- a/testdata/p4_14_samples_outputs/action_chain1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-midend.p4
@@ -40,15 +40,15 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_6() {
+    @name("NoAction") action NoAction_6() {
     }
-    @name("NoAction_3") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_4") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_5") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
     @name("set0b1") action set0b1_0(bit<8> val) {
         hdr.extra[0].b1 = val;

--- a/testdata/p4_14_samples_outputs/action_inline-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline-midend.p4
@@ -22,7 +22,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<1> y0;
     bit<1> y0_2;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("b") action b_0() {
         y0 = meta.md.b;

--- a/testdata/p4_14_samples_outputs/action_inline1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<8> dest;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         dest = hdr.data.b1;

--- a/testdata/p4_14_samples_outputs/action_inline2-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-midend.p4
@@ -30,7 +30,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     bit<8> dest;
     bit<8> dest_3;
     bit<8> dest_4;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<9> port) {
         dest = hdr.data.b1;

--- a/testdata/p4_14_samples_outputs/axon-midend.p4
+++ b/testdata/p4_14_samples_outputs/axon-midend.p4
@@ -80,9 +80,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("_drop") action _drop_0() {
         mark_to_drop();

--- a/testdata/p4_14_samples_outputs/basic_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-midend.p4
@@ -58,7 +58,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("on_miss") action on_miss_0() {
     }
@@ -84,15 +84,15 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_5") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_6") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_7") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("set_vrf") action set_vrf_0(bit<12> vrf) {
         meta.ingress_metadata.vrf = vrf;

--- a/testdata/p4_14_samples_outputs/bigfield1-midend.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1-midend.p4
@@ -25,7 +25,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setx1") action setx1_0(bit<48> val, bit<9> port) {
         hdr.data.x1 = val;

--- a/testdata/p4_14_samples_outputs/bridge1-midend.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-midend.p4
@@ -46,9 +46,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         meta.meta.val = val;

--- a/testdata/p4_14_samples_outputs/checksum1-midend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-midend.p4
@@ -68,9 +68,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("drop") action drop_0() {
     }

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
@@ -49,7 +49,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("_drop") action _drop_0() {
         mark_to_drop();
@@ -81,7 +81,7 @@ struct tuple_0 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("do_copy_to_cpu") action do_copy_to_cpu_0() {
         clone3<tuple_0>(CloneType.I2E, 32w250, { standard_metadata });

--- a/testdata/p4_14_samples_outputs/counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter-midend.p4
@@ -46,7 +46,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("my_indirect_counter") counter(32w16384, CounterType.packets) my_indirect_counter;
     @name("m_action") action m_action_0(bit<14> idx) {

--- a/testdata/p4_14_samples_outputs/counter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter1-midend.p4
@@ -29,7 +29,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("act") action act_0(bit<9> port) {
         standard_metadata.egress_spec = port;

--- a/testdata/p4_14_samples_outputs/counter2-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter2-midend.p4
@@ -29,7 +29,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("act") action act_0(bit<9> port) {
         standard_metadata.egress_spec = port;

--- a/testdata/p4_14_samples_outputs/counter3-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter3-midend.p4
@@ -29,7 +29,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("act") action act_0(bit<9> port) {
         standard_metadata.egress_spec = port;

--- a/testdata/p4_14_samples_outputs/counter4-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-midend.p4
@@ -29,7 +29,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("cntDum") counter(32w200, CounterType.packets) cntDum;
     @name("act") action act_0(bit<9> port, bit<8> idx) {

--- a/testdata/p4_14_samples_outputs/counter5-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-midend.p4
@@ -29,7 +29,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("cntDum") counter(32w70000, CounterType.packets) cntDum;
     @name("act") action act_0(bit<9> port, bit<17> idx) {

--- a/testdata/p4_14_samples_outputs/do_nothing-midend.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing-midend.p4
@@ -26,7 +26,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("action_0") action action_1() {
     }

--- a/testdata/p4_14_samples_outputs/exact_match1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-midend.p4
@@ -25,7 +25,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/exact_match2-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-midend.p4
@@ -25,7 +25,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/exact_match3-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-midend.p4
@@ -25,7 +25,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/exact_match4-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-midend.p4
@@ -53,7 +53,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/exact_match5-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-midend.p4
@@ -53,7 +53,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/exact_match6-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6-midend.p4
@@ -34,7 +34,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("addf2") action addf2_0() {
         meta.meta.sum = hdr.data.f2 + 32w100;

--- a/testdata/p4_14_samples_outputs/exact_match7-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-midend.p4
@@ -32,7 +32,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/exact_match8-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("noop") action noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/exact_match9-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("noop") action noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-midend.p4
@@ -37,7 +37,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -93,7 +93,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("rewrite_mac") action rewrite_mac_0(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
@@ -136,15 +136,15 @@ struct tuple_1 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_5") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_6") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_7") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id_1;
     @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_1;

--- a/testdata/p4_14_samples_outputs/gateway1-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-midend.p4
@@ -24,9 +24,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-midend.p4
@@ -26,9 +26,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway3-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-midend.p4
@@ -26,9 +26,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway4-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-midend.p4
@@ -40,9 +40,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway5-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-midend.p4
@@ -32,9 +32,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("output") action output_0(bit<9> port) {
         standard_metadata.egress_spec = port;

--- a/testdata/p4_14_samples_outputs/gateway6-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-midend.p4
@@ -26,9 +26,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("output") action output_0(bit<9> port) {
         standard_metadata.egress_spec = port;

--- a/testdata/p4_14_samples_outputs/gateway7-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-midend.p4
@@ -26,9 +26,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("output") action output_0(bit<9> port) {
         standard_metadata.egress_spec = port;

--- a/testdata/p4_14_samples_outputs/gateway8-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway8-midend.p4
@@ -24,9 +24,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/hit-midend.p4
+++ b/testdata/p4_14_samples_outputs/hit-midend.p4
@@ -27,11 +27,11 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_4() {
+    @name("NoAction") action NoAction_4() {
     }
-    @name("NoAction_3") action NoAction_5() {
+    @name("NoAction") action NoAction_5() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/hitmiss-midend.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-midend.p4
@@ -27,11 +27,11 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_4() {
+    @name("NoAction") action NoAction_4() {
     }
-    @name("NoAction_3") action NoAction_5() {
+    @name("NoAction") action NoAction_5() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/inline-midend.p4
+++ b/testdata/p4_14_samples_outputs/inline-midend.p4
@@ -20,7 +20,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("d.c.x") action d_c_x() {
     }

--- a/testdata/p4_14_samples_outputs/instruct1-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct1-midend.p4
@@ -51,7 +51,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("decap") action decap_0() {
         hdr.hdr1 = hdr.hdr2;

--- a/testdata/p4_14_samples_outputs/instruct2-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct2-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("do_add") action do_add_0() {
         hdr.data.b3 = hdr.data.b1 + hdr.data.b2;

--- a/testdata/p4_14_samples_outputs/instruct3-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct3-midend.p4
@@ -26,7 +26,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setx") action setx_0() {
         hdr.data.x2 = 2w2;

--- a/testdata/p4_14_samples_outputs/instruct4-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct4-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setf4") action setf4_0() {
         hdr.data.f4 = 32w0x70a50;

--- a/testdata/p4_14_samples_outputs/instruct5-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-midend.p4
@@ -43,7 +43,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("output") action output_0(bit<9> port) {
         standard_metadata.egress_spec = port;

--- a/testdata/p4_14_samples_outputs/mac_rewrite-midend.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-midend.p4
@@ -85,9 +85,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("do_setup") action do_setup_0(bit<9> idx, bit<1> routed) {
         meta.egress_metadata.mac_da = hdr.ethernet.dstAddr;

--- a/testdata/p4_14_samples_outputs/meter-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter-midend.p4
@@ -46,9 +46,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("my_meter") meter(32w16384, CounterType.packets) my_meter;
     @name("_drop") action _drop_0() {

--- a/testdata/p4_14_samples_outputs/meter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-midend.p4
@@ -46,9 +46,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("my_meter") direct_meter<bit<32>>(CounterType.packets) my_meter;
     @name("_drop") action _drop_0() {

--- a/testdata/p4_14_samples_outputs/miss-midend.p4
+++ b/testdata/p4_14_samples_outputs/miss-midend.p4
@@ -27,11 +27,11 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_4() {
+    @name("NoAction") action NoAction_4() {
     }
-    @name("NoAction_3") action NoAction_5() {
+    @name("NoAction") action NoAction_5() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/overflow-midend.p4
+++ b/testdata/p4_14_samples_outputs/overflow-midend.p4
@@ -26,7 +26,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("action_1_1") action action_1(bit<1> value) {
         meta.md.field_1_1_1 = value;

--- a/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
@@ -53,7 +53,7 @@ struct tuple_0 {
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("_nop") action _nop_0() {
     }
@@ -83,9 +83,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_5() {
+    @name("NoAction") action NoAction_5() {
     }
     @name("_nop") action _nop_1() {
     }

--- a/testdata/p4_14_samples_outputs/parser1-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser1-midend.p4
@@ -105,7 +105,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("do_noop") action do_noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/parser2-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser2-midend.p4
@@ -191,7 +191,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("do_noop") action do_noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/parser3-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser3-midend.p4
@@ -47,7 +47,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("noop") action noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/parser4-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser4-midend.p4
@@ -107,7 +107,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("do_noop") action do_noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
@@ -721,7 +721,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("set_bd") action set_bd_0(bit<16> outer_vlan_bd, bit<12> vrf, bit<10> rmac_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> igmp_snooping_enabled, bit<10> stp_group) {
         meta.ingress_metadata.vrf = vrf;

--- a/testdata/p4_14_samples_outputs/queueing-midend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-midend.p4
@@ -47,7 +47,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("copy_queueing_data") action copy_queueing_data_0() {
         hdr.queueing_hdr.setValid();
@@ -69,7 +69,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("set_port") action set_port_0(bit<9> port) {
         standard_metadata.egress_spec = port;

--- a/testdata/p4_14_samples_outputs/register-midend.p4
+++ b/testdata/p4_14_samples_outputs/register-midend.p4
@@ -46,7 +46,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("my_register") register<bit<32>>(32w16384) my_register;
     @name("m_action") action m_action_0(bit<8> register_idx) {

--- a/testdata/p4_14_samples_outputs/repeater-midend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-midend.p4
@@ -26,7 +26,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("my_drop") action my_drop_0() {
         mark_to_drop();

--- a/testdata/p4_14_samples_outputs/resubmit-midend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-midend.p4
@@ -52,9 +52,9 @@ struct tuple_0 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("_nop") action _nop_0() {
     }

--- a/testdata/p4_14_samples_outputs/sai_p4-midend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-midend.p4
@@ -135,23 +135,23 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_3") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
-    @name("NoAction_4") action NoAction_12() {
+    @name("NoAction") action NoAction_12() {
     }
-    @name("NoAction_5") action NoAction_13() {
+    @name("NoAction") action NoAction_13() {
     }
-    @name("NoAction_6") action NoAction_14() {
+    @name("NoAction") action NoAction_14() {
     }
-    @name("NoAction_7") action NoAction_15() {
+    @name("NoAction") action NoAction_15() {
     }
-    @name("NoAction_8") action NoAction_16() {
+    @name("NoAction") action NoAction_16() {
     }
-    @name("NoAction_9") action NoAction_17() {
+    @name("NoAction") action NoAction_17() {
     }
     @name("fdb_set") action fdb_set_0(bit<1> type_, bit<9> port_id) {
         meta.ingress_metadata.mac_type = type_;

--- a/testdata/p4_14_samples_outputs/selector0-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector0-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("noop") action noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/selector0.p4-stderr
+++ b/testdata/p4_14_samples_outputs/selector0.p4-stderr
@@ -1,3 +1,0 @@
-../testdata/p4_14_samples/selector0.p4(53): warning: fair: Action selector attribute ignored
-    selection_mode : fair;
-                     ^^^^

--- a/testdata/p4_14_samples_outputs/selector1-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector1-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("noop") action noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/selector1.p4-stderr
+++ b/testdata/p4_14_samples_outputs/selector1.p4-stderr
@@ -1,3 +1,0 @@
-../testdata/p4_14_samples/selector1.p4(53): warning: fair: Action selector attribute ignored
-    selection_mode : fair;
-                     ^^^^

--- a/testdata/p4_14_samples_outputs/selector2-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector2-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("noop") action noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/selector2.p4-stderr
+++ b/testdata/p4_14_samples_outputs/selector2.p4-stderr
@@ -1,3 +1,0 @@
-../testdata/p4_14_samples/selector2.p4(53): warning: fair: Action selector attribute ignored
-    selection_mode : fair;
-                     ^^^^

--- a/testdata/p4_14_samples_outputs/selector3-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector3-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("noop") action noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/selector3.p4-stderr
+++ b/testdata/p4_14_samples_outputs/selector3.p4-stderr
@@ -1,3 +1,0 @@
-../testdata/p4_14_samples/selector3.p4(53): warning: fair: Action selector attribute ignored
-    selection_mode : fair;
-                     ^^^^

--- a/testdata/p4_14_samples_outputs/simple_nat-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-midend.p4
@@ -120,9 +120,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
     @name("do_rewrites") action do_rewrites_0(bit<48> smac) {
         hdr.cpu_header.setInvalid();
@@ -174,13 +174,13 @@ struct tuple_0 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_4") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_5") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_6") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_7") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("set_dmac") action set_dmac_0(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/simple_router-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-midend.p4
@@ -56,7 +56,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("rewrite_mac") action rewrite_mac_0(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
@@ -82,9 +82,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_5() {
+    @name("NoAction") action NoAction_5() {
     }
     @name("set_dmac") action set_dmac_0(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/source_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-midend.p4
@@ -46,7 +46,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("_drop") action _drop_0() {
         mark_to_drop();

--- a/testdata/p4_14_samples_outputs/swap_1-midend.p4
+++ b/testdata/p4_14_samples_outputs/swap_1-midend.p4
@@ -27,7 +27,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("a11") action a11_0() {
         standard_metadata.egress_spec = 9w1;

--- a/testdata/p4_14_samples_outputs/swap_2-midend.p4
+++ b/testdata/p4_14_samples_outputs/swap_2-midend.p4
@@ -28,7 +28,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("a21") action a21_0() {
         standard_metadata.egress_spec = 9w3;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -1150,65 +1150,65 @@ struct tuple_1 {
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_86() {
+    @name("NoAction") action NoAction_86() {
     }
-    @name("NoAction_5") action NoAction_87() {
+    @name("NoAction") action NoAction_87() {
     }
-    @name("NoAction_6") action NoAction_88() {
+    @name("NoAction") action NoAction_88() {
     }
-    @name("NoAction_7") action NoAction_89() {
+    @name("NoAction") action NoAction_89() {
     }
-    @name("NoAction_8") action NoAction_90() {
+    @name("NoAction") action NoAction_90() {
     }
-    @name("NoAction_9") action NoAction_91() {
+    @name("NoAction") action NoAction_91() {
     }
-    @name("NoAction_10") action NoAction_92() {
+    @name("NoAction") action NoAction_92() {
     }
-    @name("NoAction_11") action NoAction_93() {
+    @name("NoAction") action NoAction_93() {
     }
-    @name("NoAction_12") action NoAction_94() {
+    @name("NoAction") action NoAction_94() {
     }
-    @name("NoAction_13") action NoAction_95() {
+    @name("NoAction") action NoAction_95() {
     }
-    @name("NoAction_14") action NoAction_96() {
+    @name("NoAction") action NoAction_96() {
     }
-    @name("NoAction_15") action NoAction_97() {
+    @name("NoAction") action NoAction_97() {
     }
-    @name("NoAction_16") action NoAction_98() {
+    @name("NoAction") action NoAction_98() {
     }
-    @name("NoAction_17") action NoAction_99() {
+    @name("NoAction") action NoAction_99() {
     }
-    @name("NoAction_18") action NoAction_100() {
+    @name("NoAction") action NoAction_100() {
     }
-    @name("NoAction_19") action NoAction_101() {
+    @name("NoAction") action NoAction_101() {
     }
-    @name("NoAction_20") action NoAction_102() {
+    @name("NoAction") action NoAction_102() {
     }
-    @name("NoAction_21") action NoAction_103() {
+    @name("NoAction") action NoAction_103() {
     }
-    @name("NoAction_22") action NoAction_104() {
+    @name("NoAction") action NoAction_104() {
     }
-    @name("NoAction_23") action NoAction_105() {
+    @name("NoAction") action NoAction_105() {
     }
-    @name("NoAction_24") action NoAction_106() {
+    @name("NoAction") action NoAction_106() {
     }
-    @name("NoAction_25") action NoAction_107() {
+    @name("NoAction") action NoAction_107() {
     }
-    @name("NoAction_26") action NoAction_108() {
+    @name("NoAction") action NoAction_108() {
     }
-    @name("NoAction_27") action NoAction_109() {
+    @name("NoAction") action NoAction_109() {
     }
-    @name("NoAction_28") action NoAction_110() {
+    @name("NoAction") action NoAction_110() {
     }
-    @name("NoAction_29") action NoAction_111() {
+    @name("NoAction") action NoAction_111() {
     }
-    @name("NoAction_30") action NoAction_112() {
+    @name("NoAction") action NoAction_112() {
     }
-    @name("NoAction_31") action NoAction_113() {
+    @name("NoAction") action NoAction_113() {
     }
     @name("egress_port_type_normal") action egress_port_type_normal_0() {
         meta.egress_metadata.port_type = 2w0;
@@ -2961,113 +2961,113 @@ struct tuple_7 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_32") action NoAction_114() {
+    @name("NoAction") action NoAction_114() {
     }
-    @name("NoAction_33") action NoAction_115() {
+    @name("NoAction") action NoAction_115() {
     }
-    @name("NoAction_34") action NoAction_116() {
+    @name("NoAction") action NoAction_116() {
     }
-    @name("NoAction_35") action NoAction_117() {
+    @name("NoAction") action NoAction_117() {
     }
-    @name("NoAction_36") action NoAction_118() {
+    @name("NoAction") action NoAction_118() {
     }
-    @name("NoAction_37") action NoAction_119() {
+    @name("NoAction") action NoAction_119() {
     }
-    @name("NoAction_38") action NoAction_120() {
+    @name("NoAction") action NoAction_120() {
     }
-    @name("NoAction_39") action NoAction_121() {
+    @name("NoAction") action NoAction_121() {
     }
-    @name("NoAction_40") action NoAction_122() {
+    @name("NoAction") action NoAction_122() {
     }
-    @name("NoAction_41") action NoAction_123() {
+    @name("NoAction") action NoAction_123() {
     }
-    @name("NoAction_42") action NoAction_124() {
+    @name("NoAction") action NoAction_124() {
     }
-    @name("NoAction_43") action NoAction_125() {
+    @name("NoAction") action NoAction_125() {
     }
-    @name("NoAction_44") action NoAction_126() {
+    @name("NoAction") action NoAction_126() {
     }
-    @name("NoAction_45") action NoAction_127() {
+    @name("NoAction") action NoAction_127() {
     }
-    @name("NoAction_46") action NoAction_128() {
+    @name("NoAction") action NoAction_128() {
     }
-    @name("NoAction_47") action NoAction_129() {
+    @name("NoAction") action NoAction_129() {
     }
-    @name("NoAction_48") action NoAction_130() {
+    @name("NoAction") action NoAction_130() {
     }
-    @name("NoAction_49") action NoAction_131() {
+    @name("NoAction") action NoAction_131() {
     }
-    @name("NoAction_50") action NoAction_132() {
+    @name("NoAction") action NoAction_132() {
     }
-    @name("NoAction_51") action NoAction_133() {
+    @name("NoAction") action NoAction_133() {
     }
-    @name("NoAction_52") action NoAction_134() {
+    @name("NoAction") action NoAction_134() {
     }
-    @name("NoAction_53") action NoAction_135() {
+    @name("NoAction") action NoAction_135() {
     }
-    @name("NoAction_54") action NoAction_136() {
+    @name("NoAction") action NoAction_136() {
     }
-    @name("NoAction_55") action NoAction_137() {
+    @name("NoAction") action NoAction_137() {
     }
-    @name("NoAction_56") action NoAction_138() {
+    @name("NoAction") action NoAction_138() {
     }
-    @name("NoAction_57") action NoAction_139() {
+    @name("NoAction") action NoAction_139() {
     }
-    @name("NoAction_58") action NoAction_140() {
+    @name("NoAction") action NoAction_140() {
     }
-    @name("NoAction_59") action NoAction_141() {
+    @name("NoAction") action NoAction_141() {
     }
-    @name("NoAction_60") action NoAction_142() {
+    @name("NoAction") action NoAction_142() {
     }
-    @name("NoAction_61") action NoAction_143() {
+    @name("NoAction") action NoAction_143() {
     }
-    @name("NoAction_62") action NoAction_144() {
+    @name("NoAction") action NoAction_144() {
     }
-    @name("NoAction_63") action NoAction_145() {
+    @name("NoAction") action NoAction_145() {
     }
-    @name("NoAction_64") action NoAction_146() {
+    @name("NoAction") action NoAction_146() {
     }
-    @name("NoAction_65") action NoAction_147() {
+    @name("NoAction") action NoAction_147() {
     }
-    @name("NoAction_66") action NoAction_148() {
+    @name("NoAction") action NoAction_148() {
     }
-    @name("NoAction_67") action NoAction_149() {
+    @name("NoAction") action NoAction_149() {
     }
-    @name("NoAction_68") action NoAction_150() {
+    @name("NoAction") action NoAction_150() {
     }
-    @name("NoAction_69") action NoAction_151() {
+    @name("NoAction") action NoAction_151() {
     }
-    @name("NoAction_70") action NoAction_152() {
+    @name("NoAction") action NoAction_152() {
     }
-    @name("NoAction_71") action NoAction_153() {
+    @name("NoAction") action NoAction_153() {
     }
-    @name("NoAction_72") action NoAction_154() {
+    @name("NoAction") action NoAction_154() {
     }
-    @name("NoAction_73") action NoAction_155() {
+    @name("NoAction") action NoAction_155() {
     }
-    @name("NoAction_74") action NoAction_156() {
+    @name("NoAction") action NoAction_156() {
     }
-    @name("NoAction_75") action NoAction_157() {
+    @name("NoAction") action NoAction_157() {
     }
-    @name("NoAction_76") action NoAction_158() {
+    @name("NoAction") action NoAction_158() {
     }
-    @name("NoAction_77") action NoAction_159() {
+    @name("NoAction") action NoAction_159() {
     }
-    @name("NoAction_78") action NoAction_160() {
+    @name("NoAction") action NoAction_160() {
     }
-    @name("NoAction_79") action NoAction_161() {
+    @name("NoAction") action NoAction_161() {
     }
-    @name("NoAction_80") action NoAction_162() {
+    @name("NoAction") action NoAction_162() {
     }
-    @name("NoAction_81") action NoAction_163() {
+    @name("NoAction") action NoAction_163() {
     }
-    @name("NoAction_82") action NoAction_164() {
+    @name("NoAction") action NoAction_164() {
     }
-    @name("NoAction_83") action NoAction_165() {
+    @name("NoAction") action NoAction_165() {
     }
-    @name("NoAction_84") action NoAction_166() {
+    @name("NoAction") action NoAction_166() {
     }
-    @name("NoAction_85") action NoAction_167() {
+    @name("NoAction") action NoAction_167() {
     }
     @name("rmac_hit") action rmac_hit_0() {
         meta.l3_metadata.rmac_hit = 1w1;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4-stderr
@@ -1,12 +1,3 @@
-../testdata/p4_14_samples/switch_20160226/nexthop.p4(138): warning: fair: Action selector attribute ignored
-    selection_mode : fair;
-                     ^^^^
-../testdata/p4_14_samples/switch_20160226/fabric.p4(254): warning: fair: Action selector attribute ignored
-    selection_mode : fair;
-                     ^^^^
-../testdata/p4_14_samples/switch_20160226/port.p4(312): warning: fair: Action selector attribute ignored
-    selection_mode : fair;
-                     ^^^^
 ../testdata/p4_14_samples/switch_20160226/l3.p4(140): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -1208,75 +1208,75 @@ struct tuple_1 {
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_115() {
+    @name("NoAction") action NoAction_115() {
     }
-    @name("NoAction_5") action NoAction_116() {
+    @name("NoAction") action NoAction_116() {
     }
-    @name("NoAction_6") action NoAction_117() {
+    @name("NoAction") action NoAction_117() {
     }
-    @name("NoAction_7") action NoAction_118() {
+    @name("NoAction") action NoAction_118() {
     }
-    @name("NoAction_8") action NoAction_119() {
+    @name("NoAction") action NoAction_119() {
     }
-    @name("NoAction_9") action NoAction_120() {
+    @name("NoAction") action NoAction_120() {
     }
-    @name("NoAction_10") action NoAction_121() {
+    @name("NoAction") action NoAction_121() {
     }
-    @name("NoAction_11") action NoAction_122() {
+    @name("NoAction") action NoAction_122() {
     }
-    @name("NoAction_12") action NoAction_123() {
+    @name("NoAction") action NoAction_123() {
     }
-    @name("NoAction_13") action NoAction_124() {
+    @name("NoAction") action NoAction_124() {
     }
-    @name("NoAction_14") action NoAction_125() {
+    @name("NoAction") action NoAction_125() {
     }
-    @name("NoAction_15") action NoAction_126() {
+    @name("NoAction") action NoAction_126() {
     }
-    @name("NoAction_16") action NoAction_127() {
+    @name("NoAction") action NoAction_127() {
     }
-    @name("NoAction_17") action NoAction_128() {
+    @name("NoAction") action NoAction_128() {
     }
-    @name("NoAction_18") action NoAction_129() {
+    @name("NoAction") action NoAction_129() {
     }
-    @name("NoAction_19") action NoAction_130() {
+    @name("NoAction") action NoAction_130() {
     }
-    @name("NoAction_20") action NoAction_131() {
+    @name("NoAction") action NoAction_131() {
     }
-    @name("NoAction_21") action NoAction_132() {
+    @name("NoAction") action NoAction_132() {
     }
-    @name("NoAction_22") action NoAction_133() {
+    @name("NoAction") action NoAction_133() {
     }
-    @name("NoAction_23") action NoAction_134() {
+    @name("NoAction") action NoAction_134() {
     }
-    @name("NoAction_24") action NoAction_135() {
+    @name("NoAction") action NoAction_135() {
     }
-    @name("NoAction_25") action NoAction_136() {
+    @name("NoAction") action NoAction_136() {
     }
-    @name("NoAction_26") action NoAction_137() {
+    @name("NoAction") action NoAction_137() {
     }
-    @name("NoAction_27") action NoAction_138() {
+    @name("NoAction") action NoAction_138() {
     }
-    @name("NoAction_28") action NoAction_139() {
+    @name("NoAction") action NoAction_139() {
     }
-    @name("NoAction_29") action NoAction_140() {
+    @name("NoAction") action NoAction_140() {
     }
-    @name("NoAction_30") action NoAction_141() {
+    @name("NoAction") action NoAction_141() {
     }
-    @name("NoAction_31") action NoAction_142() {
+    @name("NoAction") action NoAction_142() {
     }
-    @name("NoAction_32") action NoAction_143() {
+    @name("NoAction") action NoAction_143() {
     }
-    @name("NoAction_33") action NoAction_144() {
+    @name("NoAction") action NoAction_144() {
     }
-    @name("NoAction_34") action NoAction_145() {
+    @name("NoAction") action NoAction_145() {
     }
-    @name("NoAction_35") action NoAction_146() {
+    @name("NoAction") action NoAction_146() {
     }
-    @name("NoAction_36") action NoAction_147() {
+    @name("NoAction") action NoAction_147() {
     }
     @name("egress_port_type_normal") action egress_port_type_normal_0(bit<16> ifindex) {
         meta.egress_metadata.port_type = 2w0;
@@ -3175,161 +3175,161 @@ struct tuple_9 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_37") action NoAction_148() {
+    @name("NoAction") action NoAction_148() {
     }
-    @name("NoAction_38") action NoAction_149() {
+    @name("NoAction") action NoAction_149() {
     }
-    @name("NoAction_39") action NoAction_150() {
+    @name("NoAction") action NoAction_150() {
     }
-    @name("NoAction_40") action NoAction_151() {
+    @name("NoAction") action NoAction_151() {
     }
-    @name("NoAction_41") action NoAction_152() {
+    @name("NoAction") action NoAction_152() {
     }
-    @name("NoAction_42") action NoAction_153() {
+    @name("NoAction") action NoAction_153() {
     }
-    @name("NoAction_43") action NoAction_154() {
+    @name("NoAction") action NoAction_154() {
     }
-    @name("NoAction_44") action NoAction_155() {
+    @name("NoAction") action NoAction_155() {
     }
-    @name("NoAction_45") action NoAction_156() {
+    @name("NoAction") action NoAction_156() {
     }
-    @name("NoAction_46") action NoAction_157() {
+    @name("NoAction") action NoAction_157() {
     }
-    @name("NoAction_47") action NoAction_158() {
+    @name("NoAction") action NoAction_158() {
     }
-    @name("NoAction_48") action NoAction_159() {
+    @name("NoAction") action NoAction_159() {
     }
-    @name("NoAction_49") action NoAction_160() {
+    @name("NoAction") action NoAction_160() {
     }
-    @name("NoAction_50") action NoAction_161() {
+    @name("NoAction") action NoAction_161() {
     }
-    @name("NoAction_51") action NoAction_162() {
+    @name("NoAction") action NoAction_162() {
     }
-    @name("NoAction_52") action NoAction_163() {
+    @name("NoAction") action NoAction_163() {
     }
-    @name("NoAction_53") action NoAction_164() {
+    @name("NoAction") action NoAction_164() {
     }
-    @name("NoAction_54") action NoAction_165() {
+    @name("NoAction") action NoAction_165() {
     }
-    @name("NoAction_55") action NoAction_166() {
+    @name("NoAction") action NoAction_166() {
     }
-    @name("NoAction_56") action NoAction_167() {
+    @name("NoAction") action NoAction_167() {
     }
-    @name("NoAction_57") action NoAction_168() {
+    @name("NoAction") action NoAction_168() {
     }
-    @name("NoAction_58") action NoAction_169() {
+    @name("NoAction") action NoAction_169() {
     }
-    @name("NoAction_59") action NoAction_170() {
+    @name("NoAction") action NoAction_170() {
     }
-    @name("NoAction_60") action NoAction_171() {
+    @name("NoAction") action NoAction_171() {
     }
-    @name("NoAction_61") action NoAction_172() {
+    @name("NoAction") action NoAction_172() {
     }
-    @name("NoAction_62") action NoAction_173() {
+    @name("NoAction") action NoAction_173() {
     }
-    @name("NoAction_63") action NoAction_174() {
+    @name("NoAction") action NoAction_174() {
     }
-    @name("NoAction_64") action NoAction_175() {
+    @name("NoAction") action NoAction_175() {
     }
-    @name("NoAction_65") action NoAction_176() {
+    @name("NoAction") action NoAction_176() {
     }
-    @name("NoAction_66") action NoAction_177() {
+    @name("NoAction") action NoAction_177() {
     }
-    @name("NoAction_67") action NoAction_178() {
+    @name("NoAction") action NoAction_178() {
     }
-    @name("NoAction_68") action NoAction_179() {
+    @name("NoAction") action NoAction_179() {
     }
-    @name("NoAction_69") action NoAction_180() {
+    @name("NoAction") action NoAction_180() {
     }
-    @name("NoAction_70") action NoAction_181() {
+    @name("NoAction") action NoAction_181() {
     }
-    @name("NoAction_71") action NoAction_182() {
+    @name("NoAction") action NoAction_182() {
     }
-    @name("NoAction_72") action NoAction_183() {
+    @name("NoAction") action NoAction_183() {
     }
-    @name("NoAction_73") action NoAction_184() {
+    @name("NoAction") action NoAction_184() {
     }
-    @name("NoAction_74") action NoAction_185() {
+    @name("NoAction") action NoAction_185() {
     }
-    @name("NoAction_75") action NoAction_186() {
+    @name("NoAction") action NoAction_186() {
     }
-    @name("NoAction_76") action NoAction_187() {
+    @name("NoAction") action NoAction_187() {
     }
-    @name("NoAction_77") action NoAction_188() {
+    @name("NoAction") action NoAction_188() {
     }
-    @name("NoAction_78") action NoAction_189() {
+    @name("NoAction") action NoAction_189() {
     }
-    @name("NoAction_79") action NoAction_190() {
+    @name("NoAction") action NoAction_190() {
     }
-    @name("NoAction_80") action NoAction_191() {
+    @name("NoAction") action NoAction_191() {
     }
-    @name("NoAction_81") action NoAction_192() {
+    @name("NoAction") action NoAction_192() {
     }
-    @name("NoAction_82") action NoAction_193() {
+    @name("NoAction") action NoAction_193() {
     }
-    @name("NoAction_83") action NoAction_194() {
+    @name("NoAction") action NoAction_194() {
     }
-    @name("NoAction_84") action NoAction_195() {
+    @name("NoAction") action NoAction_195() {
     }
-    @name("NoAction_85") action NoAction_196() {
+    @name("NoAction") action NoAction_196() {
     }
-    @name("NoAction_86") action NoAction_197() {
+    @name("NoAction") action NoAction_197() {
     }
-    @name("NoAction_87") action NoAction_198() {
+    @name("NoAction") action NoAction_198() {
     }
-    @name("NoAction_88") action NoAction_199() {
+    @name("NoAction") action NoAction_199() {
     }
-    @name("NoAction_89") action NoAction_200() {
+    @name("NoAction") action NoAction_200() {
     }
-    @name("NoAction_90") action NoAction_201() {
+    @name("NoAction") action NoAction_201() {
     }
-    @name("NoAction_91") action NoAction_202() {
+    @name("NoAction") action NoAction_202() {
     }
-    @name("NoAction_92") action NoAction_203() {
+    @name("NoAction") action NoAction_203() {
     }
-    @name("NoAction_93") action NoAction_204() {
+    @name("NoAction") action NoAction_204() {
     }
-    @name("NoAction_94") action NoAction_205() {
+    @name("NoAction") action NoAction_205() {
     }
-    @name("NoAction_95") action NoAction_206() {
+    @name("NoAction") action NoAction_206() {
     }
-    @name("NoAction_96") action NoAction_207() {
+    @name("NoAction") action NoAction_207() {
     }
-    @name("NoAction_97") action NoAction_208() {
+    @name("NoAction") action NoAction_208() {
     }
-    @name("NoAction_98") action NoAction_209() {
+    @name("NoAction") action NoAction_209() {
     }
-    @name("NoAction_99") action NoAction_210() {
+    @name("NoAction") action NoAction_210() {
     }
-    @name("NoAction_100") action NoAction_211() {
+    @name("NoAction") action NoAction_211() {
     }
-    @name("NoAction_101") action NoAction_212() {
+    @name("NoAction") action NoAction_212() {
     }
-    @name("NoAction_102") action NoAction_213() {
+    @name("NoAction") action NoAction_213() {
     }
-    @name("NoAction_103") action NoAction_214() {
+    @name("NoAction") action NoAction_214() {
     }
-    @name("NoAction_104") action NoAction_215() {
+    @name("NoAction") action NoAction_215() {
     }
-    @name("NoAction_105") action NoAction_216() {
+    @name("NoAction") action NoAction_216() {
     }
-    @name("NoAction_106") action NoAction_217() {
+    @name("NoAction") action NoAction_217() {
     }
-    @name("NoAction_107") action NoAction_218() {
+    @name("NoAction") action NoAction_218() {
     }
-    @name("NoAction_108") action NoAction_219() {
+    @name("NoAction") action NoAction_219() {
     }
-    @name("NoAction_109") action NoAction_220() {
+    @name("NoAction") action NoAction_220() {
     }
-    @name("NoAction_110") action NoAction_221() {
+    @name("NoAction") action NoAction_221() {
     }
-    @name("NoAction_111") action NoAction_222() {
+    @name("NoAction") action NoAction_222() {
     }
-    @name("NoAction_112") action NoAction_223() {
+    @name("NoAction") action NoAction_223() {
     }
-    @name("NoAction_113") action NoAction_224() {
+    @name("NoAction") action NoAction_224() {
     }
-    @name("NoAction_114") action NoAction_225() {
+    @name("NoAction") action NoAction_225() {
     }
     @name("rmac_hit") action rmac_hit_0() {
         meta.l3_metadata.rmac_hit = 1w1;

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
@@ -1,12 +1,3 @@
-../testdata/p4_14_samples/switch_20160512/nexthop.p4(203): warning: fair: Action selector attribute ignored
-    selection_mode : fair;
-                     ^^^^
-../testdata/p4_14_samples/switch_20160512/fabric.p4(234): warning: fair: Action selector attribute ignored
-    selection_mode : fair;
-                     ^^^^
-../testdata/p4_14_samples/switch_20160512/port.p4(292): warning: fair: Action selector attribute ignored
-    selection_mode : fair;
-                     ^^^^
 ../testdata/p4_14_samples/switch_20160512/l3.p4(155): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^

--- a/testdata/p4_14_samples_outputs/ternary_match0-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("noop") action noop_0() {
     }

--- a/testdata/p4_14_samples_outputs/ternary_match1-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-midend.p4
@@ -27,7 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/ternary_match2-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-midend.p4
@@ -26,7 +26,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/ternary_match3-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-midend.p4
@@ -26,7 +26,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/ternary_match4-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-midend.p4
@@ -26,7 +26,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-midend.p4
@@ -103,7 +103,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("no_action") action no_action_0() {
     }

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-midend.p4
@@ -36,11 +36,11 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_4() {
+    @name("NoAction") action NoAction_4() {
     }
-    @name("NoAction_3") action NoAction_5() {
+    @name("NoAction") action NoAction_5() {
     }
     @name("action_0") action action_2() {
         hdr.pkt.field_a_32 = (bit<32>)~(hdr.pkt.field_b_32 | (int<32>)hdr.pkt.field_c_32);

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-midend.p4
@@ -64,7 +64,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("action_0") action action_2(bit<8> my_param0, bit<8> my_param1) {
         hdr.ipv4.protocol[7:3] = my_param0[7:3];

--- a/testdata/p4_14_samples_outputs/testgw-midend.p4
+++ b/testdata/p4_14_samples_outputs/testgw-midend.p4
@@ -45,11 +45,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_4() {
+    @name("NoAction") action NoAction_4() {
     }
-    @name("NoAction_3") action NoAction_5() {
+    @name("NoAction") action NoAction_5() {
     }
     @name("route_eth") action route_eth_0(bit<9> egress_spec, bit<48> src_addr) {
         standard_metadata.egress_spec = egress_spec;

--- a/testdata/p4_14_samples_outputs/tmvalid-midend.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid-midend.p4
@@ -27,7 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/tp2a-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-midend.p4
@@ -28,13 +28,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_5() {
+    @name("NoAction") action NoAction_5() {
     }
-    @name("NoAction_3") action NoAction_6() {
+    @name("NoAction") action NoAction_6() {
     }
-    @name("NoAction_4") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
     @name("setb1") action setb1_0(bit<32> val) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/tp2b-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-midend.p4
@@ -28,11 +28,11 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
     @name("setf1") action setf1_0(bit<32> val) {
         hdr.data.f1 = val;
@@ -92,13 +92,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_5") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_6") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
-    @name("NoAction_7") action NoAction_12() {
+    @name("NoAction") action NoAction_12() {
     }
-    @name("NoAction_8") action NoAction_13() {
+    @name("NoAction") action NoAction_13() {
     }
     @name("setb1") action setb1_1(bit<32> val) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/tp2c-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-midend.p4
@@ -28,17 +28,17 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_7() {
+    @name("NoAction") action NoAction_7() {
     }
-    @name("NoAction_3") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_4") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_5") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_6") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("setb1") action setb1_0(bit<32> val) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/tp3a-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-midend.p4
@@ -28,13 +28,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
-    @name("NoAction_5") action NoAction_12() {
+    @name("NoAction") action NoAction_12() {
     }
     @name("setf1") action setf1_0(bit<32> val) {
         hdr.data.f1 = val;
@@ -111,15 +111,15 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_6") action NoAction_13() {
+    @name("NoAction") action NoAction_13() {
     }
-    @name("NoAction_7") action NoAction_14() {
+    @name("NoAction") action NoAction_14() {
     }
-    @name("NoAction_8") action NoAction_15() {
+    @name("NoAction") action NoAction_15() {
     }
-    @name("NoAction_9") action NoAction_16() {
+    @name("NoAction") action NoAction_16() {
     }
-    @name("NoAction_10") action NoAction_17() {
+    @name("NoAction") action NoAction_17() {
     }
     @name("setb1") action setb1_5(bit<32> val) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/triv_eth-midend.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-midend.p4
@@ -23,7 +23,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("route_eth") action route_eth_0(bit<9> egress_spec, bit<48> src_addr) {
         standard_metadata.egress_spec = egress_spec;

--- a/testdata/p4_14_samples_outputs/triv_ipv4-midend.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-midend.p4
@@ -59,7 +59,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("do_drop") action do_drop_0() {
     }

--- a/testdata/p4_14_samples_outputs/truncate-midend.p4
+++ b/testdata/p4_14_samples_outputs/truncate-midend.p4
@@ -27,7 +27,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("_nop") action _nop_0() {
     }

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet-midend.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet-midend.p4
@@ -60,7 +60,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("set_valid_outer_unicast_packet_untagged") action set_valid_outer_unicast_packet_untagged_0() {
         meta.ingress_metadata.lkp_pkt_type = 3w1;

--- a/testdata/p4_14_samples_outputs/wide_action1-midend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-midend.p4
@@ -48,7 +48,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setmeta") action setmeta_0(bit<32> v0, bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<16> v5, bit<16> v6) {
         meta.m.m0 = v0;

--- a/testdata/p4_14_samples_outputs/wide_action2-midend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action2-midend.p4
@@ -50,7 +50,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("set_bd_info") action set_bd_info_0(bit<12> vrf, bit<10> rmac_group, bit<16> mrpf_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_multicast_mode, bit<2> ipv6_multicast_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<16> exclusion_id) {
         meta.ingress_metadata.vrf = vrf;

--- a/testdata/p4_14_samples_outputs/wide_action3-midend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-midend.p4
@@ -48,7 +48,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("setmeta") action setmeta_0(bit<8> v0, bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<16> v5, bit<16> v6) {
         meta.m.m10 = v0;

--- a/testdata/p4_16_errors_outputs/action-bind1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind1.p4-stderr
@@ -1,3 +1,20 @@
+../testdata/p4_16_errors/action-bind1.p4(22): error: a: parameter b must be bound
+        default_action = a();
+                         ^^^
+../testdata/p4_16_errors/action-bind1.p4(17)
+    action a(inout bit<32> b, bit<32> d) {
+                           ^
+../testdata/p4_16_errors/action-bind1.p4(22): error: a: parameter d must be bound
+        default_action = a();
+                         ^^^
+../testdata/p4_16_errors/action-bind1.p4(17)
+    action a(inout bit<32> b, bit<32> d) {
+                                      ^
 ../testdata/p4_16_errors/action-bind1.p4(22): error: Action for ExpressionValue has some unbound arguments
         default_action = a();
                          ^^^
+../testdata/p4_16_errors/action-bind1.p4(22): error: a: not enough arguments
+        default_action = a();
+                         ^^^
+terminate called after throwing an instance of 'std::out_of_range'
+  what():  vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)

--- a/testdata/p4_16_errors_outputs/action-bind2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind2.p4-stderr
@@ -7,6 +7,12 @@
 ../testdata/p4_16_errors/action-bind2.p4(22): error: 0: must be a left-value
         default_action = a(0);
                            ^
+../testdata/p4_16_errors/action-bind2.p4(22): error: a: parameter d must be bound
+        default_action = a(0);
+                         ^^^^
+../testdata/p4_16_errors/action-bind2.p4(17)
+    action a(inout bit<32> b, bit<32> d) {
+                                      ^
 ../testdata/p4_16_errors/action-bind2.p4(22): error: Action for ExpressionValue has some unbound arguments
         default_action = a(0);
                          ^^^^

--- a/testdata/p4_16_errors_outputs/action-bind3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind3.p4-stderr
@@ -4,6 +4,24 @@
 ../testdata/p4_16_errors/action-bind3.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                                       ^
-../testdata/p4_16_errors/action-bind3.p4(22): error: 0 Too many parameters for action
+../testdata/p4_16_errors/action-bind3.p4(22): error: 0: must be a left-value
         default_action = a(0);
                            ^
+../testdata/p4_16_errors/action-bind3.p4(22): error: a: parameter d must be bound
+        default_action = a(0);
+                         ^^^^
+../testdata/p4_16_errors/action-bind3.p4(17)
+    action a(inout bit<32> b, bit<32> d) {
+                                      ^
+../testdata/p4_16_errors/action-bind3.p4(22): error: Action for ExpressionValue has some unbound arguments
+        default_action = a(0);
+                         ^^^^
+../testdata/p4_16_errors/action-bind3.p4(22): error: a: not enough arguments
+        default_action = a(0);
+                         ^^^^
+../testdata/p4_16_errors/action-bind3.p4(22): error: 0: argument does not match declaration in actions list: x
+        default_action = a(0);
+                           ^
+../testdata/p4_16_errors/action-bind3.p4(21)
+        actions = { a(x, 0); }
+                      ^

--- a/testdata/p4_16_errors_outputs/constructor1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor1_e.p4-stderr
@@ -1,3 +1,4 @@
-../testdata/p4_16_errors/constructor1_e.p4(18): error: <T>: Constructors cannot have type parameters
-    Y<T>(in T arg);
-     ^^^
+../testdata/p4_16_errors/constructor1_e.p4(18):syntax error, unexpected IDENTIFIER "T"
+    Y<T
+      ^
+error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/default_action.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default_action.p4-stderr
@@ -1,9 +1,3 @@
 ../testdata/p4_16_errors/default_action.p4(21): error: b not present in action list
         default_action = b;
                          ^
-../testdata/p4_16_errors/default_action.p4(21): error: Could not find type of b
-        default_action = b;
-                         ^
-../testdata/p4_16_errors/default_action.p4(21): error: Could not find type of b
-        default_action = b;
-                         ^

--- a/testdata/p4_16_errors_outputs/default_action1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default_action1.p4-stderr
@@ -10,9 +10,3 @@ action b() {}
 ../testdata/p4_16_errors/default_action1.p4(22)
         actions = { a; b; }
                        ^
-../testdata/p4_16_errors/default_action1.p4(23): error: Could not find type of .b
-        default_action = .b();
-                          ^
-../testdata/p4_16_errors/default_action1.p4(23): error: Could not find type of .b
-        default_action = .b();
-                         ^^^^

--- a/testdata/p4_16_errors_outputs/div1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/div1.p4-stderr
@@ -1,16 +1,24 @@
 ../testdata/p4_16_errors/div1.p4(18): error: /: not defined on negative numbers
     a = a / -1;
         ^^^^^^
-error: Could not find type of <Div>(117)
+../testdata/p4_16_errors/div1.p4(18): error: Could not find type of /
+    a = a / -1;
+        ^^^^^^
 ../testdata/p4_16_errors/div1.p4(19): error: /: not defined on negative numbers
     a = -5 / a;
         ^^^^^^
-error: Could not find type of <Div>(127)
+../testdata/p4_16_errors/div1.p4(19): error: Could not find type of /
+    a = -5 / a;
+        ^^^^^^
 ../testdata/p4_16_errors/div1.p4(20): error: %: not defined on negative numbers
     a = a % -1;
         ^^^^^^
-error: Could not find type of <Mod>(137)
+../testdata/p4_16_errors/div1.p4(20): error: Could not find type of %
+    a = a % -1;
+        ^^^^^^
 ../testdata/p4_16_errors/div1.p4(21): error: %: not defined on negative numbers
     a = -5 % a;
         ^^^^^^
-error: Could not find type of <Mod>(147)
+../testdata/p4_16_errors/div1.p4(21): error: Could not find type of %
+    a = -5 % a;
+        ^^^^^^

--- a/testdata/p4_16_errors_outputs/dupConst.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dupConst.p4-stderr
@@ -1,7 +1,13 @@
+../testdata/p4_16_errors/dupConst.p4(17): error: Duplicate declaration of a; previous at 
+const bit<4> a = 2;
+             ^
+../testdata/p4_16_errors/dupConst.p4(16)
+const bit<4> a = 1;
+             ^
 ../testdata/p4_16_errors/dupConst.p4(16): error: a: Duplicates declaration a
 const bit<4> a = 1;
                    ^
 ../testdata/p4_16_errors/dupConst.p4(16)
 const bit<4> a = 1;
                  ^
-error: 1 errors encountered, aborting compilation
+error: 2 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/duplicateMethod_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/duplicateMethod_e.p4-stderr
@@ -5,3 +5,10 @@ error: Ambiguous method append with 1 parameters
 ../testdata/p4_16_errors/duplicateMethod_e.p4(23): error: Candidate is append
     void append(in packet_in b);
          ^^^^^^
+error: Ambiguous method append with 1 parameters
+../testdata/p4_16_errors/duplicateMethod_e.p4(21): error: Candidate is append
+    void append<D>(in D d);
+         ^^^^^^
+../testdata/p4_16_errors/duplicateMethod_e.p4(23): error: Candidate is append
+    void append(in packet_in b);
+         ^^^^^^

--- a/testdata/p4_16_errors_outputs/expression_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/expression_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/expression_e.p4(21):syntax error, unexpected DONTCARE, expecting NAMESPACE
+../testdata/p4_16_errors/expression_e.p4(21):syntax error, unexpected DONTCARE
         b = 32w0 & _
                    ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/extern.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extern.p4-stderr
@@ -1,33 +1,8 @@
 ../testdata/p4_16_errors/extern.p4(19): error: x: a parameter with an extern type cannot have a direction
 control c(in X x) {
                ^
-../testdata/p4_16_errors/extern.p4(19): error: x: a parameter with an extern type cannot have a direction
-control c(in X x) {
-               ^
-../testdata/p4_16_errors/extern.p4(24): error: x: a parameter with an extern type cannot have a direction
-control proto(in X x);
-                   ^
-../testdata/p4_16_errors/extern.p4(24): error: Could not find type of control proto
-control proto(in X x);
-        ^^^^^
-../testdata/p4_16_errors/extern.p4(25): error: Could not find type of proto
-package top(proto _c);
-            ^^^^^
-../testdata/p4_16_errors/extern.p4(25): error: Could not find type of package top
-package top(proto _c);
-        ^^^
-../testdata/p4_16_errors/extern.p4(19): error: Could not find type of control c
-control c(in X x) {
-        ^
-../testdata/p4_16_errors/extern.p4(27): error: Could not find type of c
-top(c()) main;
-    ^
-../testdata/p4_16_errors/extern.p4(25): error: Could not find type of package top
-package top(proto _c);
-        ^^^
-../testdata/p4_16_errors/extern.p4(19): error: Could not find type of control c
-control c(in X x) {
-        ^
-../testdata/p4_16_errors/extern.p4(27): error: Could not find type of c
-top(c()) main;
-    ^
+error: Could not find type of <Type_Control>(19) c
+terminate called after throwing an instance of 'Util::CompilerBug'
+  what():  COMPILER BUG: /home/antonin/Documents/p4lang/p4c/build/ir/ir-generated.cpp:4217
+/home/antonin/Documents/p4lang/p4c/build/ir/ir-generated.cpp:4217: Null type
+

--- a/testdata/p4_16_errors_outputs/extract.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extract.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/extract.p4(28): error: main: Cannot unify functions with different number of arguments:  _(p, h) to  _(p)
+../testdata/p4_16_errors/extract.p4(28): error: main: Cannot unify functions with different number of arguments:  function(p, h) to  function(p)
 top(P()) main;
          ^^^^

--- a/testdata/p4_16_errors_outputs/extract1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extract1.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/extract1.p4(31): error: main: Cannot unify functions with different number of arguments:  _(p, h) to  _(p)
+../testdata/p4_16_errors/extract1.p4(31): error: main: Cannot unify functions with different number of arguments:  function(p, h) to  function(p)
 top(P()) main;
          ^^^^

--- a/testdata/p4_16_errors_outputs/function_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/function_e.p4(22): error: f: Passing 0 arguments when 1 expected
+../testdata/p4_16_errors/function_e.p4(22): error: f: Not enough arguments for call
         f();
         ^^^
 ../testdata/p4_16_errors/function_e.p4(23): error: f: Passing 2 arguments when 1 expected

--- a/testdata/p4_16_errors_outputs/generic1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/generic1_e.p4-stderr
@@ -1,33 +1,11 @@
 ../testdata/p4_16_errors/generic1_e.p4(21): error: Type parameters needed for x
 control p1(If x)
               ^
-../testdata/p4_16_errors/generic1_e.p4(26): error: If<...>: Type If has 1 type parameter(s), but it is specialized with 2
-control p2(If<int<32>, int<32>> x)
-           ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/generic1_e.p4(16)
-extern If<T>
-       ^^
-../testdata/p4_16_errors/generic1_e.p4(26): error: Could not find type of If<...>
-control p2(If<int<32>, int<32>> x)
-           ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/generic1_e.p4(26): error: If<...>: Type If has 1 type parameter(s), but it is specialized with 2
-control p2(If<int<32>, int<32>> x)
-           ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/generic1_e.p4(16)
-extern If<T>
-       ^^
-../testdata/p4_16_errors/generic1_e.p4(26): error: If<...>: Type If has 1 type parameter(s), but it is specialized with 2
-control p2(If<int<32>, int<32>> x)
-           ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/generic1_e.p4(16)
-extern If<T>
-       ^^
-../testdata/p4_16_errors/generic1_e.p4(36): error: h<...>: Type header h is not generic and thus it cannot be specialized using type arguments
-        h<bit> x;
-        ^^^^^^
-../testdata/p4_16_errors/generic1_e.p4(31)
-header h {}
-       ^
-../testdata/p4_16_errors/generic1_e.p4(36): error: Could not find type of h<...>
-        h<bit> x;
-        ^^^^^^
+../testdata/p4_16_errors/generic1_e.p4(21): error: Could not find type of x
+control p1(If x)
+              ^
+error: Could not find type of <Type_Control>(31) p1
+terminate called after throwing an instance of 'Util::CompilerBug'
+  what():  COMPILER BUG: /home/antonin/Documents/p4lang/p4c/build/ir/ir-generated.cpp:4217
+/home/antonin/Documents/p4lang/p4c/build/ir/ir-generated.cpp:4217: Null type
+

--- a/testdata/p4_16_errors_outputs/header1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header1_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/header1_e.p4(18):syntax error, unexpected DONTCARE, expecting NAMESPACE
+../testdata/p4_16_errors/header1_e.p4(18):syntax error, unexpected DONTCARE
     _
     ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/header2_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header2_e.p4-stderr
@@ -4,11 +4,29 @@
 ../testdata/p4_16_errors/header2_e.p4(16)
 struct s {}
        ^
+../testdata/p4_16_errors/header2_e.p4(20): error: Field field of header h cannot have type struct s
+    s field;
+      ^^^^^
+../testdata/p4_16_errors/header2_e.p4(16)
+struct s {}
+       ^
 ../testdata/p4_16_errors/header2_e.p4(27): error: Field field of struct s1 cannot have type parser p
     p field;
       ^^^^^
 ../testdata/p4_16_errors/header2_e.p4(23)
 parser p();
+       ^
+../testdata/p4_16_errors/header2_e.p4(27): error: Field field of struct s1 cannot have type parser p
+    p field;
+      ^^^^^
+../testdata/p4_16_errors/header2_e.p4(23)
+parser p();
+       ^
+../testdata/p4_16_errors/header2_e.p4(32): error: Field field of header_union u cannot have type struct s
+   s field;
+     ^^^^^
+../testdata/p4_16_errors/header2_e.p4(16)
+struct s {}
        ^
 ../testdata/p4_16_errors/header2_e.p4(32): error: Field field of header_union u cannot have type struct s
    s field;

--- a/testdata/p4_16_errors_outputs/header3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header3.p4-stderr
@@ -1,9 +1,6 @@
-terminate called after throwing an instance of 'Util::CompilerBug'
-  what():  COMPILER BUG: ../frontends/p4/typeChecking/typeChecker.h:100
-../testdata/p4_16_errors/header3.p4(18): Field tuple<bit<1>, bit<1>> field1 of header H cannot have type tuple<bit<1>, bit<1>>
+../testdata/p4_16_errors/header3.p4(18): error: Field field1 of header H cannot have type Tuple(2)
     tuple<bit, bit> field1;
                     ^^^^^^
 ../testdata/p4_16_errors/header3.p4(18)
     tuple<bit, bit> field1;
     ^^^^^^^^^^^^^^^
-

--- a/testdata/p4_16_errors_outputs/next.p4-stderr
+++ b/testdata/p4_16_errors_outputs/next.p4-stderr
@@ -1,3 +1,6 @@
 ../testdata/p4_16_errors/next.p4(24): error: stack.last: 'last' and 'next' for stacks cannot be used in a control
         stack.last = { 10 };
         ^^^^^^^^^^
+../testdata/p4_16_errors/next.p4(24): error: Expression stack.last cannot be the target of an assignment
+        stack.last = { 10 };
+        ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/not_bound.p4
+++ b/testdata/p4_16_errors_outputs/not_bound.p4
@@ -3,6 +3,7 @@ struct headers {
 
 struct metadata {
 }
+
 #include <core.p4>
 #include <v1model.p4>
 

--- a/testdata/p4_16_errors_outputs/parser-arg.p4-stderr
+++ b/testdata/p4_16_errors_outputs/parser-arg.p4-stderr
@@ -7,66 +7,22 @@ parser Parser();
 ../testdata/p4_16_errors/parser-arg.p4(18): error: Could not find type of parser MyParser
 parser MyParser(Parser p);
        ^^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(19): error: Could not find type of MyParser
-package Package(MyParser p1, MyParser p2);
-                ^^^^^^^^
+error: Could not find type of <Type_Name>(23) MyParser
 ../testdata/p4_16_errors/parser-arg.p4(18): error: Could not find type of parser MyParser
 parser MyParser(Parser p);
        ^^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(19): error: Could not find type of MyParser
+error: Could not find type of <Type_Name>(27) MyParser
+../testdata/p4_16_errors/parser-arg.p4(19): error: Could not find type of p1
 package Package(MyParser p1, MyParser p2);
-                             ^^^^^^^^
+                         ^^
 ../testdata/p4_16_errors/parser-arg.p4(21): error: p: parameter cannot have type parser Parser
 parser Parser1(Parser p) {
                       ^
 ../testdata/p4_16_errors/parser-arg.p4(17)
 parser Parser();
        ^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(21): error: p: parameter cannot have type parser Parser
-parser Parser1(Parser p) {
-                      ^
-../testdata/p4_16_errors/parser-arg.p4(17)
-parser Parser();
-       ^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(28): error: p: parameter cannot have type parser Parser
-parser Parser2(Parser p) {
-                      ^
-../testdata/p4_16_errors/parser-arg.p4(17)
-parser Parser();
-       ^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(28): error: p: parameter cannot have type parser Parser
-parser Parser2(Parser p) {
-                      ^
-../testdata/p4_16_errors/parser-arg.p4(17)
-parser Parser();
-       ^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(21): error: Could not find type of parser Parser1
-parser Parser1(Parser p) {
-       ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(21): error: Could not find type of parser Parser1
-parser Parser1(Parser p) {
-       ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(28): error: Could not find type of parser Parser2
-parser Parser2(Parser p) {
-       ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(28): error: Could not find type of parser Parser2
-parser Parser2(Parser p) {
-       ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(19): error: Could not find type of package Package
-package Package(MyParser p1, MyParser p2);
-        ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(35): error: Could not find type of p1
-Parser1() p1;
-          ^^
-../testdata/p4_16_errors/parser-arg.p4(36): error: Could not find type of p2
-Parser2() p2;
-          ^^
-../testdata/p4_16_errors/parser-arg.p4(19): error: Could not find type of package Package
-package Package(MyParser p1, MyParser p2);
-        ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(35): error: Could not find type of p1
-Parser1() p1;
-          ^^
-../testdata/p4_16_errors/parser-arg.p4(36): error: Could not find type of p2
-Parser2() p2;
-          ^^
+error: Could not find type of <Type_Parser>(38) Parser1
+terminate called after throwing an instance of 'Util::CompilerBug'
+  what():  COMPILER BUG: /home/antonin/Documents/p4lang/p4c/build/ir/ir-generated.cpp:4136
+/home/antonin/Documents/p4lang/p4c/build/ir/ir-generated.cpp:4136: Null type
+

--- a/testdata/p4_16_errors_outputs/scope.p4-stderr
+++ b/testdata/p4_16_errors_outputs/scope.p4-stderr
@@ -1,3 +1,9 @@
+../testdata/p4_16_errors/scope.p4(25): error: Cannot extract field x from q which has type Type(control q)
+        bit<8> y = .q.x.get();
+                      ^
+../testdata/p4_16_errors/scope.p4(25)
+        bit<8> y = .q.x.get();
+                   ^^
 ../testdata/p4_16_errors/scope.p4(25): error: Could not find type of q.x
         bit<8> y = .q.x.get();
                    ^^^^

--- a/testdata/p4_16_errors_outputs/stack1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack1_e.p4-stderr
@@ -1,6 +1,9 @@
 ../testdata/p4_16_errors/stack1_e.p4(21): warning: 5: signed value does not fit in 3 bits
         int<3> w = 5;
                    ^
-../testdata/p4_16_errors/stack1_e.p4(22): error: h[]: Size of header stack type should be a constant
+terminate called after throwing an instance of 'Util::CompilerBug'
+  what():  COMPILER BUG: ../ir/ir.cpp:80
+../testdata/p4_16_errors/stack1_e.p4(22): w;: Size not yet known
         h[w] stack;
-        ^^^^
+          ^
+

--- a/testdata/p4_16_errors_outputs/stack_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack_e.p4-stderr
@@ -1,3 +1,6 @@
+../testdata/p4_16_errors/stack_e.p4(23): error: Header stack struct s[] used with non-header type struct s
+        s[5] stack1;
+        ^^^^
 ../testdata/p4_16_errors/stack_e.p4(23): error: Header stack s[] used with non-header type struct s
         s[5] stack1;
         ^^^^

--- a/testdata/p4_16_errors_outputs/type-field.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-field.p4-stderr
@@ -4,4 +4,6 @@
 ../testdata/p4_16_errors/type-field.p4(60)
     b.emit(h.d);
            ^
-error: Could not find type of <Member>(756) .d
+../testdata/p4_16_errors/type-field.p4(60): error: Could not find type of h.d
+    b.emit(h.d);
+           ^^^

--- a/testdata/p4_16_errors_outputs/type-params_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-params_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/type-params_e.p4(18):syntax error, unexpected IDENTIFIER, expecting NAMESPACE
+../testdata/p4_16_errors/type-params_e.p4(18):syntax error, unexpected IDENTIFIER "D"
 package m(p<D
             ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
@@ -15,9 +15,9 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("drop") action drop_0() {
         smeta.drop = 1w1;

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4-stderr
@@ -1,0 +1,6 @@
+../testdata/p4_16_samples/drop-bmv2.p4(27): warning: out parameter smeta may be uninitialized when drop terminates
+action drop(out standard_metadata_t smeta) { smeta.drop = 1; }
+                                    ^^^^^
+../testdata/p4_16_samples/drop-bmv2.p4(27)
+action drop(out standard_metadata_t smeta) { smeta.drop = 1; }
+       ^^^^

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -93,7 +93,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_2") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("rewrite_mac") action rewrite_mac_0(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
@@ -148,15 +148,15 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     bit<32> tmp_23;
     bit<16> tmp_24;
     bool tmp_25;
-    @name("NoAction_3") action NoAction_1() {
+    @name("NoAction") action NoAction_1() {
     }
-    @name("NoAction_4") action NoAction_8() {
+    @name("NoAction") action NoAction_8() {
     }
-    @name("NoAction_5") action NoAction_9() {
+    @name("NoAction") action NoAction_9() {
     }
-    @name("NoAction_6") action NoAction_10() {
+    @name("NoAction") action NoAction_10() {
     }
-    @name("NoAction_7") action NoAction_11() {
+    @name("NoAction") action NoAction_11() {
     }
     @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id_1;
     @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_1;

--- a/testdata/p4_16_samples_outputs/functors.p4
+++ b/testdata/p4_16_samples_outputs/functors.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p()(bit<1> b, bit<1> c) {
     state start {
         bit<1> z = b & c;

--- a/testdata/p4_16_samples_outputs/functors1.p4
+++ b/testdata/p4_16_samples_outputs/functors1.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p00() {
     state start {
         bit<1> z = 1w0 & 1w1;

--- a/testdata/p4_16_samples_outputs/functors2.p4
+++ b/testdata/p4_16_samples_outputs/functors2.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1(out bit<2> z1)(bit<2> a) {
     state start {
         z1 = a;

--- a/testdata/p4_16_samples_outputs/functors3.p4
+++ b/testdata/p4_16_samples_outputs/functors3.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1(out bit<1> z1)(bit<1> b1) {
     state start {
         z1 = b1;

--- a/testdata/p4_16_samples_outputs/functors4.p4
+++ b/testdata/p4_16_samples_outputs/functors4.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1(out bit<1> z1)(bit<1> b1) {
     state start {
         z1 = b1;

--- a/testdata/p4_16_samples_outputs/functors5.p4
+++ b/testdata/p4_16_samples_outputs/functors5.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1(out bit<2> w)(bit<2> a) {
     state start {
         w = 2;

--- a/testdata/p4_16_samples_outputs/functors6.p4
+++ b/testdata/p4_16_samples_outputs/functors6.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1<T>(in T a) {
     state start {
         T w = a;

--- a/testdata/p4_16_samples_outputs/functors7.p4
+++ b/testdata/p4_16_samples_outputs/functors7.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1<T>(in T a) {
     state start {
         T w = a;

--- a/testdata/p4_16_samples_outputs/functors8.p4
+++ b/testdata/p4_16_samples_outputs/functors8.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 extern e<T> {
     e();
     T get();

--- a/testdata/p4_16_samples_outputs/functors9.p4
+++ b/testdata/p4_16_samples_outputs/functors9.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 extern e<T> {
     e();
     T get();

--- a/testdata/p4_16_samples_outputs/highorder.p4
+++ b/testdata/p4_16_samples_outputs/highorder.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser parse<H>(out H headers);
 package ebpfFilter<H>(parse<H> prs);
 struct Headers_t {

--- a/testdata/p4_16_samples_outputs/hit-expr-midend.p4
+++ b/testdata/p4_16_samples_outputs/hit-expr-midend.p4
@@ -14,7 +14,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("t") table t() {
         key = {

--- a/testdata/p4_16_samples_outputs/hit_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/hit_ebpf-midend.p4
@@ -45,7 +45,7 @@ parser prs(packet_in p, out Headers_t headers) {
 
 control pipe(inout Headers_t headers, out bool pass) {
     bool hasReturned_0;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("Reject") action Reject_0(IPv4Address add) {
         pass = false;

--- a/testdata/p4_16_samples_outputs/initializers.p4
+++ b/testdata/p4_16_samples_outputs/initializers.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 extern Fake {
     Fake();
     void call(in bit<32> data);

--- a/testdata/p4_16_samples_outputs/inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-bmv2-midend.p4
@@ -30,7 +30,7 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
     ipv4_t tmp_ipv4;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("do_aux.adjust_lkp_fields") table do_aux_adjust_lkp_fields_0() {
         key = {

--- a/testdata/p4_16_samples_outputs/inline1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2-midend.p4
@@ -30,7 +30,7 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
     ipv4_t tmp_ipv4;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("do_aux.adjust_lkp_fields") table do_aux_adjust_lkp_fields_0() {
         key = {

--- a/testdata/p4_16_samples_outputs/interface.p4
+++ b/testdata/p4_16_samples_outputs/interface.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 extern Crc16<T> {
     Crc16();
     Crc16(in int<32> x);

--- a/testdata/p4_16_samples_outputs/interface1.p4
+++ b/testdata/p4_16_samples_outputs/interface1.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 extern X<T> {
     X();
 }

--- a/testdata/p4_16_samples_outputs/interface2.p4
+++ b/testdata/p4_16_samples_outputs/interface2.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 extern X {
     X();
 }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
@@ -135,7 +135,7 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("_drop") action _drop_0() {
         mark_to_drop();

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2-midend.p4
@@ -14,7 +14,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("t") table t() {
         key = {

--- a/testdata/p4_16_samples_outputs/key-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2-midend.p4
@@ -43,7 +43,7 @@ control deparser(packet_out b, in Headers h) {
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<32> key_0;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("c.a") action c_a() {
         h.h.b = h.h.a;

--- a/testdata/p4_16_samples_outputs/key1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/key1-bmv2-midend.p4
@@ -43,7 +43,7 @@ control deparser(packet_out b, in Headers h) {
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<32> key_0;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("c.a") action c_a() {
         h.h.b = h.h.a;

--- a/testdata/p4_16_samples_outputs/match.p4
+++ b/testdata/p4_16_samples_outputs/match.p4
@@ -1,8 +1,7 @@
-#include <core.p4>
-
 error {
     InvalidOptions
 }
+#include <core.p4>
 
 header Ipv4_no_options_h {
     bit<4>  version;

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
@@ -46,9 +46,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("namedmeter") direct_meter<bit<32>>(CounterType.packets) my_meter;
     @name("_drop") action _drop_0() {

--- a/testdata/p4_16_samples_outputs/parser-arg.p4
+++ b/testdata/p4_16_samples_outputs/parser-arg.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser Parser();
 package Package(Parser p1, Parser p2);
 parser Parser1()(Parser p) {

--- a/testdata/p4_16_samples_outputs/parser-locals.p4
+++ b/testdata/p4_16_samples_outputs/parser-locals.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 header H {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/pipe-midend.p4
+++ b/testdata/p4_16_samples_outputs/pipe-midend.p4
@@ -44,7 +44,7 @@ control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
     TArg1 tArg1_0;
     TArg2 aArg2_0;
     bit<9> barg_0;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("p1.B_action") action p1_B_action(BParamType bData) {
         barg_0 = (bit<9>)bData;

--- a/testdata/p4_16_samples_outputs/reject.p4
+++ b/testdata/p4_16_samples_outputs/reject.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser f() {
     state start {
     }

--- a/testdata/p4_16_samples_outputs/reject.p4-stderr
+++ b/testdata/p4_16_samples_outputs/reject.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_samples/reject.p4(18): warning: start: implicit transition to `reject'
+../testdata/p4_16_samples/reject.p4(20): warning: start: implicit transition to `reject'
     state start {
           ^^^^^
-../testdata/p4_16_samples/reject.p4(17): warning: accept state in parser f is unreachable
+../testdata/p4_16_samples/reject.p4(19): warning: accept state in parser f is unreachable
 parser f() {
        ^
-../testdata/p4_16_samples/reject.p4(17): warning: accept state in parser f is unreachable
+../testdata/p4_16_samples/reject.p4(19): warning: accept state in parser f is unreachable
 parser f() {
        ^

--- a/testdata/p4_16_samples_outputs/simplify-midend.p4
+++ b/testdata/p4_16_samples_outputs/simplify-midend.p4
@@ -4,9 +4,9 @@ control c(out bool x) {
     bool tmp_2;
     bool tmp_3;
     bool tmp_4;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
-    @name("NoAction_2") action NoAction_3() {
+    @name("NoAction") action NoAction_3() {
     }
     @name("t1") table t1() {
         key = {

--- a/testdata/p4_16_samples_outputs/spec-ex18.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex18.p4
@@ -1,8 +1,7 @@
-#include <core.p4>
-
 error {
     InvalidOptions
 }
+#include <core.p4>
 
 header IPv4_no_options_h {
     bit<4>  version;

--- a/testdata/p4_16_samples_outputs/spec-ex26.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex26.p4
@@ -1,6 +1,5 @@
 #include <core.p4>
 
-
 typedef bit<4> PortId;
 const PortId REAL_PORT_COUNT = 4w8;
 struct InControl {

--- a/testdata/p4_16_samples_outputs/spec-ex29.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex29.p4
@@ -1,10 +1,9 @@
-#include <core.p4>
-
 error {
     IPv4FragmentsNotSupported,
     IPv4OptionsNotSupported,
     IPv4IncorrectVersion
 }
+#include <core.p4>
 
 header Ethernet {
     bit<16> etherType;

--- a/testdata/p4_16_samples_outputs/stack.p4
+++ b/testdata/p4_16_samples_outputs/stack.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 header h {
 }
 

--- a/testdata/p4_16_samples_outputs/string_anno.p4-stderr
+++ b/testdata/p4_16_samples_outputs/string_anno.p4-stderr
@@ -1,1 +1,7 @@
+../testdata/p4_16_samples/string_anno.p4:19:7: warning: missing terminating " character
+ @name("string with
+       ^
+../testdata/p4_16_samples/string_anno.p4:20:8: warning: missing terminating " character
+ newline") const bit d = 1;
+        ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/switch_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/switch_ebpf-midend.p4
@@ -44,7 +44,7 @@ parser prs(packet_in p, out Headers_t headers) {
 }
 
 control pipe(inout Headers_t headers, out bool pass) {
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("Reject") action Reject_0(IPv4Address add) {
         pass = false;

--- a/testdata/p4_16_samples_outputs/test_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/test_ebpf-midend.p4
@@ -45,7 +45,7 @@ parser prs(packet_in p, out Headers_t headers) {
 
 control pipe(inout Headers_t headers, out bool pass) {
     bool hasReturned_0;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("Reject") action Reject_0(IPv4Address add) {
         pass = false;

--- a/testdata/p4_16_samples_outputs/two_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/two_ebpf-midend.p4
@@ -46,7 +46,7 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     IPv4Address address_0;
     bool hasReturned_0;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("Reject") action Reject_0() {
         pass = false;

--- a/testdata/p4_16_samples_outputs/vss-example-midend.p4
+++ b/testdata/p4_16_samples_outputs/vss-example-midend.p4
@@ -98,7 +98,7 @@ control TopPipe(inout Parsed_packet headers, in error parseError, in InControl i
     IPv4Address nextHop_3;
     bool hasReturned_0;
     IPv4Address nextHop_0;
-    @name("NoAction_1") action NoAction_0() {
+    @name("NoAction") action NoAction_0() {
     }
     @name("Drop_action") action Drop_action_0() {
         outCtrl.outputPort = 4w0xf;


### PR DESCRIPTION
To avoid ending up with NoAction_<x> names for NoAction clones in the
IR and eventually in the p4runtime data.

Addresses #309 partially at least.