### PR TITLE
Check if expression uses a IR::Member object

### DIFF
--- a/midend/expr_uses.h
+++ b/midend/expr_uses.h
@@ -27,6 +27,9 @@ class exprUses : public Inspector {
     bool preorder(const IR::Path *p) override {
         if (p->name == look_for) result = true;
         return !result; }
+    bool preorder(const IR::Member *m) override {
+        if (m->toString() == look_for) result = true;
+        return !result; }
     bool preorder(const IR::Primitive *p) override {
         if (p->name == look_for) result = true;
         return !result; }

--- a/midend/expr_uses.h
+++ b/midend/expr_uses.h
@@ -28,7 +28,10 @@ class exprUses : public Inspector {
         if (p->name == look_for) result = true;
         return !result; }
     bool preorder(const IR::Member *m) override {
-        if (m->toString() == look_for) result = true;
+        if (look_for.endsWith(m->member)) {
+            if (exprUses(m->expr, look_for.before(look_for.findlast('.'))))
+                result = true;
+        }
         return !result; }
     bool preorder(const IR::Primitive *p) override {
         if (p->name == look_for) result = true;


### PR DESCRIPTION
Check if an expression uses a `IR::Member` object. `exprUses` can be now used to check if an expression uses a packet header or metadata field.  

Edit: `make check` passes on my local machine, any reason why Travis would fail? The repo is synced with the latest commit. 