### PR TITLE
Three minor changes

### DIFF
--- a/backends/bmv2/run-bmv2-test.py
+++ b/backends/bmv2/run-bmv2-test.py
@@ -162,6 +162,10 @@ def run_model(options, tmpdir, jsonfile):
     testfile = dirname + "/" + base + ".stf"
     print("Check for ", testfile)
     if not os.path.isfile(testfile):
+        # If no stf file is present just use the empty file
+        testfile = dirname + "/empty.stf"
+    if not os.path.isfile(testfile):
+        # If no empty.stf present, don't try to run the model at all
         return SUCCESS
 
     bmv2 = RunBMV2(tmpdir, options, jsonfile)

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -76,8 +76,8 @@ class FrontEndLast : public PassManager {
     FrontEndLast() { setName("FrontEndLast"); }
 };
 
-const IR::P4Program*
-FrontEnd::run(const CompilerOptions &options, const IR::P4Program* program, bool skipSideEffectOrdering) {
+const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4Program* program,
+                                   bool skipSideEffectOrdering) {
     if (program == nullptr)
         return nullptr;
 

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -77,7 +77,7 @@ class FrontEndLast : public PassManager {
 };
 
 const IR::P4Program*
-FrontEnd::run(const CompilerOptions &options, const IR::P4Program* program) {
+FrontEnd::run(const CompilerOptions &options, const IR::P4Program* program, bool skipSideEffectOrdering) {
     if (program == nullptr)
         return nullptr;
 
@@ -113,7 +113,7 @@ FrontEnd::run(const CompilerOptions &options, const IR::P4Program* program) {
         new UniqueNames(&refMap),  // Give each local declaration a unique internal name
         new MoveDeclarations(),  // Move all local declarations to the beginning
         new MoveInitializers(),
-        new SideEffectOrdering(&refMap, &typeMap),
+        skipSideEffectOrdering ? nullptr : new SideEffectOrdering(&refMap, &typeMap),
         new SimplifyControlFlow(&refMap, &typeMap),
         new MoveDeclarations(),  // Move all local declarations to the beginning
         new SimplifyDefUse(&refMap, &typeMap),

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -28,7 +28,8 @@ class FrontEnd {
     FrontEnd() = default;
     explicit FrontEnd(DebugHook hook) { hooks.push_back(hook); }
     void addDebugHook(DebugHook hook) { hooks.push_back(hook); }
-    const IR::P4Program* run(const CompilerOptions& options, const IR::P4Program* program);
+    const IR::P4Program* run(const CompilerOptions& options, const IR::P4Program* program,
+                             bool skipSideEffectOrdering = false);
 };
 
 }  // namespace P4

--- a/testdata/p4_14_samples/misc_prim.p4
+++ b/testdata/p4_14_samples/misc_prim.p4
@@ -1,0 +1,136 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc. 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Sample P4 program */
+header_type pkt_t {
+    fields {
+        field_a_32 : 32;
+        field_b_32 : 32 (signed);
+        field_c_32 : 32;
+        field_d_32 : 32;
+
+        field_e_16 : 16;
+        field_f_16 : 16;
+        field_g_16 : 16;
+        field_h_16 : 16;
+
+        field_i_8 : 8;
+        field_j_8 : 8;
+        field_k_8 : 8;
+        field_l_8 : 8;
+
+        field_x_32 : 32 (signed);
+    }
+}
+
+parser start {
+    return parse_ethernet;
+}
+
+header pkt_t pkt;
+
+parser parse_ethernet {
+    extract(pkt);
+    return ingress;
+}
+
+action action_0(){
+    bit_nor(pkt.field_a_32, pkt.field_b_32, pkt.field_c_32);
+}
+action action_1(param0){
+    bit_nand(pkt.field_a_32, param0, pkt.field_c_32);
+}
+action action_2(param0){
+    bit_xnor(pkt.field_a_32, pkt.field_b_32, param0);
+}
+action action_3(){
+    bit_not(pkt.field_a_32, pkt.field_d_32);
+}
+action action_4(param0){
+    min(pkt.field_a_32, pkt.field_d_32, param0);
+}
+action action_5(param0){
+    max(pkt.field_a_32, param0, pkt.field_d_32);
+}
+action action_6(){
+    min(pkt.field_b_32, pkt.field_d_32, 7);
+}
+action action_7(param0){
+    max(pkt.field_b_32, param0, pkt.field_d_32);
+}
+action action_8(param0){
+    max(pkt.field_x_32, pkt.field_x_32, param0);
+}
+action action_9(){
+    shift_right(pkt.field_x_32, pkt.field_x_32, 7);
+}
+
+action action_10(param0){
+     //bit_andca(pkt.field_a_32, pkt.field_a_32, param0);
+     bit_andca(pkt.field_a_32, param0, pkt.field_a_32);
+}
+
+action action_11(param0){
+     //bit_andcb(pkt.field_a_32, pkt.field_a_32, param0);
+     bit_andcb(pkt.field_a_32, param0, pkt.field_a_32);
+}
+
+action action_12(param0){
+     //bit_orca(pkt.field_a_32, pkt.field_a_32, param0);
+     bit_orca(pkt.field_a_32, param0, pkt.field_a_32);
+}
+
+action action_13(param0){
+     //bit_orcb(pkt.field_a_32, pkt.field_a_32, param0);
+     bit_orcb(pkt.field_a_32, param0, pkt.field_a_32);
+}
+
+action do_nothing(){}
+
+table table_0 {
+    reads {
+        pkt.field_a_32 : ternary;
+        pkt.field_b_32 : ternary;
+        pkt.field_c_32 : ternary;
+        pkt.field_d_32 : ternary;
+        pkt.field_g_16 : ternary;
+        pkt.field_h_16 : ternary;
+    }
+    actions {
+        action_0;
+        action_1;
+        action_2;
+        action_3;
+        action_4;
+        action_5;
+        action_6;
+        action_7;
+        action_8;
+        action_9;
+        action_10;
+        action_11;
+        action_12;
+        action_13;
+        do_nothing;
+    }
+    size : 512;
+}
+
+/* Main control flow */
+
+control ingress {
+    apply(table_0);
+}

--- a/testdata/p4_14_samples_outputs/misc_prim-frontend.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim-frontend.p4
@@ -1,0 +1,139 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header pkt_t {
+    bit<32> field_a_32;
+    int<32> field_b_32;
+    bit<32> field_c_32;
+    bit<32> field_d_32;
+    bit<16> field_e_16;
+    bit<16> field_f_16;
+    bit<16> field_g_16;
+    bit<16> field_h_16;
+    bit<8>  field_i_8;
+    bit<8>  field_j_8;
+    bit<8>  field_k_8;
+    bit<8>  field_l_8;
+    int<32> field_x_32;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name("pkt") 
+    pkt_t pkt;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("parse_ethernet") state parse_ethernet {
+        packet.extract<pkt_t>(hdr.pkt);
+        transition accept;
+    }
+    @name("start") state start {
+        transition parse_ethernet;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("action_0") action action_14() {
+        hdr.pkt.field_a_32 = (bit<32>)~(hdr.pkt.field_b_32 | (int<32>)hdr.pkt.field_c_32);
+    }
+    @name("action_1") action action_15(bit<32> param0) {
+        hdr.pkt.field_a_32 = ~(param0 & hdr.pkt.field_c_32);
+    }
+    @name("action_2") action action_16(bit<32> param0) {
+        hdr.pkt.field_a_32 = (bit<32>)~(hdr.pkt.field_b_32 ^ (int<32>)param0);
+    }
+    @name("action_3") action action_17() {
+        hdr.pkt.field_a_32 = ~hdr.pkt.field_d_32;
+    }
+    @name("action_4") action action_18(bit<32> param0) {
+        hdr.pkt.field_a_32 = (hdr.pkt.field_d_32 <= param0 ? hdr.pkt.field_d_32 : param0);
+    }
+    @name("action_5") action action_19(bit<32> param0) {
+        hdr.pkt.field_a_32 = (param0 >= hdr.pkt.field_d_32 ? param0 : hdr.pkt.field_d_32);
+    }
+    @name("action_6") action action_20() {
+        hdr.pkt.field_b_32 = (int<32>)(hdr.pkt.field_d_32 <= 32w7 ? hdr.pkt.field_d_32 : 32w7);
+    }
+    @name("action_7") action action_21(int<32> param0) {
+        hdr.pkt.field_b_32 = (param0 >= (int<32>)hdr.pkt.field_d_32 ? param0 : (int<32>)hdr.pkt.field_d_32);
+    }
+    @name("action_8") action action_22(int<32> param0) {
+        hdr.pkt.field_x_32 = (hdr.pkt.field_x_32 >= param0 ? hdr.pkt.field_x_32 : param0);
+    }
+    @name("action_9") action action_23() {
+        hdr.pkt.field_x_32 = hdr.pkt.field_x_32 >> 7;
+    }
+    @name("action_10") action action_24(bit<32> param0) {
+        hdr.pkt.field_a_32 = ~param0 & hdr.pkt.field_a_32;
+    }
+    @name("action_11") action action_25(bit<32> param0) {
+        hdr.pkt.field_a_32 = param0 & ~hdr.pkt.field_a_32;
+    }
+    @name("action_12") action action_26(bit<32> param0) {
+        hdr.pkt.field_a_32 = ~param0 | hdr.pkt.field_a_32;
+    }
+    @name("action_13") action action_27(bit<32> param0) {
+        hdr.pkt.field_a_32 = param0 | ~hdr.pkt.field_a_32;
+    }
+    @name("do_nothing") action do_nothing_0() {
+    }
+    @name("table_0") table table_1() {
+        actions = {
+            action_14();
+            action_15();
+            action_16();
+            action_17();
+            action_18();
+            action_19();
+            action_20();
+            action_21();
+            action_22();
+            action_23();
+            action_24();
+            action_25();
+            action_26();
+            action_27();
+            do_nothing_0();
+            @default_only NoAction();
+        }
+        key = {
+            hdr.pkt.field_a_32: ternary @name("hdr.pkt.field_a_32") ;
+            hdr.pkt.field_b_32: ternary @name("hdr.pkt.field_b_32") ;
+            hdr.pkt.field_c_32: ternary @name("hdr.pkt.field_c_32") ;
+            hdr.pkt.field_d_32: ternary @name("hdr.pkt.field_d_32") ;
+            hdr.pkt.field_g_16: ternary @name("hdr.pkt.field_g_16") ;
+            hdr.pkt.field_h_16: ternary @name("hdr.pkt.field_h_16") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    apply {
+        table_1.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<pkt_t>(hdr.pkt);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/misc_prim-midend.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim-midend.p4
@@ -1,0 +1,141 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header pkt_t {
+    bit<32> field_a_32;
+    int<32> field_b_32;
+    bit<32> field_c_32;
+    bit<32> field_d_32;
+    bit<16> field_e_16;
+    bit<16> field_f_16;
+    bit<16> field_g_16;
+    bit<16> field_h_16;
+    bit<8>  field_i_8;
+    bit<8>  field_j_8;
+    bit<8>  field_k_8;
+    bit<8>  field_l_8;
+    int<32> field_x_32;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name("pkt") 
+    pkt_t pkt;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("parse_ethernet") state parse_ethernet {
+        packet.extract<pkt_t>(hdr.pkt);
+        transition accept;
+    }
+    @name("start") state start {
+        transition parse_ethernet;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("NoAction") action NoAction_0() {
+    }
+    @name("action_0") action action_14() {
+        hdr.pkt.field_a_32 = (bit<32>)~(hdr.pkt.field_b_32 | (int<32>)hdr.pkt.field_c_32);
+    }
+    @name("action_1") action action_15(bit<32> param0) {
+        hdr.pkt.field_a_32 = ~(param0 & hdr.pkt.field_c_32);
+    }
+    @name("action_2") action action_16(bit<32> param0) {
+        hdr.pkt.field_a_32 = (bit<32>)~(hdr.pkt.field_b_32 ^ (int<32>)param0);
+    }
+    @name("action_3") action action_17() {
+        hdr.pkt.field_a_32 = ~hdr.pkt.field_d_32;
+    }
+    @name("action_4") action action_18(bit<32> param0) {
+        hdr.pkt.field_a_32 = (hdr.pkt.field_d_32 <= param0 ? hdr.pkt.field_d_32 : param0);
+    }
+    @name("action_5") action action_19(bit<32> param0) {
+        hdr.pkt.field_a_32 = (param0 >= hdr.pkt.field_d_32 ? param0 : hdr.pkt.field_d_32);
+    }
+    @name("action_6") action action_20() {
+        hdr.pkt.field_b_32 = (int<32>)(hdr.pkt.field_d_32 <= 32w7 ? hdr.pkt.field_d_32 : 32w7);
+    }
+    @name("action_7") action action_21(int<32> param0) {
+        hdr.pkt.field_b_32 = (param0 >= (int<32>)hdr.pkt.field_d_32 ? param0 : (int<32>)hdr.pkt.field_d_32);
+    }
+    @name("action_8") action action_22(int<32> param0) {
+        hdr.pkt.field_x_32 = (hdr.pkt.field_x_32 >= param0 ? hdr.pkt.field_x_32 : param0);
+    }
+    @name("action_9") action action_23() {
+        hdr.pkt.field_x_32 = hdr.pkt.field_x_32 >> 7;
+    }
+    @name("action_10") action action_24(bit<32> param0) {
+        hdr.pkt.field_a_32 = ~param0 & hdr.pkt.field_a_32;
+    }
+    @name("action_11") action action_25(bit<32> param0) {
+        hdr.pkt.field_a_32 = param0 & ~hdr.pkt.field_a_32;
+    }
+    @name("action_12") action action_26(bit<32> param0) {
+        hdr.pkt.field_a_32 = ~param0 | hdr.pkt.field_a_32;
+    }
+    @name("action_13") action action_27(bit<32> param0) {
+        hdr.pkt.field_a_32 = param0 | ~hdr.pkt.field_a_32;
+    }
+    @name("do_nothing") action do_nothing_0() {
+    }
+    @name("table_0") table table_0() {
+        actions = {
+            action_14();
+            action_15();
+            action_16();
+            action_17();
+            action_18();
+            action_19();
+            action_20();
+            action_21();
+            action_22();
+            action_23();
+            action_24();
+            action_25();
+            action_26();
+            action_27();
+            do_nothing_0();
+            @default_only NoAction_0();
+        }
+        key = {
+            hdr.pkt.field_a_32: ternary @name("hdr.pkt.field_a_32") ;
+            hdr.pkt.field_b_32: ternary @name("hdr.pkt.field_b_32") ;
+            hdr.pkt.field_c_32: ternary @name("hdr.pkt.field_c_32") ;
+            hdr.pkt.field_d_32: ternary @name("hdr.pkt.field_d_32") ;
+            hdr.pkt.field_g_16: ternary @name("hdr.pkt.field_g_16") ;
+            hdr.pkt.field_h_16: ternary @name("hdr.pkt.field_h_16") ;
+        }
+        size = 512;
+        default_action = NoAction_0();
+    }
+    apply {
+        table_0.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<pkt_t>(hdr.pkt);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/misc_prim.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim.p4
@@ -1,0 +1,139 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header pkt_t {
+    bit<32> field_a_32;
+    int<32> field_b_32;
+    bit<32> field_c_32;
+    bit<32> field_d_32;
+    bit<16> field_e_16;
+    bit<16> field_f_16;
+    bit<16> field_g_16;
+    bit<16> field_h_16;
+    bit<8>  field_i_8;
+    bit<8>  field_j_8;
+    bit<8>  field_k_8;
+    bit<8>  field_l_8;
+    int<32> field_x_32;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name("pkt") 
+    pkt_t pkt;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("parse_ethernet") state parse_ethernet {
+        packet.extract(hdr.pkt);
+        transition accept;
+    }
+    @name("start") state start {
+        transition parse_ethernet;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("action_0") action action_0() {
+        hdr.pkt.field_a_32 = ~(hdr.pkt.field_b_32 | (int<32>)hdr.pkt.field_c_32);
+    }
+    @name("action_1") action action_1(bit<32> param0) {
+        hdr.pkt.field_a_32 = ~(param0 & hdr.pkt.field_c_32);
+    }
+    @name("action_2") action action_2(bit<32> param0) {
+        hdr.pkt.field_a_32 = ~(hdr.pkt.field_b_32 ^ (int<32>)param0);
+    }
+    @name("action_3") action action_3() {
+        hdr.pkt.field_a_32 = ~hdr.pkt.field_d_32;
+    }
+    @name("action_4") action action_4(bit<32> param0) {
+        hdr.pkt.field_a_32 = (hdr.pkt.field_d_32 <= param0 ? hdr.pkt.field_d_32 : param0);
+    }
+    @name("action_5") action action_5(bit<32> param0) {
+        hdr.pkt.field_a_32 = (param0 >= hdr.pkt.field_d_32 ? param0 : hdr.pkt.field_d_32);
+    }
+    @name("action_6") action action_6() {
+        hdr.pkt.field_b_32 = (hdr.pkt.field_d_32 <= (bit<32>)32s7 ? hdr.pkt.field_d_32 : (bit<32>)32s7);
+    }
+    @name("action_7") action action_7(int<32> param0) {
+        hdr.pkt.field_b_32 = (param0 >= (int<32>)hdr.pkt.field_d_32 ? param0 : (int<32>)hdr.pkt.field_d_32);
+    }
+    @name("action_8") action action_8(int<32> param0) {
+        hdr.pkt.field_x_32 = (hdr.pkt.field_x_32 >= param0 ? hdr.pkt.field_x_32 : param0);
+    }
+    @name("action_9") action action_9() {
+        hdr.pkt.field_x_32 = hdr.pkt.field_x_32 >> 7;
+    }
+    @name("action_10") action action_10(bit<32> param0) {
+        hdr.pkt.field_a_32 = ~param0 & hdr.pkt.field_a_32;
+    }
+    @name("action_11") action action_11(bit<32> param0) {
+        hdr.pkt.field_a_32 = param0 & ~hdr.pkt.field_a_32;
+    }
+    @name("action_12") action action_12(bit<32> param0) {
+        hdr.pkt.field_a_32 = ~param0 | hdr.pkt.field_a_32;
+    }
+    @name("action_13") action action_13(bit<32> param0) {
+        hdr.pkt.field_a_32 = param0 | ~hdr.pkt.field_a_32;
+    }
+    @name("do_nothing") action do_nothing() {
+    }
+    @name("table_0") table table_0() {
+        actions = {
+            action_0;
+            action_1;
+            action_2;
+            action_3;
+            action_4;
+            action_5;
+            action_6;
+            action_7;
+            action_8;
+            action_9;
+            action_10;
+            action_11;
+            action_12;
+            action_13;
+            do_nothing;
+            @default_only NoAction;
+        }
+        key = {
+            hdr.pkt.field_a_32: ternary;
+            hdr.pkt.field_b_32: ternary;
+            hdr.pkt.field_c_32: ternary;
+            hdr.pkt.field_d_32: ternary;
+            hdr.pkt.field_g_16: ternary;
+            hdr.pkt.field_h_16: ternary;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    apply {
+        table_0.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.pkt);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;


### PR DESCRIPTION
These relate to #367, in that they are minor cleanups that help with it, plus a test case that is problematic.

The ability to disable the SideEffectOrdering pass is a bit of a hack -- it is problematic in that it introduces too many unneeded copies that are too hard to get rid of, and isn't really necessary for most targets.  It should probably be a midend pass rather than a frontend pass in the first place.