### PR TITLE
Front-end support for header_unions

### DIFF
--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -107,7 +107,7 @@ EBPFStructType::EBPFStructType(const IR::Type_StructLike* strct) :
         kind = "struct";
     else if (strct->is<IR::Type_Header>())
         kind = "struct";
-    else if (strct->is<IR::Type_Union>())
+    else if (strct->is<IR::Type_HeaderUnion>())
         kind = "union";
     else
         BUG("Unexpected struct type %1%", strct);
@@ -139,7 +139,7 @@ EBPFStructType::declare(CodeBuilder* builder, cstring id, bool asPointer) {
 
 void EBPFStructType::emitInitializer(CodeBuilder* builder) {
     builder->blockStart();
-    if (type->is<IR::Type_Struct>() || type->is<IR::Type_Union>()) {
+    if (type->is<IR::Type_Struct>() || type->is<IR::Type_HeaderUnion>()) {
         for (auto f : fields) {
             builder->emitIndent();
             builder->appendFormat(".%s = ", f->field->name.name);

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -128,7 +128,7 @@ struct HeaderFieldPath {
 
                 // Top-level structs and unions don't show up in P4Runtime field names, so we use a
                 // blank path component name.
-                if (type->is<IR::Type_Struct>() || type->is<IR::Type_Union>()) {
+                if (type->is<IR::Type_Struct>() || type->is<IR::Type_HeaderUnion>()) {
                     return HeaderFieldPath::root("", type);
                 }
             }

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 
 namespace P4 {
 
-// name for header valid bit
+// internal name for header valid bit; used only locally
 const cstring StorageFactory::validFieldName = "$valid";
 const cstring StorageFactory::indexFieldName = "$lastIndex";
 const LocationSet* LocationSet::empty = new LocationSet();
@@ -46,8 +46,21 @@ StorageLocation* StorageFactory::create(const IR::Type* type, cstring name) cons
         type = typeMap->getTypeType(type, true);  // get the canonical version
         auto st = type->to<IR::Type_StructLike>();
         auto result = new StructLocation(type, name);
+
+        // For header unions we will model all of the valid fields
+        // for all components as a single shared field.  The
+        // reason is that updating one of may change all of the
+        // other ones.
+        StorageLocation* globalValid = nullptr;
+        if (type->is<IR::Type_HeaderUnion>())
+            globalValid = create(IR::Type_Boolean::get(), name + "." + validFieldName);
+
         for (auto f : st->fields) {
-            auto sl = create(f->type, name + "." + f->name);
+            cstring fieldName = name + "." + f->name;
+            auto sl = create(f->type, fieldName);
+            if (globalValid != nullptr)
+                dynamic_cast<StructLocation*>(sl)->replaceField(
+                    fieldName + "." + validFieldName, globalValid);
             result->addField(f->name, sl);
         }
         if (st->is<IR::Type_Header>()) {

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -161,7 +161,14 @@ const LocationSet* LocationSet::getField(cstring field) const {
     for (auto l : locations) {
         if (l->is<StructLocation>()) {
             auto strct = l->to<StructLocation>();
-            strct->addField(field, result);
+            if (field == StorageFactory::validFieldName && strct->isHeaderUnion()) {
+                // special handling for union.isValid()
+                for (auto f : strct->fields()) {
+                    f->to<StructLocation>()->addField(field, result);
+                }
+            } else {
+                strct->addField(field, result);
+            }
         } else {
             BUG_CHECK(l->is<ArrayLocation>(), "%1%: expected an ArrayLocation", l);
             auto array = l->to<ArrayLocation>();

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -86,6 +86,7 @@ class StructLocation : public StorageLocation {
     { fieldLocations.emplace(name, field); CHECK_NULL(field); }
     void replaceField(cstring field, StorageLocation* replacement)
     { fieldLocations[field] = replacement; }
+
  public:
     StructLocation(const IR::Type* type, cstring name) :
             StorageLocation(type, name) {

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -70,7 +70,8 @@ class BaseLocation : public StorageLocation {
             StorageLocation(type, name)
     { BUG_CHECK(type->is<IR::Type_Bits>() || type->is<IR::Type_Enum>() ||
                 type->is<IR::Type_Boolean>() || type->is<IR::Type_Var>() ||
-                type->is<IR::Type_Tuple>() || type-is<IR::Type_Error>(),
+                type->is<IR::Type_Tuple>() || type->is<IR::Type_Error>() ||
+                type->is<IR::Type_Varbits>(),
                 "%1%: unexpected type", type); }
     void addValidBits(LocationSet*) const override {}
     void addLastIndexField(LocationSet*) const override {}

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -84,6 +84,8 @@ class StructLocation : public StorageLocation {
 
     void addField(cstring name, StorageLocation* field)
     { fieldLocations.emplace(name, field); CHECK_NULL(field); }
+    void replaceField(cstring field, StorageLocation* replacement)
+    { fieldLocations[field] = replacement; }
  public:
     StructLocation(const IR::Type* type, cstring name) :
             StorageLocation(type, name) {

--- a/frontends/p4/methodInstance.cpp
+++ b/frontends/p4/methodInstance.cpp
@@ -49,7 +49,10 @@ MethodInstance::resolve(const IR::MethodCallExpression* mce, ReferenceMap* refMa
             else
                 BUG("Could not find type for %1%", mem->expr);
         }
-        if (basetype->is<IR::Type_Header>()) {
+        if (basetype->is<IR::Type_HeaderUnion>()) {
+            if (mem->member == IR::Type_Header::isValid)
+                return new BuiltInMethod(mce, mem->member, mem->expr, mt->to<IR::Type_Method>());
+        } else if (basetype->is<IR::Type_Header>()) {
             if (mem->member == IR::Type_Header::setValid ||
                 mem->member == IR::Type_Header::setInvalid ||
                 mem->member == IR::Type_Header::isValid)

--- a/frontends/p4/methodInstance.h
+++ b/frontends/p4/methodInstance.h
@@ -151,6 +151,7 @@ These methods are:
 - header.setValid(),
 - header.setInvalid(),
 - header.isValid(),
+- union.isValid(),
 - stack.push(int),
 - stack.pop(int)
 */

--- a/frontends/p4/resetHeaders.cpp
+++ b/frontends/p4/resetHeaders.cpp
@@ -23,7 +23,7 @@ void DoResetHeaders::generateResets(
     const IR::Type* type,
     const IR::Expression* expr,
     IR::Vector<IR::StatOrDecl>* resets) {
-    if (type->is<IR::Type_Struct>() || type->is<IR::Type_Union>()) {
+    if (type->is<IR::Type_Struct>() || type->is<IR::Type_HeaderUnion>()) {
         auto sl = type->to<IR::Type_StructLike>();
         for (auto f : sl->fields) {
             auto ftype = typeMap->getType(f, true);

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -126,7 +126,7 @@ class ToP4 : public Inspector {
     { return process(t, "struct"); }
     bool preorder(const IR::Type_Header* t) override
     { return process(t, "header"); }
-    bool preorder(const IR::Type_Union* t) override
+    bool preorder(const IR::Type_HeaderUnion* t) override
     { return process(t, "header_union"); }
     bool preorder(const IR::Type_Package* t) override;
     bool preorder(const IR::Type_Parser* t) override;

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -457,14 +457,14 @@ const IR::Type* TypeInference::canonicalize(const IR::Type* type) {
         else
             canon = str;
         return canon;
-    } else if (type->is<IR::Type_Union>()) {
-        auto str = type->to<IR::Type_Union>();
+    } else if (type->is<IR::Type_HeaderUnion>()) {
+        auto str = type->to<IR::Type_HeaderUnion>();
         auto fields = canonicalizeFields(str);
         if (fields == nullptr)
             return nullptr;
         const IR::Type* canon;
         if (fields != &str->fields)
-            canon = new IR::Type_Union(str->srcInfo, str->name, str->annotations, *fields);
+            canon = new IR::Type_HeaderUnion(str->srcInfo, str->name, str->annotations, *fields);
         else
             canon = str;
         return canon;
@@ -1107,7 +1107,7 @@ const IR::Node* TypeInference::postorder(IR::Type_Stack* type) {
     if (etype == nullptr)
         return type;
 
-    if (!etype->is<IR::Type_Header>() && !etype->is<IR::Type_Union>())
+    if (!etype->is<IR::Type_Header>() && !etype->is<IR::Type_HeaderUnion>())
         typeError("Header stack %1% used with non-header type %2%",
                   type, etype->toString());
     return type;
@@ -1168,7 +1168,7 @@ const IR::Node* TypeInference::postorder(IR::Type_Struct* type) {
     auto canon = setTypeType(type);
     auto validator = [] (const IR::Type* t) {
         return t->is<IR::Type_Struct>() || t->is<IR::Type_Bits>() ||
-        t->is<IR::Type_Header>() || t->is<IR::Type_Union>() ||
+        t->is<IR::Type_Header>() || t->is<IR::Type_HeaderUnion>() ||
         t->is<IR::Type_Enum>() || t->is<IR::Type_Error>() ||
         t->is<IR::Type_Boolean>() || t->is<IR::Type_Stack>() ||
         t->is<IR::Type_Varbits>() ||
@@ -1177,7 +1177,7 @@ const IR::Node* TypeInference::postorder(IR::Type_Struct* type) {
     return type;
 }
 
-const IR::Node* TypeInference::postorder(IR::Type_Union *type) {
+const IR::Node* TypeInference::postorder(IR::Type_HeaderUnion *type) {
     auto canon = setTypeType(type);
     auto validator = [] (const IR::Type* t) { return t->is<IR::Type_Header>(); };
     validateFields(canon, validator);
@@ -2130,7 +2130,7 @@ const IR::Node* TypeInference::postorder(IR::Member* expression) {
     }
 
     if (type->is<IR::Type_StructLike>()) {
-        if (type->is<IR::Type_Header>()) {
+        if (type->is<IR::Type_Header>() || type->is<IR::Type_HeaderUnion>()) {
             if (member == IR::Type_Header::isValid) {
                 // Built-in method
                 auto type = new IR::Type_Method(IR::Type_Boolean::get(), new IR::ParameterList());
@@ -2140,8 +2140,11 @@ const IR::Node* TypeInference::postorder(IR::Member* expression) {
                 setType(getOriginal(), ctype);
                 setType(expression, ctype);
                 return expression;
-            } else if (member == IR::Type_Header::setValid ||
-                       member == IR::Type_Header::setInvalid) {
+            }
+        }
+        if (type->is<IR::Type_Header>()) {
+            if (member == IR::Type_Header::setValid ||
+                member == IR::Type_Header::setInvalid) {
                 if (!isLeftValue(expression->expr))
                     ::error("%1%: must be applied to a left-value", expression);
                 // Built-in method
@@ -2371,7 +2374,8 @@ bool TypeInference::hasVarbits(const IR::Type_Header* type) const {
 }
 
 void TypeInference::checkEmitType(const IR::Expression* emit, const IR::Type* type) const {
-    if (type->is<IR::Type_Header>() || type->is<IR::Type_Stack>() || type->is<IR::Type_Union>())
+    if (type->is<IR::Type_Header>() || type->is<IR::Type_Stack>() ||
+        type->is<IR::Type_HeaderUnion>())
         return;
 
     if (type->is<IR::Type_Struct>()) {
@@ -2643,7 +2647,8 @@ const IR::Node* TypeInference::postorder(IR::DefaultExpression* expression) {
 }
 
 bool TypeInference::containsHeader(const IR::Type* type) {
-    if (type->is<IR::Type_Header>() || type->is<IR::Type_Stack>() || type->is<IR::Type_Union>())
+    if (type->is<IR::Type_Header>() || type->is<IR::Type_Stack>() ||
+        type->is<IR::Type_HeaderUnion>())
         return true;
     if (type->is<IR::Type_Struct>()) {
         auto st = type->to<IR::Type_Struct>();

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -200,7 +200,7 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::Type_Header* type) override;
     const IR::Node* postorder(IR::Type_Stack* type) override;
     const IR::Node* postorder(IR::Type_Struct* type) override;
-    const IR::Node* postorder(IR::Type_Union* type) override;
+    const IR::Node* postorder(IR::Type_HeaderUnion* type) override;
     const IR::Node* postorder(IR::Type_Typedef* type) override;
     const IR::Node* postorder(IR::Type_Specialized* type) override;
     const IR::Node* postorder(IR::Type_SpecializedCanonical* type) override;

--- a/frontends/p4/validateParsedProgram.cpp
+++ b/frontends/p4/validateParsedProgram.cpp
@@ -54,12 +54,6 @@ void ValidateParsedProgram::postorder(const IR::StructField* f) {
         ::error("%1%: Illegal field name", f->name);
 }
 
-/// Unions must have at least one field
-void ValidateParsedProgram::postorder(const IR::Type_Union* type) {
-    if (type->fields.size() == 0)
-        ::error("%1%: empty union", type);
-}
-
 /// Width of a bit<> type is at least 0
 /// Width of an int<> type is at least 1
 void ValidateParsedProgram::postorder(const IR::Type_Bits* type) {

--- a/frontends/p4/validateParsedProgram.h
+++ b/frontends/p4/validateParsedProgram.h
@@ -31,7 +31,6 @@ namespace P4 {
 
    - integer constants have valid types
    - don't care _ is not used as a name for methods, fields, variables, instances
-   - unions have at least one field
    - width of bit<> types is positive
    - width of int<> types is larger than 1
    - no parser state is named 'accept' or 'reject'
@@ -62,7 +61,6 @@ class ValidateParsedProgram final : public Inspector {
     void postorder(const IR::StructField* f) override;
     void postorder(const IR::ParserState* s) override;
     void postorder(const IR::P4Table* t) override;
-    void postorder(const IR::Type_Union* type) override;
     void postorder(const IR::Type_Bits* type) override;
     void postorder(const IR::ConstructorCallExpression* expression) override;
     void postorder(const IR::Declaration_Variable* decl) override;

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -641,7 +641,7 @@ structTypeDeclaration
 headerUnionDeclaration
     : optAnnotations
         HEADER_UNION name { driver.structure->declareType(*$3); }
-        "{" structFieldList "}" { $$ = new IR::Type_Union(@3, *$3, $1, *$6); }
+        "{" structFieldList "}" { $$ = new IR::Type_HeaderUnion(@3, *$3, $1, *$6); }
     ;
 
 structFieldList
@@ -928,7 +928,8 @@ argument
     ;
 
 expressionList
-    : expression                         { $$ = new IR::Vector<IR::Expression>();
+    : /* empty */                        { $$ = new IR::Vector<IR::Expression>(); }
+    | expression                         { $$ = new IR::Vector<IR::Expression>();
                                            $$->push_back($1); }
     | expressionList "," expression      { $$ = $1; $$->push_back($3); }
     ;

--- a/ir/type.def
+++ b/ir/type.def
@@ -242,10 +242,10 @@ class Type_Struct : Type_StructLike {
     toString{ return cstring("struct ") + externalName(); }
 }
 
-class Type_Union : Type_StructLike {
+class Type_HeaderUnion : Type_StructLike {
 #nodbprint
     toString{ return cstring("header_union ") + externalName(); }
-    /// this makes some assumptions on padding
+    // this makes some assumptions on padding
     int width_bits() const override {
         int rv = 0;
         for (auto f : fields)

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -84,9 +84,9 @@ unsigned SymbolicValueFactory::getWidth(const IR::Type* type) const {
         return type->to<IR::Type_Bits>()->size;
     if (type->is<IR::Type_Boolean>())
         return 1;
-    if (type->is<IR::Type_Union>()) {
+    if (type->is<IR::Type_HeaderUnion>()) {
         unsigned width = 0;
-        for (auto f : type->to<IR::Type_Union>()->fields)
+        for (auto f : type->to<IR::Type_HeaderUnion>()->fields)
             width = std::max(width, getWidth(f->type));
         return width;
     }

--- a/testdata/p4_16_errors/issue561-1.p4
+++ b/testdata/p4_16_errors/issue561-1.p4
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+header H1 { bit<32> f; }
+header H2 { bit<32> g; }
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct();
+package top(ct _ct);
+
+control c() {
+    apply {
+        U u = { { 10 }, { 20 } };  // illegal to initialize unions
+        u.setValid(); // no such method
+    }
+}
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/issue561-1.p4
+++ b/testdata/p4_16_errors_outputs/issue561-1.p4
@@ -1,0 +1,23 @@
+header H1 {
+    bit<32> f;
+}
+
+header H2 {
+    bit<32> g;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct();
+package top(ct _ct);
+control c() {
+    apply {
+        U u = { { 10 }, { 20 } };
+        u.setValid();
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
@@ -1,0 +1,18 @@
+../testdata/p4_16_errors/issue561-1.p4(29): error: u: Cannot unify Tuple(2) to header_union U
+        U u = { { 10 }, { 20 } }; // illegal to initialize unions
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+../testdata/p4_16_errors/issue561-1.p4(29)
+        U u = { { 10 }, { 20 } }; // illegal to initialize unions
+              ^^^^^^^^^^^^^^^^^^
+../testdata/p4_16_errors/issue561-1.p4(19)
+header_union U {
+             ^
+../testdata/p4_16_errors/issue561-1.p4(19): error: Structure header_union U does not have a field setValid
+header_union U {
+             ^
+../testdata/p4_16_errors/issue561-1.p4(30)
+        u.setValid(); // no such method
+          ^^^^^^^^
+../testdata/p4_16_errors/issue561-1.p4(30): error: Could not find type of u.setValid
+        u.setValid(); // no such method
+        ^^^^^^^^^^

--- a/testdata/p4_16_samples/issue561.p4
+++ b/testdata/p4_16_samples/issue561.p4
@@ -1,0 +1,48 @@
+/*
+Copyright 2017 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+header H1 { bit<32> f; }
+header H2 { bit<32> g; }
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(out bit<32> b);
+package top(ct _ct);
+
+control c(out bit<32> x) {
+    apply {
+        U u;
+        U[2] u2;
+
+        bool b = u.isValid();
+        b = b || u.h1.isValid();
+
+        x = u.h1.f + u.h2.g;
+        u.h1.setValid();
+        u.h1.f = 0;
+        x = x + u.h1.f;
+
+        u.h2.g = 0;
+        x = x + u.h2.g;
+
+        u2[0].h1.setValid();
+        u2[0].h1.f = 2;
+        x = x + u2[1].h2.g + u2[0].h1.f;
+    }
+}
+top(c()) main;

--- a/testdata/p4_16_samples/struct.p4
+++ b/testdata/p4_16_samples/struct.p4
@@ -14,23 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-struct P
-{
+struct P {
     bit<32> f1;
     bit<32> f2;
 }
 
-struct T
-{
+struct T {
     int<32> t1;
     int<32> t2;
 }
 
-struct S
-{
+struct S {
     T s1;
     T s2;
 }
+
+struct Empty {};
 
 const T t = { 32s10, 32s20 };
 const S s = { { 32s15, 32s25}, t };
@@ -41,3 +40,5 @@ const int<32> y = s.s1.t2;
 const int<32> w = .t.t1;
 
 const T t1 = s.s1;
+const T t1 = (T)s.s1;
+const Empty e = {};

--- a/testdata/p4_16_samples/struct.p4
+++ b/testdata/p4_16_samples/struct.p4
@@ -40,5 +40,4 @@ const int<32> y = s.s1.t2;
 const int<32> w = .t.t1;
 
 const T t1 = s.s1;
-const T t1 = (T)s.s1;
 const Empty e = {};

--- a/testdata/p4_16_samples_outputs/issue561-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-first.p4
@@ -1,0 +1,34 @@
+header H1 {
+    bit<32> f;
+}
+
+header H2 {
+    bit<32> g;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(out bit<32> b);
+package top(ct _ct);
+control c(out bit<32> x) {
+    apply {
+        U u;
+        U[2] u2;
+        bool b = u.isValid();
+        b = b || u.h1.isValid();
+        x = u.h1.f + u.h2.g;
+        u.h1.setValid();
+        u.h1.f = 32w0;
+        x = x + u.h1.f;
+        u.h2.g = 32w0;
+        x = x + u.h2.g;
+        u2[0].h1.setValid();
+        u2[0].h1.f = 32w2;
+        x = x + u2[1].h2.g + u2[0].h1.f;
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue561-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-frontend.p4
@@ -1,0 +1,35 @@
+header H1 {
+    bit<32> f;
+}
+
+header H2 {
+    bit<32> g;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(out bit<32> b);
+package top(ct _ct);
+control c(out bit<32> x) {
+    U u_0;
+    U[2] u2_0;
+    bool b_0;
+    apply {
+        b_0 = u_0.isValid();
+        u_0.h1.isValid();
+        x = u_0.h1.f + u_0.h2.g;
+        u_0.h1.setValid();
+        u_0.h1.f = 32w0;
+        x = x + u_0.h1.f;
+        u_0.h2.g = 32w0;
+        x = x + u_0.h2.g;
+        u2_0[0].h1.setValid();
+        u2_0[0].h1.f = 32w2;
+        x = x + u2_0[1].h2.g + u2_0[0].h1.f;
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue561-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-midend.p4
@@ -1,0 +1,42 @@
+header H1 {
+    bit<32> f;
+}
+
+header H2 {
+    bit<32> g;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(out bit<32> b);
+package top(ct _ct);
+control c(out bit<32> x) {
+    U u;
+    U[2] u2;
+    @hidden action act() {
+        u.h1.isValid();
+        x = u.h1.f + u.h2.g;
+        u.h1.setValid();
+        u.h1.f = 32w0;
+        x = x + u.h1.f;
+        u.h2.g = 32w0;
+        x = x + u.h2.g;
+        u2[0].h1.setValid();
+        u2[0].h1.f = 32w2;
+        x = x + u2[1].h2.g + u2[0].h1.f;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue561.p4
+++ b/testdata/p4_16_samples_outputs/issue561.p4
@@ -1,0 +1,34 @@
+header H1 {
+    bit<32> f;
+}
+
+header H2 {
+    bit<32> g;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(out bit<32> b);
+package top(ct _ct);
+control c(out bit<32> x) {
+    apply {
+        U u;
+        U[2] u2;
+        bool b = u.isValid();
+        b = b || u.h1.isValid();
+        x = u.h1.f + u.h2.g;
+        u.h1.setValid();
+        u.h1.f = 0;
+        x = x + u.h1.f;
+        u.h2.g = 0;
+        x = x + u.h2.g;
+        u2[0].h1.setValid();
+        u2[0].h1.f = 2;
+        x = x + u2[1].h2.g + u2[0].h1.f;
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue561.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue561.p4-stderr
@@ -1,0 +1,9 @@
+../testdata/p4_16_samples/issue561.p4(35): warning: u.h1.f may be uninitialized
+        x = u.h1.f + u.h2.g;
+            ^^^^^^
+../testdata/p4_16_samples/issue561.p4(35): warning: u.h2.g may be uninitialized
+        x = u.h1.f + u.h2.g;
+                     ^^^^^^
+../testdata/p4_16_samples/issue561.p4(45): warning: [].h2.g may be uninitialized
+        x = x + u2[1].h2.g + u2[0].h1.f;
+                ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/struct-first.p4
+++ b/testdata/p4_16_samples_outputs/struct-first.p4
@@ -13,9 +13,13 @@ struct S {
     T s2;
 }
 
+struct Empty {
+}
+
 const T t = { 32s10, 32s20 };
 const S s = { { 32s15, 32s25 }, { 32s10, 32s20 } };
 const int<32> x = 32s10;
 const int<32> y = 32s25;
 const int<32> w = 32s10;
 const T t1 = { 32s15, 32s25 };
+const Empty e = {  };

--- a/testdata/p4_16_samples_outputs/struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/struct-frontend.p4
@@ -13,3 +13,6 @@ struct S {
     T s2;
 }
 
+struct Empty {
+}
+

--- a/testdata/p4_16_samples_outputs/struct.p4
+++ b/testdata/p4_16_samples_outputs/struct.p4
@@ -13,9 +13,13 @@ struct S {
     T s2;
 }
 
+struct Empty {
+}
+
 const T t = { 32s10, 32s20 };
 const S s = { { 32s15, 32s25 }, t };
 const int<32> x = t.t1;
 const int<32> y = s.s1.t2;
 const int<32> w = .t.t1;
 const T t1 = s.s1;
+const Empty e = {  };


### PR DESCRIPTION
I renamed the IR node to header_union, in case we ever get a real union. Most changes are due to this renaming.
Def-use analysis now handles unions; not many changes were required.
Also, changed the grammar to allow empty list expressions - good for initializing empty structs.
