### PR TITLE
Apply GTest feature flags globally in AM_CPPFLAGS

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -20,6 +20,11 @@
 GTEST_ROOT = $(top_srcdir)/test/frameworks/gtest/googletest
 GTEST_CPPFLAGS = -I$(GTEST_ROOT) -I$(GTEST_ROOT)/include
 
+# Configure GTest to disable support for SEH (which is irrelevant for p4c since
+# we don't currently support Windows) and pthreads (which prevents GTest from
+# using its internal TLS implementation, which interacts badly with libgc).
+GTEST_CPPFLAGS += -DGTEST_HAS_SEH=0 -DGTEST_HAS_PTHREAD=0
+
 # Make the GTest headers globally available for code which needs to include
 # `gtest_prod.h`.
 AM_CPPFLAGS += $(GTEST_CPPFLAGS)
@@ -33,11 +38,6 @@ libgtest_la_SOURCES = test/frameworks/gtest/googletest/src/gtest-all.cc
 gtestp4c_SOURCES = \
 	test/gtest/gtestp4c.cpp \
 	$(gtest_SOURCES)
-
-# Configure GTest to disable support for SEH (which is irrelevant for p4c since
-# we don't currently support Windows) and pthreads (which prevents GTest from
-# using its internal TLS implementation, which interacts badly with libgc).
-gtestp4c_CPPFLAGS = -DGTEST_HAS_SEH=0 -DGTEST_HAS_PTHREAD=0 $(AM_CPPFLAGS)
 
 # Makefiles can add libraries to $(gtest_LDADD) to include them in the test
 # executable.


### PR DESCRIPTION
We've observed `gtestp4c` crashing on Linux recently. It was pretty clear that the issue was a bad interaction between GTest's TLS implementation and libgc, and I tried to fix the problem in d38a37cf69 by setting GTest feature flags that disable threading-related features.

Unfortunately that didn't resolve the problem completely. Those feature flags do indeed fix the problem, but applying them to `gtestp4c` isn't enough - they need to be applied when we build `libgtest.la` as well. In fact, it's safest to just set those flags globally, just in case GTest code finds its way into any other executables or libraries - the headers are available globally, after all, since they need to be to make `gtest_prod.h` available.

This PR does just that: the feature flags from d38a37cf69 are added to `GTEST_CPPFLAGS`, which leads them to be included in `AM_CPPFLAGS`.

I reran `gtestp4c` dozens of times in a Linux container and with this PR applied, I couldn't get a crash to happen, so hopefully this is the last fix we need for this problem.