### PR TITLE
converts boolean expressions comparing bools to ints

### DIFF
--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -195,11 +195,11 @@ const IR::Node* ExpressionConverter::postorder(IR::Equ *equ) {
 
     auto val = constExpr->to<IR::Constant>()->asInt();
     if (val == 1)
-        return boolExpr; // == 1 return the boolean
+        return boolExpr;  // == 1 return the boolean
     else if (val == 0)
-        return new IR::LNot(equ->srcInfo, boolExpr); // return the !boolean
+        return new IR::LNot(equ->srcInfo, boolExpr);  // return the !boolean
     else
-        return new IR::BoolLiteral(equ->srcInfo, false); // everything else is false
+        return new IR::BoolLiteral(equ->srcInfo, false);  // everything else is false
 }
 
 /// And the Neq
@@ -223,7 +223,7 @@ const IR::Node* ExpressionConverter::postorder(IR::Neq *neq) {
     else if (val == 1)
         return new IR::LNot(neq->srcInfo, boolExpr);
     else
-        return new IR::BoolLiteral(neq->srcInfo, true); // everything else is true
+        return new IR::BoolLiteral(neq->srcInfo, true);  // everything else is true
 }
 
 const IR::Node* StatementConverter::preorder(IR::Apply* apply) {

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -176,6 +176,53 @@ const IR::Node* ExpressionConverter::postorder(IR::GlobalRef *ref) {
             new IR::Path(ref->srcInfo, IR::ID(ref->srcInfo, ref->toString())));
 }
 
