### PR TITLE
Enable warnings globally

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,11 +13,16 @@
 # limitations under the License.
 
 ACLOCAL_AMFLAGS = -I m4
-AM_CFLAGS = -Wall -Wextra -Wno-overloaded-virtual -Wno-deprecated
+WARNING_FLAGS = -Wall \
+		-Wextra \
+		-Wno-overloaded-virtual \
+		-Wno-deprecated \
+		$(EXTRA_WARNING_FLAGS)
+AM_CFLAGS = $(WARNING_FLAGS)
+AM_CXXFLAGS = $(WARNING_FLAGS)
 AM_CPPFLAGS = -I$(srcdir)/frontends \
 	      -I$(srcdir)/backends \
 	      -I$(srcdir)/extensions
-
 AM_YFLAGS = -v
 
 TOOLSDIR=$(srcdir)/tools

--- a/configure.ac
+++ b/configure.ac
@@ -62,9 +62,11 @@ AC_COMPILE_IFELSE(
 [CLANG=yes], [CLANG=no])
 AC_MSG_RESULT([$CLANG])
 
+EXTRA_WARNING_FLAGS=""
 if test "x$CLANG" = "xyes"; then
-   CXXFLAGS="$CXXFLAGS -Wno-deprecated-register -Wuninitialized -Wsometimes-uninitialized"
+  EXTRA_WARNING_FLAGS="-Wno-deprecated-register -Wuninitialized -Wsometimes-uninitialized"
 fi
+AC_SUBST([EXTRA_WARNING_FLAGS])
 
 PKG_CHECK_MODULES([PROTOBUF], [protobuf >= 3.0.0])
 AC_SUBST([PROTOBUF_CFLAGS])

--- a/control-plane/Makefile.am
+++ b/control-plane/Makefile.am
@@ -55,4 +55,4 @@ noinst_HEADERS += \
 # fixed in v.3.1, but unfortunately there are p4c extensions which use Google's
 # or-tools library, and there is no release of or-tools which is compatible with
 # protoc v.3.1 at this time.
-libcontrolplane_la_CFLAGS = -Wno-unused-parameters $(AM_CFLAGS)
+libcontrolplane_la_CXXFLAGS = $(AM_CXXFLAGS) -Wno-unused-parameter


### PR DESCRIPTION
Some snafus in our build system have resulted in warnings not being enabled for much of the codebase. This PR fixes this.

I'd love to enable `-Werror` for at least some classes of warnings, but there are currently too many warnings in the codebase to do that. We can work to fix them, and then enable `-Werror` to ensure more don't show up.