### PR TITLE
Minor change in bmv2 backend: set action_const

### DIFF
--- a/backends/bmv2/control.cpp
+++ b/backends/bmv2/control.cpp
@@ -626,7 +626,7 @@ ControlConverter::convertTable(const CFG::TableNode* node,
         unsigned actionid = get(backend->getStructure().ids, action);
         auto entry = new Util::JsonObject();
         entry->emplace("action_id", actionid);
-        entry->emplace("action_const", false);
+        entry->emplace("action_const", defact->isConstant);
         auto fields = mkArrayField(entry, "action_data");
         if (args != nullptr) {
             for (auto a : *args) {


### PR DESCRIPTION
In the bmv2 JSON, a match-table can indicate that its default action is
constant (using 'action_const') and that the default action entry
(action + action parameter values) is constant (using
'action_entry_const'). `action_entry_const == true => action_const ==
true`. The bmv2 backend was setting 'action_entry_const' correctly, but
'action_const' was always set to false. Note that P4_16 does not make a
difference between the 2, the presence of `const` in the P4_16 source
implies that both attributes should be true.