### PR TITLE
Lower Bison version requirement

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Use Bison's C++ mode.
 %skeleton "lalr1.cc" /* -*-C++-*- */
-%require "3.0.4"
+%require "3.0.0"
 
 // Set up names.
 %defines

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Use Bison's C++ mode.
 %skeleton "lalr1.cc" /* -*-C++-*- */
-%require "3.0.4"
+%require "3.0.0"
 
 // Set up names.
 %defines


### PR DESCRIPTION
The version requirement for the grammars was set conservatively, but these grammars should work on any Bison 3.x release. This PR lowers the requirement.