### PR TITLE
extensible PrimitveConverter framework

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -211,12 +211,6 @@ class ProgramStructure {
     const IR::Type_Control* controlType(IR::ID name);
     const IR::PathExpression* getState(IR::ID dest);
     const IR::Declaration_Instance* checksumUnit(const IR::FieldListCalculation* flc);
-    const IR::FieldList* getFieldLists(const IR::FieldListCalculation* flc);
-    const IR::Expression* convertFieldList(const IR::Expression* expression);
-    const IR::Type_Struct* createFieldListType(const IR::Expression* expression);
-    const IR::Expression* convertHashAlgorithm(IR::ID algorithm);
-    const IR::Statement* sliceAssign(Util::SourceInfo srcInfo, const IR::Expression* left,
-                                     const IR::Expression* right, const IR::Expression* mask);
     const IR::Expression* counterType(const IR::CounterOrMeter* cm) const;
     cstring mapAlgorithm(IR::ID algorithm) const;
     void createChecksumVerifications();
@@ -235,7 +229,13 @@ class ProgramStructure {
     void include(cstring filename);
     const IR::AssignmentStatement* assign(Util::SourceInfo srcInfo, const IR::Expression* left,
                                           const IR::Expression* right, const IR::Type* type);
+    const IR::Expression* convertFieldList(const IR::Expression* expression);
+    const IR::Expression* convertHashAlgorithm(IR::ID algorithm);
+    const IR::Type_Struct* createFieldListType(const IR::Expression* expression);
+    const IR::FieldList* getFieldLists(const IR::FieldListCalculation* flc);
     const IR::Expression* paramReference(const IR::Parameter* param);
+    const IR::Statement* sliceAssign(Util::SourceInfo srcInfo, const IR::Expression* left,
+                                     const IR::Expression* right, const IR::Expression* mask);
     void tablesReferred(const IR::V1Control* control, std::vector<const IR::V1Table*> &out);
     bool isHeader(const IR::ConcreteHeaderRef* nhr) const;
     cstring makeUniqueName(cstring base);


### PR DESCRIPTION
Initial ideas for an extensible primitive P4_14->16 conversion framework.  The goal is to be able to easily support target architecture specific primitives, rather than having everything ties to v1model.

This ends up requiring some duplication of code in the conversion routines (for example, all of the simple binop conversions); it would be nice to figure out a way to reduce that.

This also has the disadvantage of being statically built into the executable, which will make it difficult to support mutiple targets in a single executable.  At the moment we're using separate executables for each target, so this is not an issue.