### PR TITLE
Remove bmv2 header include from P4_14 frontend

### DIFF
--- a/backends/bmv2/control.cpp
+++ b/backends/bmv2/control.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "backend.h"
 #include "control.h"
+#include "sharedActionSelectorCheck.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/simpleSwitch.h
+++ b/backends/bmv2/simpleSwitch.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <cstring>
 #include "frontends/p4/fromv1.0/v1model.h"
 #include "backend.h"
+#include "sharedActionSelectorCheck.h"
 
 namespace BMV2 {
 class Backend;

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -23,7 +23,6 @@ limitations under the License.
 #include "frontends/p4/methodInstance.h"
 #include "ir/ir.h"
 #include "lib/json.h"
-#include "backends/bmv2/sharedActionSelectorCheck.h"
 
 namespace P4V1 {
 


### PR DESCRIPTION
It is IMO architecturally incorrect to have a frontend file include a
header from a specific backend. It also does not seem to be needed.