### PR TITLE
Support annotations for actions params and match keys. (#463)

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -233,6 +233,8 @@ struct MatchField {
     const cstring name;       // The fully qualified external name of this field.
     const MatchType type;     // The match algorithm - exact, ternary, range, etc.
     const uint32_t bitwidth;  // How wide this field is.
+    const IR::IAnnotated* annotations;  // If non-null, any annotations applied
+                                        // to this field.
 };
 
 /// The types of action profiles available in the V1 model.
@@ -1017,6 +1019,7 @@ public:
             auto match_field = table->add_match_fields();
             match_field->set_id(index++);
             match_field->set_name(field.name);
+            addAnnotations(match_field, field.annotations);
             match_field->set_bitwidth(field.bitwidth);
             match_field->set_match_type(field.type);
         }
@@ -1333,7 +1336,8 @@ getMatchFields(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMap)
         }
 
         matchFields.push_back(MatchField{path->serialize(), matchType,
-                                         uint32_t(path->type->width_bits())});
+                                         uint32_t(path->type->width_bits()),
+                                         keyElement->to<IR::IAnnotated>()});
     }
 
     return matchFields;

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -179,11 +179,12 @@ class ActionList : PropertyValue {
     size_t size() const { return actionList->size(); }
 }
 
-class KeyElement {
+class KeyElement : IAnnotated {
     optional Annotations annotations = Annotations::empty;
     Expression           expression;
     PathExpression       matchType;
 
+    Annotations     getAnnotations() const override { return annotations; }
     const IR::Node *transform_visit(Transform &v) {
         // call this from Transform::preorder(KeyElement) if the transform might split
         // the expression into a Vector<Expression>


### PR DESCRIPTION
This PR implements P4Runtime serializer support for annotations on action parameters and match keys.

I had to make KeyElement implement IAnnotated; this is just an oversight of the current code, since KeyElement already contains a list of annotations.