### PR TITLE
Use ASSERT_TRUE when checking nullness in GTests

### DIFF
--- a/test/gtest/arch_test.cpp
+++ b/test/gtest/arch_test.cpp
@@ -57,7 +57,7 @@ TEST(arch, packet_out) {
     });
 
     pgm = pgm->apply(passes);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 }
 
 // Potential bug
@@ -91,7 +91,7 @@ TEST(arch, duplicatedDeclarationBug) {
     });
 
     pgm = pgm->apply(passes);
-    ASSERT_EQ(nullptr, pgm);
+    ASSERT_TRUE(pgm == nullptr);
 }
 
 TEST(arch, instantiation) {
@@ -141,7 +141,7 @@ TEST(arch, instantiation) {
     });
 
     pgm = pgm->apply(passes);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 }
 
 TEST(arch, psa_package_with_body) {
@@ -172,7 +172,7 @@ TEST(arch, psa_package_with_body) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_EQ(nullptr, pgm);
+    ASSERT_TRUE(pgm == nullptr);
 }
 
 TEST(arch, psa_control_in_control) {
@@ -208,7 +208,7 @@ TEST(arch, psa_control_in_control) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 }
 
 TEST(arch, psa_clone_as_param_to_package) {
@@ -233,7 +233,7 @@ TEST(arch, psa_clone_as_param_to_package) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 }
 
 TEST(arch, psa_clone_as_param_to_control) {
@@ -268,7 +268,7 @@ TEST(arch, psa_clone_as_param_to_control) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 }
 
 TEST(arch, psa_clone_as_param_to_extern) {
@@ -311,7 +311,7 @@ TEST(arch, psa_clone_as_param_to_extern) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 }
 
 TEST(arch, clone_as_extern_method) {
@@ -343,6 +343,6 @@ TEST(arch, clone_as_extern_method) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 }
 

--- a/test/gtest/midend_test.cpp
+++ b/test/gtest/midend_test.cpp
@@ -45,7 +45,7 @@ TEST(midend, convertEnums_pass) {
         control m() { C(E.A) ctr; apply{} }
     )");
     const IR::P4Program* pgm = parse_string(program);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 
     // Example to enable logging in source
     // Log::addDebugSpec("convertEnums:0");
@@ -56,7 +56,7 @@ TEST(midend, convertEnums_pass) {
         convertEnums
     };
     pgm = pgm->apply(passes);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 }
 
 TEST(midend, convertEnums_used_before_declare) {
@@ -65,7 +65,7 @@ TEST(midend, convertEnums_used_before_declare) {
         enum E { A, B, C, D };
     )");
     const IR::P4Program* pgm = parse_string(program);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 
     ReferenceMap  refMap;
     TypeMap       typeMap;
@@ -75,7 +75,7 @@ TEST(midend, convertEnums_used_before_declare) {
     };
     auto result = pgm->apply(passes);
     // use enum before declaration should fail
-    ASSERT_EQ(nullptr, result);
+    ASSERT_TRUE(result == nullptr);
 }
 
 // use enumMap in convertEnums directly
@@ -85,7 +85,7 @@ TEST(midend, getEnumMapping) {
         const bool a = E.A == E.B;
     )");
     const IR::P4Program* pgm = parse_string(program);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_TRUE(pgm != nullptr);
 
     ReferenceMap  refMap;
     TypeMap       typeMap;
@@ -95,7 +95,7 @@ TEST(midend, getEnumMapping) {
         convertEnums
     };
     auto result = pgm->apply(passes_);
-    ASSERT_NE(nullptr, result);
+    ASSERT_TRUE(result != nullptr);
 
     enumMap = convertEnums->getEnumMapping();
     ASSERT_EQ(enumMap.size(), (unsigned long)1);


### PR DESCRIPTION
Here's the fix for #480. Just a search and replace.

It's an unfortunate issue with GTest, especially since they did it *deliberately*, but it's not too bad to use `ASSERT_TRUE` for null checks instead.