### PR TITLE
Fix for issue #816

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -582,8 +582,7 @@ const IR::Node* TypeInference::postorder(IR::P4Action* action) {
     auto pl = canonicalizeParameters(action->parameters);
     if (pl == nullptr)
         return action;
-    auto ok = checkParameters(action->parameters, true);
-    if (!ok)
+    if (!checkParameters(action->parameters, true))
         return action;
     auto type = new IR::Type_Action(new IR::TypeParameters(), nullptr, pl);
 

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -229,15 +229,19 @@ bool TypeInference::checkParameters(const IR::ParameterList* paramList, bool for
         auto type = getType(p);
         if (type == nullptr)
             return false;
+        if (type->is<IR::Type_Package>()) {
+            typeError("%1%: parameter cannot be a package", p);
+            return false;
+        }
         if (p->direction != IR::Direction::None && type->is<IR::Type_Extern>()) {
             typeError("%1%: a parameter with an extern type cannot have a direction", p);
             return false;
         }
-        if (forbidModules && (type->is<IR::Type_Parser>() ||
-                              type->is<IR::Type_Control>() ||
-                              type->is<IR::Type_Package>() ||
-                              type->is<IR::P4Parser>() ||
-                              type->is<IR::P4Control>())) {
+        if ((forbidModules || p->direction != IR::Direction::None) &&
+            (type->is<IR::Type_Parser>() ||
+             type->is<IR::Type_Control>() ||
+             type->is<IR::P4Parser>() ||
+             type->is<IR::P4Control>())) {
             typeError("%1%: parameter cannot have type %2%", p, type);
             return false;
         }
@@ -577,6 +581,9 @@ const IR::Node* TypeInference::postorder(IR::P4Action* action) {
     if (done()) return action;
     auto pl = canonicalizeParameters(action->parameters);
     if (pl == nullptr)
+        return action;
+    auto ok = checkParameters(action->parameters, true);
+    if (!ok)
         return action;
     auto type = new IR::Type_Action(new IR::TypeParameters(), nullptr, pl);
 

--- a/testdata/p4_16_errors/issue816-1.p4
+++ b/testdata/p4_16_errors/issue816-1.p4
@@ -1,0 +1,32 @@
+#include <core.p4>
+
+// Architecture
+control C();
+package S(C c);
+
+// User Program
+package P(C c1, C c2);
+
+control Dummy() {
+  apply { }
+}
+
+control MyC1()(P p) {
+  apply {
+  }
+}
+control MyC2()(P p) {
+  apply {
+  }
+}
+control MyC3() {
+  Dummy() d;
+  P(d,d) p;
+  C c1 = MyC1(p);
+  C c2 = MyC2(p);
+  apply {
+    c1.apply();
+  }
+}
+
+S(MyC3()) main;

--- a/testdata/p4_16_errors/issue816.p4
+++ b/testdata/p4_16_errors/issue816.p4
@@ -1,0 +1,38 @@
+#include <core.p4>
+
+// Architecture
+control C();
+package S(C c);
+extern BoolRegister {
+    BoolRegister();
+    bool get();
+    void flip();
+}
+
+// User Program
+BoolRegister() r;
+
+action a(in C c1, in C c2) {
+    r.flip();
+    if (r.get()) {
+        c1.apply();
+    } else {
+        c2.apply();
+    }
+}
+
+control MyC1() {
+    apply {
+    }
+}
+control MyC2() {
+    apply {
+    }
+}
+control MyC3() {
+    apply {
+        a(MyC1(), MyC2());
+    }
+}
+
+S(MyC3()) main;

--- a/testdata/p4_16_errors/param.p4
+++ b/testdata/p4_16_errors/param.p4
@@ -19,7 +19,7 @@ extern E {
 }
 
 control c() {
-    action a(in E e) { e.call(); }
+    action a(E e) { e.call(); }
     E() einst;
     apply {
         a(einst);

--- a/testdata/p4_16_errors_outputs/issue816-1.p4
+++ b/testdata/p4_16_errors_outputs/issue816-1.p4
@@ -1,0 +1,31 @@
+#include <core.p4>
+
+control C();
+package S(C c);
+package P(C c1, C c2);
+control Dummy() {
+    apply {
+    }
+}
+
+control MyC1()(P p) {
+    apply {
+    }
+}
+
+control MyC2()(P p) {
+    apply {
+    }
+}
+
+control MyC3() {
+    Dummy() d;
+    P(d, d) p;
+    C c1 = MyC1(p);
+    C c2 = MyC2(p);
+    apply {
+        c1.apply();
+    }
+}
+
+S(MyC3()) main;

--- a/testdata/p4_16_errors_outputs/issue816-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue816-1.p4-stderr
@@ -1,0 +1,5 @@
+In file: /home/mbudiu/git/p4c/frontends/p4/typeChecking/typeChecker.h:101
+[31mCompiler Bug[0m: /home/mbudiu/git/p4c/testdata/p4_16_errors/issue816-1.p4(14):  package P<>( C c1,  C c2); p: parameter cannot be a package
+control MyC1()(P p) {
+                 ^
+

--- a/testdata/p4_16_errors_outputs/issue816-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue816-1.p4-stderr
@@ -1,5 +1,6 @@
-In file: /home/mbudiu/git/p4c/frontends/p4/typeChecking/typeChecker.h:101
-[31mCompiler Bug[0m: /home/mbudiu/git/p4c/testdata/p4_16_errors/issue816-1.p4(14):  package P<>( C c1,  C c2); p: parameter cannot be a package
+issue816-1.p4(14): error: p: parameter cannot be a package
 control MyC1()(P p) {
                  ^
-
+issue816-1.p4(18): error: p: parameter cannot be a package
+control MyC2()(P p) {
+                 ^

--- a/testdata/p4_16_errors_outputs/issue816-first.p4
+++ b/testdata/p4_16_errors_outputs/issue816-first.p4
@@ -1,0 +1,35 @@
+#include <core.p4>
+
+control C();
+package S(C c);
+extern BoolRegister {
+    BoolRegister();
+    bool get();
+    void flip();
+}
+
+BoolRegister() r;
+action a(in C c1, in C c2) {
+    r.flip();
+    if (r.get()) 
+        c1.apply();
+    else 
+        c2.apply();
+}
+control MyC1() {
+    apply {
+    }
+}
+
+control MyC2() {
+    apply {
+    }
+}
+
+control MyC3() {
+    apply {
+        a(MyC1(), MyC2());
+    }
+}
+
+S(MyC3()) main;

--- a/testdata/p4_16_errors_outputs/issue816.p4
+++ b/testdata/p4_16_errors_outputs/issue816.p4
@@ -1,0 +1,37 @@
+#include <core.p4>
+
+control C();
+package S(C c);
+extern BoolRegister {
+    BoolRegister();
+    bool get();
+    void flip();
+}
+
+BoolRegister() r;
+action a(in C c1, in C c2) {
+    r.flip();
+    if (r.get()) {
+        c1.apply();
+    }
+    else {
+        c2.apply();
+    }
+}
+control MyC1() {
+    apply {
+    }
+}
+
+control MyC2() {
+    apply {
+    }
+}
+
+control MyC3() {
+    apply {
+        a(MyC1(), MyC2());
+    }
+}
+
+S(MyC3()) main;

--- a/testdata/p4_16_errors_outputs/issue816.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue816.p4-stderr
@@ -4,9 +4,3 @@ action a(in C c1, in C c2) {
 issue816.p4(4)
 control C();
         ^
-issue816.p4(15): error: Could not find type of a
-action a(in C c1, in C c2) {
-       ^
-issue816.p4(34): error: Could not find type of a
-        a(MyC1(), MyC2());
-        ^

--- a/testdata/p4_16_errors_outputs/issue816.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue816.p4-stderr
@@ -1,0 +1,12 @@
+issue816.p4(15): error: c1: parameter cannot have type control C
+action a(in C c1, in C c2) {
+              ^^
+issue816.p4(4)
+control C();
+        ^
+issue816.p4(15): error: Could not find type of a
+action a(in C c1, in C c2) {
+       ^
+issue816.p4(34): error: Could not find type of a
+        a(MyC1(), MyC2());
+        ^

--- a/testdata/p4_16_errors_outputs/param.p4
+++ b/testdata/p4_16_errors_outputs/param.p4
@@ -4,7 +4,7 @@ extern E {
 }
 
 control c() {
-    action a(in E e) {
+    action a(E e) {
         e.call();
     }
     E() einst;

--- a/testdata/p4_16_errors_outputs/param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/param.p4-stderr
@@ -1,3 +1,3 @@
 param.p4(22): error: E: Action parameters cannot have extern types
-    action a(in E e) { e.call(); }
-                ^
+    action a(E e) { e.call(); }
+             ^


### PR DESCRIPTION
The fix enforces the following:
- packages can only be passed as arguments to other packages
- controls, parsers, packages and externs cannot be passed as parameter with a direction