### PR TITLE
add option to skip preprocess

### DIFF
--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -54,6 +54,9 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
     registerOption("-E", nullptr,
                    [this](const char*) { doNotCompile = true; return true; },
                    "Preprocess only, do not compile (prints program on stdout)");
+    registerOption("-e", nullptr,
+                   [this](const char*) { doNotPreprocess = true; return true; },
+                   "Skip preprocess, assume input file is already preprocessed.");
     registerOption("--p4-14", nullptr,
                    [this](const char*) {
                        langVersion = CompilerOptions::FrontendVersion::P4_14;

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -54,7 +54,7 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
     registerOption("-E", nullptr,
                    [this](const char*) { doNotCompile = true; return true; },
                    "Preprocess only, do not compile (prints program on stdout)");
-    registerOption("-e", nullptr,
+    registerOption("--nocpp", nullptr,
                    [this](const char*) { doNotPreprocess = true; return true; },
                    "Skip preprocess, assume input file is already preprocessed.");
     registerOption("--p4-14", nullptr,

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -54,6 +54,8 @@ class CompilerOptions : public Util::Options {
     cstring file = nullptr;
     // if true preprocess only
     bool doNotCompile = false;
+    // if true skip preprocess
+    bool doNotPreprocess = false;
     // debugging dumps of programs written in this folder
     cstring dumpFolder = ".";
     // Pretty-print the program in the specified file

--- a/frontends/common/parseInput.cpp
+++ b/frontends/common/parseInput.cpp
@@ -25,6 +25,10 @@ const IR::P4Program* parseP4File(CompilerOptions& options) {
     FILE* in = nullptr;
     if (options.doNotPreprocess) {
         in = fopen(options.file, "r");
+        if (in == nullptr) {
+            ::error("%s: No such file or directory.", options.file);
+            return nullptr;
+        }
     } else {
         options.preprocess();
         if (::errorCount() > 0 || in == nullptr)

--- a/frontends/common/parseInput.cpp
+++ b/frontends/common/parseInput.cpp
@@ -22,10 +22,14 @@ limitations under the License.
 #include "frontends/p4/p4-parse.h"
 
 const IR::P4Program* parseP4File(CompilerOptions& options) {
-    FILE* in = options.preprocess();
-    if (::errorCount() > 0 || in == nullptr)
-        return nullptr;
-
+    FILE* in = nullptr;
+    if (options.doNotPreprocess) {
+        in = fopen(options.file, "r");
+    } else {
+        options.preprocess();
+        if (::errorCount() > 0 || in == nullptr)
+            return nullptr;
+    }
     const IR::P4Program* result = nullptr;
     bool compiling10 = options.isv1();
     if (compiling10) {

--- a/frontends/common/parseInput.cpp
+++ b/frontends/common/parseInput.cpp
@@ -30,7 +30,7 @@ const IR::P4Program* parseP4File(CompilerOptions& options) {
             return nullptr;
         }
     } else {
-        options.preprocess();
+        in = options.preprocess();
         if (::errorCount() > 0 || in == nullptr)
             return nullptr;
     }


### PR DESCRIPTION
Add an option to skip preprocessing in p4c, to give user the flexibility to separate preprocessing from compilation. Driver may choose to call cpp directly without going through p4c.