### PR TITLE
Add support for IR node fields of boost::optional type

### DIFF
--- a/ir/json_generator.h
+++ b/ir/json_generator.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define _IR_JSON_GENERATOR_H_
 
 #include <assert.h>
+#include <boost/optional.hpp>
 #include <gmpxx.h>
 #include <string>
 #include "lib/cstring.h"
@@ -79,6 +80,19 @@ class JSONGenerator {
         generate(v.first);
         out << "," << std::endl << indent << "\"second\" : ";
         generate(v.second);
+        out << std::endl << --indent << "}";
+    }
+
+    template<typename T>
+    void generate(const boost::optional<T> &v) {
+        if (!v) {
+            out << "{ \"valid\" : false }";
+            return;
+        }
+        out << "{" << std::endl << ++indent;
+        out << "\"valid\" : true," << std::endl;
+        out << "\"value\" : ";
+        generate(*v);
         out << std::endl << --indent << "}";
     }
 

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -18,10 +18,12 @@ limitations under the License.
 #define _IR_JSON_LOADER_H_
 
 #include <assert.h>
+#include <boost/optional.hpp>
 #include <gmpxx.h>
 #include <string>
 #include <map>
 #include <unordered_map>
+#include <utility>
 #include "lib/cstring.h"
 #include "lib/indent.h"
 #include "lib/match.h"
@@ -142,6 +144,20 @@ class JSONLoader {
         const JsonObject* obj = json->to<JsonObject>();
         load(::get(obj, "first"), v.first);
         load(::get(obj, "second"), v.second);
+    }
+
+    template<typename T>
+    void unpack_json(boost::optional<T> &v) {
+        const JsonObject* obj = json->to<JsonObject>();
+        bool isValid = false;
+        load(::get(obj, "valid"), isValid);
+        if (!isValid) {
+            v = boost::none;
+            return;
+        }
+        T value;
+        load(::get(obj, "value"), value),
+        v = std::move(value);
     }
 
     void unpack_json(bool &v) { v = *json->to<JsonBoolean>(); }

--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -325,6 +325,7 @@ lookup_scope
 nonRefType
     : IDENTIFIER                        { $$ = new NamedType(@1, 0, $1); }
     | lookup_scope IDENTIFIER           { $$ = new NamedType(@2, $1, $2); }
+    | lookup_scope OPTIONAL             { $$ = new NamedType(@2, $1, "optional"); }
     | nonRefType '<' type_args '>'      { $$ = new TemplateInstantiation(@1+@4, $1, *$3); }
     | nonRefType '[' INTEGER ']'        { $$ = new ArrayType(@1+@4, $1, atoi($3)); }
     ;


### PR DESCRIPTION
Does what it says on the tin. `boost::optional` is, in my view, anything but optional.

The patch to the IR generator grammar is needed because of a lexical ambiguity, since "optional" is also a keyword in IR generator .def files. With this change, "optional" is also permitted as a type name as long as it's qualified by a namespace. (i.e., you can have fields of type "boost::optional", but using just "optional" will still result in "optional" being parsed as a keyword)