### PR TITLE
Add inline in ir classes to reduce indirections

### DIFF
--- a/backends/bmv2/analyzer.cpp
+++ b/backends/bmv2/analyzer.cpp
@@ -199,7 +199,7 @@ class CFGBuilder : public Inspector {
         return false;
     }
     bool preorder(const IR::BlockStatement* statement) override {
-        for (auto s : *statement->components) {
+        for (auto s : statement->components) {
             auto stat = s->to<IR::Statement>();
             if (stat == nullptr) continue;
             visit(stat);

--- a/backends/bmv2/lower.cpp
+++ b/backends/bmv2/lower.cpp
@@ -421,10 +421,10 @@ RemoveComplexExpressions::simplifyExpressions(const IR::Vector<IR::Expression>* 
     for (auto e : *vec) {
         if (e->is<IR::ListExpression>()) {
             auto list = e->to<IR::ListExpression>();
-            auto simpl = simplifyExpressions(list->components);
-            if (simpl != list->components) {
+            auto simpl = simplifyExpressions(&list->components);
+            if (simpl != &list->components) {
                 changes = true;
-                auto l = new IR::ListExpression(e->srcInfo, simpl);
+                auto l = new IR::ListExpression(e->srcInfo, *simpl);
                 result->push_back(l);
             } else {
                 result->push_back(e);
@@ -449,9 +449,9 @@ RemoveComplexExpressions::simplifyExpressions(const IR::Vector<IR::Expression>* 
 
 const IR::Node*
 RemoveComplexExpressions::postorder(IR::SelectExpression* expression) {
-    auto vec = simplifyExpressions(expression->select->components);
-    if (vec != expression->select->components)
-        expression->select = new IR::ListExpression(expression->select->srcInfo, vec);
+    auto vec = simplifyExpressions(&expression->select->components);
+    if (vec != &expression->select->components)
+        expression->select = new IR::ListExpression(expression->select->srcInfo, *vec);
     return expression;
 }
 
@@ -484,9 +484,8 @@ const IR::Node*
 RemoveComplexExpressions::postorder(IR::Statement* statement) {
     if (assignments.empty())
         return statement;
-    auto vec = new IR::IndexedVector<IR::StatOrDecl>(assignments);
-    vec->push_back(statement);
-    auto block = new IR::BlockStatement(vec);
+    auto block = new IR::BlockStatement(assignments);
+    block->push_back(statement);
     assignments.clear();
     return block;
 }

--- a/backends/bmv2/lower.h
+++ b/backends/bmv2/lower.h
@@ -94,31 +94,19 @@ class RemoveComplexExpressions : public Transform {
     const IR::Node* preorder(IR::ParserState* state) override
     { assignments.clear(); return state; }
     const IR::Node* postorder(IR::ParserState* state) override {
-        if (!assignments.empty()) {
-            auto comp = new IR::IndexedVector<IR::StatOrDecl>(*state->components);
-            comp->append(assignments);
-            state->components = comp;
-        }
+        state->components.append(assignments);
         return state;
     }
     const IR::Node* postorder(IR::MethodCallExpression* expression) override;
     const IR::Node* preorder(IR::P4Parser* parser) override
     { newDecls.clear(); return parser; }
     const IR::Node* postorder(IR::P4Parser* parser) override {
-        if (!newDecls.empty()) {
-            auto locals = new IR::IndexedVector<IR::Declaration>(*parser->parserLocals);
-            locals->append(newDecls);
-            parser->parserLocals = locals;
-        }
+        parser->parserLocals.append(newDecls);
         return parser;
     }
     const IR::Node* preorder(IR::P4Control* control) override;
     const IR::Node* postorder(IR::P4Control* control) override {
-        if (!newDecls.empty()) {
-            auto locals = new IR::IndexedVector<IR::Declaration>(*control->controlLocals);
-            locals->append(newDecls);
-            control->controlLocals = locals;
-        }
+        control->controlLocals.append(newDecls);
         return control;
     }
     const IR::Node* postorder(IR::Statement* statement) override;

--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -156,7 +156,7 @@ bool CodeGenInspector::preorder(const IR::BoolLiteral* b) {
 
 bool CodeGenInspector::preorder(const IR::ListExpression* expression) {
     bool first = true;
-    for (auto e : *expression->components) {
+    for (auto e : expression->components) {
         if (!first)
             builder->append(", ");
         first = false;
@@ -242,7 +242,7 @@ bool CodeGenInspector::preorder(const IR::AssignmentStatement* a) {
 bool CodeGenInspector::preorder(const IR::BlockStatement* s) {
     builder->blockStart();
     setVecSep("\n", "\n");
-    visit(s->components);
+    s->components.visit_children(*this);
     doneVec();
     builder->blockEnd(false);
     return false;

--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -217,7 +217,7 @@ void ControlBodyTranslator::compileEmit(const IR::Vector<IR::Expression>* args) 
     builder->blockEnd(true);
 
     unsigned alignment = 0;
-    for (auto f : *ht->fields) {
+    for (auto f : ht->fields) {
         auto ftype = typeMap->getType(f);
         auto etype = EBPFTypeFactory::instance->create(ftype);
         auto et = dynamic_cast<IHasWidth*>(etype);
@@ -487,7 +487,7 @@ bool EBPFControl::build() {
         return false;
     }
 
-    auto it = pl->parameters->begin();
+    auto it = pl->parameters.begin();
     headers = *it;
     ++it;
     accept = *it;
@@ -522,7 +522,7 @@ void EBPFControl::emit(CodeBuilder* builder) {
     builder->emitIndent();
     hitType->declare(builder, hitVariable, false);
     builder->endOfStatement(true);
-    for (auto a : *controlBlock->container->controlLocals)
+    for (auto a : controlBlock->container->controlLocals)
         emitDeclaration(builder, a);
     builder->emitIndent();
     codeGen->setBuilder(builder);

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -56,7 +56,7 @@ bool StateTranslationVisitor::preorder(const IR::ParserState* parserState) {
     builder->blockStart();
 
     setVecSep("\n", "\n");
-    visit(parserState->components);
+    parserState->components.visit_children(*this);
     doneVec();
 
     if (parserState->selectExpression == nullptr) {
@@ -82,7 +82,7 @@ bool StateTranslationVisitor::preorder(const IR::ParserState* parserState) {
 
 bool StateTranslationVisitor::preorder(const IR::SelectExpression* expression) {
     hasDefault = false;
-    if (expression->select->components->size() != 1) {
+    if (expression->select->components.size() != 1) {
         // TODO: this does not handle correctly tuples
         ::error("%1%: only supporting a single argument for select", expression->select);
         return false;
@@ -248,7 +248,7 @@ StateTranslationVisitor::compileExtract(const IR::Vector<IR::Expression>* args) 
     builder->blockEnd(true);
 
     unsigned alignment = 0;
-    for (auto f : *ht->fields) {
+    for (auto f : ht->fields) {
         auto ftype = state->parser->typeMap->getType(f);
         auto etype = EBPFTypeFactory::instance->create(ftype);
         auto et = dynamic_cast<IHasWidth*>(etype);
@@ -353,10 +353,10 @@ bool EBPFParser::build() {
         return false;
     }
 
-    auto it = pl->parameters->begin();
+    auto it = pl->parameters.begin();
     packet = *it; ++it;
     headers = *it;
-    for (auto state : *parserBlock->container->states) {
+    for (auto state : parserBlock->container->states) {
         auto ps = new EBPFParserState(state, this);
         states.push_back(ps);
     }

--- a/backends/ebpf/ebpfProgram.cpp
+++ b/backends/ebpf/ebpfProgram.cpp
@@ -139,7 +139,7 @@ void EBPFProgram::emitH(CodeBuilder* builder, cstring) {
 }
 
 void EBPFProgram::emitTypes(CodeBuilder* builder) {
-    for (auto d : *program->declarations) {
+    for (auto d : program->declarations) {
         if (d->is<IR::Type>() && !d->is<IR::IContainer>() &&
             !d->is<IR::Type_Extern>() && !d->is<IR::Type_Parser>() &&
             !d->is<IR::Type_Control>() && !d->is<IR::Type_Typedef>() &&

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -85,7 +85,7 @@ void EBPFTable::emitKeyType(CodeBuilder* builder) {
     // Use this to order elements by size
     std::map<size_t, const IR::KeyElement*> ordered;
     unsigned fieldNumber = 0;
-    for (auto c : *keyGenerator->keyElements) {
+    for (auto c : keyGenerator->keyElements) {
         auto type = program->typeMap->getType(c->expression);
         auto ebpfType = EBPFTypeFactory::instance->create(type);
         cstring fieldName = cstring("field") + Util::toString(fieldNumber);
@@ -150,7 +150,7 @@ void EBPFTable::emitValueType(CodeBuilder* builder) {
     builder->spc();
     builder->blockStart();
 
-    for (auto a : *actionList->actionList) {
+    for (auto a : actionList->actionList) {
         auto adecl = program->refMap->getDeclaration(a->getPath(), true);
         auto action = adecl->getNode()->to<IR::P4Action>();
         cstring name = action->externalName();
@@ -176,7 +176,7 @@ void EBPFTable::emitValueType(CodeBuilder* builder) {
     builder->append("union ");
     builder->blockStart();
 
-    for (auto a : *actionList->actionList) {
+    for (auto a : actionList->actionList) {
         auto adecl = program->refMap->getDeclaration(a->getPath(), true);
         auto action = adecl->getNode()->to<IR::P4Action>();
         cstring name = action->externalName();
@@ -260,7 +260,7 @@ void EBPFTable::emitInstance(CodeBuilder* builder) {
 }
 
 void EBPFTable::emitKey(CodeBuilder* builder, cstring keyName) {
-    for (auto c : *keyGenerator->keyElements) {
+    for (auto c : keyGenerator->keyElements) {
         auto ebpfType = ::get(keyTypes, c);
         cstring fieldName = ::get(keyFieldNames, c);
         CHECK_NULL(fieldName);
@@ -291,7 +291,7 @@ void EBPFTable::emitAction(CodeBuilder* builder, cstring valueName) {
     builder->appendFormat("switch (%s->action) ", valueName);
     builder->blockStart();
 
-    for (auto a : *actionList->actionList) {
+    for (auto a : actionList->actionList) {
         auto adecl = program->refMap->getDeclaration(a->getPath(), true);
         auto action = adecl->getNode()->to<IR::P4Action>();
         builder->emitIndent();

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -115,7 +115,7 @@ EBPFStructType::EBPFStructType(const IR::Type_StructLike* strct) :
     width = 0;
     implWidth = 0;
 
-    for (auto f : *strct->fields) {
+    for (auto f : strct->fields) {
         auto type = EBPFTypeFactory::instance->create(f->type);
         auto wt = dynamic_cast<IHasWidth*>(type);
         if (wt == nullptr) {
@@ -239,7 +239,7 @@ void EBPFEnumType::emit(EBPF::CodeBuilder* builder) {
     auto et = getType();
     builder->append(et->name);
     builder->blockStart();
-    for (auto m : *et->members) {
+    for (auto m : et->members) {
         builder->append(m->name);
         builder->appendLine(",");
     }

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -152,7 +152,7 @@ struct HeaderFieldPath {
                       "Member is not contained in a structlike type?");
 
             boost::optional<cstring> name;
-            for (auto field : *parentType->to<IR::Type_StructLike>()->fields) {
+            for (auto field : parentType->to<IR::Type_StructLike>()->fields) {
                 if (field->name == memberExpression->member) {
                     name = controlPlaneName(field);
                     break;
@@ -1105,7 +1105,7 @@ static void collectControlSymbols(P4RuntimeSymbolTable& symbols,
     CHECK_NULL(control);
 
     // Collect action symbols.
-    forAllMatching<IR::P4Action>(control->controlLocals,
+    forAllMatching<IR::P4Action>(&control->controlLocals,
                                  [&](const IR::P4Action* action) {
         symbols.add(P4RuntimeSymbolType::ACTION, action);
     });
@@ -1123,7 +1123,7 @@ static void serializeControl(P4RuntimeSerializer& serializer,
     CHECK_NULL(control);
 
     // Serialize actions and, implicitly, their parameters.
-    forAllMatching<IR::P4Action>(control->controlLocals,
+    forAllMatching<IR::P4Action>(&control->controlLocals,
                                  [&](const IR::P4Action* action) {
         serializer.addAction(action);
     });
@@ -1248,7 +1248,7 @@ getMatchFields(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMap)
     auto key = table->getKey();
     if (!key) return matchFields;
 
-    for (auto keyElement : *key->keyElements) {
+    for (auto keyElement : key->keyElements) {
         auto matchTypeDecl = refMap->getDeclaration(keyElement->matchType->path, true)
                                    ->to<IR::Declaration_ID>();
         BUG_CHECK(matchTypeDecl != nullptr, "No declaration for match type '%1%'",
@@ -1410,7 +1410,7 @@ static void serializeTable(P4RuntimeSerializer& serializer,
     auto matchFields = getMatchFields(table, refMap, typeMap);
 
     std::vector<cstring> actions;
-    for (auto action : *table->getActionList()->actionList) {
+    for (auto action : table->getActionList()->actionList) {
         auto decl = refMap->getDeclaration(action->getPath(), true);
         BUG_CHECK(decl->is<IR::P4Action>(), "Not an action: '%1%'", decl);
         actions.push_back(controlPlaneName(decl->to<IR::P4Action>()));

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -32,7 +32,7 @@ const IR::Expression* DoConstantFolding::getConstant(const IR::Expression* expr)
         return expr;
     if (expr->is<IR::ListExpression>()) {
         auto list = expr->to<IR::ListExpression>();
-        for (auto e : *list->components)
+        for (auto e : list->components)
             if (getConstant(e) == nullptr)
                 return nullptr;
         return list;
@@ -482,7 +482,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Member* e) {
 
         bool found = false;
         int index = 0;
-        for (auto f : *structType->fields) {
+        for (auto f : structType->fields) {
             if (f->name.name == e->member.name) {
                 found = true;
                 break;
@@ -492,7 +492,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Member* e) {
 
         if (!found)
             BUG("Could not find field %1% in type %2%", e->member, type);
-        result = list->components->at(index)->clone();
+        result = list->components.at(index)->clone();
     }
     typeMap->setType(result, origtype);
     typeMap->setCompileTimeConstant(result);
@@ -686,17 +686,17 @@ DoConstantFolding::setContains(const IR::Expression* keySet, const IR::Expressio
         auto list = select->to<IR::ListExpression>();
         if (keySet->is<IR::ListExpression>()) {
             auto klist = keySet->to<IR::ListExpression>();
-            BUG_CHECK(list->components->size() == klist->components->size(),
+            BUG_CHECK(list->components.size() == klist->components.size(),
                       "%1% and %2% size mismatch", list, klist);
-            for (unsigned i=0; i < list->components->size(); i++) {
-                auto r = setContains(klist->components->at(i), list->components->at(i));
+            for (unsigned i=0; i < list->components.size(); i++) {
+                auto r = setContains(klist->components.at(i), list->components.at(i));
                 if (r == Result::DontKnow || r == Result::No)
                     return r;
             }
             return Result::Yes;
         } else {
-            BUG_CHECK(list->components->size() == 1, "%1%: mismatch in list size", list);
-            return setContains(keySet, list->components->at(0));
+            BUG_CHECK(list->components.size() == 1, "%1%: mismatch in list size", list);
+            return setContains(keySet, list->components.at(0));
         }
     }
 

--- a/frontends/p4-14/header_type.cpp
+++ b/frontends/p4-14/header_type.cpp
@@ -22,7 +22,7 @@ HeaderTypeMaxLengthCalculator::preorder(IR::Type_StructLike *hdr_type) {
     auto *max_length = hdr_type->annotations->getSingle("max_length");
     if (!max_length) {
         unsigned len = 0;
-        for (auto field : *hdr_type->fields)
+        for (auto field : hdr_type->fields)
             len += field->type->width_bits();
         max_length = new IR::Annotation("max_length", len);
         if (!annot) annot = hdr_type->annotations->clone();

--- a/frontends/p4-14/intrinsic.cpp
+++ b/frontends/p4-14/intrinsic.cpp
@@ -19,22 +19,16 @@ limitations under the License.
 
 IR::V1Program::V1Program(const CompilerOptions &) {
     // This should be kept in sync with v1model.p4
-    auto fields = new IndexedVector<StructField>;
-#define ADDF(name, type) do { \
-    fields->push_back(new IR::StructField(IR::ID(name), type)); \
-} while (0)
-
-    ADDF("ingress_port", IR::Type::Bits::get(9));
-    ADDF("packet_length", IR::Type::Bits::get(32));
-    ADDF("egress_spec", IR::Type::Bits::get(9));
-    ADDF("egress_port", IR::Type::Bits::get(9));
-    ADDF("egress_instance", IR::Type::Bits::get(16));
-    ADDF("instance_type", IR::Type::Bits::get(32));
-    ADDF("parser_status", IR::Type::Bits::get(8));
-    ADDF("parser_error_location", IR::Type::Bits::get(8));
-#undef ADDF
-    auto *standard_metadata_t = new IR::Type_Struct("standard_metadata_t", fields);
-
+    auto *standard_metadata_t = new IR::Type_Struct("standard_metadata_t", {
+        new IR::StructField("ingress_port", IR::Type::Bits::get(9)),
+        new IR::StructField("packet_length", IR::Type::Bits::get(32)),
+        new IR::StructField("egress_spec", IR::Type::Bits::get(9)),
+        new IR::StructField("egress_port", IR::Type::Bits::get(9)),
+        new IR::StructField("egress_instance", IR::Type::Bits::get(16)),
+        new IR::StructField("instance_type", IR::Type::Bits::get(32)),
+        new IR::StructField("parser_status", IR::Type::Bits::get(8)),
+        new IR::StructField("parser_error_location", IR::Type::Bits::get(8)),
+    });
     scope.add("standard_metadata_t", new IR::v1HeaderType(standard_metadata_t));
     scope.add("standard_metadata", new IR::Metadata("standard_metadata", standard_metadata_t));
 }

--- a/frontends/p4-14/p4-14-parse.ypp
+++ b/frontends/p4-14/p4-14-parse.ypp
@@ -84,7 +84,6 @@ static const IR::Annotations *getPragmas() {
     IR::Meter                   *Meter;
     IR::Parameter               *Parameter;
     IR::ParameterList           *ParameterList;
-    IR::IndexedVector<IR::Parameter> *ParameterVector;
     IR::V1Parser                *Parser;
     IR::Register                *Register;
     IR::V1Table                 *Table;
@@ -162,8 +161,7 @@ static const IR::Annotations *getPragmas() {
 %type<NameList>         action_list name_list opt_name_list field_list_list
 %type<Meter>            meter_spec_list
 %type<Parameter>        argument
-%type<ParameterList>    opt_argument_list
-%type<ParameterVector>  argument_list
+%type<ParameterList>    opt_argument_list argument_list
 %type<Parser>           parser_statement_list
 %type<Register>         register_spec_list
 %type<Table>            table_body
@@ -209,9 +207,9 @@ header_type_declaration: HEADER_TYPE name '{' header_dec_body '}'
         current_pragmas.clear();
         global->add($2, new IR::v1HeaderType(@1+@5, $2,
             new IR::Type_Struct(@1+@5, IR::ID(@2, $2),
-                                new IR::Annotations(*$4.annotations), $4.fields),
+                                new IR::Annotations(*$4.annotations), *$4.fields),
             new IR::Type_Header(@1+@5, IR::ID(@2, $2),
-                                new IR::Annotations(*$4.annotations), $4.fields))); }
+                                new IR::Annotations(*$4.annotations), *$4.fields))); }
 ;
 
 header_dec_body: FIELDS '{' field_declarations '}' opt_length opt_max_length
@@ -714,7 +712,7 @@ apply_case_list: /* epsilon */ { $$ = new IR::Apply; }
 /************/
 
 blackbox_type_declaration: BLACKBOX_TYPE name '{' blackbox_body '}'
-      { global->add($2, new IR::Type_Extern(@1+@5, IR::ID(@2, $2), $4.methods,
+      { global->add($2, new IR::Type_Extern(@1+@5, IR::ID(@2, $2), *$4.methods,
                                             *$4.attribs, getPragmas())); }
 ;
 
@@ -750,12 +748,12 @@ blackbox_method: { $$ = new IR::Annotations; }
 ;
 
 opt_argument_list:
-      /* epsilon */ { $$ = new IR::ParameterList(new IR::IndexedVector<IR::Parameter>); }
-    | argument_list { $$ = new IR::ParameterList($1); }
+      /* epsilon */ { $$ = new IR::ParameterList; }
+    | argument_list { $$ = $1; }
 ;
 
 argument_list:
-      argument                          { $$ = new IR::IndexedVector<IR::Parameter>($1); }
+      argument                          { $$ = new IR::ParameterList({$1}); }
     | argument_list ',' argument        { ($$=$1)->push_back($3); }
 ;
 

--- a/frontends/p4/createBuiltins.cpp
+++ b/frontends/p4/createBuiltins.cpp
@@ -19,16 +19,8 @@ limitations under the License.
 
 namespace P4 {
 void CreateBuiltins::postorder(IR::P4Parser* parser) {
-    auto newStates = new IR::IndexedVector<IR::ParserState>(*parser->states);
-    IR::ParserState* ac = new IR::ParserState(IR::ParserState::accept,
-                                              new IR::IndexedVector<IR::StatOrDecl>(),
-                                              nullptr);
-    IR::ParserState* rj = new IR::ParserState(IR::ParserState::reject,
-                                              new IR::IndexedVector<IR::StatOrDecl>(),
-                                              nullptr);
-    newStates->push_back(ac);
-    newStates->push_back(rj);
-    parser->states = newStates;
+    parser->states.push_back(new IR::ParserState(IR::ParserState::accept, nullptr));
+    parser->states.push_back(new IR::ParserState(IR::ParserState::reject, nullptr));
 }
 
 void CreateBuiltins::postorder(IR::ActionListElement* element) {

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -428,7 +428,6 @@ class ComputeWriteSet : public Inspector {
     bool preorder(const IR::DefaultExpression* expression) override;
     bool preorder(const IR::Expression* expression) override;
     // statements
-    bool preorder(const IR::ParserState* state) override;
     bool preorder(const IR::P4Parser* parser) override;
     bool preorder(const IR::P4Control* control) override;
     bool preorder(const IR::P4Action* action) override;

--- a/frontends/p4/evaluator/evaluator.cpp
+++ b/frontends/p4/evaluator/evaluator.cpp
@@ -70,7 +70,7 @@ bool Evaluator::preorder(const IR::P4Program* program) {
     toplevelBlock = new IR::ToplevelBlock(program->srcInfo, program);
 
     pushBlock(toplevelBlock);
-    for (auto d : *program->declarations) {
+    for (auto d : program->declarations) {
         if (d->is<IR::Type_Declaration>())
             // we will visit various containers and externs only when we instantiated them
             continue;
@@ -161,7 +161,7 @@ Evaluator::processConstructor(
         auto values = evaluateArguments(arguments, current);
         if (values != nullptr) {
             block->instantiate(values);
-            for (auto a : *cont->controlLocals)
+            for (auto a : cont->controlLocals)
                 visit(a);
         }
         popBlock(block);
@@ -173,9 +173,9 @@ Evaluator::processConstructor(
         auto values = evaluateArguments(arguments, current);
         if (values != nullptr) {
             block->instantiate(values);
-            for (auto a : *cont->parserLocals)
+            for (auto a : cont->parserLocals)
                 visit(a);
-            for (auto a : *cont->states)
+            for (auto a : cont->states)
                 visit(a);
         }
         popBlock(block);

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -61,7 +61,7 @@ const IR::Node* ExpressionConverter::postorder(IR::Constant* expression) {
 
 const IR::Node* ExpressionConverter::postorder(IR::FieldList* fl) {
     // Field lists may contain other field lists
-    return new IR::ListExpression(fl->srcInfo, &fl->fields);
+    return new IR::ListExpression(fl->srcInfo, fl->fields);
 }
 
 const IR::Node* ExpressionConverter::postorder(IR::Member* field) {
@@ -286,7 +286,7 @@ const IR::Statement* StatementConverter::convert(const IR::Vector<IR::Expression
         auto s = convert(e);
         stats->push_back(s);
     }
-    auto result = new IR::BlockStatement(toConvert->srcInfo, stats);
+    auto result = new IR::BlockStatement(toConvert->srcInfo, *stats);
     return result;
 }
 

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -170,7 +170,7 @@ class ProgramStructure {
     convertExtern(const IR::Declaration_Instance* ext, cstring newName);
     const IR::P4Table*
     convertTable(const IR::V1Table* table, cstring newName,
-                 IR::IndexedVector<IR::Declaration>* stateful, std::map<cstring, cstring> &);
+                 IR::IndexedVector<IR::Declaration> &stateful, std::map<cstring, cstring> &);
     const IR::P4Action* convertAction(const IR::ActionFunction* action, cstring newName,
                                       const IR::Meter* meterToAccess, cstring counterToAccess);
     const IR::Type_Control* controlType(IR::ID name);

--- a/frontends/p4/p4-parse.ypp
+++ b/frontends/p4/p4-parse.ypp
@@ -314,8 +314,8 @@ direction
 
 packageTypeDeclaration
     : optAnnotations PACKAGE name { structure.pushContainerType(*$3, false); }
-      optTypeParameters { structure.declareTypes($5->parameters); }
-      '(' parameterList ')'                { auto pl = new IR::ParameterList(@8, $8);
+      optTypeParameters { structure.declareTypes(&$5->parameters); }
+      '(' parameterList ')'                { auto pl = new IR::ParameterList(@8, *$8);
                                              $$ = new IR::Type_Package(@3, *$3, $1, $5, pl); }
     ;
 
@@ -342,7 +342,7 @@ instantiation
 objInitializer
     : '{' { structure.pushNamespace(@1, false); } objDeclarations '}'
                                { structure.pop();
-                                 $$ = new IR::BlockStatement(@1+@4, $3); }
+                                 $$ = new IR::BlockStatement(@1+@4, *$3); }
     ;
 
 objDeclarations
@@ -370,9 +370,9 @@ parserDeclaration
     : parserTypeDeclaration optConstructorParameters
       '{' parserLocalElements parserStates '}'
                              { structure.pop();
-                               auto pl = new IR::ParameterList(@2, $2);
+                               auto pl = new IR::ParameterList(@2, *$2);
                                $$ = new IR::P4Parser($1->name.srcInfo, $1->name,
-                                                     $1, pl, $4, $5);}
+                                                     $1, pl, *$4, *$5);}
     ;
 
 parserLocalElements
@@ -388,9 +388,9 @@ parserLocalElement
 
 parserTypeDeclaration
     : optAnnotations PARSER name      { structure.pushContainerType(*$3, false); }
-                            optTypeParameters { structure.declareTypes($5->parameters); }
+                            optTypeParameters { structure.declareTypes(&$5->parameters); }
                             '(' parameterList ')'
-                                      { auto pl = new IR::ParameterList(@8, $8);
+                                      { auto pl = new IR::ParameterList(@8, *$8);
                                         $$ = new IR::Type_Parser(@3, *$3, $1, $5, pl); }
     ;
 
@@ -402,7 +402,7 @@ parserStates
 
 parserState
     : optAnnotations STATE name '{' parserStatements transitionStatement '}'
-                                      { $$ = new IR::ParserState(@3, *$3, $1, $5, $6); }
+                                      { $$ = new IR::ParserState(@3, *$3, $1, *$5, $6); }
     ;
 
 parserStatements
@@ -418,7 +418,7 @@ parserStatement
     ;
 
 parserBlockStatement
-    : optAnnotations '{' parserStatements '}' { $$ = new IR::BlockStatement(@1+@4, $1, $3); }
+    : optAnnotations '{' parserStatements '}' { $$ = new IR::BlockStatement(@1+@4, $1, *$3); }
     ;
 
 transitionStatement
@@ -434,7 +434,7 @@ stateExpression
 selectExpression
     : SELECT '(' expressionList ')' '{' selectCaseList '}'
                               { $$ = new IR::SelectExpression(@1 + @7,
-                                      new IR::ListExpression(@3, $3), std::move(*$6)); }
+                                      new IR::ListExpression(@3, *$3), std::move(*$6)); }
     ;
 
 selectCaseList
@@ -448,7 +448,7 @@ selectCase
     ;
 
 keysetExpression
-    : tupleKeysetExpression     { $$ = new IR::ListExpression(@1, $1); }
+    : tupleKeysetExpression     { $$ = new IR::ListExpression(@1, *$1); }
     | simpleKeysetExpression    { $$ = $1; }
     ;
 
@@ -477,15 +477,15 @@ controlDeclaration
     : controlTypeDeclaration optConstructorParameters
       '{' controlLocalDeclarations APPLY controlBody '}'
                             { structure.pop();
-                              auto pl = new IR::ParameterList(@2, $2);
-                              $$ = new IR::P4Control($1->name.srcInfo, $1->name, $1, pl, $4, $6); }
+                              auto pl = new IR::ParameterList(@2, *$2);
+                              $$ = new IR::P4Control($1->name.srcInfo, $1->name, $1, pl, *$4, $6); }
     ;
 
 controlTypeDeclaration
     : optAnnotations CONTROL name { structure.pushContainerType(*$3, false); }
-                            optTypeParameters { structure.declareTypes($5->parameters); }
+                            optTypeParameters { structure.declareTypes(&$5->parameters); }
                             '(' parameterList ')'
-                              { auto pl = new IR::ParameterList(@8, $8);
+                              { auto pl = new IR::ParameterList(@8, *$8);
                                 $$ = new IR::Type_Control(@3, *$3, $1, $5, pl); }
     ;
 
@@ -510,9 +510,9 @@ controlBody
 
 externDeclaration
     : optAnnotations EXTERN nonTypeName { structure.pushContainerType(*$3, true); }
-                            optTypeParameters { structure.declareTypes($5->parameters); }
+                            optTypeParameters { structure.declareTypes(&$5->parameters); }
                             '{' methodPrototypes '}' { structure.pop();
-                                         $$ = new IR::Type_Extern(@3, *$3, $5, $8, $1); }
+                                         $$ = new IR::Type_Extern(@3, *$3, $5, *$8, $1); }
     | optAnnotations EXTERN functionPrototype ';'     { $$ = $3; $3->annotations = $1; }
     ;
 
@@ -523,9 +523,9 @@ methodPrototypes
 
 functionPrototype
     : typeOrVoid name optTypeParameters { structure.pushNamespace(@2, false);
-                     structure.declareTypes($3->parameters); }
+                     structure.declareTypes(&$3->parameters); }
                      '(' parameterList ')' { structure.pop(); }
-                                        { auto params = new IR::ParameterList(@6, $6);
+                                        { auto params = new IR::ParameterList(@6, *$6);
                                           auto mt = new IR::Type_Method(@2, $3, $1, params);
                                           $$ = new IR::Method(@2, *$2, mt); }
     ;
@@ -534,7 +534,7 @@ methodPrototype
     : functionPrototype ';' { $$ = $1; }
     | ABSTRACT functionPrototype ';'    { $$ = $2; $$->setAbstract(); }  // experimental
     | TYPE '(' parameterList ')' ';'  // constructor
-                                        { auto par = new IR::ParameterList(@3, $3);
+                                        { auto par = new IR::ParameterList(@3, *$3);
                                           auto mt = new IR::Type_Method(@1, par);
                                           $$ = new IR::Method(@1, IR::ID(@1, $1), mt); }
     ;
@@ -560,7 +560,7 @@ typeName
     ;
 
 tupleType
-    : TUPLE '<' typeArgumentList '>'   { $$ = new IR::Type_Tuple(@1+@4, $3); }
+    : TUPLE '<' typeArgumentList '>'   { $$ = new IR::Type_Tuple(@1+@4, *$3); }
     ;
 
 headerStackType
@@ -591,7 +591,7 @@ typeOrVoid
 
 optTypeParameters
     : /* empty */                      { $$ = new IR::TypeParameters(); }
-    | '<' typeParameterList '>'        { $$ = new IR::TypeParameters(@1+@3, $2); }
+    | '<' typeParameterList '>'        { $$ = new IR::TypeParameters(@1+@3, *$2); }
     ;
 
 typeParameterList
@@ -627,18 +627,18 @@ derivedTypeDeclaration
 
 headerTypeDeclaration
     : optAnnotations HEADER name       { structure.declareType(*$3); } '{' structFieldList '}'
-                                       { $$ = new IR::Type_Header(@3, *$3, $1, $6); }
+                                       { $$ = new IR::Type_Header(@3, *$3, $1, *$6); }
     ;
 
 structTypeDeclaration
     : optAnnotations STRUCT name       { structure.declareType(*$3); } '{' structFieldList '}'
-                                       { $$ = new IR::Type_Struct(@3, *$3, $1, $6); }
+                                       { $$ = new IR::Type_Struct(@3, *$3, $1, *$6); }
     ;
 
 // experimental
 headerUnionDeclaration
     : optAnnotations HEADER_UNION name { structure.declareType(*$3); }
-      '{' structFieldList '}'          { $$ = new IR::Type_Union(@3, *$3, $1, $6); }
+      '{' structFieldList '}'          { $$ = new IR::Type_Union(@3, *$3, $1, *$6); }
     ;
 
 structFieldList
@@ -652,17 +652,17 @@ structField
 
 enumDeclaration
     : optAnnotations ENUM name          { structure.declareType(*$3); } '{' identifierList '}'
-                                        { $$ = new IR::Type_Enum(@2, *$3, $6); }
+                                        { $$ = new IR::Type_Enum(@2, *$3, *$6); }
     ;
 
 errorDeclaration
     : T_ERROR '{' identifierList '}'
                                         { $$ = new IR::Type_Error(@1 + @4,
-                                                                  IR::ID(@1, "error"), $3); }
+                                                                  IR::ID(@1, "error"), *$3); }
     ;
 
 matchKindDeclaration
-    : MATCH_KIND '{' identifierList '}' { $$ = new IR::Declaration_MatchKind(@1 + @4, $3); }
+    : MATCH_KIND '{' identifierList '}' { $$ = new IR::Declaration_MatchKind(@1 + @4, *$3); }
     ;
 
 identifierList
@@ -729,7 +729,7 @@ statement
 blockStatement
     : optAnnotations '{'               { structure.pushNamespace(@2, false); }
       statOrDeclList '}'               { structure.pop();
-                                              $$ = new IR::BlockStatement(@1 + @5, $1, $4); }
+                                              $$ = new IR::BlockStatement(@1 + @5, $1, *$4); }
     ;
 
 statOrDeclList
@@ -769,7 +769,7 @@ statementOrDeclaration
 tableDeclaration
     : optAnnotations TABLE name '{' tablePropertyList '}'
                                          { $$ = new IR::P4Table(@3, *$3, $1,
-                                                     new IR::TableProperties(@5, $5)); }
+                                                     new IR::TableProperties(@5, *$5)); }
     ;
 
 tablePropertyList
@@ -779,16 +779,16 @@ tablePropertyList
     ;
 
 tableProperty
-    : KEY '=' '{' keyElementList '}'     { auto v = new IR::Key(@4, $4);
+    : KEY '=' '{' keyElementList '}'     { auto v = new IR::Key(@4, *$4);
                                            auto id = IR::ID(@1, "key");
                                            $$ = new IR::Property(
                                                @1 + @5, id, v, false); }
-    | ACTIONS '=' '{' actionList '}'     { auto v = new IR::ActionList(@4, $4);
+    | ACTIONS '=' '{' actionList '}'     { auto v = new IR::ActionList(@4, *$4);
                                            auto id = IR::ID(@1, "actions");
                                            $$ = new IR::Property(
                                                @1 + @5, id, v, false); }
     | optAnnotations optCONST ENTRIES '=' '{' entriesList '}' {
-                                            auto l = new IR::EntriesList(@3, $6);
+                                            auto l = new IR::EntriesList(@3, *$6);
                                             auto id = IR::ID(@3+@7, "entries");
                                             $$ = new IR::Property(@3, id, $1, l, $2); }
     | optAnnotations optCONST IDENTIFIER '=' initializer ';'
@@ -831,8 +831,7 @@ entry
                                            if (auto l = $1->to<IR::ListExpression>())
                                              $$ = new IR::Entry(@1+@4, $4, l, $3);
                                            else {  // if not a tuple, make it a list of 1
-                                             auto le = new IR::Vector<IR::Expression>();
-                                             le->push_back($1);
+                                             IR::Vector<IR::Expression> le($1);
                                              $$ = new IR::Entry(@1+@4, $4,
                                                                 new IR::ListExpression(@1, le),
                                                                 $3);
@@ -855,7 +854,7 @@ entriesList
 
 actionDeclaration
     : optAnnotations ACTION name '(' parameterList ')' blockStatement
-                                         { auto pl = new IR::ParameterList(@5, $5);
+                                         { auto pl = new IR::ParameterList(@5, *$5);
                                            $$ = new IR::P4Action(@3, *$3, $1, pl, $7);
                                          }
     ;
@@ -938,7 +937,7 @@ expression
     | '.' nonTypeName                    { $$ = new IR::PathExpression(new IR::Path(*$2, true)); }
     | expression '[' expression ']'      { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | expression '[' expression ':' expression ']'   { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
-    | '{' expressionList '}'             { $$ = new IR::ListExpression(@1 + @3, $2); }
+    | '{' expressionList '}'             { $$ = new IR::ListExpression(@1 + @3, *$2); }
     | '(' expression ')'                 { $$ = $2; }
     | '!' expression %prec PREFIX        { $$ = new IR::LNot(@1 + @2, $2); }
     | '~' expression %prec PREFIX        { $$ = new IR::Cmpl(@1 + @2, $2); }
@@ -1026,7 +1025,7 @@ const IR::P4Program *parse_P4_16_file(const char *name, FILE *in) {
     } else {
         structure.endParse();
     }
-    return new IR::P4Program(declarations->srcInfo, declarations);
+    return new IR::P4Program(declarations->srcInfo, *declarations);
 }
 
 const IR::P4Program *parse_string(const std::string &pgm) {
@@ -1047,7 +1046,7 @@ const IR::P4Program *parse_string(const std::string &pgm) {
         return nullptr;
     }
     structure.endParse();
-    return new IR::P4Program(declarations->srcInfo, declarations);
+    return new IR::P4Program(declarations->srcInfo, *declarations);
 }
 
 // check that right shift >>
@@ -1070,7 +1069,5 @@ void addErrors(IR::Type_Error* errors) {
         allErrors = errors;
         return;
     }
-    auto vec = new IR::IndexedVector<IR::Declaration_ID>(*allErrors->members);
-    vec->append(*errors->members);
-    allErrors->members = vec;
+    allErrors->members.append(errors->members);
 }

--- a/frontends/p4/resetHeaders.cpp
+++ b/frontends/p4/resetHeaders.cpp
@@ -22,7 +22,7 @@ void DoResetHeaders::generateResets(const TypeMap* typeMap, const IR::Type* type
                                   const IR::Expression* expr, IR::Vector<IR::StatOrDecl>* resets) {
     if (type->is<IR::Type_Struct>() || type->is<IR::Type_Union>()) {
         auto sl = type->to<IR::Type_StructLike>();
-        for (auto f : *sl->fields) {
+        for (auto f : sl->fields) {
             auto ftype = typeMap->getType(f, true);
             auto member = new IR::Member(expr, f->name);
             generateResets(typeMap, ftype, member, resets);
@@ -54,7 +54,9 @@ const IR::Node* DoResetHeaders::postorder(IR::Declaration_Variable* decl) {
         return decl;
     auto resets = new IR::Vector<IR::StatOrDecl>();
     resets->push_back(decl);
-    BUG_CHECK(getContext()->node->is<IR::Vector<IR::StatOrDecl>>(),
+    BUG_CHECK(getContext()->node->is<IR::Vector<IR::StatOrDecl>>() ||
+              getContext()->node->is<IR::ParserState>() ||
+              getContext()->node->is<IR::BlockStatement>(),
               "%1%: parent is not Vector<StatOrDecl>, but %2%",
               decl, getContext()->node);
     auto type = typeMap->getType(getOriginal(), true);

--- a/frontends/p4/simplify.cpp
+++ b/frontends/p4/simplify.cpp
@@ -33,24 +33,23 @@ const IR::Node* DoSimplifyControlFlow::postorder(IR::BlockStatement* statement) 
         return statement;
     }
     bool withinBlock = statancestor != nullptr && statancestor->is<IR::BlockStatement>();
-    auto grandParent = getContext()->parent ? getContext()->parent->node : nullptr;
-    bool withinAction = grandParent != nullptr && grandParent->is<IR::P4Action>();
-    bool withinParserState = grandParent != nullptr && grandParent->is<IR::ParserState>();
+    bool withinAction = parent != nullptr && parent->is<IR::P4Action>();
+    bool withinParserState = parent != nullptr && parent->is<IR::ParserState>();
     if (withinParserState || withinBlock || withinAction) {
         // if there are no local declarations we can remove this block
         bool hasDeclarations = false;
-        for (auto c : *statement->components)
+        for (auto c : statement->components)
             if (!c->is<IR::Statement>()) {
                 hasDeclarations = true;
                 break;
             }
         if (!hasDeclarations)
-            return statement->components;
+            return &statement->components;
     }
-    if (statement->components->empty())
+    if (statement->components.empty())
         return new IR::EmptyStatement(statement->srcInfo);
-    if (statement->components->size() == 1) {
-        auto first = statement->components->at(0);
+    if (statement->components.size() == 1) {
+        auto first = statement->components.at(0);
         if (first->is<IR::Statement>())
             return first;
     }

--- a/frontends/p4/simplifyParsers.cpp
+++ b/frontends/p4/simplifyParsers.cpp
@@ -112,7 +112,7 @@ class CollapseChains : public Transform {
         }
 
         auto states = new IR::IndexedVector<IR::ParserState>();
-        for (auto s : *parser->states) {
+        for (auto s : parser->states) {
             if (pred.find(s) != pred.end())
                 continue;
             if (chainStart.find(s) != chainStart.end()) {
@@ -122,7 +122,7 @@ class CollapseChains : public Transform {
                 LOG1("Chaining states into " << dbp(crt));
                 const IR::Expression *select = nullptr;
                 while (true) {
-                    components->append(*crt->components);
+                    components->append(crt->components);
                     select = crt->selectExpression;
                     crt = ::get(chain, crt);
                     if (crt == nullptr)
@@ -130,12 +130,12 @@ class CollapseChains : public Transform {
                     LOG1("Adding " << dbp(crt) << " to chain");
                 }
                 s = new IR::ParserState(s->srcInfo, s->name, s->annotations,
-                                        components, select);
+                                        *components, select);
             }
             states->push_back(s);
         }
 
-        parser->states = states;
+        parser->states = *states;
         prune();
         return parser;
     }

--- a/frontends/p4/specialize.cpp
+++ b/frontends/p4/specialize.cpp
@@ -41,17 +41,17 @@ const IR::Type_Declaration* SpecializationInfo::synthesize(ReferenceMap* refMap)
         auto newtype = new IR::Type_Parser(name, parser->type->annotations,
                                            new IR::TypeParameters(),
                                            parser->type->applyParams);
-        declarations->append(*parser->parserLocals);
+        declarations->append(parser->parserLocals);
         result = new IR::P4Parser(name, newtype, new IR::ParameterList(),
-                                  declarations, parser->states);
+                                  *declarations, parser->states);
     } else if (clone->is<IR::P4Control>()) {
         auto control = clone->to<IR::P4Control>();
         auto newtype = new IR::Type_Control(name, control->type->annotations,
                                             new IR::TypeParameters(),
                                             control->type->applyParams);
-        declarations->append(*control->controlLocals);
+        declarations->append(control->controlLocals);
         result = new IR::P4Control(name, newtype, new IR::ParameterList(),
-                                   declarations, control->body);
+                                   *declarations, control->body);
 
     } else {
         BUG("%1%: unexpected type", specialized);
@@ -165,7 +165,7 @@ bool FindSpecializations::isSimpleConstant(const IR::Expression* expr) const {
         return true;
     if (expr->is<IR::ListExpression>()) {
         auto list = expr->to<IR::ListExpression>();
-        for (auto e : *list->components)
+        for (auto e : list->components)
             if (!isSimpleConstant(e))
                 return false;
         return true;

--- a/frontends/p4/substitution.cpp
+++ b/frontends/p4/substitution.cpp
@@ -89,14 +89,14 @@ bool TypeVariableSubstitution::setBindings(const IR::Node* errorLocation,
     if (params == nullptr || args == nullptr)
         BUG("Nullptr argument to setBindings");
 
-    if (params->parameters->size() != args->size()) {
+    if (params->parameters.size() != args->size()) {
         ::error("%1% has %2% type parameters, invoked with %3% %4%",
-                errorLocation, params->parameters->size(), args->size(), args);
+                errorLocation, params->parameters.size(), args->size(), args);
         return false;
     }
 
     auto it = args->begin();
-    for (auto tp : *params->parameters) {
+    for (auto tp : params->parameters) {
         auto t = *it;
         ++it;
 

--- a/frontends/p4/substitutionVisitor.cpp
+++ b/frontends/p4/substitutionVisitor.cpp
@@ -32,19 +32,19 @@ bool TypeOccursVisitor::preorder(const IR::Type_InfInt* typeVariable) {
 
 const IR::Node* TypeVariableSubstitutionVisitor::preorder(IR::TypeParameters *tps) {
     // remove all variables that were substituted
-    auto result = new IR::IndexedVector<IR::Type_Var>();
-    for (auto param : *tps->parameters) {
-        const IR::Type* type = bindings->lookup(param);
+    for (auto it = tps->parameters.begin(); it != tps->parameters.end();) {
+        const IR::Type* type = bindings->lookup(*it);
         if (type != nullptr && !replace) {
-            LOG1("Removing from generic parameters " << param);
+            LOG1("Removing from generic parameters " << *it);
+            it = tps->parameters.erase(it);
         } else {
             if (type != nullptr)
                 BUG_CHECK(type->is<IR::Type_Var>(),
-                          "cannot replace a type parameter %1% with %2%:", param, type);
-            result->push_back(param);
+                          "cannot replace a type parameter %1% with %2%:", *it, type);
+            ++it;
         }
     }
-    return new IR::TypeParameters(tps->srcInfo, result);
+    return tps;
 }
 
 const IR::Node* TypeVariableSubstitutionVisitor::preorder(IR::Type_Var* typeVariable) {

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -168,17 +168,21 @@ class ToP4 : public Inspector {
     bool preorder(const IR::This* e) override;
 
     // vectors
-    bool preorder(const IR::Vector<IR::Type>* v) override;
+    bool preorder(const IR::Vector<IR::ActionListElement>* v) override;
+    bool preorder(const IR::Vector<IR::Annotation>* v) override;
+    bool preorder(const IR::Vector<IR::Entry>* v) override;
     bool preorder(const IR::Vector<IR::Expression>* v) override;
+    bool preorder(const IR::Vector<IR::KeyElement>* v) override;
+    bool preorder(const IR::Vector<IR::Method>* v) override;
+    bool preorder(const IR::Vector<IR::Node>* v) override;
     bool preorder(const IR::Vector<IR::SelectCase>* v) override;
     bool preorder(const IR::Vector<IR::SwitchCase>* v) override;
-    bool preorder(const IR::Vector<IR::Node>* v) override;
-    bool preorder(const IR::Vector<IR::ActionListElement>* v) override;
-    bool preorder(const IR::Vector<IR::Method>* v) override;
-    bool preorder(const IR::IndexedVector<IR::Node>* v) override;
-    bool preorder(const IR::IndexedVector<IR::StatOrDecl>* v) override;
-    bool preorder(const IR::IndexedVector<IR::ParserState>* v) override;
+    bool preorder(const IR::Vector<IR::Type>* v) override;
+    bool preorder(const IR::IndexedVector<IR::Declaration_ID>* v) override;
     bool preorder(const IR::IndexedVector<IR::Declaration>* v) override;
+    bool preorder(const IR::IndexedVector<IR::Node>* v) override;
+    bool preorder(const IR::IndexedVector<IR::ParserState>* v) override;
+    bool preorder(const IR::IndexedVector<IR::StatOrDecl>* v) override;
 
     // statements
     bool preorder(const IR::AssignmentStatement* s) override;

--- a/frontends/p4/typeChecking/bindVariables.cpp
+++ b/frontends/p4/typeChecking/bindVariables.cpp
@@ -34,7 +34,7 @@ const IR::Node* BindTypeVariables::postorder(IR::Declaration_Instance* decl) {
     if (mt->getTypeParameters()->empty())
         return decl;
     auto typeArgs = new IR::Vector<IR::Type>();
-    for (auto p : *mt->getTypeParameters()->parameters) {
+    for (auto p : mt->getTypeParameters()->parameters) {
         auto type = getVarValue(p);
         if (type == nullptr) {
             ::error("%1%: cannot infer type for type parameter %2%", decl, p);
@@ -57,7 +57,7 @@ const IR::Node* BindTypeVariables::postorder(IR::MethodCallExpression* expressio
     if (mt->getTypeParameters()->empty())
         return expression;
     auto typeArgs = new IR::Vector<IR::Type>();
-    for (auto p : *mt->getTypeParameters()->parameters) {
+    for (auto p : mt->getTypeParameters()->parameters) {
         auto type = getVarValue(p);
         if (type == nullptr) {
             ::error("%1%: cannot infer type for type parameter %2%", expression, p);
@@ -79,7 +79,7 @@ const IR::Node* BindTypeVariables::postorder(IR::ConstructorCallExpression* expr
     if (mt->getTypeParameters()->empty())
         return expression;
     auto typeArgs = new IR::Vector<IR::Type>();
-    for (auto p : *mt->getTypeParameters()->parameters) {
+    for (auto p : mt->getTypeParameters()->parameters) {
         auto type = getVarValue(p);
         if (type == nullptr) {
             ::error("%1%: cannot infer type for type parameter %2%", expression, p);

--- a/frontends/p4/typeChecking/syntacticEquivalence.cpp
+++ b/frontends/p4/typeChecking/syntacticEquivalence.cpp
@@ -78,7 +78,7 @@ bool SameExpression::sameExpression(const IR::Expression* left, const IR::Expres
     } else if (left->is<IR::ListExpression>()) {
         auto ll = left->to<IR::ListExpression>();
         auto rl = right->to<IR::ListExpression>();
-        return sameExpressions(ll->components, rl->components);
+        return sameExpressions(&ll->components, &rl->components);
     } else if (left->is<IR::MethodCallExpression>()) {
         auto lm = left->to<IR::MethodCallExpression>();
         auto rm = right->to<IR::MethodCallExpression>();

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -27,14 +27,14 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
     CHECK_NULL(dest); CHECK_NULL(src);
     LOG1("Unifying function " << dest << " with caller " << src);
 
-    for (auto tv : *dest->typeParameters->parameters)
+    for (auto tv : dest->typeParameters->parameters)
         constraints->addUnifiableTypeVariable(tv);
     if (dest->returnType == nullptr)
         constraints->addEqualityConstraint(IR::Type_Void::get(), src->returnType);
     else
         constraints->addEqualityConstraint(dest->returnType, src->returnType);
 
-    for (auto tv : *dest->typeParameters->parameters)
+    for (auto tv : dest->typeParameters->parameters)
         constraints->addUnifiableTypeVariable(tv);
     constraints->addUnifiableTypeVariable(src->returnType);  // always a type variable
 
@@ -47,7 +47,7 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
         }
 
         size_t i = 0;
-        for (auto tv : *dest->typeParameters->parameters) {
+        for (auto tv : dest->typeParameters->parameters) {
             auto type = src->typeArguments->at(i++);
             constraints->addEqualityConstraint(tv, type);
         }
@@ -106,9 +106,9 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
     CHECK_NULL(dest); CHECK_NULL(src);
     LOG1("Unifying functions " << dest << " to " << src);
 
-    for (auto tv : *dest->typeParameters->parameters)
+    for (auto tv : dest->typeParameters->parameters)
         constraints->addUnifiableTypeVariable(tv);
-    for (auto tv : *src->typeParameters->parameters)
+    for (auto tv : src->typeParameters->parameters)
         constraints->addUnifiableTypeVariable(tv);
 
     if ((src->returnType == nullptr) != (dest->returnType == nullptr)) {
@@ -126,7 +126,7 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
         return false;
     }
 
-    auto sit = src->parameters->parameters->begin();
+    auto sit = src->parameters->parameters.begin();
     for (auto dit : *dest->parameters->getEnumerator()) {
         if ((*sit)->direction != dit->direction) {
             if (reportErrors)
@@ -155,9 +155,9 @@ bool TypeUnification::unifyBlocks(const IR::Node* errorPosition,
                     errorPosition, src->toString(), dest->toString());
         return false;
     }
-    for (auto tv : *dest->typeParameters->parameters)
+    for (auto tv : dest->typeParameters->parameters)
         constraints->addUnifiableTypeVariable(tv);
-    for (auto tv : *src->typeParameters->parameters)
+    for (auto tv : src->typeParameters->parameters)
         constraints->addUnifiableTypeVariable(tv);
     if (dest->is<IR::IApply>()) {
         auto srcapply = src->to<IR::IApply>()->getApplyMethodType();
@@ -224,15 +224,15 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
         }
         auto td = dest->to<IR::Type_Tuple>();
         auto ts = src->to<IR::Type_Tuple>();
-        if (td->components->size() != ts->components->size()) {
+        if (td->components.size() != ts->components.size()) {
             ::error("%1%: Cannot match tuples with different sizes %2% vs %3%",
-                    errorPosition, td->components->size(), ts->components->size());
+                    errorPosition, td->components.size(), ts->components.size());
             return false;
         }
 
-        for (size_t i=0; i < td->components->size(); i++) {
-            auto si = ts->components->at(i);
-            auto di = td->components->at(i);
+        for (size_t i=0; i < td->components.size(); i++) {
+            auto si = ts->components.at(i);
+            auto di = td->components.at(i);
             bool success = unify(errorPosition, di, si, reportErrors);
             if (!success)
                 return false;
@@ -242,18 +242,18 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
         auto strct = dest->to<IR::Type_StructLike>();
         if (src->is<IR::Type_Tuple>()) {
             const IR::Type_Tuple* tpl = src->to<IR::Type_Tuple>();
-            if (strct->fields->size() != tpl->components->size()) {
+            if (strct->fields.size() != tpl->components.size()) {
                 if (reportErrors)
                     ::error("%1%: Number of fields %2% in initializer different "
                             "than number of fields in structure %3%: %4% to %5%",
-                            errorPosition, tpl->components->size(),
-                            strct->fields->size(), tpl, strct);
+                            errorPosition, tpl->components.size(),
+                            strct->fields.size(), tpl, strct);
                 return false;
             }
 
             int index = 0;
-            for (const IR::StructField* f : *strct->fields) {
-                const IR::Type* tplField = tpl->components->at(index);
+            for (const IR::StructField* f : strct->fields) {
+                const IR::Type* tplField = tpl->components.at(index);
                 const IR::Type* destt = f->type;
 
                 bool success = unify(errorPosition, destt, tplField, reportErrors);

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -146,11 +146,11 @@ bool TypeMap::equivalent(const IR::Type* left, const IR::Type* right) {
     if (left->is<IR::Type_StructLike>()) {
         auto sl = left->to<IR::Type_StructLike>();
         auto sr = right->to<IR::Type_StructLike>();
-        if (sl->fields->size() != sr->fields->size())
+        if (sl->fields.size() != sr->fields.size())
             return false;
-        for (size_t i = 0; i < sl->fields->size(); i++) {
-            auto fl = sl->fields->at(i);
-            auto fr = sr->fields->at(i);
+        for (size_t i = 0; i < sl->fields.size(); i++) {
+            auto fl = sl->fields.at(i);
+            auto fr = sr->fields.at(i);
             if (fl->name != fr->name)
                 return false;
             if (!equivalent(fl->type, fr->type))
@@ -161,11 +161,11 @@ bool TypeMap::equivalent(const IR::Type* left, const IR::Type* right) {
     if (left->is<IR::Type_Tuple>()) {
         auto lt = left->to<IR::Type_Tuple>();
         auto rt = right->to<IR::Type_Tuple>();
-        if (lt->components->size() != rt->components->size())
+        if (lt->components.size() != rt->components.size())
             return false;
-        for (size_t i = 0; i < lt->components->size(); i++) {
-            auto l = lt->components->at(i);
-            auto r = rt->components->at(i);
+        for (size_t i = 0; i < lt->components.size(); i++) {
+            auto l = lt->components.at(i);
+            auto r = rt->components.at(i);
             if (!equivalent(l, r))
                 return false;
         }
@@ -188,8 +188,8 @@ bool TypeMap::equivalent(const IR::Type* left, const IR::Type* right) {
         if (lm->typeParameters->size() != rm->typeParameters->size())
             return false;
         for (size_t i = 0; i < lm->typeParameters->size(); i++) {
-            auto lp = lm->typeParameters->parameters->at(i);
-            auto rp = rm->typeParameters->parameters->at(i);
+            auto lp = lm->typeParameters->parameters.at(i);
+            auto rp = rm->typeParameters->parameters.at(i);
             if (!equivalent(lp, rp))
                 return false;
         }
@@ -197,8 +197,8 @@ bool TypeMap::equivalent(const IR::Type* left, const IR::Type* right) {
         if (lm->parameters->size() != rm->parameters->size())
             return false;
         for (size_t i = 0; i < lm->parameters->size(); i++) {
-            auto lp = lm->parameters->parameters->at(i);
-            auto rp = rm->parameters->parameters->at(i);
+            auto lp = lm->parameters->parameters.at(i);
+            auto rp = rm->parameters->parameters.at(i);
             if (lp->direction != rp->direction)
                 return false;
             if (!equivalent(lp->type, rp->type))
@@ -226,8 +226,8 @@ bool TypeMap::equivalent(const IR::Type* left, const IR::Type* right) {
         if (lm->typeParameters->size() != rm->typeParameters->size())
             return false;
         for (size_t i = 0; i < lm->typeParameters->size(); i++) {
-            auto lp = lm->typeParameters->parameters->at(i);
-            auto rp = rm->typeParameters->parameters->at(i);
+            auto lp = lm->typeParameters->parameters.at(i);
+            auto rp = rm->typeParameters->parameters.at(i);
             if (!equivalent(lp, rp))
                 return false;
         }
@@ -236,8 +236,8 @@ bool TypeMap::equivalent(const IR::Type* left, const IR::Type* right) {
         if (lm->parameters->size() != rm->parameters->size())
             return false;
         for (size_t i = 0; i < lm->parameters->size(); i++) {
-            auto lp = lm->parameters->parameters->at(i);
-            auto rp = rm->parameters->parameters->at(i);
+            auto lp = lm->parameters->parameters.at(i);
+            auto rp = rm->parameters->parameters.at(i);
             if (lp->direction != rp->direction)
                 return false;
             if (!equivalent(lp->type, rp->type))

--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -119,7 +119,7 @@ class FindParameters : public Inspector {
     // If all is true then rename all parameters, else rename only
     // directional parameters
     void doParameters(const IR::ParameterList* pl, bool all) {
-        for (auto p : *pl->parameters) {
+        for (auto p : pl->parameters) {
             if (!all && p->direction == IR::Direction::None)
                 continue;
             cstring newName = refMap->newName(p->name);

--- a/frontends/p4/validateParsedProgram.cpp
+++ b/frontends/p4/validateParsedProgram.cpp
@@ -56,7 +56,7 @@ void ValidateParsedProgram::postorder(const IR::StructField* f) {
 
 /// Unions must have at least one field
 void ValidateParsedProgram::postorder(const IR::Type_Union* type) {
-    if (type->fields->size() == 0)
+    if (type->fields.size() == 0)
         ::error("%1%: empty union", type);
 }
 
@@ -79,7 +79,7 @@ void ValidateParsedProgram::postorder(const IR::ParserState* s) {
 /// All parameters of a constructor must be directionless.
 /// This only checks controls, parsers and packages
 void ValidateParsedProgram::container(const IR::IContainer* type) {
-    for (auto p : *type->getConstructorParameters()->parameters)
+    for (auto p : type->getConstructorParameters()->parameters)
         if (p->direction != IR::Direction::None)
             ::error("%1%: constructor parameters cannot have a direction", p);
 }
@@ -105,9 +105,9 @@ void ValidateParsedProgram::distinctParameters(
     const IR::ParameterList* constr) {
     std::map<cstring, const IR::Node*> found;
 
-    for (auto p : *typeParams->parameters)
+    for (auto p : typeParams->parameters)
         found.emplace(p->getName(), p);
-    for (auto p : *apply->parameters) {
+    for (auto p : apply->parameters) {
         auto it = found.find(p->getName());
         if (it != found.end())
             ::error("Duplicated parameter name: %1% and %2%",
@@ -115,7 +115,7 @@ void ValidateParsedProgram::distinctParameters(
         else
             found.emplace(p->getName(), p);
     }
-    for (auto p : *constr->parameters) {
+    for (auto p : constr->parameters) {
         auto it = found.find(p->getName());
         if (it != found.end())
             ::error("Duplicated parameter name: %1% and %2%",

--- a/ir/dbprint-expression.cpp
+++ b/ir/dbprint-expression.cpp
@@ -217,7 +217,7 @@ void IR::ListExpression::dbprint(std::ostream &out) const {
     if (prec > Prec_Postfix) out << '(';
     out << setprec(Prec_Postfix) << "{" << setprec(Prec_Low);
     bool first = true;
-    for (auto a : *components) {
+    for (auto a : components) {
         if (!first) out << ", ";
         out << setprec(Prec_Low) << a;
         first = false;

--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -89,7 +89,7 @@ void IR::V1Parser::dbprint(std::ostream &out) const {
 void IR::ParserException::dbprint(std::ostream &out) const { out << "IR::ParserException"; }
 void IR::ParserState::dbprint(std::ostream &out) const {
     out << "state " << name << " " << annotations << "{" << indent;
-    for (auto *s : *components)
+    for (auto s : components)
         out << endl << s;
     if (selectExpression)
         out << endl << selectExpression;
@@ -102,9 +102,9 @@ void IR::P4Parser::dbprint(std::ostream &out) const {
     if (constructorParams)
         out << '(' << constructorParams << ')';
     out << " " << type->annotations << "{" << indent;
-    for (auto d : *parserLocals)
+    for (auto d : parserLocals)
         out << endl << d;
-    for (auto s : *states)
+    for (auto s : states)
         out << endl << s;
     out << " }" << unindent;
 }
@@ -130,26 +130,25 @@ void IR::ActionFunction::dbprint(std::ostream &out) const {
 void IR::P4Action::dbprint(std::ostream &out) const {
     out << "action " << name << "(";
     const char *sep = "";
-    for (auto &arg : *parameters->parameters) {
+    for (auto arg : parameters->parameters) {
         out << sep << arg->direction << ' ' << arg->type << ' ' << arg->name;
         sep = ", "; }
     out << ") {" << indent;
     if (body)
-        for (auto &p : *body->components)
+        for (auto p : body->components)
             out << endl << p;
     out << unindent << " }";
 }
 
 void IR::BlockStatement::dbprint(std::ostream &out) const {
     out << "{" << indent;
-    if (components) {
-        bool first = true;
-        for (auto &p : *components) {
-            if (first) {
-                out << ' ' << p;
-                first = false;
-            } else {
-                out << endl << p; } } }
+    bool first = true;
+    for (auto p : components) {
+        if (first) {
+            out << ' ' << p;
+            first = false;
+        } else {
+            out << endl << p; } }
     out << unindent << " }";
 }
 
@@ -160,7 +159,7 @@ void IR::V1Table::dbprint(std::ostream &out) const { out << "IR::V1Table " << na
 void IR::ActionList::dbprint(std::ostream &out) const {
     out << "{" << indent;
     bool first = true;
-    for (auto *el : *actionList) {
+    for (auto el : actionList) {
         if (first)
             out << ' ' << el;
         else
@@ -176,7 +175,7 @@ void IR::KeyElement::dbprint(std::ostream &out) const {
 void IR::Key::dbprint(std::ostream &out) const {
     out << "{" << indent;
     bool first = true;
-    for (auto *el : *keyElements) {
+    for (auto el : keyElements) {
         if (first)
             out << ' ' << el;
         else
@@ -187,7 +186,7 @@ void IR::Key::dbprint(std::ostream &out) const {
 void IR::P4Table::dbprint(std::ostream &out) const {
     out << "table " << name;
     out << " " << annotations << "{" << indent;
-    for (auto p : *properties->properties)
+    for (auto p : properties->properties)
         out << endl << p;
     out << " }" << unindent;
 }
@@ -202,11 +201,10 @@ void IR::P4Control::dbprint(std::ostream &out) const {
     if (constructorParams)
         out << '(' << constructorParams << ')';
     out << " " << type->annotations << "{" << indent;
-    for (auto d : *controlLocals)
+    for (auto d : controlLocals)
         out << endl << d;
-    if (body->components)
-        for (auto s : *body->components)
-            out << endl << s;
+    for (auto s : body->components)
+        out << endl << s;
     out << " }" << unindent;
 }
 
@@ -216,14 +214,14 @@ void IR::V1Program::dbprint(std::ostream &out) const {
 }
 
 void IR::P4Program::dbprint(std::ostream &out) const {
-    for (auto &obj : *declarations)
+    for (auto obj : declarations)
         out << obj << endl;
 }
 
 void IR::Type_Error::dbprint(std::ostream &out) const {
     out << "error {";
     const char *sep = " ";
-    for (auto &id : *members) {
+    for (auto id : members) {
         out << sep << id->name;
         sep = ", "; }
     out << (sep+1) << "}";
@@ -232,7 +230,7 @@ void IR::Type_Error::dbprint(std::ostream &out) const {
 void IR::Declaration_MatchKind::dbprint(std::ostream &out) const {
     out << "match_kind {";
     const char *sep = " ";
-    for (auto &id : *members) {
+    for (auto id : members) {
         out << sep << id->name;
         sep = ", "; }
     out << (sep+1) << "}";

--- a/ir/dbprint-stmt.cpp
+++ b/ir/dbprint-stmt.cpp
@@ -55,9 +55,8 @@ void IR::Function::dbprint(std::ostream &out) const {
     if (type->typeParameters && !type->typeParameters->empty())
         out << type->typeParameters;
     out << "(" << type->parameters << ") {" << indent;
-    if (body->components)
-        for (auto s : *body->components)
-            out << endl << s;
+    for (auto s : body->components)
+        out << endl << s;
     out << unindent << " }";
 }
 

--- a/ir/dbprint-type.cpp
+++ b/ir/dbprint-type.cpp
@@ -25,7 +25,7 @@ void IR::ParameterList::dbprint(std::ostream &out) const {
     int flags = dbgetflags(out);
     const char *sep = "";
     out << Brief;
-    for (auto param : *parameters) {
+    for (auto param : parameters) {
         out << sep << param;
         sep = ", "; }
     dbsetflags(out, flags);
@@ -98,7 +98,7 @@ void IR::Type_Tuple::dbprint(std::ostream& out) const {
     int flags = dbgetflags(out);
     out << Brief << "tuple<";
     const char *sep = "";
-    for (auto t : *components) {
+    for (auto t : components) {
         out << sep << t;
         sep = ", "; }
     out << ">";
@@ -113,7 +113,7 @@ void IR::Type_Extern::dbprint(std::ostream& out) const {
     if (typeParameters != nullptr)
         out << typeParameters;
     out << " {" << indent << clrflag(Brief);
-    for (auto &method : *methods)
+    for (auto &method : methods)
         out << endl << method << ';';
     out << " }" << unindent;
 }
@@ -122,7 +122,7 @@ void IR::TypeParameters::dbprint(std::ostream& out) const {
     int flags = dbgetflags(out);
     out << Brief << "<";
     const char *sep = "";
-    for (auto p : *parameters) {
+    for (auto p : parameters) {
         out << sep << p;
         sep = ", "; }
     out << ">";
@@ -140,7 +140,7 @@ void IR::Type_StructLike::dbprint(std::ostream &out) const {
         out << name;
         return; }
     out << toString() << " " << annotations << "{" << indent;
-    for (auto &field : *fields)
+    for (auto &field : fields)
         out << endl << field << ';';
     out << " }" << unindent;
 }

--- a/ir/expression.cpp
+++ b/ir/expression.cpp
@@ -26,11 +26,11 @@ int IR::Member::offset_bits() const {
 int IR::Member::lsb() const {
   int rv = 0;
   auto header_type = dynamic_cast<const IR::Type_StructLike *>(expr->type);
-  auto field_iter = header_type->fields->rbegin();
+  auto field_iter = header_type->fields.rbegin();
   // This assumes little-endian number for bits.
   while ((*field_iter)->name != member) {
       rv += (*field_iter)->type->width_bits();
-    if (++field_iter == header_type->fields->rend())
+    if (++field_iter == header_type->fields.rend())
         BUG("No field %s in %s", member, expr->type); }
   return rv;
 }

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -330,10 +330,11 @@ class ConstructorCallExpression : Expression {
 
 /// Represents a list of expressions separated by commas
 class ListExpression : Expression {
-    Vector<Expression> components;
+    inline Vector<Expression> components;
     validate {
-        components->check_null();
+        components.check_null();
     }
+    void push_back(Expression e) { components.push_back(e); }
 }
 
 /** @} *//* end group irdefs */

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -70,6 +70,8 @@ class IndexedVector : public Vector<T> {
     IndexedVector() = default;
     IndexedVector(const IndexedVector &) = default;
     IndexedVector(IndexedVector &&) = default;
+    IndexedVector(const std::initializer_list<const T *> &a) : Vector<T>(a) {
+        for (auto el : *this) insertInMap(el); }
     IndexedVector &operator=(const IndexedVector &) = default;
     IndexedVector &operator=(IndexedVector &&) = default;
     explicit IndexedVector(const T *a) {
@@ -117,7 +119,7 @@ class IndexedVector : public Vector<T> {
         return insert(Vector<T>::end(), toAppend.begin(), toAppend.end()); }
     iterator insert(iterator i, const T* v) {
         insertInMap(v);
-        return typename Vector<T>::insert(i, v); }
+        return Vector<T>::insert(i, v); }
     template <class... Args> void emplace_back(Args&&... args) {
         auto el = new T(std::forward<Args>(args)...);
         insert(el); }
@@ -146,6 +148,10 @@ class IndexedVector : public Vector<T> {
 
     void toJSON(JSONGenerator &json) const override;
     static IndexedVector<T>* fromJSON(JSONLoader &json);
+    void check_valid() const {
+        for (auto el : *this) {
+            auto it = declarations.find(el->getName());
+            assert(it != declarations.end() && it->second == el); } }
 };
 
 }  // namespace IR

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -54,8 +54,7 @@ Util::Enumerator<const IR::IDeclaration*>* IGeneralNamespace::getDeclsByName(cst
 
 void IGeneralNamespace::checkDuplicateDeclarations() const {
     std::unordered_map<cstring, ID> seen;
-    auto decls = getDeclarations();
-    for (auto decl : *decls) {
+    for (auto decl : *getDeclarations()) {
         IR::ID name = decl->getName();
         auto f = seen.find(name.name);
         if (f != seen.end()) {
@@ -67,8 +66,8 @@ void IGeneralNamespace::checkDuplicateDeclarations() const {
 }
 
 void P4Parser::checkDuplicates() const {
-    for (auto decl : *states) {
-        auto prev = parserLocals->getDeclaration(decl->getName().name);
+    for (auto decl : states) {
+        auto prev = parserLocals.getDeclaration(decl->getName().name);
         if (prev != nullptr)
             ::error("State %1% has same name as %2%", decl, prev);
     }
@@ -95,7 +94,7 @@ const Method* Type_Extern::lookupMethod(cstring name, int paramCount) const {
     size_t upc = paramCount;
 
     bool reported = false;
-    for (auto m : *methods) {
+    for (auto m : methods) {
         if (m->name == name && m->minParameterCount() <= upc && m->maxParameterCount() >= upc) {
             if (result == nullptr) {
                 result = m;
@@ -144,12 +143,9 @@ P4Table::getApplyMethodType() const {
         BUG("Action property is not an IR::ActionList, but %1%",
             actions);
     auto alv = actions->value->to<IR::ActionList>();
-    auto fields = new IR::IndexedVector<IR::StructField>();
     auto hit = new IR::StructField(IR::Type_Table::hit, IR::Type_Boolean::get());
-    fields->push_back(hit);
     auto label = new IR::StructField(IR::Type_Table::action_run, new IR::Type_ActionEnum(alv));
-    fields->push_back(label);
-    auto rettype = new IR::Type_Struct(ID(name), fields);
+    auto rettype = new IR::Type_Struct(ID(name), { hit, label });
     auto applyMethod = new IR::Type_Method(rettype, new IR::ParameterList());
     return applyMethod;
 }
@@ -178,7 +174,7 @@ Util::Enumerator<const IDeclaration*>* P4Action::getDeclarations() const
 { return body->getDeclarations(); }
 
 const IDeclaration* P4Action::getDeclByName(cstring name) const
-{ return body->components->getDeclaration(name); }
+{ return body->components.getDeclaration(name); }
 
 const IR::PackageBlock* ToplevelBlock::getMain() const {
     auto program = getProgram();

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -33,19 +33,39 @@
   Some assignments are turned into methods returning constant values:
   stringOp     -> cstring getStringOp() const
   precedence   -> int getPrecedence() const
+
+  When defining fields and methods in an IR class, all fields and arguments of any IR
+  class type are automatically converted into const IR::class * fields or arguments, unless
+  they are identified as 'inline'.  It is not possible to create a non-const pointer to
+  an IR class in any other IR class.
+
+  There are some special keywords that can be applied (as decl modifiers) to fields that
+  affect how they are created, checked, and initialized.
+
+  inline      The field (of IR class type) should be defined directly in the object
+              rather than being converted to a const T * as described above.
+  NullOK      The field is a ppointer and may be null (verify will check that it is not otherwise)
+  optional    The field may be proveded as an argument to the constructor but need not be.
+              (overloaded constructors will be created as needed)
+
+  Unless there is a '#noconstructor' tag in the class, a constructor
+  will automatically be generated that takes as arguments values to
+  initialize all fields of the IR class and its bases that do not have
+  explicit initializers.  Fields marked 'optional' will create multiple
+  constructors both with and without an argument for that field.
  */
 
 class ParserState : ISimpleNamespace, Declaration, IAnnotated {
-    optional Annotations        annotations = Annotations::empty;
-    IndexedVector<StatOrDecl>   components;
+    optional Annotations                        annotations = Annotations::empty;
+    optional inline IndexedVector<StatOrDecl>   components;
     // selectExpression can be a SelectExpression, or a PathExpression representing a state
-    NullOK Expression         selectExpression;
+    NullOK Expression                   selectExpression;
 
     Annotations getAnnotations() const override { return annotations; }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return components->getDeclarations(); }
+        return components.getDeclarations(); }
     const IDeclaration* getDeclByName(cstring name) const override {
-        return components->getDeclaration(name); }
+        return components.getDeclaration(name); }
 
     static const cstring accept;
     static const cstring reject;
@@ -62,19 +82,19 @@ class ParserState : ISimpleNamespace, Declaration, IAnnotated {
 
 // A parser that contains all states (unlike the P4 v1.0 parser, which is really just a state)
 class P4Parser : Type_Declaration, ISimpleNamespace, IApply, IContainer {
-    Type_Parser                 type;
-    optional ParameterList      constructorParams = new ParameterList;
-    IndexedVector<Declaration>  parserLocals;
-    IndexedVector<ParserState>  states;
+    Type_Parser                                 type;
+    optional ParameterList                      constructorParams = new ParameterList;
+    optional inline IndexedVector<Declaration>  parserLocals;
+    optional inline IndexedVector<ParserState>  states;
 
     TypeParameters getTypeParameters() const override { return type->getTypeParameters(); }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return parserLocals->getDeclarations()->concat(states->getDeclarations()); }
+        return parserLocals.getDeclarations()->concat(states.getDeclarations()); }
     IDeclaration getDeclByName(cstring name) const override {
-        auto decl = parserLocals->getDeclaration(name);
+        auto decl = parserLocals.getDeclaration(name);
         if (decl != nullptr)
             return decl;
-        return states->getDeclaration(name); }
+        return states.getDeclaration(name); }
     Type_Method getApplyMethodType() const override { return type->getApplyMethodType(); }
     Type_Method getConstructorMethodType() const override;
     ParameterList getConstructorParameters() const override { return constructorParams; }
@@ -83,32 +103,32 @@ class P4Parser : Type_Declaration, ISimpleNamespace, IApply, IContainer {
     validate {
         if (!(name == type->name))
             BUG("Name mismatch for %1%: %2% != %3%", this, name, type->name);
-        parserLocals->check_null();
-        states->check_null();
+        parserLocals.check_null();
+        states.check_null();
         checkDuplicates();
     }
     toString { return cstring("parser ") + externalName(); }
 }
 
 class P4Control : Type_Declaration, ISimpleNamespace, IApply, IContainer {
-    Type_Control                type;
-    optional ParameterList      constructorParams = new ParameterList;
-    IndexedVector<Declaration>  controlLocals;
-    BlockStatement       body;
+    Type_Control                                type;
+    optional ParameterList                      constructorParams = new ParameterList;
+    optional inline IndexedVector<Declaration>  controlLocals;
+    BlockStatement                              body;
 
     TypeParameters getTypeParameters() const override { return type->getTypeParameters(); }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return controlLocals->getDeclarations(); }
+        return controlLocals.getDeclarations(); }
     Type_Method getApplyMethodType() const override { return type->getApplyMethodType(); }
     Type_Method getConstructorMethodType() const override;
     IDeclaration getDeclByName(cstring name) const override {
-        return controlLocals->getDeclaration(name); }
+        return controlLocals.getDeclaration(name); }
     ParameterList getConstructorParameters() const override { return constructorParams; }
 #apply
     validate {
         if (!(name == type->name))
             BUG("Name mismatch for %1%: %2% != %3%", this, name, type->name);
-        controlLocals->check_null();
+        controlLocals.check_null();
     }
     toString { return cstring("control ") + externalName(); }
 }
@@ -124,22 +144,22 @@ class P4Action : Declaration, ISimpleNamespace, IAnnotated {
 
 class Type_Error : ISimpleNamespace, Type_Declaration {
     static const cstring error;
-    IndexedVector<Declaration_ID> members;
+    optional inline IndexedVector<Declaration_ID> members;
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return members->getDeclarations(); }
+        return members.getDeclarations(); }
     IDeclaration getDeclByName(cstring name) const override {
-        return members->getDeclaration(name); }
-    validate{ members->check_null(); }
+        return members.getDeclaration(name); }
+    validate{ members.check_null(); }
 }
 
 // Not a subclass of IDeclaration
 class Declaration_MatchKind : ISimpleNamespace {
-    IndexedVector<Declaration_ID> members;
+    optional inline IndexedVector<Declaration_ID> members;
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return members->getDeclarations(); }
+        return members.getDeclarations(); }
     IDeclaration getDeclByName(cstring name) const override {
-        return members->getDeclaration(name); }
-    validate{ members->check_null(); }
+        return members.getDeclaration(name); }
+    validate{ members.check_null(); }
 }
 
 // Table property value abstract base class
@@ -174,9 +194,12 @@ class ActionListElement : IAnnotated, IDeclaration {
 
 // A list of actions (in a table)
 class ActionList : PropertyValue {
-    IndexedVector<ActionListElement> actionList;
-    validate{ actionList->check_null(); }
-    size_t size() const { return actionList->size(); }
+    inline IndexedVector<ActionListElement> actionList;
+    validate{ actionList.check_null(); }
+    size_t size() const { return actionList.size(); }
+    void push_back(ActionListElement e) { actionList.push_back(e); }
+    ActionListElement getDeclaration(cstring n) const {
+        return actionList.getDeclaration<ActionListElement>(n); }
 }
 
 class KeyElement : IAnnotated {
@@ -207,8 +230,9 @@ class KeyElement : IAnnotated {
 
 // Value of a table key property
 class Key : PropertyValue {
-    Vector<KeyElement> keyElements;
-    validate { keyElements->check_null(); }
+    inline Vector<KeyElement> keyElements;
+    validate { keyElements.check_null(); }
+    void push_back(KeyElement ke) { keyElements.push_back(ke); }
 }
 
 /// Pre-defined entry in a table
@@ -227,8 +251,8 @@ class Entry : IAnnotated {
 
 /// List of predefined entries. Part of table properties
 class EntriesList : PropertyValue {
-    Vector<Entry> entries;
-    size_t size() const { return entries->size(); }
+    inline Vector<Entry> entries;
+    size_t size() const { return entries.size(); }
     dbprint { out << "{ " << entries << "}"; }
 }
 
@@ -241,22 +265,22 @@ class Property : Declaration, IAnnotated {
 }
 
 class TableProperties : ISimpleNamespace {
-    IndexedVector<Property> properties;
-    toString{ return "TableProperties(" + Util::toString(properties->size()) + ")"; }
-    TableProperties() { properties = new IndexedVector<Property>(); }
+    optional inline IndexedVector<Property> properties;
+    toString{ return "TableProperties(" + Util::toString(properties.size()) + ")"; }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return properties->getDeclarations(); }
+        return properties.getDeclarations(); }
     Property getProperty(cstring name) const {
-        return properties->getDeclaration<Property>(name); }
+        return properties.getDeclaration<Property>(name); }
     IDeclaration getDeclByName(cstring name) const override {
-        return properties->getDeclaration(name); }
+        return properties.getDeclaration(name); }
+    void push_back(Property prop) { properties.push_back(prop); }
 
     static const cstring actionsPropertyName;
     static const cstring keyPropertyName;
     static const cstring defaultActionPropertyName;
     static const cstring entriesPropertyName;
 #nodbprint
-    validate{ properties->check_null(); }
+    validate{ properties.check_null(); properties.check_valid(); }
 }
 
 class P4Table : Declaration, IAnnotated, IApply {
@@ -351,11 +375,11 @@ class Declaration_Instance : Declaration, IAnnotated, IInstance {
 
 // Toplevel program representation
 class P4Program : ISimpleNamespace {
-    IndexedVector<Node> declarations;
+    optional inline IndexedVector<Node> declarations;
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return declarations->getDeclarations(); }
+        return declarations.getDeclarations(); }
     IDeclaration getDeclByName(cstring name) const override {
-        return declarations->getDeclaration(name); }
+        return declarations.getDeclaration(name); }
     static const cstring main;
 #apply
 }
@@ -398,12 +422,13 @@ class IfStatement : Statement {
 }
 
 class BlockStatement : Statement, ISimpleNamespace {
-    optional Annotations        annotations = Annotations::empty;
-    IndexedVector<StatOrDecl>   components;
+    optional Annotations                        annotations = Annotations::empty;
+    optional inline IndexedVector<StatOrDecl>   components;
     IDeclaration getDeclByName(cstring name) const override {
-        return components->getDeclaration(name); }
+        return components.getDeclaration(name); }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return components->getDeclarations(); }
+        return components.getDeclarations(); }
+    void push_back(StatOrDecl st) { components.push_back(st); }
 }
 
 class MethodCallStatement : Statement {

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -85,6 +85,8 @@ class JSONLoader {
         v = *IR::Vector<T>::fromJSON(*this); }
     template<typename T> void unpack_json(const IR::Vector<T> *&v) {
         v = IR::Vector<T>::fromJSON(*this); }
+    template<typename T> void unpack_json(IR::IndexedVector<T> &v) {
+        v = *IR::IndexedVector<T>::fromJSON(*this); }
     template<typename T> void unpack_json(const IR::IndexedVector<T> *&v) {
         v = IR::IndexedVector<T>::fromJSON(*this); }
     template<class T, template<class K, class V, class COMP, class ALLOC> class MAP,
@@ -93,7 +95,7 @@ class JSONLoader {
         m = *IR::NameMap<T, MAP, COMP, ALLOC>::fromJSON(*this); }
     template<class T, template<class K, class V, class COMP, class ALLOC> class MAP,
              class COMP, class ALLOC>
-    void unpack_json(IR::NameMap<T, MAP, COMP, ALLOC> *&m) {
+    void unpack_json(const IR::NameMap<T, MAP, COMP, ALLOC> *&m) {
         m = IR::NameMap<T, MAP, COMP, ALLOC>::fromJSON(*this); }
 
     template<typename K, typename V>

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -121,7 +121,7 @@ const Type_MatchKind *Type_MatchKind::get() {
 }
 
 bool Type_ActionEnum::contains(cstring name) const {
-    for (auto a : *actionList->actionList) {
+    for (auto a : actionList->actionList) {
         if (a->getName() == name)
             return true;
     }

--- a/ir/type.def
+++ b/ir/type.def
@@ -110,26 +110,26 @@ class Parameter : Declaration, IAnnotated {
 }
 
 class ParameterList : ISimpleNamespace {
-    IndexedVector<Parameter> parameters;
-    validate{ parameters->check_null(); }
-    ParameterList() { parameters = new IndexedVector<Parameter>(); }
+    optional inline IndexedVector<Parameter> parameters;
+    validate{ parameters.check_null(); }
     Util::Enumerator<Parameter>* getEnumerator() const {
-        return parameters->getEnumerator(); }
+        return parameters.getEnumerator(); }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return parameters->getDeclarations(); }
-    size_t size() const { return parameters->size(); }
+        return parameters.getDeclarations(); }
+    size_t size() const { return parameters.size(); }
     bool empty() const { return size() == 0; }
     IR::Parameter getParameter(cstring name) const {
-        return parameters->getDeclaration<Parameter>(name); }
+        return parameters.getDeclaration<Parameter>(name); }
     IR::Parameter getParameter(unsigned index) const {
-        for (auto &param : *parameters)
+        for (auto &param : parameters)
             if (0 == index--) return param;
         BUG("Only %1% parameters; index #%2% requested", size(), size()+index); }
     IR::IDeclaration getDeclByName(cstring name) const override { return getParameter(name); }
+    void push_back(const Parameter *p) { parameters.push_back(p); }
     toString {
         cstring result = "";
         bool first = true;
-        for (auto p : *parameters) {
+        for (auto p : parameters) {
             if (!first)
                 result += ", ";
             first = false;
@@ -138,8 +138,8 @@ class ParameterList : ISimpleNamespace {
         return result;
     }
 #emit
-    decltype(parameters->begin()) begin() const { return parameters->begin(); }
-    decltype(parameters->end()) end() const { return parameters->end(); }
+    auto begin() const -> decltype(parameters.begin()) { return parameters.begin(); }
+    auto end() const -> decltype(parameters.end()) { return parameters.end(); }
 #end
 }
 
@@ -186,21 +186,21 @@ class Type_MatchKind : Type_Base {
 }
 
 class TypeParameters : ISimpleNamespace {
-    IndexedVector<Type_Var> parameters;
-    TypeParameters() : parameters(new IndexedVector<Type_Var>()) {}
+    optional inline IndexedVector<Type_Var> parameters;
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return parameters->getDeclarations(); }
-    bool empty() const { return parameters->empty(); }
-    size_t size() const { return parameters->size(); }
+        return parameters.getDeclarations(); }
+    bool empty() const { return parameters.empty(); }
+    size_t size() const { return parameters.size(); }
     IR::IDeclaration getDeclByName(cstring name) const override {
-        return parameters->getDeclaration(name); }
-    validate{ parameters->check_null(); }
+        return parameters.getDeclaration(name); }
+    void push_back(Type_Var tv) { parameters.push_back(tv); }
+    validate{ parameters.check_null(); }
     toString {
-        if (parameters->size() == 0)
+        if (parameters.size() == 0)
             return "";
         cstring result = "<";
         bool first = true;
-        for (auto p : *parameters) {
+        for (auto p : parameters) {
             if (!first)
                 result += ", ";
             first = false;
@@ -218,21 +218,21 @@ class StructField : Declaration, IAnnotated {
 }
 
 abstract Type_StructLike : Type_Declaration, ISimpleNamespace, IAnnotated {
-    optional Annotations       annotations = Annotations::empty;
-    IndexedVector<StructField> fields;
+    optional Annotations                        annotations = Annotations::empty;
+    optional inline IndexedVector<StructField>  fields;
     Annotations getAnnotations() const override { return annotations; }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return fields->getDeclarations(); }
+        return fields.getDeclarations(); }
     StructField getField(cstring name) const {
-        return fields->getDeclaration<StructField>(name); }
+        return fields.getDeclaration<StructField>(name); }
     int width_bits() const override {
         int rv = 0;
-        for (auto f : *fields)
+        for (auto f : fields)
             rv += f->type->width_bits();
         return rv; }
     IR::IDeclaration getDeclByName(cstring name) const override {
-        return fields->getDeclaration(name); }
-    validate{ fields->check_null(); }
+        return fields.getDeclaration(name); }
+    validate{ fields.check_null(); }
     dbprint;
 #apply
 }
@@ -248,7 +248,7 @@ class Type_Union : Type_StructLike {
     /// this makes some assumptions on padding
     int width_bits() const override {
         int rv = 0;
-        for (auto f : *fields)
+        for (auto f : fields)
             rv = std::max(rv, f->type->width_bits());
         return rv; }
 }
@@ -274,9 +274,9 @@ class Type_Set : Type {
 
 /// The type of an expressionList
 class Type_Tuple : Type {
-    Vector<Type> components;
-    toString{ return "Tuple(" + Util::toString(components->size()) + ")"; }
-    validate{ components->check_null(); }
+    optional inline Vector<Type> components;
+    toString{ return "Tuple(" + Util::toString(components.size()) + ")"; }
+    validate{ components.check_null(); }
     const Type* getP4Type() const override { return this; }
 }
 
@@ -377,13 +377,13 @@ class Type_String : Type_Base {
 }
 
 class Type_Enum : Type_Declaration, ISimpleNamespace {
-    IndexedVector<Declaration_ID> members;
+    inline IndexedVector<Declaration_ID> members;
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return members->getDeclarations(); }
+        return members.getDeclarations(); }
     IDeclaration getDeclByName(cstring name) const override {
-        return members->getDeclaration(name); }
+        return members.getDeclaration(name); }
 #nodbprint
-    validate{ members->check_null(); }
+    validate{ members.check_null(); }
  }
 
 class Type_Table : Type, IApply {
@@ -481,16 +481,16 @@ class Type_Typedef : Type_Declaration, IAnnotated {
 /// An 'extern' black-box (not a function)
 class Type_Extern : Type_Declaration, IGeneralNamespace, IMayBeGenericType {
     optional TypeParameters typeParameters = new TypeParameters;
-    Vector<Method> methods;  // methods can be overloaded, so this is not IndexedVector
+    optional inline Vector<Method> methods;  // methods can be overloaded, so this is not NameMap
     optional inline NameMap<Attribute, ordered_map> attributes;  // P4_14 only, currently
     optional Annotations annotations = Annotations::empty;
 
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return methods->getEnumerator()->as<const IDeclaration*>()
+        return methods.getEnumerator()->as<const IDeclaration*>()
             ->concat(attributes.valueEnumerator()->as<const IDeclaration*>()); }
     virtual TypeParameters getTypeParameters() const override { return typeParameters; }
     Method lookupMethod(cstring name, int argCount) const;
-    validate{ methods->check_null(); }
+    validate{ methods.check_null(); }
 }
 
 /** @} *//* end group irdefs */

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -416,11 +416,7 @@ class V1Table {
     inline TableProperties      properties = {};  // non-standard properties
     optional Annotations        annotations = Annotations::empty;
 
-    // inefficient add
-    void addProperty(Property prop) {
-        auto props = new IndexedVector<Property>(*properties.properties);
-        props->push_back(prop);
-        properties = TableProperties(properties.srcInfo, props); }
+    void addProperty(Property prop) { properties.push_back(prop); }
     toString { return node_type_name() + " " + name; }
 }
 

--- a/midend/convertEnums.cpp
+++ b/midend/convertEnums.cpp
@@ -7,7 +7,7 @@ const IR::Node* DoConvertEnums::preorder(IR::Type_Enum* type) {
     bool convert = policy->convert(type);
     if (!convert)
         return type;
-    unsigned count = type->members->size();
+    unsigned count = type->members.size();
     unsigned width = policy->enumSize(count);
     LOG1("Converting enum " << type->name << " to " << "bit<" << width << ">");
     BUG_CHECK(count >= (1U << width),
@@ -17,7 +17,7 @@ const IR::Node* DoConvertEnums::preorder(IR::Type_Enum* type) {
     BUG_CHECK(canontype->is<IR::Type_Enum>(),
               "canon type of enum %s is non enum %s?", type, canontype);
     repr.emplace(canontype->to<IR::Type_Enum>(), r);
-    for (auto d : *type->members)
+    for (auto d : type->members)
         r->add(d->name.name);
     return nullptr;  // delete the declaration
 }

--- a/midend/copyStructures.cpp
+++ b/midend/copyStructures.cpp
@@ -26,8 +26,8 @@ const IR::Node* DoCopyStructures::postorder(IR::AssignmentStatement* statement) 
         if (statement->right->is<IR::ListExpression>()) {
             auto list = statement->right->to<IR::ListExpression>();
             unsigned index = 0;
-            for (auto f : *strct->fields) {
-                auto right = list->components->at(index);
+            for (auto f : strct->fields) {
+                auto right = list->components.at(index);
                 auto left = new IR::Member(statement->left, f->name);
                 retval->push_back(new IR::AssignmentStatement(statement->srcInfo, left, right));
                 index++;
@@ -37,7 +37,7 @@ const IR::Node* DoCopyStructures::postorder(IR::AssignmentStatement* statement) 
                 // Leave headers as they are -- copy_header will also copy the valid bit
                 return statement;
 
-            for (auto f : *strct->fields) {
+            for (auto f : strct->fields) {
                 BUG_CHECK(statement->right->is<IR::PathExpression>() ||
                           statement->right->is<IR::Member>() ||
                           statement->right->is<IR::ArrayIndex>(),

--- a/midend/expandLookahead.h
+++ b/midend/expandLookahead.h
@@ -49,11 +49,8 @@ class DoExpandLookahead : public Transform {
     const IR::Node* preorder(IR::P4Parser* parser) override
     { newDecls.clear(); return parser; }
     const IR::Node* postorder(IR::P4Parser* parser) override {
-        if (!newDecls.empty()) {
-            auto locals = new IR::IndexedVector<IR::Declaration>(*parser->parserLocals);
-            locals->append(newDecls);
-            parser->parserLocals = locals;
-        }
+        if (!newDecls.empty())
+            parser->parserLocals.append(newDecls);
         return parser;
     }
 };

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -62,14 +62,14 @@ bool SymbolicValueFactory::isFixedWidth(const IR::Type* type) const {
         return isFixedWidth(type->to<IR::Type_Stack>()->elementType);
     if (type->is<IR::Type_StructLike>()) {
         auto st = type->to<IR::Type_StructLike>();
-        for (auto f : *st->fields)
+        for (auto f : st->fields)
             if (!isFixedWidth(f->type))
                 return false;
         return true;
     }
     if (type->is<IR::Type_Tuple>()) {
         auto tt = type->to<IR::Type_Tuple>();
-        for (auto f : *tt->components) {
+        for (auto f : tt->components) {
             if (!isFixedWidth(f))
                 return false;
         }
@@ -86,14 +86,14 @@ unsigned SymbolicValueFactory::getWidth(const IR::Type* type) const {
         return 1;
     if (type->is<IR::Type_Union>()) {
         unsigned width = 0;
-        for (auto f : *type->to<IR::Type_Union>()->fields)
+        for (auto f : type->to<IR::Type_Union>()->fields)
             width = std::max(width, getWidth(f->type));
         return width;
     }
     if (type->is<IR::Type_StructLike>()) {
         unsigned width = 0;
         auto st = type->to<IR::Type_StructLike>();
-        for (auto f : *st->fields)
+        for (auto f : st->fields)
             width += getWidth(f->type);
         return width;
     }
@@ -105,7 +105,7 @@ unsigned SymbolicValueFactory::getWidth(const IR::Type* type) const {
     if (type->is<IR::Type_Tuple>()) {
         auto tt = type->to<IR::Type_Tuple>();
         unsigned width = 0;
-        for (auto f : *tt->components)
+        for (auto f : tt->components)
             width += getWidth(f);
         return width;
     }
@@ -238,7 +238,7 @@ bool SymbolicEnum::equals(const SymbolicValue* other) const {
 SymbolicStruct::SymbolicStruct(const IR::Type_StructLike* type, bool uninitialized,
                                const SymbolicValueFactory* factory) : SymbolicValue(type) {
     CHECK_NULL(type); CHECK_NULL(factory);
-    for (auto f : *type->fields) {
+    for (auto f : type->fields) {
         auto value = factory->create(f->type, uninitialized);
         fieldValue[f->name.name] = value;
     }
@@ -269,7 +269,7 @@ bool SymbolicStruct::merge(const SymbolicValue* other) {
 }
 
 void SymbolicStruct::setAllUnknown() {
-    for (auto f : *type->to<IR::Type_StructLike>()->fields)
+    for (auto f : type->to<IR::Type_StructLike>()->fields)
         fieldValue[f->name.name]->setAllUnknown();
 }
 
@@ -509,7 +509,7 @@ SymbolicValue* AnyElement::collapse() const {
 SymbolicTuple::SymbolicTuple(const IR::Type_Tuple* type, bool uninitialized,
                              const SymbolicValueFactory* factory) :
         SymbolicValue(type) {
-    for (auto t : *type->components) {
+    for (auto t : type->components) {
         auto v = factory->create(t, uninitialized);
         values.push_back(v);
     }
@@ -669,7 +669,7 @@ void ExpressionEvaluator::postorder(const IR::Constant* expression) {
 void ExpressionEvaluator::postorder(const IR::ListExpression* expression) {
     auto type = typeMap->getType(expression, true);
     auto result = new SymbolicTuple(type->to<IR::Type_Tuple>());
-    for (auto e : *expression->components) {
+    for (auto e : expression->components) {
         auto v = get(e);
         result->add(v);
     }

--- a/midend/localizeActions.cpp
+++ b/midend/localizeActions.cpp
@@ -89,14 +89,14 @@ const IR::Node* LocalizeActions::postorder(IR::P4Control* control) {
     auto actions = ::get(repl->repl, getOriginal<IR::P4Control>());
     if (actions == nullptr)
         return control;
-    auto newDecls = new IR::IndexedVector<IR::Declaration>();
+    IR::IndexedVector<IR::Declaration> newDecls;
     for (auto pair : *actions) {
         auto toInsert = pair.second;
         LOG1("Adding " << dbp(toInsert));
-        newDecls->push_back(toInsert);
+        newDecls.push_back(toInsert);
     }
 
-    newDecls->append(*control->controlLocals);
+    newDecls.append(control->controlLocals);
     control->controlLocals = newDecls;
     return control;
 }
@@ -176,9 +176,9 @@ bool FindRepeatedActionUses::preorder(const IR::PathExpression* expression) {
 
 const IR::Node* DuplicateActions::postorder(IR::P4Control* control) {
     bool changes = false;
-    auto newDecls = new IR::IndexedVector<IR::Declaration>();
-    for (auto d : *control->controlLocals) {
-        newDecls->push_back(d);
+    IR::IndexedVector<IR::Declaration> newDecls;
+    for (auto d : control->controlLocals) {
+        newDecls.push_back(d);
         if (d->is<IR::P4Action>()) {
             // The replacement are inserted in the same place
             // as the original.
@@ -186,7 +186,7 @@ const IR::Node* DuplicateActions::postorder(IR::P4Control* control) {
             if (replacements != nullptr) {
                 for (auto action : Values(*replacements)) {
                     LOG1("Adding " << dbp(action));
-                    newDecls->push_back(action);
+                    newDecls.push_back(action);
                     changes = true;
                 }
             }

--- a/midend/nestedStructs.cpp
+++ b/midend/nestedStructs.cpp
@@ -6,7 +6,7 @@ bool ComplexValues::isNestedStruct(const IR::Type* type) {
     if (!type->is<IR::Type_Struct>())
         return false;
     auto st = type->to<IR::Type_Struct>();
-    for (auto f : *st->fields) {
+    for (auto f : st->fields) {
         auto ftype = typeMap->getType(f, true);
         if (ftype->is<IR::Type_StructLike>() ||
             ftype->is<IR::Type_Tuple>() ||
@@ -21,7 +21,7 @@ bool ComplexValues::isNestedStruct(const IR::Type* type) {
 void ComplexValues::explode(cstring prefix, const IR::Type_Struct* type,
                             FieldsMap* map, IR::Vector<IR::Declaration>* result) {
     CHECK_NULL(type);
-    for (auto f : *type->fields) {
+    for (auto f : type->fields) {
         cstring fname = prefix + "_" + f->name;
         auto ftype = typeMap->getType(f, true);
         if (isNestedStruct(ftype)) {

--- a/midend/nestedStructs.h
+++ b/midend/nestedStructs.h
@@ -45,12 +45,12 @@ class ComplexValues final {
         ordered_map<cstring, Component*> members;
         FieldsMap() = default;
         const IR::Expression* convertToExpression() override {
-            auto vec = new IR::Vector<IR::Expression>();
+            auto vec = new IR::ListExpression({});
             for (auto m : members) {
                 auto e = m.second->convertToExpression();
                 vec->push_back(e);
             }
-            return new IR::ListExpression(vec);
+            return vec;
         }
         Component* get(cstring name) override
         { return ::get(members, name); }

--- a/midend/noMatch.cpp
+++ b/midend/noMatch.cpp
@@ -36,7 +36,6 @@ const IR::Node* DoHandleNoMatch::preorder(IR::P4Parser* parser) {
 
     cstring name = nameGen->newName("noMatch");
     LOG2("Inserting " << name << " state");
-    auto vec = new IR::IndexedVector<IR::StatOrDecl>();
     auto args = new IR::Vector<IR::Expression>();
     args->push_back(new IR::BoolLiteral(false));
     args->push_back(new IR::Member(
@@ -44,12 +43,9 @@ const IR::Node* DoHandleNoMatch::preorder(IR::P4Parser* parser) {
         lib.noMatch.Id()));
     auto verify = new IR::MethodCallExpression(
         new IR::PathExpression(IR::ID(IR::ParserState::verify)), args);
-    vec->push_back(new IR::MethodCallStatement(verify));
-    noMatch = new IR::ParserState(IR::ID(name), vec,
+    noMatch = new IR::ParserState(IR::ID(name), { new IR::MethodCallStatement(verify) },
                                   new IR::PathExpression(IR::ID(IR::ParserState::reject)));
-    auto comp = new IR::IndexedVector<IR::ParserState>(*parser->states);
-    comp->push_back(noMatch);
-    parser->states = comp;
+    parser->states.push_back(noMatch);
     return parser;
 }
 

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -55,14 +55,14 @@ class ParserSymbolicInterpreter {
         ValueMap* result = new ValueMap();
         ExpressionEvaluator ev(refMap, typeMap, result);
 
-        for (auto p : *parser->type->applyParams->parameters) {
+        for (auto p : parser->type->applyParams->parameters) {
             auto type = typeMap->getType(p);
             bool initialized = p->direction == IR::Direction::In ||
                     p->direction == IR::Direction::InOut;
             auto value = factory->create(type, !initialized);
             result->set(p, value);
         }
-        for (auto d : *parser->parserLocals) {
+        for (auto d : parser->parserLocals) {
             auto type = typeMap->getType(d);
             SymbolicValue* value = nullptr;
             if (d->is<IR::Declaration_Constant>()) {
@@ -295,7 +295,7 @@ class ParserSymbolicInterpreter {
     std::vector<ParserStateInfo*>* evaluateState(ParserStateInfo* state) {
         LOG1("Analyzing " << state->state);
         auto valueMap = state->before->clone();
-        for (auto s : *state->state->components) {
+        for (auto s : state->state->components) {
             bool success = executeStatement(state, s, valueMap);
             if (!success)
                 return nullptr;

--- a/midend/predication.cpp
+++ b/midend/predication.cpp
@@ -31,26 +31,26 @@ const IR::Node* Predication::preorder(IR::IfStatement* statement) {
         return statement;
 
     ++ifNestingLevel;
-    auto vec = new IR::IndexedVector<IR::StatOrDecl>();
+    auto rv = new IR::BlockStatement;
     cstring conditionName = generator->newName("cond");
     auto condDecl = new IR::Declaration_Variable(conditionName, IR::Type::Boolean::get());
-    vec->push_back(condDecl);
+    rv->push_back(condDecl);
     auto condition = new IR::PathExpression(IR::ID(conditionName));
 
     // A vector for a new BlockStatement.
-    auto blockVec = new IR::IndexedVector<IR::StatOrDecl>();
+    auto block = new IR::BlockStatement;
 
     const IR::Expression* previousPredicate = predicate();  // This may be nullptr
     // a new name for the new predicate
     cstring newPredName = generator->newName("pred");
     predicateName.push_back(newPredName);
     auto decl = new IR::Declaration_Variable(newPredName, IR::Type::Boolean::get());
-    blockVec->push_back(decl);
+    block->push_back(decl);
     // This evaluates the if condition.
     // We are careful not to evaluate any conditional more times
     // than in the original program, since the evaluation may have side-effects.
     auto trueCond = new IR::AssignmentStatement(condition->clone(), statement->condition);
-    blockVec->push_back(trueCond);
+    block->push_back(trueCond);
 
     const IR::Expression* pred;
     if (previousPredicate == nullptr) {
@@ -59,33 +59,32 @@ const IR::Node* Predication::preorder(IR::IfStatement* statement) {
         pred = new IR::LAnd(previousPredicate, condition->clone());
     }
     auto truePred = new IR::AssignmentStatement(predicate(), pred);
-    blockVec->push_back(truePred);
+    block->push_back(truePred);
 
     visit(statement->ifTrue);
-    blockVec->push_back(statement->ifTrue);
+    block->push_back(statement->ifTrue);
 
     if (statement->ifFalse != nullptr) {
         auto neg = new IR::LNot(condition->clone());
         auto falseCond = new IR::AssignmentStatement(condition->clone(), neg);
-        blockVec->push_back(falseCond);
+        block->push_back(falseCond);
         if (previousPredicate == nullptr) {
             pred = condition->clone();
         } else {
             pred = new IR::LAnd(previousPredicate->clone(), condition->clone());
         }
         auto falsePred = new IR::AssignmentStatement(predicate(), pred);
-        blockVec->push_back(falsePred);
+        block->push_back(falsePred);
 
         visit(statement->ifFalse);
-        blockVec->push_back(statement->ifFalse);
+        block->push_back(statement->ifFalse);
     }
 
-    auto block = new IR::BlockStatement(blockVec);
-    vec->push_back(block);
+    rv->push_back(block);
     predicateName.pop_back();
     --ifNestingLevel;
     prune();
-    return new IR::BlockStatement(vec);
+    return rv;
 }
 
 const IR::Node* Predication::preorder(IR::P4Action* action) {

--- a/midend/removeSelectBooleans.cpp
+++ b/midend/removeSelectBooleans.cpp
@@ -22,17 +22,17 @@ namespace P4 {
 const IR::Expression*
 DoRemoveSelectBooleans::addToplevelCasts(const IR::Expression* expression) {
     if (expression->is<IR::ListExpression>()) {
-        auto vec = new IR::Vector<IR::Expression>();
+        IR::Vector<IR::Expression> vec;
         bool changes = false;
         auto list = expression->to<IR::ListExpression>();
-        for (auto e : *list->components) {
+        for (auto e : list->components) {
             auto type = typeMap->getType(e, true);
             if (type->is<IR::Type_Boolean>()) {
                 changes = true;
                 auto cast = new IR::Cast(IR::Type_Bits::get(1), e);
-                vec->push_back(cast);
+                vec.push_back(cast);
             } else {
-                vec->push_back(e);
+                vec.push_back(e);
             }
         }
         if (changes)

--- a/midend/simplifySelectCases.cpp
+++ b/midend/simplifySelectCases.cpp
@@ -35,7 +35,7 @@ void DoSimplifySelectCases::checkSimpleConstant(const IR::Expression* expr) cons
     }
     if (expr->is<IR::ListExpression>()) {
         auto list = expr->to<IR::ListExpression>();
-        for (auto e : *list->components)
+        for (auto e : list->components)
             checkSimpleConstant(e);
         return;
     }


### PR DESCRIPTION
This change seems large but is relatively simple.  The basic change is to use the `inline` keyword in more places in the IR .def files to reduce the number of indirections.  This generally allow simpler transforms as an inline subobject can be modified when the containing object is modified, instead of having to coordinate the changes across multiple preorder/postorder functions.

This change does not (yet) change any of the transform passes in any major way to take advantage of this, but is because I have several times wanted to simplify some pass, but have had difficulty doing that because of the extra indirections.