### PR TITLE
Run tests with MAKEFLAGS=-j2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ install:
   - docker build -t p4c --build-arg IMAGE_TYPE=test .
 
 script:
-  - docker run -w /p4c/build p4c make check VERBOSE=1
-  - docker run -w /p4c/build p4c make cpplint
+  - docker run -w /p4c/build -e 'MAKEFLAGS=-j2' p4c make check VERBOSE=1
+  - docker run -w /p4c/build -e 'MAKEFLAGS=-j2' p4c make cpplint


### PR DESCRIPTION
Since we stopped persisting the `MAKEFLAGS` environment variable in the image, we need to pass it in manually when running the tests. Failing to do this was doubling the length of time our tests took to run.