### PR TITLE
Speed up the build by reducing the amount of headers we're including

### DIFF
--- a/backends/bmv2/synthesizeValidField.cpp
+++ b/backends/bmv2/synthesizeValidField.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
+#include "ir/visitor.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/synthesizeValidField.h
+++ b/backends/bmv2/synthesizeValidField.h
@@ -17,6 +17,7 @@ limitations under the License.
 #ifndef _BACKENDS_BMV2_SYNTHESIZEVALIDFIELD_H_
 #define _BACKENDS_BMV2_SYNTHESIZEVALIDFIELD_H_
 
+#include "ir/ir.h"
 #include "ir/pass_manager.h"
 
 namespace P4 {

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <fstream>
+#include <iostream>
+
 #include "ir/ir.h"
 #include "ir/json_loader.h"
 #include "lib/log.h"

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -19,7 +19,6 @@ limitations under the License.
 #ifndef FRONTENDS_COMMON_OPTIONS_H_
 #define FRONTENDS_COMMON_OPTIONS_H_
 
-#include <regex>
 #include "lib/cstring.h"
 #include "lib/options.h"
 #include "ir/ir.h"  // for DebugHook definition

--- a/ir/Makefile.am
+++ b/ir/Makefile.am
@@ -22,6 +22,7 @@ ir_UNIFIED = \
 	ir/dump.cpp \
 	ir/expression.cpp \
 	ir/ir.cpp \
+	ir/json_parser.cpp \
 	ir/node.cpp \
 	ir/pass_manager.cpp \
 	ir/type.cpp \

--- a/ir/ir-inline.h
+++ b/ir/ir-inline.h
@@ -17,49 +17,27 @@ limitations under the License.
 #ifndef _IR_IR_INLINE_H_
 #define _IR_IR_INLINE_H_
 
-#define DEFINE_APPLY_FUNCTIONS(CLASS, TEMPLATE, TT)                                             \
-    TEMPLATE inline bool IR::CLASS TT::apply_visitor_preorder(Modifier &v)                      \
+#define DEFINE_APPLY_FUNCTIONS(CLASS, TEMPLATE, TT, INLINE)                                     \
+    TEMPLATE INLINE bool IR::CLASS TT::apply_visitor_preorder(Modifier &v)                      \
     { Node::traceVisit("Mod pre"); return v.preorder(this); }                                   \
-    TEMPLATE inline void IR::CLASS TT::apply_visitor_postorder(Modifier &v)                     \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_postorder(Modifier &v)                     \
     { Node::traceVisit("Mod post"); v.postorder(this); }                                        \
-    TEMPLATE inline void IR::CLASS TT::apply_visitor_revisit(Modifier &v, const Node *n) const  \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Modifier &v, const Node *n) const  \
     { Node::traceVisit("Mod revisit"); v.revisit(this, n); }                                    \
-    TEMPLATE inline bool IR::CLASS TT::apply_visitor_preorder(Inspector &v) const               \
+    TEMPLATE INLINE bool IR::CLASS TT::apply_visitor_preorder(Inspector &v) const               \
     { Node::traceVisit("Insp pre"); return v.preorder(this); }                                  \
-    TEMPLATE inline void IR::CLASS TT::apply_visitor_postorder(Inspector &v) const              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_postorder(Inspector &v) const              \
     { Node::traceVisit("Insp post"); v.postorder(this); }                                       \
-    TEMPLATE inline void IR::CLASS TT::apply_visitor_revisit(Inspector &v) const                \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Inspector &v) const                \
     { Node::traceVisit("Insp revisit"); v.revisit(this); }                                      \
-    TEMPLATE inline const IR::Node *IR::CLASS TT::apply_visitor_preorder(Transform &v)          \
+    TEMPLATE INLINE const IR::Node *IR::CLASS TT::apply_visitor_preorder(Transform &v)          \
     { Node::traceVisit("Trans pre"); return v.preorder(this); }                                 \
-    TEMPLATE inline const IR::Node *IR::CLASS TT::apply_visitor_postorder(Transform &v)         \
+    TEMPLATE INLINE const IR::Node *IR::CLASS TT::apply_visitor_postorder(Transform &v)         \
     { Node::traceVisit("Trans post"); return v.postorder(this); }                               \
