### PR TITLE
constant folding streamlining, bugfixes, and Doxygen comments

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -23,9 +23,6 @@ namespace P4 {
 
 const IR::Expression* DoConstantFolding::getConstant(const IR::Expression* expr) const {
     CHECK_NULL(expr);
-    auto cst = get(constants, expr);
-    if (cst != nullptr)
-        return cst;
     if (expr->is<IR::Constant>())
         return expr;
     if (expr->is<IR::BoolLiteral>())
@@ -35,38 +32,33 @@ const IR::Expression* DoConstantFolding::getConstant(const IR::Expression* expr)
         for (auto e : list->components)
             if (getConstant(e) == nullptr)
                 return nullptr;
-        return list;
+        return expr;
     }
     if (typesKnown) {
         auto ei = EnumInstance::resolve(expr, typeMap);
         if (ei != nullptr)
             return expr;
     }
-
     return nullptr;
 }
-
-// This has to be called from a visitor method - it calls getOriginal()
-void DoConstantFolding::setConstant(const IR::Node* node, const IR::Expression* result) {
-    LOG2("Folding " << node << " to " << result << " (" << result->id << ")");
-    auto orig = getOriginal();
-    constants.emplace(node, result);
-    constants.emplace(orig, result);
-}
-
+    
 const IR::Node* DoConstantFolding::postorder(IR::PathExpression* e) {
     if (refMap == nullptr)
         return e;
     auto decl = refMap->getDeclaration(e->path);
     if (decl == nullptr)
         return e;
-    auto v = get(constants, decl->getNode());
-    if (v == nullptr)
-        return e;
-    setConstant(e, v);
-    if (v->is<IR::ListExpression>())
-        return e;
-    return v;
+    if (auto dc = decl->to<IR::Declaration_Constant>()) {
+        auto cst = get(constants, dc);
+        if (cst == nullptr)
+            cst = getConstant(dc->initializer);
+        if (cst == nullptr)
+            return e;
+        if (!typesKnown && cst->is<IR::ListExpression>())
+            return e;
+        return cst;
+    }
+    return e;
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Declaration_Constant* d) {
@@ -76,27 +68,24 @@ const IR::Node* DoConstantFolding::postorder(IR::Declaration_Constant* d) {
             ::error("%1%: Cannot evaluate initializer for constant", d->initializer);
         return d;
     }
-
-    if (typesKnown) {
-        // If we typechecked we're safe
-        setConstant(d, init);
-    } else {
-        // In fact, this declaration may imply a cast, so the actual value of
-        // d is not init, but (d->type)init.  The typechecker inserts casts,
-        // but if we run this before typechecking we have to be more conservative.
+    if (!typesKnown) {
+        // This declaration may imply a cast, so the actual value of d
+        // is not init, but (d->type)init. The typechecker inserts
+        // casts, but if we run this before typechecking we have to be
+        // more conservative.
         if (init->is<IR::Constant>()) {
             auto cst = init->to<IR::Constant>();
             if (d->type->is<IR::Type_Bits>()) {
                 if (cst->type->is<IR::Type_InfInt>() ||
                     (cst->type->is<IR::Type_Bits>() &&
-                     !(*d->type->to<IR::Type_Bits>() == *cst->type->to<IR::Type_Bits>())))
+                     !(*d->type->to<IR::Type_Bits>() == *cst->type->to<IR::Type_Bits>()))) 
                     init = new IR::Constant(init->srcInfo, d->type, cst->value, cst->base);
-                setConstant(d, init);
             }
         }
+        if (init != d->initializer) 
+            d = new IR::Declaration_Constant(d->srcInfo, d->name, d->annotations, d->type, init);
     }
-    if (init != d->initializer)
-        d = new IR::Declaration_Constant(d->srcInfo, d->name, d->annotations, d->type, init);
+    constants.emplace(getOriginal<IR::Declaration_Constant>(), init);
     return d;
 }
 
