### PR TITLE
Filter out file paths in error messages in expected outputs.

### DIFF
--- a/testdata/p4_14_samples_outputs/TLV_parsing.p4-stderr
+++ b/testdata/p4_14_samples_outputs/TLV_parsing.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_14_samples/TLV_parsing.p4(118): warning: 20: value does not fit in 4 bits
+TLV_parsing.p4(118): warning: 20: value does not fit in 4 bits
     set_metadata(my_metadata.parse_ipv4_counter, ipv4_base.ihl * 4 - 20);
                                                                      ^^
 warning: The order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/acl1.p4-stderr
+++ b/testdata/p4_14_samples_outputs/acl1.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_14_samples/acl1.p4(223): warning: Could not infer type for session_id, using bit<8>
+acl1.p4(223): warning: Could not infer type for session_id, using bit<8>
 action negative_mirror(session_id) {
                        ^^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/basic_routing.p4-stderr
+++ b/testdata/p4_14_samples_outputs/basic_routing.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_14_samples/basic_routing.p4(117): warning: bd shadows bd
+basic_routing.p4(117): warning: bd shadows bd
 action set_bd(bd) {
               ^^
-../testdata/p4_14_samples/basic_routing.p4(135)
+basic_routing.p4(135)
 table bd {
 ^

--- a/testdata/p4_14_samples_outputs/checksum1.p4-stderr
+++ b/testdata/p4_14_samples_outputs/checksum1.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_14_samples/checksum1.p4(122): warning: -1: negative value with unsigned type
+checksum1.p4(122): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^

--- a/testdata/p4_14_samples_outputs/flowlet_switching.p4-stderr
+++ b/testdata/p4_14_samples_outputs/flowlet_switching.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_14_samples/flowlet_switching.p4(128): warning: Could not infer type for ecmp_base, using bit<8>
+flowlet_switching.p4(128): warning: Could not infer type for ecmp_base, using bit<8>
 action set_ecmp_select(ecmp_base, ecmp_count) {
                        ^^^^^^^^^
-../testdata/p4_14_samples/flowlet_switching.p4(128): warning: Could not infer type for ecmp_count, using bit<8>
+flowlet_switching.p4(128): warning: Could not infer type for ecmp_count, using bit<8>
 action set_ecmp_select(ecmp_base, ecmp_count) {
                                   ^^^^^^^^^^
-../testdata/p4_14_samples/flowlet_switching.p4(72): warning: -1: negative value with unsigned type
+flowlet_switching.p4(72): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^

--- a/testdata/p4_14_samples_outputs/issue583.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue583.p4-stderr
@@ -1,7 +1,7 @@
-../testdata/p4_14_samples/issue583.p4(189): warning: -1: negative value with unsigned type
+issue583.p4(189): warning: -1: negative value with unsigned type
     add_to_field(ttl, -1);
                        ^
-../testdata/p4_14_samples/issue583.p4(190): warning: 4294967295: value does not fit in 9 bits
+issue583.p4(190): warning: 4294967295: value does not fit in 9 bits
     modify_field(standard_metadata.egress_spec, egress_spec, 0xFFFFFFFF);
                                                              ^^^^^^^^^^
 warning: The order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/issue604.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue604.p4-stderr
@@ -1,12 +1,12 @@
-../testdata/p4_14_samples/issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
+issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
 extern_type extern_test {
 ^
-../testdata/p4_14_samples/issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
+issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
 extern_type extern_test {
 ^
-../testdata/p4_14_samples/issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
+issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
 extern_type extern_test {
 ^
-../testdata/p4_14_samples/issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
+issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
 extern_type extern_test {
 ^

--- a/testdata/p4_14_samples_outputs/mac_rewrite.p4-stderr
+++ b/testdata/p4_14_samples_outputs/mac_rewrite.p4-stderr
@@ -1,12 +1,12 @@
-../testdata/p4_14_samples/mac_rewrite.p4(124): warning: -1: negative value with unsigned type
+mac_rewrite.p4(124): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-../testdata/p4_14_samples/mac_rewrite.p4(130): warning: -1: negative value with unsigned type
+mac_rewrite.p4(130): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-../testdata/p4_14_samples/mac_rewrite.p4(136): warning: -1: negative value with unsigned type
+mac_rewrite.p4(136): warning: -1: negative value with unsigned type
     add_to_field(ipv6.hopLimit, -1);
                                  ^
-../testdata/p4_14_samples/mac_rewrite.p4(142): warning: -1: negative value with unsigned type
+mac_rewrite.p4(142): warning: -1: negative value with unsigned type
     add_to_field(ipv6.hopLimit, -1);
                                  ^

--- a/testdata/p4_14_samples_outputs/overflow.p4-stderr
+++ b/testdata/p4_14_samples_outputs/overflow.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_14_samples/overflow.p4(36): warning: 11: value does not fit in 1 bits
+overflow.p4(36): warning: 11: value does not fit in 1 bits
 action action_1_1(value) { modify_field(md.field_1_1_1, value); modify_field(md.field_2_1_1, 11); }
                                                                                              ^^

--- a/testdata/p4_14_samples_outputs/register.p4-stderr
+++ b/testdata/p4_14_samples_outputs/register.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_14_samples/register.p4(67): warning: Could not infer type for register_idx, using bit<8>
+register.p4(67): warning: Could not infer type for register_idx, using bit<8>
 action m_action(register_idx) {
                 ^^^^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
+++ b/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
@@ -1,117 +1,117 @@
-../testdata/p4_14_samples/sai_p4.p4(432): warning: Could not infer type for type_, using bit<8>
+sai_p4.p4(432): warning: Could not infer type for type_, using bit<8>
 action set_next_hop(type_, ip, router_interface_id) {
                     ^^^^^
-../testdata/p4_14_samples/sai_p4.p4(432): warning: Could not infer type for ip, using bit<8>
+sai_p4.p4(432): warning: Could not infer type for ip, using bit<8>
 action set_next_hop(type_, ip, router_interface_id) {
                            ^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for admin_state, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for admin_state, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                     ^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for default_vlan_priority, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for default_vlan_priority, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                ^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for sflow, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for sflow, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                     ^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for flood_storm_control, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for flood_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for broadcast_storm_control, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for broadcast_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for multicast_storm_control, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for multicast_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                                          ^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(405): warning: -1: negative value with unsigned type
+sai_p4.p4(405): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-../testdata/p4_14_samples/sai_p4.p4(412): warning: -1: negative value with unsigned type
+sai_p4.p4(412): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for max_virtual_routers, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for max_virtual_routers, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                          ^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for fdb_table_size, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for fdb_table_size, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                               ^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for on_link_route_supported, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for on_link_route_supported, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                               ^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for max_temp, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for max_temp, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                     ^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for switching_mode, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for switching_mode, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                               ^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for cpu_flood_enable, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for cpu_flood_enable, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                               ^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for ttl1_action, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for ttl1_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                 ^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for fdb_aging_time, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for fdb_aging_time, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                             ^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for fdb_unicast_miss_action, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for fdb_unicast_miss_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for fdb_broadcast_miss_action, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for fdb_broadcast_miss_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for fdb_multicast_miss_action, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for fdb_multicast_miss_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for ecmp_hash_seed, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for ecmp_hash_seed, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for ecmp_hash_type, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for ecmp_hash_type, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for ecmp_hash_fields, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for ecmp_hash_fields, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(265): warning: Could not infer type for ecmp_max_paths, using bit<8>
+sai_p4.p4(265): warning: Could not infer type for ecmp_max_paths, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                                                                              ^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(583): warning: Could not infer type for violation_ttl1_action, using bit<8>
+sai_p4.p4(583): warning: Could not infer type for violation_ttl1_action, using bit<8>
 action set_router(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
                                                                    ^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(583): warning: Could not infer type for violation_ip_options, using bit<8>
+sai_p4.p4(583): warning: Could not infer type for violation_ip_options, using bit<8>
 action set_router(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
                                                                                           ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for admin_state, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for admin_state, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                     ^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for default_vlan_priority, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for default_vlan_priority, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                ^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for sflow, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for sflow, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                     ^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for flood_storm_control, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for flood_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for broadcast_storm_control, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for broadcast_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for multicast_storm_control, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for multicast_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                                          ^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
+sai_p4.p4(282): warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: port shadows port
+sai_p4.p4(282): warning: port shadows port
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                    ^^^^
-../testdata/p4_14_samples/sai_p4.p4(305)
+sai_p4.p4(305)
 table port {
 ^
-../testdata/p4_14_samples/sai_p4.p4(282): warning: port shadows port
+sai_p4.p4(282): warning: port shadows port
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                    ^^^^
-../testdata/p4_14_samples/sai_p4.p4(305)
+sai_p4.p4(305)
 table port {
 ^

--- a/testdata/p4_14_samples_outputs/simple_nat.p4-stderr
+++ b/testdata/p4_14_samples_outputs/simple_nat.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_14_samples/simple_nat.p4(280): warning: -1: negative value with unsigned type
+simple_nat.p4(280): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^

--- a/testdata/p4_14_samples_outputs/simple_router.p4-stderr
+++ b/testdata/p4_14_samples_outputs/simple_router.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_14_samples/simple_router.p4(108): warning: -1: negative value with unsigned type
+simple_router.p4(108): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^

--- a/testdata/p4_14_samples_outputs/source_routing.p4-stderr
+++ b/testdata/p4_14_samples_outputs/source_routing.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_14_samples/source_routing.p4(60): warning: -1: negative value with unsigned type
+source_routing.p4(60): warning: -1: negative value with unsigned type
     add_to_field(easyroute_head.num_valid, -1);
                                             ^

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4-stderr
@@ -1,22 +1,22 @@
-../testdata/p4_14_samples/switch_20160226/l3.p4(140): warning: -1: negative value with unsigned type
+l3.p4(140): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-../testdata/p4_14_samples/switch_20160226/l3.p4(150): warning: -1: negative value with unsigned type
+l3.p4(150): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-../testdata/p4_14_samples/switch_20160226/l3.p4(156): warning: -1: negative value with unsigned type
+l3.p4(156): warning: -1: negative value with unsigned type
     add_to_field(ipv6.hopLimit, -1);
                                  ^
-../testdata/p4_14_samples/switch_20160226/l3.p4(166): warning: -1: negative value with unsigned type
+l3.p4(166): warning: -1: negative value with unsigned type
     add_to_field(ipv6.hopLimit, -1);
                                  ^
-../testdata/p4_14_samples/switch_20160226/l3.p4(172): warning: -1: negative value with unsigned type
+l3.p4(172): warning: -1: negative value with unsigned type
     add_to_field(mpls[0].ttl, -1);
                                ^
-../testdata/p4_14_samples/switch_20160226/tunnel.p4(880): warning: -14: negative value with unsigned type
+tunnel.p4(880): warning: -14: negative value with unsigned type
     add(egress_metadata.payload_length, standard_metadata.packet_length, -14);
                                                                           ^^
-../testdata/p4_14_samples/switch_20160226/fabric.p4(230): warning: Could not infer type for fabric_mgid, using bit<8>
+fabric.p4(230): warning: Could not infer type for fabric_mgid, using bit<8>
 action set_fabric_multicast(fabric_mgid) {
                             ^^^^^^^^^^^
 warning: The order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
@@ -1,25 +1,25 @@
-../testdata/p4_14_samples/switch_20160512/l3.p4(155): warning: -1: negative value with unsigned type
+l3.p4(155): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-../testdata/p4_14_samples/switch_20160512/l3.p4(160): warning: -1: negative value with unsigned type
+l3.p4(160): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-../testdata/p4_14_samples/switch_20160512/l3.p4(165): warning: -1: negative value with unsigned type
+l3.p4(165): warning: -1: negative value with unsigned type
     add_to_field(ipv6.hopLimit, -1);
                                  ^
-../testdata/p4_14_samples/switch_20160512/l3.p4(170): warning: -1: negative value with unsigned type
+l3.p4(170): warning: -1: negative value with unsigned type
     add_to_field(ipv6.hopLimit, -1);
                                  ^
-../testdata/p4_14_samples/switch_20160512/l3.p4(175): warning: -1: negative value with unsigned type
+l3.p4(175): warning: -1: negative value with unsigned type
     add_to_field(mpls[0].ttl, -1);
                                ^
-../testdata/p4_14_samples/switch_20160512/tunnel.p4(1002): warning: -14: negative value with unsigned type
+tunnel.p4(1002): warning: -14: negative value with unsigned type
     add(egress_metadata.payload_length, standard_metadata.packet_length, -14);
                                                                           ^^
-../testdata/p4_14_samples/switch_20160512/fabric.p4(210): warning: Could not infer type for fabric_mgid, using bit<8>
+fabric.p4(210): warning: Could not infer type for fabric_mgid, using bit<8>
 action set_fabric_multicast(fabric_mgid) {
                             ^^^^^^^^^^^
 warning: The order of headers in deparser is not uniquely determined by parser!
-../testdata/p4_14_samples/switch_20160512/includes/parser.p4(487): warning: SelectCase: unreachable
+parser.p4(487): warning: SelectCase: unreachable
         default: parse_all_int_meta_value_heders;
         ^^^^^^^

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified.p4-stderr
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_14_samples/test_config_23_same_container_modified.p4(88): warning: Could not infer type for my_param2, using bit<8>
+test_config_23_same_container_modified.p4(88): warning: Could not infer type for my_param2, using bit<8>
 action action_1(my_param2) {
                 ^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/triv_ipv4.p4-stderr
+++ b/testdata/p4_14_samples_outputs/triv_ipv4.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_14_samples/triv_ipv4.p4(67): warning: -1: negative value with unsigned type
+triv_ipv4.p4(67): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^

--- a/testdata/p4_16_errors_outputs/accept_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/accept_e.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/accept_e.p4(18): error: accept: parser state should not be implemented, it is built-in
+accept_e.p4(18): error: accept: parser state should not be implemented, it is built-in
     state accept { // reserved name
           ^^^^^^

--- a/testdata/p4_16_errors_outputs/action-bind.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/action-bind.p4(23): error: y: argument does not match declaration in actions list: x
+action-bind.p4(23): error: y: argument does not match declaration in actions list: x
         default_action = a(y, 0); // error: different bound argument
                            ^
-../testdata/p4_16_errors/action-bind.p4(22)
+action-bind.p4(22)
         actions = { a(x); }
                       ^

--- a/testdata/p4_16_errors_outputs/action-bind1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind1.p4-stderr
@@ -1,18 +1,18 @@
-../testdata/p4_16_errors/action-bind1.p4(22): error: a: parameter b must be bound
+action-bind1.p4(22): error: a: parameter b must be bound
         default_action = a(); // error: too few arguments
                          ^^^
-../testdata/p4_16_errors/action-bind1.p4(17)
+action-bind1.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                            ^
-../testdata/p4_16_errors/action-bind1.p4(22): error: a: parameter d must be bound
+action-bind1.p4(22): error: a: parameter d must be bound
         default_action = a(); // error: too few arguments
                          ^^^
-../testdata/p4_16_errors/action-bind1.p4(17)
+action-bind1.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                                       ^
-../testdata/p4_16_errors/action-bind1.p4(22): error: Action for ExpressionValue has some unbound arguments
+action-bind1.p4(22): error: Action for ExpressionValue has some unbound arguments
         default_action = a(); // error: too few arguments
                          ^^^
-../testdata/p4_16_errors/action-bind1.p4(22): error: a: not enough arguments
+action-bind1.p4(22): error: a: not enough arguments
         default_action = a(); // error: too few arguments
                          ^^^

--- a/testdata/p4_16_errors_outputs/action-bind2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind2.p4-stderr
@@ -1,18 +1,18 @@
-../testdata/p4_16_errors/action-bind2.p4(21): error: a: parameter b must be bound
+action-bind2.p4(21): error: a: parameter b must be bound
         actions = { a; } // error: not enough arguments
                     ^
-../testdata/p4_16_errors/action-bind2.p4(17)
+action-bind2.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                            ^
-../testdata/p4_16_errors/action-bind2.p4(22): error: 0: must be a left-value
+action-bind2.p4(22): error: 0: must be a left-value
         default_action = a(0);
                            ^
-../testdata/p4_16_errors/action-bind2.p4(22): error: a: parameter d must be bound
+action-bind2.p4(22): error: a: parameter d must be bound
         default_action = a(0);
                          ^^^^
-../testdata/p4_16_errors/action-bind2.p4(17)
+action-bind2.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                                       ^
-../testdata/p4_16_errors/action-bind2.p4(22): error: Action for ExpressionValue has some unbound arguments
+action-bind2.p4(22): error: Action for ExpressionValue has some unbound arguments
         default_action = a(0);
                          ^^^^

--- a/testdata/p4_16_errors_outputs/action-bind3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind3.p4-stderr
@@ -1,21 +1,21 @@
-../testdata/p4_16_errors/action-bind3.p4(21): error: 0: parameter d cannot be bound: it is set by the control plane
+action-bind3.p4(21): error: 0: parameter d cannot be bound: it is set by the control plane
         actions = { a(x, 0); } // error: too many arguments
                          ^
-../testdata/p4_16_errors/action-bind3.p4(17)
+action-bind3.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                                       ^
-../testdata/p4_16_errors/action-bind3.p4(22): error: 0: must be a left-value
+action-bind3.p4(22): error: 0: must be a left-value
         default_action = a(0);
                            ^
-../testdata/p4_16_errors/action-bind3.p4(22): error: a: parameter d must be bound
+action-bind3.p4(22): error: a: parameter d must be bound
         default_action = a(0);
                          ^^^^
-../testdata/p4_16_errors/action-bind3.p4(17)
+action-bind3.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                                       ^
-../testdata/p4_16_errors/action-bind3.p4(22): error: Action for ExpressionValue has some unbound arguments
+action-bind3.p4(22): error: Action for ExpressionValue has some unbound arguments
         default_action = a(0);
                          ^^^^
-../testdata/p4_16_errors/action-bind3.p4(22): error: a: not enough arguments
+action-bind3.p4(22): error: a: not enough arguments
         default_action = a(0);
                          ^^^^

--- a/testdata/p4_16_errors_outputs/assign.p4-stderr
+++ b/testdata/p4_16_errors_outputs/assign.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/assign.p4(23): error: Expression e1 cannot be the target of an assignment
+assign.p4(23): error: Expression e1 cannot be the target of an assignment
         e1 = e2;
         ^^

--- a/testdata/p4_16_errors_outputs/binary_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/binary_e.p4-stderr
@@ -1,30 +1,30 @@
-../testdata/p4_16_errors/binary_e.p4(32): error: Array indexing [] applied to non-array type int<2>
+binary_e.p4(32): error: Array indexing [] applied to non-array type int<2>
         c = a[2]; // not an array
             ^^^^
-../testdata/p4_16_errors/binary_e.p4(32): error: Could not find type of []
+binary_e.p4(32): error: Could not find type of []
         c = a[2]; // not an array
             ^^^^
-../testdata/p4_16_errors/binary_e.p4(33): error: Array index d must be an integer, but it has type bool
+binary_e.p4(33): error: Array index d must be an integer, but it has type bool
         c = stack[d]; // indexing with bool
                   ^
-../testdata/p4_16_errors/binary_e.p4(33): error: Could not find type of []
+binary_e.p4(33): error: Could not find type of []
         c = stack[d]; // indexing with bool
             ^^^^^^^^
-../testdata/p4_16_errors/binary_e.p4(35): error: &: Cannot operate on values with different types bit<2> and bit<4>
+binary_e.p4(35): error: &: Cannot operate on values with different types bit<2> and bit<4>
         f = e & f; // different width
             ^^^^^
-../testdata/p4_16_errors/binary_e.p4(35): error: Could not find type of &
+binary_e.p4(35): error: Could not find type of &
         f = e & f; // different width
             ^^^^^
-../testdata/p4_16_errors/binary_e.p4(38): error: <: not defined on bool and bool
+binary_e.p4(38): error: <: not defined on bool and bool
         d = d < d; // not defined on bool
             ^^^^^
-../testdata/p4_16_errors/binary_e.p4(38): error: Could not find type of <
+binary_e.p4(38): error: Could not find type of <
         d = d < d; // not defined on bool
             ^^^^^
-../testdata/p4_16_errors/binary_e.p4(39): error: >: not defined on int<2> and int<4>
+binary_e.p4(39): error: >: not defined on int<2> and int<4>
         d = a > c; // different width
             ^^^^^
-../testdata/p4_16_errors/binary_e.p4(39): error: Could not find type of >
+binary_e.p4(39): error: Could not find type of >
         d = a > c; // different width
             ^^^^^

--- a/testdata/p4_16_errors_outputs/bitExtract_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/bitExtract_e.p4-stderr
@@ -1,18 +1,18 @@
-../testdata/p4_16_errors/bitExtract_e.p4(25): error: s[3:0]: bit extraction only defined for bit<> types
+bitExtract_e.p4(25): error: s[3:0]: bit extraction only defined for bit<> types
         bit<4> x = s[3:0]; // wrong type for s
                    ^^^^^^
-../testdata/p4_16_errors/bitExtract_e.p4(25): error: Could not find type of s[3:0]
+bitExtract_e.p4(25): error: Could not find type of s[3:0]
         bit<4> x = s[3:0]; // wrong type for s
                    ^^^^^^
-../testdata/p4_16_errors/bitExtract_e.p4(26): error: Bit index 7 greater than width 4
+bitExtract_e.p4(26): error: Bit index 7 greater than width 4
         bit<8> y = dt[7:0]; // too many bits
                       ^
-../testdata/p4_16_errors/bitExtract_e.p4(26): error: Could not find type of dt[7:0]
+bitExtract_e.p4(26): error: Could not find type of dt[7:0]
         bit<8> y = dt[7:0]; // too many bits
                    ^^^^^^^
-../testdata/p4_16_errors/bitExtract_e.p4(27): error: Bit index 7 greater than width 4
+bitExtract_e.p4(27): error: Bit index 7 greater than width 4
         bit<4> z = dt[7:4]; // too many bits
                       ^
-../testdata/p4_16_errors/bitExtract_e.p4(27): error: Could not find type of dt[7:4]
+bitExtract_e.p4(27): error: Could not find type of dt[7:4]
         bit<4> z = dt[7:4]; // too many bits
                    ^^^^^^^

--- a/testdata/p4_16_errors_outputs/call-table.p4-stderr
+++ b/testdata/p4_16_errors_outputs/call-table.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/call-table.p4(24): error: t.apply: tables cannot be invoked from actions
+call-table.p4(24): error: t.apply: tables cannot be invoked from actions
         t.apply(); // cannot invoke table from action
         ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/call1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/call1_e.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/call1_e.p4(20): error: s: cannot allocate objects of type struct S
+call1_e.p4(20): error: s: cannot allocate objects of type struct S
     S() s; // structs have no constructors
         ^
-../testdata/p4_16_errors/call1_e.p4(16)
+call1_e.p4(16)
 struct S { }
        ^

--- a/testdata/p4_16_errors_outputs/conditional_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/conditional_e.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/conditional_e.p4(21): error: Condition of IfStatement does not evaluate to a bool but bit<1>
+conditional_e.p4(21): error: Condition of IfStatement does not evaluate to a bool but bit<1>
         if (b) ; else ; // non-bool condition
         ^^

--- a/testdata/p4_16_errors_outputs/const1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/const1_e.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/const1_e.p4(19): error: +: operands have different types: bit<32> and bit<16>
+const1_e.p4(19): error: +: operands have different types: bit<32> and bit<16>
     x = 32w5 + 16w3;
         ^^^^^^^^^^^
-../testdata/p4_16_errors/const1_e.p4(21): error: /: Division by zero
+: Division by zero
     x = 5 / 0;
         ^^^^^

--- a/testdata/p4_16_errors_outputs/const_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/const_e.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/const_e.p4(18): error: x: Cannot declare constants of extern types
+const_e.p4(18): error: x: Cannot declare constants of extern types
 const I x = I(); // illegal constants of extern types
         ^

--- a/testdata/p4_16_errors_outputs/constructor1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor1_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/constructor1_e.p4(18):syntax error, unexpected IDENTIFIER "T"
+constructor1_e.p4(18):syntax error, unexpected IDENTIFIER "T"
     Y<T
       ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/constructor2_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor2_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/constructor2_e.p4(18):syntax error, unexpected (
+constructor2_e.p4(18):syntax error, unexpected (
     m(
      ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/constructor3_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor3_e.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/constructor3_e.p4(22): error: e: Cannot unify bool to bit<1>
+constructor3_e.p4(22): error: e: Cannot unify bool to bit<1>
     E(true) e;
             ^

--- a/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/constructor_e.p4(18): error: X: Constructor cannot have a return type
+constructor_e.p4(18): error: X: Constructor cannot have a return type
     void X(); // no return type allowed
          ^

--- a/testdata/p4_16_errors_outputs/control-inline.p4-stderr
+++ b/testdata/p4_16_errors_outputs/control-inline.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/control-inline.p4(35): error: vc: instances cannot be in a control 'apply' block
+control-inline.p4(35): error: vc: instances cannot be in a control 'apply' block
         VC() vc;
              ^^

--- a/testdata/p4_16_errors_outputs/control-verify.p4-stderr
+++ b/testdata/p4_16_errors_outputs/control-verify.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/control-verify.p4(7): error: verify: may only be invoked in parsers
+control-verify.p4(7): error: verify: may only be invoked in parsers
     verify(8w0 == 8w1, error.Oops);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/default_action.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default_action.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/default_action.p4(21): error: b not present in action list
+default_action.p4(21): error: b not present in action list
         default_action = b; // not in the list of actions
                          ^

--- a/testdata/p4_16_errors_outputs/default_action1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default_action1.p4-stderr
@@ -1,12 +1,12 @@
-../testdata/p4_16_errors/default_action1.p4(20): warning: b shadows b
+default_action1.p4(20): warning: b shadows b
     action b() {}
            ^
-../testdata/p4_16_errors/default_action1.p4(16)
+default_action1.p4(16)
 action b() {}
        ^
-../testdata/p4_16_errors/default_action1.p4(23): error: .b and b refer to different actions
+default_action1.p4(23): error: .b and b refer to different actions
         default_action = .b(); // not the same b
                           ^
-../testdata/p4_16_errors/default_action1.p4(22)
+default_action1.p4(22)
         actions = { a; b; }
                        ^

--- a/testdata/p4_16_errors_outputs/directionless.p4-stderr
+++ b/testdata/p4_16_errors_outputs/directionless.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/directionless.p4(18): error: y0: direction-less action parameters have to be at the end
+directionless.p4(18): error: y0: direction-less action parameters have to be at the end
     action a(bit x0, out bit y0)
                              ^^
-../testdata/p4_16_errors/directionless.p4(24): error: y: direction-less action parameters have to be at the end
+directionless.p4(24): error: y: direction-less action parameters have to be at the end
     action b(bit x, out bit y)
                             ^

--- a/testdata/p4_16_errors_outputs/div.p4-stderr
+++ b/testdata/p4_16_errors_outputs/div.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_errors/div.p4(18): error: /: Division is not defined for negative numbers
+: Division is not defined for negative numbers
     a = - 8 / -2;
         ^^^^^^^^
-../testdata/p4_16_errors/div.p4(19): error: %: Modulo is not defined for negative numbers
+div.p4(19): error: %: Modulo is not defined for negative numbers
     a = -10 % 2;
         ^^^^^^^
-../testdata/p4_16_errors/div.p4(20): error: %: Modulo is not defined for negative numbers
+div.p4(20): error: %: Modulo is not defined for negative numbers
     a = 10 % -2;
         ^^^^^^^

--- a/testdata/p4_16_errors_outputs/div0.p4-stderr
+++ b/testdata/p4_16_errors_outputs/div0.p4-stderr
@@ -1,12 +1,12 @@
-../testdata/p4_16_errors/div0.p4(18): error: /: Division by zero
+: Division by zero
     a = a / 0;
         ^^^^^
-../testdata/p4_16_errors/div0.p4(19): error: %: Modulo by zero
+div0.p4(19): error: %: Modulo by zero
     a = a % 0;
         ^^^^^
-../testdata/p4_16_errors/div0.p4(20): error: /: Division by zero
+: Division by zero
     a = a / 8w0;
         ^^^^^^^
-../testdata/p4_16_errors/div0.p4(21): error: %: Modulo by zero
+div0.p4(21): error: %: Modulo by zero
     a = a % 8w0;
         ^^^^^^^

--- a/testdata/p4_16_errors_outputs/div1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/div1.p4-stderr
@@ -1,24 +1,24 @@
-../testdata/p4_16_errors/div1.p4(18): error: /: not defined on negative numbers
+: not defined on negative numbers
     a = a / -1; // not defined for negative numbers
         ^^^^^^
-../testdata/p4_16_errors/div1.p4(18): error: Could not find type of /
+
     a = a / -1; // not defined for negative numbers
         ^^^^^^
-../testdata/p4_16_errors/div1.p4(19): error: /: not defined on negative numbers
+: not defined on negative numbers
     a = -5 / a;
         ^^^^^^
-../testdata/p4_16_errors/div1.p4(19): error: Could not find type of /
+
     a = -5 / a;
         ^^^^^^
-../testdata/p4_16_errors/div1.p4(20): error: %: not defined on negative numbers
+div1.p4(20): error: %: not defined on negative numbers
     a = a % -1;
         ^^^^^^
-../testdata/p4_16_errors/div1.p4(20): error: Could not find type of %
+div1.p4(20): error: Could not find type of %
     a = a % -1;
         ^^^^^^
-../testdata/p4_16_errors/div1.p4(21): error: %: not defined on negative numbers
+div1.p4(21): error: %: not defined on negative numbers
     a = -5 % a;
         ^^^^^^
-../testdata/p4_16_errors/div1.p4(21): error: Could not find type of %
+div1.p4(21): error: Could not find type of %
     a = -5 % a;
         ^^^^^^

--- a/testdata/p4_16_errors_outputs/div3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/div3.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/div3.p4(19): error: /: could not evaluate at compilation time
+: could not evaluate at compilation time
         a = a / b; // not a compile-time constant
             ^^^^^

--- a/testdata/p4_16_errors_outputs/dup-param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/dup-param.p4(17): error: Duplicated parameter name: p and p
+dup-param.p4(17): error: Duplicated parameter name: p and p
 control c(bit<32> p)(bool p) {
                   ^
-../testdata/p4_16_errors/dup-param.p4(17)
+dup-param.p4(17)
 control c(bit<32> p)(bool p) {
                           ^

--- a/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/dup-param1.p4(17): error: Duplicated parameter name: p and p
+dup-param1.p4(17): error: Duplicated parameter name: p and p
 control MyIngress<p>(inout bit<32> p) {
                   ^
-../testdata/p4_16_errors/dup-param1.p4(17)
+dup-param1.p4(17)
 control MyIngress<p>(inout bit<32> p) {
                                    ^

--- a/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/dup-param2.p4(17): error: Duplicated parameter name: p and p
+dup-param2.p4(17): error: Duplicated parameter name: p and p
 control MyIngress<p>(inout bit<32> x)(bit<32> p) {
                   ^
-../testdata/p4_16_errors/dup-param2.p4(17)
+dup-param2.p4(17)
 control MyIngress<p>(inout bit<32> x)(bit<32> p) {
                                               ^

--- a/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
@@ -1,12 +1,12 @@
-../testdata/p4_16_errors/dup-param3.p4(17): error: Duplicated parameter name: p and p
+dup-param3.p4(17): error: Duplicated parameter name: p and p
 control MyIngress<p>(inout bit<32> p)(bit<32> p) {
                   ^
-../testdata/p4_16_errors/dup-param3.p4(17)
+dup-param3.p4(17)
 control MyIngress<p>(inout bit<32> p)(bit<32> p) {
                                    ^
-../testdata/p4_16_errors/dup-param3.p4(17): error: Duplicated parameter name: p and p
+dup-param3.p4(17): error: Duplicated parameter name: p and p
 control MyIngress<p>(inout bit<32> p)(bit<32> p) {
                   ^
-../testdata/p4_16_errors/dup-param3.p4(17)
+dup-param3.p4(17)
 control MyIngress<p>(inout bit<32> p)(bit<32> p) {
                                               ^

--- a/testdata/p4_16_errors_outputs/dupConst.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dupConst.p4-stderr
@@ -1,13 +1,13 @@
-../testdata/p4_16_errors/dupConst.p4(17): error: Duplicate declaration of a; previous at 
+dupConst.p4(17): error: Duplicate declaration of a; previous at 
 const bit<4> a = 2;
              ^
-../testdata/p4_16_errors/dupConst.p4(16)
+dupConst.p4(16)
 const bit<4> a = 1;
              ^
-../testdata/p4_16_errors/dupConst.p4(16): error: a: Duplicates declaration a
+dupConst.p4(16): error: a: Duplicates declaration a
 const bit<4> a = 1;
                    ^
-../testdata/p4_16_errors/dupConst.p4(16)
+dupConst.p4(16)
 const bit<4> a = 1;
                  ^
 error: 2 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/duplicate-label.p4-stderr
+++ b/testdata/p4_16_errors_outputs/duplicate-label.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/duplicate-label.p4(26): error: a: duplicate switch label
+duplicate-label.p4(26): error: a: duplicate switch label
             a: { arun = 1; } // duplicate label
             ^

--- a/testdata/p4_16_errors_outputs/duplicateMethod_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/duplicateMethod_e.p4-stderr
@@ -1,7 +1,7 @@
 error: Ambiguous method append with 1 parameters
-../testdata/p4_16_errors/duplicateMethod_e.p4(21): error: Candidate is append
+duplicateMethod_e.p4(21): error: Candidate is append
     void append<D>(in D d);
          ^^^^^^
-../testdata/p4_16_errors/duplicateMethod_e.p4(23): error: Candidate is append
+duplicateMethod_e.p4(23): error: Candidate is append
     void append(in packet_in b); // duplicate method
          ^^^^^^

--- a/testdata/p4_16_errors_outputs/expression_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/expression_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/expression_e.p4(21):syntax error, unexpected _
+expression_e.p4(21):syntax error, unexpected _
         b = 32w0 & _
                    ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/extern.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extern.p4-stderr
@@ -1,30 +1,30 @@
-../testdata/p4_16_errors/extern.p4(19): error: x: a parameter with an extern type cannot have a direction
+extern.p4(19): error: x: a parameter with an extern type cannot have a direction
 control c(in X x) { // Cannot have externs with direction
                ^
-../testdata/p4_16_errors/extern.p4(19): error: Could not find type of control c
+extern.p4(19): error: Could not find type of control c
 control c(in X x) { // Cannot have externs with direction
         ^
-../testdata/p4_16_errors/extern.p4(24): error: x: a parameter with an extern type cannot have a direction
+extern.p4(24): error: x: a parameter with an extern type cannot have a direction
 control proto(in X x);
                    ^
-../testdata/p4_16_errors/extern.p4(24): error: Could not find type of control proto
+extern.p4(24): error: Could not find type of control proto
 control proto(in X x);
         ^^^^^
-../testdata/p4_16_errors/extern.p4(25): error: Could not find type of proto
+extern.p4(25): error: Could not find type of proto
 package top(proto _c);
             ^^^^^
-../testdata/p4_16_errors/extern.p4(25): error: Could not find type of _c
+extern.p4(25): error: Could not find type of _c
 package top(proto _c);
                   ^^
-../testdata/p4_16_errors/extern.p4(25): error: Could not find type of package top
+extern.p4(25): error: Could not find type of package top
 package top(proto _c);
         ^^^
-../testdata/p4_16_errors/extern.p4(19): error: Could not find type of control c
+extern.p4(19): error: Could not find type of control c
 control c(in X x) { // Cannot have externs with direction
         ^
-../testdata/p4_16_errors/extern.p4(27): error: Could not find type of c
+extern.p4(27): error: Could not find type of c
 top(c()) main;
     ^
-../testdata/p4_16_errors/extern.p4(27): error: Could not find type of top
+extern.p4(27): error: Could not find type of top
 top(c()) main;
 ^^^

--- a/testdata/p4_16_errors_outputs/extract.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extract.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/extract.p4(20): error: h: argument must be a header
+extract.p4(20): error: h: argument must be a header
         p.extract(h); // error: not a header
                   ^

--- a/testdata/p4_16_errors_outputs/extract1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extract1.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/extract1.p4(24): error: h: argument should contain a varbit field
+extract1.p4(24): error: h: argument should contain a varbit field
         p.extract(h, 32); // error: not a variable-sized header
                   ^

--- a/testdata/p4_16_errors_outputs/function1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function1_e.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/function1_e.p4(21): error: : Read-only value used for out/inout parameter x
+inout parameter x
         f(1w1 & 1w0); // non lvalue passed to out parameter
           ^^^^^^^^^
-../testdata/p4_16_errors/function1_e.p4(16)
+function1_e.p4(16)
 extern void f(out bit x);
                       ^

--- a/testdata/p4_16_errors_outputs/function_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function_e.p4-stderr
@@ -1,12 +1,12 @@
-../testdata/p4_16_errors/function_e.p4(22): error: f: Not enough arguments for call
+function_e.p4(22): error: f: Not enough arguments for call
         f(); // not enough arguments
         ^^^
-../testdata/p4_16_errors/function_e.p4(23): error: f: Passing 2 arguments when 1 expected
+function_e.p4(23): error: f: Passing 2 arguments when 1 expected
         f(1w1, 1w0); // too many arguments
         ^^^^^^^^^^^
-../testdata/p4_16_errors/function_e.p4(24): error: f has 0 type parameters, but is invoked with 1 type arguments
+function_e.p4(24): error: f has 0 type parameters, but is invoked with 1 type arguments
         f<bit>(1w0); // too many type arguments
         ^^^^^^^^^^^
-../testdata/p4_16_errors/function_e.p4(25): error: g has 1 type parameters, but is invoked with 2 type arguments
+function_e.p4(25): error: g has 1 type parameters, but is invoked with 2 type arguments
         g<bit, bit>(); // too many type arguments
         ^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/functors2_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/functors2_e.p4-stderr
@@ -1,15 +1,15 @@
-../testdata/p4_16_errors/functors2_e.p4(20): error: Could not find type of p
+functors2_e.p4(20): error: Could not find type of p
         p.apply();
         ^^^^^^^^^
-../testdata/p4_16_errors/functors2_e.p4(20): error: Could not find type of p_inst
+functors2_e.p4(20): error: Could not find type of p_inst
         p.apply();
         ^^^^^^^^^
-../testdata/p4_16_errors/functors2_e.p4(20): error: Could not find type of p_inst.apply
+functors2_e.p4(20): error: Could not find type of p_inst.apply
         p.apply();
         ^^^^^^^^^
-../testdata/p4_16_errors/functors2_e.p4(16): error: Could not find type of control p
+functors2_e.p4(16): error: Could not find type of control p
 control p()
         ^
-../testdata/p4_16_errors/functors2_e.p4(20): error: Could not find type of p
+functors2_e.p4(20): error: Could not find type of p
         p.apply();
         ^

--- a/testdata/p4_16_errors_outputs/functors3_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/functors3_e.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/functors3_e.p4(18): error: s1: cannot allocate objects of type struct s
+functors3_e.p4(18): error: s1: cannot allocate objects of type struct s
 s() s1;
     ^^
-../testdata/p4_16_errors/functors3_e.p4(16)
+functors3_e.p4(16)
 struct s {}
        ^

--- a/testdata/p4_16_errors_outputs/generic1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/generic1_e.p4-stderr
@@ -1,33 +1,33 @@
-../testdata/p4_16_errors/generic1_e.p4(21): error: Type parameters needed for x
+generic1_e.p4(21): error: Type parameters needed for x
 control p1(If x) // missing type parameter
               ^
-../testdata/p4_16_errors/generic1_e.p4(21): error: Could not find type of x
+generic1_e.p4(21): error: Could not find type of x
 control p1(If x) // missing type parameter
               ^
-../testdata/p4_16_errors/generic1_e.p4(21): error: Could not find type of control p1
+generic1_e.p4(21): error: Could not find type of control p1
 control p1(If x) // missing type parameter
         ^^
-../testdata/p4_16_errors/generic1_e.p4(26): error: If<...>: Type If has 1 type parameter(s), but it is specialized with 2
+generic1_e.p4(26): error: If<...>: Type If has 1 type parameter(s), but it is specialized with 2
 control p2(If<int<32>, int<32>> x) // too many type parameters
            ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/generic1_e.p4(16)
+generic1_e.p4(16)
 extern If<T>
        ^^
-../testdata/p4_16_errors/generic1_e.p4(26): error: Could not find type of If<...>
+generic1_e.p4(26): error: Could not find type of If<...>
 control p2(If<int<32>, int<32>> x) // too many type parameters
            ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/generic1_e.p4(26): error: Could not find type of x
+generic1_e.p4(26): error: Could not find type of x
 control p2(If<int<32>, int<32>> x) // too many type parameters
                                 ^
-../testdata/p4_16_errors/generic1_e.p4(26): error: Could not find type of control p2
+generic1_e.p4(26): error: Could not find type of control p2
 control p2(If<int<32>, int<32>> x) // too many type parameters
         ^^
-../testdata/p4_16_errors/generic1_e.p4(36): error: h<...>: Type header h is not generic and thus it cannot be specialized using type arguments
+generic1_e.p4(36): error: h<...>: Type header h is not generic and thus it cannot be specialized using type arguments
         h<bit> x; // no type parameter
         ^^^^^^
-../testdata/p4_16_errors/generic1_e.p4(31)
+generic1_e.p4(31)
 header h {}
        ^
-../testdata/p4_16_errors/generic1_e.p4(36): error: Could not find type of h<...>
+generic1_e.p4(36): error: Could not find type of h<...>
         h<bit> x; // no type parameter
         ^^^^^^

--- a/testdata/p4_16_errors_outputs/globalVar_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/globalVar_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/globalVar_e.p4(16):syntax error, unexpected IDENTIFIER, expecting (
+globalVar_e.p4(16):syntax error, unexpected IDENTIFIER, expecting (
 bit x
     ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/header1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header1_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/header1_e.p4(18):syntax error, unexpected _
+header1_e.p4(18):syntax error, unexpected _
     _
     ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/header2_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header2_e.p4-stderr
@@ -1,21 +1,21 @@
-../testdata/p4_16_errors/header2_e.p4(20): error: Field field of header h cannot have type struct s
+header2_e.p4(20): error: Field field of header h cannot have type struct s
     s field; // no struct fields allowed in headers
       ^^^^^
-../testdata/p4_16_errors/header2_e.p4(16)
+header2_e.p4(16)
 struct s {}
        ^
-../testdata/p4_16_errors/header2_e.p4(27): error: Field field of struct s1 cannot have type parser p
+header2_e.p4(27): error: Field field of struct s1 cannot have type parser p
     p field; // no functor-typed fields allowed
       ^^^^^
-../testdata/p4_16_errors/header2_e.p4(23)
+header2_e.p4(23)
 parser p();
        ^
-../testdata/p4_16_errors/header2_e.p4(32): error: Field field of header_union u cannot have type struct s
+header2_e.p4(32): error: Field field of header_union u cannot have type struct s
    s field; // no struct field allowed in header_union
      ^^^^^
-../testdata/p4_16_errors/header2_e.p4(16)
+header2_e.p4(16)
 struct s {}
        ^
-../testdata/p4_16_errors/header2_e.p4(33): error: Field field1 of header_union u cannot have type bit<1>
+header2_e.p4(33): error: Field field1 of header_union u cannot have type bit<1>
    bit field1; // no non-header field allowed in header_union
        ^^^^^^

--- a/testdata/p4_16_errors_outputs/header3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header3.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/header3.p4(18): error: Field field1 of header H cannot have type Tuple(2)
+header3.p4(18): error: Field field1 of header H cannot have type Tuple(2)
     tuple<bit, bit> field1; // tuples not allowed in header
                     ^^^^^^
-../testdata/p4_16_errors/header3.p4(18)
+header3.p4(18)
     tuple<bit, bit> field1; // tuples not allowed in header
     ^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/implicit.p4-stderr
+++ b/testdata/p4_16_errors_outputs/implicit.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/implicit.p4(19): error: b: Cannot unify int<32> to bit<32>
+implicit.p4(19): error: b: Cannot unify int<32> to bit<32>
     bit<32> b = 32s1;
     ^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/inro.p4-stderr
+++ b/testdata/p4_16_errors_outputs/inro.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/inro.p4(19): error: Expression x cannot be the target of an assignment
+inro.p4(19): error: Expression x cannot be the target of an assignment
         x = 3; // x is not a left-value
         ^

--- a/testdata/p4_16_errors_outputs/interface1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/interface1_e.p4-stderr
@@ -1,12 +1,12 @@
-../testdata/p4_16_errors/interface1_e.p4(25): error: x.f: Interface X does not have a method named f with 0 arguments
+interface1_e.p4(25): error: x.f: Interface X does not have a method named f with 0 arguments
         x.f();
         ^^^
-../testdata/p4_16_errors/interface1_e.p4(16)
+interface1_e.p4(16)
 extern X {
        ^
-../testdata/p4_16_errors/interface1_e.p4(25)
+interface1_e.p4(25)
         x.f();
           ^
-../testdata/p4_16_errors/interface1_e.p4(25): error: Could not find type of x.f
+interface1_e.p4(25): error: Could not find type of x.f
         x.f();
         ^^^

--- a/testdata/p4_16_errors_outputs/interface_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/interface_e.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/interface_e.p4(21): error: x: Type parameters must be supplied for constructor
+interface_e.p4(21): error: x: Type parameters must be supplied for constructor
     X() x;
         ^

--- a/testdata/p4_16_errors_outputs/issue272.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue272.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/issue272.p4(20): error: Field x of header boolfield cannot have type bool
+issue272.p4(20): error: Field x of header boolfield cannot have type bool
     bool x;
          ^

--- a/testdata/p4_16_errors_outputs/issue306.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue306.p4-stderr
@@ -1,84 +1,84 @@
-../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+issue306.p4(30): error: Structure struct my_packet does not have a field stack
 struct my_packet {
        ^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(45)
+issue306.p4(45)
     b.extract(p.stack.next);
                 ^^^^^
-../testdata/p4_16_errors/issue306.p4(45): error: Could not find type of p.stack
+issue306.p4(45): error: Could not find type of p.stack
     b.extract(p.stack.next);
               ^^^^^^^
-../testdata/p4_16_errors/issue306.p4(45): error: Could not find type of p.stack.next
+issue306.p4(45): error: Could not find type of p.stack.next
     b.extract(p.stack.next);
               ^^^^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+issue306.p4(30): error: Structure struct my_packet does not have a field stack
 struct my_packet {
        ^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(46)
+issue306.p4(46)
     transition select(p.stack.last.op_code) {
                         ^^^^^
-../testdata/p4_16_errors/issue306.p4(46): error: Could not find type of p.stack
+issue306.p4(46): error: Could not find type of p.stack
     transition select(p.stack.last.op_code) {
                       ^^^^^^^
-../testdata/p4_16_errors/issue306.p4(46): error: Could not find type of p.stack.last
+issue306.p4(46): error: Could not find type of p.stack.last
     transition select(p.stack.last.op_code) {
                       ^^^^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(46): error: Could not find type of p.stack.last.op_code
+issue306.p4(46): error: Could not find type of p.stack.last.op_code
     transition select(p.stack.last.op_code) {
                       ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(46): error: Could not find type of ListExpression
+issue306.p4(46): error: Could not find type of ListExpression
     transition select(p.stack.last.op_code) {
                       ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+issue306.p4(30): error: Structure struct my_packet does not have a field stack
 struct my_packet {
        ^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(53)
+issue306.p4(53)
     b.extract(p.stack.next);
                 ^^^^^
-../testdata/p4_16_errors/issue306.p4(53): error: Could not find type of p.stack
+issue306.p4(53): error: Could not find type of p.stack
     b.extract(p.stack.next);
               ^^^^^^^
-../testdata/p4_16_errors/issue306.p4(53): error: Could not find type of p.stack.next
+issue306.p4(53): error: Could not find type of p.stack.next
     b.extract(p.stack.next);
               ^^^^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+issue306.p4(30): error: Structure struct my_packet does not have a field stack
 struct my_packet {
        ^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(54)
+issue306.p4(54)
     transition select(p.stack.last.op_code) {
                         ^^^^^
-../testdata/p4_16_errors/issue306.p4(54): error: Could not find type of p.stack
+issue306.p4(54): error: Could not find type of p.stack
     transition select(p.stack.last.op_code) {
                       ^^^^^^^
-../testdata/p4_16_errors/issue306.p4(54): error: Could not find type of p.stack.last
+issue306.p4(54): error: Could not find type of p.stack.last
     transition select(p.stack.last.op_code) {
                       ^^^^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(54): error: Could not find type of p.stack.last.op_code
+issue306.p4(54): error: Could not find type of p.stack.last.op_code
     transition select(p.stack.last.op_code) {
                       ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(54): error: Could not find type of ListExpression
+issue306.p4(54): error: Could not find type of ListExpression
     transition select(p.stack.last.op_code) {
                       ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+issue306.p4(30): error: Structure struct my_packet does not have a field stack
 struct my_packet {
        ^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(73)
+issue306.p4(73)
     key = { p.stack[0].op_code : exact; }
               ^^^^^
-../testdata/p4_16_errors/issue306.p4(73): error: Could not find type of p.stack
+issue306.p4(73): error: Could not find type of p.stack
     key = { p.stack[0].op_code : exact; }
             ^^^^^^^
-../testdata/p4_16_errors/issue306.p4(73): error: Could not find type of []
+issue306.p4(73): error: Could not find type of []
     key = { p.stack[0].op_code : exact; }
             ^^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(73): error: Could not find type of [].op_code
+issue306.p4(73): error: Could not find type of [].op_code
     key = { p.stack[0].op_code : exact; }
             ^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(30): error: Structure struct my_packet does not have a field stack
+issue306.p4(30): error: Structure struct my_packet does not have a field stack
 struct my_packet {
        ^^^^^^^^^
-../testdata/p4_16_errors/issue306.p4(91)
+issue306.p4(91)
     b.emit(p.stack);
              ^^^^^
-../testdata/p4_16_errors/issue306.p4(91): error: Could not find type of p.stack
+issue306.p4(91): error: Could not find type of p.stack
     b.emit(p.stack);
            ^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue344.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue344.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/issue344.p4(24): error: C: cannot infer type for type parameter H
+issue344.p4(24): error: C: cannot infer type for type parameter H
 top(C()) c;
     ^^^
-../testdata/p4_16_errors/issue344.p4(17)
+issue344.p4(17)
 control C<H>() {
           ^

--- a/testdata/p4_16_errors_outputs/issue345.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue345.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/issue345.p4(19): error: h: Cannot unify type int with H
+issue345.p4(19): error: h: Cannot unify type int with H
         H h = 0;
         ^^^^^^^^
-../testdata/p4_16_errors/issue345.p4(17)
+issue345.p4(17)
 control C<H>() {
           ^

--- a/testdata/p4_16_errors_outputs/issue388.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue388.p4-stderr
@@ -1,12 +1,12 @@
-../testdata/p4_16_errors/issue388.p4(29): error: c: cannot instantiate at top-level
+issue388.p4(29): error: c: cannot instantiate at top-level
 C() c;
     ^
-../testdata/p4_16_errors/issue388.p4(29): error: Could not find type of c
+issue388.p4(29): error: Could not find type of c
 C() c;
     ^
-../testdata/p4_16_errors/issue388.p4(32): error: Could not find type of c
+issue388.p4(32): error: Could not find type of c
   apply { c.apply(); }
           ^
-../testdata/p4_16_errors/issue388.p4(32): error: Could not find type of c.apply
+issue388.p4(32): error: Could not find type of c.apply
   apply { c.apply(); }
           ^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue394.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue394.p4-stderr
@@ -1,18 +1,18 @@
-../testdata/p4_16_errors/issue394.p4(19): error: c: cannot declare variables of type C (consider using an instantiation)
+issue394.p4(19): error: c: cannot declare variables of type C (consider using an instantiation)
     C c;
     ^^^^
-../testdata/p4_16_errors/issue394.p4(16)
+issue394.p4(16)
 extern C { bool get(); }
        ^
-../testdata/p4_16_errors/issue394.p4(19): error: Could not find type of c
+issue394.p4(19): error: Could not find type of c
     C c;
     ^^^^
-../testdata/p4_16_errors/issue394.p4(20): error: Could not find type of c
+issue394.p4(20): error: Could not find type of c
     apply { b = c.get(); }
                 ^
-../testdata/p4_16_errors/issue394.p4(20): error: Could not find type of c.get
+issue394.p4(20): error: Could not find type of c.get
     apply { b = c.get(); }
                 ^^^^^
-../testdata/p4_16_errors/issue394.p4(20): error: Could not find type of c.get
+issue394.p4(20): error: Could not find type of c.get
     apply { b = c.get(); }
                 ^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue401.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue401.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/issue401.p4(42): error: cast: Cannot unify Tuple(1) to bit<1>
+issue401.p4(42): error: cast: Cannot unify Tuple(1) to bit<1>
     bit<1> b = (bit<1>) { 0 };
                ^^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue401.p4(42): error: cast: Illegal cast from Tuple(1) to bit<1>
+issue401.p4(42): error: cast: Illegal cast from Tuple(1) to bit<1>
     bit<1> b = (bit<1>) { 0 };
                ^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue407-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue407-1.p4-stderr
@@ -1,45 +1,45 @@
-../testdata/p4_16_errors/issue407-1.p4(47): error: Field x7 of header H cannot have type error
+issue407-1.p4(47): error: Field x7 of header H cannot have type error
     error x7;
           ^^
-/p4c/build/p4include/core.p4(22)
+core.p4(23)
 error {
 ^
-../testdata/p4_16_errors/issue407-1.p4(48): error: Field x8 of header H cannot have type bool
+issue407-1.p4(48): error: Field x8 of header H cannot have type bool
     bool x8;
          ^^
-../testdata/p4_16_errors/issue407-1.p4(49): error: Field x9 of header H cannot have type myenum1
+issue407-1.p4(49): error: Field x9 of header H cannot have type myenum1
     myenum1 x9;
             ^^
-../testdata/p4_16_errors/issue407-1.p4(32)
+issue407-1.p4(32)
 enum myenum1 {
 ^^^^
-../testdata/p4_16_errors/issue407-1.p4(50): error: Field x10 of header H cannot have type header Ethernet_h
+issue407-1.p4(50): error: Field x10 of header H cannot have type header Ethernet_h
     Ethernet_h x10;
                ^^^
-../testdata/p4_16_errors/issue407-1.p4(38)
+issue407-1.p4(38)
 header Ethernet_h {
        ^^^^^^^^^^
-../testdata/p4_16_errors/issue407-1.p4(51): error: Field x11 of header H cannot have type header Ethernet_h[]
+issue407-1.p4(51): error: Field x11 of header H cannot have type header Ethernet_h[]
     Ethernet_h[4] x11;
                   ^^^
-../testdata/p4_16_errors/issue407-1.p4(51)
+issue407-1.p4(51)
     Ethernet_h[4] x11;
     ^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue407-1.p4(52): error: Field x12 of header H cannot have type struct mystruct1
+issue407-1.p4(52): error: Field x12 of header H cannot have type struct mystruct1
     mystruct1 x12;
               ^^^
-../testdata/p4_16_errors/issue407-1.p4(21)
+issue407-1.p4(21)
 struct mystruct1 {
        ^^^^^^^^^
-../testdata/p4_16_errors/issue407-1.p4(53): error: Field x13 of header H cannot have type struct mystruct2
+issue407-1.p4(53): error: Field x13 of header H cannot have type struct mystruct2
     mystruct2 x13;
               ^^^
-../testdata/p4_16_errors/issue407-1.p4(26)
+issue407-1.p4(26)
 struct mystruct2 {
        ^^^^^^^^^
-../testdata/p4_16_errors/issue407-1.p4(54): error: Field x14 of header H cannot have type Tuple(2)
+issue407-1.p4(54): error: Field x14 of header H cannot have type Tuple(2)
     myTuple0 x14;
              ^^^
-../testdata/p4_16_errors/issue407-1.p4(44)
+issue407-1.p4(44)
 typedef tuple<bit<8>, bit<16>> myTuple0;
         ^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue413.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue413.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/issue413.p4(34): warning: 3405691582: value does not fit in 16 bits
+issue413.p4(34): warning: 3405691582: value does not fit in 16 bits
     const bit<32> c1d = 32w0xcafebabe;
                         ^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue413.p4(41): error: foo2: Action calls are not allowed within parsers
+issue413.p4(41): error: foo2: Action calls are not allowed within parsers
         foo2((bit<16>) c1d, b1a);
         ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue435.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue435.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/issue435.p4(7): error: mystruct1: Method has no return type
+issue435.p4(7): error: mystruct1: Method has no return type
     mystruct1(in bit<8> a, out bit<16> b);
     ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue473.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue473.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/issue473.p4(70): error: cast: action argument must be a compile-time constant
+issue473.p4(70): error: cast: action argument must be a compile-time constant
         default_action = b(meta.c, (bit<8>) meta.d);
                                    ^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue477.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue477.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/issue477.p4(28): error: p.h: argument must be a header
+issue477.p4(28): error: p.h: argument must be a header
         b.extract(p.h);
                   ^^^

--- a/testdata/p4_16_errors_outputs/issue478.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue478.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/issue478.p4(29): error: p.h: argument cannot contain varbit fields
+issue478.p4(29): error: p.h: argument cannot contain varbit fields
         b.extract(p.h);
                   ^^^

--- a/testdata/p4_16_errors_outputs/issue513.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue513.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/issue513.p4(60): error: MethodCallStatement: Conditional execution in actions is not supported on this target
+issue513.p4(60): error: MethodCallStatement: Conditional execution in actions is not supported on this target
             mark_to_drop();
             ^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue529-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue529-1.p4-stderr
@@ -1,12 +1,12 @@
-../testdata/p4_16_errors/issue529-1.p4(28): error: h_t: casts are only supported to base types
+issue529-1.p4(28): error: h_t: casts are only supported to base types
         h_t h2 = (h_t) h; // illegal cast
                   ^^^
-../testdata/p4_16_errors/issue529-1.p4(28): error: Could not find type of cast
+issue529-1.p4(28): error: Could not find type of cast
         h_t h2 = (h_t) h; // illegal cast
                  ^^^^^^^
-../testdata/p4_16_errors/issue529-1.p4(29): error: h_t: casts are only supported to base types
+issue529-1.p4(29): error: h_t: casts are only supported to base types
         h_t h4 = (h_t) { h.f }; // illegal cast
                   ^^^
-../testdata/p4_16_errors/issue529-1.p4(29): error: Could not find type of cast
+issue529-1.p4(29): error: Could not find type of cast
         h_t h4 = (h_t) { h.f }; // illegal cast
                  ^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue532.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue532.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/issue532.p4(35): error: choose_entry: functions or methods returning structures are not supported on this target
+issue532.p4(35): error: choose_entry: functions or methods returning structures are not supported on this target
     my_meta.entry = choose_entry(choices);
                     ^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
@@ -1,18 +1,18 @@
-../testdata/p4_16_errors/issue561-1.p4(29): error: u: Cannot unify Tuple(2) to header_union U
+issue561-1.p4(29): error: u: Cannot unify Tuple(2) to header_union U
         U u = { { 10 }, { 20 } }; // illegal to initialize unions
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue561-1.p4(29)
+issue561-1.p4(29)
         U u = { { 10 }, { 20 } }; // illegal to initialize unions
               ^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/issue561-1.p4(19)
+issue561-1.p4(19)
 header_union U {
              ^
-../testdata/p4_16_errors/issue561-1.p4(19): error: Structure header_union U does not have a field setValid
+issue561-1.p4(19): error: Structure header_union U does not have a field setValid
 header_union U {
              ^
-../testdata/p4_16_errors/issue561-1.p4(30)
+issue561-1.p4(30)
         u.setValid(); // no such method
           ^^^^^^^^
-../testdata/p4_16_errors/issue561-1.p4(30): error: Could not find type of u.setValid
+issue561-1.p4(30): error: Could not find type of u.setValid
         u.setValid(); // no such method
         ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue584.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue584.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/issue584.p4(28): error: hash: cannot infer type for type parameter T
+issue584.p4(28): error: hash: cannot infer type for type parameter T
         hash(var, HashAlgorithm.crc16, 0, hdr, 0xFFFF);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-/home/mbudiu/git/p4c/build/p4include/v1model.p4(106)
+v1model.p4(125)
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
                     ^

--- a/testdata/p4_16_errors_outputs/issue600.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue600.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/issue600.p4(25): error: H: type argument must be a fixed-width type
+issue600.p4(25): error: H: type argument must be a fixed-width type
         h = pkt.lookahead<H>();
                           ^

--- a/testdata/p4_16_errors_outputs/issue67.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue67.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/issue67.p4(1): error: x: Cannot unify type int with bool
+issue67.p4(1): error: x: Cannot unify type int with bool
 const bool x = 20; // error
                ^^

--- a/testdata/p4_16_errors_outputs/key-name.p4-stderr
+++ b/testdata/p4_16_errors_outputs/key-name.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/key-name.p4(28): error: +: Complex key expression requires a @name annotation
+key-name.p4(28): error: +: Complex key expression requires a @name annotation
         key = { h.a + h.a : exact; }
                 ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/local_instance.p4-stderr
+++ b/testdata/p4_16_errors_outputs/local_instance.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/local_instance.p4(33): error: vc: instances cannot be in a control 'apply' block
+local_instance.p4(33): error: vc: instances cannot be in a control 'apply' block
         VC() vc; // illegal instance within an apply block
              ^^

--- a/testdata/p4_16_errors_outputs/missing_actions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/missing_actions.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/missing_actions.p4(19): error: Table t does not have an `actions' property
+missing_actions.p4(19): error: Table t does not have an `actions' property
     table t {
           ^

--- a/testdata/p4_16_errors_outputs/missing_match.p4-stderr
+++ b/testdata/p4_16_errors_outputs/missing_match.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/missing_match.p4(20): error: Could not find declaration for noSuchMatch
+missing_match.p4(20): error: Could not find declaration for noSuchMatch
         key = { b : noSuchMatch; }
                     ^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/module_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/module_e.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_errors/module_e.p4(25): error: main: Cannot unify parameter x with filter because they have different directions
+module_e.p4(25): error: main: Cannot unify parameter x with filter because they have different directions
 top(g()) main;
          ^^^^
-../testdata/p4_16_errors/module_e.p4(20)
+module_e.p4(20)
 parser g(in bit x) // mismatch in direction
                 ^
-../testdata/p4_16_errors/module_e.p4(16)
+module_e.p4(16)
 parser Filter(out bool filter);
                        ^^^^^^

--- a/testdata/p4_16_errors_outputs/mux_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/mux_e.p4-stderr
@@ -1,10 +1,10 @@
 error: Selector of ?: must be bool, not bit<1>
-../testdata/p4_16_errors/mux_e.p4(24): error: Could not find type of ?:
+mux_e.p4(24): error: Could not find type of ?:
         a = a ? b : c; // wrong type for a
             ^^^^^^^^^
-../testdata/p4_16_errors/mux_e.p4(25): error: ?:: Cannot unify bool to bit<1>
+mux_e.p4(25): error: ?:: Cannot unify bool to bit<1>
         d = d ? a : d; // wrong types a <-> d
             ^^^^^^^^^
-../testdata/p4_16_errors/mux_e.p4(25): error: Could not find type of ?:
+mux_e.p4(25): error: Could not find type of ?:
         d = d ? a : d; // wrong types a <-> d
             ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/neg.p4-stderr
+++ b/testdata/p4_16_errors_outputs/neg.p4-stderr
@@ -1,12 +1,12 @@
-../testdata/p4_16_errors/neg.p4(21): error: /: Cannot operate on signed values
+: Cannot operate on signed values
     c = a / b; // not defined for signed values
         ^^^^^
-../testdata/p4_16_errors/neg.p4(21): error: Could not find type of /
+
     c = a / b; // not defined for signed values
         ^^^^^
-../testdata/p4_16_errors/neg.p4(22): error: %: Cannot operate on signed values
+neg.p4(22): error: %: Cannot operate on signed values
     c = a % b;
         ^^^^^
-../testdata/p4_16_errors/neg.p4(22): error: Could not find type of %
+neg.p4(22): error: Could not find type of %
     c = a % b;
         ^^^^^

--- a/testdata/p4_16_errors_outputs/next.p4-stderr
+++ b/testdata/p4_16_errors_outputs/next.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/next.p4(24): error: stack.last: 'last' and 'next' for stacks cannot be used in a control
+next.p4(24): error: stack.last: 'last' and 'next' for stacks cannot be used in a control
         stack.last = { 10 };
         ^^^^^^^^^^
-../testdata/p4_16_errors/next.p4(24): error: Expression stack.last cannot be the target of an assignment
+next.p4(24): error: Expression stack.last cannot be the target of an assignment
         stack.last = { 10 };
         ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/nostart.p4-stderr
+++ b/testdata/p4_16_errors_outputs/nostart.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_errors/nostart.p4(18): warning: next: implicit transition to `reject'
+nostart.p4(18): warning: next: implicit transition to `reject'
     state next {}
           ^^^^
-../testdata/p4_16_errors/nostart.p4(17): error: parser p: parser does not have a `start' state
+nostart.p4(17): error: parser p: parser does not have a `start' state
 parser p() {
        ^
-../testdata/p4_16_errors/nostart.p4(17): warning: accept state in parser p is unreachable
+nostart.p4(17): warning: accept state in parser p is unreachable
 parser p() {
        ^

--- a/testdata/p4_16_errors_outputs/not_bound.p4-stderr
+++ b/testdata/p4_16_errors_outputs/not_bound.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/not_bound.p4(36): error: set_nhop: parameter port must be bound
+not_bound.p4(36): error: set_nhop: parameter port must be bound
         set_nhop(); // parameter not bound
         ^^^^^^^^^^
-../testdata/p4_16_errors/not_bound.p4(32)
+not_bound.p4(32)
     action set_nhop(bit<9> port) {
                            ^^^^

--- a/testdata/p4_16_errors_outputs/p_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/p_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/p_e.p4(17):syntax error, unexpected IDENTIFIER "x"
+p_e.p4(17):syntax error, unexpected IDENTIFIER "x"
    x
    ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/package.p4-stderr
+++ b/testdata/p4_16_errors_outputs/package.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/package.p4(18): error: _c: constructor parameters cannot have a direction
+package.p4(18): error: _c: constructor parameters cannot have a direction
 package top(in proto _c); // Package should not have in parameters
                      ^^

--- a/testdata/p4_16_errors_outputs/param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/param.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/param.p4(22): error: E: Action parameters cannot have extern types
+param.p4(22): error: E: Action parameters cannot have extern types
     action a(in E e) { e.call(); }
                 ^

--- a/testdata/p4_16_errors_outputs/parser-arg.p4-stderr
+++ b/testdata/p4_16_errors_outputs/parser-arg.p4-stderr
@@ -1,63 +1,63 @@
-../testdata/p4_16_errors/parser-arg.p4(18): error: p: parameter cannot have type parser Parser
+parser-arg.p4(18): error: p: parameter cannot have type parser Parser
 parser MyParser(Parser p);
                        ^
-../testdata/p4_16_errors/parser-arg.p4(17)
+parser-arg.p4(17)
 parser Parser();
        ^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(18): error: Could not find type of parser MyParser
+parser-arg.p4(18): error: Could not find type of parser MyParser
 parser MyParser(Parser p);
        ^^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(19): error: Could not find type of MyParser
+parser-arg.p4(19): error: Could not find type of MyParser
 package Package(MyParser p1, MyParser p2);
                 ^^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(18): error: Could not find type of parser MyParser
+parser-arg.p4(18): error: Could not find type of parser MyParser
 parser MyParser(Parser p);
        ^^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(19): error: Could not find type of MyParser
+parser-arg.p4(19): error: Could not find type of MyParser
 package Package(MyParser p1, MyParser p2);
                              ^^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(19): error: Could not find type of p1
+parser-arg.p4(19): error: Could not find type of p1
 package Package(MyParser p1, MyParser p2);
                          ^^
-../testdata/p4_16_errors/parser-arg.p4(21): error: p: parameter cannot have type parser Parser
+parser-arg.p4(21): error: p: parameter cannot have type parser Parser
 parser Parser1(Parser p) {
                       ^
-../testdata/p4_16_errors/parser-arg.p4(17)
+parser-arg.p4(17)
 parser Parser();
        ^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(21): error: Could not find type of parser Parser1
+parser-arg.p4(21): error: Could not find type of parser Parser1
 parser Parser1(Parser p) {
        ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(28): error: p: parameter cannot have type parser Parser
+parser-arg.p4(28): error: p: parameter cannot have type parser Parser
 parser Parser2(Parser p) {
                       ^
-../testdata/p4_16_errors/parser-arg.p4(17)
+parser-arg.p4(17)
 parser Parser();
        ^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(28): error: Could not find type of parser Parser2
+parser-arg.p4(28): error: Could not find type of parser Parser2
 parser Parser2(Parser p) {
        ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(21): error: Could not find type of parser Parser1
+parser-arg.p4(21): error: Could not find type of parser Parser1
 parser Parser1(Parser p) {
        ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(35): error: Could not find type of Parser1
+parser-arg.p4(35): error: Could not find type of Parser1
 Parser1() p1;
 ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(28): error: Could not find type of parser Parser2
+parser-arg.p4(28): error: Could not find type of parser Parser2
 parser Parser2(Parser p) {
        ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(36): error: Could not find type of Parser2
+parser-arg.p4(36): error: Could not find type of Parser2
 Parser2() p2;
 ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(19): error: Could not find type of package Package
+parser-arg.p4(19): error: Could not find type of package Package
 package Package(MyParser p1, MyParser p2);
         ^^^^^^^
-../testdata/p4_16_errors/parser-arg.p4(35): error: Could not find type of p1
+parser-arg.p4(35): error: Could not find type of p1
 Parser1() p1;
           ^^
-../testdata/p4_16_errors/parser-arg.p4(36): error: Could not find type of p2
+parser-arg.p4(36): error: Could not find type of p2
 Parser2() p2;
           ^^
-../testdata/p4_16_errors/parser-arg.p4(38): error: Could not find type of Package
+parser-arg.p4(38): error: Could not find type of Package
 Package(p1,p2) main;
 ^^^^^^^

--- a/testdata/p4_16_errors_outputs/persistent_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/persistent_e.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/persistent_e.p4(23): error: z: cannot evaluate to a compile-time constant
+persistent_e.p4(23): error: z: cannot evaluate to a compile-time constant
     p(z) p1; // argument is not constant
       ^

--- a/testdata/p4_16_errors_outputs/range_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/range_e.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/range_e.p4(20): error: ..: Cannot operate on values with different types bit<2> and bit<3>
+range_e.p4(20): error: ..: Cannot operate on values with different types bit<2> and bit<3>
             2w2 .. 3w3 : reject; // different widths
             ^^^^^^^^^^
-../testdata/p4_16_errors/range_e.p4(20): error: Could not find type of ..
+range_e.p4(20): error: Could not find type of ..
             2w2 .. 3w3 : reject; // different widths
             ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/scope.p4-stderr
+++ b/testdata/p4_16_errors_outputs/scope.p4-stderr
@@ -1,15 +1,15 @@
-../testdata/p4_16_errors/scope.p4(25): error: Cannot extract field x from q which has type Type(control q)
+scope.p4(25): error: Cannot extract field x from q which has type Type(control q)
         bit<8> y = .q.x.get(); // should be unreachable
                       ^
-../testdata/p4_16_errors/scope.p4(25)
+scope.p4(25)
         bit<8> y = .q.x.get(); // should be unreachable
                    ^^
-../testdata/p4_16_errors/scope.p4(25): error: Could not find type of q.x
+scope.p4(25): error: Could not find type of q.x
         bit<8> y = .q.x.get(); // should be unreachable
                    ^^^^
-../testdata/p4_16_errors/scope.p4(25): error: Could not find type of q.x.get
+scope.p4(25): error: Could not find type of q.x.get
         bit<8> y = .q.x.get(); // should be unreachable
                    ^^^^^^^^
-../testdata/p4_16_errors/scope.p4(25): error: Could not find type of q.x.get
+scope.p4(25): error: Could not find type of q.x.get
         bit<8> y = .q.x.get(); // should be unreachable
                    ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/self-call.p4-stderr
+++ b/testdata/p4_16_errors_outputs/self-call.p4-stderr
@@ -1,15 +1,15 @@
-../testdata/p4_16_errors/self-call.p4(16): error: Could not find type of control c
+self-call.p4(16): error: Could not find type of control c
 control c() {
         ^
-../testdata/p4_16_errors/self-call.p4(17): error: Could not find type of c
+self-call.p4(17): error: Could not find type of c
     c() c_inst;
     ^
-../testdata/p4_16_errors/self-call.p4(17): error: Could not find type of c_inst
+self-call.p4(17): error: Could not find type of c_inst
     c() c_inst;
         ^^^^^^
-../testdata/p4_16_errors/self-call.p4(19): error: Could not find type of c_inst
+self-call.p4(19): error: Could not find type of c_inst
         c_inst.apply();
         ^^^^^^
-../testdata/p4_16_errors/self-call.p4(19): error: Could not find type of c_inst.apply
+self-call.p4(19): error: Could not find type of c_inst.apply
         c_inst.apply();
         ^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/shift_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/shift_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/shift_e.p4(20): error: Syntax error at shift operator: 
+shift_e.p4(20): error: Syntax error at shift operator: 
         int<32> b = a > > 1;
                       ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/signs.p4-stderr
+++ b/testdata/p4_16_errors_outputs/signs.p4-stderr
@@ -1,15 +1,15 @@
-../testdata/p4_16_errors/signs.p4(17): warning: a shadows a
+signs.p4(17): warning: a shadows a
     bit<8> a = 8w0;
     ^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/signs.p4(16)
+signs.p4(16)
 action a() {
        ^
-../testdata/p4_16_errors/signs.p4(18): error: b: Cannot unify bit<8> to int<8>
+signs.p4(18): error: b: Cannot unify bit<8> to int<8>
     int<8> b = 8w0;
     ^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/signs.p4(19): error: -: Cannot operate on values with different signs
+signs.p4(19): error: -: Cannot operate on values with different signs
     a = a - b;
         ^^^^^
-../testdata/p4_16_errors/signs.p4(19): error: Could not find type of -
+signs.p4(19): error: Could not find type of -
     a = a - b;
         ^^^^^

--- a/testdata/p4_16_errors_outputs/spec-ex32_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/spec-ex32_e.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/spec-ex32_e.p4(22): error: Could not find declaration for size2
+spec-ex32_e.p4(22): error: Could not find declaration for size2
     @length(size2) // illegal: cannot use size2, defined after data2
             ^^^^^

--- a/testdata/p4_16_errors_outputs/stack1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack1_e.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_errors/stack1_e.p4(21): warning: 5: signed value does not fit in 3 bits
+stack1_e.p4(21): warning: 5: signed value does not fit in 3 bits
         int<3> w = 5;
                    ^
-../testdata/p4_16_errors/stack1_e.p4(22): error: header h[]: Size of header stack type should be a constant
+stack1_e.p4(22): error: header h[]: Size of header stack type should be a constant
         h[w] stack;
         ^^^^
-../testdata/p4_16_errors/stack1_e.p4(22): error: Could not find type of h[]
+stack1_e.p4(22): error: Could not find type of h[]
         h[w] stack;
         ^^^^

--- a/testdata/p4_16_errors_outputs/stack2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack2.p4-stderr
@@ -1,15 +1,15 @@
-../testdata/p4_16_errors/stack2.p4(24): error: AssignmentStatement: cannot unify stacks with different sized header h[] and header h[]
+stack2.p4(24): error: AssignmentStatement: cannot unify stacks with different sized header h[] and header h[]
         stack1 = stack2; // assignment between different stacks
                ^
-../testdata/p4_16_errors/stack2.p4(21)
+stack2.p4(21)
         h[5] stack1;
         ^^^^
-../testdata/p4_16_errors/stack2.p4(22)
+stack2.p4(22)
         h[3] stack2;
         ^^^^
-../testdata/p4_16_errors/stack2.p4(25): error: Expression stack1.lastIndex cannot be the target of an assignment
+stack2.p4(25): error: Expression stack1.lastIndex cannot be the target of an assignment
         stack1.lastIndex = 3; // not an l-value
         ^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/stack2.p4(26): error: Expression stack2.size cannot be the target of an assignment
+stack2.p4(26): error: Expression stack2.size cannot be the target of an assignment
         stack2.size = 4; // not an l-value
         ^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/stack3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack3.p4-stderr
@@ -1,36 +1,36 @@
-../testdata/p4_16_errors/stack3.p4(34): error: header h[]: Size of header stack type should be a constant
+stack3.p4(34): error: header h[]: Size of header stack type should be a constant
         h[s1.size + 1] s2;
         ^^^^^^^^^^^^^^
-../testdata/p4_16_errors/stack3.p4(34): error: header h[]: Size of header stack type should be a constant
+stack3.p4(34): error: header h[]: Size of header stack type should be a constant
         h[s1.size + 1] s2;
         ^^^^^^^^^^^^^^
-../testdata/p4_16_errors/stack3.p4(34): error: header h[]: Size of header stack type should be a constant
+stack3.p4(34): error: header h[]: Size of header stack type should be a constant
         h[s1.size + 1] s2;
         ^^^^^^^^^^^^^^
-../testdata/p4_16_errors/stack3.p4(34): error: Could not find type of h[]
+stack3.p4(34): error: Could not find type of h[]
         h[s1.size + 1] s2;
         ^^^^^^^^^^^^^^
-../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+stack3.p4(35): error: header h[]: Size of header stack type should be a constant
         h[x] s3;
         ^^^^
-../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+stack3.p4(35): error: header h[]: Size of header stack type should be a constant
         h[x] s3;
         ^^^^
-../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+stack3.p4(35): error: header h[]: Size of header stack type should be a constant
         h[x] s3;
         ^^^^
-../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+stack3.p4(35): error: header h[]: Size of header stack type should be a constant
         h[x] s3;
         ^^^^
-../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+stack3.p4(35): error: header h[]: Size of header stack type should be a constant
         h[x] s3;
         ^^^^
-../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+stack3.p4(35): error: header h[]: Size of header stack type should be a constant
         h[x] s3;
         ^^^^
-../testdata/p4_16_errors/stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+stack3.p4(35): error: header h[]: Size of header stack type should be a constant
         h[x] s3;
         ^^^^
-../testdata/p4_16_errors/stack3.p4(35): error: Could not find type of h[]
+stack3.p4(35): error: Could not find type of h[]
         h[x] s3;
         ^^^^

--- a/testdata/p4_16_errors_outputs/stack_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack_e.p4-stderr
@@ -1,27 +1,27 @@
-../testdata/p4_16_errors/stack_e.p4(23): error: Header stack struct s[] used with non-header type struct s
+stack_e.p4(23): error: Header stack struct s[] used with non-header type struct s
         s[5] stack1; // non-header illegal in header stack
         ^^^^
-../testdata/p4_16_errors/stack_e.p4(23): error: Could not find type of s[]
+stack_e.p4(23): error: Could not find type of s[]
         s[5] stack1; // non-header illegal in header stack
         ^^^^
-../testdata/p4_16_errors/stack_e.p4(26): error: Index too large: 1231092310293
+stack_e.p4(26): error: Index too large: 1231092310293
         h b = stack[1231092310293];
                     ^^^^^^^^^^^^^
-../testdata/p4_16_errors/stack_e.p4(26): error: Could not find type of []
+stack_e.p4(26): error: Could not find type of []
         h b = stack[1231092310293];
               ^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/stack_e.p4(27): error: Negative array index -2
+stack_e.p4(27): error: Negative array index -2
         h c = stack[-2];
                      ^
-../testdata/p4_16_errors/stack_e.p4(27): error: Could not find type of []
+stack_e.p4(27): error: Could not find type of []
         h c = stack[-2];
               ^^^^^^^^^
-../testdata/p4_16_errors/stack_e.p4(28): error: Array index 6 larger or equal to array size 5
+stack_e.p4(28): error: Array index 6 larger or equal to array size 5
         h d = stack[6];
                     ^
-../testdata/p4_16_errors/stack_e.p4(22)
+stack_e.p4(22)
         h[5] stack;
           ^
-../testdata/p4_16_errors/stack_e.p4(28): error: Could not find type of []
+stack_e.p4(28): error: Could not find type of []
         h d = stack[6];
               ^^^^^^^^

--- a/testdata/p4_16_errors_outputs/struct_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/struct_e.p4-stderr
@@ -1,18 +1,18 @@
-../testdata/p4_16_errors/struct_e.p4(16): error: Structure struct s does not have a field data
+struct_e.p4(16): error: Structure struct s does not have a field data
 struct s {}
        ^
-../testdata/p4_16_errors/struct_e.p4(24)
+struct_e.p4(24)
         v.data = 1w0; // no such field
           ^^^^
-../testdata/p4_16_errors/struct_e.p4(24): error: Could not find type of v.data
+struct_e.p4(24): error: Could not find type of v.data
         v.data = 1w0; // no such field
         ^^^^^^
-../testdata/p4_16_errors/struct_e.p4(25): error: Cannot extract field data from b which has type bit<1>
+struct_e.p4(25): error: Cannot extract field data from b which has type bit<1>
         b.data = 5; // no such field
           ^^^^
-../testdata/p4_16_errors/struct_e.p4(25)
+struct_e.p4(25)
         b.data = 5; // no such field
         ^
-../testdata/p4_16_errors/struct_e.p4(25): error: Could not find type of b.data
+struct_e.p4(25): error: Could not find type of b.data
         b.data = 5; // no such field
         ^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-decl-order.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-decl-order.p4
@@ -53,9 +53,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     }
     table t_ternary {
         const entries = {
-            0x1111 &&& 0xf : a_with_control_params(1);
-            0x1181 : a_with_control_params(2);
-            0x1181 &&& 0xf00f : a_with_control_params(3);
+                        0x1111 &&& 0xf : a_with_control_params(1);
+
+                        0x1181 : a_with_control_params(2);
+
+                        0x1181 &&& 0xf00f : a_with_control_params(3);
+
         }
 
         key = {

--- a/testdata/p4_16_errors_outputs/table-entries-decl-order.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-decl-order.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/table-entries-decl-order.p4(64): error: Could not find type for table key Key
+table-entries-decl-order.p4(64): error: Could not find type for table key Key
    key = {
           ^

--- a/testdata/p4_16_errors_outputs/table-entries-exact-ternary.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-exact-ternary.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/table-entries-exact-ternary.p4(74):syntax error, unexpected ), expecting ","
+table-entries-exact-ternary.p4(74):syntax error, unexpected ), expecting ","
             (0x1111 &&& 0xF )
                             ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/table-entries-exact.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-exact.p4
@@ -61,10 +61,14 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         const entries = {
-            0x1 : a_with_control_params(1);
-            0x2 : a_with_control_params(2);
-            default : a_with_control_params(3);
-            (0x1111 &&& 0xf, 0x1) : a();
+                        0x1 : a_with_control_params(1);
+
+                        0x2 : a_with_control_params(2);
+
+                        default : a_with_control_params(3);
+
+                        (0x1111 &&& 0xf, 0x1) : a();
+
         }
 
     }

--- a/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/table-entries-exact.p4(72): error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-exact.p4(72): error: Entry: Cannot match tuples with different sizes 1 vs 2
             (0x1111 &&& 0xF, 0x1 ) : a(); // invalid exact key
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-lpm.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm.p4
@@ -61,11 +61,16 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         const entries = {
-            0x11 &&& 0xf0 : a_with_control_params(11);
-            0x12 : a_with_control_params(12);
-            default : a_with_control_params(13);
-            0x11 &&& 0xf : a_with_control_params(14);
-            (0x1, 0x11 &&& 0xf0) : a();
+                        0x11 &&& 0xf0 : a_with_control_params(11);
+
+                        0x12 : a_with_control_params(12);
+
+                        default : a_with_control_params(13);
+
+                        0x11 &&& 0xf : a_with_control_params(14);
+
+                        (0x1, 0x11 &&& 0xf0) : a();
+
         }
 
     }

--- a/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/table-entries-lpm.p4(72): error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-lpm.p4(72): error: Entry: Cannot match tuples with different sizes 1 vs 2
             (0x1, 0x11 &&& 0xF0): a(); // invalid keyset
             ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         entries = {
-            0x1111 &&& 0xf : a_with_control_params(1);
-            0x1181 : a_with_control_params(2);
-            0x1181 &&& 0xf00f : a_with_control_params(3);
+                        0x1111 &&& 0xf : a_with_control_params(1);
+
+                        0x1181 : a_with_control_params(2);
+
+                        0x1181 &&& 0xf00f : a_with_control_params(3);
+
         }
 
     }

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/table-entries-non-const.p4(68): error: EntriesList: table initializers must be constant
+table-entries-non-const.p4(68): error: EntriesList: table initializers must be constant
         entries = {
         ^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-outside-table.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-outside-table.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/table-entries-outside-table.p4(68):syntax error, unexpected ENTRIES
+table-entries-outside-table.p4(68):syntax error, unexpected ENTRIES
     const entries
           ^^^^^^^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/table-entries-range.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-range.p4
@@ -61,10 +61,14 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         const entries = {
-            1 .. 8 : a_with_control_params(21);
-            6 .. 12 : a_with_control_params(22);
-            default : a_with_control_params(23);
-            (0x18, 0xf) : a_with_control_params(24);
+                        1 .. 8 : a_with_control_params(21);
+
+                        6 .. 12 : a_with_control_params(22);
+
+                        default : a_with_control_params(23);
+
+                        (0x18, 0xf) : a_with_control_params(24);
+
         }
 
     }

--- a/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/table-entries-range.p4(71): error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-range.p4(71): error: Entry: Cannot match tuples with different sizes 1 vs 2
             (0x18, 0xF) : a_with_control_params(24); // not a range
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-ternary.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-ternary.p4
@@ -61,14 +61,22 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         const entries = {
-            0x1111 &&& 0xf : a_with_control_params(1);
-            0x1187 : a_with_control_params(2);
-            0x1111 &&& 0xf000 : a_with_control_params(3);
-            default : a_with_control_params(4);
-            1 .. 2 : a();
-            (0x2, 0x3) : a();
-            0x1111 : missing_a();
-            0x1111 : a_with_control_params(32w10);
+                        0x1111 &&& 0xf : a_with_control_params(1);
+
+                        0x1187 : a_with_control_params(2);
+
+                        0x1111 &&& 0xf000 : a_with_control_params(3);
+
+                        default : a_with_control_params(4);
+
+                        1 .. 2 : a();
+
+                        (0x2, 0x3) : a();
+
+                        0x1111 : missing_a();
+
+                        0x1111 : a_with_control_params(32w10);
+
         }
 
     }

--- a/testdata/p4_16_errors_outputs/table-entries-ternary.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-ternary.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/table-entries-ternary.p4(76): error: Could not find declaration for missing_a
+table-entries-ternary.p4(76): error: Could not find declaration for missing_a
             0x1111 : missing_a(); // action not in action list
                      ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/template_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/template_e.p4-stderr
@@ -1,13 +1,13 @@
-../testdata/p4_16_errors/template_e.p4(16): error: T: Duplicates declaration T
+template_e.p4(16): error: T: Duplicates declaration T
 package S<T, T
              ^
-../testdata/p4_16_errors/template_e.p4(16)
+template_e.p4(16)
 package S<T, T
           ^
-../testdata/p4_16_errors/template_e.p4(16): error: Duplicate declaration of T; previous at 
+template_e.p4(16): error: Duplicate declaration of T; previous at 
 package S<T, T>
              ^
-../testdata/p4_16_errors/template_e.p4(16)
+template_e.p4(16)
 package S<T, T>
           ^
 error: 2 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/tuple-left.p4-stderr
+++ b/testdata/p4_16_errors_outputs/tuple-left.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/tuple-left.p4(21):syntax error, unexpected ","
+tuple-left.p4(21):syntax error, unexpected ","
         { a,
            ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/tuple-to-header.p4-stderr
+++ b/testdata/p4_16_errors_outputs/tuple-to-header.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_errors/tuple-to-header.p4(23): error: AssignmentStatement: Cannot assign a Tuple(1) to a header H
+tuple-to-header.p4(23): error: AssignmentStatement: Cannot assign a Tuple(1) to a header H
         h = t; // illegal assignment between tuple and header
           ^
-../testdata/p4_16_errors/tuple-to-header.p4(20)
+tuple-to-header.p4(20)
     tuple<bit<32>> t = { 0 };
     ^^^^^^^^^^^^^^
-../testdata/p4_16_errors/tuple-to-header.p4(17)
+tuple-to-header.p4(17)
 header H { bit<32> x; }
        ^

--- a/testdata/p4_16_errors_outputs/twovarbit.p4-stderr
+++ b/testdata/p4_16_errors_outputs/twovarbit.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/twovarbit.p4(2): error: x and u: multiple varbit fields in a header
+twovarbit.p4(2): error: x and u: multiple varbit fields in a header
     varbit<120> x;
                 ^
-../testdata/p4_16_errors/twovarbit.p4(3)
+twovarbit.p4(3)
     varbit<120> u;
                 ^

--- a/testdata/p4_16_errors_outputs/type-field.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-field.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_errors/type-field.p4(60): error: Cannot extract field d from h which has type Type(struct h)
+type-field.p4(60): error: Cannot extract field d from h which has type Type(struct h)
     b.emit(h.d);
              ^
-../testdata/p4_16_errors/type-field.p4(60)
+type-field.p4(60)
     b.emit(h.d);
            ^
-../testdata/p4_16_errors/type-field.p4(60): error: Could not find type of h.d
+type-field.p4(60): error: Could not find type of h.d
     b.emit(h.d);
            ^^^

--- a/testdata/p4_16_errors_outputs/type-params_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-params_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/type-params_e.p4(18):syntax error, unexpected IDENTIFIER "D"
+type-params_e.p4(18):syntax error, unexpected IDENTIFIER "D"
 package m(p<D
             ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/typecheck1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typecheck1_e.p4-stderr
@@ -1,30 +1,30 @@
-../testdata/p4_16_errors/typecheck1_e.p4(27): error: Cannot apply ~ to value d of type bool
+typecheck1_e.p4(27): error: Cannot apply ~ to value d of type bool
         d = ~d;
              ^
-../testdata/p4_16_errors/typecheck1_e.p4(27): error: Could not find type of ~
+typecheck1_e.p4(27): error: Could not find type of ~
         d = ~d;
             ^^
-../testdata/p4_16_errors/typecheck1_e.p4(32): error: +: cannot be applied to d of type bool
+typecheck1_e.p4(32): error: +: cannot be applied to d of type bool
         d = d + d;
             ^
-../testdata/p4_16_errors/typecheck1_e.p4(32): error: Could not find type of +
+typecheck1_e.p4(32): error: Could not find type of +
         d = d + d;
             ^^^^^
-../testdata/p4_16_errors/typecheck1_e.p4(33): error: -: cannot be applied to d of type bool
+typecheck1_e.p4(33): error: -: cannot be applied to d of type bool
         d = d - d;
             ^
-../testdata/p4_16_errors/typecheck1_e.p4(33): error: Could not find type of -
+typecheck1_e.p4(33): error: Could not find type of -
         d = d - d;
             ^^^^^
-../testdata/p4_16_errors/typecheck1_e.p4(35): error: Cannot apply ! to value a of type bit<32>
+typecheck1_e.p4(35): error: Cannot apply ! to value a of type bit<32>
         a = !a;
              ^
-../testdata/p4_16_errors/typecheck1_e.p4(35): error: Could not find type of !
+typecheck1_e.p4(35): error: Could not find type of !
         a = !a;
             ^^
-../testdata/p4_16_errors/typecheck1_e.p4(36): error: Cannot apply ! to value b of type int<32>
+typecheck1_e.p4(36): error: Cannot apply ! to value b of type int<32>
         b = !b;
              ^
-../testdata/p4_16_errors/typecheck1_e.p4(36): error: Could not find type of !
+typecheck1_e.p4(36): error: Could not find type of !
         b = !b;
             ^^

--- a/testdata/p4_16_errors_outputs/typecheck_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typecheck_e.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/typecheck_e.p4(21): error: f: Cannot unify T to int<32>
+typecheck_e.p4(21): error: f: Cannot unify T to int<32>
         f(x);
         ^^^^

--- a/testdata/p4_16_errors_outputs/underscore1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/underscore1_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/underscore1_e.p4(17):syntax error, unexpected _
+underscore1_e.p4(17):syntax error, unexpected _
     bit _
         ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/underscore2_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/underscore2_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/underscore2_e.p4(19):syntax error, unexpected _
+underscore2_e.p4(19):syntax error, unexpected _
         bit _
             ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/underscore3_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/underscore3_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/underscore3_e.p4(16):syntax error, unexpected _
+underscore3_e.p4(16):syntax error, unexpected _
 const bit _
           ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/underscore_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/underscore_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/underscore_e.p4(16):syntax error, unexpected _
+underscore_e.p4(16):syntax error, unexpected _
 extern void _
             ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/virtual1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual1.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/virtual1.p4(23): error: return: Cannot unify bit<16> to bool
+virtual1.p4(23): error: return: Cannot unify bit<16> to bool
             return (ix + 1);
             ^^^^^^
-../testdata/p4_16_errors/virtual1.p4(21): error: cntr: Cannot unify bool to bit<16>
+virtual1.p4(21): error: cntr: Cannot unify bool to bit<16>
     Virtual() cntr = {
               ^^^^

--- a/testdata/p4_16_errors_outputs/virtual2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual2.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/virtual2.p4(23): error: return: return expression in function with void return
+virtual2.p4(23): error: return: return expression in function with void return
             return (ix + 1);
             ^^^^^^
-../testdata/p4_16_errors/virtual2.p4(21): error: cntr: Cannot unify void to bit<16>
+virtual2.p4(21): error: cntr: Cannot unify void to bit<16>
     Virtual() cntr = {
               ^^^^

--- a/testdata/p4_16_errors_outputs/virtual3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual3.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/virtual3.p4(24): error: return: return with no expression in a function returning bit<16>
+virtual3.p4(24): error: return: return with no expression in a function returning bit<16>
             return;
             ^^^^^^

--- a/testdata/p4_16_errors_outputs/virtual4.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual4.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/virtual4.p4(22): error: g: no matching abstract method in Virtual
+virtual4.p4(22): error: g: no matching abstract method in Virtual
         bit<16> g(in bit<16> ix) {
         ^
-../testdata/p4_16_errors/virtual4.p4(16)
+virtual4.p4(16)
 extern Virtual {
        ^^^^^^^

--- a/testdata/p4_16_errors_outputs/virtual5.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual5.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/virtual5.p4(25): error: g: no matching abstract method in Virtual
+virtual5.p4(25): error: g: no matching abstract method in Virtual
         bit<16> g() { return 0; }
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_errors/virtual5.p4(16)
+virtual5.p4(16)
 extern Virtual {
        ^^^^^^^

--- a/testdata/p4_16_errors_outputs/virtual6.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual6.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_errors/virtual6.p4(22): error: cntr: g abstract method not implemented
+virtual6.p4(22): error: cntr: g abstract method not implemented
     Virtual() cntr = {
               ^^^^
-../testdata/p4_16_errors/virtual6.p4(18)
+virtual6.p4(18)
     abstract bit<16> g();
                      ^

--- a/testdata/p4_16_errors_outputs/width1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/width1_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/width1_e.p4(17):syntax error, unexpected (, expecting INTEGER
+width1_e.p4(17):syntax error, unexpected (, expecting INTEGER
 const int<(
           ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/width_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/width_e.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_errors/width_e.p4(16): error: 12301923123132: Value too large
+width_e.p4(16): error: 12301923123132: Value too large
 const bit<12301923123132>
           ^^^^^^^^^^^^^^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/wrong-cast.p4-stderr
+++ b/testdata/p4_16_errors_outputs/wrong-cast.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_errors/wrong-cast.p4(1): error: cast: Only 0 and 1 can be cast to booleans
+wrong-cast.p4(1): error: cast: Only 0 and 1 can be cast to booleans
 const bool b = (bool)3;
                ^^^^^^^
-../testdata/p4_16_errors/wrong-cast.p4(2): error: cast: Cannot cast signed value to boolean
+wrong-cast.p4(2): error: cast: Cannot cast signed value to boolean
 const bool c = (bool)2s0;
                ^^^^^^^^^
-../testdata/p4_16_errors/wrong-cast.p4(3): error: cast: Only bit<1> values can be cast to bool
+wrong-cast.p4(3): error: cast: Only bit<1> values can be cast to bool
 const bool d = (bool)10w0;
                ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_samples/action_selector_unused-bmv2.p4(20): warning: as: unused instance
+action_selector_unused-bmv2.p4(20): warning: as: unused instance
     action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
                                                              ^^

--- a/testdata/p4_16_samples_outputs/bfd_offload.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bfd_offload.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_samples/bfd_offload.p4(29): warning: bfd_session_liveness_tracker: unused instance
+bfd_offload.p4(29): warning: bfd_session_liveness_tracker: unused instance
 BFD_Offload(32768) bfd_session_liveness_tracker = {
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/cases-first.p4
+++ b/testdata/p4_16_samples_outputs/cases-first.p4
@@ -15,7 +15,7 @@ control ctrl() {
     }
     apply {
         switch (t.apply().action_run) {
-            a:
+            a: 
             b: {
                 return;
             }
@@ -23,3 +23,4 @@ control ctrl() {
 
     }
 }
+

--- a/testdata/p4_16_samples_outputs/cases.p4
+++ b/testdata/p4_16_samples_outputs/cases.p4
@@ -15,12 +15,13 @@ control ctrl() {
     }
     apply {
         switch (t.apply().action_run) {
-            a:
+            a: 
             b: {
                 return;
             }
-            c:
+            c: 
         }
 
     }
 }
+

--- a/testdata/p4_16_samples_outputs/cases.p4-stderr
+++ b/testdata/p4_16_samples_outputs/cases.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_samples/cases.p4(31): warning: SwitchCase: fallthrough with no statement
+cases.p4(31): warning: SwitchCase: fallthrough with no statement
             c:
             ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/chain1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/chain1.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_samples/chain1.p4(26): warning: x may be uninitialized
+chain1.p4(26): warning: x may be uninitialized
         transition select (x) {
                            ^

--- a/testdata/p4_16_samples_outputs/const.p4-stderr
+++ b/testdata/p4_16_samples_outputs/const.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_samples/const.p4(19): warning: 48057234611961600: value does not fit in 48 bits
+const.p4(19): warning: 48057234611961600: value does not fit in 48 bits
 const bit<48> tooLarge = 48w0xAA_BB_CC_DD_EE_FF_00
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/constant_folding.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constant_folding.p4-stderr
@@ -1,15 +1,15 @@
-../testdata/p4_16_samples/constant_folding.p4(95): warning: <<: Shifting 8-bit value with 9
+constant_folding.p4(95): warning: <<: Shifting 8-bit value with 9
         z = 8w1 << 9;
             ^^^^^^^^
-../testdata/p4_16_samples/constant_folding.p4(95): warning: 512: value does not fit in 8 bits
+constant_folding.p4(95): warning: 512: value does not fit in 8 bits
         z = 8w1 << 9;
             ^^^^^^^^
-../testdata/p4_16_samples/constant_folding.p4(88): warning: 256: value does not fit in 8 bits
+constant_folding.p4(88): warning: 256: value does not fit in 8 bits
         z = 128 + 128;
             ^^^^^^^^^
-../testdata/p4_16_samples/constant_folding.p4(91): warning: -128: negative value with unsigned type
+constant_folding.p4(91): warning: -128: negative value with unsigned type
         z = 0 - 128;
             ^^^^^^^
-../testdata/p4_16_samples/constant_folding.p4(94): warning: 512: value does not fit in 8 bits
+constant_folding.p4(94): warning: 512: value does not fit in 8 bits
         z = 1 << 9;
             ^^^^^^

--- a/testdata/p4_16_samples_outputs/constsigned.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constsigned.p4-stderr
@@ -1,46 +1,46 @@
-../testdata/p4_16_samples/constsigned.p4(37): warning: 128: signed value does not fit in 8 bits
+constsigned.p4(37): warning: 128: signed value does not fit in 8 bits
 const int<8> e0 = -8s128
                    ^^^^^
-../testdata/p4_16_samples/constsigned.p4(38): warning: 129: signed value does not fit in 8 bits
+constsigned.p4(38): warning: 129: signed value does not fit in 8 bits
 const int<8> f0 = -8s129
                    ^^^^^
-../testdata/p4_16_samples/constsigned.p4(39): warning: 255: signed value does not fit in 8 bits
+constsigned.p4(39): warning: 255: signed value does not fit in 8 bits
 const int<8> g0 = -8s255
                    ^^^^^
-../testdata/p4_16_samples/constsigned.p4(40): warning: 256: signed value does not fit in 8 bits
+constsigned.p4(40): warning: 256: signed value does not fit in 8 bits
 const int<8> h0 = -8s256
                    ^^^^^
-../testdata/p4_16_samples/constsigned.p4(44): warning: 128: signed value does not fit in 8 bits
+constsigned.p4(44): warning: 128: signed value does not fit in 8 bits
 const int<8> l0 = 8s128
                   ^^^^^
-../testdata/p4_16_samples/constsigned.p4(45): warning: 129: signed value does not fit in 8 bits
+constsigned.p4(45): warning: 129: signed value does not fit in 8 bits
 const int<8> m0 = 8s129
                   ^^^^^
-../testdata/p4_16_samples/constsigned.p4(46): warning: 255: signed value does not fit in 8 bits
+constsigned.p4(46): warning: 255: signed value does not fit in 8 bits
 const int<8> n0 = 8s255
                   ^^^^^
-../testdata/p4_16_samples/constsigned.p4(47): warning: 256: signed value does not fit in 8 bits
+constsigned.p4(47): warning: 256: signed value does not fit in 8 bits
 const int<8> o0 = 8s256
                   ^^^^^
-../testdata/p4_16_samples/constsigned.p4(22): warning: -129: signed value does not fit in 8 bits
+constsigned.p4(22): warning: -129: signed value does not fit in 8 bits
 const int<8> f = -129;
                   ^^^
-../testdata/p4_16_samples/constsigned.p4(23): warning: -255: signed value does not fit in 8 bits
+constsigned.p4(23): warning: -255: signed value does not fit in 8 bits
 const int<8> g = -255;
                   ^^^
-../testdata/p4_16_samples/constsigned.p4(24): warning: -256: signed value does not fit in 8 bits
+constsigned.p4(24): warning: -256: signed value does not fit in 8 bits
 const int<8> h = -256;
                   ^^^
-../testdata/p4_16_samples/constsigned.p4(28): warning: 128: signed value does not fit in 8 bits
+constsigned.p4(28): warning: 128: signed value does not fit in 8 bits
 const int<8> l = 128;
                  ^^^
-../testdata/p4_16_samples/constsigned.p4(29): warning: 129: signed value does not fit in 8 bits
+constsigned.p4(29): warning: 129: signed value does not fit in 8 bits
 const int<8> m = 129;
                  ^^^
-../testdata/p4_16_samples/constsigned.p4(30): warning: 255: signed value does not fit in 8 bits
+constsigned.p4(30): warning: 255: signed value does not fit in 8 bits
 const int<8> n = 255;
                  ^^^
-../testdata/p4_16_samples/constsigned.p4(31): warning: 256: signed value does not fit in 8 bits
+constsigned.p4(31): warning: 256: signed value does not fit in 8 bits
 const int<8> o = 256;
                  ^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/decl.p4-stderr
+++ b/testdata/p4_16_samples_outputs/decl.p4-stderr
@@ -1,13 +1,13 @@
-../testdata/p4_16_samples/decl.p4(33): warning: y shadows y
+decl.p4(33): warning: y shadows y
                 bit y;
                 ^^^^^^
-../testdata/p4_16_samples/decl.p4(30)
+decl.p4(30)
             bit y;
             ^^^^^^
-../testdata/p4_16_samples/decl.p4(37): warning: y shadows y
+decl.p4(37): warning: y shadows y
                     bit y;
                     ^^^^^^
-../testdata/p4_16_samples/decl.p4(33)
+decl.p4(33)
                 bit y;
                 ^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/default2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/default2.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_samples/default2.p4(28): warning: SelectCase: unreachable
+default2.p4(28): warning: SelectCase: unreachable
             default: reject;
             ^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/default2.p4(26): warning: ListExpression: transition does not depend on select argument
+default2.p4(26): warning: ListExpression: transition does not depend on select argument
         transition select(h.data) {
                           ^^^^^^

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_samples/drop-bmv2.p4(27): warning: out parameter smeta may be uninitialized when drop terminates
+drop-bmv2.p4(27): warning: out parameter smeta may be uninitialized when drop terminates
 action drop(out standard_metadata_t smeta) { smeta.drop = 1; } // this global action seems to cause the problem
                                     ^^^^^
-../testdata/p4_16_samples/drop-bmv2.p4(27)
+drop-bmv2.p4(27)
 action drop(out standard_metadata_t smeta) { smeta.drop = 1; } // this global action seems to cause the problem
        ^^^^

--- a/testdata/p4_16_samples_outputs/fold_match.p4-stderr
+++ b/testdata/p4_16_samples_outputs/fold_match.p4-stderr
@@ -1,49 +1,49 @@
-../testdata/p4_16_samples/fold_match.p4(25): warning: SelectCase: unreachable case
+fold_match.p4(25): warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(35): warning: SelectCase: unreachable case
+fold_match.p4(35): warning: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(44): warning: SelectCase: unreachable case
+fold_match.p4(44): warning: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(45): warning: SelectCase: unreachable case
+fold_match.p4(45): warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(54): warning: SelectCase: unreachable case
+fold_match.p4(54): warning: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(55): warning: SelectCase: unreachable case
+fold_match.p4(55): warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(64): warning: SelectCase: unreachable case
+fold_match.p4(64): warning: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(65): warning: SelectCase: unreachable case
+fold_match.p4(65): warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(75): warning: SelectCase: unreachable case
+fold_match.p4(75): warning: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(84): warning: SelectCase: unreachable case
+fold_match.p4(84): warning: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(85): warning: SelectCase: unreachable case
+fold_match.p4(85): warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(94): warning: SelectCase: unreachable case
+fold_match.p4(94): warning: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(95): warning: SelectCase: unreachable case
+fold_match.p4(95): warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(104): warning: SelectCase: unreachable case
+fold_match.p4(104): warning: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(105): warning: SelectCase: unreachable case
+fold_match.p4(105): warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/fold_match.p4(111): warning: SelectExpression: no case matches
+fold_match.p4(111): warning: SelectExpression: no case matches
         transition select(32w0)
                    ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/functors-first.p4
+++ b/testdata/p4_16_samples_outputs/functors-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p()(bit<1> b, bit<1> c) {
     state start {
         bit<1> z = b & c;

--- a/testdata/p4_16_samples_outputs/functors1-first.p4
+++ b/testdata/p4_16_samples_outputs/functors1-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p00() {
     state start {
         bit<1> z = 1w0;

--- a/testdata/p4_16_samples_outputs/functors2-first.p4
+++ b/testdata/p4_16_samples_outputs/functors2-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1(out bit<2> z1)(bit<2> a) {
     state start {
         z1 = a;

--- a/testdata/p4_16_samples_outputs/functors3-first.p4
+++ b/testdata/p4_16_samples_outputs/functors3-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1(out bit<1> z1)(bit<1> b1) {
     state start {
         z1 = b1;

--- a/testdata/p4_16_samples_outputs/functors4-first.p4
+++ b/testdata/p4_16_samples_outputs/functors4-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1(out bit<1> z1)(bit<1> b1) {
     state start {
         z1 = b1;

--- a/testdata/p4_16_samples_outputs/functors5-first.p4
+++ b/testdata/p4_16_samples_outputs/functors5-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1(out bit<2> w)(bit<2> a) {
     state start {
         w = 2w2;

--- a/testdata/p4_16_samples_outputs/functors6-first.p4
+++ b/testdata/p4_16_samples_outputs/functors6-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1<T>(in T a) {
     state start {
         T w = a;

--- a/testdata/p4_16_samples_outputs/functors7-first.p4
+++ b/testdata/p4_16_samples_outputs/functors7-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser p1<T>(in T a) {
     state start {
         T w = a;

--- a/testdata/p4_16_samples_outputs/functors8-first.p4
+++ b/testdata/p4_16_samples_outputs/functors8-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 extern e<T> {
     e();
     T get();

--- a/testdata/p4_16_samples_outputs/functors9-first.p4
+++ b/testdata/p4_16_samples_outputs/functors9-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 extern e<T> {
     e();
     T get();

--- a/testdata/p4_16_samples_outputs/highorder-first.p4
+++ b/testdata/p4_16_samples_outputs/highorder-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser parse<H>(out H headers);
 package ebpfFilter<H>(parse<H> prs);
 struct Headers_t {

--- a/testdata/p4_16_samples_outputs/inline-switch.p4-stderr
+++ b/testdata/p4_16_samples_outputs/inline-switch.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_samples/inline-switch.p4(17): warning: out parameter x may be uninitialized when c terminates
+inline-switch.p4(17): warning: out parameter x may be uninitialized when c terminates
 control c(out bit<32> x) {
                       ^
-../testdata/p4_16_samples/inline-switch.p4(17)
+inline-switch.p4(17)
 control c(out bit<32> x) {
         ^

--- a/testdata/p4_16_samples_outputs/inline.p4-stderr
+++ b/testdata/p4_16_samples_outputs/inline.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_samples/inline.p4(25): warning: y shadows y
+inline.p4(25): warning: y shadows y
     action b(in bit x, out bit y)
                                ^
-../testdata/p4_16_samples/inline.p4(17)
+inline.p4(17)
 control p(out bit y)
                   ^

--- a/testdata/p4_16_samples_outputs/interface.p4-stderr
+++ b/testdata/p4_16_samples_outputs/interface.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_samples/interface.p4(31): warning: crc0: unused instance
+interface.p4(31): warning: crc0: unused instance
     Crc16<bit<32>>() crc0;
                      ^^^^
-../testdata/p4_16_samples/interface.p4(32): warning: crc1: unused instance
+interface.p4(32): warning: crc1: unused instance
     Crc16<int<32>>(32s0) crc1;
                          ^^^^
-../testdata/p4_16_samples/interface.p4(33): warning: crc2: unused instance
+interface.p4(33): warning: crc2: unused instance
     Crc16<int<32>>() crc2;
                      ^^^^

--- a/testdata/p4_16_samples_outputs/interface1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/interface1.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_samples/interface1.p4(24): warning: x: unused instance
+interface1.p4(24): warning: x: unused instance
     X<int<32>>() x;
                  ^
-../testdata/p4_16_samples/interface1.p4(25): warning: y: unused instance
+interface1.p4(25): warning: y: unused instance
     Y() y;
         ^

--- a/testdata/p4_16_samples_outputs/interface2-first.p4
+++ b/testdata/p4_16_samples_outputs/interface2-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 extern X {
     X();
 }

--- a/testdata/p4_16_samples_outputs/issue313_2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue313_2-frontend.p4
@@ -1,5 +1,3 @@
-#include <core.p4>
-
 header header_h {
     bit<8> field;
 }

--- a/testdata/p4_16_samples_outputs/issue313_2.p4
+++ b/testdata/p4_16_samples_outputs/issue313_2.p4
@@ -1,5 +1,3 @@
-#include <core.p4>
-
 header header_h {
     bit<8> field;
 }

--- a/testdata/p4_16_samples_outputs/issue414-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_samples/issue414-bmv2.p4(64): warning: cbar_inst2: unused instance
+issue414-bmv2.p4(64): warning: cbar_inst2: unused instance
     cBar() cbar_inst2;
            ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue561.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue561.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_samples/issue561.p4(35): warning: u.h1.f may be uninitialized
+issue561.p4(35): warning: u.h1.f may be uninitialized
         x = u.h1.f + u.h2.g;
             ^^^^^^
-../testdata/p4_16_samples/issue561.p4(35): warning: u.h2.g may be uninitialized
+issue561.p4(35): warning: u.h2.g may be uninitialized
         x = u.h1.f + u.h2.g;
                      ^^^^^^
-../testdata/p4_16_samples/issue561.p4(45): warning: [].h2.g may be uninitialized
+issue561.p4(45): warning: [].h2.g may be uninitialized
         x = x + u2[1].h2.g + u2[0].h1.f;
                 ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/large.p4-stderr
+++ b/testdata/p4_16_samples_outputs/large.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_samples/large.p4(17): warning: 103929005307130220006098923584552504982110632080: value does not fit in 128 bits
+large.p4(17): warning: 103929005307130220006098923584552504982110632080: value does not fit in 128 bits
 const bit<128> large = 0x1234567890123456789012345678901234567890;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/module.p4-stderr
+++ b/testdata/p4_16_samples_outputs/module.p4-stderr
@@ -1,22 +1,22 @@
-../testdata/p4_16_samples/module.p4(38): warning: main1: unused instance
+module.p4(38): warning: main1: unused instance
 switch0(f()) main1;
              ^^^^^
-../testdata/p4_16_samples/module.p4(39): warning: main3: unused instance
+module.p4(39): warning: main3: unused instance
 switch1<bool>(f()) main3;
                    ^^^^^
-../testdata/p4_16_samples/module.p4(40): warning: main4: unused instance
+module.p4(40): warning: main4: unused instance
 switch2(f()) main4;
              ^^^^^
-../testdata/p4_16_samples/module.p4(41): warning: main5: unused instance
+module.p4(41): warning: main5: unused instance
 switch3(f2()) main5;
               ^^^^^
-../testdata/p4_16_samples/module.p4(42): warning: main6: unused instance
+module.p4(42): warning: main6: unused instance
 switch4<bool>(f2()) main6;
                     ^^^^^
-../testdata/p4_16_samples/module.p4(43): warning: main2: unused instance
+module.p4(43): warning: main2: unused instance
 switch1(f()) main2;
              ^^^^^
-../testdata/p4_16_samples/module.p4(44): warning: main7: unused instance
+module.p4(44): warning: main7: unused instance
 switch4(f2()) main7;
               ^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/nested-tuple.p4-stderr
+++ b/testdata/p4_16_samples_outputs/nested-tuple.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_samples/nested-tuple.p4(25): warning: T shadows struct T
+nested-tuple.p4(25): warning: T shadows struct T
 extern void f<T>(in T data);
               ^
-../testdata/p4_16_samples/nested-tuple.p4(17)
+nested-tuple.p4(17)
 struct T { bit f; }
        ^

--- a/testdata/p4_16_samples_outputs/noMatch.p4-stderr
+++ b/testdata/p4_16_samples_outputs/noMatch.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_samples/noMatch.p4(20): warning: accept state in parser p is unreachable
+noMatch.p4(20): warning: accept state in parser p is unreachable
 parser p() {
        ^
-../testdata/p4_16_samples/noMatch.p4(23): warning: x may be uninitialized
+noMatch.p4(23): warning: x may be uninitialized
         transition select(x) {
                           ^
-../testdata/p4_16_samples/noMatch.p4(20): warning: accept state in parser p is unreachable
+noMatch.p4(20): warning: accept state in parser p is unreachable
 parser p() {
        ^

--- a/testdata/p4_16_samples_outputs/parser-locals-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-locals-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 header H {
     bit<32> a;
     bit<32> b;

--- a/testdata/p4_16_samples_outputs/pred2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pred2.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_samples/pred2.p4(29): warning: tmp_1 may be uninitialized
+pred2.p4(29): warning: tmp_1 may be uninitialized
         tmp_1 = (!true && !true ? false : tmp_1);
                                           ^^^^^
-../testdata/p4_16_samples/pred2.p4(30): warning: tmp_2 may be uninitialized
+pred2.p4(30): warning: tmp_2 may be uninitialized
         tmp_2 = (!true && !!true ? a == 32w5 : tmp_2);
                                                ^^^^^

--- a/testdata/p4_16_samples_outputs/reject-first.p4
+++ b/testdata/p4_16_samples_outputs/reject-first.p4
@@ -1,3 +1,5 @@
+#include <core.p4>
+
 parser f() {
     state start {
         transition reject;

--- a/testdata/p4_16_samples_outputs/reject.p4-stderr
+++ b/testdata/p4_16_samples_outputs/reject.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_samples/reject.p4(20): warning: start: implicit transition to `reject'
+reject.p4(20): warning: start: implicit transition to `reject'
     state start {
           ^^^^^
-../testdata/p4_16_samples/reject.p4(19): warning: accept state in parser f is unreachable
+reject.p4(19): warning: accept state in parser f is unreachable
 parser f() {
        ^
-../testdata/p4_16_samples/reject.p4(19): warning: accept state in parser f is unreachable
+reject.p4(19): warning: accept state in parser f is unreachable
 parser f() {
        ^

--- a/testdata/p4_16_samples_outputs/shadow.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow.p4-stderr
@@ -1,7 +1,7 @@
-../testdata/p4_16_samples/shadow.p4(22): warning: x shadows x
+shadow.p4(22): warning: x shadows x
             bit x;
             ^^^^^^
-../testdata/p4_16_samples/shadow.p4(20)
+shadow.p4(20)
         bit x;
         ^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/shadow1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow1.p4-stderr
@@ -1,7 +1,7 @@
-../testdata/p4_16_samples/shadow1.p4(20): warning: counter shadows counter
+shadow1.p4(20): warning: counter shadows counter
   bit<16> counter;
   ^^^^^^^^^^^^^^^^
-../testdata/p4_16_samples/shadow1.p4(17)
+shadow1.p4(17)
 extern counter {}
        ^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/shadow3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow3.p4-stderr
@@ -1,7 +1,7 @@
-../testdata/p4_16_samples/shadow3.p4(20): warning: p shadows p
+shadow3.p4(20): warning: p shadows p
   bit<8> p = 0;
   ^^^^^^^^^^^^^
-../testdata/p4_16_samples/shadow3.p4(19)
+shadow3.p4(19)
 control MyIngress(inout H p) {
                           ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/side_effects.p4-stderr
+++ b/testdata/p4_16_samples_outputs/side_effects.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_samples/side_effects.p4(31): warning: [].z may be uninitialized
+side_effects.p4(31): warning: [].z may be uninitialized
         a = f(s[a].z, g(a));
               ^^^^^^

--- a/testdata/p4_16_samples_outputs/spec-ex04.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex04.p4-stderr
@@ -1,4 +1,4 @@
-../testdata/p4_16_samples/spec-ex04.p4(24): warning: 170: signed value does not fit in 8 bits
+spec-ex04.p4(24): warning: 170: signed value does not fit in 8 bits
 const int<8> b8 = 8s0b1010_1010
                   ^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex16.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex16.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_samples/spec-ex16.p4(32): warning: main1: unused instance
+spec-ex16.p4(32): warning: main1: unused instance
                 Map1()) main1;
                         ^^^^^
-../testdata/p4_16_samples/spec-ex16.p4(24): warning: out parameter d may be uninitialized when P terminates
+spec-ex16.p4(24): warning: out parameter d may be uninitialized when P terminates
 parser P(packet_in b, out bit<32> d) { state start { transition accept; } }
                                   ^
-../testdata/p4_16_samples/spec-ex16.p4(24)
+spec-ex16.p4(24)
 parser P(packet_in b, out bit<32> d) { state start { transition accept; } }
        ^

--- a/testdata/p4_16_samples_outputs/strength.p4-stderr
+++ b/testdata/p4_16_samples_outputs/strength.p4-stderr
@@ -1,7 +1,7 @@
-../testdata/p4_16_samples/strength.p4(50): warning: 15: signed value does not fit in 4 bits
+strength.p4(50): warning: 15: signed value does not fit in 4 bits
         w = w - 4s0xF
                 ^^^^^
-../testdata/p4_16_samples/strength.p4(38): warning: 16: value does not fit in 4 bits
+strength.p4(38): warning: 16: value does not fit in 4 bits
         y = y * 16;
                 ^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/two_ebpf.p4-stderr
+++ b/testdata/p4_16_samples_outputs/two_ebpf.p4-stderr
@@ -1,6 +1,6 @@
-../testdata/p4_16_samples/two_ebpf.p4(42): warning: out parameter pass may be uninitialized when Check terminates
+two_ebpf.p4(42): warning: out parameter pass may be uninitialized when Check terminates
 control Check(in IPv4Address address, out bool pass) {
                                                ^^^^
-../testdata/p4_16_samples/two_ebpf.p4(42)
+two_ebpf.p4(42)
 control Check(in IPv4Address address, out bool pass) {
         ^^^^^

--- a/testdata/p4_16_samples_outputs/type-shadow.p4-stderr
+++ b/testdata/p4_16_samples_outputs/type-shadow.p4-stderr
@@ -1,7 +1,7 @@
-../testdata/p4_16_samples/type-shadow.p4(18): warning: D shadows D
+type-shadow.p4(18): warning: D shadows D
    void f<D>(in D d); // D shadows D
           ^
-../testdata/p4_16_samples/type-shadow.p4(16)
+type-shadow.p4(16)
 extern X<D>
          ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/uninit.p4-stderr
+++ b/testdata/p4_16_samples_outputs/uninit.p4-stderr
@@ -1,39 +1,39 @@
-../testdata/p4_16_samples/uninit.p4(35): warning: h may not be completely initialized
+uninit.p4(35): warning: h may not be completely initialized
         func(h); // uninitialized
              ^
-../testdata/p4_16_samples/uninit.p4(36): warning: h.data2 may be uninitialized
+uninit.p4(36): warning: h.data2 may be uninitialized
         g(h.data2, g(h.data2, h.data2)); // uninitialized
           ^^^^^^^
-../testdata/p4_16_samples/uninit.p4(36): warning: h.data2 may be uninitialized
+uninit.p4(36): warning: h.data2 may be uninitialized
         g(h.data2, g(h.data2, h.data2)); // uninitialized
                      ^^^^^^^
-../testdata/p4_16_samples/uninit.p4(36): warning: h.data2 may be uninitialized
+uninit.p4(36): warning: h.data2 may be uninitialized
         g(h.data2, g(h.data2, h.data2)); // uninitialized
                               ^^^^^^^
-../testdata/p4_16_samples/uninit.p4(41): warning: h.data3 may be uninitialized
+uninit.p4(41): warning: h.data3 may be uninitialized
         h.data2 = h.data3 + 1; // uninitialized
                   ^^^^^^^
-../testdata/p4_16_samples/uninit.p4(42): warning: [] may not be completely initialized
+uninit.p4(42): warning: [] may not be completely initialized
         stack[0] = stack[1]; // uninitialized
                    ^^^^^^^^
-../testdata/p4_16_samples/uninit.p4(62): warning: c may be uninitialized
+uninit.p4(62): warning: c may be uninitialized
         c = !c; // uninitialized;
              ^
-../testdata/p4_16_samples/uninit.p4(82): warning: b may be uninitialized
+uninit.p4(82): warning: b may be uninitialized
         b = b + 1; // uninitialized
             ^
-../testdata/p4_16_samples/uninit.p4(86): warning: e may be uninitialized
+uninit.p4(86): warning: e may be uninitialized
         if (e > 0) { // uninitialized
             ^
-../testdata/p4_16_samples/uninit.p4(92): warning: e may be uninitialized
+uninit.p4(92): warning: e may be uninitialized
         e = e + 1; // uninitialized
             ^
-../testdata/p4_16_samples/uninit.p4(97): warning: touched may be uninitialized
+uninit.p4(97): warning: touched may be uninitialized
         touched = !touched; // uninitialized
                    ^^^^^^^
-../testdata/p4_16_samples/uninit.p4(68): warning: out parameter v may be uninitialized when c terminates
+uninit.p4(68): warning: out parameter v may be uninitialized when c terminates
 control c(out bit<32> v) { // uninitialized
                       ^
-../testdata/p4_16_samples/uninit.p4(68)
+uninit.p4(68)
 control c(out bit<32> v) { // uninitialized
         ^

--- a/testdata/p4_16_samples_outputs/unreachable-accept.p4-stderr
+++ b/testdata/p4_16_samples_outputs/unreachable-accept.p4-stderr
@@ -1,9 +1,9 @@
-../testdata/p4_16_samples/unreachable-accept.p4(31): warning: start: implicit transition to `reject'
+unreachable-accept.p4(31): warning: start: implicit transition to `reject'
     state start {
           ^^^^^
-../testdata/p4_16_samples/unreachable-accept.p4(30): warning: accept state in parser Parser is unreachable
+unreachable-accept.p4(30): warning: accept state in parser Parser is unreachable
 parser Parser(packet_in pkt_in, out headers_t hdr) {
        ^^^^^^
-../testdata/p4_16_samples/unreachable-accept.p4(30): warning: accept state in parser Parser is unreachable
+unreachable-accept.p4(30): warning: accept state in parser Parser is unreachable
 parser Parser(packet_in pkt_in, out headers_t hdr) {
        ^^^^^^

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_samples/unused-counter-bmv2.p4(51): warning: c1: unused instance
+unused-counter-bmv2.p4(51): warning: c1: unused instance
     direct_counter(CounterType.packets) c1;
                                         ^^

--- a/testdata/p4_16_samples_outputs/vss-example.p4-stderr
+++ b/testdata/p4_16_samples_outputs/vss-example.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_samples/vss-example.p4(159): warning: nextHop may be uninitialized
+vss-example.p4(159): warning: nextHop may be uninitialized
           key = { nextHop : exact; }
                   ^^^^^^^


### PR DESCRIPTION
This filters out the file name paths in the -stderr files generated when running p4test, so that there's no need to use diff -I options, it remains independent of how you configure (in a subdirectory or parallel directory or other) and details of whoever happened to create the expected outputs don't leak into the repo.