### PR TITLE
Partial implementation of adding filename, line, column info to JSON …

### DIFF
--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -1082,7 +1082,9 @@ JsonConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                     auto ei = P4::EnumInstance::resolve(mc->arguments->at(1), typeMap);
                     CHECK_NULL(ei);
                     cstring algo = convertHashAlgorithm(ei->name);
-                    cstring calcName = createCalculation(algo, mc->arguments->at(3), calculations, mc);
+                    cstring calcName = createCalculation(algo,
+                                                         mc->arguments->at(3),
+                                                         calculations, mc);
                     calc->emplace("type", "calculation");
                     calc->emplace("value", calcName);
                     parameters->append(calc);

--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -2146,7 +2146,7 @@ void JsonConverter::addHeaderStacks(const IR::Type_Struct* headersStruct) {
         auto json = new Util::JsonObject();
         json->emplace("name", extVisibleName(f));
         json->emplace("id", nextId("stack"));
-        // TBD jafinger - add line/col here?
+        addSrcInfoData(json, f);
         json->emplace("size", stack->getSize());
         auto type = typeMap->getTypeType(stack->elementType, true);
         BUG_CHECK(type->is<IR::Type_Header>(), "%1% not a header type", stack->elementType);
@@ -2295,7 +2295,6 @@ void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
     CHECK_NULL(refMap);
     CHECK_NULL(enumMap);
 
-    ::warning("%1%: JsonConverter::convert ", toplevelBlock);
     auto package = toplevelBlock->getMain();
     if (package == nullptr) {
         ::error("No output to generate");

--- a/backends/bmv2/jsonconverter.cpp
+++ b/backends/bmv2/jsonconverter.cpp
@@ -355,7 +355,7 @@ class ExpressionConverter : public Inspector {
                 v->append(0);
                 v->append(width);
                 map.emplace(expression, j);
-                // TBD jafinger - add line/col here?
+                // TODO(jafingerhut) - add line/col here?
                 return;
             }
         } else if (instance->is<P4::BuiltInMethod>()) {
@@ -370,7 +370,7 @@ class ExpressionConverter : public Inspector {
                 auto l = get(bim->appliedTo);
                 e->emplace("right", l);
                 map.emplace(expression, result);
-                // TBD jafinger - add line/col here?
+                // TODO(jafingerhut) - add line/col here?
                 return;
             }
         }
@@ -810,13 +810,13 @@ void addSrcInfoData(Util::JsonObject* result,
     unsigned lineNumber, columnNumber;
     cstring fName = node->srcInfo.toSourcePositionData(&lineNumber,
                                                        &columnNumber);
-    if (fName == NULL) {
+    if (fName == nullptr) {
         // Do not add anything to the JSON file for this, as this is
         // likely a statement synthesized by the compiler, and either
         // not easy, or it is impossible, to correlate it directly
         // with anything in the user's P4 source code.
     } else {
-        cstring sourceFrag = node->srcInfo.toSourceFragment2();
+        cstring sourceFrag = node->srcInfo.toBriefSourceFragment();
         result->emplace("filename", fName);
         result->emplace("line", lineNumber);
         result->emplace("column", columnNumber);
@@ -829,19 +829,19 @@ void addSrcInfoDataAssignment(Util::JsonObject* result,
                               const IR::Node* lhsNode,
                               const IR::Node* rhsNode) {
     unsigned lineNumber, columnNumber;
-    cstring fName = node->srcInfo.toSourcePositionData(NULL, NULL);
+    cstring fName = node->srcInfo.toSourcePositionData(nullptr, nullptr);
     cstring lhsStr = lhsNode->srcInfo.toSourcePositionData(&lineNumber,
                                                         &columnNumber);
-    cstring rhsStr = rhsNode->srcInfo.toSourcePositionData(NULL, NULL);
-    if (fName == NULL || lhsStr == NULL || rhsStr == NULL) {
+    cstring rhsStr = rhsNode->srcInfo.toSourcePositionData(nullptr, nullptr);
+    if (fName == nullptr || lhsStr == nullptr || rhsStr == nullptr) {
         // Do not add anything to the JSON file for this, as this is
         // likely a statement synthesized by the compiler, and either
         // not easy, or it is impossible, to correlate it directly
         // with anything in the user's P4 source code.
     } else {
-        cstring sourceFrag = node->srcInfo.toSourceFragment2();
-        cstring lhsFrag = lhsNode->srcInfo.toSourceFragment2();
-        cstring rhsFrag = rhsNode->srcInfo.toSourceFragment2();
+        cstring sourceFrag = node->srcInfo.toBriefSourceFragment();
+        cstring lhsFrag = lhsNode->srcInfo.toBriefSourceFragment();
+        cstring rhsFrag = rhsNode->srcInfo.toBriefSourceFragment();
         result->emplace("filename", fName);
         result->emplace("line", lineNumber);
         result->emplace("column", columnNumber);
@@ -885,7 +885,7 @@ JsonConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                                  Util::JsonArray* result, Util::JsonArray* fieldLists,
                                  Util::JsonArray* calculations, Util::JsonArray* learn_lists) {
     for (auto s : *body) {
-        // TBD jafinger - add line/col at all individual cases below,
+        // TODO(jafingerhut) - add line/col at all individual cases below,
         // or perhaps it can be done as a common case above or below
         // for all of them?
         if (!s->is<IR::Statement>()) {
@@ -1058,6 +1058,7 @@ JsonConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                         auto session = conv->convert(mc->arguments->at(1));
                         auto primitive = mkPrimitive(prim, result);
                         auto parameters = mkParameters(primitive);
+                        // TODO(jafingerhut): addSrcInfoData(primitive, s);
                         parameters->append(session);
 
                         if (id >= 0) {
@@ -1092,7 +1093,7 @@ JsonConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                     BUG_CHECK(mc->arguments->size() == 2, "Expected 2 arguments for %1%", mc);
                     auto primitive = mkPrimitive("generate_digest", result);
                     auto parameters = mkParameters(primitive);
-                    // TBD jafinger: addSrcInfoData(primitive, s);
+                    // TODO(jafingerhut): addSrcInfoData(primitive, s);
                     auto dest = conv->convert(mc->arguments->at(0));
                     parameters->append(dest);
                     cstring listName = "digest";
@@ -1123,7 +1124,7 @@ JsonConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                             "resubmit" : "recirculate";
                     auto primitive = mkPrimitive(prim, result);
                     auto parameters = mkParameters(primitive);
-                    // TBD jafinger: addSrcInfoData(primitive, s);
+                    // TODO(jafingerhut): addSrcInfoData(primitive, s);
                     cstring listName = prim;
                     // If we are supplied a type argument that is a named type use
                     // that for the list name.
@@ -1156,7 +1157,7 @@ JsonConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                     auto primitive =
                             mkPrimitive(v1model.random.modify_field_rng_uniform.name, result);
                     auto params = mkParameters(primitive);
-                    // TBD jafinger: addSrcInfoData(primitive, s);
+                    // TODO(jafingerhut): addSrcInfoData(primitive, s);
                     auto dest = conv->convert(mc->arguments->at(0));
                     auto lo = conv->convert(mc->arguments->at(1));
                     auto hi = conv->convert(mc->arguments->at(2));
@@ -1168,7 +1169,7 @@ JsonConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                     BUG_CHECK(mc->arguments->size() == 1, "Expected 1 arguments for %1%", mc);
                     auto primitive = mkPrimitive(v1model.truncate.name, result);
                     auto params = mkParameters(primitive);
-                    // TBD jafinger: addSrcInfoData(primitive, s);
+                    // TODO(jafingerhut): addSrcInfoData(primitive, s);
                     auto len = conv->convert(mc->arguments->at(0));
                     params->append(len);
                     continue;
@@ -1212,7 +1213,7 @@ int JsonConverter::createFieldList(const IR::Expression* expr, cstring group, cs
     int id = nextId(group);
     fl->emplace("id", id);
     fl->emplace("name", listName);
-    // TBD jafinger - add line/col here?
+    // TODO(jafingerhut) - add line/col here?
     auto elements = mkArrayField(fl, "elements");
     addToFieldList(expr, elements);
     return id;
@@ -1311,7 +1312,7 @@ void JsonConverter::convertTableEntries(const IR::P4Table *table,
     auto entries = mkArrayField(jsonTable, "entries");
     int entryPriority = 1;  // default priority is defined by index position
     for (auto e : entriesList->entries) {
-        // TBD jafinger - add line/col here?
+        // TODO(jafingerhut) - add line/col here?
         auto entry = new Util::JsonObject();
 
         auto keyset = e->getKeys();
@@ -1454,7 +1455,7 @@ bool JsonConverter::handleTableImplementation(const IR::Property* implementation
         action_profiles->append(action_profile);
         action_profile->emplace("name", apname);
         action_profile->emplace("id", nextId("action_profiles"));
-        // TBD jafinger - add line/col here?
+        // TODO(jafingerhut) - add line/col here?
         // TBD what about the else if cases below?
 
         auto add_size = [&action_profile, &arguments](size_t arg_index) {
@@ -1718,9 +1719,9 @@ JsonConverter::convertTable(const CFG::TableNode* node,
                 cstring ctrname = ctrs->externalName("counter");
                 jctr->emplace("name", ctrname);
                 jctr->emplace("id", nextId("counter_arrays"));
-                // TBD jafinger - what kind of P4_16 code causes this
+                // TODO(jafingerhut) - what kind of P4_16 code causes this
                 // code to run, if any?
-                // TBD jafinger: addSrcInfoData(jctr, ctrs);
+                // TODO(jafingerhut): addSrcInfoData(jctr, ctrs);
                 bool direct = te->name == v1model.directCounter.name;
                 jctr->emplace("is_direct", direct);
                 jctr->emplace("binding", name);
@@ -2001,7 +2002,7 @@ Util::IJson* JsonConverter::convertControl(const IR::ControlBlock* block, cstrin
                 // So we don't do anything.
                 continue;
 
-            // TBD jafinger - add line/col here? for a thing declared
+            // TODO(jafingerhut) - add line/col here? for a thing declared
             // within a control
 
             if (bl->is<IR::ExternBlock>()) {
@@ -2071,7 +2072,7 @@ Util::IJson* JsonConverter::convertControl(const IR::ControlBlock* block, cstrin
                         LOG3("Created direct counter " << name);
                         jctr->emplace("name", name);
                         jctr->emplace("id", nextId("counter_arrays"));
-                        // TBD jafinger - add line/col here?
+                        // TODO(jafingerhut) - add line/col here?
                         jctr->emplace("is_direct", true);
                         jctr->emplace("binding", it->second->externalName());
                         counters->append(jctr);
@@ -2113,7 +2114,7 @@ Util::IJson* JsonConverter::convertControl(const IR::ControlBlock* block, cstrin
                     auto action_profile = new Util::JsonObject();
                     action_profile->emplace("name", name);
                     action_profile->emplace("id", nextId("action_profiles"));
-                    // TBD jafinger - add line/col here?
+                    // TODO(jafingerhut) - add line/col here?
 
                     auto add_size = [&action_profile, &eb](const cstring &pname) {
                       auto sz = eb->getParameterValue(pname);
@@ -2185,7 +2186,7 @@ void JsonConverter::addHeaderStacks(const IR::Type_Struct* headersStruct) {
             cstring name = extVisibleName(f) + "[" + Util::toString(i) + "]";
             header->emplace("name", name);
             header->emplace("id", id);
-            // TBD jafinger - add line/col here?
+            // TODO(jafingerhut) - add line/col here?
             header->emplace("header_type", header_type);
             header->emplace("metadata", false);
             headerInstances->append(header);
@@ -2208,7 +2209,7 @@ void JsonConverter::addLocals() {
             auto json = new Util::JsonObject();
             json->emplace("name", v->name);
             json->emplace("id", nextId("headers"));
-            // TBD jafinger - add line/col here?
+            // TODO(jafingerhut) - add line/col here?
             json->emplace("header_type", name);
             json->emplace("metadata", true);
             json->emplace("pi_omit", true);  // Don't expose in PI.
@@ -2217,7 +2218,7 @@ void JsonConverter::addLocals() {
             auto json = new Util::JsonObject();
             json->emplace("name", v->name);
             json->emplace("id", nextId("stack"));
-            // TBD jafinger - add line/col here?
+            // TODO(jafingerhut) - add line/col here?
             json->emplace("size", stack->getSize());
             auto type = typeMap->getTypeType(stack->elementType, true);
             BUG_CHECK(type->is<IR::Type_Header>(), "%1% not a header type", stack->elementType);
@@ -2234,7 +2235,7 @@ void JsonConverter::addLocals() {
                 cstring name = v->name + "[" + Util::toString(i) + "]";
                 header->emplace("name", name);
                 header->emplace("id", id);
-                // TBD jafinger - add line/col here?
+                // TODO(jafingerhut) - add line/col here?
                 header->emplace("header_type", header_type);
                 header->emplace("metadata", false);
                 header->emplace("pi_omit", true);  // Don't expose in PI.
@@ -2273,7 +2274,7 @@ void JsonConverter::addLocals() {
     auto json = new Util::JsonObject();
     json->emplace("name", scalarsName);
     json->emplace("id", nextId("headers"));
-    // TBD jafinger - add line/col here?
+    // TODO(jafingerhut) - add line/col here?
     json->emplace("header_type", scalarsName);
     json->emplace("metadata", true);
     json->emplace("pi_omit", true);  // Don't expose in PI.
@@ -2357,8 +2358,8 @@ void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
     scalarsName = refMap->newName("scalars");
     scalarsStruct->emplace("name", scalarsName);
     scalarsStruct->emplace("id", nextId("header_types"));
-    // TBD jafinger - add line/col here?
-    // TBD jafinger: addSrcInfoData(scalarsStruct, refMap);
+    // TODO(jafingerhut) - add line/col here?
+    // TODO(jafingerhut): addSrcInfoData(scalarsStruct, refMap);
     scalars_width = 0;
     mkArrayField(scalarsStruct, "fields");
 
@@ -2403,7 +2404,7 @@ void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
         return;
     dprs->append(deparserJson);
 
-    // TBD jafinger - add line/col for meters, counters, registers,
+    // TODO(jafingerhut) - add line/col for meters, counters, registers,
     // calculations, learn_lists?  Where best to do that?  Perhaps
     // inside convertControl()
     auto meters = mkArrayField(&toplevel, "meter_arrays");
@@ -2442,7 +2443,7 @@ void JsonConverter::convert(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
         auto json = new Util::JsonObject();
         json->emplace("name", v1model.ingress.standardMetadataParam.name);
         json->emplace("id", nextId("headers"));
-        // TBD jafinger - add line/col here?
+        // TODO(jafingerhut) - add line/col here?
         json->emplace("header_type", stdMetaName);
         json->emplace("metadata", true);
         headerInstances->append(json);
@@ -2506,7 +2507,7 @@ void JsonConverter::generateUpdate(const IR::BlockStatement *block,
                                                              calculations, mc);
                         cksum->emplace("name", refMap->newName("cksum_"));
                         cksum->emplace("id", nextId("checksums"));
-                        // TBD jafinger - add line/col here?
+                        // TODO(jafingerhut) - add line/col here?
                         auto jleft = conv->convert(assign->left);
                         cksum->emplace("target", jleft->to<Util::JsonObject>()->get("value"));
                         cksum->emplace("type", "generic");

--- a/backends/bmv2/jsonconverter.h
+++ b/backends/bmv2/jsonconverter.h
@@ -116,7 +116,8 @@ class JsonConverter final {
                                 Util::JsonArray* counters, Util::JsonArray* meters,
                                 Util::JsonArray* registers);
     cstring createCalculation(cstring algo, const IR::Expression* fields,
-                              Util::JsonArray* calculations);
+                              Util::JsonArray* calculations,
+                              const IR::Node* node);
     Util::IJson* nodeName(const CFG::Node* node) const;
     void createForceArith(const IR::Type* stdMetaType, cstring name,
                           Util::JsonArray* force_list) const;

--- a/ir/node.cpp
+++ b/ir/node.cpp
@@ -78,9 +78,9 @@ Util::JsonObject* IR::Node::sourceInfoJsonObj() const {
         // directly with anything in the user's P4 source code.
         return nullptr;
     }
-    bool isAssignment = this->is<IR::AssignmentStatement>();
+    bool isAssignment = is<IR::AssignmentStatement>();
     if (isAssignment) {
-        auto assign = this->to<IR::AssignmentStatement>();
+        auto assign = to<IR::AssignmentStatement>();
         lhs = assign->left;
         rhs = assign->right;
         lhs->srcInfo.toSourcePositionData(&lineNumber, &columnNumber);

--- a/ir/node.cpp
+++ b/ir/node.cpp
@@ -98,7 +98,7 @@ Util::JsonObject* IR::Node::sourceInfoJsonObj() const {
     } else {
         fullSourceFrag = sourceFrag;
     }
-    json->emplace("expression_string", fullSourceFrag);
+    json->emplace("source_fragment", fullSourceFrag);
     return json;
 }
 

--- a/ir/node.h
+++ b/ir/node.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "lib/source_file.h"
 #include "ir-tree-macros.h"
 #include "lib/log.h"
+#include "lib/json.h"
 
 class Visitor;
 class Inspector;
@@ -104,6 +105,7 @@ class Node : public virtual INode {
     explicit Node(JSONLoader &json);
     cstring toString() const override { return node_type_name(); }
     void toJSON(JSONGenerator &json) const override;
+    Util::JsonObject* sourceInfoJsonObj() const;
     virtual bool operator==(const Node &a) const { return typeid(*this) == typeid(a); }
 #define DEFINE_OPEQ_FUNC(CLASS, BASE) \
     virtual bool operator==(const CLASS &) const { return false; }

--- a/lib/json.cpp
+++ b/lib/json.cpp
@@ -173,4 +173,11 @@ JsonObject* JsonObject::emplace(cstring label, IJson* value) {
     return this;
 }
 
+JsonObject* JsonObject::emplace_non_null(cstring label, IJson* value) {
+    if (value != nullptr) {
+        return emplace(label, value);
+    }
+    return this;
+}
+
 }  // namespace Util

--- a/lib/json.h
+++ b/lib/json.h
@@ -126,6 +126,7 @@ class JsonObject final : public IJson, public ordered_map<cstring, IJson*> {
     JsonObject() = default;
     void serialize(std::ostream& out) const;
     JsonObject* emplace(cstring label, IJson* value);
+    JsonObject* emplace_non_null(cstring label, IJson* value);
     JsonObject* emplace(cstring label, bool b)
     { emplace(label, new JsonValue(b)); return this; }
     JsonObject* emplace(cstring label, mpz_class v)

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -226,7 +226,7 @@ cstring InputSources::getSourceFragment(const SourceInfo &position) const {
     return result + toadd + marker + cstring::newline;
 }
 
-cstring InputSources::getSourceFragment2(const SourceInfo &position) const {
+cstring InputSources::getBriefSourceFragment(const SourceInfo &position) const {
     if (!position.isValid())
         return "";
 
@@ -238,7 +238,7 @@ cstring InputSources::getSourceFragment2(const SourceInfo &position) const {
     // If the position spans multiple lines, truncate to just the first line
     if (position.getEnd().getLineNumber() > position.getStart().getLineNumber()) {
         // go to the end of the first line
-        end = strlen(result);
+        end = result.size();
         if (result.find('\n') != nullptr) {
             --end;
         }
@@ -265,8 +265,8 @@ cstring SourceInfo::toSourceFragment() const {
     return InputSources::instance->getSourceFragment(*this);
 }
 
-cstring SourceInfo::toSourceFragment2() const {
-    return InputSources::instance->getSourceFragment2(*this);
+cstring SourceInfo::toBriefSourceFragment() const {
+    return InputSources::instance->getBriefSourceFragment(*this);
 }
 
 cstring SourceInfo::toPositionString() const {

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -231,9 +231,8 @@ cstring InputSources::getSourceFragment2(const SourceInfo &position) const {
         return "";
 
     cstring result = this->getLine(position.getStart().getLineNumber());
-    unsigned int result_len = strlen(result);
     unsigned int start = position.getStart().getColumnNumber();
-    unsigned int end, len;
+    unsigned int end;
     cstring toadd = "";
 
     // If the position spans multiple lines, truncate to just the first line
@@ -247,13 +246,7 @@ cstring InputSources::getSourceFragment2(const SourceInfo &position) const {
     } else {
         end = position.getEnd().getColumnNumber();
     }
-    len = end - start;
-
-    char substr[result_len+1];
-    memcpy(substr, &result[start], len);
-    substr[len] = '\0';
-
-    return substr + toadd;
+    return result.substr(start, end - start) + toadd;
 }
 
 cstring InputSources::toDebugString() const {

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -74,7 +74,7 @@ void InputSources::seal() {
 }
 
 unsigned InputSources::lineCount() const {
-    int size = this->contents.size();
+    int size = contents.size();
     if (contents.back().isNullOrEmpty()) {
         // do not count the last line if it is empty.
         size -= 1;
@@ -156,8 +156,8 @@ void InputSources::mapLine(cstring file, unsigned originalSourceLineNo) {
 }
 
 SourceFileLine InputSources::getSourceLine(unsigned line) const {
-    auto it = this->line_file_map.upper_bound(line);
-    if (it == this->line_file_map.begin())
+    auto it = line_file_map.upper_bound(line);
+    if (it == line_file_map.begin())
         // There must be always something mapped to line 0
         BUG("No source information for line %1%", line);
     --it;
@@ -230,7 +230,7 @@ cstring InputSources::getBriefSourceFragment(const SourceInfo &position) const {
     if (!position.isValid())
         return "";
 
-    cstring result = this->getLine(position.getStart().getLineNumber());
+    cstring result = getLine(position.getStart().getLineNumber());
     unsigned int start = position.getStart().getColumnNumber();
     unsigned int end;
     cstring toadd = "";
@@ -278,12 +278,12 @@ cstring SourceInfo::toPositionString() const {
 
 cstring SourceInfo::toSourcePositionData(unsigned *outLineNumber,
                                          unsigned *outColumnNumber) const {
-    SourceFileLine position = InputSources::instance->getSourceLine(this->start.getLineNumber());
-    if (outLineNumber != NULL) {
+    SourceFileLine position = InputSources::instance->getSourceLine(start.getLineNumber());
+    if (outLineNumber != nullptr) {
         *outLineNumber = position.sourceLine;
     }
-    if (outColumnNumber != NULL) {
-        *outColumnNumber = this->start.getColumnNumber();
+    if (outColumnNumber != nullptr) {
+        *outColumnNumber = start.getColumnNumber();
     }
     return position.fileName.c_str();
 }

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -179,7 +179,10 @@ class SourceInfo final {
     { out << this->toDebugString(); }
 
     cstring toSourceFragment() const;
+    cstring toSourceFragment2() const;
     cstring toPositionString() const;
+    cstring toSourcePositionData(unsigned *outLineNumber,
+                                 unsigned *outColumnNumber) const;
     SourceFileLine toPosition() const;
 
     bool isValid() const
@@ -274,6 +277,7 @@ class InputSources final {
                ^^^^^^^^ */
     cstring getSourceFragment(const SourcePosition &position) const;
     cstring getSourceFragment(const SourceInfo &position) const;
+    cstring getSourceFragment2(const SourceInfo &position) const;
 
     cstring toDebugString() const;
 

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -179,7 +179,7 @@ class SourceInfo final {
     { out << this->toDebugString(); }
 
     cstring toSourceFragment() const;
-    cstring toSourceFragment2() const;
+    cstring toBriefSourceFragment() const;
     cstring toPositionString() const;
     cstring toSourcePositionData(unsigned *outLineNumber,
                                  unsigned *outColumnNumber) const;
@@ -277,7 +277,7 @@ class InputSources final {
                ^^^^^^^^ */
     cstring getSourceFragment(const SourcePosition &position) const;
     cstring getSourceFragment(const SourceInfo &position) const;
-    cstring getSourceFragment2(const SourceInfo &position) const;
+    cstring getBriefSourceFragment(const SourceInfo &position) const;
 
     cstring toDebugString() const;
 


### PR DESCRIPTION
…output

This PR is not ready to go yet, but I wanted to see if anyone had time to consider whether such a change would be welcome in p4c-bm2-ss.  The basic idea is to add keys "filename", "line", and "column" to many of the objects in the bmv2 JSON configuration file that is written.  There are 2 possible purposes I can think of for this:

+ help people looking at the JSON file correlate the objects back to the original P4 source code
+ enable future enhancements to bmv2 where its logging output can include this information, for easier debugging of P4 programs by developers.

If this is considered interesting for future inclusion in p4c, then I am also looking for comments on ways to improve the code I have written.  These changes aren't likely to be what someone skilled in C++ would write.