### PR TITLE
Infer types correctly for P4-14 action parameters and clone primitives

### DIFF
--- a/frontends/p4-14/typecheck.cpp
+++ b/frontends/p4-14/typecheck.cpp
@@ -169,6 +169,17 @@ combineTypes(const Util::SourceInfo &loc, const IR::Type *a, const IR::Type *b) 
     if (a->is<IR::Type_InfInt>()) return b;
     if (b->is<IR::Type_InfInt>()) return a;
     if (*a == *b) return a;
+    if (a->is<IR::Type_Bits>() && b->is<IR::Type_Bits>()) {
+        auto aBits = a->to<IR::Type_Bits>();
+        auto bBits = b->to<IR::Type_Bits>();
+        if (aBits->isSigned != bBits->isSigned) {
+            error("%s: Types %s and %s differ in signedness",
+                  loc, a->toString(), b->toString());
+            return a;
+        }
+        return IR::Type_Bits::get(std::max(aBits->width_bits(), bBits->width_bits()),
+                                  aBits->isSigned);
+    }
     error("%s: Incompatible types %s and %s", loc, a->toString(), b->toString());
     return a;
 }

--- a/frontends/p4-14/typecheck.h
+++ b/frontends/p4-14/typecheck.h
@@ -23,9 +23,12 @@ limitations under the License.
 class TypeCheck : public PassManager {
     std::map<const IR::Node *, const IR::Type *>        actionArgUseTypes;
     int                                                 iterCounter = 0;
-    class Pass1;
-    class Pass2;
-    class Pass3;
+    class AssignInitialTypes;
+    class InferExpressionsBottomUp;
+    class InferExpressionsTopDown;
+    class InferActionArgsBottomUp;
+    class InferActionArgsTopDown;
+    class AssignActionArgTypes;
  public:
     TypeCheck();
     const IR::Node *apply_visitor(const IR::Node *, const char *) override;

--- a/ir/v1.cpp
+++ b/ir/v1.cpp
@@ -139,5 +139,10 @@ const IR::Type *IR::Primitive::inferOperandType(int operand) const {
                     return IR::Type::Bits::get(width); } } } }
     if (name.startsWith("execute_stateful") && operand == 1) {
             return IR::Type::Bits::get(32); }
+    if ((name == "clone_ingress_pkt_to_egress" || name == "clone_i2e" ||
+         name == "clone_egress_pkt_to_egress" || name == "clone_e2e") &&
+        operand == 0) {
+        return IR::Type::Bits::get(32);
+    }
     return IR::Type::Unknown::get();
 }

