### PR TITLE
Handle list literals in IR::Cast case in constantFolding.cpp

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -633,7 +633,7 @@ const IR::Node *DoConstantFolding::postorder(IR::Cast *e) {
             auto result = new IR::Constant(e->srcInfo, type, v, 10);
             setConstant(e, result);
             return result;
-	} else {
+	} else { /* expr is a list literal */
 	  return e;
 	}
     } else if (etype->is<IR::Type_StructLike>()) {

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -151,7 +151,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Neg* e) {
     }
 
     mpz_class value = -cst->value;
-    auto result = new IR::Constant(cst->srcInfo, t, value, cst->base, true); //don't warn about overflow
+    auto result = new IR::Constant(cst->srcInfo, t, value, cst->base, true);
     setConstant(e, result);
     return result;
 }
@@ -633,9 +633,9 @@ const IR::Node *DoConstantFolding::postorder(IR::Cast *e) {
             auto result = new IR::Constant(e->srcInfo, type, v, 10);
             setConstant(e, result);
             return result;
-	} else { /* expr is a list literal */
-	  return e;
-	}
+        } else { /* expr is a list literal */
+            return e;
+        }
     } else if (etype->is<IR::Type_StructLike>()) {
         auto result = expr->clone();
         auto origtype = typeMap->getType(getOriginal());

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -151,7 +151,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Neg* e) {
     }
 
     mpz_class value = -cst->value;
-    auto result = new IR::Constant(cst->srcInfo, t, value, cst->base, true);
+    auto result = new IR::Constant(cst->srcInfo, t, value, cst->base, true); //don't warn about overflow
     setConstant(e, result);
     return result;
 }
@@ -627,14 +627,15 @@ const IR::Node *DoConstantFolding::postorder(IR::Cast *e) {
             auto result = cast(arg, arg->base, type);
             setConstant(e, result);
             return result;
-        } else {
-            BUG_CHECK(expr->is<IR::BoolLiteral>(), "%1%: expected a boolean literal", expr);
+        } else if (expr -> is<IR::BoolLiteral>()) {
             auto arg = expr->to<IR::BoolLiteral>();
             int v = arg->value ? 1 : 0;
             auto result = new IR::Constant(e->srcInfo, type, v, 10);
             setConstant(e, result);
             return result;
-        }
+	  } else {
+	    return e;
+	  }
     } else if (etype->is<IR::Type_StructLike>()) {
         auto result = expr->clone();
         auto origtype = typeMap->getType(getOriginal());

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -633,9 +633,9 @@ const IR::Node *DoConstantFolding::postorder(IR::Cast *e) {
             auto result = new IR::Constant(e->srcInfo, type, v, 10);
             setConstant(e, result);
             return result;
-	  } else {
-	    return e;
-	  }
+	} else {
+	  return e;
+	}
     } else if (etype->is<IR::Type_StructLike>()) {
         auto result = expr->clone();
         auto origtype = typeMap->getType(getOriginal());

--- a/testdata/p4_16_errors/issue401.p4
+++ b/testdata/p4_16_errors/issue401.p4
@@ -1,0 +1,51 @@
+#include <v1model.p4>
+
+header h_t {
+  bit<8> f;
+}
+
+struct my_packet {
+  h_t h;
+}
+
+struct my_metadata {
+
+}
+
+parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+  state start {
+    transition accept;
+  }
+}
+
+control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+  apply { }
+}
+
+control MyIngress(inout my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+  apply { 
+    bit<1> b = (bit<1>) { 0 };
+  }
+}
+
+control MyEgress(inout my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+  apply { }
+}
+
+control MyComputeChecksum(inout my_packet p, inout my_metadata m) {
+  apply { }
+}
+
+control MyDeparser(packet_out b, in my_packet p) {
+  apply { }
+}
+
+/* Instantiate */
+MyParser() p;
+MyVerifyChecksum() vck;
+MyIngress() i;
+MyEgress() e;
+MyComputeChecksum() cck;
+MyDeparser() dp;
+
+V1Switch(p, vck, i, e, cck, dp) main;

--- a/testdata/p4_16_errors_outputs/issue401.p4
+++ b/testdata/p4_16_errors_outputs/issue401.p4
@@ -1,0 +1,53 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header h_t {
+    bit<8> f;
+}
+
+struct my_packet {
+    h_t h;
+}
+
+struct my_metadata {
+}
+
+parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+    apply {
+        bit<1> b = (bit<1>){ 0 };
+    }
+}
+
+control MyEgress(inout my_packet p, inout my_metadata m, inout standard_metadata_t s) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout my_packet p, inout my_metadata m) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out b, in my_packet p) {
+    apply {
+    }
+}
+
+MyParser() p;
+MyVerifyChecksum() vck;
+MyIngress() i;
+MyEgress() e;
+MyComputeChecksum() cck;
+MyDeparser() dp;
+V1Switch(p, vck, i, e, cck, dp) main;

--- a/testdata/p4_16_errors_outputs/issue401.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue401.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_errors/issue-401.p4(27): error: cast: Cannot unify Tuple(1) to bit<1>
+../testdata/p4_16_errors/issue401.p4(27): error: cast: Cannot unify Tuple(1) to bit<1>
     bit<1> b = (bit<1>) { 0 };
                ^^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue-401.p4(27): error: cast: Illegal cast from Tuple(1) to bit<1>
+../testdata/p4_16_errors/issue401.p4(27): error: cast: Illegal cast from Tuple(1) to bit<1>
     bit<1> b = (bit<1>) { 0 };
                ^^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue-401.p4(27)
+../testdata/p4_16_errors/issue401.p4(27)
     bit<1> b = (bit<1>) { 0 };
                         ^^^^^

--- a/testdata/p4_16_errors_outputs/issue401.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue401.p4-stderr
@@ -1,0 +1,9 @@
+../testdata/p4_16_errors/issue-401.p4(27): error: cast: Cannot unify Tuple(1) to bit<1>
+    bit<1> b = (bit<1>) { 0 };
+               ^^^^^^^^^^^^^^
+../testdata/p4_16_errors/issue-401.p4(27): error: cast: Illegal cast from Tuple(1) to bit<1>
+    bit<1> b = (bit<1>) { 0 };
+               ^^^^^^^^^^^^^^
+../testdata/p4_16_errors/issue-401.p4(27)
+    bit<1> b = (bit<1>) { 0 };
+                        ^^^^^


### PR DESCRIPTION
The IR::Cast case had a bug where it assumed that a constant was either a boolean or numeric literal. This pull request adds an extra case to handle list literals.

Fixes #401.