### PR TITLE
Easily and efficiently use standard P4 headers in GTests

### DIFF
--- a/test/gtest/gtestp4c.cpp
+++ b/test/gtest/gtestp4c.cpp
@@ -15,8 +15,10 @@ limitations under the License.
 */
 
 #include "gtest/gtest.h"
+#include "helpers.h"
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(P4CTestEnvironment::get());
     return RUN_ALL_TESTS();
 }

--- a/test/gtest/gtestp4c.cpp
+++ b/test/gtest/gtestp4c.cpp
@@ -19,6 +19,9 @@ limitations under the License.
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    ::testing::AddGlobalTestEnvironment(P4CTestEnvironment::get());
+
+    // Initialize the global test environment.
+    (void) P4CTestEnvironment::get();
+
     return RUN_ALL_TESTS();
 }

--- a/test/gtest/helpers.h
+++ b/test/gtest/helpers.h
@@ -20,38 +20,62 @@ limitations under the License.
 #include <string>
 #include "gtest/gtest.h"
 
+/// Specifies which standard headers should be included by a GTest.
+enum class P4Headers {
+    NONE,    // No headers.
+    CORE,    // Just core.p4.
+    V1MODEL  // Both core.p4 and v1model.p4.
+};
+
 namespace detail {
 
 /**
- * Creates a "nice" version of the P4 program in @rawSource which contains
- * additional information for the preprocessor to aid in debugging. @file and
- * @line should be the __FILE__ and __LINE__, respectively, at which @rawSource
- * is defined.
+ * Transforms the P4 program (or program fragment) in @rawSource to turn it into
+ * a complete program and make it more suitable for debugging.
+ *
+ * @param file  The __FILE__ at which @rawSource is defined; used along with
+ *              @line to improve compiler error messages.
+ * @param line  The __LINE__ at which @rawSource is defined.
+ * @param headers  Specifies any standard headers that should be prepended to
+ *                 @rawSource to make a complete P4 program.
+ * @param rawSource  A P4 program or program fragment. Callers will normally
+ *                   find it convenient to specify this as a raw string.
+ * @return the transformed P4 program.
  */
+std::string makeP4Source(const char* file, unsigned line,
+                         P4Headers headers, const char* rawSource);
+
+/// An overload of makeP4Source which doesn't prepend any headers; equivalent to
+/// `makeP4Source(file, line, P4Headers::NONE, rawSource);`.
 std::string makeP4Source(const char* file, unsigned line, const char* rawSource);
 
 }  // namespace detail
 
 // A macro which should be used by unit tests to define P4 source code. It adds
 // additional information to the source code to aid in debugging; see
-// makeP4Source for more information.
-#define P4_SOURCE(SRC) detail::makeP4Source(__FILE__, __LINE__, SRC)
+// makeP4Source for more information and parameter details.
+#define P4_SOURCE(...) detail::makeP4Source(__FILE__, __LINE__, __VA_ARGS__)
 
-class P4CTestEnvironment : public ::testing::Environment {
-public:
+class P4CTestEnvironment {
+    // XXX(seth): Ideally this would be a ::testing::Environment subclass, but
+    // if you register a global test environment with GTest it tries to tear it
+    // down in an atexit() handler, and in some configurations libgc does the
+    // same, resulting in a double delete that's not easy to resolve cleanly.
+ public:
     /// @return the global instance of P4CTestEnvironment.
     static P4CTestEnvironment* get();
 
-    void SetUp() override;
-
-    /// @return a string containing the "core.p4" P4 standard library.
+    /// @return a string containing the "core.p4" P4 standard header.
     const std::string& coreP4() const { return _coreP4; }
 
-private:
-    std::string _coreP4;
-};
+    /// @return a string containing the "v1model.p4" P4 standard header.
+    const std::string& v1Model() const { return _v1Model; }
 
-/* preprocessing by prepending the content of core.p4 to test program */
-std::string with_core_p4(const std::string& pgm);
+ private:
+    P4CTestEnvironment();
+
+    std::string _coreP4;
+    std::string _v1Model;
+};
 
 #endif /* TEST_GTEST_HELPERS_H_ */

--- a/test/gtest/helpers.h
+++ b/test/gtest/helpers.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define TEST_GTEST_HELPERS_H_
 
 #include <string>
+#include "gtest/gtest.h"
 
 namespace detail {
 
@@ -35,6 +36,20 @@ std::string makeP4Source(const char* file, unsigned line, const char* rawSource)
 // additional information to the source code to aid in debugging; see
 // makeP4Source for more information.
 #define P4_SOURCE(SRC) detail::makeP4Source(__FILE__, __LINE__, SRC)
+
+class P4CTestEnvironment : public ::testing::Environment {
+public:
+    /// @return the global instance of P4CTestEnvironment.
+    static P4CTestEnvironment* get();
+
+    void SetUp() override;
+
+    /// @return a string containing the "core.p4" P4 standard library.
+    const std::string& coreP4() const { return _coreP4; }
+
+private:
+    std::string _coreP4;
+};
 
 /* preprocessing by prepending the content of core.p4 to test program */
 std::string with_core_p4(const std::string& pgm);


### PR DESCRIPTION
In P4 programs or program fragments embedded in GTests, we'd often like to use the standard P4 headers. We have a mechanism for doing this for `core.p4` right now, but it's inefficient (we reread `core.p4` every time) and it adds visual noise to the test. This PR improves on the existing mechanism by:

- Adding a global test environment that caches the contents of `core.p4` and `v1model.p4`, so we don't need to reread them for every test that uses them.
- Merging the functionality for prepending the contents of these headers into the `P4_SOURCE` macro we're already using. This reduces visual noise and also lets us reduce the number of string copies we perform.