### PR TITLE
avoid crashing on null pointers

### DIFF
--- a/frontends/common/programMap.h
+++ b/frontends/common/programMap.h
@@ -34,9 +34,7 @@ class ProgramMap : public IHasDbPrint {
  public:
     // Check if map is up-to-date for the specified node; return true if it is
     bool checkMap(const IR::Node* node) const {
-        if (!node->is<IR::P4Program>() || program == nullptr)
-            return false;
-        if (node->to<IR::P4Program>() == program) {
+        if (node == program) {
             // program has not changed
             LOG2(mapKind << " is up-to-date");
             return true;
@@ -46,14 +44,14 @@ class ProgramMap : public IHasDbPrint {
         return false;
     }
     void validateMap(const IR::Node* node) const {
-        if (!node->is<IR::P4Program>() || program == nullptr)
+        if (node == nullptr || !node->is<IR::P4Program>() || program == nullptr)
             return;
-        if (program != node->to<IR::P4Program>())
+        if (program != node)
             BUG("Invalid map %1%: computed for %2%, used for %3%",
                 mapKind, dbp(program), dbp(node));
     }
     void updateMap(const IR::Node* node) {
-        if (!node->is<IR::P4Program>())
+        if (node == nullptr || !node->is<IR::P4Program>())
             return;
         program = node->to<IR::P4Program>();
         LOG2(mapKind << " updated to " << dbp(node));

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -195,9 +195,9 @@ const IR::ParameterList* TypeInference::canonicalizeParameters(const IR::Paramet
     auto vec = new IR::IndexedVector<IR::Parameter>();
     for (auto p : *params->getEnumerator()) {
         auto paramType = getType(p);
-        BUG_CHECK(!paramType->is<IR::Type_Type>(), "%1%: Unexpected parameter type", paramType);
         if (paramType == nullptr)
             return nullptr;
+        BUG_CHECK(!paramType->is<IR::Type_Type>(), "%1%: Unexpected parameter type", paramType);
         if (paramType != p->type) {
             p = new IR::Parameter(p->srcInfo, p->name, p->annotations, p->direction, paramType);
             changes = true;
@@ -1193,9 +1193,9 @@ const IR::Node* TypeInference::postorder(IR::Type_HeaderUnion *type) {
 const IR::Node* TypeInference::postorder(IR::Parameter* param) {
     if (done()) return param;
     const IR::Type* paramType = getTypeType(param->type);
-    BUG_CHECK(!paramType->is<IR::Type_Type>(), "%1%: unexpected type", paramType);
     if (paramType == nullptr)
         return param;
+    BUG_CHECK(!paramType->is<IR::Type_Type>(), "%1%: unexpected type", paramType);
 
     // The parameter type cannot have free type variables
     if (paramType->is<IR::IMayBeGenericType>()) {


### PR DESCRIPTION
Old bug revealed by new versions of gcc -- calling a non-virtual method on a nullptr that just calls dynamic_cast used to work fine, but it is technically undefined behavior.