### PR TITLE
make createTypes() and createExterns() in P4V1::ProgramStructure public

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -216,10 +216,8 @@ class ProgramStructure {
     void createChecksumVerifications();
     void createChecksumUpdates();
     void createStructures();
-    void createExterns();
     cstring createType(const IR::Type_StructLike* type, bool header,
                        std::unordered_set<const IR::Type*> *converted);
-    void createTypes();
     void createParser();
     void createControls();
     void createDeparser();
@@ -251,6 +249,8 @@ class ProgramStructure {
     const int defaultRegisterWidth = 32;
 
     void loadModel();
+    void createExterns();
+    void createTypes();
     const IR::P4Program* create(Util::SourceInfo info);
 };
 


### PR DESCRIPTION
making these two methods public to be used in other translation passes.