### PR TITLE
Update CMakeLists.txt to support CMake 3.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,12 @@ enable_testing ()
 # endif ()
 
 # set (CMAKE_CXX_EXTENSIONS OFF) # prefer using -std=c++11 rather than -std=gnu++11
-set (CMAKE_CXX_STANDARD 11)
+# CMAKE_CXX_STANDARD was introduced in CMake 3.1, so for older versions of CMake, we use -std=gnu++11
+if (CMAKE_VERSION VERSION_LESS "3.1")
+    set (CMAKE_CXX_FLAGS "-std=gnu++11 ${CMAKE_CXX_FLAGS}")
+else ()
+    set (CMAKE_CXX_STANDARD 11)
+endif ()
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_cxx_compiler_option ("-Wall")


### PR DESCRIPTION
Note: CMAKE_CXX_STANDARD was not introduced until 3.1