### PR TITLE
Use libtool for all p4c convenience libraries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,7 +123,9 @@ setup.o setup.lo: setup.h
 
 # Front-end library
 noinst_LTLIBRARIES += libfrontend.la
-libfrontend_la_LIBADD = libcontrolplane.la
+libfrontend_la_LIBADD = \
+	libcontrolplane.la \
+	libp4ctoolkit.la
 libfrontend_la_SOURCES = \
 	setup.h \
 	setup.cpp \

--- a/backends/bmv2/Makefile.am
+++ b/backends/bmv2/Makefile.am
@@ -17,13 +17,14 @@
 # To be included in the main P4C compiler makefile
 
 bin_PROGRAMS += p4c-bm2-ss
-p4c_bm2_ss_LDADD = libfrontend.la libp4ctoolkit.a
+p4c_bm2_ss_LDADD = libbackendbmv2.la
+p4c_bm2_ss_SOURCES = backends/bmv2/bmv2.cpp
+cpplint_FILES += $(p4c_bm2_ss_SOURCES)
 
-p4c_bm2_ss_UNIFIED = \
+libbackendbmv2_la_UNIFIED = \
 	backends/bmv2/analyzer.cpp \
 	backends/bmv2/action.cpp \
 	backends/bmv2/backend.cpp \
-	backends/bmv2/bmv2.cpp \
 	backends/bmv2/control.cpp \
 	backends/bmv2/deparser.cpp \
 	backends/bmv2/errorcode.cpp \
@@ -63,14 +64,12 @@ noinst_HEADERS += \
 	backends/bmv2/simpleSwitch.h \
 	backends/bmv2/portableSwitch.h
 
-cpplint_FILES += $(p4c_bm2_ss_UNIFIED) $(p4c_bm2_ss_NONUNIFIED)
+cpplint_FILES += $(libbackendbmv2_la_UNIFIED) $(libbackendbmv2_la_NONUNIFIED)
 
 ir_DEF_FILES += $(srcdir)/backends/bmv2/bmv2.def
 
-noinst_LIBRARIES += libbackendbmv2.a
-libbackendbmv2_a_LIBADD = libfrontend.la
-libbackendbmv2_a_SOURCES = \
-	$(p4c_bm2_ss_SOURCES)
+noinst_LTLIBRARIES += libbackendbmv2.la
+libbackendbmv2_la_LIBADD = libfrontend.la
 
 # Tests
 -include bmv2tests.mk
@@ -85,4 +84,4 @@ bmv2tests.mk: $(GENTESTS) $(srcdir)/%reldir%/Makefile.am \
 	      $(srcdir)/testdata/p4_16_samples $(srcdir)/testdata/p4_14_samples
 	@$(GENTESTS) $(srcdir) bmv2 $(srcdir)/backends/bmv2/run-bmv2-test.py $^ >$@
 
-gtest_LDADD += libbackendbmv2.a
+gtest_LDADD += libbackendbmv2.la

--- a/backends/ebpf/Makefile.am
+++ b/backends/ebpf/Makefile.am
@@ -16,7 +16,7 @@
 # To be included in the main P4C compiler makefile
 
 bin_PROGRAMS += p4c-ebpf
-p4c_ebpf_LDADD = libfrontend.la libp4ctoolkit.a
+p4c_ebpf_LDADD = libfrontend.la
 
 p4c_ebpf_UNIFIED = \
 	backends/ebpf/p4c-ebpf.cpp \

--- a/backends/p4test/Makefile.am
+++ b/backends/p4test/Makefile.am
@@ -16,7 +16,7 @@
 # To be included in the main P4C compiler makefile
 
 noinst_PROGRAMS += p4test
-p4test_LDADD = libfrontend.la libp4ctoolkit.a
+p4test_LDADD = libfrontend.la
 
 p4test_UNIFIED = \
     backends/p4test/p4test.cpp \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-noinst_LIBRARIES += libp4ctoolkit.a
-libp4ctoolkit_a_UNIFIED = \
+noinst_LTLIBRARIES += libp4ctoolkit.la
+libp4ctoolkit_la_UNIFIED = \
 	lib/bitvec.cpp \
 	lib/crash.cpp \
 	lib/cstring.cpp \
@@ -66,4 +66,4 @@ noinst_HEADERS += \
 	lib/stringref.h \
 	lib/symbitmatrix.h
 
-cpplint_FILES += $(libp4ctoolkit_a_UNIFIED) $(libp4ctoolkit_a_NONUNIFIED)
+cpplint_FILES += $(libp4ctoolkit_la_UNIFIED) $(libp4ctoolkit_la_NONUNIFIED)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -41,7 +41,7 @@ gtestp4c_CPPFLAGS = -DGTEST_HAS_SEH=0 -DGTEST_HAS_PTHREAD=0 $(AM_CPPFLAGS)
 
 # Makefiles can add libraries to $(gtest_LDADD) to include them in the test
 # executable.
-gtestp4c_LDADD = libgtest.la libfrontend.la libp4ctoolkit.a $(gtest_LDADD)
+gtestp4c_LDADD = libgtest.la libfrontend.la $(gtest_LDADD)
 
 check_PROGRAMS += gtestp4c
 cpplint_FILES += test/gtest/gtestp4c.cpp

--- a/tools/ir-generator/Makefile.am
+++ b/tools/ir-generator/Makefile.am
@@ -36,7 +36,7 @@ tools/ir-generator/ir-generator-lex.c: tools/ir-generator/ir-generator-lex.l
 BUILT_SOURCES += \
 	tools/ir-generator/ir-generator-lex.c
 
-irgenerator_LDADD = libp4ctoolkit.a
+irgenerator_LDADD = libp4ctoolkit.la
 
 noinst_PROGRAMS += irgenerator
 


### PR DESCRIPTION
We ran into some trouble recently with libtool being unable to track dependencies of our convenience libraries correctly. This was partially because the dependencies weren't set up correctly, but an additional issue is that we aren't using libtool for some libraries. Let's switch things over to consistently use libtool everywhere.

A small but nice win is that now backends do not have to explicitly link against `libp4ctoolkit`, since libtool understands the dependencies and can handle that for them.