### PR TITLE
Prepare the Dockerfile for running PD-based PTF tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ ENV P4C_DEPS automake \
              libtool \
              pkg-config \
              python-ipaddr \
+             python-pip \
+             python-setuptools \
              tcpdump
 ENV P4C_RUNTIME_DEPS cpp \
                      libboost-iostreams1.58.0 \
@@ -36,7 +38,8 @@ COPY . /p4c/
 WORKDIR /p4c/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $P4C_DEPS $P4C_RUNTIME_DEPS && \
-    ./bootstrap.sh && \
+    pip install tenjin && \
+    ./bootstrap.sh --enable-p4runtime-to-pd && \
     cd build && \
     make && \
     make install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ ENV P4C_DEPS automake \
              libtool \
              pkg-config \
              python-ipaddr \
-             python-scapy \
              tcpdump
 ENV P4C_RUNTIME_DEPS cpp \
                      libboost-iostreams1.58.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,12 @@ RUN apt-get update && \
     cd build && \
     make && \
     make install && \
-    (test "$IMAGE_TYPE" = "build" && \
-      apt-get purge -y $P4C_DEPS && \
-      apt-get autoremove --purge -y && \
-      rm -rf /p4c /var/cache/apt/* /var/lib/apt/lists/* && \
-      echo 'Build image ready') || \
-    (test "$IMAGE_TYPE" = "test" && \
-      echo 'Test image ready')
+    ( \
+      (test "$IMAGE_TYPE" = "build" && \
+        apt-get purge -y $P4C_DEPS && \
+        apt-get autoremove --purge -y && \
+        rm -rf /p4c /var/cache/apt/* /var/lib/apt/lists/* && \
+        echo 'Build image ready') || \
+      (test "$IMAGE_TYPE" = "test" && \
+        echo 'Test image ready') \
+    )


### PR DESCRIPTION
We need to make a few changes to the Dockerfile to run PD-based PTF tests.

We need to use scapy-vxlan instead of Ubuntu's scapy package - here we're relying on scapy-vxlan being present in the upstream third-party image. (see p4lang/third-party#11)

We also need `p4runtime-to-pd` available in the Docker image, so I've enabled it. That requires us to install the `tenjin` Python package.

Finally, I noticed while making these changes that the `||` in the `RUN` statement makes `docker build` succeed even if `bootstrap.sh` returns an error. Multistage builds will eliminate the need for these huge shell expressions, but it may take as long as two weeks for us to be able to use them, it's worth fixing the problem now.