### PR TITLE
[do not merge]: replace typeMap->constants with IR-based constants

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -495,7 +495,6 @@ const IR::Node* DoConstantFolding::postorder(IR::Member* e) {
         result = list->components.at(index)->clone();
     }
     typeMap->setType(result, origtype);
-    typeMap->setCompileTimeConstant(result);
     setConstant(e, result);
     return result;
 }
@@ -670,7 +669,6 @@ const IR::Node *DoConstantFolding::postorder(IR::Cast *e) {
         auto result = expr->clone();
         auto origtype = typeMap->getType(getOriginal());
         typeMap->setType(result, origtype);
-        typeMap->setCompileTimeConstant(result);
         setConstant(e, result);
         return result;
     }

--- a/frontends/p4/evaluator/evaluator.cpp
+++ b/frontends/p4/evaluator/evaluator.cpp
@@ -47,7 +47,7 @@ void Evaluator::popBlock(IR::Block* block) {
     blockStack.pop_back();
 }
 
-void Evaluator::setValue(const IR::Node* node, const IR::CompileTimeValue* constant) {
+void Evaluator::setValue(const IR::Node* node, const IR::ICompileTimeValue* constant) {
     CHECK_NULL(node);
     CHECK_NULL(constant);
     auto block = currentBlock();
@@ -55,7 +55,7 @@ void Evaluator::setValue(const IR::Node* node, const IR::CompileTimeValue* const
     block->setValue(node, constant);
 }
 
-const IR::CompileTimeValue* Evaluator::getValue(const IR::Node* node) const {
+const IR::ICompileTimeValue* Evaluator::getValue(const IR::Node* node) const {
     CHECK_NULL(node);
     auto block = currentBlock();
     auto result = block->getValue(node);
@@ -92,10 +92,10 @@ bool Evaluator::preorder(const IR::Declaration_Constant* decl) {
     return false;
 }
 
-std::vector<const IR::CompileTimeValue*>*
+std::vector<const IR::ICompileTimeValue*>*
 Evaluator::evaluateArguments(const IR::Vector<IR::Expression>* arguments, IR::Block* context) {
     P4::DoConstantFolding cf(refMap, nullptr);
-    auto values = new std::vector<const IR::CompileTimeValue*>();
+    auto values = new std::vector<const IR::ICompileTimeValue*>();
     pushBlock(context);
     for (auto e : *arguments) {
         auto folded = e->apply(cf);  // constant fold argument

--- a/frontends/p4/evaluator/evaluator.h
+++ b/frontends/p4/evaluator/evaluator.h
@@ -45,10 +45,10 @@ class Evaluator final : public Inspector, public IHasBlock {
     IR::ToplevelBlock* getToplevelBlock() override { return toplevelBlock; }
 
     IR::Block* currentBlock() const;
-    void setValue(const IR::Node* node, const IR::CompileTimeValue* constant);
-    const IR::CompileTimeValue* getValue(const IR::Node* node) const;
+    void setValue(const IR::Node* node, const IR::ICompileTimeValue* constant);
+    const IR::ICompileTimeValue* getValue(const IR::Node* node) const;
 
-    std::vector<const IR::CompileTimeValue*>*
+    std::vector<const IR::ICompileTimeValue*>*
             evaluateArguments(const IR::Vector<IR::Expression>* arguments,
                               IR::Block* context);
 

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -76,8 +76,6 @@ class DismantleExpression : public Transform {
         typeMap->setType(expression, type);
         if (typeMap->isLeftValue(orig))
             typeMap->setLeftValue(expression);
-        if (typeMap->isCompileTimeConstant(orig))
-            typeMap->setCompileTimeConstant(expression);
         result->final = expression;
         return result->final;
     }

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -89,10 +89,6 @@ class TypeInference : public Transform {
     { typeMap->setLeftValue(expression); }
     bool isLeftValue(const IR::Expression* expression) const
     { return typeMap->isLeftValue(expression); }
-    void setCompileTimeConstant(const IR::Expression* expression)
-    { typeMap->setCompileTimeConstant(expression); }
-    bool isCompileTimeConstant(const IR::Expression* expression) const
-    { return typeMap->isCompileTimeConstant(expression); }
 
     template<typename... T>
     void typeError(const char* format, T... args) const {
@@ -283,8 +279,8 @@ class ApplyTypesToExpressions : public Transform {
                 typeMap->setType(e, type);
                 if (typeMap->isLeftValue(orig))
                     typeMap->setLeftValue(e);
-                if (typeMap->isCompileTimeConstant(orig))
-                    typeMap->setCompileTimeConstant(e);
+                if(orig->isCompileTimeConstant() != e->isCompileTimeConstant())
+                    ::error("******* Messed up compile time const for %1%", e);
             }
         }
         return e; }

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -26,9 +26,6 @@ void TypeMap::dbprint(std::ostream& out) const {
     out << "Left values" << std::endl;
     for (auto it : leftValues)
         out << "\t" << dbp(it) << std::endl;
-    out << "Constants" << std::endl;
-    for (auto it : constants)
-        out << "\t" << dbp(it) << std::endl;
     out << "--------------" << std::endl;
 }
 
@@ -37,20 +34,9 @@ void TypeMap::setLeftValue(const IR::Expression* expression) {
     LOG1("Left value " << dbp(expression));
 }
 
-void TypeMap::setCompileTimeConstant(const IR::Expression* expression) {
-    constants.insert(expression);
-    LOG1("Constant value " << dbp(expression));
-}
-
-bool TypeMap::isCompileTimeConstant(const IR::Expression* expression) const {
-    bool result = constants.find(expression) != constants.end();
-    LOG1(dbp(expression) << (result ? " constant" : " not constant"));
-    return result;
-}
-
 void TypeMap::clear() {
     LOG1("Clearing typeMap");
-    typeMap.clear(); leftValues.clear(); constants.clear(); allTypeVariables.clear();
+    typeMap.clear(); leftValues.clear(); allTypeVariables.clear();
     program = nullptr;
 }
 

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -48,10 +48,7 @@ class TypeMap final : public ProgramMap {
     std::map<const IR::Node*, const IR::Type*> typeMap;
     // All left-values in the program.
     std::set<const IR::Expression*> leftValues;
-    // All compile-time constants.  A compile-time constant
-    // is not necessarily a constant - it could be a directionless
-    // parameter as well.
-    std::set<const IR::Expression*> constants;
+
     // For each type variable in the program the actual
     // type that is substituted for it.
     TypeVariableSubstitution allTypeVariables;
@@ -71,12 +68,10 @@ class TypeMap final : public ProgramMap {
     void clear();
     bool isLeftValue(const IR::Expression* expression) const
     { return leftValues.count(expression) > 0; }
-    bool isCompileTimeConstant(const IR::Expression* expression) const;
     size_t size() const
     { return typeMap.size(); }
 
     void setLeftValue(const IR::Expression* expression);
-    void setCompileTimeConstant(const IR::Expression* expression);
     void addSubstitutions(const TypeVariableSubstitution* tvs);
     const IR::Type* getSubstitution(const IR::Type_Var* var)
     { return allTypeVariables.lookup(var); }

--- a/ir/base.def
+++ b/ir/base.def
@@ -13,7 +13,14 @@
 */
 
 /// a value that can be evaluated at compile-time
-interface CompileTimeValue {}
+interface ICompileTimeValue {
+    /// Return whether the compile time value is a constant
+    /// It is needed because some expressions will evaluate to constants,
+    /// but need to traverse the tree to determine whether the value is constant
+    ///
+    /// @return True if the IR node is a compile time constant
+    virtual bool isCompileTimeConstant() const = 0;
+}
 
 /// Base class for P4 types
 abstract Type {
@@ -119,7 +126,7 @@ abstract Type_Declaration : Type, IDeclaration {
     const Type* getP4Type() const override { return new Type_Name(name); }
 }
 
-abstract Expression {
+abstract Expression : ICompileTimeValue {
     /// Note that the type field is not visited.
     /// Most P4_16 passes don't use this field.
     /// It is a used to hold the result of TypeInferencing for the expression.

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -193,10 +193,14 @@ class StringLiteral : Literal {
 
 class PathExpression : Expression {
     Path path;
+    bool isConstant = false;
     PathExpression { if (!srcInfo && path) srcInfo = path->srcInfo; }
     PathExpression(IR::ID id) : Expression(id.srcInfo), path(new IR::Path(id)) {}
     toString{ return path->toString(); }
-    bool isCompileTimeConstant() const override { return false; }
+    bool isCompileTimeConstant() const override { return isConstant; }
+    /// PathExpressions may be constants if they refer to directionless
+    /// parameters or constant declarations
+    void setCompileTimeConstant() { isConstant = true; }
 }
 
 // enum X { a }
@@ -209,7 +213,7 @@ class TypeNameExpression : Expression {
                                 typeName(new IR::Type_Name(new IR::Path(id))) {}
     dbprint{ Node::dbprint(out); out << typeName; }
     toString { return typeName->toString(); }
-    bool isCompileTimeConstant() const override { return false; }
+    bool isCompileTimeConstant() const override { return true; }
 }
 
 class Slice : Operation_Ternary {
@@ -226,16 +230,24 @@ class Slice : Operation_Ternary {
     Slice {
         if (type->is<Type::Unknown>() && e1 && e1->is<Constant>() && e2 && e2->is<Constant>())
             type = IR::Type::Bits::get(getH() - getL() + 1); }
-    bool isCompileTimeConstant() const override { return false; }
+    bool isCompileTimeConstant() const override { return e0->isCompileTimeConstant(); }
 }
 
 class Member : Operation_Unary {
     ID member;
+    bool isConstant = false;
     virtual int offset_bits() const;
     int lsb() const;
     int msb() const;
     stringOp = ".";
     toString{ return expr->toString() + "." + member; }
+    /// Like any other Unary expression, we look at the type of the expr member
+    /// except for extern methods
+    bool isCompileTimeConstant() const override {
+        return isConstant ? isConstant : expr->isCompileTimeConstant(); }
+    /// a method of an extern type is considered compile time constant
+    /// and since we don't know the type we allow it to be set.
+    void setCompileTimeConstant() { isConstant = true; }
 }
 
 class Concat : Operation_Binary {
@@ -282,11 +294,13 @@ class Mux : Operation_Ternary {
         v.flow_merge(clone); }
     Mux { if (type->is<Type::Unknown>() && e1 && e2 && e1->type == e2->type) type = e1->type; }
     bool isCompileTimeConstant() const override {
-        return e1->isCompileTimeConstant() && e2->isCompileTimeConstant(); }
+        return e0->isCompileTimeConstant() &&
+               e1->isCompileTimeConstant() &&
+               e2->isCompileTimeConstant(); }
 }
 
 class DefaultExpression : Expression {
-    bool isCompileTimeConstant() const override { return false; }
+    bool isCompileTimeConstant() const override { return true; }
 }
 
 // Two different This should not be equal.
@@ -343,7 +357,7 @@ class ConstructorCallExpression : Expression {
                         constructedType->is<Type_Specialized>(),
                         "%1%: unexpected type", constructedType);
         arguments->check_null(); }
-    bool isCompileTimeConstant() const override { return false; }
+    bool isCompileTimeConstant() const override { return true; }
 }
 
 /// Represents a list of expressions separated by commas

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -12,6 +12,7 @@ abstract Operation_Unary : Operation {
         if (!srcInfo && expr) srcInfo = expr->srcInfo;
         if (type->is<Type::Unknown>() && expr) type = expr->type; }
     precedence = DBPrint::Prec_Prefix;
+    bool isCompileTimeConstant() const override { return expr->isCompileTimeConstant(); }
 }
 
 class Neg : Operation_Unary {
@@ -33,6 +34,8 @@ abstract Operation_Binary : Operation {
         if (!srcInfo && left && right) srcInfo = left->srcInfo + right->srcInfo;
         if (type->is<Type::Unknown>() && left && right && left->type == right->type)
             type = left->type; }
+    bool isCompileTimeConstant() const override {
+        return left->isCompileTimeConstant() && right->isCompileTimeConstant(); }
 }
 
 abstract Operation_Ternary : Operation {
@@ -122,8 +125,9 @@ class LOr : Operation_Binary {
     precedence = DBPrint::Prec_LOr;
 }
 
-abstract Literal : Expression, CompileTimeValue {
+abstract Literal : Expression, ICompileTimeValue {
 #nodbprint
+    bool isCompileTimeConstant() const override { return true; }
 }
 
 /// This is an integer literal on arbitrary-precision.
@@ -169,6 +173,7 @@ class Constant : Literal {
 #end
     toString { return Util::toString(&value); }
     visit_children { v.visit(type, "type"); }
+    bool isCompileTimeConstant() const override { return true; }
 }
 
 class BoolLiteral : Literal {
@@ -191,6 +196,7 @@ class PathExpression : Expression {
     PathExpression { if (!srcInfo && path) srcInfo = path->srcInfo; }
     PathExpression(IR::ID id) : Expression(id.srcInfo), path(new IR::Path(id)) {}
     toString{ return path->toString(); }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 // enum X { a }
@@ -203,6 +209,7 @@ class TypeNameExpression : Expression {
                                 typeName(new IR::Type_Name(new IR::Path(id))) {}
     dbprint{ Node::dbprint(out); out << typeName; }
     toString { return typeName->toString(); }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 class Slice : Operation_Ternary {
@@ -219,6 +226,7 @@ class Slice : Operation_Ternary {
     Slice {
         if (type->is<Type::Unknown>() && e1 && e1->is<Constant>() && e2 && e2->is<Constant>())
             type = IR::Type::Bits::get(getH() - getL() + 1); }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 class Member : Operation_Unary {
@@ -273,9 +281,13 @@ class Mux : Operation_Ternary {
         clone.visit(e2, "e2");
         v.flow_merge(clone); }
     Mux { if (type->is<Type::Unknown>() && e1 && e2 && e1->type == e2->type) type = e1->type; }
+    bool isCompileTimeConstant() const override {
+        return e1->isCompileTimeConstant() && e2->isCompileTimeConstant(); }
 }
 
-class DefaultExpression : Expression {}
+class DefaultExpression : Expression {
+    bool isCompileTimeConstant() const override { return false; }
+}
 
 // Two different This should not be equal.
 // That's why we use a hidden id field to distinguish them.
@@ -283,6 +295,9 @@ class This : Expression {
     int id = nextId++;
  private:
     static int nextId;
+ public:
+    bool isCompileTimeConstant() const override { return false; }
+
 }  // experimental
 
 class Cast : Operation_Unary {
@@ -308,6 +323,7 @@ class SelectExpression : Expression {
     visit_children {
         v.visit(select, "select");
         selectCases.parallel_visit_children(v); }
+    bool isCompileTimeConstant() const override { return select->isCompileTimeConstant(); }
 }
 
 class MethodCallExpression : Expression {
@@ -316,6 +332,7 @@ class MethodCallExpression : Expression {
     optional Vector<Expression> arguments = new Vector<Expression>;
     toString{ return method->toString(); }
     validate{ typeArguments->check_null(); arguments->check_null(); }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 class ConstructorCallExpression : Expression {
@@ -326,6 +343,7 @@ class ConstructorCallExpression : Expression {
                         constructedType->is<Type_Specialized>(),
                         "%1%: unexpected type", constructedType);
         arguments->check_null(); }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 /// Represents a list of expressions separated by commas
@@ -335,6 +353,12 @@ class ListExpression : Expression {
         components.check_null();
     }
     void push_back(Expression e) { components.push_back(e); }
+    bool isCompileTimeConstant() const override {
+      bool result = true;
+      for (auto e : components)
+        result = result && e->isCompileTimeConstant();
+      return result;
+    }
 }
 
 /** @} *//* end group irdefs */

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -153,7 +153,7 @@ P4Table::getApplyMethodType() const {
 const Type_Method* Type_Table::getApplyMethodType() const
 { return table->getApplyMethodType(); }
 
-void InstantiatedBlock::instantiate(std::vector<const CompileTimeValue*> *args) {
+void InstantiatedBlock::instantiate(std::vector<const ICompileTimeValue*> *args) {
     CHECK_NULL(args);
     auto it = args->begin();
     for (auto p : *getConstructorParameters()->getEnumerator()) {
@@ -163,7 +163,7 @@ void InstantiatedBlock::instantiate(std::vector<const CompileTimeValue*> *args) 
     }
 }
 
-const IR::CompileTimeValue* InstantiatedBlock::getParameterValue(cstring paramName) const {
+const IR::ICompileTimeValue* InstantiatedBlock::getParameterValue(cstring paramName) const {
     auto param = getConstructorParameters()->getDeclByName(paramName);
     BUG_CHECK(param != nullptr, "No parameter named %1%", paramName);
     BUG_CHECK(param->is<IR::Parameter>(), "No parameter named %1%", paramName);

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -472,28 +472,29 @@ class Function : Declaration {
 // Blocks are not visited using visitors, so the visit_children()
 // method is empty.  Users have to write custom visitors to
 // traverse the constantValue map.
-abstract Block : CompileTimeValue {
+abstract Block : ICompileTimeValue {
     Node node;  // Node that evaluates to this block.
     // It's either a Declaration_Instance or a ConstructorCallExpression.
 
     // One value for each Node inside that evaluates to a compile-time constant.
     // This includes all constructor parameters, and all inner nested blocks.
-    ordered_map<Node, CompileTimeValue> constantValue = {};
+    ordered_map<Node, ICompileTimeValue> constantValue = {};
 
     virtual void dbprint(std::ostream& out) const override;
     virtual void dbprint_recursive(std::ostream& out) const;
-    void setValue(Node node, CompileTimeValue value) {
+    void setValue(Node node, ICompileTimeValue value) {
         CHECK_NULL(node); CHECK_NULL(value);
         auto it = constantValue.find(node);
         BUG_CHECK(it == constantValue.end(), "%1% already set", node);
         constantValue[node] = value; }
-    CompileTimeValue getValue(Node node) const {
+    ICompileTimeValue getValue(Node node) const {
         CHECK_NULL(node);
         auto it = constantValue.find(node);
         if (it == constantValue.end())
             return nullptr;
         return it->second; }
     visit_children { (void)v; }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 class TableBlock : Block {
@@ -507,8 +508,8 @@ abstract InstantiatedBlock : Block {
     Type instanceType;  // May be a SpecializedType
 
     virtual ParameterList getConstructorParameters() const = 0;
-    void instantiate(std::vector<CompileTimeValue> *args);
-    CompileTimeValue getParameterValue(cstring paramName) const;
+    void instantiate(std::vector<ICompileTimeValue> *args);
+    ICompileTimeValue getParameterValue(cstring paramName) const;
     virtual void dbprint(std::ostream& out) const override;
 }
 

--- a/ir/type.def
+++ b/ir/type.def
@@ -365,8 +365,9 @@ class Type_SpecializedCanonical : Type {
 }
 
 /// A declaration that consists of just an identifier, e.g., an enum member
-class Declaration_ID : Declaration, CompileTimeValue {
+class Declaration_ID : Declaration, ICompileTimeValue {
 #nodbprint
+    bool isCompileTimeConstant() const override { return true; }
 }
 
 /// The type of a string literal

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -107,6 +107,7 @@ class Metadata : HeaderOrMetadata {
 
 abstract HeaderRef : Expression {
     virtual HeaderOrMetadata baseRef() const = 0;
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 class ConcreteHeaderRef : HeaderRef {
@@ -143,6 +144,7 @@ class If :  Expression {
         v.flow_merge(clone);
         Expression::visit_children(v);
     }
+    bool isCompileTimeConstant() const override { return pred->isCompileTimeConstant(); }
 }
 
 // an if condition tagged with a name so we can refer to it
@@ -175,6 +177,7 @@ class Apply : Expression {
             v.flow_merge(clone2); }
         Expression::visit_children(v);
     }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 class Primitive : Operation {
@@ -213,6 +216,10 @@ class Primitive : Operation {
 #apply
     stringOp = name;
     precedence = DBPrint::Prec_Postfix;
+    // \TODO(calin): is there a case where a Primtive can be a compile time constant?
+    // E.g. all the operands are constant and the compiler replaces the primitive
+    // with an assignment?
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 class FieldList {
@@ -359,6 +366,7 @@ class ActionArg : Expression {
     ActionArg { if (!srcInfo) srcInfo = name.srcInfo; }
     dbprint{ out << action_name << ':' << name; }
     toString{ return name.name; }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 // Represents a P4 v1.0 action
@@ -435,6 +443,7 @@ class AttribLocal : Expression, IDeclaration {
     ID  name;
 #nodbprint
     ID getName() const override { return name; }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 class AttribLocals : ISimpleNamespace {
@@ -459,6 +468,7 @@ class GlobalRef : Expression {
     validate { obj->is<IInstance>(); }
     toString { return obj->to<IInstance>()->Name(); }
     dbprint { out << obj->to<IInstance>()->Name(); }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 class AttributeRef : Expression {
@@ -468,6 +478,7 @@ class AttributeRef : Expression {
     AttributeRef { type = attrib->type; }
     toString { return attrib->name; }
     dbprint { out << attrib->name; }
+    bool isCompileTimeConstant() const override { return false; }
 }
 
 #emit


### PR DESCRIPTION
This PR attempts to replace the typeMap->isCompileTimeConstant/setCompileTimeConstant with that functionality handled by IR nodes.

Note that less than half of all tests pass with this change. Most fail with the dreaded:
```
terminating with uncaught exception of type Util::CompilerBug: COMPILER BUG: ../frontends/p4/typeChecking/typeChecker.cpp:118
<P4Program>(19779): typechecker mutated node <P4Program>(17743)
```
@mbudiu-vmw: I need help in figuring out which of the IR nodes in typeChecker is missing the right information. I traced all the changes and they seem to capture all the places where constants were set. For one of the test cases (testdata/p4_16_samples/inline-stack-bmv2.p4), I tracked this down to invoking the apply method on the aux instance in the sequence below. Commenting out the aux.apply line allows the program to go through.
```
control X {
  Aux();
  apply {
     aux.apply(hdr);
  }
}
```
