### PR TITLE
Don't include json_loader.h in ir.h

### DIFF
--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "ir/ir.h"
+#include "ir/json_loader.h"
 #include "lib/log.h"
 #include "lib/error.h"
 #include "lib/exceptions.h"

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -25,6 +25,8 @@ limitations under the License.
 #include "vector.h"
 #include "id.h"
 
+class JSONLoader;
+
 namespace IR {
 
 // declaration interface: objects with names

--- a/ir/ir-inline.h
+++ b/ir/ir-inline.h
@@ -146,15 +146,6 @@ template<class T> void IR::Vector<T>::toJSON(JSONGenerator &json) const {
     if (*sep) json << std::endl << json.indent;
     json << "]";
 }
-template<class T>
-IR::Vector<T>::Vector(JSONLoader &json) : VectorBase(json) {
-    json.load("vec", vec);
-}
-template<class T>
-IR::Vector<T>* IR::Vector<T>::fromJSON(JSONLoader &json) {
-    return new Vector<T>(json);
-}
-
 
 std::ostream &operator<<(std::ostream &out, const IR::Vector<IR::Expression> &v);
 inline std::ostream &operator<<(std::ostream &out, const IR::Vector<IR::Expression> *v) {
@@ -192,14 +183,6 @@ void IR::IndexedVector<T>::toJSON(JSONGenerator &json) const {
     --json.indent;
     if (*sep) json << std::endl << json.indent;
     json << "}";
-}
-template<class T>
-IR::IndexedVector<T>::IndexedVector(JSONLoader &json) : Vector<T>(json) {
-    json.load("declarations", declarations);
-}
-template<class T>
-IR::IndexedVector<T>* IR::IndexedVector<T>::fromJSON(JSONLoader &json) {
-    return new IndexedVector<T>(json);
 }
 IRNODE_DEFINE_APPLY_OVERLOAD(IndexedVector, template<class T>, <T>)
 
@@ -273,18 +256,6 @@ void IR::NameMap<T, MAP, COMP, ALLOC>::toJSON(JSONGenerator &json) const {
     --json.indent;
     if (*sep) json << std::endl << json.indent;
     json << "}";
-}
-template<class T, template<class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
-         class COMP /*= std::less<cstring>*/,
-         class ALLOC /*= std::allocator<std::pair<cstring, const T*>>*/>
-IR::NameMap<T, MAP, COMP, ALLOC>::NameMap(JSONLoader &json) : Node(json) {
-    json.load("symbols", symbols);
-}
-template<class T, template<class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
-         class COMP /*= std::less<cstring>*/,
-         class ALLOC /*= std::allocator<std::pair<cstring, const T*>>*/>
-IR::NameMap<T, MAP, COMP, ALLOC> *IR::NameMap<T, MAP, COMP, ALLOC>::fromJSON(JSONLoader &json) {
-    return new IR::NameMap<T, MAP, COMP, ALLOC>(json);
 }
 
 template<class KEY, class VALUE,

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -46,7 +46,7 @@ limitations under the License.
 // generated ir file
 #include "ir/ir-generated.h"
 
-#include "json_loader.h"
+class JSONLoader;
 #include "json_generator.h"
 
 #include "pass_manager.h"

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -25,9 +25,8 @@ limitations under the License.
 #include "lib/cstring.h"
 #include "lib/indent.h"
 #include "lib/match.h"
-#include "json_parser.h"
-
 #include "ir.h"
+#include "json_parser.h"
 
 class JSONLoader {
     template<typename T> class has_fromJSON {
@@ -201,5 +200,34 @@ class JSONLoader {
         unpack_json(v);
         return *this; }
 };
+
+template<class T>
+IR::Vector<T>::Vector(JSONLoader &json) : VectorBase(json) {
+    json.load("vec", vec);
+}
+template<class T>
+IR::Vector<T>* IR::Vector<T>::fromJSON(JSONLoader &json) {
+    return new Vector<T>(json);
+}
+template<class T>
+IR::IndexedVector<T>::IndexedVector(JSONLoader &json) : Vector<T>(json) {
+    json.load("declarations", declarations);
+}
+template<class T>
+IR::IndexedVector<T>* IR::IndexedVector<T>::fromJSON(JSONLoader &json) {
+    return new IndexedVector<T>(json);
+}
+template<class T, template<class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
+         class COMP /*= std::less<cstring>*/,
+         class ALLOC /*= std::allocator<std::pair<cstring, const T*>>*/>
+IR::NameMap<T, MAP, COMP, ALLOC>::NameMap(JSONLoader &json) : Node(json) {
+    json.load("symbols", symbols);
+}
+template<class T, template<class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
+         class COMP /*= std::less<cstring>*/,
+         class ALLOC /*= std::allocator<std::pair<cstring, const T*>>*/>
+IR::NameMap<T, MAP, COMP, ALLOC> *IR::NameMap<T, MAP, COMP, ALLOC>::fromJSON(JSONLoader &json) {
+    return new IR::NameMap<T, MAP, COMP, ALLOC>(json);
+}
 
 #endif /* _IR_JSON_LOADER_H_ */

--- a/ir/namemap.h
+++ b/ir/namemap.h
@@ -17,6 +17,8 @@ limitations under the License.
 #ifndef _IR_NAMEMAP_H_
 #define _IR_NAMEMAP_H_
 
+class JSONLoader;
+
 namespace IR {
 
 template<class T, template<class K, class V, class COMP, class ALLOC> class MAP = std::map,

--- a/ir/node.cpp
+++ b/ir/node.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "ir.h"
+#include "ir/json_loader.h"
 
 void IR::Node::traceVisit(const char* visitor) const
 { LOG3("Visiting " << visitor << " " << id << ":" << node_type_name()); }

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -21,6 +21,8 @@ limitations under the License.
 #include "lib/enumerator.h"
 #include "lib/null.h"
 
+class JSONLoader;
+
 namespace IR {
 
 

--- a/test/unittests/dumpjson.cpp
+++ b/test/unittests/dumpjson.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "ir/ir.h"
+#include "ir/json_loader.h"
 #include "ir/visitor.h"
 #include <assert.h>
 #include <unordered_set>

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -81,7 +81,8 @@ void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &i
         << "#define " << macroname << "\n" << std::endl;
 
     impl << "#include \"ir/ir.h\"\n"
-         << "#include \"ir/visitor.h\"\n" << std::endl;
+         << "#include \"ir/visitor.h\"\n"
+         << "#include \"ir/json_loader.h\"\n" << std::endl;
 
     out << "#include <map>\n"
         << "#include <functional>\n" << std::endl


### PR DESCRIPTION
Here's a PR I've summoned from an old branch.

p4c takes a long time to compile, and one of the biggest factors is duplicate template instantiations in different translation units. We've worked around this to some degree with unified builds, but it'd be much better to resolve the underlying problem.

This patch takes one small step in that direction by eliminating the need to include `json_loader.h` in `ir.h`. This is accomplished by adding forward declarations for `JSONLoader` where needed (including in `ir-generated.cpp`) and moving the code that references `JSONLoader` from `ir-inline.h` into `json_loader.h` itself.

I had tried to do the same for `json_generator.h`, but while I have a patch that does it, it requires some icky explicit template instantiations. Getting rid of it cleanly would require a redesign that didn't implement `toJSON()` as a virtual method.