### PR TITLE
Interface for architecture-specific conversion of P4_14 externs to P4_16

### DIFF
--- a/frontends/common/parseInput.h
+++ b/frontends/common/parseInput.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define _FRONTENDS_COMMON_PARSEINPUT_H_
 
 #include "options.h"
+#include "frontends/p4/fromv1.0/converters.h"
 
 namespace IR {
 class P4Program;
@@ -38,7 +39,8 @@ namespace P4 {
  * @return a P4-16 IR tree representing the contents of the given file, or null
  * on failure. If failure occurs, an error will also be reported.
  */
-const IR::P4Program* parseP4File(CompilerOptions& options);
+const IR::P4Program* parseP4File(CompilerOptions& options,
+                                 P4V1::ExternConverter *extCvt = nullptr);
 
 /**
  * Parse P4 source from the string @input, interpreting it as having language
@@ -55,7 +57,8 @@ const IR::P4Program* parseP4File(CompilerOptions& options);
  * null on failure. If failure occurs, an error will also be reported.
  */
 const IR::P4Program* parseP4String(const std::string& input,
-                                   CompilerOptions::FrontendVersion version);
+                                   CompilerOptions::FrontendVersion version,
+                                   P4V1::ExternConverter *extCvt = nullptr);
 
 /**
  * Clear global program state so that a new program can be parsed.

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -423,8 +423,12 @@ void ResolveReferences::postorder(const IR::BlockStatement *b)
 
 bool ResolveReferences::preorder(const IR::Declaration_Instance *decl) {
     refMap->usedName(decl->name.name);
-    if (auto ext = context->resolveType(decl->type)->to<IR::Type_Extern>())
-        addToContext(ext);
+    if (auto ext = context->resolveType(decl->type)->to<IR::Type_Extern>()) {
+        // FIXME -- this is special-case handling for P4_14 externs with properties,
+        // FIXME -- so that visitors for IR::Propertty can find the corresponding
+        // FIXME -- IR::Attribute in the extern.  It should go away once we no
+        // FIXME -- longer need to deal with P4_14 externs
+        addToContext(ext); }
     if (decl->initializer != nullptr)
         addToContext(decl->initializer);
     return true;
@@ -442,6 +446,10 @@ bool ResolveReferences::preorder(const IR::Property *prop) {
     /// @todo: why is `forwardOK` set to `true` here?
     if (auto attr = dynamic_cast<const IR::Attribute *>(context->
                     resolveUnique(prop->name, ResolutionType::Any, true))) {
+        // FIXME -- this is special-case handling for P4_14 extern properties.
+        // It should go away once we no longer need to deal with P4_14 externs
+        // The 'dynamic_cast' above is used (instead of 'to') in case resolveUnique
+        // returns a nullptr.
         if (attr->locals)
             addToContext(attr->locals);
         if (attr->type->is<IR::Type::String>())

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -78,12 +78,23 @@ class TypeConverter : public ExpressionConverter {
     explicit TypeConverter(ProgramStructure* structure) : ExpressionConverter(structure) {}
 };
 
+class ExternConverter {
+ public:
+    ProgramStructure *structure = nullptr;
+
+    virtual const IR::Type_Extern *convertExternType(const IR::Type_Extern *, cstring);
+    virtual const IR::Declaration_Instance *convertExternInstance(
+                const IR::Declaration_Instance *, cstring);
+    ExternConverter() {}
+    explicit ExternConverter(ProgramStructure *s) : structure(s) {}
+};
+
 // Is fed a P4 v1.0 program and outputs an equivalent P4 v1.2 program
 class Converter : public PassManager {
     ProgramStructure structure;
 
  public:
-    Converter();
+    explicit Converter(ExternConverter *extCvt);
     void loadModel() { structure.loadModel(); }
     Visitor::profile_t init_apply(const IR::Node* node) override;
 };

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -533,6 +533,11 @@ externDeclaration
         "{" methodPrototypes "}" { driver.structure->pop();
                                    $$ = new IR::Type_Extern(@3, *$3, $5, *$8, $1); }
     | optAnnotations EXTERN functionPrototype ";" { $$ = $3; $3->annotations = $1; }
+    | optAnnotations EXTERN name ";" {
+            // forward declaration;
+            driver.structure->pushContainerType(*$3, true);
+            driver.structure->pop();
+            $$ = nullptr; }
     ;
 
 methodPrototypes

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -870,9 +870,9 @@ blackbox_config: /* epsilon */ { $$ = new IR::NameMap<IR::Property>; }
     | blackbox_config name ":" expressions ";"
           { const IR::PropertyValue *pv;
             if ($4->size() == 1)
-                pv = new IR::ExpressionValue($4->front());
+                pv = new IR::ExpressionValue(@4, $4->front());
             else
-                pv = new IR::ExpressionListValue(std::move(*$4));
+                pv = new IR::ExpressionListValue(@4, std::move(*$4));
             ($$=$1)->add($2, new IR::Property(@2+@4, $2, pv, false)); }
     | blackbox_config name "{" expressions "}"
           { auto *pv = new IR::ExpressionListValue(std::move(*$4));

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -386,7 +386,7 @@ class ActionSelector : Attached {
     const char *kind() const override { return "action_selector"; }
 }
 
-class V1Table {
+class V1Table : IInstance {
     optional ID                 name;
     NullOK Vector<Expression>   reads = 0;
     vector<ID>                  reads_types = {};
@@ -402,6 +402,8 @@ class V1Table {
 
     void addProperty(Property prop) { properties.push_back(prop); }
     toString { return node_type_name() + " " + name; }
+    cstring Name() const override { return name; }
+    Type getType() const override { return Type_AnyTable::get(); }
 }
 
 class V1Control {

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -194,7 +194,7 @@ void IrMethod::generate_proto(std::ostream &out, bool fullname, bool defaults) c
 }
 
 void IrMethod::generate_hdr(std::ostream &out) const {
-    if (!inImpl)
+    if (srcInfo.isValid())
         out << LineDirective(srcInfo);
     out << IrClass::indent;
     if (isStatic) out << "static ";
@@ -216,7 +216,7 @@ void IrMethod::generate_hdr(std::ostream &out) const {
     } else if (name == "node_type_name") {
         out << LineDirective(srcInfo) << IrClass::indent << "static " << rtype->toString()
             << " static_type_name() " << body << std::endl; }
-    if (!inImpl && srcInfo.isValid())
+    if (srcInfo.isValid())
         out << LineDirective();
 }
 


### PR DESCRIPTION
Extern types in P4 are by definition architecture specific -- different architectures will support different ones.  In addition, they will often need to be different between P4_14 and P4_16 as P4_16 has more and different capabilities.  So when converting code from P4_14 there's a need to convert externs as well, but that cannot be done in an architecture-neutral way in general.

This change adds a interface hook to the P4_14->P4_16 converter that allows a backend/architecture to supply a custom extension for converting externs from P4_14 to P4_16 rather than just copying them through unchanged.