### PR TITLE
Refactor and document change tracker

### DIFF
--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -42,10 +42,9 @@ class Visitor::ChangeTracker {
         // Initialization
         visited_t::iterator visited_it;
         bool inserted;
+        bool visit_in_progress = true;
         std::tie(visited_it, inserted) =
-            visited.emplace(
-                n,
-                visit_info_t{.visit_in_progress = true, .result = n});
+            visited.emplace(n, visit_info_t{visit_in_progress, n});
 
         // Sanity check for IR loops
         bool already_present = !inserted;
@@ -78,10 +77,9 @@ class Visitor::ChangeTracker {
             orig_visit_info->result = final;
             return true;
         } else if (final != orig && *final != *orig) {
+            bool visit_in_progress = false;
             orig_visit_info->result = final;
-            visited.emplace(
-                final,
-                visit_info_t{.visit_in_progress = false, .result = final});
+            visited.emplace(final, visit_info_t{visit_in_progress, final});
             return true;
         } else {
             // FIXME -- not safe if the visitor resurrects the node (which it shouldn't)

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -74,10 +74,11 @@ class Visitor::ChangeTracker {
 
         visit_info_t *orig_visit_info = &(it->second);
         orig_visit_info->visit_in_progress = false;
-        orig_visit_info->result = final;
         if (!final) {
+            orig_visit_info->result = final;
             return true;
         } else if (final != orig && *final != *orig) {
+            orig_visit_info->result = final;
             visited.emplace(
                 final,
                 visit_info_t{.visit_in_progress = false, .result = final});

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -20,76 +20,68 @@ limitations under the License.
 
 class Visitor::ChangeTracker {
     struct visit_info_t {
-        bool visit_finished;
+        bool visit_in_progress;
         const IR::Node *result;
     };
-    // typedef unordered_map<const IR::Node *, std::pair<bool, const IR::Node *>>  visited_t;
     typedef unordered_map<const IR::Node *, visit_info_t>  visited_t;
     visited_t           visited;
 
  public:
-    struct change_t {
-        // std::pair<visited_t::iterator, bool>    state;  // result of visited.emplace
-        bool           valid;
-        bool           already_present;
-        const IR::Node *original_node;
-        visit_info_t   *visit_info;    // Points into ChangeTracker.visited.
 
-        change_t() : valid(false) {}
-        change_t(visited_t *visited, const IR::Node *n) : valid(true) {
-                // Initialization
-                visited_t::iterator visited_it;
-                bool inserted;
-                std::tie(visited_it, inserted) =
-                    visited->emplace(n, visit_info_t({false,n}));
-                already_present = !inserted;
-                original_node = visited_it->first;
-                visit_info = &(visited_it->second);
+    /* Begin tracking `n` during a visiting pass.  Use `finish` to mark `n` as
+     * visited once the pass completes.
+    */
+    void start(const IR::Node *n) {
+        // Initialization
+        visited_t::iterator visited_it;
+        bool inserted;
+        std::tie(visited_it, inserted) =
+            visited.emplace(n, visit_info_t({true,n}));
 
-                // Sanity check for IR loops
-                if (!inserted && !visit_info->visit_finished)
-                    BUG("IR loop detected "); }
-
-        explicit operator bool() { return valid; }
-        bool done() { return already_present; }
-        const IR::Node *orig() { return original_node; }
-        const IR::Node *result() { return visit_info->result; }
-    };
-
-    bool done(const IR::Node *n) const {
-        return visited.count(n) && visited.at(n).visit_finished;
+        // Sanity check for IR loops
+        bool already_present = !inserted;
+        visit_info_t *visit_info = &(visited_it->second);
+        if (already_present && visit_info->visit_in_progress)
+            BUG("IR loop detected "); 
     }
-    const IR::Node *result(IR::Node *n) const { return visited.at(n).result; }
 
-    change_t track(const IR::Node *n) { return change_t(&visited, n); }
-    void start(change_t &change) { change.visit_info->visit_finished = false; }
-    bool finish(change_t &change, const IR::Node *orig, const IR::Node *final) {
+    /* Mark `n` as finished.  `done(n)` will return true, and `result(n)` will
+     * return the resulting node, if any. */
+    bool finish(const IR::Node *orig, const IR::Node *final) {
         auto it = visited.find(orig);
-        if (!change.valid || it == visited.end() || change.original_node != it->first)
+        if (it == visited.end())
             BUG("visitor state tracker corrupted");
-        change.visit_info->visit_finished = true;
+
+        visit_info_t *visit_info = &(it->second);
+        visit_info->visit_in_progress = false;
         if (!final || *final != *orig) {
-            change.visit_info->result = final;
-            visited.emplace(final, visit_info_t({true,final}));
+            visit_info->result = final;
+            visited.emplace(final, visit_info_t({false,final}));
             return true;
         } else {
             // FIXME -- not safe if the visitor resurrects the node (which it shouldn't)
             // if (final && final->id == IR::Node::currentId - 1)
             //     --IR::Node::currentId;
             return false; } }
-    const IR::Node *result(const IR::Node *n) const {
-        auto it = visited.find(n);
-        if (it == visited.end())
-            return n;
-        if (!it->second.visit_finished)
-            BUG("IR loop detected");
-        return it->second.result; }
+
+    /* Forget nodes that have already been visited, allowing them to be visited
+     * again. */
     void revisit_visited() {
         for (auto it = visited.begin(); it != visited.end();) {
-            if (it->second.visit_finished)
+            if (!it->second.visit_in_progress)
                 it = visited.erase(it);
             else
                 ++it; } }
+
+    /* False if n has never been visited or is currently being visited.
+     * True if n has been visited and the visitor has finished. */
+    bool done(const IR::Node *n) const {
+        return visited.count(n) && !visited.at(n).visit_in_progress;
+    }
+
+    /* Fails with out_of_range exception if n has not been tracked. */
+    const IR::Node *result(const IR::Node *n) const { return visited.at(n).result; }
+
 };
 
 Visitor::profile_t Visitor::init_apply(const IR::Node *root) {
@@ -185,7 +177,9 @@ namespace {
 class ForwardChildren : public Visitor {
     const ChangeTracker &visited;
     const IR::Node *apply_visitor(const IR::Node *n, const char * = 0) {
-        return visited.result(n); }
+        if (visited.done(n))
+            return visited.result(n);
+        return n; }
  public:
     explicit ForwardChildren(const ChangeTracker &v) : visited(v) {}
 };
@@ -195,12 +189,11 @@ const IR::Node *Modifier::apply_visitor(const IR::Node *n, const char *name) {
     if (ctxt) ctxt->child_name = name;
     if (n) {
         PushContext local(ctxt, n);
-        auto track = visited->track(n);
-        if (track.done() && visitDagOnce) {
-            track.orig()->apply_visitor_revisit(*this, track.result());
-            n = track.result();
+        if (visited->done(n) && visitDagOnce) {
+            n->apply_visitor_revisit(*this, visited->result(n));
+            n = visited->result(n);
         } else {
-            visited->start(track);
+            visited->start(n);
             IR::Node *copy = n->clone();
             local.current.node = copy;
             if (visitDagOnce && !dontForwardChildrenBeforePreorder) {
@@ -209,7 +202,7 @@ const IR::Node *Modifier::apply_visitor(const IR::Node *n, const char *name) {
             if (copy->apply_visitor_preorder(*this)) {
                 copy->visit_children(*this);
                 copy->apply_visitor_postorder(*this); }
-            if (visited->finish(track, n, copy))
+            if (visited->finish(n, copy))
                 (n = copy)->validate(); } }
     if (ctxt)
         ctxt->child_index++;
@@ -247,22 +240,21 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
     if (ctxt) ctxt->child_name = name;
     if (n) {
         PushContext local(ctxt, n);
-        auto track = visited->track(n);
-        if (track.done() && visitDagOnce) {
-            track.orig()->apply_visitor_revisit(*this, track.result());
-            n = track.result();
+        if (visited->done(n) && visitDagOnce) {
+            n->apply_visitor_revisit(*this, visited->result(n));
+            n = visited->result(n);
         } else {
-            visited->start(track);
+            visited->start(n);
             auto copy = n->clone();
             local.current.node = copy;
             if (visitDagOnce && !dontForwardChildrenBeforePreorder) {
                 ForwardChildren forward_children(*visited);
                 copy->visit_children(forward_children); }
             prune_flag = false;
-            auto preorder_result = copy->apply_visitor_preorder(*this);
-            ChangeTracker::change_t preorder_result_track;
+            bool extra_clone = false;
+            const IR::Node *preorder_result = copy->apply_visitor_preorder(*this);
             assert(preorder_result != n);  // should never happen
-            auto final = preorder_result;
+            const IR::Node *final_result = preorder_result;
             if (preorder_result != copy) {
                 // FIXME -- not safe if the visitor resurrects the node (which it shouldn't)
                 // if (copy->id == IR::Node::currentId - 1)
@@ -270,21 +262,21 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
                 if (!preorder_result) {
                     prune_flag = true;
                 } else if (visited->done(preorder_result) && visitDagOnce) {
-                    final = visited->result(preorder_result);
+                    final_result = visited->result(preorder_result);
                     prune_flag = true;
                 } else {
-                    preorder_result_track = visited->track(preorder_result);
-                    visited->start(preorder_result_track);
+                    extra_clone = true;
+                    visited->start(preorder_result);
                     local.current.node = copy = preorder_result->clone(); } }
             if (!prune_flag) {
                 copy->visit_children(*this);
-                final = copy->apply_visitor_postorder(*this); }
-            if (final && final != preorder_result && *final == *preorder_result)
-                final = preorder_result;
-            if (visited->finish(track, n, final) && (n = final))
-                final->validate();
-            if (preorder_result_track)
-                visited->finish(preorder_result_track, preorder_result, final); } }
+                final_result = copy->apply_visitor_postorder(*this); }
+            if (final_result && final_result != preorder_result && *final_result == *preorder_result)
+                final_result = preorder_result;
+            if (visited->finish(n, final_result) && (n = final_result))
+                final_result->validate();
+            if (extra_clone)
+                visited->finish(preorder_result, final_result); } }
     if (ctxt)
         ctxt->child_index++;
     else

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -27,7 +27,6 @@ class Visitor::ChangeTracker {
     visited_t           visited;
 
  public:
-
     /* Begin tracking `n` during a visiting pass.  Use `finish` to mark `n` as
      * visited once the pass completes.
     */
@@ -36,13 +35,13 @@ class Visitor::ChangeTracker {
         visited_t::iterator visited_it;
         bool inserted;
         std::tie(visited_it, inserted) =
-            visited.emplace(n, visit_info_t({true,n}));
+            visited.emplace(n, visit_info_t{true, n});
 
         // Sanity check for IR loops
         bool already_present = !inserted;
         visit_info_t *visit_info = &(visited_it->second);
         if (already_present && visit_info->visit_in_progress)
-            BUG("IR loop detected "); 
+            BUG("IR loop detected ");
     }
 
     /* Mark `n` as finished.  `done(n)` will return true, and `result(n)` will
@@ -56,7 +55,7 @@ class Visitor::ChangeTracker {
         visit_info->visit_in_progress = false;
         if (!final || *final != *orig) {
             visit_info->result = final;
-            visited.emplace(final, visit_info_t({false,final}));
+            visited.emplace(final, visit_info_t{false, final});
             return true;
         } else {
             // FIXME -- not safe if the visitor resurrects the node (which it shouldn't)
@@ -81,7 +80,6 @@ class Visitor::ChangeTracker {
 
     /* Fails with out_of_range exception if n has not been tracked. */
     const IR::Node *result(const IR::Node *n) const { return visited.at(n).result; }
-
 };
 
 Visitor::profile_t Visitor::init_apply(const IR::Node *root) {
@@ -183,7 +181,7 @@ class ForwardChildren : public Visitor {
  public:
     explicit ForwardChildren(const ChangeTracker &v) : visited(v) {}
 };
-}
+}    // namespace
 
 const IR::Node *Modifier::apply_visitor(const IR::Node *n, const char *name) {
     if (ctxt) ctxt->child_name = name;
@@ -271,7 +269,9 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
             if (!prune_flag) {
                 copy->visit_children(*this);
                 final_result = copy->apply_visitor_postorder(*this); }
-            if (final_result && final_result != preorder_result && *final_result == *preorder_result)
+            if (final_result
+                && final_result != preorder_result
+                && *final_result == *preorder_result)
                 final_result = preorder_result;
             if (visited->finish(n, final_result) && (n = final_result))
                 final_result->validate();


### PR DESCRIPTION
The ChangeTracker class kept state in two ways: Internally to the ChangeTracker object, and in change_t objects returned to clients for each object being tracked.

The change_t objects mostly just pointed to the internal ChangeTracker state.  Presumably things were set up this way to allow more sophisticated visitor behavior, where the handle to the original node might be lost but could be recovered through the change_t tracker.  However, this doesn't seem to be used, and it complicates the code.

This PR removes change_t objects and replaces them with calls to the ChangeTracker object.  It also adds documentation and removes many of the "first"/"second" names that made the code hard to read.