### PR TITLE
Update P4Runtime to begin the phase-out of header fields

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -97,6 +97,8 @@ struct HeaderFieldPath {
                                  const TypeMap* typeMap) {
         auto type = typeMap->getType(expression->getNode(), true);
         if (expression->is<IR::PathExpression>()) {
+            // Top-level structlike types only show up in P4Runtime names if
+            // they're metadata types. See forAllHeaderFields() for more info.
             if (isMetadataType(type) && type->is<IR::Type_Declaration>()) {
                 auto name = type->to<IR::Type_Declaration>()->externalName();
                 return HeaderFieldPath::root(name, type);


### PR DESCRIPTION
This PR brings p4c's p4RuntimeSerializer code up to date with the latest P4Info changes. The update adds some new features, but the main story is that it's the beginning of a refactoring that will eventually result in removal of header fields and header field lists from the P4Info schema. To accomplish the switch, the plan is to generate P4Info that supports both the old and the new approaches simultaneously, and then phase out the old approach. This PR begins that process by adding support for the main features of the new approach.

5e04f2c updates p4c's submodule to the newest revision of the PI repo.

af47c9f adds support for aliases, which give an additional, shorter name to P4 objects. The way that aliases interact with the existing set of annotations needs some thought, so I took an incremental approach here: we still calculate the name using the same algorithm we've used until now, and then aliases are programmatically generated. An object's alias is the shortest unique suffix of the object's name.

Since action parameter ids are now local to the actions, 61727bb makes us allocate them locally. A huge amount of code is removed. We previously didn't support `@id` for action parameters, and we still don't after this patch, but I made a note of it so we can come back and fix it later.

6e43f6b adds partial support for the new Table attributes added to this version of P4Info. `support_timeout` is now totally supported. `const_default_action_has_mutable_params` is not yet supported because I need to clarify a bit when this can be enabled, but the code now makes it clear that this work has to be done.

2c8f7ff is a very small refactoring patch to add a comment to HeaderFieldPath::from(); I happened to look at it while writing these patches and noticed that the code I commented was rather unclear.

cb8ef49 is in some sense the main event here. Like 61727bb did for action parameters, this patch makes us allocate local ids for match fields. Match fields previously didn't have much of an identity in P4Info, so this patch also makes us serialize their name and bit width, and generally cleans up how we handle them a little. These changes move us one step closer to getting rid of header fields and header field lists in P4Info.