### PR TITLE
adds an unimplemented exception and exception catching in drivers

### DIFF
--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -70,7 +70,12 @@ int main(int argc, char *const argv[]) {
     if (::errorCount() > 0)
         exit(1);
 
-    compile(options);
+    try {
+        compile(options);
+    } catch (const Util::P4CExceptionBase &bug) {
+        std::cerr << bug.what() << std::endl;
+        return 1;
+    }
 
     if (Log::verbose())
         std::cerr << "Done." << std::endl;

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -24,9 +24,14 @@ limitations under the License.
 
 namespace Util {
 
-// Base class for all exceptions.
-// The constructor uses boost::format for the format string, i.e.,
-// %1%, %2%, etc (starting at 1, not at 0)
+// colors to pretty print messages
+constexpr char ANSI_RED[]  = "\e[31m";
+constexpr char ANSI_BLUE[] = "\e[34m";
+constexpr char ANSI_CLR[]  = "\e[0m";
+
+/// Base class for all exceptions.
+/// The constructor uses boost::format for the format string, i.e.,
+/// %1%, %2%, etc (starting at 1, not at 0)
 class P4CExceptionBase : public std::exception {
  protected:
     cstring message;
@@ -35,47 +40,45 @@ class P4CExceptionBase : public std::exception {
     template <typename... T>
     P4CExceptionBase(const char* format, T... args) {
         boost::format fmt(format);
-        this->message = ::bug_helper(fmt, "", "", "", std::forward<T>(args)...);
+        message = ::bug_helper(fmt, "", "", "", std::forward<T>(args)...);
     }
 
     const char* what() const noexcept
-    { return this->message.c_str(); }
+    { return message.c_str(); }
 };
 
-// This class indicates a bug in the compiler
+/// This class indicates a bug in the compiler
 class CompilerBug final : public P4CExceptionBase {
  public:
     template <typename... T>
     CompilerBug(const char* format, T... args)
             : P4CExceptionBase(format, args...)
-    // \e[31m prints the text in red
-    { message = "\e[31mCOMPILER BUG\e[0m:\n" + message; }
+    { message = cstring(ANSI_RED) + "Compiler Bug" + ANSI_CLR + ":\n" + message; }
     template <typename... T>
     CompilerBug(const char* file, int line, const char* format, T... args)
             : P4CExceptionBase(format, args...)
     { message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
-                cstring("\e[31mCOMPILER BUG\e[0m: ") + message; }
+                + ANSI_RED + "Compiler Bug" + ANSI_CLR + ": " + message; }
 };
 
-// This class indicates an unimplemented feature in the compiler
+/// This class indicates an unimplemented feature in the compiler
 class CompilerUnimplemented final : public P4CExceptionBase {
  public:
     template <typename... T>
     CompilerUnimplemented(const char* format, T... args)
             : P4CExceptionBase(format, args...)
-    // \e[34m prints the text in blue
-    { message = "\e[34mUnimplemented compiler support\e[0m:\n" + message; }
+    { message = cstring(ANSI_BLUE) +"Unimplemented compiler support"+ ANSI_CLR + ":\n" + message; }
     template <typename... T>
     CompilerUnimplemented(const char* file, int line, const char* format, T... args)
             : P4CExceptionBase(format, args...)
     { message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
-                cstring("\e[34mUnimplemented compiler support\e[0m: ") + message; }
+                ANSI_BLUE + "Unimplemented compiler support" + ANSI_CLR + ": " + message; }
 };
 
 
-// This class indicates a compilation error that we do not want to recover from.
-// This may be due to a malformed input program.
-// TODO: this class is very seldom used, perhaps we can remove it.
+/// This class indicates a compilation error that we do not want to recover from.
+/// This may be due to a malformed input program.
+/// TODO: this class is very seldom used, perhaps we can remove it.
 class CompilationError : public P4CExceptionBase {
  public:
     template <typename... T>

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -48,12 +48,30 @@ class CompilerBug final : public P4CExceptionBase {
     template <typename... T>
     CompilerBug(const char* format, T... args)
             : P4CExceptionBase(format, args...)
-    { message = "COMPILER BUG:\n" + message; }
+    // \e[31m prints the text in red
+    { message = "\e[31mCOMPILER BUG\e[0m:\n" + message; }
     template <typename... T>
     CompilerBug(const char* file, int line, const char* format, T... args)
             : P4CExceptionBase(format, args...)
-    { message = cstring("COMPILER BUG: ") + file + ":" + Util::toString(line) + "\n" + message; }
+    { message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
+                cstring("\e[31mCOMPILER BUG\e[0m: ") + message; }
 };
+
+// This class indicates an unimplemented feature in the compiler
+class CompilerUnimplemented final : public P4CExceptionBase {
+ public:
+    template <typename... T>
+    CompilerUnimplemented(const char* format, T... args)
+            : P4CExceptionBase(format, args...)
+    // \e[34m prints the text in blue
+    { message = "\e[34mUnimplemented compiler support\e[0m:\n" + message; }
+    template <typename... T>
+    CompilerUnimplemented(const char* file, int line, const char* format, T... args)
+            : P4CExceptionBase(format, args...)
+    { message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
+                cstring("\e[34mUnimplemented compiler support\e[0m: ") + message; }
+};
+
 
 // This class indicates a compilation error that we do not want to recover from.
 // This may be due to a malformed input program.
@@ -67,6 +85,9 @@ class CompilationError : public P4CExceptionBase {
 
 #define BUG(...) do { throw Util::CompilerBug(__FILE__, __LINE__, __VA_ARGS__); } while (0)
 #define BUG_CHECK(e, ...) do { if (!(e)) BUG(__VA_ARGS__); } while (0)
+#define P4C_UNIMPLEMENTED(...) do { \
+        throw Util::CompilerUnimplemented(__FILE__, __LINE__, __VA_ARGS__); \
+    } while (0)
 
 }  // namespace Util
 #endif /* P4C_LIB_EXCEPTIONS_H_ */

--- a/test/unittests/exception_test.cpp
+++ b/test/unittests/exception_test.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ class TestException : public TestBase {
         }
         catch (std::exception &ex) {
             cstring err(ex.what());
-            ASSERT_EQ(err, "COMPILER BUG:\ntest\n");
+            cstring expected = cstring(ANSI_RED) + "Compiler Bug" + ANSI_CLR +":\ntest\n";
+            ASSERT_EQ(err, expected);
         }
 
         try {


### PR DESCRIPTION
Adds a new type of P4Exception: CompilerUnimplemented to replace
instances where we use BUG/BUG_CHECK as a placeholder for features
that we have not yet implemented.

Also adds exception catching in the compiler drivers, such that the
compiler exits cleanly.