### PR TITLE
Improve InstantiatedBlock, Vector, and JSONLoader APIs, and fix a GC bug

### DIFF
--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -173,6 +173,14 @@ const IR::CompileTimeValue* InstantiatedBlock::getParameterValue(cstring paramNa
     return getValue(param->getNode());
 }
 
+const IR::CompileTimeValue*
+InstantiatedBlock::findParameterValue(cstring paramName) const {
+    auto* param = getConstructorParameters()->getDeclByName(paramName);
+    if (!param) return nullptr;
+    if (!param->is<IR::Parameter>()) return nullptr;
+    return getValue(param->getNode());
+}
+
 Util::Enumerator<const IDeclaration*>* P4Action::getDeclarations() const
 { return body->getDeclarations(); }
 

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -517,7 +517,15 @@ abstract InstantiatedBlock : Block {
 
     virtual ParameterList getConstructorParameters() const = 0;
     void instantiate(std::vector<CompileTimeValue> *args);
+
+    /// @return the argument that the given parameter was instantiated with.
+    /// It's a fatal error if no such parameter exists.
     CompileTimeValue getParameterValue(cstring paramName) const;
+
+    /// @return the argument that the given parameter was instantiated with, or
+    /// null if no such parameter exists.
+    CompileTimeValue findParameterValue(cstring paramName) const;
+
     virtual void dbprint(std::ostream& out) const override;
 }
 

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -183,11 +183,28 @@ class JSONLoader {
             s->c_str() >> v; }
 
     template<typename T>
-    typename std::enable_if<has_fromJSON<T>::value && !std::is_base_of<IR::Node, T>::value>::type
+    typename std::enable_if<
+        has_fromJSON<T>::value &&
+        !std::is_base_of<IR::Node, T>::value &&
+        std::is_pointer<decltype(T::fromJSON(std::declval<JSONLoader&>()))>::value
+    >::type
     unpack_json(T *&v) { v = T::fromJSON(*this); }
+
     template<typename T>
-    typename std::enable_if<has_fromJSON<T>::value && !std::is_base_of<IR::Node, T>::value>::type
+    typename std::enable_if<
+        has_fromJSON<T>::value &&
+        !std::is_base_of<IR::Node, T>::value &&
+        std::is_pointer<decltype(T::fromJSON(std::declval<JSONLoader&>()))>::value
+    >::type
     unpack_json(T &v) { v = *(T::fromJSON(*this)); }
+
+    template<typename T>
+    typename std::enable_if<
+        has_fromJSON<T>::value &&
+        !std::is_base_of<IR::Node, T>::value &&
+        !std::is_pointer<decltype(T::fromJSON(std::declval<JSONLoader&>()))>::value
+    >::type
+    unpack_json(T &v) { v = T::fromJSON(*this); }
 
     template<typename T> typename std::enable_if<std::is_base_of<IR::INode, T>::value>::type
     unpack_json(T &v) { v = *(get_node()->to<T>()); }

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -98,9 +98,27 @@ class Vector : public VectorBase {
         int index = i - vec.begin();
         vec.insert(i, b, e);
         return vec.begin() + index; }
+
     template<typename Container>
     iterator append(const Container &toAppend)
     { return insert(end(), toAppend.begin(), toAppend.end()); }
+
+    /**
+     * Appends the provided node or vector of nodes to the end of this Vector.
+     *
+     * @param item  A node to append; if this is a Vector, its contents will be
+     *              appended.
+     */
+    void pushBackOrAppend(const IR::Node* item) {
+        if (item == nullptr) return;
+        if (auto* itemAsVector = item->to<IR::Vector<T>>()) {
+            append(*itemAsVector);
+            return;
+        }
+        BUG_CHECK(item->is<T>(), "Unexpected vector element: %1%", item);
+        push_back(item->to<T>());
+    }
+
     iterator insert(iterator i, const T* v) {
         /* FIXME -- gcc prior to 4.9 is broken and the insert routine returns void
          * FIXME -- rather than an iterator.  So we recalculate it from an index */

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -56,10 +56,17 @@ extern "C" size_t GC_get_heap_size(void);
 extern "C" int GC_print_stats;
 
 static void gc_callback() {
-    size_t count;
-    LOG1("****** GC called ****** (heap size " << GC_get_heap_size() << ")");
-    LOG2("cstring cache size " << cstring::cache_size(count) << " (count=" << count << ")");
-    GC_print_stats = LOGGING(2) ? 1 : 0;  // unfortunately goes directly to stderr!
+    if (Log::verbose())
+        std::clog << "****** GC called ****** (heap size " << GC_get_heap_size() << ")";
+
+    if (Log::verbosity() >= 2) {
+        size_t count;
+        std::clog << "cstring cache size " << cstring::cache_size(count)
+                  << " (count=" << count << ")";
+    }
+
+    // Maybe print GC statistics. Unfortunately they go directly to stderr!
+    GC_print_stats = Log::verbosity() >= 2 ? 1 : 0;
 }
 
 void silent(char *, GC_word) {}


### PR DESCRIPTION
This PR contains a number of small improvements and fixes that didn't seem worthy of their own individual PRs.

- `InstantiatedBlock::getParameterValue()` calls `BUG()` if the parameter doesn't exist. This PR adds `InstantiatedBlock::findParameterValue()` for cases where the parameter may not exist; it returns null on failure.
- It's a common idiom in p4c to take a Node and either append it to a Vector or, if it is itself a Vector, append its content to the Vector. Now this idiom is captured in the new method `Vector::pushBackOrAppend()`.
- Calling `LOG()` macros, which may allocate memory, is unsafe in `gc_callback()`. I've seen this trigger stack overflows, but not anymore, because the issue is fixed in this PR.
- Sometimes it's both more convenient and more efficient to return a value type from `fromJSON()`. Now you can.