### PR TITLE
Strip out p4_14 extern support code in ResolveReferences

### DIFF
--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -423,47 +423,7 @@ void ResolveReferences::postorder(const IR::BlockStatement *b)
 
 bool ResolveReferences::preorder(const IR::Declaration_Instance *decl) {
     refMap->usedName(decl->name.name);
-    if (auto ext = context->resolveType(decl->type)->to<IR::Type_Extern>()) {
-        // FIXME -- this is special-case handling for P4_14 externs with properties,
-        // FIXME -- so that visitors for IR::Propertty can find the corresponding
-        // FIXME -- IR::Attribute in the extern.  It should go away once we no
-        // FIXME -- longer need to deal with P4_14 externs
-        addToContext(ext); }
-    if (decl->initializer != nullptr)
-        addToContext(decl->initializer);
     return true;
-}
-
-void ResolveReferences::postorder(const IR::Declaration_Instance *decl) {
-    if (decl->initializer != nullptr)
-        removeFromContext(decl->initializer);
-    if (auto ext = context->resolveType(decl->type)->to<IR::Type_Extern>())
-        removeFromContext(ext);
-}
-
-bool ResolveReferences::preorder(const IR::Property *prop) {
-    /// @todo: why is `dynamic_cast` used here instead of `to`?
-    /// @todo: why is `forwardOK` set to `true` here?
-    if (auto attr = dynamic_cast<const IR::Attribute *>(context->
-                    resolveUnique(prop->name, ResolutionType::Any, true))) {
-        // FIXME -- this is special-case handling for P4_14 extern properties.
-        // It should go away once we no longer need to deal with P4_14 externs
-        // The 'dynamic_cast' above is used (instead of 'to') in case resolveUnique
-        // returns a nullptr.
-        if (attr->locals)
-            addToContext(attr->locals);
-        if (attr->type->is<IR::Type::String>())
-            // Attribute is arbitrary string -- need not match anything
-            return false;
-    }
-    return true;
-}
-void ResolveReferences::postorder(const IR::Property *prop) {
-    if (auto attr = dynamic_cast<const IR::Attribute *>(context->
-                    resolveUnique(prop->name, ResolutionType::Any, true))) {
-        if (attr->locals)
-            removeFromContext(attr->locals);
-    }
 }
 
 #undef PROCESS_NAMESPACE

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -139,6 +139,7 @@ class ResolveReferences : public Inspector {
     bool preorder(const IR::Type_Name* type) override;
     bool preorder(const IR::PathExpression* path) override;
     bool preorder(const IR::This* pointer) override;
+    bool preorder(const IR::Declaration_Instance *decl) override;
 
 #define DECLARE(TYPE)                           \
     bool preorder(const IR::TYPE* t) override;  \
@@ -156,8 +157,6 @@ class ResolveReferences : public Inspector {
     DECLARE(Type_ArchBlock)
     DECLARE(Type_StructLike)
     DECLARE(BlockStatement)
-    DECLARE(Declaration_Instance)
-    DECLARE(Property)
 #undef DECLARE
 
     bool preorder(const IR::P4Table* table) override;

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -372,6 +372,9 @@ class FixupExtern : public Modifier {
 
 const IR::Type_Extern *ExternConverter::convertExternType(ProgramStructure *structure,
             const IR::Type_Extern *ext, cstring name) {
+    if (!ext->attributes.empty())
+        warning("%s: P4_14 extern type with attributes cannot be used in P4_16 "
+                "without conversion", ext);
     return ext->apply(FixupExtern(structure, name))->to<IR::Type_Extern>();
 }
 
@@ -380,6 +383,9 @@ const IR::Declaration_Instance *ExternConverter::convertExternInstance(ProgramSt
     auto *rv = ext->clone();
     auto *et = rv->type->to<IR::Type_Extern>();
     BUG_CHECK(et, "Extern %s is not extern type, but %s", ext, ext->type);
+    if (!ext->properties.empty())
+        warning("%s: P4_14 extern with properties cannot be used in P4_16 "
+                "without conversion", ext);
     if (structure->extern_remap.count(et))
         et = structure->extern_remap.at(et);
     rv->name = name;

--- a/testdata/p4_14_samples_outputs/issue604.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue604.p4-stderr
@@ -1,3 +1,9 @@
+issue604.p4(2): warning: extern_test: P4_14 extern type with attributes cannot be used in P4_16 without conversion
+extern_type extern_test {
+^
+issue604.p4(8): warning: my_extern_inst: P4_14 extern with properties cannot be used in P4_16 without conversion
+extern extern_test my_extern_inst {
+                   ^^^^^^^^^^^^^^
 issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
 extern_type extern_test {
 ^


### PR DESCRIPTION
- this code was to support P4_14-style externs with attributes and is no
  longer needed now that we have ExternConverters to convert those P4_14
  extern_types to P4_16 properly.