### PR TITLE
Fix slice generation for table keys in P4_14->16 conversion

### DIFF
--- a/backends/bmv2/Makefile.am
+++ b/backends/bmv2/Makefile.am
@@ -48,7 +48,3 @@ bmv2tests.mk: $(GENTESTS) $(srcdir)/%reldir%/Makefile.am \
 	      $(srcdir)/testdata/p4_14_samples/switch_*/switch.p4 \
 	      $(srcdir)/testdata/p4_16_samples $(srcdir)/testdata/p4_14_samples
 	@$(GENTESTS) $(srcdir) bmv2 $(srcdir)/backends/bmv2/run-bmv2-test.py $^ >$@
-
-
-#issue #404
-XFAIL_TESTS += bmv2/testdata/p4_14_samples/exact_match_mask1.p4.test

--- a/backends/bmv2/Makefile.am
+++ b/backends/bmv2/Makefile.am
@@ -48,3 +48,7 @@ bmv2tests.mk: $(GENTESTS) $(srcdir)/%reldir%/Makefile.am \
 	      $(srcdir)/testdata/p4_14_samples/switch_*/switch.p4 \
 	      $(srcdir)/testdata/p4_16_samples $(srcdir)/testdata/p4_14_samples
 	@$(GENTESTS) $(srcdir) bmv2 $(srcdir)/backends/bmv2/run-bmv2-test.py $^ >$@
+
+
+#issue #404
+XFAIL_TESTS += bmv2/testdata/p4_14_samples/exact_match_mask1.p4.test

--- a/backends/bmv2/midend.cpp
+++ b/backends/bmv2/midend.cpp
@@ -150,7 +150,7 @@ MidEnd::MidEnd(CompilerOptions& options) {
         new P4::SimplifyControlFlow(&refMap, &typeMap),
         new P4::RemoveActionParameters(&refMap, &typeMap),
         new P4::SimplifyKey(&refMap, &typeMap,
-                            new P4::NonLeftValue(&refMap, &typeMap)),
+                            new P4::NonMaskLeftValue(&refMap, &typeMap)),
         new P4::ConstantFolding(&refMap, &typeMap),
         new P4::StrengthReduction(),
         new P4::SimplifySelectCases(&refMap, &typeMap, true),  // require constant keysets

--- a/backends/p4test/Makefile.am
+++ b/backends/p4test/Makefile.am
@@ -52,3 +52,6 @@ p14_to_16tests.mk: $(GENTESTS) $(srcdir)/%reldir%/Makefile.am \
 # This is issue #13
 XFAIL_TESTS += \
     p4/testdata/p4_16_samples/cast-call.p4.test
+
+#issue #404
+XFAIL_TESTS += p14_to_16/testdata/p4_14_samples/exact_match_mask1.p4.test

--- a/backends/p4test/Makefile.am
+++ b/backends/p4test/Makefile.am
@@ -52,6 +52,3 @@ p14_to_16tests.mk: $(GENTESTS) $(srcdir)/%reldir%/Makefile.am \
 # This is issue #13
 XFAIL_TESTS += \
     p4/testdata/p4_16_samples/cast-call.p4.test
-
-#issue #404
-XFAIL_TESTS += p14_to_16/testdata/p4_14_samples/exact_match_mask1.p4.test

--- a/frontends/p4/tableKeyNames.cpp
+++ b/frontends/p4/tableKeyNames.cpp
@@ -57,6 +57,17 @@ class KeyNameGenerator : public Inspector {
         name.emplace(expression, l + "[" + r + "]");
     }
 