@@ -124,9 +113,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Cmpl* e) {
     }
 
     mpz_class value = ~cst->value;
-    auto result = new IR::Constant(cst->srcInfo, t, value, cst->base, true);
-    setConstant(e, result);
-    return result;
+    return new IR::Constant(cst->srcInfo, t, value, cst->base, true);
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Neg* e) {
@@ -151,9 +138,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Neg* e) {
     }
 
     mpz_class value = -cst->value;
-    auto result = new IR::Constant(cst->srcInfo, t, value, cst->base, true);
-    setConstant(e, result);
-    return result;
+    return new IR::Constant(cst->srcInfo, t, value, cst->base, true);
 }
 
 const IR::Constant*
@@ -260,9 +245,7 @@ DoConstantFolding::compare(const IR::Operation_Binary* e) {
             return e;
         }
         bool bresult = (left->value == right->value) == eqTest;
-        auto result = new IR::BoolLiteral(e->srcInfo, bresult);
-        setConstant(e, result);
-        return result;
+        return new IR::BoolLiteral(e->srcInfo, bresult);
     } else if (typesKnown) {
         auto le = EnumInstance::resolve(eleft, typeMap);
         auto re = EnumInstance::resolve(eright, typeMap);
@@ -270,9 +253,7 @@ DoConstantFolding::compare(const IR::Operation_Binary* e) {
             BUG_CHECK(le->type == re->type,
                       "%1%: different enum types in comparison", e);
             bool bresult = (le->name == re->name) == eqTest;
-            auto result = new IR::BoolLiteral(e->srcInfo, bresult);
-            setConstant(e, result);
-            return result;
+            return new IR::BoolLiteral(e->srcInfo, bresult);
         }
     }
 
@@ -349,13 +330,10 @@ DoConstantFolding::binary(const IR::Operation_Binary* e,
         }
     }
 
-    const IR::Expression* result;
     if (e->is<IR::Operation_Relation>())
-        result = new IR::BoolLiteral(e->srcInfo, value != 0);
+        return new IR::BoolLiteral(e->srcInfo, value != 0);
     else
