### PR TITLE
adjusts the paths for the include files to the env variable set by p4c driver

### DIFF
--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -222,8 +222,15 @@ FILE* CompilerOptions::preprocess() {
 #else
         std::string cmd("cpp");
 #endif
+        // the p4c driver sets environment variables for include
+        // paths.  check the environment and add these to the command
+        // line for the preporicessor
+        char * driverP4IncludePath =
+          isv1() ? getenv("P4C_14_INCLUDE_PATH") : getenv("P4C_16_INCLUDE_PATH");
         cmd += cstring(" -C -undef -nostdinc") + " " + preprocessor_options
+            + (driverP4IncludePath ? " -I" + cstring(driverP4IncludePath) : "")
             + " -I" + (isv1() ? p4_14includePath : p4includePath) + " " + file;
+
         if (Log::verbose())
             std::cerr << "Invoking preprocessor " << std::endl << cmd << std::endl;
         in = popen(cmd.c_str(), "r");

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -467,7 +467,11 @@ void ProgramStructure::createParser() {
 }
 
 void ProgramStructure::include(cstring filename) {
-    Util::PathName path(p4includePath);
+  // the p4c driver sets environment variables for include
+  // paths.  check the environment and add these to the command
+  // line for the preporicessor
+  char * drvP4IncludePath = getenv("P4C_16_INCLUDE_PATH");
+  Util::PathName path(drvP4IncludePath ? drvP4IncludePath : p4includePath);
     path = path.join(filename);
 
     CompilerOptions options;


### PR DESCRIPTION
Install and developer builds provide different paths to the include files.

In the current configuration, we hardcode the p4include path to some
directory decided at configuration time, which makes the compiler
non-relocatable. However, this issue has been addressed in the driver,
which sets environment variables for both the P4 14 and 16 include
paths. With this change, the compiler no longer needs to hardcode the
path.