### PR TITLE
Fix bmv2 inspector which validates selector sharing

### DIFF
--- a/backends/bmv2/sharedActionSelectorCheck.cpp
+++ b/backends/bmv2/sharedActionSelectorCheck.cpp
@@ -16,6 +16,8 @@ limitations under the License.
 
 #include "sharedActionSelectorCheck.h"
 
+#include <algorithm>
+
 namespace BMV2 {
 
 const SelectorInput*
@@ -65,13 +67,8 @@ SharedActionSelectorCheck::preorder(const IR::P4Table* table) {
     }
     // returns true if inputs are the same, false otherwise
     auto cmp_inputs = [](const SelectorInput &i1, const SelectorInput &i2) {
-        for (auto e1 : i1) {
-            auto cmp_e = [e1](const IR::Expression *e2) {
-                return checkSameKeyExpr(e1, e2);
-            };
-            if (std::find_if(i2.begin(), i2.end(), cmp_e) == i2.end()) return false;
-        }
-        return true;
+        if (i1.size() != i2.size()) return false;
+        return std::equal(i1.begin(), i1.end(), i2.begin(), checkSameKeyExpr);
     };
 
     if (!cmp_inputs(it->second, input)) {

--- a/testdata/p4_16_bmv_errors/issue679-bmv2.p4
+++ b/testdata/p4_16_bmv_errors/issue679-bmv2.p4
@@ -1,0 +1,75 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+struct H { };
+struct M {
+    bit<32> hash1;
+    bit<32> hash2;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start { transition accept; }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+
+    action drop() { smeta.drop = 1; }
+
+    action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
+
+    table indirect_ws {
+        key = { meta.hash2 : selector; meta.hash1 : selector; }
+        actions = { drop; NoAction; }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = as;
+    }
+
+
+    table indirect_ws_1 {
+        key = { meta.hash1 : selector; meta.hash2 : selector; }
+        actions = { drop; NoAction; }
+        const default_action = NoAction();
+        @name("ap_ws") implementation = as;
+    }
+
+    apply {
+        indirect_ws.apply();
+        indirect_ws_1.apply();
+    }
+
+};
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply { }
+};
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply { }
+}
+
+control VerifyChecksumI(in H hdr, inout M meta) {
+    apply { }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(),
+         ComputeChecksumI(), DeparserI()) main;


### PR DESCRIPTION
Selector input fields should appear in the same order in all tables.

fixes #679