### PR TITLE
Added contiguous function to bitvec

### DIFF
--- a/lib/bitvec.cpp
+++ b/lib/bitvec.cpp
@@ -140,9 +140,7 @@ unsigned bitvec::ffz(unsigned start) const {
 
 bool bitvec::is_contiguous() const {
     // Empty bitvec is not contiguous
-    if (popcount() == 0)
+    if (empty())
         return false;
-    if (max().index() - min().index() + 1 == popcount())
-        return true;
-    return false;
+    return max().index() - min().index() + 1 == popcount();
 }

--- a/lib/bitvec.cpp
+++ b/lib/bitvec.cpp
@@ -137,3 +137,12 @@ unsigned bitvec::ffz(unsigned start) const {
 #endif
     return rv;
 }
+
+bool bitvec::is_contiguous() const {
+    // Empty bitvec is not contiguous
+    if (popcount() == 0)
+        return false;
+    if (max().index() - min().index() + 1 == popcount())
+        return true;
+    return false;
+}

--- a/lib/bitvec.h
+++ b/lib/bitvec.h
@@ -395,6 +395,7 @@ class bitvec {
                 ++rv;
 #endif
         return rv; }
+    bool is_contiguous() const;
 
  private:
     void expand(size_t newsize) {


### PR DESCRIPTION
Just added a continuous function to bitvec.  I needed something in the Barefoot backend, but the function is useful for any bitvec.

Not optimized for speed, but is correct.  Could be optimized if that is a major concern for people.