### PR TITLE
Fix invalid dereferencing in bmv2/inlining.cpp

### DIFF
--- a/backends/bmv2/inlining.cpp
+++ b/backends/bmv2/inlining.cpp
@@ -37,7 +37,7 @@ const IR::Node* SimpleControlsInliner::preorder(IR::P4Control* caller) {
     workToDo = &toInline->callerToWork[orig];
     LOG1("Simple inliner " << caller);
     auto stateful = new IR::IndexedVector<IR::Declaration>();
-    for (auto s : *caller->controlLocals) {
+    for (auto s : caller->controlLocals) {
         auto inst = s->to<IR::Declaration_Instance>();
         if (inst == nullptr ||
             workToDo->declToCallee.find(inst) == workToDo->declToCallee.end()) {
@@ -63,7 +63,7 @@ const IR::Node* SimpleControlsInliner::preorder(IR::P4Control* caller) {
             auto clone = callee->getNode()->apply(sp);
             if (clone == nullptr)
                 return caller;
-            for (auto i : *clone->to<IR::P4Control>()->controlLocals) {
+            for (auto i : clone->to<IR::P4Control>()->controlLocals) {
                 if (stateful->getDeclaration(i->name) == nullptr)
                     stateful->push_back(i);
             }
@@ -73,7 +73,7 @@ const IR::Node* SimpleControlsInliner::preorder(IR::P4Control* caller) {
 
     visit(caller->body);
     auto result = new IR::P4Control(caller->srcInfo, caller->name, caller->type,
-                                    caller->constructorParams, stateful,
+                                    caller->constructorParams, *stateful,
                                     caller->body);
     list->replace(orig, result);
     workToDo = nullptr;


### PR DESCRIPTION
Thanks to @teverman for reporting this issue. Only some compilers actually complain about this, which is very confusing to me...