### PR TITLE
Fix for issue #629

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -2456,19 +2456,16 @@ void TypeInference::checkCorelibMethods(const ExternMethod* em) const {
         }
     } else if (et->name == corelib.packetOut.name) {
         if (em->method->name == corelib.packetOut.emit.name) {
-            const IR::Expression* arg = nullptr;
             if (argCount == 1) {
-                arg = em->expr->arguments->at(0);
-            } else if (argCount == 2) {
-                arg = em->expr->arguments->at(1);
+                auto arg = em->expr->arguments->at(0);
+                auto argType = typeMap->getType(arg, true);
+                checkEmitType(em->expr, argType);
             } else {
                 // core.p4 is corrupted.
-                typeError("%1%: Expected 1 or 2 arguments for '%2%' method",
+                typeError("%1%: Expected 1 argument for '%2%' method",
                           em->expr, corelib.packetOut.emit.name);
                 return;
             }
-            auto argType = typeMap->getType(arg, true);
-            checkEmitType(em->expr, argType);
         }
     }
 }

--- a/p4include/core.p4
+++ b/p4include/core.p4
@@ -56,11 +56,6 @@ extern packet_out {
     /// @T can be a header type, a header stack, a header_union, or a struct
     /// containing fields with such types.
     void emit<T>(in T hdr);
-    /// If @condition is true write the specified @data into the output packet,
-    /// advancing cursor.  @T can be a header type, a header stack, a header_union,
-    /// or a struct containing fields with such types.  If @condition is false,
-    /// do nothing.
-    void emit<T>(in bool condition, in T data);
 }
 
 // TODO: remove from this file, convert to built-in


### PR DESCRIPTION
The P4-16 spec has removed the two-argument emit method of packet_out.
