### PR TITLE
Strip leading dot from control plane names in p4RuntimeSerializer

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -64,6 +64,32 @@ static bool isMetadataType(const IR::Type* type) {
     return metadataAnnotation != nullptr;
 }
 
+static cstring controlPlaneName(const cstring& name) {
+    // A leading '.' in a symbol name indicates that the name is absolute -
+    // in other words, that it's a top-level name. That information isn't
+    // relevant to the control plane, which only cares about the final name,
+    // so we strip the dot off here.
+    return name.startsWith(".") ? name.substr(1) : name;
+}
+
+/// @return a version of @node's external name which has been sanitized for
+/// exposure to the control plane.
+template <typename Node>
+static cstring controlPlaneName(const Node node) {
+    return controlPlaneName(node->externalName());
+}
+
+
+/// @return a version of @name which has been sanitized for exposure to the
+/// control plane.
+template<> cstring controlPlaneName(const cstring& name) {
+    // A leading '.' in a symbol name indicates that the name is absolute -
+    // in other words, that it's a top-level name. That information isn't
+    // relevant to the control plane, which only cares about the final name,
+    // so we strip the dot off here.
+    return name.startsWith(".") ? name.substr(1) : name;
+}
+
 /**
  * A path through a sequence of P4 data structures (headers, header stacks,
  * structs, etc.). This is used to represent fully-qualified external names for
@@ -93,7 +119,7 @@ struct HeaderFieldPath {
             // Unlike other top-level structs, top-level metadata structs are
             // fully exposed to P4Runtime and show up in P4Runtime field names.
             if (isMetadataType(type) && type->is<IR::Type_Declaration>()) {
-                auto name = type->to<IR::Type_Declaration>()->externalName();
+                auto name = controlPlaneName(type->to<IR::Type_Declaration>());
                 return HeaderFieldPath::root(name, type);
             }
 
@@ -106,7 +132,7 @@ struct HeaderFieldPath {
             // This is a top-level header or a non-structlike value.
             auto declaration =
                 refMap->getDeclaration(expression->to<IR::PathExpression>()->path);
-            return HeaderFieldPath::root(declaration->externalName(), type);
+            return HeaderFieldPath::root(controlPlaneName(declaration), type);
         } else if (expression->is<IR::Member>()) {
             auto memberExpression = expression->to<IR::Member>();
             auto parent = memberExpression->expr;
@@ -122,7 +148,7 @@ struct HeaderFieldPath {
             boost::optional<cstring> name;
             for (auto field : *parentType->to<IR::Type_StructLike>()->fields) {
                 if (field->name == memberExpression->member) {
-                    name = field->externalName();
+                    name = controlPlaneName(field);
                     break;
                 }
             }
@@ -319,7 +345,7 @@ struct Counterlike {
             return boost::none;
         }
 
-        return Counterlike<Kind>{declaration->externalName(),
+        return Counterlike<Kind>{controlPlaneName(declaration),
                                  declaration->to<IR::IAnnotated>(),
                                  unit->to<IR::Declaration_ID>()->name,
                                  size->to<IR::Constant>()->value.get_si(),
@@ -356,7 +382,7 @@ struct Counterlike {
         auto unit = unitArgument->to<IR::Member>()->member.name;
         return Counterlike<Kind>{*instance.name, instance.annotations,
                                  unit, getTableSize(table),
-                                 table->externalName()};
+                                 controlPlaneName(table)};
     }
 };
 
@@ -550,7 +576,7 @@ public:
     /// Add a @type symbol, extracting the name and id from @declaration.
     void add(P4RuntimeSymbolType type, const IR::IDeclaration* declaration) {
         CHECK_NULL(declaration);
-        add(type, declaration->externalName(), externalId(declaration));
+        add(type, controlPlaneName(declaration), externalId(declaration));
     }
 
     /// Add a @type symbol with @name and possibly an explicit P4 '@id'.
@@ -568,7 +594,7 @@ public:
     /// @return the P4Runtime id for the symbol of @type corresponding to @declaration.
     pi_p4_id_t getId(P4RuntimeSymbolType type, const IR::IDeclaration* declaration) const {
         CHECK_NULL(declaration);
-        return getId(type, declaration->externalName());
+        return getId(type, controlPlaneName(declaration));
     }
 
     /// @return the P4Runtime id for the symbol of @type with name @name.
@@ -847,7 +873,7 @@ public:
     }
 
     void addAction(const IR::P4Action* actionDeclaration) {
-        auto name = actionDeclaration->externalName();
+        auto name = controlPlaneName(actionDeclaration);
         auto id = symbols.getId(P4RuntimeSymbolType::ACTION, name);
         auto annotations = actionDeclaration->to<IR::IAnnotated>();
 
@@ -881,7 +907,7 @@ public:
         size_t index = 0;
         for (auto actionParam : *actionDeclaration->parameters->getEnumerator()) {
             auto param = action->add_params();
-            auto paramName = actionParam->externalName();
+            auto paramName = controlPlaneName(actionParam);
             param->set_id(index++);
             param->set_name(paramName);
 
@@ -910,7 +936,7 @@ public:
                   const std::vector<cstring>& actions,
                   const std::vector<MatchField>& matchFields,
                   bool supportsTimeout) {
-        auto name = tableDeclaration->externalName();
+        auto name = controlPlaneName(tableDeclaration);
         auto annotations = tableDeclaration->to<IR::IAnnotated>();
 
         auto table = p4Info->add_tables();
@@ -1107,16 +1133,16 @@ getExternInstanceFromProperty(const IR::P4Table* table,
     if (property == nullptr) return boost::none;
     if (!property->value->is<IR::ExpressionValue>()) {
         ::error("Expected %1% property value for table %2% to be an expression: %3%",
-                propertyName, table->externalName(), property);
+                propertyName, controlPlaneName(table), property);
         return boost::none;
     }
 
     auto expr = property->value->to<IR::ExpressionValue>()->expression;
-    auto name = property->externalName();
+    auto name = controlPlaneName(property);
     auto externInstance = ExternInstance::resolve(expr, refMap, typeMap, name);
     if (!externInstance) {
         ::error("Expected %1% property value for table %2% to resolve to an "
-                "extern instance: %3%", propertyName, table->externalName(),
+                "extern instance: %3%", propertyName, controlPlaneName(table),
                 property);
         return boost::none;
     }
@@ -1152,7 +1178,7 @@ static void collectTableSymbols(P4RuntimeSymbolTable& symbols,
                                                 .tableAttributes
                                                 .tableImplementation.name);
     if (impl) {
-        symbols.add(P4RuntimeSymbolType::ACTION_PROFILE, impl->externalName());
+        symbols.add(P4RuntimeSymbolType::ACTION_PROFILE, controlPlaneName(impl));
     }
 
     auto directCounter = getDirectCounterlike<IR::Counter>(table, refMap, typeMap);
@@ -1243,18 +1269,18 @@ getMatchFields(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMap)
                                                         .tableImplementation.name);
             BUG_CHECK(impl != nullptr, "Table '%1%' has match type 'selector' "
                                        "but no implementation property",
-                      table->externalName());
+                      controlPlaneName(table));
             continue;
         } else {
             ::error("Table '%1%': cannot represent match type '%2%' in P4Runtime",
-                    table->externalName(), matchTypeName);
+                    controlPlaneName(table), matchTypeName);
             break;
         }
 
         HeaderFieldPath* path = HeaderFieldPath::from(expr, refMap, typeMap);
         if (!path) {
             ::error("Table '%1%': Match field '%2%' is too complicated "
-                    "to represent in P4Runtime", table->externalName(), expr);
+                    "to represent in P4Runtime", controlPlaneName(table), expr);
             break;
         }
 
@@ -1272,7 +1298,7 @@ getMatchFields(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMap)
         // to decide how it makes sense to present something like that in P4Runtime.
         if (!path->parent) {
             ::error("Table '%1%': Match field '%2%' references a local",
-                    table->externalName(), expr);
+                    controlPlaneName(table), expr);
             break;
         }
 
@@ -1300,15 +1326,15 @@ getDefaultAction(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMa
     if (expr->is<IR::PathExpression>()) {
         auto decl = refMap->getDeclaration(expr->to<IR::PathExpression>()->path, true);
         BUG_CHECK(decl->is<IR::P4Action>(), "Expected an action: %1%", expr);
-        actionName = decl->to<IR::P4Action>()->externalName();
+        actionName = controlPlaneName(decl->to<IR::P4Action>());
     } else if (expr->is<IR::MethodCallExpression>()) {
         auto callExpr = expr->to<IR::MethodCallExpression>();
         auto instance = P4::MethodInstance::resolve(callExpr, refMap, typeMap);
         BUG_CHECK(instance->is<P4::ActionCall>(), "Expected an action: %1%", expr);
-        actionName = instance->to<P4::ActionCall>()->action->externalName();
+        actionName = controlPlaneName(instance->to<P4::ActionCall>()->action);
     } else {
         ::error("Unexpected expression in default action for table %1%: %2%",
-                table->externalName(), expr);
+                controlPlaneName(table), expr);
         return boost::none;
     }
 
@@ -1353,14 +1379,14 @@ static void serializeTable(P4RuntimeSerializer& serializer,
     for (auto action : *table->getActionList()->actionList) {
         auto decl = refMap->getDeclaration(action->getPath(), true);
         BUG_CHECK(decl->is<IR::P4Action>(), "Not an action: '%1%'", decl);
-        actions.push_back(decl->to<IR::P4Action>()->externalName());
+        actions.push_back(controlPlaneName(decl->to<IR::P4Action>()));
     }
 
     auto impl = table->properties->getProperty(P4V1::V1Model::instance
                                                 .tableAttributes
                                                 .tableImplementation.name);
     boost::optional<cstring> implementation;
-    if (impl) implementation = impl->externalName();
+    if (impl) implementation = controlPlaneName(impl);
 
     auto directCounter = getDirectCounterlike<IR::Counter>(table, refMap, typeMap);
     auto directMeter = getDirectCounterlike<IR::Meter>(table, refMap, typeMap);
@@ -1418,7 +1444,7 @@ getActionProfile(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMa
         sizeExpression = instance->arguments->at(0);
     } else {
         ::error("Table '%1%' has an implementation which doesn't resolve to an "
-                "action profile: %2%", table->externalName(), instance->expression);
+                "action profile: %2%", controlPlaneName(table), instance->expression);
         return boost::none;
     }
 
@@ -1445,7 +1471,7 @@ static void serializeActionProfiles(P4RuntimeSerializer& serializer,
         auto table = block->to<IR::TableBlock>()->container;
         auto actionProfile = getActionProfile(table, refMap, typeMap);
         if (actionProfile) {
-          actionProfiles[*actionProfile].insert(table->externalName());
+          actionProfiles[*actionProfile].insert(controlPlaneName(table));
         }
     });
 


### PR DESCRIPTION
As discussed in #395, this patch removes leading dots from control plane names in the P4Runtime serializer.

Although currently special behavior for leading dots in `@name` is only implemented for actions, I've gone ahead and implemented this feature for all object types. (Doing otherwise seems a bit error-prone.)