+/// P4_16 is stricter on comparing booleans with ints
+/// Therefore we convert such expressions into simply the boolean test
+const IR::Node* ExpressionConverter::postorder(IR::Equ *equ) {
+  const IR::Expression *boolExpr = nullptr;
+  const IR::Expression *constExpr = nullptr;
+  if (equ->left->type->is<IR::Type_Boolean>() &&
+      (equ->right->type->is<IR::Type_InfInt>() && equ->right->is<IR::Constant>())) {
+    boolExpr = equ->left;
+    constExpr = equ->right;
+  } else if (equ->right->type->is<IR::Type_Boolean>() &&
+             (equ->left->type->is<IR::Type_InfInt>() && equ->left->is<IR::Constant>())) {
+    boolExpr = equ->right;
+    constExpr = equ->left;
+  }
+
+  if (boolExpr == nullptr)
+    return equ;
+
+  if (constExpr->to<IR::Constant>()->asInt() == 0)
+    return new IR::LNot(equ->srcInfo, boolExpr);
+  else
+    return boolExpr;
+}
+
+/// And the Neq
+const IR::Node* ExpressionConverter::postorder(IR::Neq *neq) {
+  const IR::Expression *boolExpr = nullptr;
+  const IR::Expression *constExpr = nullptr;
+  if (neq->left->type->is<IR::Type_Boolean>() &&
+      (neq->right->type->is<IR::Type_InfInt>() && neq->right->is<IR::Constant>())) {
+    boolExpr = neq->left;
+    constExpr = neq->right;
+  } else if (neq->right->type->is<IR::Type_Boolean>() &&
+             (neq->left->type->is<IR::Type_InfInt>() && neq->left->is<IR::Constant>())) {
+    boolExpr = neq->right;
+    constExpr = neq->left;
+  }
+
+  if (boolExpr == nullptr)
+    return neq;
+
+  if (constExpr->to<IR::Constant>()->asInt() != 0)
+    return new IR::LNot(neq->srcInfo, boolExpr);
+  else
+    return boolExpr;
+}
+
 const IR::Node* StatementConverter::preorder(IR::Apply* apply) {
     auto table = structure->tables.get(apply->name);
     auto newname = structure->tables.get(table);

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -29,6 +29,7 @@ class ExpressionConverter : public Transform {
  protected:
     ProgramStructure* structure;
     P4::P4CoreLibrary &p4lib;
+
  public:
     bool replaceNextWithLast;  // if true p[next] becomes p.last
     explicit ExpressionConverter(ProgramStructure* structure)
@@ -45,6 +46,8 @@ class ExpressionConverter : public Transform {
     const IR::Node* postorder(IR::ConcreteHeaderRef* nhr) override;
     const IR::Node* postorder(IR::HeaderStackItemRef* ref) override;
     const IR::Node* postorder(IR::GlobalRef *gr) override;
+    const IR::Node* postorder(IR::Equ *equ) override;
+    const IR::Node* postorder(IR::Neq *neq) override;
     const IR::Expression* convert(const IR::Node* node) {
         auto result = node->apply(*this);
         return result->to<IR::Expression>();

--- a/testdata/p4_14_samples/issue846.p4
+++ b/testdata/p4_14_samples/issue846.p4
@@ -1,0 +1,124 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+header_type hdr0_t {
+    fields {
+        a : 16;
+        b : 8;
+        c : 8;
+    }
+}
+
+header_type meta_t {
+    fields {
+       x : 16;
+       y : 16;
+       z : 16;
+    }
+}
+
+header hdr0_t hdr0;
+metadata meta_t meta;
+
+
+parser start {
+   return p_hdr0;
+}
+
+parser p_hdr0 {
+   extract(hdr0);
+   return ingress;
+}
+
+action do_nothing(){}
+action action_0(p){
+   modify_field(meta.x, 1);
+   modify_field(meta.y, 2);
+}
+action action_1(p){
+   add(meta.z, meta.y, meta.x);
+}
+action action_2(p){
+   modify_field(hdr0.a, meta.z);
+}
+
+table t0 {
+    reads {
+        hdr0.a : ternary;
+    }
+    actions {
+        do_nothing;
+        action_0;
+    }
+    size : 512;
+}
+
+table t1 {
+    reads {
+        hdr0.a : ternary;
+    }
+    actions {
+        do_nothing;
+        action_1;
+    }
+    size : 512;
+}
+
+table t2 {
+    reads {
+        meta.y : ternary;
+        meta.z : exact;
+    }
+    actions {
+        do_nothing;
+        action_2;
+    }
+    size : 512;
+}
+
+table t3 {
+    reads {
+        hdr0.a : ternary;
+    }
+    actions {
+        do_nothing;
+        action_1;
+    }
+    size : 512;
+}
+
+
+control ingress {
+  if (hdr0.valid == 1){
+      apply(t0);
+  }
+
+  if (hdr0.valid == 0) {
+      apply(t1);
+  }
+
+  if (hdr0.valid == 1 or valid(hdr0)) {
+      apply(t2);
+  }
+
+  if (hdr0.valid != 0) {
+      apply(t3);
+  }
+
+}
+
+control egress {
+}

--- a/testdata/p4_14_samples_outputs/issue846-first.p4
+++ b/testdata/p4_14_samples_outputs/issue846-first.p4
@@ -1,0 +1,131 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct meta_t {
+    bit<16> x;
+    bit<16> y;
+    bit<16> z;
+}
+
+header hdr0_t {
+    bit<16> a;
+    bit<8>  b;
+    bit<8>  c;
+}
+
+struct metadata {
+    @name("meta") 
+    meta_t meta;
+}
+
+struct headers {
+    @name("hdr0") 
+    hdr0_t hdr0;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".p_hdr0") state p_hdr0 {
+        packet.extract<hdr0_t>(hdr.hdr0);
+        transition accept;
+    }
+    @name(".start") state start {
+        transition p_hdr0;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_nothing") action do_nothing() {
+    }
+    @name(".action_0") action action_0(bit<8> p) {
+        meta.meta.x = 16w1;
+        meta.meta.y = 16w2;
+    }
+    @name(".action_1") action action_1(bit<8> p) {
+        meta.meta.z = meta.meta.y + meta.meta.x;
+    }
+    @name(".action_2") action action_2(bit<8> p) {
+        hdr.hdr0.a = meta.meta.z;
+    }
+    @name(".t0") table t0 {
+        actions = {
+            do_nothing();
+            action_0();
+            @defaultonly NoAction();
+        }
+        key = {
+            hdr.hdr0.a: ternary @name("hdr.hdr0.a") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    @name(".t1") table t1 {
+        actions = {
+            do_nothing();
+            action_1();
+            @defaultonly NoAction();
+        }
+        key = {
+            hdr.hdr0.a: ternary @name("hdr.hdr0.a") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    @name(".t2") table t2 {
+        actions = {
+            do_nothing();
+            action_2();
+            @defaultonly NoAction();
+        }
+        key = {
+            meta.meta.y: ternary @name("meta.meta.y") ;
+            meta.meta.z: exact @name("meta.meta.z") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    @name(".t3") table t3 {
+        actions = {
+            do_nothing();
+            action_1();
+            @defaultonly NoAction();
+        }
+        key = {
+            hdr.hdr0.a: ternary @name("hdr.hdr0.a") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    apply {
+        if (hdr.hdr0.isValid()) 
+            t0.apply();
+        if (!hdr.hdr0.isValid()) 
+            t1.apply();
+        if (hdr.hdr0.isValid() || hdr.hdr0.isValid()) 
+            t2.apply();
+        if (hdr.hdr0.isValid()) 
+            t3.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<hdr0_t>(hdr.hdr0);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/issue846-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue846-frontend.p4
@@ -1,0 +1,131 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct meta_t {
+    bit<16> x;
+    bit<16> y;
+    bit<16> z;
+}
+
+header hdr0_t {
+    bit<16> a;
+    bit<8>  b;
+    bit<8>  c;
+}
+
+struct metadata {
+    @name("meta") 
+    meta_t meta;
+}
+
+struct headers {
+    @name("hdr0") 
+    hdr0_t hdr0;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".p_hdr0") state p_hdr0 {
+        packet.extract<hdr0_t>(hdr.hdr0);
+        transition accept;
+    }
+    @name(".start") state start {
+        transition p_hdr0;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_nothing") action do_nothing_0() {
+    }
+    @name(".action_0") action action_3(bit<8> p) {
+        meta.meta.x = 16w1;
+        meta.meta.y = 16w2;
+    }
+    @name(".action_1") action action_4(bit<8> p) {
+        meta.meta.z = meta.meta.y + meta.meta.x;
+    }
+    @name(".action_2") action action_5(bit<8> p) {
+        hdr.hdr0.a = meta.meta.z;
+    }
+    @name(".t0") table t0_0 {
+        actions = {
+            do_nothing_0();
+            action_3();
+            @defaultonly NoAction();
+        }
+        key = {
+            hdr.hdr0.a: ternary @name("hdr.hdr0.a") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    @name(".t1") table t1_0 {
+        actions = {
+            do_nothing_0();
+            action_4();
+            @defaultonly NoAction();
+        }
+        key = {
+            hdr.hdr0.a: ternary @name("hdr.hdr0.a") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    @name(".t2") table t2_0 {
+        actions = {
+            do_nothing_0();
+            action_5();
+            @defaultonly NoAction();
+        }
+        key = {
+            meta.meta.y: ternary @name("meta.meta.y") ;
+            meta.meta.z: exact @name("meta.meta.z") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    @name(".t3") table t3_0 {
+        actions = {
+            do_nothing_0();
+            action_4();
+            @defaultonly NoAction();
+        }
+        key = {
+            hdr.hdr0.a: ternary @name("hdr.hdr0.a") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    apply {
+        if (hdr.hdr0.isValid()) 
+            t0_0.apply();
+        if (!hdr.hdr0.isValid()) 
+            t1_0.apply();
+        if (hdr.hdr0.isValid() || hdr.hdr0.isValid()) 
+            t2_0.apply();
+        if (hdr.hdr0.isValid()) 
+            t3_0.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<hdr0_t>(hdr.hdr0);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/issue846-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue846-midend.p4
@@ -1,0 +1,148 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct meta_t {
+    bit<16> x;
+    bit<16> y;
+    bit<16> z;
+}
+
+header hdr0_t {
+    bit<16> a;
+    bit<8>  b;
+    bit<8>  c;
+}
+
+struct metadata {
+    @name("meta") 
+    meta_t meta;
+}
+
+struct headers {
+    @name("hdr0") 
+    hdr0_t hdr0;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".p_hdr0") state p_hdr0 {
+        packet.extract<hdr0_t>(hdr.hdr0);
+        transition accept;
+    }
+    @name(".start") state start {
+        transition p_hdr0;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("NoAction") action NoAction_0() {
+    }
+    @name("NoAction") action NoAction_5() {
+    }
+    @name("NoAction") action NoAction_6() {
+    }
+    @name("NoAction") action NoAction_7() {
+    }
+    @name(".do_nothing") action do_nothing_0() {
+    }
+    @name(".do_nothing") action do_nothing_4() {
+    }
+    @name(".do_nothing") action do_nothing_5() {
+    }
+    @name(".do_nothing") action do_nothing_6() {
+    }
+    @name(".action_0") action action_3(bit<8> p) {
+        meta.meta.x = 16w1;
+        meta.meta.y = 16w2;
+    }
+    @name(".action_1") action action_4(bit<8> p) {
+        meta.meta.z = meta.meta.y + meta.meta.x;
+    }
+    @name(".action_1") action action_5(bit<8> p) {
+        meta.meta.z = meta.meta.y + meta.meta.x;
+    }
+    @name(".action_2") action action_7(bit<8> p) {
+        hdr.hdr0.a = meta.meta.z;
+    }
+    @name(".t0") table t0 {
+        actions = {
+            do_nothing_0();
+            action_3();
+            @defaultonly NoAction_0();
+        }
+        key = {
+            hdr.hdr0.a: ternary @name("hdr.hdr0.a") ;
+        }
+        size = 512;
+        default_action = NoAction_0();
+    }
+    @name(".t1") table t1 {
+        actions = {
+            do_nothing_4();
+            action_4();
+            @defaultonly NoAction_5();
+        }
+        key = {
+            hdr.hdr0.a: ternary @name("hdr.hdr0.a") ;
+        }
+        size = 512;
+        default_action = NoAction_5();
+    }
+    @name(".t2") table t2 {
+        actions = {
+            do_nothing_5();
+            action_7();
+            @defaultonly NoAction_6();
+        }
+        key = {
+            meta.meta.y: ternary @name("meta.meta.y") ;
+            meta.meta.z: exact @name("meta.meta.z") ;
+        }
+        size = 512;
+        default_action = NoAction_6();
+    }
+    @name(".t3") table t3 {
+        actions = {
+            do_nothing_6();
+            action_5();
+            @defaultonly NoAction_7();
+        }
+        key = {
+            hdr.hdr0.a: ternary @name("hdr.hdr0.a") ;
+        }
+        size = 512;
+        default_action = NoAction_7();
+    }
+    apply {
+        if (hdr.hdr0.isValid()) 
+            t0.apply();
+        if (!hdr.hdr0.isValid()) 
+            t1.apply();
+        if (hdr.hdr0.isValid() || hdr.hdr0.isValid()) 
+            t2.apply();
+        if (hdr.hdr0.isValid()) 
+            t3.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<hdr0_t>(hdr.hdr0);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/issue846.p4
+++ b/testdata/p4_14_samples_outputs/issue846.p4
@@ -1,0 +1,127 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct meta_t {
+    bit<16> x;
+    bit<16> y;
+    bit<16> z;
+}
+
+header hdr0_t {
+    bit<16> a;
+    bit<8>  b;
+    bit<8>  c;
+}
+
+struct metadata {
+    @name("meta") 
+    meta_t meta;
+}
+
+struct headers {
+    @name("hdr0") 
+    hdr0_t hdr0;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".p_hdr0") state p_hdr0 {
+        packet.extract(hdr.hdr0);
+        transition accept;
+    }
+    @name(".start") state start {
+        transition p_hdr0;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_nothing") action do_nothing() {
+    }
+    @name(".action_0") action action_0(bit<8> p) {
+        meta.meta.x = 16w1;
+        meta.meta.y = 16w2;
+    }
+    @name(".action_1") action action_1(bit<8> p) {
+        meta.meta.z = meta.meta.y + meta.meta.x;
+    }
+    @name(".action_2") action action_2(bit<8> p) {
+        hdr.hdr0.a = meta.meta.z;
+    }
+    @name(".t0") table t0 {
+        actions = {
+            do_nothing;
+            action_0;
+        }
+        key = {
+            hdr.hdr0.a: ternary;
+        }
+        size = 512;
+    }
+    @name(".t1") table t1 {
+        actions = {
+            do_nothing;
+            action_1;
+        }
+        key = {
+            hdr.hdr0.a: ternary;
+        }
+        size = 512;
+    }
+    @name(".t2") table t2 {
+        actions = {
+            do_nothing;
+            action_2;
+        }
+        key = {
+            meta.meta.y: ternary;
+            meta.meta.z: exact;
+        }
+        size = 512;
+    }
+    @name(".t3") table t3 {
+        actions = {
+            do_nothing;
+            action_1;
+        }
+        key = {
+            hdr.hdr0.a: ternary;
+        }
+        size = 512;
+    }
+    apply {
+        if (hdr.hdr0.isValid()) {
+            t0.apply();
+        }
+        if (!hdr.hdr0.isValid()) {
+            t1.apply();
+        }
+        if (hdr.hdr0.isValid() || hdr.hdr0.isValid()) {
+            t2.apply();
+        }
+        if (hdr.hdr0.isValid()) {
+            t3.apply();
+        }
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.hdr0);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/issue846.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue846.p4-stderr
@@ -1,0 +1,9 @@
+issue846.p4(47): warning: Could not infer type for p, using bit<8>
+action action_0(p){
+                ^
+issue846.p4(51): warning: Could not infer type for p, using bit<8>
+action action_1(p){
+                ^
+issue846.p4(54): warning: Could not infer type for p, using bit<8>
+action action_2(p){
+                ^


### PR DESCRIPTION
Convert the expression `(boolExpr == constExpr)` to either
`(boolExpr)` or `(! boolExpr)` depending on the value of the
constant. Similarly for `(boolExpr != constExpr)` and permutations of
the expressions.