-        result = new IR::Constant(e->srcInfo, resultType, value, left->base, true);
-    setConstant(e, result);
-    return result;
+        return new IR::Constant(e->srcInfo, resultType, value, left->base, true);
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::LAnd* e) {
@@ -368,16 +346,10 @@ const IR::Node* DoConstantFolding::postorder(IR::LAnd* e) {
         ::error("%1%: Expected a boolean value", left);
         return e;
     }
-
     if (lcst->value) {
-        setConstant(e, e->right);
         return e->right;
     }
-
-    // Short-circuit folding
-    auto result = new IR::BoolLiteral(left->srcInfo, false);
-    setConstant(e, result);
-    return result;
+    return new IR::BoolLiteral(left->srcInfo, false);
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::LOr* e) {
@@ -390,16 +362,10 @@ const IR::Node* DoConstantFolding::postorder(IR::LOr* e) {
         ::error("%1%: Expected a boolean value", left);
         return e;
     }
-
     if (!lcst->value) {
-        setConstant(e, e->right);
         return e->right;
     }
-
-    // Short-circuit folding
-    auto result = new IR::BoolLiteral(left->srcInfo, true);
-    setConstant(e, result);
-    return result;
+    return new IR::BoolLiteral(left->srcInfo, true);
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Slice* e) {
@@ -451,9 +417,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Slice* e) {
     auto resultType = typeMap->getType(getOriginal(), true);
     if (!resultType->is<IR::Type_Bits>())
         BUG("Type of slice is not Type_Bits, but %1%", resultType);
-    auto result = new IR::Constant(e->srcInfo, resultType, value, cbase->base, true);
-    setConstant(e, result);
-    return result;
+    return new IR::Constant(e->srcInfo, resultType, value, cbase->base, true);
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Member* e) {
@@ -467,7 +431,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Member* e) {
     if (type->is<IR::Type_Stack>() && e->member == IR::Type_Stack::arraySize) {
         auto st = type->to<IR::Type_Stack>();
         auto size = st->getSize();
-        result = new IR::Constant(st->size->srcInfo, size);
+        result = new IR::Constant(st->size->srcInfo, origtype, size);
     } else {
         auto expr = getConstant(e->expr);
         if (expr == nullptr)
@@ -494,9 +458,6 @@ const IR::Node* DoConstantFolding::postorder(IR::Member* e) {
             BUG("Could not find field %1% in type %2%", e->member, type);
         result = list->components.at(index)->clone();
     }
-    typeMap->setType(result, origtype);
-    typeMap->setCompileTimeConstant(result);
-    setConstant(e, result);
     return result;
 }
 
@@ -526,9 +487,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Concat* e) {
 
     auto resultType = IR::Type_Bits::get(lt->size + rt->size, lt->isSigned);
     mpz_class value = Util::shift_left(left->value, static_cast<unsigned>(rt->size)) + right->value;
-    auto result = new IR::Constant(e->srcInfo, resultType, value, left->base);
-    setConstant(e, result);
-    return result;
+    return new IR::Constant(e->srcInfo, resultType, value, left->base);
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::LNot* e) {
@@ -541,10 +500,7 @@ const IR::Node* DoConstantFolding::postorder(IR::LNot* e) {
         ::error("%1%: Expected a boolean value", op);
         return e;
     }
-
-    auto result = new IR::BoolLiteral(cst->srcInfo, !cst->value);
-    setConstant(e, result);
-    return result;
+    return new IR::BoolLiteral(cst->srcInfo, !cst->value);
 }
 
 const IR::Node* DoConstantFolding::postorder(IR::Mux* e) {
@@ -577,7 +533,6 @@ const IR::Node* DoConstantFolding::shift(const IR::Operation_Binary* e) {
 
     if (sgn(cr->value) == 0) {
         // ::warning("%1% with zero", e);
-        setConstant(e, e->left);
         return e->left;
     }
 
@@ -604,9 +559,7 @@ const IR::Node* DoConstantFolding::shift(const IR::Operation_Binary* e) {
         value = Util::shift_left(value, shift);
     else
         value = Util::shift_right(value, shift);
-    auto result = new IR::Constant(e->srcInfo, left->type, value, cl->base);
-    setConstant(e, result);
-    return result;
+    return new IR::Constant(e->srcInfo, left->type, value, cl->base);
 }
 
 const IR::Node *DoConstantFolding::postorder(IR::Cast *e) {
@@ -624,15 +577,11 @@ const IR::Node *DoConstantFolding::postorder(IR::Cast *e) {
         auto type = etype->to<IR::Type_Bits>();
         if (expr->is<IR::Constant>()) {
             auto arg = expr->to<IR::Constant>();
-            auto result = cast(arg, arg->base, type);
-            setConstant(e, result);
-            return result;
+            return cast(arg, arg->base, type);
         } else if (expr -> is<IR::BoolLiteral>()) {
             auto arg = expr->to<IR::BoolLiteral>();
             int v = arg->value ? 1 : 0;
-            auto result = new IR::Constant(e->srcInfo, type, v, 10);
-            setConstant(e, result);
-            return result;
+            return new IR::Constant(e->srcInfo, type, v, 10);
         } else {
             return e;
         }
@@ -662,19 +611,11 @@ const IR::Node *DoConstantFolding::postorder(IR::Cast *e) {
                 ::error("%1%: Only 0 and 1 can be cast to booleans", e);
                 return e;
             }
-            auto lit = new IR::BoolLiteral(e->srcInfo, v == 1);
-            setConstant(e, lit);
-            return lit;
+            return new IR::BoolLiteral(e->srcInfo, v == 1);
         }
     } else if (etype->is<IR::Type_StructLike>()) {
-        auto result = expr->clone();
-        auto origtype = typeMap->getType(getOriginal());
-        typeMap->setType(result, origtype);
-        typeMap->setCompileTimeConstant(result);
-        setConstant(e, result);
-        return result;
+        return expr->clone();
     }
-
     return e;
 }
 

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -41,7 +41,7 @@ const IR::Expression* DoConstantFolding::getConstant(const IR::Expression* expr)
     }
     return nullptr;
 }
