### PR TITLE
Add support for writing P4Runtime in text format

### DIFF
--- a/backends/bmv2/bmv2.cpp
+++ b/backends/bmv2/bmv2.cpp
@@ -80,10 +80,8 @@ int main(int argc, char *const argv[]) {
     if (!options.p4RuntimeFile.isNullOrEmpty()) {
         std::ostream* out = openFile(options.p4RuntimeFile, false);
         if (out != nullptr) {
-            auto format = options.p4RuntimeAsJson ? P4::P4RuntimeFormat::JSON
-                                                  : P4::P4RuntimeFormat::BINARY;
             serializeP4Runtime(out, program, toplevel, &midEnd.refMap,
-                               &midEnd.typeMap, format);
+                               &midEnd.typeMap, options.p4RuntimeFormat);
         }
     }
 

--- a/control-plane/p4RuntimeSerializer.h
+++ b/control-plane/p4RuntimeSerializer.h
@@ -31,7 +31,8 @@ class TypeMap;
 
 enum class P4RuntimeFormat {
   BINARY,
-  JSON
+  JSON,
+  TEXT
 };
 
 void serializeP4Runtime(std::ostream* destination,

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -94,9 +94,26 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
     registerOption("--p4runtime-file", "file",
                    [this](const char* arg) { p4RuntimeFile = arg; return true; },
                    "Write a P4Runtime control plane API description to the specified file.");
+    registerOption("--p4runtime-format", "{binary,json,text}",
+                   [this](const char* arg) {
+                       if (!strcmp(arg, "binary")) {
+                           p4RuntimeFormat = P4::P4RuntimeFormat::BINARY;
+                       } else if (!strcmp(arg, "json")) {
+                           p4RuntimeFormat = P4::P4RuntimeFormat::JSON;
+                       } else if (!strcmp(arg, "text")) {
+                           p4RuntimeFormat = P4::P4RuntimeFormat::TEXT;
+                       } else {
+                           ::error("Illegal P4Runtime format %1%", arg);
+                           return false;
+                       }
+                       return true; },
+                   "Choose output format for the P4Runtime API description (default is binary).");
     registerOption("--p4runtime-as-json", nullptr,
-                   [this](const char*) { p4RuntimeAsJson = true; return true; },
-                   "Write out the P4Runtime API description as human-readable JSON.");
+                   [this](const char*) {
+                       p4RuntimeAsJson = true;
+                       p4RuntimeFormat = P4::P4RuntimeFormat::JSON;
+                       return true; },
+                   "[Deprecated] Write out the P4Runtime API description as human-readable JSON.");
     registerOption("-o", "outfile",
                    [this](const char* arg) { outputFile = arg; return true; },
                    "Write output to outfile");

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -23,6 +23,8 @@ limitations under the License.
 #include "lib/cstring.h"
 #include "lib/options.h"
 #include "ir/ir.h"  // for DebugHook definition
+// for p4::P4RuntimeFormat definition
+#include "control-plane/p4RuntimeSerializer.h"
 
 // Base class for compiler options.
 // This class contains the options for the front-ends.
@@ -74,6 +76,9 @@ class CompilerOptions : public Util::Options {
     // Write a P4Runtime control plane API description to the specified file.
     cstring p4RuntimeFile = nullptr;
 
+    // Choose format for P4Runtime API description.
+    P4::P4RuntimeFormat p4RuntimeFormat = P4::P4RuntimeFormat::BINARY;
+    // TODO: Deprecated, remove and use p4RuntimeFormat instead
     // If true, write out the P4Runtime API description as human-readable JSON.
     bool p4RuntimeAsJson = false;
 


### PR DESCRIPTION
This is an alternative to the JSON format for debugging / testing /
manual editing. Because we now support 3 formats: binary, json and text,
it made sense to update the command line options support to use a
choice-type argument instead of having a flag for each format. Therefore
this introduces '--p4runtime-format' and deprecates
'--p4runtime-as-json'.