### PR TITLE
Add utilities that make writing GTests easier

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,7 @@ IFAIL_TESTS =                  # intermittent failures
 export XFAIL_TESTS
 export IFAIL_TESTS
 gtest_SOURCES =                # GTests
+gtest_LDADD =                  # Libraries needed by GTests
 cpplint_FILES =                # Files that should be passed to cpplint (and etags)
 ir_DEF_FILES =                 # Files that generate the IR
 extension_frontend_SOURCES =   # Files added to libfrontend by extensions

--- a/backends/bmv2/Makefile.am
+++ b/backends/bmv2/Makefile.am
@@ -84,3 +84,5 @@ bmv2tests.mk: $(GENTESTS) $(srcdir)/%reldir%/Makefile.am \
 	      $(srcdir)/testdata/p4_14_samples/switch_*/switch.p4 \
 	      $(srcdir)/testdata/p4_16_samples $(srcdir)/testdata/p4_14_samples
 	@$(GENTESTS) $(srcdir) bmv2 $(srcdir)/backends/bmv2/run-bmv2-test.py $^ >$@
+
+gtest_LDADD += libbackendbmv2.a

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1112,19 +1112,6 @@ private:
     TypeMap* typeMap;
 };
 
-/// Invoke @function for every node of type @Node in the subtree rooted at
-/// @root. The nodes are visited in postorder.
-template <typename Node, typename Func>
-static void forAllMatching(const IR::Node* root, Func&& function) {
-    struct NodeVisitor : public Inspector {
-        explicit NodeVisitor(Func&& function) : function(function) { }
-        Func function;
-        void postorder(const Node* node) override { function(node); }
-    };
-
-    root->apply(NodeVisitor(std::forward<Func>(function)));
-}
-
 static void collectControlSymbols(P4RuntimeSymbolTable& symbols,
                                   const IR::ControlBlock* controlBlock,
                                   TypeMap* typeMap) {

--- a/lib/error.h
+++ b/lib/error.h
@@ -423,6 +423,12 @@ class ErrorReporter final {
         return warningCount;
     }
 
+    /// @return the number of diagnostics (warnings and errors) encountered
+    /// since the last time clear() was called.
+    unsigned getDiagnosticCount() const {
+        return errorCount + warningCount;
+    }
+
     // Resets this ErrorReporter to its initial state.
     void clear() {
       errorCount = 0;

--- a/lib/error.h
+++ b/lib/error.h
@@ -238,10 +238,10 @@ std::string bug_helper(boost::format& f, std::string message, std::string positi
 
 template<typename T, class... Args>
 auto
-bug_helper(boost::format& f, std::string message,
-           std::string position, std::string tail,
-           const T& t, Args... args) ->
-    typename std::enable_if<std::is_arithmetic<T>::value, std::string>::type;
+bug_helper(boost::format& f, std::string message, std::string position,
+           std::string tail, const T& t, Args... args) ->
+    typename std::enable_if<!std::is_base_of<Util::IHasSourceInfo, T>::value,
+                            std::string>::type;
 
 // actual implementations
 
@@ -283,7 +283,8 @@ template<typename T, class... Args>
 auto
 bug_helper(boost::format& f, std::string message, std::string position,
            std::string tail, const T& t, Args... args) ->
-    typename std::enable_if<std::is_arithmetic<T>::value, std::string>::type {
+    typename std::enable_if<!std::is_base_of<Util::IHasSourceInfo, T>::value,
+                            std::string>::type {
     return bug_helper(f % t, message, position, tail, std::forward<Args>(args)...);
 }
 

--- a/lib/error.h
+++ b/lib/error.h
@@ -491,10 +491,14 @@ inline void error(const char* format, T... args) {
 
 inline unsigned errorCount() { return ErrorReporter::instance.getErrorCount(); }
 
+#define ERROR_CHECK(e, ...) do { if (!(e)) ::error(__VA_ARGS__); } while (0)
+
 template <typename... T>
 inline void warning(const char* format, T... args) {
     ErrorReporter::instance.warning(format, args...);
 }
+
+#define WARN_CHECK(e, ...) do { if (!(e)) ::warning(__VA_ARGS__); } while (0)
 
 inline void clearErrorReporter() {
   ErrorReporter::instance.clear();

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -61,8 +61,11 @@ gtestp4c_SOURCES = \
 	test/gtest/gtestp4c.cpp \
 	$(gtest_SOURCES)
 
+# Makefiles can add libraries to $(gtest_LDADD) to include them in the test
+# executable.
+gtestp4c_LDADD = libgtest.la libfrontend.la libp4ctoolkit.a $(gtest_LDADD)
+
 check_PROGRAMS += gtestp4c
-gtestp4c_LDADD = libgtest.la libfrontend.la libp4ctoolkit.a libbackendbmv2.a
 gtestp4c_CPPFLAGS = $(GTEST_CPPFLAGS)
 cpplint_FILES += test/gtest/gtestp4c.cpp
 TESTS += gtestp4c

--- a/test/gtest/gtestp4c.cpp
+++ b/test/gtest/gtestp4c.cpp
@@ -16,9 +16,38 @@ limitations under the License.
 
 #include "gtest/gtest.h"
 #include "helpers.h"
+#include "lib/log.h"
+#include "lib/options.h"
+
+class GTestOptions : public Util::Options {
+ public:
+    GTestOptions() : Util::Options("Additional p4c-specific options:") {
+        registerOption("--help", nullptr,
+                       [this](const char*) {
+                           std::cerr << std::endl;
+                           usage();
+                           exit(0);
+                           return false;
+                       }, "Print this help message");
+        registerOption("-v", nullptr,
+                       [this](const char*) { Log::increaseVerbosity(); return true; },
+                       "[Compiler debugging] Increase verbosity level (can be repeated)");
+        registerOption("-T", "loglevel",
+                       [](const char* arg) { Log::addDebugSpec(arg); return true; },
+                       "Adjust logging level per file (see below)");
+        registerUsage("loglevel format is:\n"
+                      "  sourceFile:level,...,sourceFile:level\n"
+                      "where 'sourceFile' is a compiler source file and\n"
+                      "'level' is the verbosity level for LOG messages in that file");
+    }
+};
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
+
+    GTestOptions options;
+    options.process(argc, argv);
+    if (::ErrorReporter::instance.getDiagnosticCount() > 0) return -1;
 
     // Initialize the global test environment.
     (void) P4CTestEnvironment::get();


### PR DESCRIPTION
This PR adds a number of facilities that make it easier to write GTests. I'm using these features in other PRs (which haven't landed yet, obviously) and they've been quite helpful. The changes included:

- Helpers for writing simple IR traversals using lambdas. `forAllMatching`, which behaves like a postorder Inspector which only matches a single node type, was already being used in the `p4RuntimeSerializer` code; I've just moved it to `visitor.h` so other code can use it. I also added Modifier and Transform variations of the concept.
- I reworked the Makefile a little bit to make it easier to link additional libraries into the GTest executable. This is necessary to cleanly add GTests in extensions.
- I generalized the types that you can pass to `BUG()` a little bit.
- I added a helper to get a combined total of warnings and errors. This makes it a bit easier to write assertions.
- I added `WARN_CHECK()` and `ERROR_CHECK()`, which behave like `BUG_CHECK()` but for warnings and errors respectively. This makes typical error and warning checks more terse.
- Finally, I added support for the same debugging flags we support in the compiler executables to the GTest executable. I've found this quite handy at times.