### PR TITLE
Improve dependency checks in configure.ac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ENV P4C_DEPS automake \
              g++ \
              libboost-dev \
              libboost-iostreams1.58-dev \
+             libfl-dev \
              libgc-dev \
              libgmp-dev \
              libtool \

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ included with `p4c` are documented here:
 
 Most dependencies can be installed using `apt-get install`:
 
-`sudo apt-get install g++ git automake libtool libgc-dev bison flex libgmp-dev libboost-dev libboost-iostreams-dev pkg-config python python-scapy python-ipaddr tcpdump`
+`sudo apt-get install g++ git automake libtool libgc-dev bison flex libfl-dev libgmp-dev libboost-dev libboost-iostreams-dev pkg-config python python-scapy python-ipaddr tcpdump`
 
 For documentation building:
 `sudo apt-get install -y doxygen graphviz texlive-full`

--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,6 @@ AC_PATH_PROG([PROTOC], [protoc], [])
 AS_IF([test "x$PROTOC" = x], [AC_MSG_ERROR([protoc not found; is protobuf installed?])])
 
 AC_CHECK_HEADER([FlexLexer.h], [], [AC_MSG_ERROR([Missing FlexLexer.h; is flex and libfl-dev installed?])])
-AC_CHECK_HEADERS([constraint_solver/constraint_solver.h])
 AC_CHECK_LIB([gc], [GC_malloc], [], [AC_MSG_ERROR([Missing GC library])])
 AC_CHECK_LIB([rt], [clock_gettime], [], [])
 AC_CHECK_LIB([gmp], [__gmpz_init], [], [AC_MSG_ERROR([GNU MP not found])])

--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,7 @@ AC_SUBST([PROTOBUF_LIBS])
 AC_PATH_PROG([PROTOC], [protoc], [])
 AS_IF([test "x$PROTOC" = x], [AC_MSG_ERROR([protoc not found; is protobuf installed?])])
 
+AC_CHECK_HEADER([FlexLexer.h], [], [AC_MSG_ERROR([Missing FlexLexer.h; is flex and libfl-dev installed?])])
 AC_CHECK_HEADERS([constraint_solver/constraint_solver.h])
 AC_CHECK_LIB([gc], [GC_malloc], [], [AC_MSG_ERROR([Missing GC library])])
 AC_CHECK_LIB([rt], [clock_gettime], [], [])


### PR DESCRIPTION
This PR makes a few improvements to the dependency checks in `configure.ac`:

- We now explicitly depend on `libfl-dev`. For some reason Debian (and thus Ubuntu) decided to split out some of the files included with flex, including `FlexLexer.h` which we depend on, into a separate package. This issue wasn't noticed until Mihai ran into it because the package is installed as a dependency of something else in our Docker CI environment. No change is necessary on macOS; a full flex installation comes with the system by default.

- We don't depend `constraint_solver.h` (which is from Google OR-Tools), so we shouldn't be checking for it.

- We don't need to check for ranlib; `LT_INIT` takes care of it. The `AC_PROG_RANLIB` check was triggering warnings from autoconf.