### PR TITLE
Update the Dockerfile for stable, Ubuntu 16.04-based builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/.git
+**/.gitmodules
+**/.travis.yml
+**/Dockerfile
+**/*.md
+
+docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 install:
-  - docker build -t p4c .
+  - docker build -t p4c --build-arg IMAGE_TYPE=test .
 
 script:
   - docker run -w /p4c/build p4c make check VERBOSE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,5 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends $P4C_DEPS && \
     ./bootstrap.sh && \
     cd build && \
-    make
+    make && \
+    make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM p4lang/behavioral-model:latest
 MAINTAINER Seth Fowler <seth.fowler@barefootnetworks.com>
 
+# Select the type of image we're building. Use `build` for a normal build, which
+# is optimized for image size. Use `test` if this image will be used for
+# testing; in this case, the source code and build-only dependencies will not be
+# removed from the image.
+ARG IMAGE_TYPE=build
+
 ENV P4C_DEPS automake \
              bison \
              build-essential \
@@ -11,15 +17,26 @@ ENV P4C_DEPS automake \
              libgmp-dev \
              libtool \
              pkg-config \
-             python \
              python-ipaddr \
              python-scapy \
              tcpdump
+ENV P4C_RUNTIME_DEPS cpp \
+                     libgc1c2 \
+                     libgmp10 \
+                     libgmpxx4ldbl \
+                     python
 COPY . /p4c/
 WORKDIR /p4c/
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends $P4C_DEPS && \
+    apt-get install -y --no-install-recommends $P4C_DEPS $P4C_RUNTIME_DEPS && \
     ./bootstrap.sh && \
     cd build && \
     make && \
-    make install
+    make install && \
+    (test "$IMAGE_TYPE" = "build" && \
+      apt-get purge -y $P4C_DEPS && \
+      apt-get autoremove --purge -y && \
+      rm -rf /p4c /var/cache/apt/* /var/lib/apt/lists/* && \
+      echo 'Build image ready') || \
+    (test "$IMAGE_TYPE" = "test" && \
+      echo 'Test image ready')


### PR DESCRIPTION
This PR makes several changes to the Dockerfile to bring it in sync with changes made in upstream repos:

- It's now based on Ubuntu 16.04.
- It's built from the `stable` tag of `behavioral-model`.
- It supports different image variants for normal builds and testing. This lets downstream repos which don't need to run the tests use a smaller version of the image. (To support this, we need to install p4c globally in the Dockerfile, so we now run `make install`.) The approach is the same one we used in the `behavioral-model` repo.
- Just as in upstream repos, we're now excluding unneeded files via a `.dockerignore` file.