### PR TITLE
Fix internal links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The code contains three sample backends:
     git submodule update --init --recursive
     ```
 
-2.  Install [dependencies](#Dependencies). You can find specific instructions
-    for Ubuntu 16.04 [here](#Ubuntu-dependencies) and for macOS 10.12
-    [here](#macOS-dependencies).
+2.  Install [dependencies](#dependencies). You can find specific instructions
+    for Ubuntu 16.04 [here](#ubuntu-dependencies) and for macOS 10.12
+    [here](#macos-dependencies).
 
 3.  Build. By default, building takes place in a subdirectory named `build`.
     ```
@@ -59,7 +59,7 @@ The code contains three sample backends:
     ```
 
 If you plan to contribute to p4c, you'll find more useful information
-[here](#Development-tools).
+[here](#development-tools).
 
 # Dependencies
 


### PR DESCRIPTION
Looks like the anchors Github generates for Markdown sections are in all lower-case, which prevents the internal links in README.md from working.