### PR TITLE
Enable sharing an action_selector between tables

### DIFF
--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -97,9 +97,13 @@ struct ActionProfile_Model : public ::Model::Extern_Model {
 
 struct ActionSelector_Model : public ::Model::Extern_Model {
     ActionSelector_Model() : Extern_Model("action_selector"),
-                             sizeType(IR::Type_Bits::get(32)), widthType(IR::Type_Bits::get(32)) {}
+                             sizeType(IR::Type_Bits::get(32)), sizeParam("size"),
+                             algorithmParam("algorithm"),
+                             widthType(IR::Type_Bits::get(32)) {}
     const IR::Type* sizeType;
+    ::Model::Elem sizeParam;
     const IR::Type* widthType;
+    ::Model::Elem algorithmParam;
 };
 
 struct Random_Model : public ::Model::Elem {

--- a/testdata/p4_16_samples/action_selector_shared-bmv2.p4
+++ b/testdata/p4_16_samples/action_selector_shared-bmv2.p4
@@ -1,0 +1,76 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+struct H { };
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start { transition accept; }
+}
+
+action empty() { }
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+
+    action drop() { smeta.drop = 1; }
+
+    action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
+
+    table indirect_ws {
+        key = { meta.hash1 : selector; }
+        actions = { drop; NoAction; }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = as;
+    }
+
+
+    table indirect_ws_1 {
+        key = { meta.hash1 : selector; }
+        actions = { drop; NoAction; }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = as;
+    }
+
+    apply {
+        indirect_ws.apply();
+        indirect_ws_1.apply();
+    }
+
+};
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply { }
+};
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply { }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply { }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(),
+         ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples/action_selector_shared-bmv2.stf
+++ b/testdata/p4_16_samples/action_selector_shared-bmv2.stf
@@ -1,0 +1,1 @@
+# empty for now

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-frontend.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("drop") action drop_0() {
+        smeta.drop = 1w1;
+    }
+    @name("as") action_selector(HashAlgorithm.identity, 32w1024, 32w10) as_0;
+    @name("indirect_ws") table indirect_ws_0() {
+        key = {
+            meta.hash1: selector @name("meta.hash1") ;
+        }
+        actions = {
+            drop_0();
+            NoAction();
+        }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = as_0;
+    }
+    @name("indirect_ws_1") table indirect_ws_2() {
+        key = {
+            meta.hash1: selector @name("meta.hash1") ;
+        }
+        actions = {
+            drop_0();
+            NoAction();
+        }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = as_0;
+    }
+    apply {
+        indirect_ws_0.apply();
+        indirect_ws_2.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-midend.p4
@@ -1,0 +1,77 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("NoAction") action NoAction_0() {
+    }
+    @name("NoAction") action NoAction_3() {
+    }
+    @name("drop") action drop_0() {
+        smeta.drop = 1w1;
+    }
+    @name("drop") action drop_3() {
+        smeta.drop = 1w1;
+    }
+    @name("as") action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
+    @name("indirect_ws") table indirect_ws() {
+        key = {
+            meta.hash1: selector @name("meta.hash1") ;
+        }
+        actions = {
+            drop_0();
+            NoAction_0();
+        }
+        const default_action = NoAction_0();
+        @name("ap_ws") implementation = as;
+    }
+    @name("indirect_ws_1") table indirect_ws_1() {
+        key = {
+            meta.hash1: selector @name("meta.hash1") ;
+        }
+        actions = {
+            drop_3();
+            NoAction_3();
+        }
+        const default_action = NoAction_3();
+        @name("ap_ws") implementation = as;
+    }
+    apply {
+        indirect_ws.apply();
+        indirect_ws_1.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4
@@ -1,0 +1,72 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+action empty() {
+}
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    action drop() {
+        smeta.drop = 1;
+    }
+    action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
+    table indirect_ws() {
+        key = {
+            meta.hash1: selector;
+        }
+        actions = {
+            drop;
+            NoAction;
+        }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = as;
+    }
+    table indirect_ws_1() {
+        key = {
+            meta.hash1: selector;
+        }
+        actions = {
+            drop;
+            NoAction;
+        }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = as;
+    }
+    apply {
+        indirect_ws.apply();
+        indirect_ws_1.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;


### PR DESCRIPTION
In the bmv2 backend. We basically added a pass to the backend which
ensures that when several match tables share the same action_selector,
the selector input is the same across all tables.