### PR TITLE
Fix typechecking MakeImplicitCastExplicit to work properly with dags

### DIFF
--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -387,6 +387,20 @@ ExternConverter::convertExternInstance(const IR::Declaration_Instance *ext, cstr
     return rv->apply(TypeConverter(structure))->to<IR::Declaration_Instance>();
 }
 
+const IR::Statement *
+ExternConverter::convertExternCall(const IR::Declaration_Instance *ext, const IR::Primitive *prim) {
+    ExpressionConverter conv(structure);
+    auto extref = new IR::PathExpression(structure->externs.get(ext));
+    auto method = new IR::Member(prim->srcInfo, extref, prim->name);
+    auto args = new IR::Vector<IR::Expression>();
+    for (unsigned i = 1; i < prim->operands.size(); ++i)
+        args->push_back(conv.convert(prim->operands.at(i)));
+    auto mc = new IR::MethodCallExpression(prim->srcInfo, method, args);
+    return new IR::MethodCallStatement(prim->srcInfo, mc);
+}
+
+
+
 ///////////////////////////////////////////////////////////////
 
 namespace {

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -85,6 +85,8 @@ class ExternConverter {
     virtual const IR::Type_Extern *convertExternType(const IR::Type_Extern *, cstring);
     virtual const IR::Declaration_Instance *convertExternInstance(
                 const IR::Declaration_Instance *, cstring);
+    virtual const IR::Statement *convertExternCall(const IR::Declaration_Instance *,
+                                                   const IR::Primitive *);
     ExternConverter() {}
     explicit ExternConverter(ProgramStructure *s) : structure(s) {}
 };

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -627,6 +627,8 @@ bool TypeInference::canCastBetween(const IR::Type* dest, const IR::Type* src) co
             auto b = dest->to<IR::Type_Bits>();
             return b->size == 1 && !b->isSigned;
         }
