### PR TITLE
Fix for issue #638

### DIFF
--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -475,8 +475,10 @@ class FindUninitialized : public Inspector {
     bool preorder(const IR::Operation_Unary* expression) override {
         BUG_CHECK(!lhs, "%1%: Unary operation on LHS?", expression);
         visit(expression->expr);
-        auto storage = getReads(expression->expr, true);
-        reads(expression, storage);
+        // This expression in fact reads the result of the operation,
+        // which is a temporary storage location, which we do not model
+        // in the def-use analysis.
+        reads(expression, LocationSet::empty);
         registerUses(expression);
         return false;
     }
@@ -485,9 +487,10 @@ class FindUninitialized : public Inspector {
         BUG_CHECK(!lhs, "%1%: Binary operation on LHS?", expression);
         visit(expression->left);
         visit(expression->right);
-        auto storageLeft = getReads(expression->left, true);
-        auto storageRight = getReads(expression->right, true);
-        reads(expression, storageLeft->join(storageRight));
+        // This expression in fact reads the result of the operation,
+        // which is a temporary storage location, which we do not model
+        // in the def-use analysis.
+        reads(expression, LocationSet::empty);
         registerUses(expression);
         return false;
     }

--- a/testdata/p4_16_samples_outputs/issue561.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue561.p4-stderr
@@ -4,15 +4,6 @@
 ../testdata/p4_16_samples/issue561.p4(35): warning: u.h2.g may be uninitialized
         x = u.h1.f + u.h2.g;
                      ^^^^^^
-../testdata/p4_16_samples/issue561.p4(35): warning: + may be uninitialized
-        x = u.h1.f + u.h2.g;
-            ^^^^^^^^^^^^^^^
 ../testdata/p4_16_samples/issue561.p4(45): warning: [].h2.g may be uninitialized
         x = x + u2[1].h2.g + u2[0].h1.f;
                 ^^^^^^^^^^
-../testdata/p4_16_samples/issue561.p4(45): warning: + may be uninitialized
-        x = x + u2[1].h2.g + u2[0].h1.f;
-            ^^^^^^^^^^^^^^
-../testdata/p4_16_samples/issue561.p4(45): warning: + may be uninitialized
-        x = x + u2[1].h2.g + u2[0].h1.f;
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/uninit.p4-stderr
+++ b/testdata/p4_16_samples_outputs/uninit.p4-stderr
@@ -13,42 +13,24 @@
 ../testdata/p4_16_samples/uninit.p4(41): warning: h.data3 may be uninitialized
         h.data2 = h.data3 + 1; // uninitialized
                   ^^^^^^^
-../testdata/p4_16_samples/uninit.p4(41): warning: + may be uninitialized
-        h.data2 = h.data3 + 1; // uninitialized
-                  ^^^^^^^^^^^
 ../testdata/p4_16_samples/uninit.p4(42): warning: [] may not be completely initialized
         stack[0] = stack[1]; // uninitialized
                    ^^^^^^^^
 ../testdata/p4_16_samples/uninit.p4(62): warning: c may be uninitialized
         c = !c; // uninitialized;
              ^
-../testdata/p4_16_samples/uninit.p4(62): warning: ! may be uninitialized
-        c = !c; // uninitialized;
-            ^^
 ../testdata/p4_16_samples/uninit.p4(82): warning: b may be uninitialized
         b = b + 1; // uninitialized
             ^
-../testdata/p4_16_samples/uninit.p4(82): warning: + may be uninitialized
-        b = b + 1; // uninitialized
-            ^^^^^
 ../testdata/p4_16_samples/uninit.p4(86): warning: e may be uninitialized
         if (e > 0) { // uninitialized
             ^
-../testdata/p4_16_samples/uninit.p4(86): warning: > may be uninitialized
-        if (e > 0) { // uninitialized
-            ^^^^^
 ../testdata/p4_16_samples/uninit.p4(92): warning: e may be uninitialized
         e = e + 1; // uninitialized
             ^
-../testdata/p4_16_samples/uninit.p4(92): warning: + may be uninitialized
-        e = e + 1; // uninitialized
-            ^^^^^
 ../testdata/p4_16_samples/uninit.p4(97): warning: touched may be uninitialized
         touched = !touched; // uninitialized
                    ^^^^^^^
-../testdata/p4_16_samples/uninit.p4(97): warning: ! may be uninitialized
-        touched = !touched; // uninitialized
-                  ^^^^^^^^
 ../testdata/p4_16_samples/uninit.p4(68): warning: out parameter v may be uninitialized when c terminates
 control c(out bit<32> v) { // uninitialized
                       ^


### PR DESCRIPTION
The spec allows tables without default_actions; in this case we insert a default_action of NoAction very early in the compilation process.

The default_only property was misspelled in the code; fixing this causes lots of reference outputs to change.