-    
+
 const IR::Node* DoConstantFolding::postorder(IR::PathExpression* e) {
     if (refMap == nullptr)
         return e;
@@ -78,11 +78,11 @@ const IR::Node* DoConstantFolding::postorder(IR::Declaration_Constant* d) {
             if (d->type->is<IR::Type_Bits>()) {
                 if (cst->type->is<IR::Type_InfInt>() ||
                     (cst->type->is<IR::Type_Bits>() &&
-                     !(*d->type->to<IR::Type_Bits>() == *cst->type->to<IR::Type_Bits>()))) 
+                     !(*d->type->to<IR::Type_Bits>() == *cst->type->to<IR::Type_Bits>())))
                     init = new IR::Constant(init->srcInfo, d->type, cst->value, cst->base);
             }
         }
-        if (init != d->initializer) 
+        if (init != d->initializer)
             d = new IR::Declaration_Constant(d->srcInfo, d->name, d->annotations, d->type, init);
     }
     constants.emplace(getOriginal<IR::Declaration_Constant>(), init);

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -23,16 +23,15 @@ limitations under the License.
 #include "frontends/p4/typeChecking/typeChecker.h"
 
 namespace P4 {
-// Can also be run before type checking, so it only uses types if
-// they are available.
+// This pass can be run before type checking; it uses types if available.
 class DoConstantFolding : public Transform {
  protected:
     const ReferenceMap* refMap;  // if null no 'const' values can be resolved
-    TypeMap* typeMap;  // if null we have no types; updated for new constants
+    const TypeMap* typeMap;      // if null we have no types; updated for new constants
     bool typesKnown;
     bool warnings;  // if true emit warnings
-    // maps expressions and declarations to their constant values
-    std::map<const IR::Node*, const IR::Expression*> constants;
+    // maps declaration constants to constant values
+    std::map<const IR::Declaration_Constant*, const IR::Expression*> constants;
 
  protected:
     // returns nullptr if the expression is not a constant

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -23,35 +23,80 @@ limitations under the License.
 #include "frontends/p4/typeChecking/typeChecker.h"
 
 namespace P4 {
-// This pass can be run before type checking; it uses types if available.
+
+/** @brief statically evaluates many constant expressions.
+ *
+ * This pass can be invoked either with or without the `refMap` and
+ * `typeMap`. When type information is not available, constant folding
+ * is not performed for many IR nodes.
+ *
+ * @pre: `typeMap` is up-to-date if not `nullptr` and similarly for `refMap`
+ *
+ * @post: Ensures 
+ *
+ *    - most expressions that can be statically shown to evaluate to a
+ *      constant are replaced with the constant value.
+ * 
+ *    - operations that involve constant InfInt operands are evaluated to
+ *      an InfInt value
+ * 
+ *    - if `typeMap` and `refMap` are not `nullptr` then
+ *      `IR::Declaration_Constant` nodes are initialized with
+ *      compile-time known constants.
+ */
 class DoConstantFolding : public Transform {
  protected:
-    const ReferenceMap* refMap;  // if null no 'const' values can be resolved
-    const TypeMap* typeMap;      // if null we have no types; updated for new constants
+    /// Used to resolve IR nodes to declarations.
+    /// If `nullptr`, then `const` values cannot be resolved.
+    const ReferenceMap* refMap;
+
+    /// Used to resolve nodes to their types.
+    /// If `nullptr`, then type information is not available.
+    const TypeMap* typeMap;
+
+    /// Set to `true` iff `typeMap` is not `nullptr`.
     bool typesKnown;
-    bool warnings;  // if true emit warnings
-    // maps declaration constants to constant values
+
+    /// If `true` then emit warnings
+    bool warnings;
+
+    /// Maps declaration constants to constant expressions
     std::map<const IR::Declaration_Constant*, const IR::Expression*> constants;
 
  protected:
-    // returns nullptr if the expression is not a constant
+    /// @returns a constant equivalent to @p expr or `nullptr`
     const IR::Expression* getConstant(const IR::Expression* expr) const;
-    void setConstant(const IR::Node* expr, const IR::Expression* result);
 
+    /// Statically cast constant @p node to @p type represented in the specified @p base.
     const IR::Constant* cast(
         const IR::Constant* node, unsigned base, const IR::Type_Bits* type) const;
+
+    /// Statically evaluate binary operation @p e implemented by @p func.
     const IR::Node* binary(const IR::Operation_Binary* op,
                            std::function<mpz_class(mpz_class, mpz_class)> func);
-    // for == and != only
+    /// Statically evaluate comparison operation @p e.
+    /// Note that this only handles the case where @p e represents `==` or `!=`.
     const IR::Node* compare(const IR::Operation_Binary* op);
+
+    /// Statically evaluate shift operation @p e.
     const IR::Node* shift(const IR::Operation_Binary* op);
 
+    /// Result type for @ref setContains.
     enum class Result {
         Yes,
         No,
         DontKnow
     };
 
+    /** Statically evaluate case in select expression. 
+     * 
+     * @returns 
+     *    - Result::Yes
+     *    - Result::No
+     *    - Result::DontKnow
+     * 
+     *  depending on whether @p constant is contained in @p keyset.
+     */
     Result setContains(const IR::Expression* keySet, const IR::Expression* constant) const;
 
  public:
@@ -91,12 +136,17 @@ class DoConstantFolding : public Transform {
     const IR::Node* postorder(IR::SelectExpression* e) override;
 };
 
+/** Optionally runs @ref TypeChecking if @p typeMap is not
+ *  `nullptr`, and then runs @ref DoConstantFolding.
+ */
 class ConstantFolding : public PassManager {
  public:
     ConstantFolding(ReferenceMap* refMap, TypeMap* typeMap, bool warnings = true) {
         if (typeMap != nullptr)
             passes.push_back(new TypeChecking(refMap, typeMap));
         passes.push_back(new DoConstantFolding(refMap, typeMap, warnings));
+        if (typeMap != nullptr)
+            passes.push_back(new ClearTypeMap(typeMap));
         setName("ConstantFolding");
     }
 };

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -80,7 +80,7 @@ class PrettyPrint : public Inspector {
 
 /**
  * This pass is a no-op whose purpose is to mark the end of the
- * front-end, used for testing.  It is implemented as an
+ * front-end, which is useful for debugging. It is implemented as an
  * empty @ref PassManager (instead of a @ref Visitor) for efficiency.
  */
 class FrontEndLast : public PassManager {

--- a/testdata/p4_16_errors/stack3.p4
+++ b/testdata/p4_16_errors/stack3.p4
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/* This test illustrates several limitations and incorrect uses of
+ * header stacks, which must be declared with compile-time constant
+ * sizes. */
+
 #include <core.p4>
 
 header h {}

--- a/testdata/p4_16_errors/stack3.p4
+++ b/testdata/p4_16_errors/stack3.p4
@@ -1,0 +1,38 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+
+header h {}
+
+parser p() {
+    state start {
+        transition accept;
+    }
+}
+
+control c()(bit<32> x) {
+    apply {
+        h[4] s1;
+        h[s1.size + 1] s2;
+        h[x] s3;
+   }
+}
+
+parser Simple();
+control Simpler();
+package top(Simple par, Simpler ctr);
+top(p(), c(32w1)) main;

--- a/testdata/p4_16_errors_outputs/stack3.p4
+++ b/testdata/p4_16_errors_outputs/stack3.p4
@@ -1,0 +1,23 @@
+#include <core.p4>
+
+header h {
+}
+
+parser p() {
+    state start {
+        transition accept;
+    }
+}
+
+control c()(bit<32> x) {
+    apply {
+        h[4] s1;
+        h[s1.size + 1] s2;
+        h[x] s3;
+    }
+}
+
+parser Simple();
+control Simpler();
+package top(Simple par, Simpler ctr);
+top(p(), c(32w1)) main;

--- a/testdata/p4_16_errors_outputs/stack3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack3.p4-stderr
@@ -1,0 +1,36 @@
+../testdata/p4_16_errors/stack3.p4(34): error: header h[]: Size of header stack type should be a constant
+        h[s1.size + 1] s2;
+        ^^^^^^^^^^^^^^
+../testdata/p4_16_errors/stack3.p4(34): error: header h[]: Size of header stack type should be a constant
+        h[s1.size + 1] s2;
+        ^^^^^^^^^^^^^^
+../testdata/p4_16_errors/stack3.p4(34): error: header h[]: Size of header stack type should be a constant
+        h[s1.size + 1] s2;
+        ^^^^^^^^^^^^^^
+../testdata/p4_16_errors/stack3.p4(34): error: Could not find type of h[]
+        h[s1.size + 1] s2;
+        ^^^^^^^^^^^^^^
+../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+        h[x] s3;
+        ^^^^
+../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+        h[x] s3;
+        ^^^^
+../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+        h[x] s3;
+        ^^^^
+../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+        h[x] s3;
+        ^^^^
+../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+        h[x] s3;
+        ^^^^
+../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+        h[x] s3;
+        ^^^^
+../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+        h[x] s3;
+        ^^^^
+../testdata/p4_16_errors/stack3.p4(35): error: Could not find type of h[]
+        h[x] s3;
+        ^^^^

--- a/testdata/p4_16_samples/stack2.p4
+++ b/testdata/p4_16_samples/stack2.p4
@@ -1,0 +1,12 @@
+#include <core.p4>
+header h { }
+control c(out bit<32> x) {
+    apply {
+        h[4] stack;
+        bit<32> sz = stack.size;
+        x = sz;
+    }
+}
+control Simpler(out bit<32> x);
+package top(Simpler ctr);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/stack-first.p4
+++ b/testdata/p4_16_samples_outputs/stack-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 header h {
 }
 
@@ -22,7 +24,7 @@ control c() {
         stack[2] = b;
         stack.push_front(2);
         stack.pop_front(2);
-        bit<32> sz = 4;
+        bit<32> sz = 32w4;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack2-first.p4
+++ b/testdata/p4_16_samples_outputs/stack2-first.p4
@@ -1,0 +1,16 @@
+#include <core.p4>
+
+header h {
+}
+
+control c(out bit<32> x) {
+    apply {
+        h[4] stack;
+        bit<32> sz = 32w4;
+        x = sz;
+    }
+}
+
+control Simpler(out bit<32> x);
+package top(Simpler ctr);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/stack2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack2-frontend.p4
@@ -1,0 +1,16 @@
+#include <core.p4>
+
+header h {
+}
+
+control c(out bit<32> x) {
+    bit<32> sz_0;
+    apply {
+        sz_0 = 32w4;
+        x = sz_0;
+    }
+}
+
+control Simpler(out bit<32> x);
+package top(Simpler ctr);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/stack2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack2-midend.p4
@@ -1,0 +1,23 @@
+#include <core.p4>
+
+header h {
+}
+
+control c(out bit<32> x) {
+    @hidden action act() {
+        x = 32w4;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control Simpler(out bit<32> x);
+package top(Simpler ctr);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/stack2.p4
+++ b/testdata/p4_16_samples_outputs/stack2.p4
@@ -1,0 +1,16 @@
+#include <core.p4>
+
+header h {
+}
+
+control c(out bit<32> x) {
+    apply {
+        h[4] stack;
+        bit<32> sz = stack.size;
+        x = sz;
+    }
+}
+
+control Simpler(out bit<32> x);
+package top(Simpler ctr);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/struct-first.p4
+++ b/testdata/p4_16_samples_outputs/struct-first.p4
@@ -14,7 +14,7 @@ struct S {
 }
 
 const T t = { 32s10, 32s20 };
-const S s = { { 32s15, 32s25 }, t };
+const S s = { { 32s15, 32s25 }, { 32s10, 32s20 } };
 const int<32> x = 32s10;
 const int<32> y = 32s25;
 const int<32> w = 32s10;

--- a/testdata/p4_16_samples_outputs/struct1-first.p4
+++ b/testdata/p4_16_samples_outputs/struct1-first.p4
@@ -14,7 +14,7 @@ struct S {
 }
 
 const T t = { 32s10, 32s20 };
-const S s = { { 32s15, 32s25 }, t };
+const S s = { { 32s15, 32s25 }, { 32s10, 32s20 } };
 const int<32> x = 32s10;
 const int<32> y = 32s25;
 const int<32> w = 32s10;


### PR DESCRIPTION
Do not merge yet! 

Submitting this pull request for comments. More documentation and tidying are needed 

The current version of constant folding has two bugs:

1. It does not fold constants in all cases, or check that declaration constants are initialized with genuine constants. For example, on the input program,
```
const T t = { 32s10, 32s20 };
const S s = { { 32s15, 32s25}, t };
const int<32> x = t.t1;
const int<32> y = s.s1.t2;
const int<32> w = .t.t1;
const T t1 = (T)s.s1;
```
constant folding (with type information) yields:
```
const T t = { 32s10, 32s20 };
const S s = { { 32s15, 32s25 }, t };
const int<32> x = 32s10;
const int<32> y = 32s25;
const int<32> w = 32s10;
const T t1 = { 32s15, 32s25 };
```
Note that the RHS of the declaration of `s` is not a constant -- it contains the variable `t`.

The root cause of this behavior is due to the use of auxiliary data structure `constants`: the pass does not ensure that all expressions that are inserted into this map are genuine constants, yet it assumes that `getConstants`, which returns arbitrary entries from `constants`, are always a constant. Hence, the current check for `Declaration_Constants` (https://github.com/p4lang/p4c/blob/master/frontends/common/constantFolding.cpp#L76) is not correct.

The fix here is to streamline the use of `constants` so it is used in exactly two places: 
* It is populated with genuine constants in the `IR::Declaration_Constant` case
* It is read in the `IR::PathExpression` (aka variable) case

2. When it transforms the IR, the constant folding pass attempts to patch the `typeMap` with type information about the newly inserted nodes. However, the types it inserts are not always correct -- e.g., in particular, in the `IR::Member` case, when header stack sizes are folded, the type map is updated with `origtype, the type of the expression, but the arbitrary-precision integer may require a cast. Hence, subsequent type-checking passes will rely on the information in the typeMap and assume that no cast is required. However, if the typeMap is ever cleared, then the typeChecker will mutate the node, triggering an error.

This error is not triggered by any of our current tests -- in examples like `p4_16_samples/stack.p4`, the `IR::Member` is dead code and is eliminated before the `typeMap` is cleared. Hence, the error never manifests. However, a close variant can trigger the error:
```
#include <core.p4>
header h { }
control c(out bit<32> x) {
    apply {
        h[4] stack;
        bit<32> sz = stack.size;
        x = sz;
    }
}
control Simpler(out bit<32> x);
package top(Simpler ctr);
top(c()) main;
```
The solution proposed here is to change the `typeMap` to `const` (which streamlines the constant folding pass) and reconstruct it after type checking. In addition, we statically convert the header stacks length to the appropriate type.