+    void postorder(const IR::BAnd *expression) override {
+        if (expression->right->is<IR::Constant>()) {
+            if (cstring l = getName(expression->left))
+                name.emplace(expression, l);
+        } else if (expression->left->is<IR::Constant>()) {
+            if (cstring r = getName(expression->right))
+                name.emplace(expression, r);
+        } else {
+            error(expression); }
+    }
+
     void postorder(const IR::Constant* expression) override {
         name.emplace(expression, expression->toString());
     }

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -248,11 +248,15 @@ class ArrayIndex : Operation_Binary {
 class Range : Operation_Binary {
     stringOp = "..";
     precedence = DBPrint::Prec_Low;
+    Range { if (left && type == left->type && !left->type->is<Type::Unknown>())
+                type = new Type_Set(left->type); }
 }
 
 class Mask : Operation_Binary {
     stringOp = "&&&";
     precedence = DBPrint::Prec_Low;
+    Mask { if (left && type == left->type && !left->type->is<Type::Unknown>())
+                type = new Type_Set(left->type); }
 }
 
 class Mux : Operation_Ternary {

--- a/midend/simplifyKey.h
+++ b/midend/simplifyKey.h
@@ -42,6 +42,19 @@ class NonLeftValue : public KeyIsComplex {
     bool isTooComplex(const IR::Expression* expression) const;
 };
 
+// Policy that allows masked lvalues as well as simple lvalues or isValid()
+class NonMaskLeftValue : public NonLeftValue {
+ public:
+    NonMaskLeftValue(ReferenceMap* refMap, TypeMap* typeMap) : NonLeftValue(refMap, typeMap) {}
+    bool isTooComplex(const IR::Expression* expression) const {
+        if (auto mask = expression->to<IR::BAnd>()) {
+            if (mask->right->is<IR::Constant>())
+                expression = mask->left;
+            else if (mask->left->is<IR::Constant>())
+                expression = mask->right; }
+        return NonLeftValue::isTooComplex(expression); }
+};
+
 class TableInsertions {
  public:
     std::vector<const IR::Declaration_Variable*> declarations;

--- a/testdata/p4_14_samples/exact_match_mask1.p4
+++ b/testdata/p4_14_samples/exact_match_mask1.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/testdata/p4_14_samples/exact_match_mask1.p4
+++ b/testdata/p4_14_samples/exact_match_mask1.p4
@@ -1,0 +1,51 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc. 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+header_type data_t {
+    fields {
+        f1 : 32;
+        f2 : 32;
+        h1 : 16;
+        b1 : 8;
+        b2 : 8;
+    }
+}
+header data_t data;
+
+parser start {
+    extract(data);
+    return ingress;
+}
+
+action noop() { }
+action setb1(val, port) {
+    modify_field(data.b1, val);
+    modify_field(standard_metadata.egress_spec, port);
+}
+
+table test1 {
+    reads {
+        data.f1 mask 0xff00ff : exact;
+    }
+    actions {
+        setb1;
+        noop;
+    }
+}
+
+control ingress {
+    apply(test1);
+}

--- a/testdata/p4_14_samples/exact_match_mask1.stf
+++ b/testdata/p4_14_samples/exact_match_mask1.stf
@@ -1,0 +1,8 @@
+
+add test1 data.f1:0x010001 setb1(val:0x7f, port:2)
+add test1 data.f1:0x020002 setb1(val:7, port:3)
+
+expect 2 01010101 ******** **** 7f 66
+packet 0 01010101 00000202 0303 55 66 77 88
+expect 3 02020202 ******** **** 07 66
+packet 2 02020202 00000303 0404 55 66 77 88

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-first.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header data_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<16> h1;
+    bit<8>  b1;
+    bit<8>  b2;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name("data") 
+    data_t data;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("start") state start {
+        packet.extract<data_t>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("setb1") action setb1(bit<8> val, bit<9> port) {
+        hdr.data.b1 = val;
+        standard_metadata.egress_spec = port;
+    }
+    @name("noop") action noop() {
+    }
+    @name("test1") table test1 {
+        actions = {
+            setb1();
+            noop();
+            @default_only NoAction();
+        }
+        key = {
+            hdr.data.f1 & 32w0xff00ff: exact @name("hdr.data.f1") ;
+        }
+        default_action = NoAction();
+    }
+    apply {
+        test1.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<data_t>(hdr.data);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-frontend.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header data_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<16> h1;
+    bit<8>  b1;
+    bit<8>  b2;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name("data") 
+    data_t data;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("start") state start {
+        packet.extract<data_t>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("setb1") action setb1_0(bit<8> val, bit<9> port) {
+        hdr.data.b1 = val;
+        standard_metadata.egress_spec = port;
+    }
+    @name("noop") action noop_0() {
+    }
+    @name("test1") table test1_0 {
+        actions = {
+            setb1_0();
+            noop_0();
+            @default_only NoAction();
+        }
+        key = {
+            hdr.data.f1 & 32w0xff00ff: exact @name("hdr.data.f1") ;
+        }
+        default_action = NoAction();
+    }
+    apply {
+        test1_0.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<data_t>(hdr.data);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/exact_match_mask1.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header data_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<16> h1;
+    bit<8>  b1;
+    bit<8>  b2;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name("data") 
+    data_t data;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("start") state start {
+        packet.extract(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("setb1") action setb1(bit<8> val, bit<9> port) {
+        hdr.data.b1 = val;
+        standard_metadata.egress_spec = port;
+    }
+    @name("noop") action noop() {
+    }
+    @name("test1") table test1 {
+        actions = {
+            setb1;
+            noop;
+            @default_only NoAction;
+        }
+        key = {
+            hdr.data.f1 & 32w0xff00ff: exact;
+        }
+        default_action = NoAction();
+    }
+    apply {
+        test1.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.data);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;


### PR DESCRIPTION
This fixes the P4_14->P4_16 converted to not generate completely invalid code for this case, but it still causes problems in the typechecker when the mask is disjoint.

Trying to split such disjoint masks into multiple key elements would be possible, but its not clear how the name/API should be managed for the result.  Easiest would be if P4_16 supported mask expressions in keys like P4_14 -- see issue #404