--- a/testdata/p4_14_samples_outputs/copy_to_cpu.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu.p4
@@ -76,7 +76,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("do_copy_to_cpu") action do_copy_to_cpu() {
-        clone3(CloneType.I2E, (bit<32>)250, { standard_metadata });
+        clone3(CloneType.I2E, (bit<32>)32w250, { standard_metadata });
     }
     @name("copy_to_cpu") table copy_to_cpu() {
         actions = {

--- a/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
@@ -53,7 +53,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name("_recirculate") action _recirculate_0() {
         recirculate<tuple<standard_metadata_t, metaA_t>>({ standard_metadata, meta.metaA });
     }
-    @name("_clone_e2e") action _clone_e2e_0(bit<8> mirror_id) {
+    @name("_clone_e2e") action _clone_e2e_0(bit<32> mirror_id) {
         clone3<tuple<standard_metadata_t, metaA_t>>(CloneType.E2E, (bit<32>)mirror_id, { standard_metadata, meta.metaA });
     }
     @name("t_egress") table t_egress_0() {
@@ -88,7 +88,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("_resubmit") action _resubmit_0() {
         resubmit<tuple<standard_metadata_t, metaA_t>>({ standard_metadata, meta.metaA });
     }
-    @name("_clone_i2e") action _clone_i2e_0(bit<8> mirror_id) {
+    @name("_clone_i2e") action _clone_i2e_0(bit<32> mirror_id) {
         clone3<tuple<standard_metadata_t, metaA_t>>(CloneType.I2E, (bit<32>)mirror_id, { standard_metadata, meta.metaA });
     }
     @name("t_ingress_1") table t_ingress() {

--- a/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
@@ -60,7 +60,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name("_recirculate") action _recirculate_0() {
         recirculate<tuple_0>({ standard_metadata, meta.metaA });
     }
-    @name("_clone_e2e") action _clone_e2e_0(bit<8> mirror_id) {
+    @name("_clone_e2e") action _clone_e2e_0(bit<32> mirror_id) {
         clone3<tuple_0>(CloneType.E2E, (bit<32>)mirror_id, { standard_metadata, meta.metaA });
     }
     @name("t_egress") table t_egress() {
@@ -101,7 +101,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("_resubmit") action _resubmit_0() {
         resubmit<tuple_0>({ standard_metadata, meta.metaA });
     }
-    @name("_clone_i2e") action _clone_i2e_0(bit<8> mirror_id) {
+    @name("_clone_i2e") action _clone_i2e_0(bit<32> mirror_id) {
         clone3<tuple_0>(CloneType.I2E, (bit<32>)mirror_id, { standard_metadata, meta.metaA });
     }
     @name("t_ingress_1") table t_ingress_1() {

--- a/testdata/p4_14_samples_outputs/packet_redirect.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect.p4
@@ -53,7 +53,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name("_recirculate") action _recirculate() {
         recirculate({ standard_metadata, meta.metaA });
     }
-    @name("_clone_e2e") action _clone_e2e(bit<8> mirror_id) {
+    @name("_clone_e2e") action _clone_e2e(bit<32> mirror_id) {
         clone3(CloneType.E2E, (bit<32>)mirror_id, { standard_metadata, meta.metaA });
     }
     @name("t_egress") table t_egress() {
@@ -88,7 +88,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("_resubmit") action _resubmit() {
         resubmit({ standard_metadata, meta.metaA });
     }
-    @name("_clone_i2e") action _clone_i2e(bit<8> mirror_id) {
+    @name("_clone_i2e") action _clone_i2e(bit<32> mirror_id) {
         clone3(CloneType.I2E, (bit<32>)mirror_id, { standard_metadata, meta.metaA });
     }
     @name("t_ingress_1") table t_ingress_1() {

--- a/testdata/p4_14_samples_outputs/packet_redirect.p4-stderr
+++ b/testdata/p4_14_samples_outputs/packet_redirect.p4-stderr
@@ -1,6 +1,0 @@
-../testdata/p4_14_samples/packet_redirect.p4(86): warning: Could not infer type for mirror_id, using bit<8>
-action _clone_e2e(mirror_id) {
-                  ^^^^^^^^^
-../testdata/p4_14_samples/packet_redirect.p4(82): warning: Could not infer type for mirror_id, using bit<8>
-action _clone_i2e(mirror_id) {
-                  ^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/simple_nat.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat.p4
@@ -185,7 +185,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
     @name("nat_miss_int_to_ext") action nat_miss_int_to_ext() {
-        clone3(CloneType.I2E, (bit<32>)250, { standard_metadata });
+        clone3(CloneType.I2E, (bit<32>)32w250, { standard_metadata });
     }
     @name("nat_miss_ext_to_int") action nat_miss_ext_to_int() {
         meta.meta.do_forward = 1w0;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -2656,11 +2656,11 @@ control process_egress_filter(inout headers hdr, inout metadata meta, inout stan
 control process_egress_acl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("nop") action nop_8() {
     }
-    @name("egress_mirror") action egress_mirror_0(bit<16> session_id) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("egress_mirror") action egress_mirror_0(bit<32> session_id) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.E2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
     }
-    @name("egress_mirror_drop") action egress_mirror_drop_0(bit<16> session_id) {
+    @name("egress_mirror_drop") action egress_mirror_drop_0(bit<32> session_id) {
         egress_mirror_0(session_id);
         mark_to_drop();
     }
@@ -3658,8 +3658,8 @@ control process_mac_acl(inout headers hdr, inout metadata meta, inout standard_m
         meta.ingress_metadata.enable_dod = 1w0;
         meta.acl_metadata.acl_stats_index = acl_stats_index;
     }
-    @name("acl_mirror") action acl_mirror_0(bit<16> session_id, bit<16> acl_stats_index) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("acl_mirror") action acl_mirror_0(bit<32> session_id, bit<16> acl_stats_index) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
@@ -3705,8 +3705,8 @@ control process_ip_acl(inout headers hdr, inout metadata meta, inout standard_me
         meta.ingress_metadata.enable_dod = 1w0;
         meta.acl_metadata.acl_stats_index = acl_stats_index;
     }
-    @name("acl_mirror") action acl_mirror_1(bit<16> session_id, bit<16> acl_stats_index) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("acl_mirror") action acl_mirror_1(bit<32> session_id, bit<16> acl_stats_index) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
@@ -4663,7 +4663,7 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
         drop_stats_1.count((bit<32>)drop_reason);
         mark_to_drop();
     }
-    @name("negative_mirror") action negative_mirror_0(bit<8> session_id) {
+    @name("negative_mirror") action negative_mirror_0(bit<32> session_id) {
         clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, (bit<32>)session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
         mark_to_drop();
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -2814,12 +2814,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name("process_egress_acl.nop") action process_egress_acl_nop() {
     }
-    @name("process_egress_acl.egress_mirror") action process_egress_acl_egress_mirror(bit<16> session_id) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("process_egress_acl.egress_mirror") action process_egress_acl_egress_mirror(bit<32> session_id) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple_0>(CloneType.E2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
     }
-    @name("process_egress_acl.egress_mirror_drop") action process_egress_acl_egress_mirror_drop(bit<16> session_id) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("process_egress_acl.egress_mirror_drop") action process_egress_acl_egress_mirror_drop(bit<32> session_id) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple_0>(CloneType.E2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         mark_to_drop();
     }
@@ -3820,8 +3820,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ingress_metadata.enable_dod = 1w0;
         meta.acl_metadata.acl_stats_index = acl_stats_index;
     }
-    @name("process_mac_acl.acl_mirror") action process_mac_acl_acl_mirror(bit<16> session_id, bit<16> acl_stats_index) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("process_mac_acl.acl_mirror") action process_mac_acl_acl_mirror(bit<32> session_id, bit<16> acl_stats_index) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3<tuple_0>(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
@@ -3876,15 +3876,15 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ingress_metadata.enable_dod = 1w0;
         meta.acl_metadata.acl_stats_index = acl_stats_index;
     }
-    @name("process_ip_acl.acl_mirror") action process_ip_acl_acl_mirror(bit<16> session_id, bit<16> acl_stats_index) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("process_ip_acl.acl_mirror") action process_ip_acl_acl_mirror(bit<32> session_id, bit<16> acl_stats_index) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3<tuple_0>(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
     }
-    @name("process_ip_acl.acl_mirror") action process_ip_acl_acl_mirror_2(bit<16> session_id, bit<16> acl_stats_index) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("process_ip_acl.acl_mirror") action process_ip_acl_acl_mirror_2(bit<32> session_id, bit<16> acl_stats_index) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3<tuple_0>(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
@@ -4732,7 +4732,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         process_system_acl_drop_stats_2.count((bit<32>)drop_reason);
         mark_to_drop();
     }
-    @name("process_system_acl.negative_mirror") action process_system_acl_negative_mirror(bit<8> session_id) {
+    @name("process_system_acl.negative_mirror") action process_system_acl_negative_mirror(bit<32> session_id) {
         clone3<tuple_7>(CloneType.I2E, (bit<32>)session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
         mark_to_drop();
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
@@ -2754,17 +2754,17 @@ control process_egress_filter(inout headers hdr, inout metadata meta, inout stan
 control process_egress_acl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("nop") action nop() {
     }
-    @name("egress_mirror") action egress_mirror(bit<16> session_id) {
+    @name("egress_mirror") action egress_mirror(bit<32> session_id) {
         meta.i2e_metadata.mirror_session_id = session_id;
         clone3(CloneType.E2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
     }
-    @name("egress_mirror_drop") action egress_mirror_drop(bit<16> session_id) {
+    @name("egress_mirror_drop") action egress_mirror_drop(bit<32> session_id) {
         egress_mirror(session_id);
         mark_to_drop();
     }
     @name("egress_copy_to_cpu") action egress_copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
-        clone3(CloneType.E2E, (bit<32>)250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
+        clone3(CloneType.E2E, (bit<32>)32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name("egress_redirect_to_cpu") action egress_redirect_to_cpu(bit<16> reason_code) {
         egress_copy_to_cpu(reason_code);
@@ -3774,7 +3774,7 @@ control process_mac_acl(inout headers hdr, inout metadata meta, inout standard_m
         meta.ingress_metadata.enable_dod = 1w0;
         meta.acl_metadata.acl_stats_index = acl_stats_index;
     }
-    @name("acl_mirror") action acl_mirror(bit<16> session_id, bit<16> acl_stats_index) {
+    @name("acl_mirror") action acl_mirror(bit<32> session_id, bit<16> acl_stats_index) {
         meta.i2e_metadata.mirror_session_id = session_id;
         meta.i2e_metadata.ingress_tstamp = meta.intrinsic_metadata.ingress_global_tstamp;
         meta.ingress_metadata.enable_dod = 1w0;
@@ -3821,7 +3821,7 @@ control process_ip_acl(inout headers hdr, inout metadata meta, inout standard_me
         meta.ingress_metadata.enable_dod = 1w0;
         meta.acl_metadata.acl_stats_index = acl_stats_index;
     }
-    @name("acl_mirror") action acl_mirror(bit<16> session_id, bit<16> acl_stats_index) {
+    @name("acl_mirror") action acl_mirror(bit<32> session_id, bit<16> acl_stats_index) {
         meta.i2e_metadata.mirror_session_id = session_id;
         meta.i2e_metadata.ingress_tstamp = meta.intrinsic_metadata.ingress_global_tstamp;
         meta.ingress_metadata.enable_dod = 1w0;
@@ -4780,7 +4780,7 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name("copy_to_cpu") action copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
-        clone3(CloneType.I2E, (bit<32>)250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
+        clone3(CloneType.I2E, (bit<32>)32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name("redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
         copy_to_cpu(reason_code);
@@ -4794,7 +4794,7 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
         drop_stats.count((bit<32>)drop_reason);
         mark_to_drop();
     }
-    @name("negative_mirror") action negative_mirror(bit<8> session_id) {
+    @name("negative_mirror") action negative_mirror(bit<32> session_id) {
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
         mark_to_drop();
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4-stderr
@@ -19,7 +19,4 @@
 ../testdata/p4_14_samples/switch_20160226/fabric.p4(230): warning: Could not infer type for fabric_mgid, using bit<8>
 action set_fabric_multicast(fabric_mgid) {
                             ^^^^^^^^^^^
-../testdata/p4_14_samples/switch_20160226/acl.p4(436): warning: Could not infer type for session_id, using bit<8>
-action negative_mirror(session_id) {
-                       ^^^^^^^^^^
 warning: The order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -2849,11 +2849,11 @@ control process_egress_filter(inout headers hdr, inout metadata meta, inout stan
 control process_egress_acl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("nop") action nop_10() {
     }
-    @name("egress_mirror") action egress_mirror_0(bit<16> session_id) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("egress_mirror") action egress_mirror_0(bit<32> session_id) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.E2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
     }
-    @name("egress_mirror_drop") action egress_mirror_drop_0(bit<16> session_id) {
+    @name("egress_mirror_drop") action egress_mirror_drop_0(bit<32> session_id) {
         egress_mirror_0(session_id);
         mark_to_drop();
     }
@@ -3374,9 +3374,9 @@ control process_int_endpoint(inout headers hdr, inout metadata meta, inout stand
     @name("int_set_no_src") action int_set_no_src_0() {
         meta.int_metadata_i2e.source = 1w0;
     }
-    @name("int_sink") action int_sink_0(bit<16> mirror_id) {
+    @name("int_sink") action int_sink_0(bit<32> mirror_id) {
         meta.int_metadata_i2e.sink = 1w1;
-        meta.i2e_metadata.mirror_session_id = mirror_id;
+        meta.i2e_metadata.mirror_session_id = (bit<16>)mirror_id;
         clone3<tuple<bit<1>, bit<16>>>(CloneType.I2E, (bit<32>)mirror_id, { meta.int_metadata_i2e.sink, meta.i2e_metadata.mirror_session_id });
         hdr.int_header.setInvalid();
         hdr.int_val[0].setInvalid();
@@ -3404,7 +3404,7 @@ control process_int_endpoint(inout headers hdr, inout metadata meta, inout stand
         hdr.int_val[22].setInvalid();
         hdr.int_val[23].setInvalid();
     }
-    @name("int_sink_gpe") action int_sink_gpe_0(bit<16> mirror_id) {
+    @name("int_sink_gpe") action int_sink_gpe_0(bit<32> mirror_id) {
         meta.int_metadata.insert_byte_cnt = meta.int_metadata.gpe_int_hdr_len << 2;
         int_sink_0(mirror_id);
     }
@@ -4157,9 +4157,9 @@ control process_tunnel(inout headers hdr, inout metadata meta, inout standard_me
 control process_ingress_sflow(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("nop") action nop_19() {
     }
-    @name("sflow_ing_pkt_to_cpu") action sflow_ing_pkt_to_cpu_0(bit<16> sflow_i2e_mirror_id, bit<16> reason_code) {
+    @name("sflow_ing_pkt_to_cpu") action sflow_ing_pkt_to_cpu_0(bit<32> sflow_i2e_mirror_id, bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
-        meta.i2e_metadata.mirror_session_id = sflow_i2e_mirror_id;
+        meta.i2e_metadata.mirror_session_id = (bit<16>)sflow_i2e_mirror_id;
         clone3<tuple<tuple<bit<16>, bit<16>, bit<16>, bit<9>>, bit<16>, bit<16>>>(CloneType.I2E, (bit<32>)sflow_i2e_mirror_id, { { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port }, meta.sflow_metadata.sflow_session_id, meta.i2e_metadata.mirror_session_id });
     }
     @name("sflow_ing_session_enable") action sflow_ing_session_enable_0(bit<32> rate_thr, bit<16> session_id) {
@@ -4204,9 +4204,9 @@ control process_storm_control(inout headers hdr, inout metadata meta, inout stan
     @name("storm_control_meter") meter(32w1024, CounterType.bytes) storm_control_meter_0;
     @name("nop") action nop_20() {
     }
-    @name("set_storm_control_meter") action set_storm_control_meter_0(bit<10> meter_idx) {
+    @name("set_storm_control_meter") action set_storm_control_meter_0(bit<16> meter_idx) {
         storm_control_meter_0.execute_meter<bit<2>>((bit<32>)meter_idx, meta.meter_metadata.meter_color);
-        meta.meter_metadata.meter_index = (bit<16>)meter_idx;
+        meta.meter_metadata.meter_index = meter_idx;
     }
     @name("storm_control") table storm_control_0() {
         actions = {
@@ -4374,8 +4374,8 @@ control process_mac_acl(inout headers hdr, inout metadata meta, inout standard_m
         meta.acl_metadata.acl_copy = acl_copy;
         meta.fabric_metadata.reason_code = acl_copy_reason;
     }
-    @name("acl_mirror") action acl_mirror_0(bit<16> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("acl_mirror") action acl_mirror_0(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
@@ -4441,8 +4441,8 @@ control process_ip_acl(inout headers hdr, inout metadata meta, inout standard_me
         meta.acl_metadata.acl_copy = acl_copy;
         meta.fabric_metadata.reason_code = acl_copy_reason;
     }
-    @name("acl_mirror") action acl_mirror_1(bit<16> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("acl_mirror") action acl_mirror_1(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
@@ -5615,7 +5615,7 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
         drop_stats_1.count((bit<32>)drop_reason);
         mark_to_drop();
     }
-    @name("negative_mirror") action negative_mirror_0(bit<8> session_id) {
+    @name("negative_mirror") action negative_mirror_0(bit<32> session_id) {
         clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, (bit<32>)session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
         mark_to_drop();
     }

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -3008,12 +3008,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name("process_egress_acl.nop") action process_egress_acl_nop() {
     }
-    @name("process_egress_acl.egress_mirror") action process_egress_acl_egress_mirror(bit<16> session_id) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("process_egress_acl.egress_mirror") action process_egress_acl_egress_mirror(bit<32> session_id) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple_0>(CloneType.E2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
     }
-    @name("process_egress_acl.egress_mirror_drop") action process_egress_acl_egress_mirror_drop(bit<16> session_id) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("process_egress_acl.egress_mirror_drop") action process_egress_acl_egress_mirror_drop(bit<32> session_id) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple_0>(CloneType.E2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         mark_to_drop();
     }
@@ -3656,10 +3656,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("process_int_endpoint.int_set_no_src") action process_int_endpoint_int_set_no_src() {
         meta.int_metadata_i2e.source = 1w0;
     }
-    @name("process_int_endpoint.int_sink_gpe") action process_int_endpoint_int_sink_gpe(bit<16> mirror_id) {
+    @name("process_int_endpoint.int_sink_gpe") action process_int_endpoint_int_sink_gpe(bit<32> mirror_id) {
         meta.int_metadata.insert_byte_cnt = meta.int_metadata.gpe_int_hdr_len << 2;
         meta.int_metadata_i2e.sink = 1w1;
-        meta.i2e_metadata.mirror_session_id = mirror_id;
+        meta.i2e_metadata.mirror_session_id = (bit<16>)mirror_id;
         clone3<tuple_2>(CloneType.I2E, (bit<32>)mirror_id, { meta.int_metadata_i2e.sink, meta.i2e_metadata.mirror_session_id });
         hdr.int_header.setInvalid();
         hdr.int_val[0].setInvalid();
@@ -4340,9 +4340,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("process_ingress_sflow.nop") action process_ingress_sflow_nop_2() {
     }
-    @name("process_ingress_sflow.sflow_ing_pkt_to_cpu") action process_ingress_sflow_sflow_ing_pkt_to_cpu(bit<16> sflow_i2e_mirror_id, bit<16> reason_code) {
+    @name("process_ingress_sflow.sflow_ing_pkt_to_cpu") action process_ingress_sflow_sflow_ing_pkt_to_cpu(bit<32> sflow_i2e_mirror_id, bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
-        meta.i2e_metadata.mirror_session_id = sflow_i2e_mirror_id;
+        meta.i2e_metadata.mirror_session_id = (bit<16>)sflow_i2e_mirror_id;
         clone3<tuple_3>(CloneType.I2E, (bit<32>)sflow_i2e_mirror_id, { { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port }, meta.sflow_metadata.sflow_session_id, meta.i2e_metadata.mirror_session_id });
     }
     @name("process_ingress_sflow.sflow_ing_session_enable") action process_ingress_sflow_sflow_ing_session_enable(bit<32> rate_thr, bit<16> session_id) {
@@ -4380,9 +4380,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("process_storm_control.storm_control_meter") meter(32w1024, CounterType.bytes) process_storm_control_storm_control_meter_0;
     @name("process_storm_control.nop") action process_storm_control_nop() {
     }
-    @name("process_storm_control.set_storm_control_meter") action process_storm_control_set_storm_control_meter(bit<10> meter_idx) {
+    @name("process_storm_control.set_storm_control_meter") action process_storm_control_set_storm_control_meter(bit<16> meter_idx) {
         process_storm_control_storm_control_meter_0.execute_meter<bit<2>>((bit<32>)meter_idx, meta.meter_metadata.meter_color);
-        meta.meter_metadata.meter_index = (bit<16>)meter_idx;
+        meta.meter_metadata.meter_index = meter_idx;
     }
     @name("process_storm_control.storm_control") table process_storm_control_storm_control_0() {
         actions = {
@@ -4529,8 +4529,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.acl_metadata.acl_copy = acl_copy;
         meta.fabric_metadata.reason_code = acl_copy_reason;
     }
-    @name("process_mac_acl.acl_mirror") action process_mac_acl_acl_mirror(bit<16> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("process_mac_acl.acl_mirror") action process_mac_acl_acl_mirror(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
         clone3<tuple_0>(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
@@ -4604,15 +4604,15 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.acl_metadata.acl_copy = acl_copy;
         meta.fabric_metadata.reason_code = acl_copy_reason;
     }
-    @name("process_ip_acl.acl_mirror") action process_ip_acl_acl_mirror(bit<16> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("process_ip_acl.acl_mirror") action process_ip_acl_acl_mirror(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
         clone3<tuple_0>(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
         meta.meter_metadata.meter_index = acl_meter_index;
     }
-    @name("process_ip_acl.acl_mirror") action process_ip_acl_acl_mirror_2(bit<16> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta.i2e_metadata.mirror_session_id = session_id;
+    @name("process_ip_acl.acl_mirror") action process_ip_acl_acl_mirror_2(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
         clone3<tuple_0>(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
@@ -5613,7 +5613,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         process_system_acl_drop_stats_2.count((bit<32>)drop_reason);
         mark_to_drop();
     }
-    @name("process_system_acl.negative_mirror") action process_system_acl_negative_mirror(bit<8> session_id) {
+    @name("process_system_acl.negative_mirror") action process_system_acl_negative_mirror(bit<32> session_id) {
         clone3<tuple_9>(CloneType.I2E, (bit<32>)session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
         mark_to_drop();
     }

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -2938,17 +2938,17 @@ control process_egress_filter(inout headers hdr, inout metadata meta, inout stan
 control process_egress_acl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("nop") action nop() {
     }
-    @name("egress_mirror") action egress_mirror(bit<16> session_id) {
+    @name("egress_mirror") action egress_mirror(bit<32> session_id) {
         meta.i2e_metadata.mirror_session_id = session_id;
         clone3(CloneType.E2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
     }
-    @name("egress_mirror_drop") action egress_mirror_drop(bit<16> session_id) {
+    @name("egress_mirror_drop") action egress_mirror_drop(bit<32> session_id) {
         egress_mirror(session_id);
         mark_to_drop();
     }
     @name("egress_copy_to_cpu") action egress_copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
-        clone3(CloneType.E2E, (bit<32>)250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
+        clone3(CloneType.E2E, (bit<32>)32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name("egress_redirect_to_cpu") action egress_redirect_to_cpu(bit<16> reason_code) {
         egress_copy_to_cpu(reason_code);
@@ -3477,7 +3477,7 @@ control process_int_endpoint(inout headers hdr, inout metadata meta, inout stand
     @name("int_set_no_src") action int_set_no_src() {
         meta.int_metadata_i2e.source = 1w0;
     }
-    @name("int_sink") action int_sink(bit<16> mirror_id) {
+    @name("int_sink") action int_sink(bit<32> mirror_id) {
         meta.int_metadata_i2e.sink = 1w1;
         meta.i2e_metadata.mirror_session_id = mirror_id;
         clone3(CloneType.I2E, (bit<32>)mirror_id, { meta.int_metadata_i2e.sink, meta.i2e_metadata.mirror_session_id });
@@ -3507,7 +3507,7 @@ control process_int_endpoint(inout headers hdr, inout metadata meta, inout stand
         hdr.int_val[22].setInvalid();
         hdr.int_val[23].setInvalid();
     }
-    @name("int_sink_gpe") action int_sink_gpe(bit<16> mirror_id) {
+    @name("int_sink_gpe") action int_sink_gpe(bit<32> mirror_id) {
         meta.int_metadata.insert_byte_cnt = meta.int_metadata.gpe_int_hdr_len << 2;
         int_sink(mirror_id);
     }
@@ -4274,7 +4274,7 @@ control process_tunnel(inout headers hdr, inout metadata meta, inout standard_me
 control process_ingress_sflow(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("nop") action nop() {
     }
-    @name("sflow_ing_pkt_to_cpu") action sflow_ing_pkt_to_cpu(bit<16> sflow_i2e_mirror_id, bit<16> reason_code) {
+    @name("sflow_ing_pkt_to_cpu") action sflow_ing_pkt_to_cpu(bit<32> sflow_i2e_mirror_id, bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
         meta.i2e_metadata.mirror_session_id = sflow_i2e_mirror_id;
         clone3(CloneType.I2E, (bit<32>)sflow_i2e_mirror_id, { { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port }, meta.sflow_metadata.sflow_session_id, meta.i2e_metadata.mirror_session_id });
@@ -4321,7 +4321,7 @@ control process_storm_control(inout headers hdr, inout metadata meta, inout stan
     @name("storm_control_meter") meter(32w1024, CounterType.bytes) storm_control_meter;
     @name("nop") action nop() {
     }
-    @name("set_storm_control_meter") action set_storm_control_meter(bit<10> meter_idx) {
+    @name("set_storm_control_meter") action set_storm_control_meter(bit<16> meter_idx) {
         storm_control_meter.execute_meter((bit<32>)meter_idx, meta.meter_metadata.meter_color);
         meta.meter_metadata.meter_index = meter_idx;
     }
@@ -4495,7 +4495,7 @@ control process_mac_acl(inout headers hdr, inout metadata meta, inout standard_m
         meta.acl_metadata.acl_copy = acl_copy;
         meta.fabric_metadata.reason_code = acl_copy_reason;
     }
-    @name("acl_mirror") action acl_mirror(bit<16> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
+    @name("acl_mirror") action acl_mirror(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta.i2e_metadata.mirror_session_id = session_id;
         meta.i2e_metadata.ingress_tstamp = meta.intrinsic_metadata.ingress_global_tstamp;
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
@@ -4563,7 +4563,7 @@ control process_ip_acl(inout headers hdr, inout metadata meta, inout standard_me
         meta.acl_metadata.acl_copy = acl_copy;
         meta.fabric_metadata.reason_code = acl_copy_reason;
     }
-    @name("acl_mirror") action acl_mirror(bit<16> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
+    @name("acl_mirror") action acl_mirror(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta.i2e_metadata.mirror_session_id = session_id;
         meta.i2e_metadata.ingress_tstamp = meta.intrinsic_metadata.ingress_global_tstamp;
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
@@ -5746,7 +5746,7 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name("copy_to_cpu_with_reason") action copy_to_cpu_with_reason(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
-        clone3(CloneType.I2E, (bit<32>)250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
+        clone3(CloneType.I2E, (bit<32>)32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name("redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
         copy_to_cpu_with_reason(reason_code);
@@ -5754,7 +5754,7 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name("copy_to_cpu") action copy_to_cpu() {
-        clone3(CloneType.I2E, (bit<32>)250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
+        clone3(CloneType.I2E, (bit<32>)32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name("drop_packet") action drop_packet() {
         mark_to_drop();
@@ -5763,7 +5763,7 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
         drop_stats.count((bit<32>)drop_reason);
         mark_to_drop();
     }
-    @name("negative_mirror") action negative_mirror(bit<8> session_id) {
+    @name("negative_mirror") action negative_mirror(bit<32> session_id) {
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
         mark_to_drop();
     }

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
@@ -19,9 +19,6 @@
 ../testdata/p4_14_samples/switch_20160512/fabric.p4(210): warning: Could not infer type for fabric_mgid, using bit<8>
 action set_fabric_multicast(fabric_mgid) {
                             ^^^^^^^^^^^
-../testdata/p4_14_samples/switch_20160512/acl.p4(441): warning: Could not infer type for session_id, using bit<8>
-action negative_mirror(session_id) {
-                       ^^^^^^^^^^
 warning: The order of headers in deparser is not uniquely determined by parser!
 ../testdata/p4_14_samples/switch_20160512/includes/parser.p4(487): warning: SelectCase: unreachable
         default: parse_all_int_meta_value_heders;


### PR DESCRIPTION
We infer different types for action parameters than `p4c-bm` on a number of our internal test cases. I investigated, and it turns out that there are a few different issues in the P4-14 type inference algorithm that contribute to this problem. This PR fixes those issues.

ef71fd6 adds type inference information for the `clone_spec` operand of the various `clone` primitives. Previously, this operand was defaulting to `Type_Unknown`.

This didn't fix most of my test cases, and the reason turned out to be that the P4-14 type inference passes are Modifiers. This implies that, by default, they only visit each node once. However, TypeCheck::Pass1, we replace all references to an action argument with the ActionArg node they refer to. This means that only the first reference the type inference passes encounter gets considered for type inference.

There is an escape hatch for this: you can set `visitDagOnce = false` on a Modifier instance to allow it to visit the same node more than once. However, it clones the node anew each time, which prevents you from accumulating information from each visit to the node. We need to store that information off to the side instead, and we need to avoid invalidating the data structure we use until we have all the information we need.

This suggests that we should collect the necessary information in Inspector passes and then apply it in a Modifier pass. 905bb61 separates `TypeCheck::Pass2` (the bottom-up pass) and `TypeCheck::Pass3` (the top-down pass) into two bottom-up passes and two top-down passes. One pair of passes is for expressions; these passes continue to perform in-place modifications to the tree. The second pair is for action arguments; these passes are simply Inspectors that accumulate type information for each ActionArg. A final Modifier pass then applies the type information accumulated by the Inspectors to each ActionArg in the tree. Having names like `Pass1` and `Pass2` doesn't really scale to this many passes, so I renamed each pass to clarify what's going on.

This change makes us *gather* the correct information, but it introduces a number of type errors in existing test cases, because considering the different uses of each ActionArg leads us to infer different types for it. In particular we run into a number of cases where we infer `bit<>` types with several different widths. 5afa055 permits widening when combining these types, which fixes the type errors.

With these changes, we infer the same types that `p4c-bm` infers. The existing tests actually have pretty good coverage for all of these issues; all I needed to do was update the expected results, which is taken care of by 71e8592.