### PR TITLE
Fix counters attribute name

### DIFF
--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -494,7 +494,10 @@ class RunBMV2(object):
             return FAILURE
         thriftPort = str(9090 + rand)
         rv = SUCCESS
-
+        try:
+            os.remove("/tmp/bmv2-%d-notifications.ipc" % rand)
+        except OSError:
+            pass
         try:
             runswitch = [FindExe("behavioral-model", "simple_switch"),
                          "--log-file", self.switchLogFile, "--log-flush",
@@ -552,6 +555,10 @@ class RunBMV2(object):
                 reportError("CLI process failed with exit code", cli.returncode)
                 rv = FAILURE
         finally:
+            try:
+                os.remove("/tmp/bmv2-%d-notifications.ipc" % rand)
+            except OSError:
+                pass
             concurrent.release(rand)
         if self.options.verbose:
             print("Execution completed")

--- a/backends/bmv2/control.cpp
+++ b/backends/bmv2/control.cpp
@@ -401,8 +401,11 @@ ControlConverter::convertTable(const CFG::TableNode* node,
         size = BMV2::TableAttributes::defaultTableSize;
 
     result->emplace("max_size", size);
-    auto ctrs = table->properties->getProperty(BMV2::TableImplementation::directCounterName);
+    auto ctrs = table->properties->getProperty(BMV2::TableAttributes::countersName);
     if (ctrs != nullptr) {
+        // The counters attribute should list the counters of the table, accessed in
+        // actions of the table.  We should be checking that this attribute and the
+        // actions are consistent?
         if (ctrs->value->is<IR::ExpressionValue>()) {
             auto expr = ctrs->value->to<IR::ExpressionValue>()->expression;
             if (expr->is<IR::ConstructorCallExpression>()) {
@@ -472,7 +475,7 @@ ControlConverter::convertTable(const CFG::TableNode* node,
     }
     result->emplace("support_timeout", sup_to);
 
-    auto dm = table->properties->getProperty(BMV2::TableAttributes::directMeterName);
+    auto dm = table->properties->getProperty(BMV2::TableAttributes::metersName);
     if (dm != nullptr) {
         if (dm->value->is<IR::ExpressionValue>()) {
             auto expr = dm->value->to<IR::ExpressionValue>()->expression;

--- a/backends/bmv2/helpers.cpp
+++ b/backends/bmv2/helpers.cpp
@@ -29,7 +29,8 @@ const cstring MatchImplementation::rangeMatchTypeName = "range";
 const cstring TableAttributes::implementationName = "implementation";
 const cstring TableAttributes::sizeName = "size";
 const cstring TableAttributes::supportTimeoutName = "supportTimeout";
-const cstring TableAttributes::directMeterName = "meters";
+const cstring TableAttributes::countersName = "counters";
+const cstring TableAttributes::metersName = "meters";
 const unsigned TableAttributes::defaultTableSize = 1024;
 const cstring V1ModelProperties::jsonMetadataParameterName = "standard_metadata";
 

--- a/backends/bmv2/helpers.h
+++ b/backends/bmv2/helpers.h
@@ -48,7 +48,8 @@ class TableAttributes {
     static const cstring sizeName;
     static const cstring supportTimeoutName;
     static const unsigned defaultTableSize;
-    static const cstring directMeterName;
+    static const cstring countersName;
+    static const cstring metersName;
 };
 
 class V1ModelProperties {

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -296,7 +296,7 @@ template <typename Kind> struct CounterlikeTraits;
 template<> struct CounterlikeTraits<IR::Counter> {
     static const cstring name() { return "counter"; }
     static const cstring directPropertyName() {
-        return P4V1::V1Model::instance.tableAttributes.directCounter.name;
+        return P4V1::V1Model::instance.tableAttributes.counters.name;
     }
     static const cstring typeName() {
         return P4V1::V1Model::instance.counter.name;
@@ -309,7 +309,7 @@ template<> struct CounterlikeTraits<IR::Counter> {
 template<> struct CounterlikeTraits<IR::Meter> {
     static const cstring name() { return "meter"; }
     static const cstring directPropertyName() {
-        return P4V1::V1Model::instance.tableAttributes.directMeter.name;
+        return P4V1::V1Model::instance.tableAttributes.meters.name;
     }
     static const cstring typeName() {
         return P4V1::V1Model::instance.meter.name;

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -822,7 +822,7 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
         auto propvalue = new IR::ExpressionValue(constructor);
         auto annos = addNameAnnotation(ctr);
         auto prop = new IR::Property(
-            IR::ID(v1model.tableAttributes.directCounter.Id()),
+            IR::ID(v1model.tableAttributes.counters.Id()),
             annos, propvalue, false);
         props->push_back(prop);
     }
@@ -831,7 +831,7 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
         auto meter = new IR::PathExpression(mtr->name);
         auto propvalue = new IR::ExpressionValue(meter);
         auto prop = new IR::Property(
-            IR::ID(v1model.tableAttributes.directMeter.Id()), propvalue, false);
+            IR::ID(v1model.tableAttributes.meters.Id()), propvalue, false);
         props->push_back(prop);
     }
 

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -234,12 +234,12 @@ struct Switch_Model : public ::Model::Elem {
 
 struct TableAttributes_Model {
     TableAttributes_Model() : tableImplementation("implementation"),
-                              directCounter("counters"),
-                              directMeter("meters"), size("size"),
+                              counters("counters"),
+                              meters("meters"), size("size"),
                               supportTimeout("support_timeout") {}
     ::Model::Elem       tableImplementation;
-    ::Model::Elem       directCounter;
-    ::Model::Elem       directMeter;
+    ::Model::Elem       counters;
+    ::Model::Elem       meters;
     ::Model::Elem       size;
     ::Model::Elem       supportTimeout;
     const unsigned defaultTableSize = 1024;


### PR DESCRIPTION
Fix (partly) issue #461 

A good example why obfuscating string constants behind `static constexpr` "names" is a bad idea -- makes the code harder to read and maintain and makes it easier for bugs to creep in.

Arguably we should add a check for `count` calls on counters that are not named in the table attributes.  Whether that should be an error or should implicitly add said counter attribute is unclear.