### PR TITLE
adds cpplint as a test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ services:
   - docker
 
 env:
-  - MAKEFLAGS="-j2"
+  - CTEST_PARALLEL_LEVEL=4
 
 install:
   - docker build -t p4c --build-arg IMAGE_TYPE=test .
 
 script:
-  - docker run -w /p4c/build -e MAKEFLAGS p4c make check VERBOSE=1
+  - docker run -w /p4c/build -e CTEST_PARALLEL_LEVEL p4c ctest -V --output-on-failure --schedule-random

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,10 @@ add_custom_target(cpplint-quiet
   COMMAND ${CPPLINT_CMD} --quiet ${CPPLINT_ARGS} ${CPPLINT_FILES}
   WORKING_DIRECTORY ${P4C_SOURCE_DIR}
   COMMENT "cpplint quietly")
+# add cpplint as a test so that make check can proceed in parallel
+add_test(NAME cpplint
+  COMMAND ${CPPLINT_CMD} --quiet ${CPPLINT_ARGS} ${CPPLINT_FILES}
+  WORKING_DIRECTORY ${P4C_SOURCE_DIR})
 
 # tags, etags
 set (CTAGS_DIRS backends extensions frontends ir lib tools midend)
@@ -249,7 +253,7 @@ foreach(t ${TEST_TAGS})
 endforeach()
 
 add_custom_target(check
-  DEPENDS check-all cpplint-quiet)
+  DEPENDS check-all)
 
 add_custom_target(recheck
   DEPENDS recheck-all)


### PR DESCRIPTION
This allows it to run in parallel with all the other tests and fail at
leisure.

Also switched travis to ctest and increased the parallel load to 4.