### PR TITLE
Fixes for issues #477 and #478

### DIFF
--- a/backends/bmv2/Makefile.am
+++ b/backends/bmv2/Makefile.am
@@ -48,3 +48,8 @@ bmv2tests.mk: $(GENTESTS) $(srcdir)/%reldir%/Makefile.am \
 	      $(srcdir)/testdata/p4_14_samples/switch_*/switch.p4 \
 	      $(srcdir)/testdata/p4_16_samples $(srcdir)/testdata/p4_14_samples
 	@$(GENTESTS) $(srcdir) bmv2 $(srcdir)/backends/bmv2/run-bmv2-test.py $^ >$@
+
+# These are issue #481
+XFAIL_TESTS += \
+   bmv2/testdata/p4_14_samples/09-IPv4OptionsUnparsed.p4.test \
+   bmv2/testdata/p4_14_samples/TLV_parsing.p4.test

--- a/backends/p4test/Makefile.am
+++ b/backends/p4test/Makefile.am
@@ -49,6 +49,11 @@ p14_to_16tests.mk: $(GENTESTS) $(srcdir)/%reldir%/Makefile.am \
 	@$(GENTESTS) $(srcdir) p14_to_16 $(srcdir)/backends/p4test/run-p4-sample.py $^ >$@
 
 
-# This is issue #13
+# First is issue #13
+# Second one is issue #447
+# Next ones are all issue #481
 XFAIL_TESTS += \
-    p4/testdata/p4_16_samples/cast-call.p4.test
+    p4/testdata/p4_16_samples/cast-call.p4.test \
+    p4/testdata/p4_16_samples/spec-ex32.p4.test \
+    p14_to_16/testdata/p4_14_samples/09-IPv4OptionsUnparsed.p4.test \
+    p14_to_16/testdata/p4_14_samples/TLV_parsing.p4.test

--- a/frontends/Makefile.am
+++ b/frontends/Makefile.am
@@ -108,7 +108,6 @@ cpplint_FILES += frontends/p4/p4-lex.l \
 		 $(p4_frontend_UNIFIED) \
 		 $(p4_frontend_NONUNIFIED)
 