+    } else if (src->is<IR::Type_InfInt>()) {
+        return dest->is<IR::Type_Bits>();
     }
     return false;
 }

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -419,8 +419,8 @@ class V1Control {
 
 class AttribLocal : Expression, IDeclaration {
     ID  name;
-#nodbprint
     ID getName() const override { return name; }
+    dbprint { out << name; }
 }
 
 class AttribLocals : ISimpleNamespace {
@@ -435,7 +435,7 @@ class Attribute : Declaration {
     NullOK Type type = nullptr;
     NullOK AttribLocals locals = nullptr;
     bool optional = false;
-#nodbprint
+    dbprint { if (type) out << type << ' '; out << name; }
 }
 
 class GlobalRef : Expression {

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -28,8 +28,9 @@ limitations under the License.
  */
 class Visitor::ChangeTracker {
     struct visit_info_t {
-        bool visit_in_progress;
-        const IR::Node *result;
+        bool            visit_in_progress;
+        bool            visitOnce;
+        const IR::Node  *result;
     };
     typedef unordered_map<const IR::Node *, visit_info_t>  visited_t;
     visited_t           visited;
@@ -38,13 +39,13 @@ class Visitor::ChangeTracker {
     /** Begin tracking @n during a visiting pass.  Use `finish(@n)` to mark @n as
      * visited once the pass completes.
      */
-    void start(const IR::Node *n) {
+    void start(const IR::Node *n, bool defaultVisitOnce) {
         // Initialization
         visited_t::iterator visited_it;
         bool inserted;
         bool visit_in_progress = true;
         std::tie(visited_it, inserted) =
-            visited.emplace(n, visit_info_t{visit_in_progress, n});
+            visited.emplace(n, visit_info_t{visit_in_progress, defaultVisitOnce, n});
 
         // Sanity check for IR loops
         bool already_present = !inserted;
@@ -77,15 +78,22 @@ class Visitor::ChangeTracker {
             orig_visit_info->result = final;
             return true;
         } else if (final != orig && *final != *orig) {
-            bool visit_in_progress = false;
             orig_visit_info->result = final;
-            visited.emplace(final, visit_info_t{visit_in_progress, final});
+            visited.emplace(final, visit_info_t{false, orig_visit_info->visitOnce, final});
             return true;
         } else {
             // FIXME -- not safe if the visitor resurrects the node (which it shouldn't)
             // if (final && final->id == IR::Node::currentId - 1)
             //     --IR::Node::currentId;
             return false; } }
+
+    /** Return a pointer to the visitOnce flag for node @n so that it can be changed
+     */
+    bool *refVisitOnce(const IR::Node *n) {
+        if (!visited.count(n))
+            BUG("visitor state tracker corrupted");
+        return &visited.at(n).visitOnce;
+    }
 
     /** Forget nodes that have already been visited, allowing them to be visited
      * again. */
@@ -96,13 +104,16 @@ class Visitor::ChangeTracker {
             else
                 ++it; } }
 
-    /** Determine whether @n has been visited and the visitor has finished.
-     * That is, `start(@n)` has been invoked, followed by `finish(@n)`.
+    /** Determine whether @n has been visited and the visitor has finished
+     *  and we don't want to visit @n again the next time we see it.
+     * That is, `start(@n)` has been invoked, followed by `finish(@n)`,
+     * and the visitOnce field is true.
      * 
-     * @return true if @n has been visited and the visitor is finished.
+     * @return true if @n has been visited and the visitor is finished and visitOnce is true
      */
     bool done(const IR::Node *n) const {
-        return visited.count(n) && !visited.at(n).visit_in_progress;
+        auto it = visited.find(n);
+        return it != visited.end() && !it->second.visit_in_progress && it->second.visitOnce;
     }
 
     /** Produce the result of visiting @n.
@@ -223,18 +234,20 @@ const IR::Node *Modifier::apply_visitor(const IR::Node *n, const char *name) {
     if (ctxt) ctxt->child_name = name;
     if (n) {
         PushContext local(ctxt, n);
-        if (visited->done(n) && visitDagOnce) {
+        if (visited->done(n)) {
             n->apply_visitor_revisit(*this, visited->result(n));
             n = visited->result(n);
         } else {
-            visited->start(n);
+            visited->start(n, visitDagOnce);
             IR::Node *copy = n->clone();
             local.current.node = copy;
-            if (visitDagOnce && !dontForwardChildrenBeforePreorder) {
+            if (!dontForwardChildrenBeforePreorder) {
                 ForwardChildren forward_children(*visited);
                 copy->visit_children(forward_children); }
+            visitCurrentOnce = visited->refVisitOnce(n);
             if (copy->apply_visitor_preorder(*this)) {
                 copy->visit_children(*this);
+                visitCurrentOnce = visited->refVisitOnce(n);
                 copy->apply_visitor_postorder(*this); }
             if (visited->finish(n, copy))
                 (n = copy)->validate(); } }
@@ -249,20 +262,21 @@ const IR::Node *Inspector::apply_visitor(const IR::Node *n, const char *name) {
     if (ctxt) ctxt->child_name = name;
     if (n && !join_flows(n)) {
         PushContext local(ctxt, n);
-        auto vp = visited->emplace(n, false);
-        if (!vp.second && !vp.first->second)
+        auto vp = visited->emplace(n, info_t{false, visitDagOnce});
+        if (!vp.second && !vp.first->second.done)
             BUG("IR loop detected");
-        if (!vp.second && visitDagOnce) {
+        if (!vp.second && vp.first->second.visitOnce) {
             n->apply_visitor_revisit(*this);
         } else {
-            vp.first->second = false;
+            vp.first->second.done = false;
+            visitCurrentOnce = &vp.first->second.visitOnce;
             if (n->apply_visitor_preorder(*this)) {
                 n->visit_children(*this);
+                visitCurrentOnce = &vp.first->second.visitOnce;
                 n->apply_visitor_postorder(*this); }
-            vp.first = visited->find(n);  // iterator may have been invalidated
-            if (vp.first == visited->end())
+            if (vp.first != visited->find(n))
                 BUG("visitor state tracker corrupted");
-            vp.first->second = true; } }
+            vp.first->second.done = true; } }
     if (ctxt)
         ctxt->child_index++;
     else
@@ -274,17 +288,18 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
     if (ctxt) ctxt->child_name = name;
     if (n) {
         PushContext local(ctxt, n);
-        if (visited->done(n) && visitDagOnce) {
+        if (visited->done(n)) {
             n->apply_visitor_revisit(*this, visited->result(n));
             n = visited->result(n);
         } else {
-            visited->start(n);
+            visited->start(n, visitDagOnce);
             auto copy = n->clone();
             local.current.node = copy;
-            if (visitDagOnce && !dontForwardChildrenBeforePreorder) {
+            if (!dontForwardChildrenBeforePreorder) {
                 ForwardChildren forward_children(*visited);
                 copy->visit_children(forward_children); }
             prune_flag = false;
+            visitCurrentOnce = visited->refVisitOnce(n);
             bool extra_clone = false;
             const IR::Node *preorder_result = copy->apply_visitor_preorder(*this);
             assert(preorder_result != n);  // should never happen
@@ -295,15 +310,16 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
                 //     --IR::Node::currentId;
                 if (!preorder_result) {
                     prune_flag = true;
-                } else if (visited->done(preorder_result) && visitDagOnce) {
+                } else if (visited->done(preorder_result)) {
                     final_result = visited->result(preorder_result);
                     prune_flag = true;
                 } else {
                     extra_clone = true;
-                    visited->start(preorder_result);
+                    visited->start(preorder_result, *visitCurrentOnce);
                     local.current.node = copy = preorder_result->clone(); } }
             if (!prune_flag) {
                 copy->visit_children(*this);
+                visitCurrentOnce = visited->refVisitOnce(n);
                 final_result = copy->apply_visitor_postorder(*this); }
             if (final_result
                 && final_result != preorder_result
@@ -322,7 +338,7 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
 
 void Inspector::revisit_visited() {
     for (auto it = visited->begin(); it != visited->end();) {
-        if (it->second)
+        if (it->second.done)
             it = visited->erase(it);
         else
             ++it; }

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -198,10 +198,15 @@ class Visitor {
     void visit_children(const IR::Node *, std::function<void()> fn) { fn(); }
     class ChangeTracker;  // used by Modifier and Transform -- private to them
     virtual bool check_clone(const Visitor *) { return true; }
+    // This overrides visitDagOnce for a single node -- can only be called from
+    // preorder and postorder functions
+    void visitOnce() const { *visitCurrentOnce = true; }
+    void visitAgain() const { *visitCurrentOnce = false; }
 
  private:
     virtual void visitor_const_error();
     const Context *ctxt = nullptr;  // should be readonly to subclasses
+    bool *visitCurrentOnce = nullptr;
     friend class Inspector;
     friend class Modifier;
     friend class Transform;
@@ -228,7 +233,8 @@ class Modifier : public virtual Visitor {
 };
 
 class Inspector : public virtual Visitor {
-    typedef unordered_map<const IR::Node *, bool>       visited_t;
+    struct info_t { bool done, visitOnce; };
+    typedef unordered_map<const IR::Node *, info_t>       visited_t;
     visited_t   *visited = nullptr;
     bool check_clone(const Visitor *) override;
  public:

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -100,7 +100,11 @@ class DoLocalCopyPropagation::RewriteTableKeys : public Transform {
         BUG_CHECK(table == &self.tables[tbl->name], "corrupt internal state");
         table = nullptr;
         return tbl; }
+    IR::Expression *preorder(IR::Expression *exp) {
+        visitAgain();
+        return exp; }
     const IR::Expression *preorder(IR::PathExpression *path) {
+        visitAgain();
         if (table) {
             const Visitor::Context *ctxt = nullptr;
             if (findContext<IR::KeyElement>(ctxt) && ctxt->child_index == 1) {
@@ -162,6 +166,11 @@ const IR::Node *DoLocalCopyPropagation::postorder(IR::Declaration_Variable *var)
     return var;
 }
 
+IR::Expression *DoLocalCopyPropagation::preorder(IR::Expression *exp) {
+    visitAgain();
+    return exp;
+}
+
 const IR::Expression *DoLocalCopyPropagation::postorder(IR::PathExpression *path) {
     if (inferForTable) {
         const Visitor::Context *ctxt = nullptr;
@@ -195,7 +204,13 @@ const IR::Expression *DoLocalCopyPropagation::postorder(IR::PathExpression *path
     return path;
 }
 
+IR::Statement *DoLocalCopyPropagation::preorder(IR::Statement *s) {
+    visitAgain();
+    return s;
+}
+
 IR::AssignmentStatement *DoLocalCopyPropagation::preorder(IR::AssignmentStatement *as) {
+    visitAgain();
     if (!working) return as;
     // visit the source subtree first, before the destination subtree
     // make sure child indexes are set properly so we can detect writes -- these are the

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -67,7 +67,9 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
 
     void visit_local_decl(const IR::Declaration_Variable *);
     const IR::Node *postorder(IR::Declaration_Variable *) override;
+    IR::Expression *preorder(IR::Expression *m) override;
     const IR::Expression *postorder(IR::PathExpression *) override;
+    IR::Statement *preorder(IR::Statement *) override;
     IR::AssignmentStatement *preorder(IR::AssignmentStatement *) override;
     IR::AssignmentStatement *postorder(IR::AssignmentStatement *) override;
     IR::IfStatement *postorder(IR::IfStatement *) override;
@@ -91,7 +93,7 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
     DoLocalCopyPropagation() : tables(*new std::map<cstring, TableInfo>),
                                actions(*new std::map<cstring, FuncInfo>),
                                methods(*new std::map<cstring, FuncInfo>)
-    { visitDagOnce = false; setName("DoLocalCopyPropagation"); }
+    { setName("DoLocalCopyPropagation"); }
 };
 
 class LocalCopyPropagation : public PassManager {


### PR DESCRIPTION
So using `visitDagOnce = false` in a Transform (or Modifier) seems to be a sure source of hard to track bugs.  Its far too easy for the Transform to inadvertently clone something that is referenced mulitple places, which seems to be ok at first, but leads to problems down the line.

This change dusts off an old change I've had sitting on a branch for awhile to add some new Visitor functions (`visitAgain()` and `visitOnce()`) that override the `visitDagOnce` flag on a per-node basis.  Any pre- or postorder function can call `visitAgain()` and it result in node being visited again if it is found as a child elsewhere in the IR Dag instead of reusing the results of the first call (as if `visitDagOnce = false`, but just for that node).  Similarly `visitOnce()` treats the node as if `visitDagOne = true` (in case you set it to `false` globally in the constructor.

This allows the fix for the P4_14 typechecker to insert casts on ActionArgs indepedently each time they appear in the tree while NOT duplicating extern object instances that are referenced multiple times.

This also adds the `int` type to the P4_16 parser (for integer constant of unspecified size in a constructor) so that P4_14 externs that use `int` can be converted to P4_16 without causing syntax errors in the result.