### PR TITLE
Fix for issue #759

### DIFF
--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -52,8 +52,6 @@ set (P4TEST_SUITES
 set (P4_XFAIL_TESTS
   # issue #13
   testdata/p4_16_samples/cast-call.p4
-  # issue 759
-  testdata/p4_16_samples/tuple0.p4
   )
 p4c_add_tests("p4" ${P4TEST_DRIVER} "${P4TEST_SUITES}" "${P4_XFAIL_TESTS}")
 

--- a/midend/eliminateTuples.h
+++ b/midend/eliminateTuples.h
@@ -77,6 +77,10 @@ class DoReplaceTuples final : public Transform {
     { return insertReplacements(parser); }
     const IR::Node* postorder(IR::P4Control* control) override
     { return insertReplacements(control); }
+    const IR::Node* postorder(IR::Method* method) override
+    { return insertReplacements(method); }
+    const IR::Node* postorder(IR::Type_Extern* ext) override
+    { return insertReplacements(ext); }
 };
 
 class EliminateTuples final : public PassManager {

--- a/testdata/p4_16_samples_outputs/tuple0-first.p4
+++ b/testdata/p4_16_samples_outputs/tuple0-first.p4
@@ -1,0 +1,12 @@
+extern void f(in tuple<bit<32>, bool> data);
+control proto();
+package top(proto _p);
+control c() {
+    tuple<bit<32>, bool> x = { 32w10, false };
+    apply {
+        f(x);
+        f({ 32w20, true });
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/tuple0-frontend.p4
+++ b/testdata/p4_16_samples_outputs/tuple0-frontend.p4
@@ -1,0 +1,13 @@
+extern void f(in tuple<bit<32>, bool> data);
+control proto();
+package top(proto _p);
+control c() {
+    tuple<bit<32>, bool> x_0;
+    apply {
+        x_0 = { 32w10, false };
+        f(x_0);
+        f({ 32w20, true });
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/tuple0-midend.p4
+++ b/testdata/p4_16_samples_outputs/tuple0-midend.p4
@@ -1,0 +1,28 @@
+struct tuple_0 {
+    bit<32> field;
+    bool    field_0;
+}
+
+extern void f(in tuple_0 data);
+control proto();
+package top(proto _p);
+control c() {
+    tuple_0 x;
+    @hidden action act() {
+        x.field = 32w10;
+        x.field_0 = false;
+        f(x);
+        f({ 32w20, true });
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/tuple0.p4
+++ b/testdata/p4_16_samples_outputs/tuple0.p4
@@ -1,0 +1,12 @@
+extern void f(in tuple<bit<32>, bool> data);
+control proto();
+package top(proto _p);
+control c() {
+    tuple<bit<32>, bool> x = { 10, false };
+    apply {
+        f(x);
+        f({ 20, true });
+    }
+}
+
+top(c()) main;


### PR DESCRIPTION
The compiler was inserting the tuple replacement type after its first use.
The fix consists in realizing that tuples can appear in method or extern declarations too.