-
 common_frontend_UNIFIED = \
 	frontends/common/options.cpp \
 	frontends/common/constantFolding.cpp \

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -50,8 +50,13 @@ limitations under the License.
 namespace P4 {
 
 namespace {
+/**
+This pass outputs the program as a P4 source file.
+*/
 class PrettyPrint : public Inspector {
+    /// output file
     cstring ppfile;
+    /// The file that is being compiled.  This used
     cstring inputfile;
  public:
     explicit PrettyPrint(const CompilerOptions& options) {
@@ -71,7 +76,9 @@ class PrettyPrint : public Inspector {
 };
 }  // namespace
 
-// This pass does nothing, it's just here to mark the end of the front-end
+/**
+This pass does nothing, it's just here to mark the end of the front-end
+*/
 class FrontEndLast : public PassManager {
  public:
     FrontEndLast() { setName("FrontEndLast"); }

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -22,8 +22,11 @@ limitations under the License.
 #include "lib/sourceCodeBuilder.h"
 
 namespace P4 {
-    // conversion from P4 v1.2 IR back to P4 source
 
+/**
+This pass converts a P4-16 IR into a P4 source (text) program.
+It can optionally emit as comments a representation of the program IR.
+*/
 class ToP4 : public Inspector {
     int expressionPrecedence;  // precedence of current IR::Operation
     bool isDeclaration;  // current type is a declaration
@@ -82,9 +85,9 @@ class ToP4 : public Inspector {
      * useful functionality the ostream does not already provide; it just serves to
      * obfuscate the code */
     std::ostream* outStream;
-    // If this is set to non-nullptr, some declarations
-    // that come from libraries and models are not
-    // emitted.  Currently unused.
+    /** If this is set to non-nullptr, some declarations
+        that come from libraries and models are not
+        emitted. */
     cstring mainFile;
 
     ToP4(Util::SourceCodeBuilder& builder, bool showIR, cstring mainFile = nullptr) :

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include "frontends/p4/substitutionVisitor.h"
 #include "typeConstraints.h"
 #include "typeUnification.h"
+#include "frontends/p4/methodInstance.h"
 
 namespace P4 {
 
@@ -109,9 +110,10 @@ class TypeInference : public Transform {
         const IR::Node* errorPosition, const IR::Type* destType,
         const IR::Type* srcType, bool reportErrors);
 
-    // Tries to assign sourceExpression to a destination with type destType.
-    // This may rewrite the sourceExpression, in particular converting InfInt values
-    // to values with concrete types.  Returns new sourceExpression.
+    /** Tries to assign sourceExpression to a destination with type destType.
+        This may rewrite the sourceExpression, in particular converting InfInt values
+        to values with concrete types.
+        @returns new sourceExpression. */
     const IR::Expression* assignment(const IR::Node* errorPosition, const IR::Type* destType,
                                      const IR::Expression* sourceExpression);
     const IR::SelectCase* matchCase(const IR::SelectExpression* select,
@@ -121,12 +123,15 @@ class TypeInference : public Transform {
     bool canCastBetween(const IR::Type* dest, const IR::Type* src) const;
     bool checkAbstractMethods(const IR::Declaration_Instance* inst, const IR::Type_Extern* type);
 
-    // Converts each type to a canonical representation.
+    /** Converts each type to a canonical representation. */
     const IR::Type* canonicalize(const IR::Type* type);
     const IR::IndexedVector<IR::StructField>* canonicalizeFields(const IR::Type_StructLike* type);
     const IR::ParameterList* canonicalizeParameters(const IR::ParameterList* params);
 
     // various helpers
+    bool hasVarbits(const IR::Type_Header* type) const;
+    void checkCorelibMethods(const ExternMethod* em) const;
+    void checkEmitType(const IR::Expression* emit, const IR::Type* type) const;
     bool containsHeader(const IR::Type* canonType);
     void validateFields(const IR::Type* type,
                         std::function<bool(const IR::Type*)> checker) const;

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -22,21 +22,21 @@ limitations under the License.
 #include "frontends/p4/substitution.h"
 
 namespace P4 {
-/*
- * Maps nodes to their canonical types.
- * Not all Node objects have types.
- * The type of each node is maintained in the typeMap.
- * Objects that have a type in the map:
- * - all Expression objects (includes Literals)
- * - function parameters
- * - variables and constant declarations
- * - functors (control, parser, etc.)
- * - functions
- * - interfaces
- * - enum fields (pointing to the enclosing enum)
- * - error (pointing to the error type)
- * - prototypes (function and functor prototypes); map name to the actual type
- */
+/**
+Maps nodes to their canonical types.
+Not all Node objects have types.
+The type of each node is maintained in the typeMap.
+Objects that have a type in the map:
+- all Expression objects (includes Literals)
+- function parameters
+- variables and constant declarations
+- functors (control, parser, etc.)
+- functions
+- interfaces
+- enum fields (pointing to the enclosing enum)
+- error (pointing to the error type)
+- type declarations - map name to the actual type
+*/
 class TypeMap final : public ProgramMap {
  protected:
     // We want to have the same canonical type for two
@@ -81,7 +81,7 @@ class TypeMap final : public ProgramMap {
     const IR::Type* getSubstitution(const IR::Type_Var* var)
     { return allTypeVariables.lookup(var); }
 
-    // deep structural equivalence between canonical types only.
+    /// Check deep structural equivalence; defined between canonical types only.
     static bool equivalent(const IR::Type* left, const IR::Type* right);
 
     // Used for tuples and stacks only

--- a/test/gtest/arch_test.cpp
+++ b/test/gtest/arch_test.cpp
@@ -38,12 +38,12 @@ TEST(arch, packet_out) {
         control Deparser<H> (packet_out b, in H hdr);
         package PSA<H> (Deparser<H> p);
         // user program
-        struct ParsedHeaders {
+        header ParsedHeaders {
             bit<32> hdr;
         }
         control MyDeparser(packet_out b, in ParsedHeaders h){
             apply {
-                b.emit(h.hdr);
+                b.emit(h);
             }
         }
         PSA(MyDeparser()) main;
@@ -109,7 +109,7 @@ TEST(arch, instantiation) {
         control Deparser<H> (packet_out b, in H hdr);
         package PSA<H, M> (Parser<M> p, Ingress<H, M> ig, Deparser<H> dp);
         // user program
-        struct ParsedHeaders {
+        header ParsedHeaders {
             bit<32> hdr;
         }
         struct Metadata {
@@ -122,9 +122,9 @@ TEST(arch, instantiation) {
             apply {
             }
         }
-        control MyDeparser(packet_out b, in ParsedHeaders h){
+        control MyDeparser(packet_out b, in ParsedHeaders h) {
             apply {
-                b.emit(h.hdr);
+                b.emit(h);
             }
         }
         MyParser() p;
@@ -141,7 +141,7 @@ TEST(arch, instantiation) {
     });
 
     pgm = pgm->apply(passes);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_NE(pgm, nullptr);
 }
 
 TEST(arch, psa_package_with_body) {
@@ -172,7 +172,7 @@ TEST(arch, psa_package_with_body) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_EQ(nullptr, pgm);
+    ASSERT_EQ(pgm, nullptr);
 }
 
 TEST(arch, psa_control_in_control) {
@@ -208,7 +208,7 @@ TEST(arch, psa_control_in_control) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_NE(nullptr, pgm);
+    ASSERT_NE(pgm, nullptr);
 }
 
 TEST(arch, psa_clone_as_param_to_package) {
@@ -345,4 +345,3 @@ TEST(arch, clone_as_extern_method) {
     pgm = pgm->apply(passes);
     ASSERT_NE(nullptr, pgm);
 }
-

--- a/testdata/p4_16_errors/extract1.p4
+++ b/testdata/p4_16_errors/extract1.p4
@@ -26,6 +26,6 @@ parser P(packet_in p, out H h) {
     }
 }
 
-parser Simple(packet_in p);
+parser Simple(packet_in p, out H h);
 package top(Simple prs);
 top(P()) main;

--- a/testdata/p4_16_errors/issue477.p4
+++ b/testdata/p4_16_errors/issue477.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 VMware, Inc.
+Copyright 2017 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,16 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#include "core.p4"
+#include <core.p4>
 
-parser P(packet_in p, out bit<32> h) {
+header h_t {
+    bit<8> f;
+}
+
+struct my_packet {
+    h_t[10] h;
+}
+
+parser MyParser(packet_in b, out my_packet p) {
     state start {
-        p.extract(h);  // error: not a header
+        b.extract(p.h);
         transition accept;
     }
 }
-
-parser Simple(packet_in p, out bit<32> h);
-
-package top(Simple prs);
-top(P()) main;

--- a/testdata/p4_16_errors/issue478.p4
+++ b/testdata/p4_16_errors/issue478.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 VMware, Inc.
+Copyright 2017 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,16 +13,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#include "core.p4"
+#include <core.p4>
 
-parser P(packet_in p, out bit<32> h) {
+header h_t {
+    bit<8> f;
+    varbit<8> g;
+}
+
+struct my_packet {
+    h_t h;
+}
+
+parser MyParser(packet_in b, out my_packet p) {
     state start {
-        p.extract(h);  // error: not a header
+        b.extract(p.h);
         transition accept;
     }
 }
-
-parser Simple(packet_in p, out bit<32> h);
-
-package top(Simple prs);
-top(P()) main;

--- a/testdata/p4_16_errors/twovarbit.p4
+++ b/testdata/p4_16_errors/twovarbit.p4
@@ -1,0 +1,4 @@
+header H {
+    varbit<120> x;
+    varbit<120> u;
+}

--- a/testdata/p4_16_errors_outputs/extract.p4
+++ b/testdata/p4_16_errors_outputs/extract.p4
@@ -7,6 +7,6 @@ parser P(packet_in p, out bit<32> h) {
     }
 }
 
-parser Simple(packet_in p);
+parser Simple(packet_in p, out bit<32> h);
 package top(Simple prs);
 top(P()) main;

--- a/testdata/p4_16_errors_outputs/extract.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extract.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/extract.p4(28): error: main: Cannot unify functions with different number of arguments:  function(p, h) to  function(p)
-top(P()) main;
-         ^^^^
+../testdata/p4_16_errors/extract.p4(20): error: h: argument must be a header
+        p.extract(h); // error: not a header
+                  ^

--- a/testdata/p4_16_errors_outputs/extract1.p4
+++ b/testdata/p4_16_errors_outputs/extract1.p4
@@ -11,6 +11,6 @@ parser P(packet_in p, out H h) {
     }
 }
 
-parser Simple(packet_in p);
+parser Simple(packet_in p, out H h);
 package top(Simple prs);
 top(P()) main;

--- a/testdata/p4_16_errors_outputs/extract1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extract1.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/extract1.p4(31): error: main: Cannot unify functions with different number of arguments:  function(p, h) to  function(p)
-top(P()) main;
-         ^^^^
+../testdata/p4_16_errors/extract1.p4(24): error: h: argument should contain a varbit field
+        p.extract(h, 32); // error: not a variable-sized header
+                  ^

--- a/testdata/p4_16_errors_outputs/issue477.p4
+++ b/testdata/p4_16_errors_outputs/issue477.p4
@@ -1,0 +1,17 @@
+#include <core.p4>
+
+header h_t {
+    bit<8> f;
+}
+
+struct my_packet {
+    h_t[10] h;
+}
+
+parser MyParser(packet_in b, out my_packet p) {
+    state start {
+        b.extract(p.h);
+        transition accept;
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/issue477.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue477.p4-stderr
@@ -1,0 +1,3 @@
+../testdata/p4_16_errors/issue477.p4(28): error: p.h: argument must be a header
+        b.extract(p.h);
+                  ^^^

--- a/testdata/p4_16_errors_outputs/issue478.p4
+++ b/testdata/p4_16_errors_outputs/issue478.p4
@@ -1,0 +1,18 @@
+#include <core.p4>
+
+header h_t {
+    bit<8>    f;
+    varbit<8> g;
+}
+
+struct my_packet {
+    h_t h;
+}
+
+parser MyParser(packet_in b, out my_packet p) {
+    state start {
+        b.extract(p.h);
+        transition accept;
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/issue478.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue478.p4-stderr
@@ -1,0 +1,3 @@
+../testdata/p4_16_errors/issue478.p4(29): error: p.h: argument cannot contain varbit fields
+        b.extract(p.h);
+                  ^^^

--- a/testdata/p4_16_errors_outputs/twovarbit.p4
+++ b/testdata/p4_16_errors_outputs/twovarbit.p4
@@ -1,0 +1,5 @@
+header H {
+    varbit<120> x;
+    varbit<120> u;
+}
+

--- a/testdata/p4_16_errors_outputs/twovarbit.p4-stderr
+++ b/testdata/p4_16_errors_outputs/twovarbit.p4-stderr
@@ -1,0 +1,6 @@
+../testdata/p4_16_errors/twovarbit.p4(2): error: x and u: multiple varbit fields in a header
+    varbit<120> x;
+                ^
+../testdata/p4_16_errors/twovarbit.p4(3)
+    varbit<120> u;
+                ^

--- a/testdata/p4_16_samples/match.p4
+++ b/testdata/p4_16_samples/match.p4
@@ -36,7 +36,7 @@ header Ipv4_options_h {
     varbit<160> options;
 }
 
-struct Tcp {
+header Tcp {
     bit<16> port;
 }
 

--- a/testdata/p4_16_samples/spec-ex18.p4
+++ b/testdata/p4_16_samples/spec-ex18.p4
@@ -36,7 +36,7 @@ header IPv4_options_h {
    varbit<160> options;
 }
 
-struct Tcp {
+header Tcp {
     bit<16> port;
 }
 

--- a/testdata/p4_16_samples/spec-ex29.p4
+++ b/testdata/p4_16_samples/spec-ex29.p4
@@ -17,8 +17,7 @@ limitations under the License.
 #include <core.p4>
 
 header Ethernet { bit<16> etherType; }
-header IPv4
-{
+header IPv4 {
    bit<4>       version;
    bit<4>      ihl;
    bit<8>       diffserv;
@@ -31,13 +30,10 @@ header IPv4
    bit<16>      hdrChecksum;
    bit<32>      srcAddr;
    bit<32>      dstAddr;
-   varbit<160>  options;
 }
-header IPv6
-{
-}
-header_union IP
-{
+
+header IPv6 {}
+header_union IP {
     IPv4 ipv4;
     IPv6 ipv6;
 }
@@ -48,8 +44,7 @@ struct Parsed_packet {
 
 error { IPv4FragmentsNotSupported, IPv4OptionsNotSupported, IPv4IncorrectVersion }
 
-parser top(packet_in b, out Parsed_packet p)
-{
+parser top(packet_in b, out Parsed_packet p) {
     state start {
        b.extract(p.ethernet);
        transition select(p.ethernet.etherType) {
@@ -72,8 +67,7 @@ parser top(packet_in b, out Parsed_packet p)
    }
 }
 
-control Automatic(packet_out b, in Parsed_packet p)
-{
+control Automatic(packet_out b, in Parsed_packet p) {
     apply {
         b.emit(p.ethernet);
         b.emit(p.ip.ipv6);

--- a/testdata/p4_16_samples/spec-ex31.p4
+++ b/testdata/p4_16_samples/spec-ex31.p4
@@ -16,8 +16,8 @@ limitations under the License.
 
 #include <core.p4>
 
-struct EthernetHeader { bit<16> etherType; }
-struct IPv4          { bit<16> protocol; }
+header EthernetHeader { bit<16> etherType; }
+header IPv4           { bit<16> protocol; }
 struct Packet_header {
     EthernetHeader ethernet;
     IPv4           ipv4;

--- a/testdata/p4_16_samples_outputs/match-frontend.p4
+++ b/testdata/p4_16_samples_outputs/match-frontend.p4
@@ -22,7 +22,7 @@ header Ipv4_options_h {
     varbit<160> options;
 }
 
-struct Tcp {
+header Tcp {
     bit<16> port;
 }
 

--- a/testdata/p4_16_samples_outputs/match.p4
+++ b/testdata/p4_16_samples_outputs/match.p4
@@ -22,7 +22,7 @@ header Ipv4_options_h {
     varbit<160> options;
 }
 
-struct Tcp {
+header Tcp {
     bit<16> port;
 }
 

--- a/testdata/p4_16_samples_outputs/spec-ex18-frontend.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex18-frontend.p4
@@ -22,7 +22,7 @@ header IPv4_options_h {
     varbit<160> options;
 }
 
-struct Tcp {
+header Tcp {
     bit<16> port;
 }
 

--- a/testdata/p4_16_samples_outputs/spec-ex18.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex18.p4
@@ -22,7 +22,7 @@ header IPv4_options_h {
     varbit<160> options;
 }
 
-struct Tcp {
+header Tcp {
     bit<16> port;
 }
 

--- a/testdata/p4_16_samples_outputs/spec-ex29-frontend.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex29-frontend.p4
@@ -10,19 +10,18 @@ header Ethernet {
 }
 
 header IPv4 {
-    bit<4>      version;
-    bit<4>      ihl;
-    bit<8>      diffserv;
-    bit<16>     totalLen;
-    bit<16>     identification;
-    bit<3>      flags;
-    bit<13>     fragOffset;
-    bit<8>      ttl;
-    bit<8>      protocol;
-    bit<16>     hdrChecksum;
-    bit<32>     srcAddr;
-    bit<32>     dstAddr;
-    varbit<160> options;
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
 }
 
 header IPv6 {

--- a/testdata/p4_16_samples_outputs/spec-ex29.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex29.p4
@@ -10,19 +10,18 @@ header Ethernet {
 }
 
 header IPv4 {
-    bit<4>      version;
-    bit<4>      ihl;
-    bit<8>      diffserv;
-    bit<16>     totalLen;
-    bit<16>     identification;
-    bit<3>      flags;
-    bit<13>     fragOffset;
-    bit<8>      ttl;
-    bit<8>      protocol;
-    bit<16>     hdrChecksum;
-    bit<32>     srcAddr;
-    bit<32>     dstAddr;
-    varbit<160> options;
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
 }
 
 header IPv6 {

--- a/testdata/p4_16_samples_outputs/spec-ex31-frontend.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex31-frontend.p4
@@ -1,10 +1,10 @@
 #include <core.p4>
 
-struct EthernetHeader {
+header EthernetHeader {
     bit<16> etherType;
 }
 
-struct IPv4 {
+header IPv4 {
     bit<16> protocol;
 }
 

--- a/testdata/p4_16_samples_outputs/spec-ex31.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex31.p4
@@ -1,10 +1,10 @@
 #include <core.p4>
 
-struct EthernetHeader {
+header EthernetHeader {
     bit<16> etherType;
 }
 
-struct IPv4 {
+header IPv4 {
     bit<16> protocol;
 }
 


### PR DESCRIPTION
This fixes issue #477 and #478 but discovers several other bugs in the process.
Issues have been filed for these bugs. Unfortunately this also converts several tests to XFAIL.
An issue has been filed against the spec: https://github.com/p4lang/p4-spec/issues/161; the current checks are quite strict, and so several other test programs have to be modified to pass, including some gtestp4c tests.

In the end the checks are part of the typechecking pass - it was lower overhead than creating a separate pass.

I have also converted more comments to Doxygen.