### PR TITLE
Don't use an invalid srcInfo to construct json source info.

### DIFF
--- a/ir/node.cpp
+++ b/ir/node.cpp
@@ -83,7 +83,8 @@ Util::JsonObject* IR::Node::sourceInfoJsonObj() const {
         auto assign = to<IR::AssignmentStatement>();
         lhs = assign->left;
         rhs = assign->right;
-        lhs->srcInfo.toSourcePositionData(&lineNumber, &columnNumber);
+        if (lhs->srcInfo.isValid())
+            lhs->srcInfo.toSourcePositionData(&lineNumber, &columnNumber);
     }
     auto json = new Util::JsonObject();
     cstring sourceFrag = srcInfo.toBriefSourceFragment();

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -58,7 +58,7 @@ InputSources* InputSources::instance = new InputSources();
 
 InputSources::InputSources() :
         sealed(false) {
-    mapLine(nullptr, 0);
+    mapLine(nullptr, 1);  // the first line read will be line 1 of stdin
     contents.push_back("");
 }
 
@@ -169,6 +169,7 @@ SourceFileLine InputSources::getSourceLine(unsigned line) const {
     // The first line indicates that line 2 is the first line in x.p4
     // line=2, it->first=1, it->second.sourceLine=1
     // So we have to subtract one to get the real line number
+    BUG_CHECK(line - it->first + it->second.sourceLine > 0, "invalid source line");
     return SourceFileLine(it->second.fileName, line - it->first + it->second.sourceLine - 1);
 }
 


### PR DESCRIPTION
- Also fix off-by-one error tracking stdin line number

I think there are more off-by-one errors in the linenumber tracking code, combined with various +1/-1 adjustments in random places to correct for them.  Much of this comes from #line directives containing the line number of the next line, not the line number of the #line directive itself.