### PR TITLE
Handle const default actions correctly in P4-14 and P4Runtime serialization

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -739,20 +739,18 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
         propvec->push_back(prop);
     }
 
-    IR::ID defaction;
-    if (!table->default_action.name.isNullOrEmpty())
-        defaction = table->default_action;
-    else
-        defaction = p4lib.noAction.Id();
     {
-        auto act = new IR::PathExpression(defaction);
+        const bool hasExplicitDefaultAction = !table->default_action.name.isNullOrEmpty();
+        auto act = new IR::PathExpression(hasExplicitDefaultAction ? table->default_action
+                                                                   : p4lib.noAction.Id());
         auto args = table->default_action_args != nullptr ?
                 table->default_action_args : new IR::Vector<IR::Expression>();
         auto methodCall = new IR::MethodCallExpression(Util::SourceInfo(), act,
                                                        emptyTypeArguments, args);
         auto prop = new IR::Property(
             Util::SourceInfo(), IR::ID(IR::TableProperties::defaultActionPropertyName),
-            IR::Annotations::empty, new IR::ExpressionValue(Util::SourceInfo(), methodCall), false);
+            IR::Annotations::empty, new IR::ExpressionValue(Util::SourceInfo(), methodCall),
+            /* isConstant = */ hasExplicitDefaultAction);
         propvec->push_back(prop);
     }
 

--- a/testdata/p4_14_samples_outputs/bridge1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-frontend.p4
@@ -38,7 +38,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         actions = {
             copyb1_0();
         }
-        default_action = copyb1_0();
+        const default_action = copyb1_0();
     }
     apply {
         output_0.apply();

--- a/testdata/p4_14_samples_outputs/bridge1-midend.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-midend.p4
@@ -38,7 +38,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         actions = {
             copyb1_0();
         }
-        default_action = copyb1_0();
+        const default_action = copyb1_0();
     }
     apply {
         output.apply();

--- a/testdata/p4_14_samples_outputs/bridge1.p4
+++ b/testdata/p4_14_samples_outputs/bridge1.p4
@@ -38,7 +38,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         actions = {
             copyb1;
         }
-        default_action = copyb1();
+        const default_action = copyb1();
     }
     apply {
         output.apply();

--- a/testdata/p4_14_samples_outputs/instruct5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-frontend.p4
@@ -70,7 +70,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         actions = {
             output_1();
         }
-        default_action = output_1(9w1);
+        const default_action = output_1(9w1);
     }
     @name("test1") table test1_0() {
         actions = {

--- a/testdata/p4_14_samples_outputs/instruct5-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-midend.p4
@@ -72,7 +72,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         actions = {
             output_0();
         }
-        default_action = output_0(9w1);
+        const default_action = output_0(9w1);
     }
     @name("test1") table test1() {
         actions = {

--- a/testdata/p4_14_samples_outputs/instruct5.p4
+++ b/testdata/p4_14_samples_outputs/instruct5.p4
@@ -70,7 +70,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         actions = {
             output;
         }
-        default_action = output(1);
+        const default_action = output(1);
     }
     @name("test1") table test1() {
         actions = {

--- a/testdata/p4_14_samples_outputs/parser_dc_full-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-frontend.p4
@@ -624,7 +624,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.data.data: exact @name("hdr.data.data") ;
         }
-        default_action = mark_forward_0();
+        const default_action = mark_forward_0();
     }
     apply {
         mark_check_0.apply();

--- a/testdata/p4_14_samples_outputs/parser_dc_full-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-midend.p4
@@ -624,7 +624,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.data.data: exact @name("hdr.data.data") ;
         }
-        default_action = mark_forward_0();
+        const default_action = mark_forward_0();
     }
     apply {
         mark_check.apply();

--- a/testdata/p4_14_samples_outputs/parser_dc_full.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full.p4
@@ -632,7 +632,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.data.data: exact;
         }
-        default_action = mark_forward();
+        const default_action = mark_forward();
     }
     apply {
         mark_check.apply();


### PR DESCRIPTION
In #309, we noticed two issues:

* The P4Runtime output we're generating has way too many `NoAction` entries.
* If a table has *any* default action, we serialize it as a `const_default_action_id` in P4Runtime, even if the default action isn't const.

These two things turn out to be related.

Explicit P4-14 default actions are all "const" from a P4-16 perspective. They're fixed at compile time, and the control plane can't change them. (The control plane may be able to change the associated *action data*, though, but that's a separate issue.)

The P4-16 non-const default action is more or less equivalent to not specifying a default action at all in P4-14. The only difference is that P4-16 allows you to set the initial state of the default action, while in P4-14, the initial state is always "take no action at all".

When we process a P4-14 program in the p4c frontend, tables without explicit default actions are assigned a default action of `NoAction` by the compiler. The problem is that the constness rules above aren't followed. We treat P4-14 default actions as if they were never const, when in fact they should always be const if they're explicitly specified.

In 39354ec, I've resolved that issue; with that patch applied, only `NoAction` default actions inserted by the compiler are non-const.

This dovetails nicely with 4a2c57e, which fixes p4runtimeSerializer so that it only produces a `const_default_action_id` for a table if the default action is actually const. That fixes a bug on its own, but with these two patches combined, we get rid of the flood of `NoAction` default actions in the P4Runtime output.

These two patches, taken together, address the most important remaining problem that I'm aware of related to issue #309.