### PR TITLE
cstring spring cleaning

### DIFF
--- a/lib/cstring.cpp
+++ b/lib/cstring.cpp
@@ -27,6 +27,13 @@ cstring &cstring::operator=(const char *p) {
     return *this;
 }
 
+cstring& cstring::operator=(const std::string& s) {
+    if (cache == nullptr)
+        cache = new std::unordered_set<std::string>();
+    str = cache->insert(s).first->c_str();
+    return *this;
+}
+
 size_t cstring::cache_size(size_t &count) {
     size_t rv = 0;
     if (cache) {

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -87,6 +87,10 @@ class cstring {
     cstring(const char *s) { *this = s; }                   // NOLINT(runtime/explicit)
     cstring(const std::string &a) { *this = a.c_str(); }    // NOLINT(runtime/explicit)
 
+    template <typename Iter> cstring(Iter begin, Iter end) {
+        *this = std::string(begin, end);
+    }
+
     const char *c_str() const { return str; }
     const char *find(int c) const { return str ? strchr(str, c) : nullptr; }
     const char *findlast(int c) const { return str ? strrchr(str, c) : str; }

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -83,23 +83,27 @@ class cstring {
 
     // Copy and assignment from other kinds of strings. These are linear time
     // operations because the underlying string must be copied.
-    cstring &operator=(const char *);
-    cstring &operator=(const std::string&);
     cstring(const std::stringstream&);                      // NOLINT(runtime/explicit)
     cstring(const char *s) { *this = s; }                   // NOLINT(runtime/explicit)
     cstring(const std::string &a) { *this = a; }            // NOLINT(runtime/explicit)
+    cstring &operator=(const char *);
+    cstring &operator=(const std::string&);
 
     template <typename Iter> cstring(Iter begin, Iter end) {
         *this = std::string(begin, end);
     }
 
     const char *c_str() const { return str; }
-    const char *find(int c) const { return str ? strchr(str, c) : nullptr; }
-    const char *findlast(int c) const { return str ? strrchr(str, c) : str; }
     operator const char *() const { return str; }
+
+    // Size tests. Constant time except for size(), which is linear time.
     size_t size() const { return str ? strlen(str) : 0; }
     bool isNull() const { return str == nullptr; }
     bool isNullOrEmpty() const { return str == nullptr ? true : str[0] == 0; }
+
+    // Search for characters. Linear time.
+    const char *find(int c) const { return str ? strchr(str, c) : nullptr; }
+    const char *findlast(int c) const { return str ? strrchr(str, c) : str; }
 
     // Equality tests with other cstrings. Constant time.
     bool operator==(const cstring &a) const { return str == a.str; }
@@ -136,6 +140,17 @@ class cstring {
     cstring operator+=(std::string a);
     cstring operator+=(char a);
 
+    cstring before(const char* at) const;
+    cstring substr(size_t start) const
+    { return (start >= size()) ? "" : substr(start, size() - start); }
+    cstring substr(size_t start, size_t length) const;
+    cstring replace(char find, char replace) const;
+
+    // Useful singletons.
+    static cstring newline;
+    static cstring empty;
+
+    // Static factory functions.
     template<typename T>
     static cstring to_cstring(const T &t) {
         std::stringstream ss;
@@ -149,15 +164,6 @@ class cstring {
             ss << *current; }
         return cstring(ss.str()); }
     template<class T> static cstring make_unique(const T &inuse, cstring base, char sep = '.');
-    cstring before(const char* at) const;
-    cstring substr(size_t start) const
-    { return (start >= size()) ? "" : substr(start, size() - start); }
-    cstring substr(size_t start, size_t length) const;
-    cstring replace(char find, char replace) const;
-
-    // Useful singletons.
-    static cstring newline;
-    static cstring empty;
 
     /// @return the total size in bytes of all interned strings. @count is set
     /// to the total number of interned strings.

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -46,7 +46,8 @@ limitations under the License.
  *   - Interning has an initial cost: converting a const char*, a
  *     std::string, or a std::stringstream to a cstring requires copying it.
  *     Currently, this happens every time you perform the conversion, whether
- *     the string is already interned or not.
+ *     the string is already interned or not, unless the source is an
+ *     std::string.
  *   - Interned strings can never be freed, so they'll stick around for the
  *     lifetime of the program.
  *   - The string interning cstring performs is currently not threadsafe, so you
@@ -83,9 +84,10 @@ class cstring {
     // Copy and assignment from other kinds of strings. These are linear time
     // operations because the underlying string must be copied.
     cstring &operator=(const char *);
+    cstring &operator=(const std::string&);
     cstring(const std::stringstream&);                      // NOLINT(runtime/explicit)
     cstring(const char *s) { *this = s; }                   // NOLINT(runtime/explicit)
-    cstring(const std::string &a) { *this = a.c_str(); }    // NOLINT(runtime/explicit)
+    cstring(const std::string &a) { *this = a; }            // NOLINT(runtime/explicit)
 
     template <typename Iter> cstring(Iter begin, Iter end) {
         *this = std::string(begin, end);

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -24,21 +24,69 @@ limitations under the License.
 #include <string>
 #include <sstream>
 
-// cstring is a zero-terminated, constant (immutable) string
+/**
+ * A cstring is a reference to a zero-terminated, immutable, interned string.
+ * The cstring object *itself* is not immutable; you can reassign it as
+ * required, and it provides a mutable interface that copies the underlying
+ * immutable string as needed.
+ *
+ * Compared to std::string, these are the benefits that cstring provides:
+ *   - Copying and assignment are cheap. Since cstring only deals with immutable
+ *     strings, these operations only involve pointer assignment.
+ *   - Comparing cstrings for equality is cheap; interning makes it possible to
+ *     test for equality using a simple pointer comparison.
+ *   - The immutability of the underlying strings means that it's always safe to
+ *     change a cstring, even if there are other references to it elsewhere.
+ *   - The API offers a number of handy helper methods that aren't available on
+ *     std::string.
+ *
+ * On the other hand, these are the disadvantages of using cstring:
+ *   - Because cstring deals with immutable strings, any modification requires
+ *     that the complete string be copied.
+ *   - Interning has an initial cost: converting a const char*, a
+ *     std::string, or a std::stringstream to a cstring requires copying it.
+ *     Currently, this happens every time you perform the conversion, whether
+ *     the string is already interned or not.
+ *   - Interned strings can never be freed, so they'll stick around for the
+ *     lifetime of the program.
+ *   - The string interning cstring performs is currently not threadsafe, so you
+ *     can't safely use cstrings off the main thread.
+ *
+ * Given these tradeoffs, the general rule of thumb to follow is that you should
+ * try to convert strings to cstrings early and keep them in that form. That
+ * way, you benefit from cheaper copying, assignment, and equality testing in as
+ * many places as possible, and you avoid paying the cost of repeated
+ * conversion.
+ *
+ * However, when you're building or mutating a string, you should use
+ * std::string. Convert to a cstring only when the string is in its final form.
+ * This ensures that you don't pay the time and space cost of interning every
+ * intermediate version of the string.
+ *
+ * Note that cstring has implicit conversions to and from other string types.
+ * This is convenient, but in performance-sensitive code it's good to be aware
+ * that mixing the two types of strings can trigger a lot of implicit copies.
+ */
 class cstring {
     const char *str;
 
  public:
-    // cstring() = default;
     cstring() : str(0) {}
+
+    // Copy and assignment from cstrings. The underlying string doesn't have to
+    // be copied, so these are constant-time operations.
     cstring(const cstring &) = default;
     cstring(cstring &&) = default;
     cstring &operator=(const cstring &) = default;
     cstring &operator=(cstring &&) = default;
+
+    // Copy and assignment from other kinds of strings. These are linear time
+    // operations because the underlying string must be copied.
     cstring &operator=(const char *);
     cstring(const std::stringstream&);                      // NOLINT(runtime/explicit)
     cstring(const char *s) { *this = s; }                   // NOLINT(runtime/explicit)
     cstring(const std::string &a) { *this = a.c_str(); }    // NOLINT(runtime/explicit)
+
     const char *c_str() const { return str; }
     const char *find(int c) const { return str ? strchr(str, c) : nullptr; }
     const char *findlast(int c) const { return str ? strrchr(str, c) : str; }
@@ -46,9 +94,13 @@ class cstring {
     size_t size() const { return str ? strlen(str) : 0; }
     bool isNull() const { return str == nullptr; }
     bool isNullOrEmpty() const { return str == nullptr ? true : str[0] == 0; }
+
+    // Equality tests with other cstrings. Constant time.
     bool operator==(const cstring &a) const { return str == a.str; }
-    bool operator==(const char *a) const { return str ? a && !strcmp(str, a) : !a; }
     bool operator!=(const cstring &a) const { return str != a.str; }
+
+    // Other comparisons and tests. Linear time.
+    bool operator==(const char *a) const { return str ? a && !strcmp(str, a) : !a; }
     bool operator!=(const char *a) const { return str ? !a || !!strcmp(str, a) : !!a; }
     bool operator<(const cstring &a) const { return *this < a.str; }
     bool operator<(const char *a) const { return str ? a && strcmp(str, a) < 0 : !!a; }
@@ -66,12 +118,18 @@ class cstring {
     bool operator>(const std::string &a) const { return *this > a.c_str(); }
     bool operator>=(const std::string &a) const { return *this >= a.c_str(); }
 
+    bool startsWith(const cstring& prefix) const;
+    bool endsWith(const cstring& suffix) const;
+
+    // Mutation operations. These are linear time and always trigger a copy,
+    // since the underlying string is immutable. (Note that this is true even
+    // for substr(); cstrings are always null-terminated, so a copy is
+    // required.)
     cstring operator+=(cstring a);
     cstring operator+=(const char *a);
     cstring operator+=(std::string a);
     cstring operator+=(char a);
-    bool startsWith(const cstring& prefix) const;
-    bool endsWith(const cstring& suffix) const;
+
     template<typename T>
     static cstring to_cstring(const T &t) {
         std::stringstream ss;
@@ -84,15 +142,20 @@ class cstring {
             if (begin != current) ss << delim;
             ss << *current; }
         return cstring(ss.str()); }
-    static cstring newline;
-    static cstring empty;
     template<class T> static cstring make_unique(const T &inuse, cstring base, char sep = '.');
     cstring before(const char* at) const;
     cstring substr(size_t start) const
     { return (start >= size()) ? "" : substr(start, size() - start); }
     cstring substr(size_t start, size_t length) const;
     cstring replace(char find, char replace) const;
-    static size_t cache_size(size_t &);
+
+    // Useful singletons.
+    static cstring newline;
+    static cstring empty;
+
+    /// @return the total size in bytes of all interned strings. @count is set
+    /// to the total number of interned strings.
+    static size_t cache_size(size_t &count);
 };
 
 inline bool operator==(const char *a, cstring b) { return b == a; }

--- a/lib/stringref.h
+++ b/lib/stringref.h
@@ -80,7 +80,7 @@ struct StringRef {
     template <class T> bool operator>(T a) const { return compare(a) > 0; }
     template <class T> bool operator>=(T a) const { return compare(a) >= 0; }
 
-    operator std::string() const { return std::string(p, len); }
+    explicit operator std::string() const { return std::string(p, len); }
     operator cstring() const { return std::string(p, len); }
     cstring toString() const { return std::string(p, len); }
     std::string string() const { return std::string(p, len); }


### PR DESCRIPTION
I was writing some cstring-heavy code recently and this prompted me to take a look at cstring.h. I was glad I did, because it turned out I hadn't quite understood how cstring was intended to behave! Though I know there is documentation of cstring elsewhere, I felt like this was a sign that it'd be good to have some documentation in the code. 70c2aa3 contains everything I've learned about cstring so far; if I've misunderstood or missed anything, let me know! fa5adaf builds on that with a little bit of cleanup.

In the course of putting cstring under the lens I noticed a couple of minor issues that I've also fixed in this PR.

c21f56f adds a cstring constructor which takes a pair of iterators; this is necessary for many STL and Boost algorithms to work.

3fa944e removes a performance gotcha when using cstring: constructing a cstring from an std::string (either via the std::string constructor/assignment operator, or indirectly via the std::string stream or pair-of-iterators constructors) involves calling `c_str()` on the std::string to get a `const char*`, and then calling `cstring::operator=(const char*)`, which creates a new std::string from the `const char*` and checks if it's present in the cache. Even if it's in the cache already, though, that std::string copy will still have been created. 3fa944e avoids this by adding an additional `cstring::operator=(const std::string&)` overload which checks the cache using the existing std::string instance. This should result in significantly fewer unnecessary copies when converting between std::string and cstring.