### PR TITLE
add policies to skip certain checks in frontend

### DIFF
--- a/frontends/p4/createBuiltins.cpp
+++ b/frontends/p4/createBuiltins.cpp
@@ -20,6 +20,8 @@ limitations under the License.
 
 namespace P4 {
 void CreateBuiltins::postorder(IR::P4Parser* parser) {
+    if (policy != nullptr && !policy->convert(parser))
+        return;
     parser->states.push_back(new IR::ParserState(IR::ParserState::accept, nullptr));
     parser->states.push_back(new IR::ParserState(IR::ParserState::reject, nullptr));
 }

--- a/frontends/p4/createBuiltins.h
+++ b/frontends/p4/createBuiltins.h
@@ -42,7 +42,7 @@ class CreateBuiltins final : public Modifier {
     CreateBuiltinsPolicy* policy;
  public:
     using Modifier::postorder;
-    CreateBuiltins(CreateBuiltinsPolicy* policy)
+    CreateBuiltins(CreateBuiltinsPolicy* policy = nullptr)
             : policy(policy) { setName("CreateBuiltins"); }
     void postorder(IR::ParserState* state) override;
     void postorder(IR::P4Parser* parser) override;

--- a/frontends/p4/createBuiltins.h
+++ b/frontends/p4/createBuiltins.h
@@ -26,11 +26,24 @@ limitations under the License.
  * Parser states without selects will transition to reject.
  */
 namespace P4 {
+
+class CreateBuiltinsPolicy {
+public:
+    virtual ~CreateBuiltinsPolicy() {}
+    /**
+       If the policy returns true the parser is processed,
+       otherwise it is left unchanged.
+    */
+    virtual bool convert(const IR::P4Parser* parser) const = 0;
+};
+
 class CreateBuiltins final : public Modifier {
     bool addNoAction;
+    CreateBuiltinsPolicy* policy;
  public:
     using Modifier::postorder;
-    CreateBuiltins() { setName("CreateBuiltins"); }
+    CreateBuiltins(CreateBuiltinsPolicy* policy)
+            : policy(policy) { setName("CreateBuiltins"); }
     void postorder(IR::ParserState* state) override;
     void postorder(IR::P4Parser* parser) override;
     void postorder(IR::ActionListElement* element) override;

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -111,9 +111,9 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
     PassManager passes = {
         new PrettyPrint(options),
         // Simple checks on parsed program
-        new ValidateParsedProgram(),
+        new ValidateParsedProgram(validateParsedProgramPolicy),
         // Synthesize some built-in constructs
-        new CreateBuiltins(),
+        new CreateBuiltins(createBuiltinsPolicy),
         new ResolveReferences(&refMap, true),  // check shadowing
         // First pass of constant folding, before types are known --
         // may be needed to compute types.

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -19,14 +19,24 @@ limitations under the License.
 
 #include "ir/ir.h"
 #include "../common/options.h"
+#include "validateParsedProgram.h"
+#include "createBuiltins.h"
 
 namespace P4 {
 
 class FrontEnd {
     std::vector<DebugHook> hooks;
+    ValidateParsedProgramPolicy* validateParsedProgramPolicy;
+    CreateBuiltinsPolicy* createBuiltinsPolicy;
+
  public:
     FrontEnd() = default;
-    explicit FrontEnd(DebugHook hook) { hooks.push_back(hook); }
+    explicit FrontEnd(DebugHook hook,
+                      ValidateParsedProgramPolicy* validateParsedProgramPolicy = nullptr,
+                      CreateBuiltinsPolicy* createBuiltinsPolicy = nullptr)
+        : validateParsedProgramPolicy(validateParsedProgramPolicy),
+          createBuiltinsPolicy(createBuiltinsPolicy)
+        { hooks.push_back(hook); }
     void addDebugHook(DebugHook hook) { hooks.push_back(hook); }
     const IR::P4Program* run(const CompilerOptions& options, const IR::P4Program* program,
                              bool skipSideEffectOrdering = false);

--- a/frontends/p4/validateParsedProgram.cpp
+++ b/frontends/p4/validateParsedProgram.cpp
@@ -65,6 +65,8 @@ void ValidateParsedProgram::postorder(const IR::Type_Bits* type) {
 
 /// The accept and reject states cannot be implemented
 void ValidateParsedProgram::postorder(const IR::ParserState* s) {
+    if (policy != nullptr && !policy->validate(s))
+        return;
     if (s->name == IR::ParserState::accept ||
         s->name == IR::ParserState::reject)
         ::error("%1%: parser state should not be implemented, it is built-in", s->name);

--- a/frontends/p4/validateParsedProgram.h
+++ b/frontends/p4/validateParsedProgram.h
@@ -66,7 +66,7 @@ class ValidateParsedProgram final : public Inspector {
         const IR::ParameterList* constr);
 
  public:
-    ValidateParsedProgram(ValidateParsedProgramPolicy* policy)
+    ValidateParsedProgram(ValidateParsedProgramPolicy* policy = nullptr)
         : policy(policy) { setName("ValidateParsedProgram"); }
     void postorder(const IR::Constant* c) override;
     void postorder(const IR::SwitchStatement* statement) override;

--- a/frontends/p4/validateParsedProgram.h
+++ b/frontends/p4/validateParsedProgram.h
@@ -22,6 +22,19 @@ limitations under the License.
 namespace P4 {
 
 /**
+Policy which selects the whether certain checks are applied.
+*/
+class ValidateParsedProgramPolicy {
+public:
+    virtual ~ValidateParsedProgramPolicy() {}
+    /**
+       If the policy returns true the check is applied,
+       otherwise the check is skipped.
+    */
+    virtual bool validate(const IR::ParserState* state) const = 0;
+};
+
+/**
    This pass performs some simple semantic checks on the program;
    since the grammar accepts many programs that are actually illegal,
    this pass does some additional validation.
@@ -44,6 +57,7 @@ namespace P4 {
    - extern constructors have the same name as the enclosing extern
  */
 class ValidateParsedProgram final : public Inspector {
+    ValidateParsedProgramPolicy* policy;
     void container(const IR::IContainer* type);
     // Make sure that type, apply and constructor parameters are distinct
     void distinctParameters(
@@ -52,8 +66,8 @@ class ValidateParsedProgram final : public Inspector {
         const IR::ParameterList* constr);
 
  public:
-    ValidateParsedProgram()
-    { setName("ValidateParsedProgram"); }
+    ValidateParsedProgram(ValidateParsedProgramPolicy* policy)
+        : policy(policy) { setName("ValidateParsedProgram"); }
     void postorder(const IR::Constant* c) override;
     void postorder(const IR::SwitchStatement* statement) override;
     void postorder(const IR::Method* t) override;

--- a/test/gtest/bmv2_isvalid.cpp
+++ b/test/gtest/bmv2_isvalid.cpp
@@ -96,7 +96,7 @@ TEST(BMV2_SynthesizeValidField, Expressions) {
     P4::ReferenceMap refMap;
     P4::TypeMap typeMap;
     PassManager passes = {
-        new P4::CreateBuiltins(nullptr),
+        new P4::CreateBuiltins(),
         new P4::TypeChecking(&refMap, &typeMap),
         new SynthesizeValidField(&refMap, &typeMap),
     };
@@ -182,7 +182,7 @@ TEST(BMV2_SynthesizeValidField, MatchKeys) {
     P4::ReferenceMap refMap;
     P4::TypeMap typeMap;
     PassManager passes = {
-        new P4::CreateBuiltins(nullptr),
+        new P4::CreateBuiltins(),
         new P4::TypeChecking(&refMap, &typeMap),
         new SynthesizeValidField(&refMap, &typeMap),
     };
@@ -284,7 +284,7 @@ TEST(BMV2_SynthesizeValidField, ConstTableEntries) {
     P4::ReferenceMap refMap;
     P4::TypeMap typeMap;
     PassManager passes = {
-        new P4::CreateBuiltins(nullptr),
+        new P4::CreateBuiltins(),
         new P4::TypeChecking(&refMap, &typeMap),
         new SynthesizeValidField(&refMap, &typeMap),
     };
@@ -362,7 +362,7 @@ TEST(BMV2_SynthesizeValidField, SimplifiedKeysHaveNoIsValid) {
     P4::ReferenceMap refMap;
     P4::TypeMap typeMap;
     PassManager passes = {
-        new P4::CreateBuiltins(nullptr),
+        new P4::CreateBuiltins(),
         new P4::TypeChecking(&refMap, &typeMap),
         new SynthesizeValidField(&refMap, &typeMap),
         new P4::TypeChecking(&refMap, &typeMap),

--- a/test/gtest/bmv2_isvalid.cpp
+++ b/test/gtest/bmv2_isvalid.cpp
@@ -96,7 +96,7 @@ TEST(BMV2_SynthesizeValidField, Expressions) {
     P4::ReferenceMap refMap;
     P4::TypeMap typeMap;
     PassManager passes = {
-        new P4::CreateBuiltins(),
+        new P4::CreateBuiltins(nullptr),
         new P4::TypeChecking(&refMap, &typeMap),
         new SynthesizeValidField(&refMap, &typeMap),
     };
@@ -182,7 +182,7 @@ TEST(BMV2_SynthesizeValidField, MatchKeys) {
     P4::ReferenceMap refMap;
     P4::TypeMap typeMap;
     PassManager passes = {
-        new P4::CreateBuiltins(),
+        new P4::CreateBuiltins(nullptr),
         new P4::TypeChecking(&refMap, &typeMap),
         new SynthesizeValidField(&refMap, &typeMap),
     };
@@ -284,7 +284,7 @@ TEST(BMV2_SynthesizeValidField, ConstTableEntries) {
     P4::ReferenceMap refMap;
     P4::TypeMap typeMap;
     PassManager passes = {
-        new P4::CreateBuiltins(),
+        new P4::CreateBuiltins(nullptr),
         new P4::TypeChecking(&refMap, &typeMap),
         new SynthesizeValidField(&refMap, &typeMap),
     };
@@ -362,7 +362,7 @@ TEST(BMV2_SynthesizeValidField, SimplifiedKeysHaveNoIsValid) {
     P4::ReferenceMap refMap;
     P4::TypeMap typeMap;
     PassManager passes = {
-        new P4::CreateBuiltins(),
+        new P4::CreateBuiltins(nullptr),
         new P4::TypeChecking(&refMap, &typeMap),
         new SynthesizeValidField(&refMap, &typeMap),
         new P4::TypeChecking(&refMap, &typeMap),


### PR DESCRIPTION
It is useful to be able to skip certain passes in the frontend pass manager, in the case that such checks are already performed in some pre-frontend passes. I ran into a case this is required, adding policies to the frontend passes seems to be the right approach.