### PR TITLE
Fix bmv2 backend crash for unused action selectors

### DIFF
--- a/testdata/p4_16_samples/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples/action_selector_unused-bmv2.p4
@@ -1,0 +1,41 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H { };
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t
+    smeta) {
+    state start { transition accept; }
+}
+
+action empty() { }
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+
+    action drop() { smeta.drop = 1; }
+
+    action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
+    apply { }
+};
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply { }
+};
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply { }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply { }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(),
+         ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
@@ -1,0 +1,48 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+action empty() {
+}
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    action drop() {
+        smeta.drop = 1w1;
+    }
+    action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
+    apply {
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-frontend.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("as") action_selector(HashAlgorithm.identity, 32w1024, 32w10) as_0;
+    apply {
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-midend.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("as") action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
+    apply {
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
@@ -1,0 +1,48 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+action empty() {
+}
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    action drop() {
+        smeta.drop = 1;
+    }
+    action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
+    apply {
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4-stderr
@@ -1,0 +1,3 @@
+../testdata/p4_16_samples/action_selector_unused-bmv2.p4(20): warning: as: unused instance
+    action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
+                                                             ^^


### PR DESCRIPTION
When an action selector is declared as a control local but never
referenced by a table, the compiler cannot figure out the selector
input, which means the action selector cannot be included in the bmv2
JSON.