### PR TITLE
Fix non unified build

### DIFF
--- a/backends/bmv2/JsonObjects.cpp
+++ b/backends/bmv2/JsonObjects.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "lib/json.h"
 #include "JsonObjects.h"
+#include "helpers.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/expression.cpp
+++ b/backends/bmv2/expression.cpp
@@ -14,6 +14,7 @@ limitations under the License.
 */
 
 #include "expression.h"
+#include "backend.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/extern.h
+++ b/backends/bmv2/extern.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "lib/json.h"
 #include "frontends/p4/typeMap.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
+#include "backend.h"
 #include "helpers.h"
 #include "JsonObjects.h"
 

--- a/backends/bmv2/helpers.cpp
+++ b/backends/bmv2/helpers.cpp
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "helpers.h"
+
 namespace BMV2 {
 
 /// constant definition for bmv2

--- a/backends/bmv2/helpers.h
+++ b/backends/bmv2/helpers.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define _BACKENDS_BMV2_HELPERS_H_
 
 #include "ir/ir.h"
+#include "lib/cstring.h"
 #include "lib/json.h"
 #include "analyzer.h"
 #include "frontends/common/model.h"

--- a/backends/bmv2/midend.cpp
+++ b/backends/bmv2/midend.cpp
@@ -51,6 +51,7 @@ limitations under the License.
 #include "midend/expandLookahead.h"
 #include "midend/tableHit.h"
 #include "midend/midEndLast.h"
+#include "copyAnnotations.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/parser.cpp
+++ b/backends/bmv2/parser.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "parser.h"
+#include "JsonObjects.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/parser.h
+++ b/backends/bmv2/parser.h
@@ -21,9 +21,12 @@ limitations under the License.
 #include "lib/json.h"
 #include "frontends/p4/typeMap.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
+#include "backend.h"
 #include "expression.h"
 
 namespace BMV2 {
+
+class JsonObjects;
 
 class Parser : public Inspector {
     Backend* backend;

--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 #include "ebpfObject.h"
 #include "ebpfType.h"
 #include "frontends/p4/enumInstance.h"
+#include "frontends/p4/methodInstance.h"
+#include "frontends/common/resolveReferences/referenceMap.h"
 
 namespace EBPF {
 

--- a/backends/ebpf/codeGen.h
+++ b/backends/ebpf/codeGen.h
@@ -22,6 +22,12 @@ limitations under the License.
 #include "target.h"
 #include "frontends/p4/typeMap.h"
 
+namespace P4 {
+
+class ReferenceMap;
+
+}
+
 namespace EBPF {
 
 class CodeBuilder : public Util::SourceCodeBuilder {

--- a/backends/ebpf/ebpfProgram.h
+++ b/backends/ebpf/ebpfProgram.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "target.h"
 #include "ebpfModel.h"
+#include "ebpfObject.h"
 #include "ir/ir.h"
 #include "frontends/p4/typeMap.h"
 #include "frontends/p4/evaluator/evaluator.h"


### PR DESCRIPTION
Some users compile this code with their own build system. Recent changes in the bmv2 backend have broken non-unified builds (`max-chunk-size` set to 1 in `bootstrap.sh`).