### PR TITLE
Inherit from the PI docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM p4lang/behavioral-model:latest
+FROM p4lang/pi:latest
 MAINTAINER Seth Fowler <seth.fowler@barefootnetworks.com>
 
 # Default to using 2 make jobs, which is a good default for CI. If you're


### PR DESCRIPTION
We can't run PTF/P4Runtime tests without having P4Runtime available. I suspect we'll eventually want to do that in p4c, but before we get to that point we have a more immediate need for both p4c and P4Runtime in downstream images.

Once we make this change, we could just grab the installed P4Runtime protobuf headers and get rid of the PI submodule. The tradeoff for doing that is that people who want to build p4c will also need to build and install P4Runtime. That seemed like too complicated an issue to decide in this PR, so for now I've left the PI submodule in place.