### PR TITLE
Add preliminary support for learning to p4runtime-to-pd

### DIFF
--- a/p4runtime-to-pd/templates/src/pd.cpp
+++ b/p4runtime-to-pd/templates/src/pd.cpp
@@ -33,6 +33,7 @@ extern "C" {
 
 void ${pd_prefix}learning_notification_cb(const char *hdr, const char *data);
 p4_pd_status_t ${pd_prefix}learning_new_device(int dev_id);
+p4_pd_status_t ${pd_prefix}learning_setup_device(int dev_id);
 p4_pd_status_t ${pd_prefix}learning_remove_device(int dev_id);
 
 void ${pd_prefix}ageing_notification_cb(const char *hdr, const char *data);
@@ -54,7 +55,9 @@ p4_pd_status_t ${pd_prefix}assign_device(int dev_id,
                               ${pd_prefix}ageing_notification_cb,
                               ${pd_prefix}learning_notification_cb);
   my_devices[dev_id] = 1;
-  return conn_mgr_state->client_init(dev_id, rpc_port_num);
+  p4_pd_status_t status = conn_mgr_state->client_init(dev_id, rpc_port_num);
+  ${pd_prefix}learning_setup_device(dev_id);
+  return status;
 }
 
 p4_pd_status_t ${pd_prefix}remove_device(int dev_id) {


### PR DESCRIPTION
This PR uses the newly-introduced `bm_get_id_from_name()` API to add support for learning to the PD frontend that `p4runtime-to-pd` generates.

Unfortunately, we still can't pass the learning PTF test for switch.p4. We get the correct learn quanta id, and everything appears to work fine, but we end up receiving a null `msg` in `notify_ack`. To avoid a crash, I've handled this case, but we'll need to debug it before the PTF test will pass.

With this change, though, the switch.p4 PTF tests at least all run without crashing the driver, so we can start using them.