### PR TITLE
Fix for issue #297

### DIFF
--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1728,7 +1728,6 @@ Util::IJson* JsonConverter::convertControl(const IR::ControlBlock* block, cstrin
                     auto sz = eb->getParameterValue(v1model.action_profile.sizeParam.name);
                     BUG_CHECK(sz->is<IR::Constant>(), "%1%: expected a constant", sz);
                     action_profile->emplace("max_size", sz->to<IR::Constant>()->value);
-                    declared_action_profiles.emplace(name, action_profile);
                     action_profiles->append(action_profile);
                     continue;
                 }

--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1268,6 +1268,8 @@ bool JsonConverter::handleTableImplementation(const IR::Property* implementation
             ::error("%1%: unexpected type for implementation", dcltype);
             return false;
         }
+        table->emplace("type", "indirect");
+        isSimpleTable = false;
     } else {
         ::error("%1%: unexpected value for property", propv);
         return false;

--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1234,7 +1234,8 @@ bool JsonConverter::handleTableImplementation(const IR::Property* implementation
             }
             auto input = mkArrayField(selector, "input");
             for (auto ke : *key->keyElements) {
-                auto mt = refMap->getDeclaration(ke->matchType->path, true)->to<IR::Declaration_ID>();
+                auto mt = refMap->getDeclaration(ke->matchType->path, true)
+                        ->to<IR::Declaration_ID>();
                 BUG_CHECK(mt != nullptr, "%1%: could not find declaration", ke->matchType);
                 if (mt->name.name != v1model.selectorMatchType.name)
                     continue;

--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1179,77 +1179,100 @@ bool JsonConverter::handleTableImplementation(const IR::Property* implementation
         return true;
     }
 
-    cstring name = implementation->externalName(refMap->newName("action_profile"));
-    table->emplace("action_profile", name);
     if (!implementation->value->is<IR::ExpressionValue>()) {
         ::error("%1%: expected expression for property", implementation);
         return false;
     }
     auto propv = implementation->value->to<IR::ExpressionValue>();
-    if (!propv->expression->is<IR::ConstructorCallExpression>()) {
-        ::error("%1%: expected constructor call for property", implementation);
-        return false;
-    }
-    auto cc = P4::ConstructorCall::resolve(
-        propv->expression->to<IR::ConstructorCallExpression>(), refMap, typeMap);
-    if (!cc->is<P4::ExternConstructorCall>()) {
-        ::error("%1%: expected extern object for property", implementation);
-        return false;
-    }
-
-    auto action_profile = new Util::JsonObject();
-    action_profiles->append(action_profile);
-    action_profile->emplace("name", name);
-    action_profile->emplace("id", nextId("action_profiles"));
 
     bool isSimpleTable = true;
-    auto ecc = cc->to<P4::ExternConstructorCall>();
+    Util::JsonObject* action_profile;
+    cstring apname;
 
-    auto add_size = [&action_profile, &ecc](size_t arg_index) {
-      auto size_expr = ecc->cce->arguments->at(arg_index);
-      int size;
-      if (!size_expr->is<IR::Constant>()) {
-        ::error("%1% must be a constant", size_expr);
-        size = 0;
-      } else {
-        size = size_expr->to<IR::Constant>()->asInt();
-      }
-      action_profile->emplace("max_size", size);
-    };
+    if (propv->expression->is<IR::ConstructorCallExpression>()) {
+        auto cc = P4::ConstructorCall::resolve(
+            propv->expression->to<IR::ConstructorCallExpression>(), refMap, typeMap);
+        if (!cc->is<P4::ExternConstructorCall>()) {
+            ::error("%1%: expected extern object for property", implementation);
+            return false;
+        }
+        auto ecc = cc->to<P4::ExternConstructorCall>();
+        auto implementationType = ecc->type;
+        auto arguments = ecc->cce->arguments;
+        apname = implementation->externalName(refMap->newName("action_profile"));
+        action_profile = new Util::JsonObject();
+        action_profiles->append(action_profile);
+        action_profile->emplace("name", apname);
+        action_profile->emplace("id", nextId("action_profiles"));
 
-    if (ecc->type->name == v1model.action_selector.name) {
-        BUG_CHECK(ecc->cce->arguments->size() == 3, "%1%: expected 3 arguments", cc->cce);
-        isSimpleTable = false;
-        auto selector = new Util::JsonObject();
-        table->emplace("type", "indirect_ws");
-        action_profile->emplace("selector", selector);
-        add_size(1);
-        auto hash = ecc->cce->arguments->at(0);
-        auto ei = P4::EnumInstance::resolve(hash, typeMap);
-        if (ei == nullptr) {
-            ::error("%1%: must be a constant on this target", hash);
+        auto add_size = [&action_profile, &arguments](size_t arg_index) {
+            auto size_expr = arguments->at(arg_index);
+            int size;
+            if (!size_expr->is<IR::Constant>()) {
+                ::error("%1% must be a constant", size_expr);
+                size = 0;
+            } else {
+                size = size_expr->to<IR::Constant>()->asInt();
+            }
+            action_profile->emplace("max_size", size);
+        };
+
+        if (implementationType->name == v1model.action_selector.name) {
+            BUG_CHECK(arguments->size() == 3, "%1%: expected 3 arguments", arguments);
+            isSimpleTable = false;
+            auto selector = new Util::JsonObject();
+            table->emplace("type", "indirect_ws");
+            action_profile->emplace("selector", selector);
+            add_size(1);
+            auto hash = arguments->at(0);
+            auto ei = P4::EnumInstance::resolve(hash, typeMap);
+            if (ei == nullptr) {
+                ::error("%1%: must be a constant on this target", hash);
+            } else {
+                cstring algo = convertHashAlgorithm(ei->name);
+                selector->emplace("algo", algo);
+            }
+            auto input = mkArrayField(selector, "input");
+            for (auto ke : *key->keyElements) {
+                auto mt = refMap->getDeclaration(ke->matchType->path, true)->to<IR::Declaration_ID>();
+                BUG_CHECK(mt != nullptr, "%1%: could not find declaration", ke->matchType);
+                if (mt->name.name != v1model.selectorMatchType.name)
+                    continue;
+
+                auto expr = ke->expression;
+                auto jk = conv->convert(expr);
+                input->append(jk);
+            }
+        } else if (implementationType->name == v1model.action_profile.name) {
+            isSimpleTable = false;
+            table->emplace("type", "indirect");
+            add_size(0);
         } else {
-            cstring algo = convertHashAlgorithm(ei->name);
-            selector->emplace("algo", algo);
+            ::error("%1%: unexpected value for property", propv);
         }
-        auto input = mkArrayField(selector, "input");
-        for (auto ke : *key->keyElements) {
-            auto mt = refMap->getDeclaration(ke->matchType->path, true)->to<IR::Declaration_ID>();
-            BUG_CHECK(mt != nullptr, "%1%: could not find declaration", ke->matchType);
-            if (mt->name.name != v1model.selectorMatchType.name)
-                continue;
-
-            auto expr = ke->expression;
-            auto jk = conv->convert(expr);
-            input->append(jk);
+    } else if (propv->expression->is<IR::PathExpression>()) {
+        auto pathe = propv->expression->to<IR::PathExpression>();
+        auto decl = refMap->getDeclaration(pathe->path, true);
+        if (!decl->is<IR::Declaration_Instance>()) {
+            ::error("%1%: expected a reference to an instance", pathe);
+            return false;
         }
-    } else if (ecc->type->name == v1model.action_profile.name) {
-        isSimpleTable = false;
-        table->emplace("type", "indirect");
-        add_size(0);
+        apname = decl->externalName();
+        auto dcltype = typeMap->getType(pathe, true);
+        if (!dcltype->is<IR::Type_Extern>()) {
+            ::error("%1%: unexpected type for implementation", dcltype);
+            return false;
+        }
+        if (dcltype->to<IR::Type_Extern>()->name != v1model.action_profile.name) {
+            ::error("%1%: unexpected type for implementation", dcltype);
+            return false;
+        }
     } else {
         ::error("%1%: unexpected value for property", propv);
+        return false;
     }
+
+    table->emplace("action_profile", apname);
     return isSimpleTable;
 }
 
@@ -1697,6 +1720,16 @@ Util::IJson* JsonConverter::convertControl(const IR::ControlBlock* block, cstrin
                     auto result = conv->convert(info->destinationField);
                     jmtr->emplace("result_target", result->to<Util::JsonObject>()->get("value"));
                     meters->append(jmtr);
+                    continue;
+                } else if (eb->type->name == v1model.action_profile.name) {
+                    auto action_profile = new Util::JsonObject();
+                    action_profile->emplace("name", name);
+                    action_profile->emplace("id", nextId("action_profiles"));
+                    auto sz = eb->getParameterValue(v1model.action_profile.sizeParam.name);
+                    BUG_CHECK(sz->is<IR::Constant>(), "%1%: expected a constant", sz);
+                    action_profile->emplace("max_size", sz->to<IR::Constant>()->value);
+                    declared_action_profiles.emplace(name, action_profile);
+                    action_profiles->append(action_profile);
                     continue;
                 }
             }

--- a/backends/bmv2/jsonconverter.h
+++ b/backends/bmv2/jsonconverter.h
@@ -83,6 +83,7 @@ class JsonConverter final {
  private:
     Util::JsonArray *headerTypes;
     std::map<cstring, cstring> headerTypesCreated;
+    std::map<cstring, Util::JsonObject*> declared_action_profiles;
     Util::JsonArray *headerInstances;
     Util::JsonArray *headerStacks;
     Util::JsonObject *scalarsStruct;

--- a/backends/bmv2/jsonconverter.h
+++ b/backends/bmv2/jsonconverter.h
@@ -83,7 +83,6 @@ class JsonConverter final {
  private:
     Util::JsonArray *headerTypes;
     std::map<cstring, cstring> headerTypesCreated;
-    std::map<cstring, Util::JsonObject*> declared_action_profiles;
     Util::JsonArray *headerInstances;
     Util::JsonArray *headerStacks;
     Util::JsonObject *scalarsStruct;

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -89,8 +89,10 @@ struct Checksum16_Model : public ::Model::Extern_Model {
 };
 
 struct ActionProfile_Model : public ::Model::Extern_Model {
-    ActionProfile_Model() : Extern_Model("action_profile"), sizeType(IR::Type_Bits::get(32)) {}
+    ActionProfile_Model() : Extern_Model("action_profile"),
+                            sizeType(IR::Type_Bits::get(32)), sizeParam("size") {}
     const IR::Type* sizeType;
+    ::Model::Elem sizeParam;
 };
 
 struct ActionSelector_Model : public ::Model::Extern_Model {

--- a/testdata/p4_16_samples/issue297-bmv2.p4
+++ b/testdata/p4_16_samples/issue297-bmv2.p4
@@ -1,0 +1,74 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+struct H { };
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start { transition accept; }
+}
+
+action empty() { }
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    action_profile(32w128) ap;
+
+    action drop() { smeta.drop = 1; }
+
+    table indirect {
+        key = { }
+        actions = { drop; NoAction; }
+        const default_action = NoAction();
+        implementation = ap;
+    }
+
+    table indirect_ws {
+        key = { meta.hash1 : selector; }
+        actions = { drop; NoAction; }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+    }
+
+    apply {
+        indirect.apply();
+        indirect_ws.apply();
+    }
+
+};
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply { }
+};
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply { }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply { }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(),
+         ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
@@ -1,0 +1,69 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("ap") action_profile(32w128) ap_0;
+    @name("drop") action drop_0() {
+        smeta.drop = 1w1;
+    }
+    @name("indirect") table indirect_0() {
+        key = {
+        }
+        actions = {
+            drop_0();
+            NoAction();
+        }
+        const default_action = NoAction();
+        implementation = ap_0;
+    }
+    @name("indirect_ws") table indirect_ws_0() {
+        key = {
+            meta.hash1: selector @name("meta.hash1") ;
+        }
+        actions = {
+            drop_0();
+            NoAction();
+        }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+    }
+    apply {
+        indirect_0.apply();
+        indirect_ws_0.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
@@ -1,0 +1,76 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("NoAction") action NoAction_0() {
+    }
+    @name("NoAction") action NoAction_3() {
+    }
+    @name("ap") action_profile(32w128) ap;
+    @name("drop") action drop_0() {
+        smeta.drop = 1w1;
+    }
+    @name("drop") action drop_3() {
+        smeta.drop = 1w1;
+    }
+    @name("indirect") table indirect() {
+        key = {
+        }
+        actions = {
+            drop_0();
+            NoAction_0();
+        }
+        const default_action = NoAction_0();
+        implementation = ap;
+    }
+    @name("indirect_ws") table indirect_ws() {
+        key = {
+            meta.hash1: selector @name("meta.hash1") ;
+        }
+        actions = {
+            drop_3();
+            NoAction_3();
+        }
+        const default_action = NoAction_3();
+        @name("ap_ws") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+    }
+    apply {
+        indirect.apply();
+        indirect_ws.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/issue297-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+action empty() {
+}
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    action_profile(32w128) ap;
+    action drop() {
+        smeta.drop = 1;
+    }
+    table indirect() {
+        key = {
+        }
+        actions = {
+            drop;
+            NoAction;
+        }
+        const default_action = NoAction();
+        implementation = ap;
+    }
+    table indirect_ws() {
+        key = {
+            meta.hash1: selector;
+        }
+        actions = {
+            drop;
+            NoAction;
+        }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+    }
+    apply {
+        indirect.apply();
+        indirect_ws.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;


### PR DESCRIPTION
that this fix allows action_profile objects to be declared outside tables. As a side-effect, this change will enable the sharing of an action_profile between multiple tables.

Note that this fix does not allow action_selectors to be declared outside tables, just action_profiles.