-    TEMPLATE inline void IR::CLASS TT::apply_visitor_revisit(Transform &v, const Node *n) const \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Transform &v, const Node *n) const \
     { Node::traceVisit("Trans revisit"); v.revisit(this, n); }
-    IRNODE_ALL_NON_TEMPLATE_CLASSES(DEFINE_APPLY_FUNCTIONS, , )
-    IRNODE_ALL_TEMPLATES(DEFINE_APPLY_FUNCTIONS)
-#undef DEFINE_APPLY_FUNCTIONS
 
-#define DEFINE_VISIT_FUNCTIONS(CLASS, BASE)                                             \
-    inline void Visitor::visit(const IR::CLASS *&n, const char *name) {                 \
-        auto t = apply_visitor(n, name);                                                \
-        n = dynamic_cast<const IR::CLASS *>(t);                                         \
-        if (t && !n)                                                                    \
-            BUG("visitor returned non-" #CLASS " type: %1%", t); }                      \
-    inline void Visitor::visit(const IR::CLASS *const &n, const char *name) {           \
-        /* This function needed solely due to order of declaration issues */            \
-        visit(static_cast<const IR::Node *const &>(n), name); }                         \
-    inline void Visitor::visit(const IR::CLASS *&n, const char *name, int cidx) {       \
-        ctxt->child_index = cidx;                                                       \
-        auto t = apply_visitor(n, name);                                                \
-        n = dynamic_cast<const IR::CLASS *>(t);                                         \
-        if (t && !n)                                                                    \
-            BUG("visitor returned non-" #CLASS " type: %1%", t); }                      \
-    inline void Visitor::visit(const IR::CLASS *const &n, const char *name, int cidx) { \
-        /* This function needed solely due to order of declaration issues */            \
-        visit(static_cast<const IR::Node *const &>(n), name, cidx); }
-    IRNODE_ALL_SUBCLASSES(DEFINE_VISIT_FUNCTIONS)
-#undef DEFINE_VISIT_FUNCTIONS
+IRNODE_ALL_TEMPLATES(DEFINE_APPLY_FUNCTIONS, inline)
 
 template<class T> void IR::Vector<T>::visit_children(Visitor &v) {
     for (auto i = vec.begin(); i != vec.end();) {
@@ -148,8 +126,6 @@ template<class T> void IR::Vector<T>::toJSON(JSONGenerator &json) const {
 }
 
 std::ostream &operator<<(std::ostream &out, const IR::Vector<IR::Expression> &v);
-inline std::ostream &operator<<(std::ostream &out, const IR::Vector<IR::Expression> *v) {
-    return v ? out << *v : out << "<null>"; }
 
 template<class T> void IR::IndexedVector<T>::visit_children(Visitor &v) {
     for (auto i = begin(); i != end();) {

--- a/ir/json_parser.cpp
+++ b/ir/json_parser.cpp
@@ -1,0 +1,158 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "ir/json_parser.h"
+
+#include <iostream>
+
+int JsonObject::get_id() const {
+    if (find("Node_ID") == end())
+        return -1;
+    else
+        return *(find("Node_ID")->second->to<JsonNumber>());
+}
+
+std::string JsonObject::get_type() const {
+    if (find("Node_Type") == end())
+        return "";
+    else
+        return *(dynamic_cast<JsonString*>(find("Node_Type")->second));
+}
+
+// Hack to make << operator work multi-threaded
+static thread_local int level = 0;
+
+std::string getIndent(int l) {
+    std::stringstream ss;
+    for (int i = 0; i < l*4; i++) ss << " ";
+    return ss.str();
+}
+
+std::ostream& operator<<(std::ostream &out, JsonData* json) {
+    if (dynamic_cast<JsonObject*>(json)) {
+        auto obj = dynamic_cast<ordered_map<std::string, JsonData*>*>(json);
+        out << "{";
+        if (obj->size() > 0) {
+            level++;
+            out << std::endl;
+            for (auto &e : *obj)
+                out << getIndent(level) << e.first << " : " << e.second << "," << std::endl;
+            out << getIndent(--level);
+        }
+        out << "}";
+    } else if (dynamic_cast<JsonVector*>(json)) {
+        std::vector<JsonData*>* vec = dynamic_cast<std::vector<JsonData*>*>(json);
+        out << "[";
+        if (vec->size() > 0) {
+            level++;
+            out << std::endl;
+            for (auto &e : *vec) {
+                out << getIndent(level) << e << "," << std::endl;
+            }
+            out << getIndent(--level);
+        }
+        out << "]";
+    } else if (dynamic_cast<JsonString*>(json)) {
+        JsonString* s = dynamic_cast<JsonString*>(json);
+        out << "\"" << s->c_str() << "\"";
+
+    } else if (dynamic_cast<JsonNumber*>(json)) {
+        JsonNumber* num = dynamic_cast<JsonNumber*>(json);
+        out << num->val;
+
+    } else if (dynamic_cast<JsonBoolean*>(json)) {
+        JsonBoolean *b = dynamic_cast<JsonBoolean*>(json);
+        out << (b->val ? "true" : "false");
+    } else if (dynamic_cast<JsonNull*>(json)) {
+        out << "null";
+    }
+    return out;
+}
+
+
+std::istream& operator>>(std::istream &in, JsonData*& json) {
+    while (in) {
+        char ch;
+        in >> ch;
+        switch (ch) {
+        case '{': {
+            ordered_map<std::string, JsonData*> obj;
+            do {
+                in >> std::ws >> ch;
+                if (ch == '}')
+                    break;
+                in.unget();
+
+                JsonData *key, *val;
+                in >> key >> std::ws >> ch >> std::ws >> val;
+                obj[*(dynamic_cast<std::string*>(key))] = val;
+
+                in >> std::ws >> ch;
+            } while (in && ch != '}');
+
+            json = new JsonObject(obj);
+            return in;
+        }
+        case '[': {
+            std::vector<JsonData*> vec;
+            do {
+                in >> std::ws >> ch;
+                if (ch == ']')
+                    break;
+                in.unget();
+
+                JsonData *elem;
+                in >> elem;
+                vec.push_back(elem);
+
+                in >> std::ws >> ch;
+            } while (in && ch != ']');
+
+            json = new JsonVector(vec);
+            return in;
+        }
+        case '"': {
+            std::string s;
+            getline(in, s, '"');
+            json = new JsonString(s);
+            return in;
+        }
+        case '-': case '0': case '1': case '2': case '3':
+        case '4': case '5': case '6': case '7': case '8': case '9': {
+            mpz_class num;
+            in.unget();
+            in >> num;
+            json = new JsonNumber(num);
+            return in;
+        }
+        case 't': case 'T':
+            in.ignore(3);
+            json = new JsonBoolean(true);
+            return in;
+        case 'f': case 'F':
+            in.ignore(4);
+            json = new JsonBoolean(false);
+            return in;
+        case 'n': case 'N':
+            in.ignore(3);
+            json = new JsonNull();
+            return in;
+        default:
+            return in;
+        }
+    }
+    return in;
+}

--- a/ir/json_parser.h
+++ b/ir/json_parser.h
@@ -1,15 +1,12 @@
 #ifndef IR_JSON_PARSER_H_
 #define IR_JSON_PARSER_H_
 
+#include <iosfwd>
 #include <vector>
-#include <map>
-#include <iostream>
-#include <fstream>
-#include <istream>
-#include <sstream>
 
-#include "../lib/ordered_map.h"
-#include "../lib/gmputil.h"
+#include "lib/cstring.h"
+#include "lib/gmputil.h"
+#include "lib/ordered_map.h"
 
 class JsonData {
  public:
@@ -63,146 +60,15 @@ class JsonObject : public JsonData, public ordered_map<std::string, JsonData*>  
     JsonObject &operator=(JsonObject&&) & = default;
     JsonObject(const ordered_map<std::string, JsonData*> & v)  // NOLINT(runtime/explicit)
     : ordered_map<std::string, JsonData*>(v) {}
-    int get_id() const {
-        if (find("Node_ID") == end())
-            return -1;
-        else
-            return *(find("Node_ID")->second->to<JsonNumber>());
-    }
-
-    std::string get_type() const {
-        if (find("Node_Type") == end())
-            return "";
-        else
-            return *(dynamic_cast<JsonString*>(find("Node_Type")->second));
-    }
+    int get_id() const;
+    std::string get_type() const;
 };
 
 class JsonNull : public JsonData {};
 
-// Hack to make << operator work multi-threaded
-static thread_local int level = 0;
+std::string getIndent(int l);
 
-inline std::string getIndent(int l) {
-    std::stringstream ss;
-    for (int i = 0; i < l*4; i++) ss << " ";
-    return ss.str();
-}
-
-inline std::ostream& operator<<(std::ostream &out, JsonData* json) {
-    if (dynamic_cast<JsonObject*>(json)) {
-        auto obj = dynamic_cast<ordered_map<std::string, JsonData*>*>(json);
-        out << "{";
-        if (obj->size() > 0) {
-            level++;
-            out << std::endl;
-            for (auto &e : *obj)
-                out << getIndent(level) << e.first << " : " << e.second << "," << std::endl;
-            out << getIndent(--level);
-        }
-        out << "}";
-    } else if (dynamic_cast<JsonVector*>(json)) {
-        std::vector<JsonData*>* vec = dynamic_cast<std::vector<JsonData*>*>(json);
-        out << "[";
-        if (vec->size() > 0) {
-            level++;
-            out << std::endl;
-            for (auto &e : *vec) {
-                out << getIndent(level) << e << "," << std::endl;
-            }
-            out << getIndent(--level);
-        }
-        out << "]";
-    } else if (dynamic_cast<JsonString*>(json)) {
-        JsonString* s = dynamic_cast<JsonString*>(json);
-        out << "\"" << s->c_str() << "\"";
-
-    } else if (dynamic_cast<JsonNumber*>(json)) {
-        JsonNumber* num = dynamic_cast<JsonNumber*>(json);
-        out << num->val;
-
-    } else if (dynamic_cast<JsonBoolean*>(json)) {
-        JsonBoolean *b = dynamic_cast<JsonBoolean*>(json);
-        out << (b->val ? "true" : "false");
-    } else if (dynamic_cast<JsonNull*>(json)) {
-        out << "null";
-    }
-    return out;
-}
-
-
-inline std::istream& operator>>(std::istream &in, JsonData*& json) {
-    while (in) {
-        char ch;
-        in >> ch;
-        switch (ch) {
-        case '{': {
-            ordered_map<std::string, JsonData*> obj;
-            do {
-                in >> std::ws >> ch;
-                if (ch == '}')
-                    break;
-                in.unget();
-
-                JsonData *key, *val;
-                in >> key >> std::ws >> ch >> std::ws >> val;
-                obj[*(dynamic_cast<std::string*>(key))] = val;
-
-                in >> std::ws >> ch;
-            } while (in && ch != '}');
-
-            json = new JsonObject(obj);
-            return in;
-        }
-        case '[': {
-            std::vector<JsonData*> vec;
-            do {
-                in >> std::ws >> ch;
-                if (ch == ']')
-                    break;
-                in.unget();
-
-                JsonData *elem;
-                in >> elem;
-                vec.push_back(elem);
-
-                in >> std::ws >> ch;
-            } while (in && ch != ']');
-
-            json = new JsonVector(vec);
-            return in;
-        }
-        case '"': {
-            std::string s;
-            getline(in, s, '"');
-            json = new JsonString(s);
-            return in;
-        }
-        case '-': case '0': case '1': case '2': case '3':
-        case '4': case '5': case '6': case '7': case '8': case '9': {
-            mpz_class num;
-            in.unget();
-            in >> num;
-            json = new JsonNumber(num);
-            return in;
-        }
-        case 't': case 'T':
-            in.ignore(3);
-            json = new JsonBoolean(true);
-            return in;
-        case 'f': case 'F':
-            in.ignore(4);
-            json = new JsonBoolean(false);
-            return in;
-        case 'n': case 'N':
-            in.ignore(3);
-            json = new JsonNull();
-            return in;
-        default:
-            return in;
-        }
-    }
-    return in;
-}
+std::ostream& operator<<(std::ostream &out, JsonData* json);
+std::istream& operator>>(std::istream &in, JsonData*& json);
 
 #endif /* IR_JSON_PARSER_H_ */


### PR DESCRIPTION
Here's a patch I've had lingering for a while now that speeds up the build a little bit by moving some code from `.h` files to `.cpp` files. The biggest win is moving some code out of `ir-inline.h`; at least on clang, that code is pretty expensive to compile.

In my environment, a full rebuild of master (`time make -j8`) takes this long:

```
107.69 real 623.43 user 22.66 sys
```

With this patch:

```
95.80 real 544.69 user 22.00 sys
```

That's an 11% speedup. Not bad.