### PR TITLE
Annotate bmv2 $valid$ fields as hidden

### DIFF
--- a/backends/bmv2/synthesizeValidField.cpp
+++ b/backends/bmv2/synthesizeValidField.cpp
@@ -37,7 +37,9 @@ class AddValidField final : public Modifier {
     bool preorder(IR::Type_Header* header) override {
         const cstring validField = V1ModelProperties::validField;
         if (header->getField(validField) != nullptr) return true;
-        auto field = new IR::StructField(validField, IR::Type::Bits::get(1));
+        auto annotations = new IR::Annotations(
+            {new IR::Annotation(IR::Annotation::hiddenAnnotation, {})});
+        auto field = new IR::StructField(validField, annotations, IR::Type::Bits::get(1));
         header->fields.push_back(field);
         return true;
     }

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1045,6 +1045,7 @@ public:
 
         size_t index = 1;
         for (auto headerField : type->fields) {
+            if (isHidden(headerField)) continue;
             auto metadata = header->add_metadata();
             auto fieldName = headerField->controlPlaneName();
             metadata->set_id(index++);


### PR DESCRIPTION
Otherwise they can show up in the p4Runtime output.