### PR TITLE
Rework ExternConverter to be simpler and more flexible

### DIFF
--- a/frontends/common/parseInput.cpp
+++ b/frontends/common/parseInput.cpp
@@ -31,11 +31,11 @@ namespace P4 {
 
 template <typename Input>
 static const IR::P4Program*
-parseV1Program(const char* name, Input& stream, P4V1::ExternConverter *extCvt,
+parseV1Program(const char* name, Input& stream,
                boost::optional<DebugHook> debugHook = boost::none) {
     // We load the model before parsing the input file, so that the SourceInfo
     // in the model comes first.
-    P4V1::Converter converter(extCvt);
+    P4V1::Converter converter;
     if (debugHook) converter.addDebugHook(*debugHook);
     converter.loadModel();
 
@@ -56,7 +56,7 @@ parseV1Program(const char* name, Input& stream, P4V1::ExternConverter *extCvt,
     return nullptr;  // Conversion failed.
 }
 
-const IR::P4Program* parseP4File(CompilerOptions& options, P4V1::ExternConverter *extCvt) {
+const IR::P4Program* parseP4File(CompilerOptions& options) {
     clearProgramState();
 
     FILE* in = nullptr;
@@ -73,7 +73,7 @@ const IR::P4Program* parseP4File(CompilerOptions& options, P4V1::ExternConverter
     }
 
     auto result = options.isv1()
-                ? parseV1Program(options.file, in, extCvt, options.getDebugHook())
+                ? parseV1Program(options.file, in, options.getDebugHook())
                 : P4ParserDriver::parse(options.file, in);
     options.closeInput(in);
 
@@ -86,13 +86,12 @@ const IR::P4Program* parseP4File(CompilerOptions& options, P4V1::ExternConverter
 }
 
 const IR::P4Program* parseP4String(const std::string& input,
-                                   CompilerOptions::FrontendVersion version,
-                                   P4V1::ExternConverter *extCvt) {
+                                   CompilerOptions::FrontendVersion version) {
     clearProgramState();
 
     std::istringstream stream(input);
     auto result = version == CompilerOptions::FrontendVersion::P4_14
-                ? parseV1Program("(string)", stream, extCvt)
+                ? parseV1Program("(string)", stream)
                 : P4ParserDriver::parse("(string)", stream);
 
     if (::errorCount() > 0) {

--- a/frontends/common/parseInput.h
+++ b/frontends/common/parseInput.h
@@ -39,8 +39,7 @@ namespace P4 {
  * @return a P4-16 IR tree representing the contents of the given file, or null
  * on failure. If failure occurs, an error will also be reported.
  */
-const IR::P4Program* parseP4File(CompilerOptions& options,
-                                 P4V1::ExternConverter *extCvt = nullptr);
+const IR::P4Program* parseP4File(CompilerOptions& options);
 
 /**
  * Parse P4 source from the string @input, interpreting it as having language
@@ -57,8 +56,7 @@ const IR::P4Program* parseP4File(CompilerOptions& options,
  * null on failure. If failure occurs, an error will also be reported.
  */
 const IR::P4Program* parseP4String(const std::string& input,
-                                   CompilerOptions::FrontendVersion version,
-                                   P4V1::ExternConverter *extCvt = nullptr);
+                                   CompilerOptions::FrontendVersion version);
 
 /**
  * Clear global program state so that a new program can be parsed.

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -29,8 +29,6 @@ limitations under the License.
 
 namespace P4V1 {
 
-class ExternConverter;
-
 /// Information about the structure of a P4-14 program, used to convert it to a P4-16 program.
 class ProgramStructure {
     // In P4-14 one can have multiple objects with different types with the same name
@@ -89,10 +87,9 @@ class ProgramStructure {
         iterator begin() { return iterator(nameToObject.begin(), objectToNewName); }
         iterator end() { return iterator(nameToObject.end(), objectToNewName); }
     };
-    ExternConverter *extCvt;
 
  public:
-    explicit ProgramStructure(ExternConverter *);
+    ProgramStructure();
 
     P4V1::V1Model &v1model;
     P4::P4CoreLibrary &p4lib;
@@ -163,6 +160,7 @@ class ProgramStructure {
     const IR::Parameter* parserPacketIn;
     const IR::Parameter* parserHeadersOut;
 
+ public:
     // output is constructed here
     IR::IndexedVector<IR::Node>* declarations;
 
@@ -205,8 +203,6 @@ class ProgramStructure {
     const IR::Declaration_Instance* convertDirectCounter(const IR::Counter* m, cstring newName);
     const IR::Declaration_Instance* convert(const IR::CounterOrMeter* cm, cstring newName);
     const IR::Declaration_Instance* convert(const IR::Register* reg, cstring newName);
-    const IR::Declaration_Instance*
-    convertExtern(const IR::Declaration_Instance* ext, cstring newName);
     const IR::P4Table*
     convertTable(const IR::V1Table* table, cstring newName,
                  IR::IndexedVector<IR::Declaration> &stateful, std::map<cstring, cstring> &);

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -716,6 +716,9 @@ TypeInference::checkExternConstructor(const IR::Node* errorPosition,
     auto result = new IR::Vector<IR::Expression>();
     size_t i = 0;
     for (auto pi : *methodType->parameters->getEnumerator()) {
+        if (i >= arguments->size()) {
+            BUG_CHECK(pi->getAnnotation("optional"), "Missing nonoptional arg %s", pi);
+            break; }
         auto arg = arguments->at(i++);
         if (!isCompileTimeConstant(arg))
             typeError("%1%: cannot evaluate to a compile-time constant", arg);

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -157,6 +157,9 @@ void InstantiatedBlock::instantiate(std::vector<const CompileTimeValue*> *args) 
     CHECK_NULL(args);
     auto it = args->begin();
     for (auto p : *getConstructorParameters()->getEnumerator()) {
+        if (it == args->end()) {
+            BUG_CHECK(p->getAnnotation("optional"), "Missing nonoptional arg %s", p);
+            continue; }
         LOG1("Set " << p << " to " << *it << " in " << id);
         setValue(p, *it);
         ++it;


### PR DESCRIPTION
This reworks my previous ExternConverter change to be both simpler and more flexible.  Now instead of having a single ExternConverter passed into the frontend, you can register multiple ExternConverter subclass instances on a per extern type basis -- the converter will manage them and call the correct one.  This allows better mixing and matching of extern converters for related targets.  Most of the change is actually undoing the previous change to the frontend API.

There's also yet another P4_14 typechecking fix with getting the right implicit conversions inserted as explicit conversions.