### PR TITLE
Fix bug in LocalCopyPropagation pass in midend

### DIFF
--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -218,13 +218,15 @@ bool DoLocalCopyPropagation::equiv(const IR::Expression *left, const IR::Express
     auto l1 = left->to<IR::PathExpression>();
     auto r1 = right->to<IR::PathExpression>();
     if (l1 && r1) {
-        return l1->path->name == r1->path->name;
+        return l1->path->name == r1->path->name &&
+        l1->path->absolute == r1->path->absolute;
     }
-    // Compare references to arrays with indices
+    // Compare binary operations (array indices)
     auto l2 = left->to<IR::Operation_Binary>();
     auto r2 = right->to<IR::Operation_Binary>();
     if (l2 && r2) {
-        return equiv(l2->left, r2->left) && equiv(l2->right, r2->right);
+        return equiv(l2->left, r2->left) && equiv(l2->right, r2->right) &&
+        typeid(*l2) == typeid(*r2);
     }
     // Compare packet header/metadata fields
     auto l3 = left->to<IR::Member>();

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -249,21 +249,8 @@ bool DoLocalCopyPropagation::equiv(const IR::Expression *left, const IR::Express
         typeid(*ul) == typeid(*ur);
     }
     // Compare literals (strings, booleans and integers)
-    auto booll = left->to<IR::BoolLiteral>();
-    auto boolr = right->to<IR::BoolLiteral>();
-    if (booll && boolr) {
-        return booll->value == boolr->value;
-    }
-    auto strl = left->to<IR::StringLiteral>();
-    auto strr = right->to<IR::StringLiteral>();
-    if (strl && strr) {
-        return strl->value == strr->value;
-    }
-    auto constl = left->to<IR::Constant>();
-    auto constr = right->to<IR::Constant>();
-    if (constl && constr) {
-        return constl->base == constr->base && constl->value == constr->value;
-    }
+    if (*left == *right)
+      return true;
     return false;
 }
 

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -70,6 +70,7 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
     const IR::Expression *postorder(IR::PathExpression *) override;
     IR::AssignmentStatement *preorder(IR::AssignmentStatement *) override;
     IR::AssignmentStatement *postorder(IR::AssignmentStatement *) override;
+    IR::IfStatement *postorder(IR::IfStatement *) override;
     IR::MethodCallExpression *postorder(IR::MethodCallExpression *) override;
     IR::P4Action *preorder(IR::P4Action *) override;
     IR::P4Action *postorder(IR::P4Action *) override;
@@ -80,6 +81,7 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
     void apply_function(FuncInfo *tbl);
     IR::P4Table *preorder(IR::P4Table *) override;
     IR::P4Table *postorder(IR::P4Table *) override;
+    bool equiv(const IR::Expression *left, const IR::Expression *right);
     class ElimDead;
     class RewriteTableKeys;
 

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-midend.p4
@@ -71,7 +71,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ipv4.ttl = my_param1;
     }
     @name(".action_1") action action_3(bit<8> my_param2) {
-        hdr.ipv4.totalLen = hdr.ipv4.totalLen;
     }
     @name("table_0") table table_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/hit_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/hit_ebpf-midend.p4
@@ -77,9 +77,6 @@ control pipe(inout Headers_t headers, out bool pass) {
     @hidden action act_2() {
         tmp_0 = false;
     }
-    @hidden action act_3() {
-        pass = pass;
-    }
     @hidden table tbl_act {
         actions = {
             act_0();
@@ -104,25 +101,16 @@ control pipe(inout Headers_t headers, out bool pass) {
         }
         const default_action = act_2();
     }
-    @hidden table tbl_act_3 {
-        actions = {
-            act_3();
-        }
-        const default_action = act_3();
-    }
     apply {
         tbl_act.apply();
         if (!headers.ipv4.isValid()) {
             tbl_act_0.apply();
         }
-        if (!hasReturned_0) {
+        if (!hasReturned_0) 
             if (Check_src_ip.apply().hit) 
                 tbl_act_1.apply();
             else 
                 tbl_act_2.apply();
-            if (tmp_0) 
-                tbl_act_3.apply();
-        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/pred2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pred2-midend.p4
@@ -6,7 +6,6 @@ package top(empty e);
 control Ing() {
     bool tmp_0;
     @name("cond") action cond() {
-        tmp_0 = tmp_0;
     }
     @name("tbl_cond") table tbl_cond {
         actions = {


### PR DESCRIPTION
Note: This PR is addressing the same bug as #716 with the required changes to code and the test outputs (I added other commits in that PR by mistake, so created a new one with only my commits).  

The LocalCopyPropagation pass in midend checks and removes assignment statements of the form:
`modify_field(metadata.port, metadata.port)`
However, these statements were not removed in practice because the check was comparing the IR nodes (which were different for the same variable), and thus, none of the no-op assignment statements were eliminated. This PR fixes that bug by adding an function to check equivalence of two IR::Expression objects for 1) Variables 2) Array references 3) Packet header/metadata fields (struct). 

This PR changes the testdata outputs because some of the sample programs have assignments of the form a=a which can be safely removed. 