### PR TITLE
avoid crashing in removeReturns for BlockStatements

### DIFF
--- a/midend/removeReturns.cpp
+++ b/midend/removeReturns.cpp
@@ -132,7 +132,8 @@ const IR::Node* DoRemoveReturns::preorder(IR::BlockStatement* statement) {
             ret = r;
         }
     }
-    set(ret);
+    if (!stack.empty())
+        set(ret);
     prune();
     return new IR::BlockStatement(statement->srcInfo, statement->annotations, body);
 }
@@ -311,7 +312,8 @@ const IR::Node* DoRemoveExits::preorder(IR::BlockStatement* statement) {
             ret = r;
         }
     }
-    set(ret);
+    if (!stack.empty())
+        set(ret);
     prune();
     return new IR::BlockStatement(statement->srcInfo, statement->annotations, body);
 }

--- a/testdata/p4_16_samples/bfd_offload.p4
+++ b/testdata/p4_16_samples/bfd_offload.p4
@@ -1,0 +1,55 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+extern BFD_Offload {
+    BFD_Offload(bit<16> size);
+
+    // State manipulation
+    void setTx(in bit<16> index, in bit<8> data);
+    bit<8> getTx(in bit<16> index);
+
+    abstract void on_rx( in bit<16> index );
+    abstract bool on_tx( in bit<16> index );
+}
+
+BFD_Offload(32768) bfd_session_liveness_tracker = {
+    void on_rx( in bit<16> index ) {
+        this.setTx(index, 0);
+    }
+    bool on_tx( in bit<16> index ) {
+        bit<8> c = this.getTx(index) + 1;
+        if (c >= 4) {
+            return true;
+        } else {
+            this.setTx(index, c);
+            return false;
+        }
+    }
+};
+
+control for_rx_bfd_packets() {
+    apply {
+        bit<16> index;
+        bfd_session_liveness_tracker.on_rx( index );
+    }
+}
+control for_tx_bfd_packets() {
+    apply {
+        bit<16> index;
+        bfd_session_liveness_tracker.on_tx( index );
+    }
+}

--- a/testdata/p4_16_samples_outputs/bfd_offload-first.p4
+++ b/testdata/p4_16_samples_outputs/bfd_offload-first.p4
@@ -1,0 +1,36 @@
+extern BFD_Offload {
+    BFD_Offload(bit<16> size);
+    void setTx(in bit<16> index, in bit<8> data);
+    bit<8> getTx(in bit<16> index);
+    abstract void on_rx(in bit<16> index);
+    abstract bool on_tx(in bit<16> index);
+}
+
+BFD_Offload(16w32768) bfd_session_liveness_tracker = {
+    void on_rx(in bit<16> index) {
+        this.setTx(index, 8w0);
+    }
+    bool on_tx(in bit<16> index) {
+        bit<8> c = this.getTx(index) + 8w1;
+        if (c >= 8w4) 
+            return true;
+        else {
+            this.setTx(index, c);
+            return false;
+        }
+    }
+};
+control for_rx_bfd_packets() {
+    apply {
+        bit<16> index;
+        bfd_session_liveness_tracker.on_rx(index);
+    }
+}
+
+control for_tx_bfd_packets() {
+    apply {
+        bit<16> index;
+        bfd_session_liveness_tracker.on_tx(index);
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/bfd_offload-frontend.p4
+++ b/testdata/p4_16_samples_outputs/bfd_offload-frontend.p4
@@ -1,0 +1,27 @@
+extern BFD_Offload {
+    BFD_Offload(bit<16> size);
+    void setTx(in bit<16> index, in bit<8> data);
+    bit<8> getTx(in bit<16> index);
+    abstract void on_rx(in bit<16> index);
+    abstract bool on_tx(in bit<16> index);
+}
+
+BFD_Offload(16w32768) bfd_session_liveness_tracker = {
+    void on_rx(in bit<16> index) {
+        this.setTx(index, 8w0);
+    }
+    bool on_tx(in bit<16> index) {
+        bit<8> tmp;
+        bit<8> tmp_0;
+        bit<8> c_0;
+        tmp = this.getTx(index);
+        tmp_0 = tmp + 8w1;
+        c_0 = tmp_0;
+        if (c_0 >= 8w4) 
+            return true;
+        else {
+            this.setTx(index, c_0);
+            return false;
+        }
+    }
+};

--- a/testdata/p4_16_samples_outputs/bfd_offload.p4
+++ b/testdata/p4_16_samples_outputs/bfd_offload.p4
@@ -1,0 +1,37 @@
+extern BFD_Offload {
+    BFD_Offload(bit<16> size);
+    void setTx(in bit<16> index, in bit<8> data);
+    bit<8> getTx(in bit<16> index);
+    abstract void on_rx(in bit<16> index);
+    abstract bool on_tx(in bit<16> index);
+}
+
+BFD_Offload(32768) bfd_session_liveness_tracker = {
+    void on_rx(in bit<16> index) {
+        this.setTx(index, 0);
+    }
+    bool on_tx(in bit<16> index) {
+        bit<8> c = this.getTx(index) + 1;
+        if (c >= 4) {
+            return true;
+        }
+        else {
+            this.setTx(index, c);
+            return false;
+        }
+    }
+};
+control for_rx_bfd_packets() {
+    apply {
+        bit<16> index;
+        bfd_session_liveness_tracker.on_rx(index);
+    }
+}
+
+control for_tx_bfd_packets() {
+    apply {
+        bit<16> index;
+        bfd_session_liveness_tracker.on_tx(index);
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/bfd_offload.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bfd_offload.p4-stderr
@@ -1,0 +1,4 @@
+../testdata/p4_16_samples/bfd_offload.p4(29): warning: bfd_session_liveness_tracker: unused instance
+BFD_Offload(32768) bfd_session_liveness_tracker = {
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+warning: Program does not contain a `main' module


### PR DESCRIPTION
- BlockStatements in the initializers of Delcaration_Instances, whicha re not under controls or actions.