### PR TITLE
Add Doxygen comments for the ResetHeaders pass.

### DIFF
--- a/frontends/p4/resetHeaders.cpp
+++ b/frontends/p4/resetHeaders.cpp
@@ -18,8 +18,12 @@ limitations under the License.
 
 namespace P4 {
 
-void DoResetHeaders::generateResets(const TypeMap* typeMap, const IR::Type* type,
-                                  const IR::Expression* expr, IR::Vector<IR::StatOrDecl>* resets) {
+void DoResetHeaders::generateResets(
+    const TypeMap* typeMap,
+    const IR::Type* type,
+    const IR::Expression* expr,
+    IR::Vector<IR::StatOrDecl>* resets)
+{
     if (type->is<IR::Type_Struct>() || type->is<IR::Type_Union>()) {
         auto sl = type->to<IR::Type_StructLike>();
         for (auto f : sl->fields) {

--- a/frontends/p4/resetHeaders.cpp
+++ b/frontends/p4/resetHeaders.cpp
@@ -22,8 +22,7 @@ void DoResetHeaders::generateResets(
     const TypeMap* typeMap,
     const IR::Type* type,
     const IR::Expression* expr,
-    IR::Vector<IR::StatOrDecl>* resets)
-{
+    IR::Vector<IR::StatOrDecl>* resets) {
     if (type->is<IR::Type_Struct>() || type->is<IR::Type_Union>()) {
         auto sl = type->to<IR::Type_StructLike>();
         for (auto f : sl->fields) {


### PR DESCRIPTION
Also format `DoResetHeaders::generateResets` signature to be less than 80 characters wide.