### PR TITLE
Work around spurious GCC warning in P4RuntimeSymbolTable::piResourceType()

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -751,6 +751,7 @@ private:
             case P4RuntimeSymbolType::METER: return PI_METER_ID;
             case P4RuntimeSymbolType::TABLE: return PI_TABLE_ID;
         }
+        BUG("Unexpected P4RuntimeSymbolType");  // Unreachable.
     }
 
 


### PR DESCRIPTION
GCC warns that P4RuntimeSymbol::piResourceType() may fail to return a value on all code paths, which is not true - the switch block is exhaustive. (As clang correctly recognizes.) This PR adds a BUG statement to make GCC happy.