### PR TITLE
In P4Runtime, reject anonymous table properties

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1400,6 +1400,12 @@ getExternInstanceFromProperty(const IR::P4Table* table,
     }
 
     auto expr = property->value->to<IR::ExpressionValue>()->expression;
+    if (expr->is<IR::ConstructorCallExpression>()
+        && expr->getAnnotation(IR::Annotation::nameAnnotation) == nullptr) {
+        ::error("Table '%1%' has an anonymous table property '%2%' with no name annotation, "
+                "which is not supported by P4Runtime", table->controlPlaneName(), propertyName);
+        return boost::none;
+    }
     auto name = property->controlPlaneName();
     auto externInstance = ExternInstance::resolve(expr, refMap, typeMap, name);
     if (!externInstance) {


### PR DESCRIPTION
Rather than generating a default name. Until now the default name was
the name of the property itself (e.g. 'implementation'). This is a
problem when multiple tables have anonymous properties, but also because
a) the name can be surprising to the control-plane programmer, and b)
backends can generate their own names for these which may not match
(which is what the bmv2 backend is doing). Taking that into account, it
seems better to just raise an error in the P4RuntimeSerializer.