### PR TITLE
Fix typo in P4Runtime

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1401,7 +1401,7 @@ getExternInstanceFromProperty(const IR::P4Table* table,
 
     auto expr = property->value->to<IR::ExpressionValue>()->expression;
     if (expr->is<IR::ConstructorCallExpression>()
-        && expr->getAnnotation(IR::Annotation::nameAnnotation) == nullptr) {
+        && property->getAnnotation(IR::Annotation::nameAnnotation) == nullptr) {
         ::error("Table '%1%' has an anonymous table property '%2%' with no name annotation, "
                 "which is not supported by P4Runtime", table->controlPlaneName(), propertyName);
         return boost::none;


### PR DESCRIPTION
This fixes commit 9b4e0db15fe9578be5f74052b993c010cbe8f454. For table
properties, the name annotation is on the property name, not the value.