### PR TITLE
Fixed a small bug in the bitvec >>= function

### DIFF
--- a/lib/bitvec.cpp
+++ b/lib/bitvec.cpp
@@ -60,7 +60,7 @@ bitvec &bitvec::operator>>=(size_t count) {
 }
 
 bitvec &bitvec::operator<<=(size_t count) {
-    size_t needsize = (max().index() + count + bits_per_unit - 1)/bits_per_unit;
+    size_t needsize = (max().index() + count + bits_per_unit)/bits_per_unit;
     if (needsize > size) expand(needsize);
     if (size == 1) {
         data <<= count;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(gtest ${GTEST_ROOT}/src/gtest-all.cc)
 
 set (GTEST_UNITTEST_SOURCES
   gtest/arch_test.cpp
+  gtest/bitvec_test.cpp
   gtest/bmv2_isvalid.cpp
   gtest/call_graph_test.cpp
   gtest/dumpjson.cpp

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -16,6 +16,7 @@
 # elsewhere in the codebase.
 gtest_unittest_UNIFIED = \
 	test/gtest/arch_test.cpp \
+	test/gtest/bitvec_test.cpp \
 	test/gtest/bmv2_isvalid.cpp \
 	test/gtest/call_graph_test.cpp \
 	test/gtest/dumpjson.cpp \

--- a/test/gtest/bitvec_test.cpp
+++ b/test/gtest/bitvec_test.cpp
@@ -1,0 +1,32 @@
+
+/*
+Copyright 2013-present Barefoot Networks, Inc. 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+#include "gtest/gtest.h"
+#include "lib/bitvec.h"
+
+namespace Test {
+
+TEST(Bitvec, Shift) {
+    bitvec simple(0, 1);
+
+    EXPECT_EQ((simple << 64).getbit(64), true);
+    EXPECT_EQ((simple << 63).getbit(63), true);
+    EXPECT_EQ((simple << 64).getbit(63), false);
+}
+
+}  // namespace Test


### PR DESCRIPTION
Essentially this was failing on the border of bits_per_unit.  The size should always be at least 1 in the calculation.