### PR TITLE
Include SourceInfo in the JSON output of p4test.

### DIFF
--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *const argv[]) {
             log_dump(program, "After midend");
             log_dump(top, "Top level block");
             if (options.dumpJsonFile)
-                JSONGenerator(*openFile(options.dumpJsonFile, true)) << program << std::endl;
+                JSONGenerator(*openFile(options.dumpJsonFile, true), true) << program << std::endl;
             if (options.debugJson) {
                 std::stringstream ss1, ss2;
                 JSONGenerator gen1(ss1), gen2(ss2);

--- a/ir/json_generator.h
+++ b/ir/json_generator.h
@@ -28,6 +28,7 @@ limitations under the License.
 class JSONGenerator {
     std::unordered_set<int> node_refs;
     std::ostream &out;
+    bool dumpSourceInfo;
 
     template<typename T>
     class has_toJSON {
@@ -43,7 +44,8 @@ class JSONGenerator {
  public:
     indent_t indent;
 
-    explicit JSONGenerator(std::ostream &out) : out(out) {}
+    explicit JSONGenerator(std::ostream &out, bool dumpSourceInfo = false) :
+        out(out), dumpSourceInfo(dumpSourceInfo) {}
 
     template<typename T>
     void generate(const vector<T> &v) {
@@ -140,7 +142,11 @@ class JSONGenerator {
             out << indent << "\"Node_ID\" : " << v.id;
         } else {
             node_refs.insert(v.id);
-            v.toJSON(*this); }
+            v.toJSON(*this);
+            if (dumpSourceInfo) {
+                v.sourceInfoToJSON(*this);
+            }
+        }
         out << std::endl << --indent << "}";
     }
 

--- a/ir/node.h
+++ b/ir/node.h
@@ -79,6 +79,9 @@ class Node : public virtual INode {
     friend class ::Inspector;
     friend class ::Modifier;
     friend class ::Transform;
+    cstring prepareSourceInfoForJSON(Util::SourceInfo& si,
+                                     unsigned *lineNumber,
+                                     unsigned *columnNumber) const;
 
  public:
     Util::SourceInfo    srcInfo;
@@ -105,6 +108,7 @@ class Node : public virtual INode {
     explicit Node(JSONLoader &json);
     cstring toString() const override { return node_type_name(); }
     void toJSON(JSONGenerator &json) const override;
+    void sourceInfoToJSON(JSONGenerator &json) const;
     Util::JsonObject* sourceInfoJsonObj() const;
     virtual bool operator==(const Node &a) const { return typeid(*this) == typeid(a); }
 #define DEFINE_OPEQ_FUNC(CLASS, BASE) \


### PR DESCRIPTION
This patch embeds the SourceInfo data in the p4test JSON output.
This makes it accessible to any post-processing tool using this output.
The format of data is compatible with Andy's patch (which is only used in the BMV2 backend).

The commit also includes a minor tweak - cleaning up the trailing space following the "," in JSON nodes.