### PR TITLE
Stop using 0 for params and match fields ids

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -892,7 +892,7 @@ public:
         // the BMV2 JSON converter does; it strips out parameters which aren't used.
         // Unless there's a good reason to do otherwise, we should probably either
         // retain the parameters or strip them out a separate compiler pass.
-        size_t index = 0;
+        size_t index = 1;
         for (auto actionParam : *actionDeclaration->parameters->getEnumerator()) {
             auto param = action->add_params();
             auto paramName = controlPlaneName(actionParam);
@@ -969,7 +969,7 @@ public:
             table->add_action_ids(id);
         }
 
-        size_t index = 0;
+        size_t index = 1;
         for (const auto& field : matchFields) {
             auto match_field = table->add_match_fields();
             match_field->set_id(index++);


### PR DESCRIPTION
It has been decided to stop using 0 in ids for action parameters and
table match fields. This is because in protobuf 3, 0 is the default
value for integers and there is an ambiguity between an id that has been
set to 0 and an id that wasn't set. Additionally this is more
consistent with the way ids used to be allocated (0 was used exclusively
as an invalid id).