### PR TITLE
handle bare @pragma line in P4_14 (convert to @pragma annotation)

### DIFF
--- a/frontends/p4-14/p4-14-lex.l
+++ b/frontends/p4-14/p4-14-lex.l
@@ -52,7 +52,9 @@ static int saveState = -1;
                   yylval.str = StringRef(yytext+7).trim();
                   BEGIN((saveState = PRAGMA_LINE));
                   return PRAGMA; }
-
+"@pragma"[ \t]* { yylval.str = "pragma";
+                  BEGIN((saveState = PRAGMA_LINE));
+                  return PRAGMA; }
 
 "action"        { yylval.str = yytext; BEGIN(saveState); return ACTION; }
 "actions"       { yylval.str = yytext; BEGIN(saveState); return ACTIONS; }


### PR DESCRIPTION
Trivial fix for a corner case -- a bare `@pragma` by itself on a line, or something like `@pragma !$#%`, which will become the annotation `@pragma("!$#%")`