### PR TITLE
Bmv2 backend calculations const fix

### DIFF
--- a/backends/bmv2/expression.cpp
+++ b/backends/bmv2/expression.cpp
@@ -145,10 +145,10 @@ void ExpressionConverter::postorder(const IR::Cast* expression)  {
 void ExpressionConverter::postorder(const IR::Constant* expression)  {
     auto result = new Util::JsonObject();
     result->emplace("type", "hexstr");
-
-    cstring repr = stringRepr(expression->value,
-                              ROUNDUP(expression->type->width_bits(), 8));
+    auto bitwidth = expression->type->width_bits();
+    cstring repr = stringRepr(expression->value, ROUNDUP(bitwidth, 8));
     result->emplace("value", repr);
+    if (withConstantWidths) result->emplace("bitwidth", bitwidth);
     map.emplace(expression, result);
 }
 
@@ -586,6 +586,13 @@ Util::IJson* ExpressionConverter::convertLeftValue(const IR::Expression* e) {
         BUG("%1%: Could not convert expression", e);
     leftValue = false;
     return result;
+}
+
+Util::IJson* ExpressionConverter::convertWithConstantWidths(const IR::Expression* e) {
+  withConstantWidths = true;
+  auto result = convert(e);
+  withConstantWidths = false;
+  return result;
 }
 
 }  // namespace BMV2

--- a/backends/bmv2/expression.h
+++ b/backends/bmv2/expression.h
@@ -54,6 +54,10 @@ class ExpressionConverter : public Inspector {
     /// after translating an Expression to JSON, save the result to 'map'.
     std::map<const IR::Expression*, Util::IJson*> map;
     bool leftValue;  // true if converting a left value
+    // in some cases the bmv2 JSON requires a 'bitwidth' attribute for hex
+    // strings (e.g. for constants in calculation inputs). When this flag is set
+    // to true, we add this attribute.
+    bool withConstantWidths{false};
 
  public:
     ExpressionConverter(Backend *backend, cstring scalarsName) :
@@ -72,6 +76,7 @@ class ExpressionConverter : public Inspector {
     Util::IJson* convert(const IR::Expression* e, bool doFixup = true,
                          bool wrap = true, bool convertBool = false);
     Util::IJson* convertLeftValue(const IR::Expression* e);
+    Util::IJson* convertWithConstantWidths(const IR::Expression* e);
 
     void postorder(const IR::BoolLiteral* expression) override;
     void postorder(const IR::MethodCallExpression* expression) override;

--- a/backends/bmv2/simpleSwitch.cpp
+++ b/backends/bmv2/simpleSwitch.cpp
@@ -588,7 +588,7 @@ SimpleSwitch::createCalculation(cstring algo, const IR::Expression* fields,
         fields = list;
         typeMap->setType(fields, type);
     }
-    auto jright = conv->convert(fields);
+    auto jright = conv->convertWithConstantWidths(fields);
     calc->emplace("input", jright);
     calculations->append(calc);
     return calcName;

--- a/testdata/p4_16_samples/constant-in-calculation-bmv2.p4
+++ b/testdata/p4_16_samples/constant-in-calculation-bmv2.p4
@@ -1,0 +1,31 @@
+/*
+Copyright 2016 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<16> a;
+}
+
+control compute(inout hdr h)
+{
+    apply {
+        hash(h.a, HashAlgorithm.crc16, 10w0, { 16w1 }, 10w4);
+    }
+}
+
+#include "arith-inline-skeleton.p4"

--- a/testdata/p4_16_samples/constant-in-calculation-bmv2.stf
+++ b/testdata/p4_16_samples/constant-in-calculation-bmv2.stf
@@ -1,0 +1,5 @@
+# bit<16> A
+# In the output we need A = 1
+
+packet 0 ABAB
+expect 0 0001

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-first.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<16> a;
+}
+
+control compute(inout hdr h) {
+    apply {
+        hash<bit<16>, bit<10>, tuple<bit<16>>, bit<10>>(h.a, HashAlgorithm.crc16, 10w0, { 16w1 }, 10w4);
+    }
+}
+
+struct Headers {
+    hdr h;
+}
+
+struct Meta {
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(in Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    compute() c;
+    apply {
+        c.apply(h.h);
+        sm.egress_spec = 9w0;
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-frontend.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<16> a;
+}
+
+control compute(inout hdr h) {
+    apply {
+        hash<bit<16>, bit<10>, tuple<bit<16>>, bit<10>>(h.a, HashAlgorithm.crc16, 10w0, { 16w1 }, 10w4);
+    }
+}
+
+struct Headers {
+    hdr h;
+}
+
+struct Meta {
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(in Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @name("c") compute() c_0;
+    apply {
+        c_0.apply(h.h);
+        sm.egress_spec = 9w0;
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-midend.p4
@@ -1,0 +1,63 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<16> a;
+}
+
+struct Headers {
+    hdr h;
+}
+
+struct Meta {
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(in Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+struct tuple_0 {
+    bit<16> field;
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @hidden action act() {
+        hash<bit<16>, bit<10>, tuple_0, bit<10>>(h.h.a, HashAlgorithm.crc16, 10w0, { 16w1 }, 10w4);
+        sm.egress_spec = 9w0;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<16> a;
+}
+
+control compute(inout hdr h) {
+    apply {
+        hash(h.a, HashAlgorithm.crc16, 10w0, { 16w1 }, 10w4);
+    }
+}
+
+struct Headers {
+    hdr h;
+}
+
+struct Meta {
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(in Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit(h.h);
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    compute() c;
+    apply {
+        c.apply(h.h);
+        sm.egress_spec = 0;
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;


### PR DESCRIPTION
This fixes a bug reported by @jnfoster 
This was caused by an omission in the bmv2 JSON format doc, which I fixed this morning: https://github.com/p4lang/behavioral-model/pull/426