### PR TITLE
add getApplyParameters() method to IApply interface

### DIFF
--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -290,34 +290,34 @@ bool ResolveReferences::preorder(const IR::Type_Name* type) {
 
 bool ResolveReferences::preorder(const IR::P4Control *c) {
     refMap->usedName(c->name.name);
-    addToContext(c->type->typeParameters);
-    addToContext(c->type->applyParams);
-    addToContext(c->constructorParams);
+    addToContext(c->getTypeParameters());
+    addToContext(c->getApplyParameters());
+    addToContext(c->getConstructorParameters());
     addToContext(c);  // add the locals
     return true;
 }
 
 void ResolveReferences::postorder(const IR::P4Control *c) {
     removeFromContext(c);
-    removeFromContext(c->constructorParams);
-    removeFromContext(c->type->applyParams);
-    removeFromContext(c->type->typeParameters);
+    removeFromContext(c->getConstructorParameters());
+    removeFromContext(c->getApplyParameters());
+    removeFromContext(c->getTypeParameters());
 }
 
 bool ResolveReferences::preorder(const IR::P4Parser *p) {
     refMap->usedName(p->name.name);
-    addToContext(p->type->typeParameters);
-    addToContext(p->type->applyParams);
-    addToContext(p->constructorParams);
+    addToContext(p->getTypeParameters());
+    addToContext(p->getApplyParameters());
+    addToContext(p->getConstructorParameters());
     addToContext(p);
     return true;
 }
 
 void ResolveReferences::postorder(const IR::P4Parser *p) {
     removeFromContext(p);
-    removeFromContext(p->constructorParams);
-    removeFromContext(p->type->applyParams);
-    removeFromContext(p->type->typeParameters);
+    removeFromContext(p->getConstructorParameters());
+    removeFromContext(p->getApplyParameters());
+    removeFromContext(p->getTypeParameters());
 }
 
 bool ResolveReferences::preorder(const IR::Function* function) {

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -702,7 +702,7 @@ bool ComputeWriteSet::preorder(const IR::P4Parser* parser) {
     LOG3("CWS Visiting " << dbp(parser));
     auto startState = parser->getDeclByName(IR::ParserState::start)->to<IR::ParserState>();
     auto startPoint = ProgramPoint(startState);
-    enterScope(parser->type->applyParams, &parser->parserLocals, startPoint);
+    enterScope(parser->getApplyParameters(), &parser->parserLocals, startPoint);
     for (auto l : parser->parserLocals) {
         if (l->is<IR::Declaration_Instance>())
             visit(l);  // process virtual Functions if any
@@ -747,7 +747,7 @@ bool ComputeWriteSet::preorder(const IR::P4Parser* parser) {
 bool ComputeWriteSet::preorder(const IR::P4Control* control) {
     LOG3("CWS Visiting " << dbp(control));
     auto startPoint = ProgramPoint(control);
-    enterScope(control->type->applyParams, &control->controlLocals, startPoint);
+    enterScope(control->getApplyParameters(), &control->controlLocals, startPoint);
     exitDefinitions = new Definitions();
     returnedDefinitions = new Definitions();
     for (auto l : control->controlLocals) {

--- a/frontends/p4/specialize.cpp
+++ b/frontends/p4/specialize.cpp
@@ -40,7 +40,7 @@ const IR::Type_Declaration* SpecializationInfo::synthesize(ReferenceMap* refMap)
         auto parser = clone->to<IR::P4Parser>();
         auto newtype = new IR::Type_Parser(name, parser->type->annotations,
                                            new IR::TypeParameters(),
-                                           parser->type->applyParams);
+                                           parser->getApplyParameters());
         declarations->append(parser->parserLocals);
         result = new IR::P4Parser(name, newtype, new IR::ParameterList(),
                                   *declarations, parser->states);
@@ -48,7 +48,7 @@ const IR::Type_Declaration* SpecializationInfo::synthesize(ReferenceMap* refMap)
         auto control = clone->to<IR::P4Control>();
         auto newtype = new IR::Type_Control(name, control->type->annotations,
                                             new IR::TypeParameters(),
-                                            control->type->applyParams);
+                                            control->getApplyParameters());
         declarations->append(control->controlLocals);
         result = new IR::P4Control(name, newtype, new IR::ParameterList(),
                                    *declarations, control->body);

--- a/frontends/p4/validateParsedProgram.h
+++ b/frontends/p4/validateParsedProgram.h
@@ -72,14 +72,14 @@ class ValidateParsedProgram final : public Inspector {
     { container(package); }
     void postorder(const IR::P4Control* control) override {
         container(control);
-        distinctParameters(control->type->typeParameters,
-                           control->type->applyParams,
-                           control->constructorParams); }
+        distinctParameters(control->getTypeParameters(),
+                           control->getApplyParameters(),
+                           control->getConstructorParameters()); }
     void postorder(const IR::P4Parser* parser) override {
         container(parser);
-        distinctParameters(parser->type->typeParameters,
-                           parser->type->applyParams,
-                           parser->constructorParams); }
+        distinctParameters(parser->getTypeParameters(),
+                           parser->getApplyParameters(),
+                           parser->getConstructorParameters()); }
 };
 
 }  // namespace P4

--- a/ir/base.def
+++ b/ir/base.def
@@ -44,6 +44,7 @@ interface IApply {
     static const cstring applyMethodName;
     /// @returns the type signature of the apply method
     virtual const Type_Method* getApplyMethodType() const = 0;
+    virtual const ParameterList* getApplyParameters() const = 0;
 }
 
 /// base class for namespaces

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -96,6 +96,7 @@ class P4Parser : Type_Declaration, ISimpleNamespace, IApply, IContainer {
             return decl;
         return states.getDeclaration(name); }
     Type_Method getApplyMethodType() const override { return type->getApplyMethodType(); }
+    ParameterList getApplyParameters() const override { return type->getApplyParameters(); }
     Type_Method getConstructorMethodType() const override;
     ParameterList getConstructorParameters() const override { return constructorParams; }
     void checkDuplicates() const;
@@ -120,6 +121,7 @@ class P4Control : Type_Declaration, ISimpleNamespace, IApply, IContainer {
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
         return controlLocals.getDeclarations(); }
     Type_Method getApplyMethodType() const override { return type->getApplyMethodType(); }
+    ParameterList getApplyParameters() const override { return type->getApplyParameters(); }
     Type_Method getConstructorMethodType() const override;
     IDeclaration getDeclByName(cstring name) const override {
         return controlLocals.getDeclaration(name); }
@@ -289,6 +291,7 @@ class P4Table : Declaration, IAnnotated, IApply {
 
     Annotations getAnnotations() const override { return annotations; }
     Type_Method getApplyMethodType() const override;
+    ParameterList getApplyParameters() const override { return nullptr; }
     ActionList getActionList() const {
         auto ap = properties->getProperty(TableProperties::actionsPropertyName);
         if (ap == nullptr)

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -291,7 +291,7 @@ class P4Table : Declaration, IAnnotated, IApply {
 
     Annotations getAnnotations() const override { return annotations; }
     Type_Method getApplyMethodType() const override;
-    ParameterList getApplyParameters() const override { return nullptr; }
+    ParameterList getApplyParameters() const override { return new ParameterList(); }
     ActionList getActionList() const {
         auto ap = properties->getProperty(TableProperties::actionsPropertyName);
         if (ap == nullptr)

--- a/ir/type.def
+++ b/ir/type.def
@@ -299,12 +299,14 @@ class Type_Package : Type_ArchBlock, IContainer {
 class Type_Parser : Type_ArchBlock, IApply {
     ParameterList applyParams;
     Type_Method getApplyMethodType() const override;
+    ParameterList getApplyParameters() const override { return applyParams; }
     toString { return cstring("parser ") + externalName(); }
 }
 
 class Type_Control : Type_ArchBlock, IApply {
     ParameterList applyParams;
     Type_Method getApplyMethodType() const override;
+    ParameterList getApplyParameters() const override { return applyParams; }
     toString { return cstring("control ") + externalName(); }
 }
 
@@ -389,6 +391,7 @@ class Type_Enum : Type_Declaration, ISimpleNamespace {
 class Type_Table : Type, IApply {
     P4Table  table;
     Type_Method getApplyMethodType() const override;
+    ParameterList getApplyParameters() const override { return nullptr; }
     /// names for the fields of the struct returned
     /// by applying a table
     static const ID hit;

--- a/ir/type.def
+++ b/ir/type.def
@@ -391,7 +391,7 @@ class Type_Enum : Type_Declaration, ISimpleNamespace {
 class Type_Table : Type, IApply {
     P4Table  table;
     Type_Method getApplyMethodType() const override;
-    ParameterList getApplyParameters() const override { return nullptr; }
+    ParameterList getApplyParameters() const override { return new ParameterList(); }
     /// names for the fields of the struct returned
     /// by applying a table
     static const ID hit;

--- a/midend/inlining.cpp
+++ b/midend/inlining.cpp
@@ -537,7 +537,7 @@ const IR::Node* GeneralInliner::preorder(IR::P4Control* caller) {
 
             // Substitute applyParameters which are not directionless
             // with fresh variable names or with the call arguments.
-            for (auto param : callee->type->applyParams->parameters) {
+            for (auto param : callee->getApplyParameters()->parameters) {
                 if (param->direction == IR::Direction::None)
                     continue;
                 if (call != nullptr && (useTemporary.find(param) == useTemporary.end())) {
@@ -744,7 +744,7 @@ const IR::Node* GeneralInliner::preorder(IR::ParserState* state) {
 
         // Evaluate in and inout parameters in order.
         auto it = call->methodCall->arguments->begin();
-        for (auto param : callee->type->applyParams->parameters) {
+        for (auto param : callee->getApplyParameters()->parameters) {
             auto initializer = *it;
             LOG3("Looking for " << param->name);
             if (param->direction == IR::Direction::In || param->direction == IR::Direction::InOut) {
@@ -788,7 +788,7 @@ const IR::Node* GeneralInliner::preorder(IR::ParserState* state) {
 
         // Copy back out and inout parameters
         it = call->methodCall->arguments->begin();
-        for (auto param : callee->type->applyParams->parameters) {
+        for (auto param : callee->getApplyParameters()->parameters) {
             auto left = *it;
             if (param->direction == IR::Direction::InOut ||
                 param->direction == IR::Direction::Out) {
@@ -851,7 +851,7 @@ const IR::Node* GeneralInliner::preorder(IR::P4Parser* caller) {
 
             // Substitute applyParameters which are not directionless
             // with fresh variable names.
-            for (auto param : callee->type->applyParams->parameters) {
+            for (auto param : callee->getApplyParameters()->parameters) {
                 if (param->direction == IR::Direction::None)
                     continue;
                 cstring newName = refMap->newName(param->name);

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -55,7 +55,7 @@ class ParserSymbolicInterpreter {
         ValueMap* result = new ValueMap();
         ExpressionEvaluator ev(refMap, typeMap, result);
 
-        for (auto p : parser->type->applyParams->parameters) {
+        for (auto p : parser->getApplyParameters()->parameters) {
             auto type = typeMap->getType(p);
             bool initialized = p->direction == IR::Direction::In ||
                     p->direction == IR::Direction::InOut;


### PR DESCRIPTION
The IR has `getConstructorParameters` and `getTypeParameters`, but not `getApplyParameters` which makes the IR API asymmetrical.

One thing I am not sure about in this commit is the `table.apply()` does not allow apply parameter in P4-16. Hence, `getApplyParameters()` on table will return a `nullptr`. We do the same for the `getP4Type()` function in `type.def`.