### PR TITLE
Fix all warnings reported by clang-800.0.42.1

### DIFF
--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -160,7 +160,6 @@ class SharedActionSelectorCheck : public Inspector {
             ::error("%1%: expected a reference to an instance", pathe);
             return false;
         }
-        const auto &apname = decl->externalName();
         auto dcltype = typeMap->getType(pathe, true);
         if (!dcltype->is<IR::Type_Extern>()) {
             ::error("%1%: unexpected type for implementation", dcltype);
@@ -2087,7 +2086,7 @@ void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
     scalarsStruct->emplace("name", scalarsName);
     scalarsStruct->emplace("id", nextId("header_types"));
     scalars_width = 0;
-    auto scalarFields = mkArrayField(scalarsStruct, "fields");
+    mkArrayField(scalarsStruct, "fields");
 
     headerTypesCreated.clear();
     addTypesAndInstances(ht, false);

--- a/backends/bmv2/lower.h
+++ b/backends/bmv2/lower.h
@@ -25,16 +25,14 @@ namespace BMV2 {
 
 // Convert expressions not supported on BMv2
 class LowerExpressions : public Transform {
-    P4::ReferenceMap* refMap;
     P4::TypeMap* typeMap;
     // Cannot shift with a value larger than 8 bits
     const int maxShiftWidth = 8;
 
     const IR::Expression* shift(const IR::Operation_Binary* expression) const;
  public:
-    LowerExpressions(P4::ReferenceMap* refMap, P4::TypeMap* typeMap) :
-            refMap(refMap), typeMap(typeMap)
-    { CHECK_NULL(refMap); CHECK_NULL(typeMap); setName("LowerExpressions"); }
+    explicit LowerExpressions(P4::TypeMap* typeMap) : typeMap(typeMap)
+    { CHECK_NULL(typeMap); setName("LowerExpressions"); }
 
     const IR::Node* postorder(IR::Expression* expression) override;
     const IR::Node* postorder(IR::Shl* expression) override

--- a/backends/bmv2/midend.cpp
+++ b/backends/bmv2/midend.cpp
@@ -178,7 +178,7 @@ MidEnd::MidEnd(CompilerOptions& options) {
         new P4::SimplifyControlFlow(&refMap, &typeMap),
         new P4::RemoveLeftSlices(&refMap, &typeMap),
         new P4::TypeChecking(&refMap, &typeMap),
-        new LowerExpressions(&refMap, &typeMap),
+        new LowerExpressions(&typeMap),
         new P4::ConstantFolding(&refMap, &typeMap, false),
         new P4::TypeChecking(&refMap, &typeMap),
         new RemoveExpressionsFromSelects(&refMap, &typeMap),

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -33,7 +33,7 @@ class EBPFType : public EBPFObject {
     virtual void emit(CodeBuilder* builder) = 0;
     virtual void declare(CodeBuilder* builder, cstring id, bool asPointer) = 0;
     virtual void emitInitializer(CodeBuilder* builder) = 0;
-    virtual void declareArray(CodeBuilder* builder, const char* /*id*/, unsigned /*size*/)
+    virtual void declareArray(CodeBuilder* /*builder*/, const char* /*id*/, unsigned /*size*/)
     { BUG("Arrays of %1% not supported", type); }
     template<typename T> bool is() const { return dynamic_cast<const T*>(this) != nullptr; }
     template<typename T> T *to() { return dynamic_cast<T*>(this); }
@@ -115,7 +115,7 @@ class EBPFStructType : public EBPFType, public IHasWidth {
         const IR::StructField* field;
 
         EBPFField(EBPFType* type, const IR::StructField* field, cstring comment = nullptr) :
-                type(type), field(field), comment(comment) {}
+            comment(comment), type(type), field(field) {}
     };
 
  public:

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -95,7 +95,7 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                    [this](const char* arg) { p4RuntimeFile = arg; return true; },
                    "Write a P4Runtime control plane API description to the specified file.");
     registerOption("--p4runtime-as-json", nullptr,
-                   [this](const char* arg) { p4RuntimeAsJson = true; return true; },
+                   [this](const char*) { p4RuntimeAsJson = true; return true; },
                    "Write out the P4Runtime API description as human-readable JSON.");
     registerOption("-o", "outfile",
                    [this](const char* arg) { outputFile = arg; return true; },

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -71,7 +71,7 @@ class BaseLocation : public StorageLocation {
                 || type-is<IR::Type_Error>() || type->is<IR::Type_Var>(),
                 "%1%: unexpected type", type); }
     void addValidBits(LocationSet*) const override {}
-    void addLastIndexField(LocationSet* result) const override {}
+    void addLastIndexField(LocationSet*) const override {}
     void removeHeaders(LocationSet* result) const override;
 };
 

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -485,7 +485,6 @@ class ComputeCallGraph : public Inspector {
         }
     }
     void postorder(const IR::GlobalRef *gref) override {
-        const Context *ctxt = nullptr;
         cstring caller;
         if (auto af = findContext<IR::ActionFunction>()) {
             caller = af->name;

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -98,8 +98,8 @@ struct ActionProfile_Model : public ::Model::Extern_Model {
 struct ActionSelector_Model : public ::Model::Extern_Model {
     ActionSelector_Model() : Extern_Model("action_selector"),
                              sizeType(IR::Type_Bits::get(32)), sizeParam("size"),
-                             algorithmParam("algorithm"),
-                             widthType(IR::Type_Bits::get(32)) {}
+                             widthType(IR::Type_Bits::get(32)),
+                             algorithmParam("algorithm") {}
     const IR::Type* sizeType;
     ::Model::Elem sizeParam;
     const IR::Type* widthType;

--- a/lib/crash.cpp
+++ b/lib/crash.cpp
@@ -201,6 +201,8 @@ static void crash_shutdown(int sig, siginfo_t *info, void *uctxt) {
         LOG1("  address = " << hex(info->si_addr));
 #if HAVE_UCONTEXT_H
     dumpregs(&(static_cast<ucontext_t *>(uctxt)->uc_mcontext));
+#else
+    (void) uctxt;  // Suppress unused parameter warning.
 #endif
 #if HAVE_EXECINFO_H
     if (LOGGING(1)) {

--- a/midend/simplifySelectList.h
+++ b/midend/simplifySelectList.h
@@ -50,7 +50,6 @@ class SubstituteStructures : public Transform {
 //     (0, 0, default, default): accept;
 // }
 class UnnestSelectList : public Transform {
-    TypeMap* typeMap;
     // Represent the nesting of lists inside of a selectExpression.
     // E.g.: [__[__]_] for two nested lists.
     cstring nesting;
@@ -59,8 +58,7 @@ class UnnestSelectList : public Transform {
     void flatten(const IR::Expression* expression, unsigned* nestingIndex,
                  IR::Vector<IR::Expression> *output);
  public:
-    explicit UnnestSelectList(TypeMap* typeMap) : typeMap(typeMap)
-    { CHECK_NULL(typeMap); setName("UnnestSelectList"); }
+    UnnestSelectList() { setName("UnnestSelectList"); }
 
     const IR::Node* preorder(IR::SelectExpression* expression) override;
     const IR::Node* preorder(IR::P4Control* control) override
@@ -73,7 +71,7 @@ class SimplifySelectList : public PassManager {
         passes.push_back(new TypeChecking(refMap, typeMap));
         passes.push_back(new SubstituteStructures(typeMap));
         passes.push_back(new TypeChecking(refMap, typeMap));
-        passes.push_back(new UnnestSelectList(typeMap));
+        passes.push_back(new UnnestSelectList);
         setName("SimplifySelectList");
     }
 };


### PR DESCRIPTION
This PR fixes all warnings reported on master by clang. (Including one which was introduced by me just today, doh!) There may still be some GCC-only warnings remaining, but this moves us closer to where we want to be.