### PR TITLE
Fix for issue #675

### DIFF
--- a/backends/bmv2/backend.cpp
+++ b/backends/bmv2/backend.cpp
@@ -91,6 +91,7 @@ Backend::process(const IR::ToplevelBlock* tlb, BMV2Options& options) {
         simpleSwitch->setPipelineControls(tlb, &pipeline_controls, &pipeline_namemap);
         simpleSwitch->setNonPipelineControls(tlb, &non_pipeline_controls);
         simpleSwitch->setUpdateChecksumControls(tlb, &update_checksum_controls);
+        simpleSwitch->setVerifyChecksumControls(tlb, &verify_checksum_controls);
         simpleSwitch->setDeparserControls(tlb, &deparser_controls);
     } else if (target == Target::PORTABLE) {
         P4C_UNIMPLEMENTED("PSA architecture is not yet implemented");

--- a/backends/bmv2/backend.h
+++ b/backends/bmv2/backend.h
@@ -85,6 +85,7 @@ class Backend : public PassManager {
     std::set<cstring>                pipeline_controls;
     std::set<cstring>                non_pipeline_controls;
     std::set<cstring>                update_checksum_controls;
+    std::set<cstring>                verify_checksum_controls;
     std::set<cstring>                deparser_controls;
 
     // bmv2 expects 'ingress' and 'egress' pipeline to have fixed name.

--- a/backends/bmv2/control.cpp
+++ b/backends/bmv2/control.cpp
@@ -738,14 +738,21 @@ bool ChecksumConverter::preorder(const IR::PackageBlock *block) {
 
 bool ChecksumConverter::preorder(const IR::ControlBlock* block) {
     auto it = backend->update_checksum_controls.find(block->container->name);
-    if (it == backend->update_checksum_controls.end()) {
-        return false;
-    }
-
-    if (backend->target == Target::SIMPLE) {
-        P4V1::SimpleSwitch* ss = backend->getSimpleSwitch();
-        ss->convertChecksumUpdate(block->container, backend->json->checksums,
-                                  backend->json->calculations);
+    if (it != backend->update_checksum_controls.end()) {
+        if (backend->target == Target::SIMPLE) {
+            P4V1::SimpleSwitch* ss = backend->getSimpleSwitch();
+            ss->convertChecksum(block->container->body, backend->json->checksums,
+                                backend->json->calculations, false);
+        }
+    } else {
+        it = backend->verify_checksum_controls.find(block->container->name);
+        if (it != backend->verify_checksum_controls.end()) {
+            if (backend->target == Target::SIMPLE) {
+                P4V1::SimpleSwitch* ss = backend->getSimpleSwitch();
+                ss->convertChecksum(block->container->body, backend->json->checksums,
+                                    backend->json->calculations, true);
+            }
+        }
     }
     return false;
 }

--- a/backends/bmv2/portableSwitch.cpp
+++ b/backends/bmv2/portableSwitch.cpp
@@ -94,12 +94,3 @@ std::ostream& operator<<(std::ostream &out, P4::Extern_Model* p) {
     }
     return out;
 }
-
-// getSkipControls();
-
-// getPipelineControls();
-
-// getUpdateChecksum();
-
-
-

--- a/backends/bmv2/simpleSwitch.h
+++ b/backends/bmv2/simpleSwitch.h
@@ -43,8 +43,6 @@ class SimpleSwitch {
     cstring convertHashAlgorithm(cstring algorithm);
     cstring createCalculation(cstring algo, const IR::Expression* fields,
                               Util::JsonArray* calculations, const IR::Node* node);
-    void generateUpdate(const IR::BlockStatement *block,
-                        Util::JsonArray* checksums, Util::JsonArray* calculations);
 
  public:
     void convertExternObjects(Util::JsonArray *result, const P4::ExternMethod *em,
@@ -54,13 +52,14 @@ class SimpleSwitch {
     void convertExternInstances(const IR::Declaration *c,
                                 const IR::ExternBlock* eb, Util::JsonArray* action_profiles,
                                 BMV2::SharedActionSelectorCheck& selector_check);
-    void convertChecksumUpdate(const IR::P4Control* updateControl,
-                               Util::JsonArray* checksums, Util::JsonArray* calculations);
+    void convertChecksum(const IR::BlockStatement* block, Util::JsonArray* checksums,
+                         Util::JsonArray* calculations, bool verify);
 
     void setPipelineControls(const IR::ToplevelBlock* blk, std::set<cstring>* controls,
                              std::map<cstring, cstring>* map);
     void setNonPipelineControls(const IR::ToplevelBlock* blk, std::set<cstring>* controls);
     void setUpdateChecksumControls(const IR::ToplevelBlock* blk, std::set<cstring>* controls);
+    void setVerifyChecksumControls(const IR::ToplevelBlock* blk, std::set<cstring>* controls);
     void setDeparserControls(const IR::ToplevelBlock* blk, std::set<cstring>* controls);
 
     explicit SimpleSwitch(BMV2::Backend* backend) :

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -1999,7 +1999,7 @@ void ProgramStructure::createChecksumVerifications() {
     auto headpath = new IR::Path(v1model.headersType.Id());
     auto headtype = new IR::Type_Name(headpath);
     auto headers = new IR::Parameter(v1model.verify.headersParam.Id(),
-                                     IR::Direction::In, headtype);
+                                     IR::Direction::InOut, headtype);
     params->push_back(headers);
     conversionContext.header = paramReference(headers);
 

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -57,6 +57,8 @@ struct standard_metadata_t {
     @alias("intrinsic_metadata.mcast_grp")     bit<16> mcast_grp;
     @alias("intrinsic_metadata.resubmit_flag") bit<1>  resubmit_flag;
     @alias("intrinsic_metadata.egress_rid")    bit<16> egress_rid;
+    /// Indicates that a verify_checksum() method has failed.
+    bit<1> checksum_error;
 }
 
 enum CounterType {

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -145,14 +145,14 @@ If this method detects that a checksum of the data is not correct it
 sets an internal error flag.
 @param T          Must be a tuple type where all the fields are bit-fields or varbits.
                   The total dynamic length of the fields is a multiple of the output size.
-@param O          Output type; must be bit<X> type.
+@param O          Checksum type; must be bit<X> type.
 @param condition  If 'false' the verification always succeeds.
 @param data       Data whose checksum is verified.
-@param checksum   Expected checksum of the data.
+@param checksum   Expected checksum of the data; note that this must be a left-value.
 @param algo       Algorithm to use for checksum (not all algorithms may be supported).
                   Must be a compile-time constant.
 */
-extern void verify_checksum<T, O>(in bool condition, in T data, in O checksum, HashAlgorithm algo);
+extern void verify_checksum<T, O>(in bool condition, in T data, inout O checksum, HashAlgorithm algo);
 /**
 Computes the checksum of the supplied data.
 @param T          Must be a tuple type where all the fields are bit-fields or varbits.
@@ -178,7 +178,7 @@ parser Parser<H, M>(packet_in b,
                     inout standard_metadata_t standard_metadata);
 /// The only legal statements in VerifyChecksum are: block statements,
 /// calls to the verify_checksum method, and returns.
-control VerifyChecksum<H, M>(in H hdr,
+control VerifyChecksum<H, M>(inout H hdr,
                              inout M meta);
 @pipeline
 control Ingress<H, M>(inout H hdr,

--- a/testdata/p4_14_samples_outputs/01-BigMatch-first.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-first.p4
@@ -133,7 +133,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-BigMatch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-frontend.p4
@@ -133,7 +133,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-BigMatch-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-midend.p4
@@ -149,7 +149,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-BigMatch.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch.p4
@@ -123,7 +123,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1-first.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1-first.p4
@@ -45,7 +45,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1-frontend.p4
@@ -45,7 +45,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1-midend.p4
@@ -47,7 +47,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1.p4
@@ -43,7 +43,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-FullPHV-first.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV-first.p4
@@ -501,7 +501,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-FullPHV-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV-frontend.p4
@@ -501,7 +501,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-FullPHV-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV-midend.p4
@@ -503,7 +503,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-FullPHV.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV.p4
@@ -499,7 +499,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-JustEthernet-first.p4
+++ b/testdata/p4_14_samples_outputs/01-JustEthernet-first.p4
@@ -38,7 +38,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-JustEthernet-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-JustEthernet-frontend.p4
@@ -38,7 +38,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-JustEthernet-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-JustEthernet-midend.p4
@@ -38,7 +38,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-JustEthernet.p4
+++ b/testdata/p4_14_samples_outputs/01-JustEthernet.p4
@@ -38,7 +38,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-NoDeps-first.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-first.p4
@@ -90,7 +90,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-NoDeps-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-frontend.p4
@@ -90,7 +90,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-NoDeps-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-midend.p4
@@ -98,7 +98,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/01-NoDeps.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-first.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-first.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-frontend.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-midend.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-BadSizeField.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField.p4
@@ -80,7 +80,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2-first.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2-first.p4
@@ -46,7 +46,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2-frontend.p4
@@ -46,7 +46,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2-midend.p4
@@ -48,7 +48,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2.p4
@@ -44,7 +44,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-FullPHV1-first.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1-first.p4
@@ -732,7 +732,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-FullPHV1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1-frontend.p4
@@ -732,7 +732,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-FullPHV1-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1-midend.p4
@@ -742,7 +742,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-FullPHV1.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1.p4
@@ -722,7 +722,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet-first.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet-first.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet-frontend.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet-midend.p4
@@ -92,7 +92,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3-first.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3-first.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3-frontend.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3-midend.p4
@@ -64,7 +64,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-FullPHV2-first.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2-first.p4
@@ -669,7 +669,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-FullPHV2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2-frontend.p4
@@ -669,7 +669,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-FullPHV2-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2-midend.p4
@@ -681,7 +681,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-FullPHV2.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2.p4
@@ -657,7 +657,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-Gateway-first.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-first.p4
@@ -151,7 +151,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-Gateway-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-frontend.p4
@@ -151,7 +151,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-Gateway-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-midend.p4
@@ -167,7 +167,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-Gateway.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway.p4
@@ -143,7 +143,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-first.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-first.p4
@@ -79,7 +79,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-frontend.p4
@@ -79,7 +79,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-midend.p4
@@ -83,7 +83,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-first.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-first.p4
@@ -142,7 +142,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-frontend.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-frontend.p4
@@ -142,7 +142,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-midend.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-midend.p4
@@ -164,7 +164,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault.p4
@@ -132,7 +132,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan-first.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan-first.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan-frontend.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan-frontend.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan-midend.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan-midend.p4
@@ -89,7 +89,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan.p4
@@ -81,7 +81,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-first.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-first.p4
@@ -77,7 +77,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-frontend.p4
@@ -77,7 +77,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-midend.p4
@@ -81,7 +81,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-FieldProblem.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem.p4
@@ -73,7 +73,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-first.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-first.p4
@@ -830,7 +830,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-frontend.p4
@@ -830,7 +830,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-midend.p4
@@ -854,7 +854,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-FullTPHV.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV.p4
@@ -818,7 +818,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1-first.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1-first.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1-frontend.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1-midend.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1.p4
@@ -80,7 +80,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-first.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-first.p4
@@ -781,7 +781,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-frontend.p4
@@ -781,7 +781,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-midend.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-midend.p4
@@ -805,7 +805,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1.p4
@@ -769,7 +769,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack-first.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack-first.p4
@@ -87,7 +87,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack-frontend.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack-frontend.p4
@@ -87,7 +87,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack-midend.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack-midend.p4
@@ -95,7 +95,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack.p4
@@ -83,7 +83,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-first.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-first.p4
@@ -784,7 +784,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-frontend.p4
@@ -784,7 +784,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-midend.p4
@@ -808,7 +808,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2.p4
@@ -772,7 +772,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
@@ -305,7 +305,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
@@ -305,7 +305,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
@@ -345,7 +345,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
@@ -294,7 +294,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-first.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-first.p4
@@ -111,7 +111,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-frontend.p4
@@ -111,7 +111,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-midend.p4
@@ -116,7 +116,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP.p4
@@ -107,7 +107,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-first.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-first.p4
@@ -1047,7 +1047,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-frontend.p4
@@ -1047,7 +1047,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-midend.p4
@@ -1071,7 +1071,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3.p4
@@ -1035,7 +1035,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-first.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-first.p4
@@ -211,7 +211,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-frontend.p4
@@ -211,7 +211,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-midend.p4
@@ -227,7 +227,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse.p4
@@ -209,7 +209,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-first.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-first.p4
@@ -113,7 +113,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-frontend.p4
@@ -113,7 +113,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-midend.p4
@@ -118,7 +118,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags.p4
@@ -109,7 +109,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-first.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-first.p4
@@ -155,7 +155,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-frontend.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-frontend.p4
@@ -155,7 +155,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
@@ -160,7 +160,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed.p4
@@ -151,7 +151,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities-first.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities-first.p4
@@ -94,7 +94,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities-frontend.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities-frontend.p4
@@ -94,7 +94,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities-midend.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities-midend.p4
@@ -98,7 +98,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities.p4
@@ -90,7 +90,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/11-MultiTags-first.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags-first.p4
@@ -102,7 +102,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/11-MultiTags-frontend.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags-frontend.p4
@@ -102,7 +102,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/11-MultiTags-midend.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags-midend.p4
@@ -106,7 +106,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/11-MultiTags.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags.p4
@@ -98,7 +98,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/12-Counters-first.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-first.p4
@@ -64,7 +64,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/12-Counters-frontend.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-frontend.p4
@@ -64,7 +64,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/12-Counters-midend.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-midend.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/12-Counters.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-first.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-first.p4
@@ -100,7 +100,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-frontend.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-frontend.p4
@@ -100,7 +100,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-midend.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-midend.p4
@@ -104,7 +104,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop.p4
@@ -96,7 +96,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-first.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-first.p4
@@ -61,7 +61,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-frontend.p4
@@ -61,7 +61,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-midend.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-midend.p4
@@ -65,7 +65,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/13-Counters1and2.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2.p4
@@ -57,7 +57,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-first.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-first.p4
@@ -112,7 +112,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-frontend.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-frontend.p4
@@ -112,7 +112,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-midend.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-midend.p4
@@ -116,7 +116,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect.p4
@@ -108,7 +108,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-Counter-first.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-first.p4
@@ -50,7 +50,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-Counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-frontend.p4
@@ -50,7 +50,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-Counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-midend.p4
@@ -52,7 +52,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-Counter.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter.p4
@@ -48,7 +48,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-first.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-first.p4
@@ -55,7 +55,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-frontend.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-frontend.p4
@@ -55,7 +55,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-midend.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-midend.p4
@@ -57,7 +57,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-first.p4
+++ b/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-first.p4
@@ -121,7 +121,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-frontend.p4
+++ b/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-frontend.p4
@@ -121,7 +121,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-midend.p4
+++ b/testdata/p4_14_samples_outputs/14-SplitEthernetVlan-midend.p4
@@ -125,7 +125,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/14-SplitEthernetVlan.p4
+++ b/testdata/p4_14_samples_outputs/14-SplitEthernetVlan.p4
@@ -117,7 +117,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-first.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-first.p4
@@ -121,7 +121,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-frontend.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-frontend.p4
@@ -121,7 +121,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-midend.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-midend.p4
@@ -130,7 +130,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal.p4
@@ -119,7 +119,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/16-NoHeaders-first.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders-first.p4
@@ -38,7 +38,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/16-NoHeaders-frontend.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders-frontend.p4
@@ -38,7 +38,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/16-NoHeaders-midend.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders-midend.p4
@@ -40,7 +40,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/16-NoHeaders.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders.p4
@@ -36,7 +36,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-first.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-first.p4
@@ -108,7 +108,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-frontend.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-frontend.p4
@@ -108,7 +108,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-midend.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-midend.p4
@@ -128,7 +128,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/16-TwoReferences.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences.p4
@@ -100,7 +100,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/17-Minimal-first.p4
+++ b/testdata/p4_14_samples_outputs/17-Minimal-first.p4
@@ -28,7 +28,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/17-Minimal-frontend.p4
+++ b/testdata/p4_14_samples_outputs/17-Minimal-frontend.p4
@@ -28,7 +28,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/17-Minimal-midend.p4
+++ b/testdata/p4_14_samples_outputs/17-Minimal-midend.p4
@@ -28,7 +28,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/17-Minimal.p4
+++ b/testdata/p4_14_samples_outputs/17-Minimal.p4
@@ -28,7 +28,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/18-EmptyPipelines-first.p4
+++ b/testdata/p4_14_samples_outputs/18-EmptyPipelines-first.p4
@@ -38,7 +38,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/18-EmptyPipelines-frontend.p4
+++ b/testdata/p4_14_samples_outputs/18-EmptyPipelines-frontend.p4
@@ -38,7 +38,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/18-EmptyPipelines-midend.p4
+++ b/testdata/p4_14_samples_outputs/18-EmptyPipelines-midend.p4
@@ -38,7 +38,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/18-EmptyPipelines.p4
+++ b/testdata/p4_14_samples_outputs/18-EmptyPipelines.p4
@@ -38,7 +38,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
@@ -199,7 +199,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
@@ -201,7 +201,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
@@ -212,7 +212,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/TLV_parsing.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing.p4
@@ -197,7 +197,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/acl1-first.p4
+++ b/testdata/p4_14_samples_outputs/acl1-first.p4
@@ -256,7 +256,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/acl1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-frontend.p4
@@ -256,7 +256,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/acl1-midend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-midend.p4
@@ -260,7 +260,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/acl1.p4
+++ b/testdata/p4_14_samples_outputs/acl1.p4
@@ -253,7 +253,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_bus1-first.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-first.p4
@@ -229,7 +229,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_bus1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-frontend.p4
@@ -229,7 +229,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_bus1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-midend.p4
@@ -259,7 +259,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_bus1.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1.p4
@@ -213,7 +213,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_chain1-first.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-first.p4
@@ -154,7 +154,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_chain1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-frontend.p4
@@ -154,7 +154,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_chain1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-midend.p4
@@ -175,7 +175,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_chain1.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1.p4
@@ -144,7 +144,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline-first.p4
+++ b/testdata/p4_14_samples_outputs/action_inline-first.p4
@@ -49,7 +49,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline-frontend.p4
@@ -49,7 +49,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline-midend.p4
@@ -48,7 +48,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline.p4
+++ b/testdata/p4_14_samples_outputs/action_inline.p4
@@ -47,7 +47,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline1-first.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-first.p4
@@ -63,7 +63,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-frontend.p4
@@ -63,7 +63,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-midend.p4
@@ -62,7 +62,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline1.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1.p4
@@ -61,7 +61,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline2-first.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-first.p4
@@ -69,7 +69,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
@@ -69,7 +69,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline2-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-midend.p4
@@ -62,7 +62,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/action_inline2.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2.p4
@@ -67,7 +67,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/axon-first.p4
+++ b/testdata/p4_14_samples_outputs/axon-first.p4
@@ -128,7 +128,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/axon-frontend.p4
+++ b/testdata/p4_14_samples_outputs/axon-frontend.p4
@@ -130,7 +130,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/axon-midend.p4
+++ b/testdata/p4_14_samples_outputs/axon-midend.p4
@@ -263,7 +263,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/axon.p4
+++ b/testdata/p4_14_samples_outputs/axon.p4
@@ -126,7 +126,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/basic_conditionals-first.p4
+++ b/testdata/p4_14_samples_outputs/basic_conditionals-first.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/basic_conditionals-frontend.p4
+++ b/testdata/p4_14_samples_outputs/basic_conditionals-frontend.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/basic_conditionals-midend.p4
+++ b/testdata/p4_14_samples_outputs/basic_conditionals-midend.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/basic_conditionals.p4
+++ b/testdata/p4_14_samples_outputs/basic_conditionals.p4
@@ -55,7 +55,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/basic_routing-first.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-first.p4
@@ -179,7 +179,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/basic_routing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-frontend.p4
@@ -179,7 +179,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/basic_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-midend.p4
@@ -213,7 +213,7 @@ struct tuple_0 {
     bit<32> field_9;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/basic_routing.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing.p4
@@ -167,7 +167,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/bigfield1-first.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1-first.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/bigfield1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1-frontend.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/bigfield1-midend.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1-midend.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/bigfield1.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/bridge1-first.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-first.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/bridge1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-frontend.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/bridge1-midend.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-midend.p4
@@ -91,7 +91,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/bridge1.p4
+++ b/testdata/p4_14_samples_outputs/bridge1.p4
@@ -81,7 +81,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/checksum-first.p4
+++ b/testdata/p4_14_samples_outputs/checksum-first.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/checksum-frontend.p4
+++ b/testdata/p4_14_samples_outputs/checksum-frontend.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/checksum-midend.p4
+++ b/testdata/p4_14_samples_outputs/checksum-midend.p4
@@ -85,7 +85,7 @@ struct tuple_0 {
     bit<32> field_9;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/checksum.p4
+++ b/testdata/p4_14_samples_outputs/checksum.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/checksum1-first.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-first.p4
@@ -116,7 +116,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/checksum1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-frontend.p4
@@ -116,7 +116,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/checksum1-midend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-midend.p4
@@ -134,7 +134,7 @@ struct tuple_0 {
     bit<32> field_9;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/checksum1.p4
+++ b/testdata/p4_14_samples_outputs/checksum1.p4
@@ -112,7 +112,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
@@ -98,7 +98,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
@@ -100,7 +100,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
@@ -108,7 +108,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/copy_to_cpu.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu.p4
@@ -94,7 +94,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter-first.p4
+++ b/testdata/p4_14_samples_outputs/counter-first.p4
@@ -86,7 +86,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter-frontend.p4
@@ -80,7 +80,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter-midend.p4
@@ -82,7 +82,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter.p4
+++ b/testdata/p4_14_samples_outputs/counter.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter1-first.p4
+++ b/testdata/p4_14_samples_outputs/counter1-first.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter1-frontend.p4
@@ -57,7 +57,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter1-midend.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter1.p4
+++ b/testdata/p4_14_samples_outputs/counter1.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter2-first.p4
+++ b/testdata/p4_14_samples_outputs/counter2-first.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter2-frontend.p4
@@ -57,7 +57,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter2-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter2-midend.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter2.p4
+++ b/testdata/p4_14_samples_outputs/counter2.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter3-first.p4
+++ b/testdata/p4_14_samples_outputs/counter3-first.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter3-frontend.p4
@@ -57,7 +57,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter3-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter3-midend.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter3.p4
+++ b/testdata/p4_14_samples_outputs/counter3.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter4-first.p4
+++ b/testdata/p4_14_samples_outputs/counter4-first.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-frontend.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter4-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-midend.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter4.p4
+++ b/testdata/p4_14_samples_outputs/counter4.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter5-first.p4
+++ b/testdata/p4_14_samples_outputs/counter5-first.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-frontend.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter5-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-midend.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/counter5.p4
+++ b/testdata/p4_14_samples_outputs/counter5.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/do_nothing-first.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing-first.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/do_nothing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing-frontend.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/do_nothing-midend.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing-midend.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/do_nothing.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing.p4
@@ -53,7 +53,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match1-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-first.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-frontend.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-midend.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match1.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match2-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-first.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-frontend.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match2-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-midend.p4
@@ -61,7 +61,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match2.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2.p4
@@ -57,7 +57,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match3-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-first.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-frontend.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match3-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-midend.p4
@@ -61,7 +61,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match3.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3.p4
@@ -57,7 +57,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match4-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-first.p4
@@ -91,7 +91,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-frontend.p4
@@ -91,7 +91,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match4-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-midend.p4
@@ -93,7 +93,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match4.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4.p4
@@ -89,7 +89,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match5-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-first.p4
@@ -92,7 +92,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-frontend.p4
@@ -92,7 +92,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match5-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-midend.p4
@@ -94,7 +94,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match5.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5.p4
@@ -90,7 +90,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match6-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6-first.p4
@@ -66,7 +66,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6-frontend.p4
@@ -66,7 +66,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match6-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6-midend.p4
@@ -68,7 +68,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match6.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6.p4
@@ -64,7 +64,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match7-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-first.p4
@@ -65,7 +65,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match7-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-frontend.p4
@@ -65,7 +65,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match7-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-midend.p4
@@ -67,7 +67,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match7.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7.p4
@@ -63,7 +63,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match8-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-first.p4
@@ -102,7 +102,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match8-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-frontend.p4
@@ -102,7 +102,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match8-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-midend.p4
@@ -104,7 +104,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match8.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8.p4
@@ -100,7 +100,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match9-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-first.p4
@@ -73,7 +73,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match9-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-frontend.p4
@@ -73,7 +73,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match9-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-midend.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match9.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9.p4
@@ -72,7 +72,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-first.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-frontend.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-midend.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match_mask1.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-first.p4
@@ -72,7 +72,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-frontend.p4
@@ -72,7 +72,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-midend.p4
@@ -74,7 +74,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/exact_match_valid1.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1.p4
@@ -70,7 +70,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
@@ -213,7 +213,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
@@ -213,7 +213,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -262,7 +262,7 @@ struct tuple_2 {
     bit<32> field_20;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_2, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/flowlet_switching.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching.p4
@@ -202,7 +202,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/gateway1-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-first.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-frontend.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway1-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-midend.p4
@@ -81,7 +81,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway1.p4
+++ b/testdata/p4_14_samples_outputs/gateway1.p4
@@ -69,7 +69,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway2-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-first.p4
@@ -73,7 +73,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-frontend.p4
@@ -73,7 +73,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-midend.p4
@@ -83,7 +83,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway2.p4
+++ b/testdata/p4_14_samples_outputs/gateway2.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway3-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-first.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-frontend.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway3-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-midend.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway3.p4
+++ b/testdata/p4_14_samples_outputs/gateway3.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway4-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-first.p4
@@ -87,7 +87,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-frontend.p4
@@ -87,7 +87,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway4-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-midend.p4
@@ -97,7 +97,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway4.p4
+++ b/testdata/p4_14_samples_outputs/gateway4.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway5-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-first.p4
@@ -78,7 +78,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-frontend.p4
@@ -78,7 +78,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway5-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-midend.p4
@@ -87,7 +87,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway5.p4
+++ b/testdata/p4_14_samples_outputs/gateway5.p4
@@ -76,7 +76,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway6-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-first.p4
@@ -72,7 +72,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-frontend.p4
@@ -72,7 +72,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway6-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-midend.p4
@@ -81,7 +81,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway6.p4
+++ b/testdata/p4_14_samples_outputs/gateway6.p4
@@ -70,7 +70,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway7-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-first.p4
@@ -72,7 +72,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway7-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-frontend.p4
@@ -72,7 +72,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway7-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-midend.p4
@@ -81,7 +81,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway7.p4
+++ b/testdata/p4_14_samples_outputs/gateway7.p4
@@ -70,7 +70,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway8-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway8-first.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway8-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway8-frontend.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway8-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway8-midend.p4
@@ -81,7 +81,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/gateway8.p4
+++ b/testdata/p4_14_samples_outputs/gateway8.p4
@@ -69,7 +69,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_basic-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-first.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_basic-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-frontend.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_basic-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-midend.p4
@@ -77,7 +77,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_basic.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic.p4
@@ -73,7 +73,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-first.p4
@@ -78,7 +78,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-frontend.p4
@@ -78,7 +78,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-midend.p4
@@ -80,7 +80,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_gateway.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway.p4
@@ -77,7 +77,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-first.p4
@@ -108,7 +108,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-frontend.p4
@@ -108,7 +108,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-midend.p4
@@ -114,7 +114,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2.p4
@@ -103,7 +103,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-first.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-frontend.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-midend.p4
@@ -92,7 +92,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_two_same.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-first.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-frontend.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-midend.p4
@@ -90,7 +90,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate.p4
@@ -86,7 +86,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hit-first.p4
+++ b/testdata/p4_14_samples_outputs/hit-first.p4
@@ -80,7 +80,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hit-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hit-frontend.p4
@@ -82,7 +82,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hit-midend.p4
+++ b/testdata/p4_14_samples_outputs/hit-midend.p4
@@ -117,7 +117,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hit.p4
+++ b/testdata/p4_14_samples_outputs/hit.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hitmiss-first.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-first.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hitmiss-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-frontend.p4
@@ -87,7 +87,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hitmiss-midend.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-midend.p4
@@ -126,7 +126,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/hitmiss.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss.p4
@@ -81,7 +81,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/inline-first.p4
+++ b/testdata/p4_14_samples_outputs/inline-first.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/inline-frontend.p4
+++ b/testdata/p4_14_samples_outputs/inline-frontend.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/inline-midend.p4
+++ b/testdata/p4_14_samples_outputs/inline-midend.p4
@@ -47,7 +47,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/inline.p4
+++ b/testdata/p4_14_samples_outputs/inline.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct1-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct1-first.p4
@@ -86,7 +86,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct1-frontend.p4
@@ -86,7 +86,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct1-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct1-midend.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct1.p4
+++ b/testdata/p4_14_samples_outputs/instruct1.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct2-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct2-first.p4
@@ -69,7 +69,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct2-frontend.p4
@@ -69,7 +69,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct2-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct2-midend.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct2.p4
+++ b/testdata/p4_14_samples_outputs/instruct2.p4
@@ -67,7 +67,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct3-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct3-first.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct3-frontend.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct3-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct3-midend.p4
@@ -61,7 +61,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct3.p4
+++ b/testdata/p4_14_samples_outputs/instruct3.p4
@@ -57,7 +57,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct4-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct4-first.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct4-frontend.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct4-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct4-midend.p4
@@ -62,7 +62,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct4.p4
+++ b/testdata/p4_14_samples_outputs/instruct4.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct5-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-first.p4
@@ -103,7 +103,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-frontend.p4
@@ -103,7 +103,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct5-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-midend.p4
@@ -108,7 +108,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct5.p4
+++ b/testdata/p4_14_samples_outputs/instruct5.p4
@@ -101,7 +101,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct6-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct6-first.p4
@@ -64,7 +64,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct6-frontend.p4
@@ -64,7 +64,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct6-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct6-midend.p4
@@ -66,7 +66,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/instruct6.p4
+++ b/testdata/p4_14_samples_outputs/instruct6.p4
@@ -62,7 +62,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue583-first.p4
+++ b/testdata/p4_14_samples_outputs/issue583-first.p4
@@ -237,7 +237,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue583-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-frontend.p4
@@ -237,7 +237,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue583-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-midend.p4
@@ -249,7 +249,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue583.p4
+++ b/testdata/p4_14_samples_outputs/issue583.p4
@@ -233,7 +233,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue60-first.p4
+++ b/testdata/p4_14_samples_outputs/issue60-first.p4
@@ -53,7 +53,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue60-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue60-frontend.p4
@@ -53,7 +53,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue60-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue60-midend.p4
@@ -55,7 +55,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue60.p4
+++ b/testdata/p4_14_samples_outputs/issue60.p4
@@ -51,7 +51,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue604-first.p4
+++ b/testdata/p4_14_samples_outputs/issue604-first.p4
@@ -45,7 +45,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue604-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue604-frontend.p4
@@ -45,7 +45,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue604-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue604-midend.p4
@@ -47,7 +47,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue604.p4
+++ b/testdata/p4_14_samples_outputs/issue604.p4
@@ -43,7 +43,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue638-2-first.p4
+++ b/testdata/p4_14_samples_outputs/issue638-2-first.p4
@@ -35,7 +35,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue638-2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue638-2-frontend.p4
@@ -35,7 +35,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue638-2-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue638-2-midend.p4
@@ -37,7 +37,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue638-2.p4
+++ b/testdata/p4_14_samples_outputs/issue638-2.p4
@@ -33,7 +33,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue767-first.p4
+++ b/testdata/p4_14_samples_outputs/issue767-first.p4
@@ -41,7 +41,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue767-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue767-frontend.p4
@@ -41,7 +41,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue767-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue767-midend.p4
@@ -43,7 +43,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue767.p4
+++ b/testdata/p4_14_samples_outputs/issue767.p4
@@ -39,7 +39,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-1-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-1-first.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-1-frontend.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-1-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-1-midend.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-1.p4
+++ b/testdata/p4_14_samples_outputs/issue780-1.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-2-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-2-first.p4
@@ -40,7 +40,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-2-frontend.p4
@@ -40,7 +40,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-2-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-2-midend.p4
@@ -40,7 +40,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-2.p4
+++ b/testdata/p4_14_samples_outputs/issue780-2.p4
@@ -40,7 +40,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-3-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-3-first.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-3-frontend.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-3-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-3-midend.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-3.p4
+++ b/testdata/p4_14_samples_outputs/issue780-3.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-5-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-5-first.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-5-frontend.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-5-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-5-midend.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-5.p4
+++ b/testdata/p4_14_samples_outputs/issue780-5.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-7-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-7-first.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-7-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-7-frontend.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-7-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-7-midend.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-7.p4
+++ b/testdata/p4_14_samples_outputs/issue780-7.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-8-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-8-first.p4
@@ -50,7 +50,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-8-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-8-frontend.p4
@@ -50,7 +50,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-8-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-8-midend.p4
@@ -52,7 +52,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-8.p4
+++ b/testdata/p4_14_samples_outputs/issue780-8.p4
@@ -48,7 +48,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-9-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-9-first.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-9-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-9-frontend.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-9-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-9-midend.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue780-9.p4
+++ b/testdata/p4_14_samples_outputs/issue780-9.p4
@@ -34,7 +34,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue781-first.p4
+++ b/testdata/p4_14_samples_outputs/issue781-first.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue781-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue781-frontend.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue781-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue781-midend.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue781.p4
+++ b/testdata/p4_14_samples_outputs/issue781.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue846-first.p4
+++ b/testdata/p4_14_samples_outputs/issue846-first.p4
@@ -118,7 +118,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue846-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue846-frontend.p4
@@ -118,7 +118,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue846-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue846-midend.p4
@@ -135,7 +135,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/issue846.p4
+++ b/testdata/p4_14_samples_outputs/issue846.p4
@@ -114,7 +114,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/mac_rewrite-first.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-first.p4
@@ -166,7 +166,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/mac_rewrite-frontend.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-frontend.p4
@@ -166,7 +166,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/mac_rewrite-midend.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-midend.p4
@@ -163,7 +163,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/mac_rewrite.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite.p4
@@ -163,7 +163,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/meter-first.p4
+++ b/testdata/p4_14_samples_outputs/meter-first.p4
@@ -92,7 +92,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/meter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter-frontend.p4
@@ -92,7 +92,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/meter-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter-midend.p4
@@ -98,7 +98,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/meter.p4
+++ b/testdata/p4_14_samples_outputs/meter.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/meter1-first.p4
+++ b/testdata/p4_14_samples_outputs/meter1-first.p4
@@ -101,7 +101,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/meter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-frontend.p4
@@ -96,7 +96,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/meter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-midend.p4
@@ -100,7 +100,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/meter1.p4
+++ b/testdata/p4_14_samples_outputs/meter1.p4
@@ -97,7 +97,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/misc_prim-first.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim-first.p4
@@ -126,7 +126,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/misc_prim-frontend.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim-frontend.p4
@@ -151,7 +151,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/misc_prim-midend.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim-midend.p4
@@ -143,7 +143,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/misc_prim.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim.p4
@@ -124,7 +124,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/miss-first.p4
+++ b/testdata/p4_14_samples_outputs/miss-first.p4
@@ -82,7 +82,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/miss-frontend.p4
+++ b/testdata/p4_14_samples_outputs/miss-frontend.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/miss-midend.p4
+++ b/testdata/p4_14_samples_outputs/miss-midend.p4
@@ -119,7 +119,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/miss.p4
+++ b/testdata/p4_14_samples_outputs/miss.p4
@@ -77,7 +77,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/overflow-first.p4
+++ b/testdata/p4_14_samples_outputs/overflow-first.p4
@@ -49,7 +49,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/overflow-frontend.p4
+++ b/testdata/p4_14_samples_outputs/overflow-frontend.p4
@@ -49,7 +49,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/overflow-midend.p4
+++ b/testdata/p4_14_samples_outputs/overflow-midend.p4
@@ -51,7 +51,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/overflow.p4
+++ b/testdata/p4_14_samples_outputs/overflow.p4
@@ -47,7 +47,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/packet_redirect-first.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-first.p4
@@ -131,7 +131,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
@@ -131,7 +131,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
@@ -144,7 +144,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/packet_redirect.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect.p4
@@ -125,7 +125,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser1-first.p4
+++ b/testdata/p4_14_samples_outputs/parser1-first.p4
@@ -137,7 +137,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser1-frontend.p4
@@ -141,7 +141,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser1-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser1-midend.p4
@@ -146,7 +146,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser1.p4
+++ b/testdata/p4_14_samples_outputs/parser1.p4
@@ -135,7 +135,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser2-first.p4
+++ b/testdata/p4_14_samples_outputs/parser2-first.p4
@@ -228,7 +228,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser2-frontend.p4
@@ -232,7 +232,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser2-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser2-midend.p4
@@ -237,7 +237,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser2.p4
+++ b/testdata/p4_14_samples_outputs/parser2.p4
@@ -226,7 +226,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser3-first.p4
+++ b/testdata/p4_14_samples_outputs/parser3-first.p4
@@ -76,7 +76,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser3-frontend.p4
@@ -76,7 +76,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser3-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser3-midend.p4
@@ -78,7 +78,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser3.p4
+++ b/testdata/p4_14_samples_outputs/parser3.p4
@@ -74,7 +74,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser4-first.p4
+++ b/testdata/p4_14_samples_outputs/parser4-first.p4
@@ -139,7 +139,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser4-frontend.p4
@@ -143,7 +143,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser4-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser4-midend.p4
@@ -148,7 +148,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser4.p4
+++ b/testdata/p4_14_samples_outputs/parser4.p4
@@ -137,7 +137,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/parser_dc_full-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-first.p4
@@ -684,7 +684,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/parser_dc_full-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-frontend.p4
@@ -680,7 +680,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/parser_dc_full-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-midend.p4
@@ -697,7 +697,7 @@ struct tuple_0 {
     bit<32> field_9;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/parser_dc_full.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full.p4
@@ -684,7 +684,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-first.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-first.p4
@@ -906,7 +906,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-frontend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-frontend.p4
@@ -902,7 +902,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
@@ -921,7 +921,7 @@ struct tuple_0 {
     bit<32> field_9;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping.p4
@@ -904,7 +904,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/queueing-first.p4
+++ b/testdata/p4_14_samples_outputs/queueing-first.p4
@@ -97,7 +97,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/queueing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-frontend.p4
@@ -97,7 +97,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/queueing-midend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-midend.p4
@@ -101,7 +101,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/queueing.p4
+++ b/testdata/p4_14_samples_outputs/queueing.p4
@@ -93,7 +93,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/register-first.p4
+++ b/testdata/p4_14_samples_outputs/register-first.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/register-frontend.p4
+++ b/testdata/p4_14_samples_outputs/register-frontend.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/register-midend.p4
+++ b/testdata/p4_14_samples_outputs/register-midend.p4
@@ -77,7 +77,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/register.p4
+++ b/testdata/p4_14_samples_outputs/register.p4
@@ -73,7 +73,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/repeater-first.p4
+++ b/testdata/p4_14_samples_outputs/repeater-first.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/repeater-frontend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-frontend.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/repeater-midend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-midend.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/repeater.p4
+++ b/testdata/p4_14_samples_outputs/repeater.p4
@@ -52,7 +52,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/resubmit-first.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-first.p4
@@ -92,7 +92,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/resubmit-frontend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-frontend.p4
@@ -92,7 +92,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/resubmit-midend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-midend.p4
@@ -103,7 +103,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/resubmit.p4
+++ b/testdata/p4_14_samples_outputs/resubmit.p4
@@ -88,7 +88,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/sai_p4-first.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-first.p4
@@ -365,7 +365,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
@@ -348,7 +348,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/sai_p4-midend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-midend.p4
@@ -377,7 +377,7 @@ struct tuple_0 {
     bit<32> field_9;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/sai_p4.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4.p4
@@ -353,7 +353,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/selector0-first.p4
+++ b/testdata/p4_14_samples_outputs/selector0-first.p4
@@ -62,7 +62,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector0-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector0-frontend.p4
@@ -62,7 +62,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector0-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector0-midend.p4
@@ -64,7 +64,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector0.p4
+++ b/testdata/p4_14_samples_outputs/selector0.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector1-first.p4
+++ b/testdata/p4_14_samples_outputs/selector1-first.p4
@@ -66,7 +66,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector1-frontend.p4
@@ -66,7 +66,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector1-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector1-midend.p4
@@ -68,7 +68,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector1.p4
+++ b/testdata/p4_14_samples_outputs/selector1.p4
@@ -64,7 +64,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector2-first.p4
+++ b/testdata/p4_14_samples_outputs/selector2-first.p4
@@ -66,7 +66,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector2-frontend.p4
@@ -66,7 +66,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector2-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector2-midend.p4
@@ -68,7 +68,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector2.p4
+++ b/testdata/p4_14_samples_outputs/selector2.p4
@@ -64,7 +64,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector3-first.p4
+++ b/testdata/p4_14_samples_outputs/selector3-first.p4
@@ -73,7 +73,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector3-frontend.p4
@@ -73,7 +73,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector3-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector3-midend.p4
@@ -75,7 +75,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/selector3.p4
+++ b/testdata/p4_14_samples_outputs/selector3.p4
@@ -71,7 +71,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/simple_nat-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-first.p4
@@ -278,7 +278,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<32>, bit<32>, bit<8>, bit<8>, bit<16>, bit<16>, bit<16>, bit<32>, bit<32>, bit<4>, bit<4>, bit<8>, bit<16>, bit<16>>, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
@@ -280,7 +280,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<32>, bit<32>, bit<8>, bit<8>, bit<16>, bit<16>, bit<16>, bit<32>, bit<32>, bit<4>, bit<4>, bit<8>, bit<16>, bit<16>>, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/simple_nat-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-midend.p4
@@ -336,7 +336,7 @@ struct tuple_2 {
     bit<16> field_24;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_1, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple_2, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/simple_nat.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat.p4
@@ -268,7 +268,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/simple_router-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-first.p4
@@ -130,7 +130,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/simple_router-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-frontend.p4
@@ -130,7 +130,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/simple_router-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-midend.p4
@@ -153,7 +153,7 @@ struct tuple_0 {
     bit<32> field_9;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/simple_router.p4
+++ b/testdata/p4_14_samples_outputs/simple_router.p4
@@ -124,7 +124,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_14_samples_outputs/source_routing-first.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-first.p4
@@ -78,7 +78,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/source_routing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-frontend.p4
@@ -80,7 +80,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/source_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-midend.p4
@@ -82,7 +82,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/source_routing.p4
+++ b/testdata/p4_14_samples_outputs/source_routing.p4
@@ -76,7 +76,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/swap_1-first.p4
+++ b/testdata/p4_14_samples_outputs/swap_1-first.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/swap_1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/swap_1-frontend.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/swap_1-midend.p4
+++ b/testdata/p4_14_samples_outputs/swap_1-midend.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/swap_1.p4
+++ b/testdata/p4_14_samples_outputs/swap_1.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/swap_2-first.p4
+++ b/testdata/p4_14_samples_outputs/swap_2-first.p4
@@ -57,7 +57,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/swap_2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/swap_2-frontend.p4
@@ -57,7 +57,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/swap_2-midend.p4
+++ b/testdata/p4_14_samples_outputs/swap_2-midend.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/swap_2.p4
+++ b/testdata/p4_14_samples_outputs/swap_2.p4
@@ -55,7 +55,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
@@ -4976,7 +4976,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -4886,7 +4886,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -5001,7 +5001,7 @@ struct tuple_8 {
     bit<32> field_45;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_8, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple_8, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
@@ -4854,7 +4854,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -6020,7 +6020,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -5880,7 +5880,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -6016,7 +6016,7 @@ struct tuple_10 {
     bit<32> field_50;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_10, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple_10, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -5864,7 +5864,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_14_samples_outputs/ternary_match0-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0-first.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match0-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0-frontend.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match0-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0-midend.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match0.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match1-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-first.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-frontend.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match1-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-midend.p4
@@ -62,7 +62,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match1.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match2-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-first.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-frontend.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match2-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-midend.p4
@@ -62,7 +62,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match2.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match3-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-first.p4
@@ -62,7 +62,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-frontend.p4
@@ -62,7 +62,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match3-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-midend.p4
@@ -64,7 +64,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match3.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3.p4
@@ -60,7 +60,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match4-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-first.p4
@@ -63,7 +63,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-frontend.p4
@@ -63,7 +63,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match4-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-midend.p4
@@ -65,7 +65,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/ternary_match4.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4.p4
@@ -61,7 +61,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-first.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-first.p4
@@ -137,7 +137,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-frontend.p4
@@ -137,7 +137,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-midend.p4
@@ -139,7 +139,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_7_storm_control.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control.p4
@@ -136,7 +136,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-first.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-first.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-frontend.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-midend.p4
@@ -90,7 +90,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key.p4
@@ -79,7 +79,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-first.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-first.p4
@@ -101,7 +101,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-frontend.p4
@@ -101,7 +101,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-midend.p4
@@ -102,7 +102,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified.p4
@@ -99,7 +99,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/testgw-first.p4
+++ b/testdata/p4_14_samples_outputs/testgw-first.p4
@@ -106,7 +106,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/testgw-frontend.p4
+++ b/testdata/p4_14_samples_outputs/testgw-frontend.p4
@@ -106,7 +106,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/testgw-midend.p4
+++ b/testdata/p4_14_samples_outputs/testgw-midend.p4
@@ -116,7 +116,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/testgw.p4
+++ b/testdata/p4_14_samples_outputs/testgw.p4
@@ -102,7 +102,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tmvalid-first.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid-first.p4
@@ -61,7 +61,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tmvalid-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid-frontend.p4
@@ -61,7 +61,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tmvalid-midend.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid-midend.p4
@@ -63,7 +63,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tmvalid.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid.p4
@@ -59,7 +59,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2a-first.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-first.p4
@@ -107,7 +107,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2a-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-frontend.p4
@@ -107,7 +107,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2a-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-midend.p4
@@ -121,7 +121,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2a.p4
+++ b/testdata/p4_14_samples_outputs/tp2a.p4
@@ -99,7 +99,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2b-first.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-first.p4
@@ -156,7 +156,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2b-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-frontend.p4
@@ -156,7 +156,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2b-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-midend.p4
@@ -180,7 +180,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2b.p4
+++ b/testdata/p4_14_samples_outputs/tp2b.p4
@@ -144,7 +144,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2c-first.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-first.p4
@@ -140,7 +140,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2c-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-frontend.p4
@@ -140,7 +140,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2c-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-midend.p4
@@ -162,7 +162,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp2c.p4
+++ b/testdata/p4_14_samples_outputs/tp2c.p4
@@ -129,7 +129,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp3a-first.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-first.p4
@@ -180,7 +180,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp3a-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-frontend.p4
@@ -180,7 +180,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp3a-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-midend.p4
@@ -218,7 +218,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/tp3a.p4
+++ b/testdata/p4_14_samples_outputs/tp3a.p4
@@ -164,7 +164,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/triv_eth-first.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-first.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/triv_eth-frontend.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-frontend.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/triv_eth-midend.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-midend.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/triv_eth.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/triv_ipv4-first.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-first.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/triv_ipv4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-frontend.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/triv_ipv4-midend.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-midend.p4
@@ -91,7 +91,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/triv_ipv4.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4.p4
@@ -82,7 +82,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/truncate-first.p4
+++ b/testdata/p4_14_samples_outputs/truncate-first.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/truncate-frontend.p4
+++ b/testdata/p4_14_samples_outputs/truncate-frontend.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/truncate-midend.p4
+++ b/testdata/p4_14_samples_outputs/truncate-midend.p4
@@ -58,7 +58,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/truncate.p4
+++ b/testdata/p4_14_samples_outputs/truncate.p4
@@ -54,7 +54,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet-first.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet-first.p4
@@ -173,7 +173,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet-frontend.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet-frontend.p4
@@ -173,7 +173,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet-midend.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet-midend.p4
@@ -176,7 +176,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet.p4
@@ -171,7 +171,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action1-first.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-first.p4
@@ -83,7 +83,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-frontend.p4
@@ -83,7 +83,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action1-midend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-midend.p4
@@ -85,7 +85,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action1.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1.p4
@@ -81,7 +81,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action2-first.p4
+++ b/testdata/p4_14_samples_outputs/wide_action2-first.p4
@@ -95,7 +95,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action2-frontend.p4
@@ -95,7 +95,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action2-midend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action2-midend.p4
@@ -97,7 +97,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action2.p4
+++ b/testdata/p4_14_samples_outputs/wide_action2.p4
@@ -93,7 +93,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action3-first.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-first.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-frontend.p4
@@ -84,7 +84,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action3-midend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-midend.p4
@@ -86,7 +86,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_14_samples_outputs/wide_action3.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3.p4
@@ -82,7 +82,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors/issue306.p4
+++ b/testdata/p4_16_errors/issue306.p4
@@ -58,7 +58,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
   }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
   apply { }
 }
 

--- a/testdata/p4_16_errors/issue388.p4
+++ b/testdata/p4_16_errors/issue388.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
   }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
   apply { }
 }
 

--- a/testdata/p4_16_errors/issue401.p4
+++ b/testdata/p4_16_errors/issue401.p4
@@ -33,7 +33,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
   }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
   apply { }
 }
 

--- a/testdata/p4_16_errors/issue413.p4
+++ b/testdata/p4_16_errors/issue413.p4
@@ -58,7 +58,7 @@ control cEgress(inout Parsed_packet hdr,
     apply { }
 }
 
-control vc(in Parsed_packet hdr,
+control vc(inout Parsed_packet hdr,
            inout mystruct1 meta) {
     apply { }
 }

--- a/testdata/p4_16_errors/issue473.p4
+++ b/testdata/p4_16_errors/issue473.p4
@@ -81,7 +81,7 @@ control cEgress(inout Parsed_packet hdr,
     apply { }
 }
 
-control vc(in Parsed_packet hdr,
+control vc(inout Parsed_packet hdr,
            inout mystruct1 meta) {
     apply { }
 }

--- a/testdata/p4_16_errors/issue513.p4
+++ b/testdata/p4_16_errors/issue513.p4
@@ -77,7 +77,7 @@ control cEgress(inout Parsed_packet hdr,
     apply { }
 }
 
-control vc(in Parsed_packet hdr,
+control vc(inout Parsed_packet hdr,
            inout mystruct1 meta) {
     apply { }
 }

--- a/testdata/p4_16_errors/issue532.p4
+++ b/testdata/p4_16_errors/issue532.p4
@@ -54,13 +54,13 @@ control deparser(packet_out b, in parsed_packet_t hdr) {
   apply { }
 }
 
-control verify_ck(in parsed_packet_t hdr,
-                        inout my_meta_t my_meta) {
+control verify_ck(inout parsed_packet_t hdr,
+                  inout my_meta_t my_meta) {
   apply { }
 }
 
 control compute_ck(inout parsed_packet_t hdr,
-                         inout my_meta_t my_meta) {
+                   inout my_meta_t my_meta) {
   apply { }
 }
 

--- a/testdata/p4_16_errors/not_bound.p4
+++ b/testdata/p4_16_errors/not_bound.p4
@@ -41,7 +41,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     apply {}
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {}
 }
 

--- a/testdata/p4_16_errors/table-entries-decl-order.p4
+++ b/testdata/p4_16_errors/table-entries-decl-order.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_errors/table-entries-exact-ternary.p4
+++ b/testdata/p4_16_errors/table-entries-exact-ternary.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_errors/table-entries-exact.p4
+++ b/testdata/p4_16_errors/table-entries-exact.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_errors/table-entries-lpm.p4
+++ b/testdata/p4_16_errors/table-entries-lpm.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_errors/table-entries-non-const.p4
+++ b/testdata/p4_16_errors/table-entries-non-const.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_errors/table-entries-outside-table.p4
+++ b/testdata/p4_16_errors/table-entries-outside-table.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_errors/table-entries-range.p4
+++ b/testdata/p4_16_errors/table-entries-range.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_errors/table-entries-ternary.p4
+++ b/testdata/p4_16_errors/table-entries-ternary.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_errors/type-field.p4
+++ b/testdata/p4_16_errors/type-field.p4
@@ -35,8 +35,8 @@ parser MyParser(packet_in b,
   }
 }
 
-control MyVerifyChecksum(in h hdr,
-                       inout m meta) {
+control MyVerifyChecksum(inout h hdr,
+                         inout m meta) {
   apply {}
 
 }

--- a/testdata/p4_16_errors_outputs/issue306.p4
+++ b/testdata/p4_16_errors_outputs/issue306.p4
@@ -38,7 +38,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/issue388.p4
+++ b/testdata/p4_16_errors_outputs/issue388.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/issue401.p4
+++ b/testdata/p4_16_errors_outputs/issue401.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/issue413.p4
+++ b/testdata/p4_16_errors_outputs/issue413.p4
@@ -47,7 +47,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/issue473.p4
+++ b/testdata/p4_16_errors_outputs/issue473.p4
@@ -60,7 +60,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/issue513-first.p4
+++ b/testdata/p4_16_errors_outputs/issue513-first.p4
@@ -55,7 +55,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/issue513-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue513-frontend.p4
@@ -55,7 +55,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/issue513.p4
+++ b/testdata/p4_16_errors_outputs/issue513.p4
@@ -56,7 +56,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/issue532-first.p4
+++ b/testdata/p4_16_errors_outputs/issue532-first.p4
@@ -52,7 +52,7 @@ control deparser(packet_out b, in parsed_packet_t hdr) {
     }
 }
 
-control verify_ck(in parsed_packet_t hdr, inout my_meta_t my_meta) {
+control verify_ck(inout parsed_packet_t hdr, inout my_meta_t my_meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/issue532-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue532-frontend.p4
@@ -54,7 +54,7 @@ control deparser(packet_out b, in parsed_packet_t hdr) {
     }
 }
 
-control verify_ck(in parsed_packet_t hdr, inout my_meta_t my_meta) {
+control verify_ck(inout parsed_packet_t hdr, inout my_meta_t my_meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/issue532.p4
+++ b/testdata/p4_16_errors_outputs/issue532.p4
@@ -52,7 +52,7 @@ control deparser(packet_out b, in parsed_packet_t hdr) {
     }
 }
 
-control verify_ck(in parsed_packet_t hdr, inout my_meta_t my_meta) {
+control verify_ck(inout parsed_packet_t hdr, inout my_meta_t my_meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/key-name.p4
+++ b/testdata/p4_16_errors_outputs/key-name.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/not_bound.p4
+++ b/testdata/p4_16_errors_outputs/not_bound.p4
@@ -32,7 +32,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/table-entries-decl-order.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-decl-order.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/table-entries-exact.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-exact.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/table-entries-lpm.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/table-entries-range.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-range.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/table-entries-ternary.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-ternary.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/type-field.p4
+++ b/testdata/p4_16_errors_outputs/type-field.p4
@@ -19,7 +19,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/action-synth.p4
+++ b/testdata/p4_16_samples/action-synth.p4
@@ -46,7 +46,7 @@ control DeparserI(packet_out pk, in H hdr) {
     apply { }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/action_profile-bmv2.p4
+++ b/testdata/p4_16_samples/action_profile-bmv2.p4
@@ -61,7 +61,7 @@ control DeparserI(packet_out pk, in H hdr) {
     apply { }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/action_selector_shared-bmv2.p4
+++ b/testdata/p4_16_samples/action_selector_shared-bmv2.p4
@@ -64,7 +64,7 @@ control DeparserI(packet_out pk, in H hdr) {
     apply { }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples/action_selector_unused-bmv2.p4
@@ -29,7 +29,7 @@ control DeparserI(packet_out pk, in H hdr) {
     apply { }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/arith-inline-skeleton.p4
+++ b/testdata/p4_16_samples/arith-inline-skeleton.p4
@@ -35,7 +35,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }

--- a/testdata/p4_16_samples/arith-skeleton.p4
+++ b/testdata/p4_16_samples/arith-skeleton.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }

--- a/testdata/p4_16_samples/clone-bmv2.p4
+++ b/testdata/p4_16_samples/clone-bmv2.p4
@@ -39,7 +39,7 @@ control DeparserI(packet_out pk, in H hdr) {
     apply { }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/def-use.p4
+++ b/testdata/p4_16_samples/def-use.p4
@@ -52,7 +52,7 @@ control EgressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 control ComputeChecksumI(inout H hdr, inout M meta) {

--- a/testdata/p4_16_samples/drop-bmv2.p4
+++ b/testdata/p4_16_samples/drop-bmv2.p4
@@ -48,7 +48,7 @@ control DeparserI(packet_out pk, in H hdr) {
     apply { }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples/flowlet_switching-bmv2.p4
@@ -215,7 +215,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples/hash-bmv2.p4
+++ b/testdata/p4_16_samples/hash-bmv2.p4
@@ -40,7 +40,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/hit-expr.p4
+++ b/testdata/p4_16_samples/hit-expr.p4
@@ -43,7 +43,7 @@ control DeparserI(packet_out pk, in H hdr) {
     apply { }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/inline-bmv2.p4
+++ b/testdata/p4_16_samples/inline-bmv2.p4
@@ -32,7 +32,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/inline-stack-bmv2.p4
+++ b/testdata/p4_16_samples/inline-stack-bmv2.p4
@@ -31,7 +31,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/inline1-bmv2.p4
+++ b/testdata/p4_16_samples/inline1-bmv2.p4
@@ -32,7 +32,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/intrinsic-bmv2.p4
+++ b/testdata/p4_16_samples/intrinsic-bmv2.p4
@@ -28,7 +28,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_m smeta) {
     state start { transition accept; }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/issue134-bmv2.p4
+++ b/testdata/p4_16_samples/issue134-bmv2.p4
@@ -44,7 +44,7 @@ control DeparserI(packet_out pk, in H hdr) {
     apply { }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/issue232-bmv2.p4
+++ b/testdata/p4_16_samples/issue232-bmv2.p4
@@ -81,7 +81,7 @@ control DP(packet_out b, in Headers p) {
     apply {}
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {}
 }
 

--- a/testdata/p4_16_samples/issue242.p4
+++ b/testdata/p4_16_samples/issue242.p4
@@ -109,7 +109,7 @@ control DP(packet_out b, in Headers p) {
 }
 
 // Fillers
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {}
 }
 

--- a/testdata/p4_16_samples/issue249.p4
+++ b/testdata/p4_16_samples/issue249.p4
@@ -53,7 +53,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     apply {}
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples/issue270-bmv2.p4
+++ b/testdata/p4_16_samples/issue270-bmv2.p4
@@ -66,7 +66,7 @@ control Eg(inout H hdrs,
 
 action drop() {}
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
         verify_checksum(hdr.inner_ipv4.ihl == 5, {
             // all inner_ipv4 fields, except checksum itself

--- a/testdata/p4_16_samples/issue272-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue272-1-bmv2.p4
@@ -33,7 +33,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     state start { transition accept; }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/issue272-2-bmv2.p4
+++ b/testdata/p4_16_samples/issue272-2-bmv2.p4
@@ -31,7 +31,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     state start { transition accept; }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/issue281.p4
+++ b/testdata/p4_16_samples/issue281.p4
@@ -115,7 +115,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
   }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
   apply {}
 }
 

--- a/testdata/p4_16_samples/issue297-bmv2.p4
+++ b/testdata/p4_16_samples/issue297-bmv2.p4
@@ -62,7 +62,7 @@ control DeparserI(packet_out pk, in H hdr) {
     apply { }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/issue298-bmv2.p4
+++ b/testdata/p4_16_samples/issue298-bmv2.p4
@@ -132,7 +132,7 @@ control TopDeparser(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, {hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples/issue323.p4
+++ b/testdata/p4_16_samples/issue323.p4
@@ -35,7 +35,7 @@ parser p(packet_in b, out Headers h,
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {

--- a/testdata/p4_16_samples/issue355-bmv2.p4
+++ b/testdata/p4_16_samples/issue355-bmv2.p4
@@ -36,7 +36,7 @@ control cEgress(inout H hdr, inout M meta, inout standard_metadata_t stdmeta) {
     }
 }
 
-control vc(in H hdr, inout M meta) {
+control vc(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/issue356-bmv2.p4
+++ b/testdata/p4_16_samples/issue356-bmv2.p4
@@ -30,7 +30,7 @@ control cEgress(inout H hdr, inout M meta, inout standard_metadata_t stdmeta) {
     }
 }
 
-control vc(in H hdr, inout M meta) {
+control vc(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/issue361-bmv2.p4
+++ b/testdata/p4_16_samples/issue361-bmv2.p4
@@ -39,7 +39,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
   apply { }
 }
 

--- a/testdata/p4_16_samples/issue364-bmv2.p4
+++ b/testdata/p4_16_samples/issue364-bmv2.p4
@@ -35,7 +35,7 @@ parser p(packet_in b, out Headers h,
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {

--- a/testdata/p4_16_samples/issue414-bmv2.p4
+++ b/testdata/p4_16_samples/issue414-bmv2.p4
@@ -88,7 +88,7 @@ control cEgress(inout Parsed_packet hdr,
     apply { }
 }
 
-control vc(in Parsed_packet hdr,
+control vc(inout Parsed_packet hdr,
            inout mystruct1 meta) {
     apply { }
 }

--- a/testdata/p4_16_samples/issue420.p4
+++ b/testdata/p4_16_samples/issue420.p4
@@ -69,7 +69,7 @@ control cEgress(inout Parsed_packet hdr,
     apply { }
 }
 
-control vc(in Parsed_packet hdr,
+control vc(inout Parsed_packet hdr,
            inout mystruct1 meta) {
     apply { }
 }

--- a/testdata/p4_16_samples/issue422.p4
+++ b/testdata/p4_16_samples/issue422.p4
@@ -81,7 +81,7 @@ control cEgress(inout Parsed_packet hdr,
     apply { }
 }
 
-control vc(in Parsed_packet hdr,
+control vc(inout Parsed_packet hdr,
            inout mystruct1 meta) {
     apply { }
 }

--- a/testdata/p4_16_samples/issue430-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue430-1-bmv2.p4
@@ -51,7 +51,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/issue430-bmv2.p4
+++ b/testdata/p4_16_samples/issue430-bmv2.p4
@@ -30,7 +30,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
   apply { }
 }
 

--- a/testdata/p4_16_samples/issue447-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue447-1-bmv2.p4
@@ -38,7 +38,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/issue447-2-bmv2.p4
+++ b/testdata/p4_16_samples/issue447-2-bmv2.p4
@@ -42,7 +42,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/issue447-3-bmv2.p4
+++ b/testdata/p4_16_samples/issue447-3-bmv2.p4
@@ -44,7 +44,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/issue447-4-bmv2.p4
+++ b/testdata/p4_16_samples/issue447-4-bmv2.p4
@@ -43,7 +43,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/issue447-5-bmv2.p4
+++ b/testdata/p4_16_samples/issue447-5-bmv2.p4
@@ -49,7 +49,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/issue447-bmv2.p4
+++ b/testdata/p4_16_samples/issue447-bmv2.p4
@@ -49,7 +49,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     apply {}
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {}
 }
 

--- a/testdata/p4_16_samples/issue496.p4
+++ b/testdata/p4_16_samples/issue496.p4
@@ -16,7 +16,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
   }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
   apply { }
 }
 

--- a/testdata/p4_16_samples/issue510-bmv2.p4
+++ b/testdata/p4_16_samples/issue510-bmv2.p4
@@ -43,7 +43,7 @@ parser MyParser(
 }
 
 control MyVerifyChecksum(
-    in    my_headers_t   hdr,
+    inout my_headers_t   hdr,
     inout my_metadata_t  meta)
 {
     apply {     }

--- a/testdata/p4_16_samples/issue512.p4
+++ b/testdata/p4_16_samples/issue512.p4
@@ -82,7 +82,7 @@ control cEgress(inout Parsed_packet hdr,
     apply { }
 }
 
-control vc(in Parsed_packet hdr,
+control vc(inout Parsed_packet hdr,
            inout mystruct1 meta) {
     apply { }
 }

--- a/testdata/p4_16_samples/issue635-bmv2.p4
+++ b/testdata/p4_16_samples/issue635-bmv2.p4
@@ -48,7 +48,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     apply {}
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {}
 }
 

--- a/testdata/p4_16_samples/issue655-bmv2.p4
+++ b/testdata/p4_16_samples/issue655-bmv2.p4
@@ -39,7 +39,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 
 control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        verify_checksum(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        verify_checksum(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples/issue655-bmv2.p4
+++ b/testdata/p4_16_samples/issue655-bmv2.p4
@@ -37,7 +37,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     apply {}
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
         verify_checksum(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples/issue655.p4
+++ b/testdata/p4_16_samples/issue655.p4
@@ -37,9 +37,9 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     apply {}
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        verify_checksum(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        verify_checksum(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples/junk-prop-bmv2.p4
+++ b/testdata/p4_16_samples/junk-prop-bmv2.p4
@@ -44,7 +44,7 @@ control DeparserI(packet_out pk, in H hdr) {
     apply { }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples/mux-bmv2.p4
+++ b/testdata/p4_16_samples/mux-bmv2.p4
@@ -66,7 +66,7 @@ control DP(packet_out b, in Headers p) {
 }
 
 // Fillers
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {}
 }
 

--- a/testdata/p4_16_samples/named_meter_bmv2.p4
+++ b/testdata/p4_16_samples/named_meter_bmv2.p4
@@ -117,7 +117,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/parser-locals2.p4
+++ b/testdata/p4_16_samples/parser-locals2.p4
@@ -104,7 +104,7 @@ control cEgress(inout Parsed_packet hdr,
     apply { }
 }
 
-control vc(in Parsed_packet hdr,
+control vc(inout Parsed_packet hdr,
            inout mystruct1 meta) {
     apply { }
 }

--- a/testdata/p4_16_samples/scalarmeta-bmv2.p4
+++ b/testdata/p4_16_samples/scalarmeta-bmv2.p4
@@ -38,7 +38,7 @@ parser MyParser(packet_in b, out h hdrs, inout m meta, inout standard_metadata_t
   }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
   apply {}
 }
 control MyIngress(inout h hdr, inout m meta, inout standard_metadata_t std) {

--- a/testdata/p4_16_samples/slice-def-use.p4
+++ b/testdata/p4_16_samples/slice-def-use.p4
@@ -101,7 +101,7 @@ control DP(packet_out b, in Headers p) {
 }
 
 // Fillers
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {}
 }
 

--- a/testdata/p4_16_samples/slice-def-use1.p4
+++ b/testdata/p4_16_samples/slice-def-use1.p4
@@ -70,7 +70,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples/stack_complex-bmv2.p4
+++ b/testdata/p4_16_samples/stack_complex-bmv2.p4
@@ -43,7 +43,7 @@ parser p(packet_in b, out Headers h,
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {

--- a/testdata/p4_16_samples/table-entries-exact-bmv2.p4
+++ b/testdata/p4_16_samples/table-entries-exact-bmv2.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_samples/table-entries-exact-ternary-bmv2.p4
+++ b/testdata/p4_16_samples/table-entries-exact-ternary-bmv2.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_samples/table-entries-lpm-bmv2.p4
+++ b/testdata/p4_16_samples/table-entries-lpm-bmv2.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_samples/table-entries-priority-bmv2.p4
+++ b/testdata/p4_16_samples/table-entries-priority-bmv2.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_samples/table-entries-range-bmv2.p4
+++ b/testdata/p4_16_samples/table-entries-range-bmv2.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
+++ b/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_samples/table-entries-valid-bmv2.p4
+++ b/testdata/p4_16_samples/table-entries-valid-bmv2.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) { apply {} }
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
 control update(inout Header_t h, inout Meta_t m) { apply {} }
 control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
 control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }

--- a/testdata/p4_16_samples/ternary2-bmv2.p4
+++ b/testdata/p4_16_samples/ternary2-bmv2.p4
@@ -51,7 +51,7 @@ parser p(packet_in b, out packet_t hdrs, inout Meta m, inout standard_metadata_t
         }
     }
 }
-control vrfy(in packet_t h, inout Meta m) { apply {} }
+control vrfy(inout packet_t h, inout Meta m) { apply {} }
 control update(inout packet_t h, inout Meta m) { apply {} }
 
 control ingress(inout packet_t hdrs, inout Meta m, inout standard_metadata_t meta) {

--- a/testdata/p4_16_samples/union-bmv2.p4
+++ b/testdata/p4_16_samples/union-bmv2.p4
@@ -57,7 +57,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }

--- a/testdata/p4_16_samples/union-valid-bmv2.p4
+++ b/testdata/p4_16_samples/union-valid-bmv2.p4
@@ -57,7 +57,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }

--- a/testdata/p4_16_samples/union1-bmv2.p4
+++ b/testdata/p4_16_samples/union1-bmv2.p4
@@ -57,7 +57,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }

--- a/testdata/p4_16_samples/union2-bmv2.p4
+++ b/testdata/p4_16_samples/union2-bmv2.p4
@@ -57,7 +57,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }

--- a/testdata/p4_16_samples/union3-bmv2.p4
+++ b/testdata/p4_16_samples/union3-bmv2.p4
@@ -58,7 +58,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }

--- a/testdata/p4_16_samples/union4-bmv2.p4
+++ b/testdata/p4_16_samples/union4-bmv2.p4
@@ -58,7 +58,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }

--- a/testdata/p4_16_samples/unused-counter-bmv2.p4
+++ b/testdata/p4_16_samples/unused-counter-bmv2.p4
@@ -35,7 +35,7 @@ parser p(packet_in b, out Headers h,
     }
 }
 
-control vrfy(in Headers h, inout Meta m) { apply {} }
+control vrfy(inout Headers h, inout Meta m) { apply {} }
 control update(inout Headers h, inout Meta m) { apply {} }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {

--- a/testdata/p4_16_samples/verify-bmv2.p4
+++ b/testdata/p4_16_samples/verify-bmv2.p4
@@ -32,7 +32,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {}
 }
 control MyIngress(inout h hdr, inout m meta, inout standard_metadata_t std) {

--- a/testdata/p4_16_samples/x-bmv2.p4
+++ b/testdata/p4_16_samples/x-bmv2.p4
@@ -23,7 +23,7 @@ header T { bit<32> y; }
 struct H { T s; }
 struct M { S s; }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply { }
 }
 

--- a/testdata/p4_16_samples_outputs/action-synth-first.p4
+++ b/testdata/p4_16_samples_outputs/action-synth-first.p4
@@ -38,7 +38,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action-synth-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action-synth-frontend.p4
@@ -38,7 +38,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action-synth-midend.p4
+++ b/testdata/p4_16_samples_outputs/action-synth-midend.p4
@@ -37,7 +37,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action-synth.p4
+++ b/testdata/p4_16_samples_outputs/action-synth.p4
@@ -38,7 +38,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-first.p4
@@ -57,7 +57,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-frontend.p4
@@ -55,7 +55,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
@@ -62,7 +62,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2.p4
@@ -57,7 +57,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-first.p4
@@ -59,7 +59,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-frontend.p4
@@ -57,7 +57,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-midend.p4
@@ -64,7 +64,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4
@@ -59,7 +59,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
@@ -35,7 +35,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-frontend.p4
@@ -30,7 +30,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-midend.p4
@@ -30,7 +30,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
@@ -35,7 +35,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith-bmv2-first.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith-bmv2-frontend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith-bmv2.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2-first.p4
@@ -36,7 +36,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2-frontend.p4
@@ -36,7 +36,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2.p4
@@ -36,7 +36,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2-first.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2-frontend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2-first.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2-frontend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2-first.p4
@@ -30,7 +30,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2-frontend.p4
@@ -30,7 +30,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2.p4
@@ -30,7 +30,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2-first.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2-frontend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2-first.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2-frontend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith4-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith5-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2-first.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith5-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2-frontend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith5-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/arith5-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/clone-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/clone-bmv2-first.p4
@@ -29,7 +29,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/clone-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/clone-bmv2-frontend.p4
@@ -29,7 +29,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/clone-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/clone-bmv2-midend.p4
@@ -38,7 +38,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/clone-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/clone-bmv2.p4
@@ -29,7 +29,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/concat-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/concat-bmv2-first.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/concat-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/concat-bmv2-frontend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/concat-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/concat-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/concat-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/concat-bmv2.p4
@@ -21,7 +21,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-first.p4
@@ -25,7 +25,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-frontend.p4
@@ -25,7 +25,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-midend.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2.p4
@@ -25,7 +25,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/def-use-first.p4
+++ b/testdata/p4_16_samples_outputs/def-use-first.p4
@@ -44,7 +44,7 @@ control EgressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/def-use-frontend.p4
+++ b/testdata/p4_16_samples_outputs/def-use-frontend.p4
@@ -44,7 +44,7 @@ control EgressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/def-use-midend.p4
+++ b/testdata/p4_16_samples_outputs/def-use-midend.p4
@@ -41,7 +41,7 @@ control EgressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/def-use.p4
+++ b/testdata/p4_16_samples_outputs/def-use.p4
@@ -44,7 +44,7 @@ control EgressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-first.p4
@@ -35,7 +35,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-frontend.p4
@@ -35,7 +35,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-midend.p4
@@ -20,7 +20,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/default_action-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2.p4
@@ -35,7 +35,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/drop-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-first.p4
@@ -40,7 +40,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
@@ -40,7 +40,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
@@ -58,7 +58,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4
@@ -40,7 +40,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/enum-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv2-first.p4
@@ -36,7 +36,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/enum-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv2-frontend.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/enum-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv2-midend.p4
@@ -26,7 +26,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/enum-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv2.p4
@@ -36,7 +36,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
@@ -215,7 +215,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
@@ -215,7 +215,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -264,7 +264,7 @@ struct tuple_2 {
     bit<32> field_20;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_2, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
@@ -215,7 +215,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/hash-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2-first.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/hash-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2-frontend.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/hash-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2-midend.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/hash-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/header-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2-first.p4
@@ -27,7 +27,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/header-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2-frontend.p4
@@ -27,7 +27,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/header-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2-midend.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/header-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2.p4
@@ -27,7 +27,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/hit-expr-first.p4
+++ b/testdata/p4_16_samples_outputs/hit-expr-first.p4
@@ -38,7 +38,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/hit-expr-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hit-expr-frontend.p4
@@ -37,7 +37,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/hit-expr-midend.p4
+++ b/testdata/p4_16_samples_outputs/hit-expr-midend.p4
@@ -39,7 +39,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/hit-expr.p4
+++ b/testdata/p4_16_samples_outputs/hit-expr.p4
@@ -38,7 +38,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/inline-bmv2-first.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-bmv2-frontend.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-bmv2-midend.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/inline-bmv2.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2-first.p4
@@ -19,7 +19,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2-frontend.p4
@@ -19,7 +19,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2-midend.p4
@@ -19,7 +19,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2.p4
@@ -19,7 +19,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2-first.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2-frontend.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2-midend.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/inline1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/intrinsic-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/intrinsic-bmv2-first.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_m smeta) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/intrinsic-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/intrinsic-bmv2-frontend.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_m smeta) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/intrinsic-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/intrinsic-bmv2-midend.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_m smeta) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/intrinsic-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/intrinsic-bmv2.p4
@@ -18,7 +18,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_m smeta) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue134-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2-first.p4
@@ -34,7 +34,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue134-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2-frontend.p4
@@ -34,7 +34,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue134-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2-midend.p4
@@ -34,7 +34,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue134-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2.p4
@@ -34,7 +34,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue232-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2-first.p4
@@ -52,7 +52,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue232-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2-frontend.p4
@@ -56,7 +56,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue232-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2-midend.p4
@@ -55,7 +55,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue232-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2.p4
@@ -53,7 +53,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue242-first.p4
+++ b/testdata/p4_16_samples_outputs/issue242-first.p4
@@ -80,7 +80,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue242-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-frontend.p4
@@ -93,7 +93,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue242-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-midend.p4
@@ -107,7 +107,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue242.p4
+++ b/testdata/p4_16_samples_outputs/issue242.p4
@@ -80,7 +80,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue249-first.p4
+++ b/testdata/p4_16_samples_outputs/issue249-first.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue249-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue249-frontend.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue249-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue249-midend.p4
@@ -70,7 +70,7 @@ struct tuple_0 {
     bit<32> field_9;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue249.p4
+++ b/testdata/p4_16_samples_outputs/issue249.p4
@@ -56,7 +56,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue270-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2-first.p4
@@ -42,7 +42,7 @@ control Eg(inout H hdrs, inout M meta, inout standard_metadata_t standard_meta) 
 
 action drop() {
 }
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_16_samples_outputs/issue270-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2-frontend.p4
@@ -40,7 +40,7 @@ control Eg(inout H hdrs, inout M meta, inout standard_metadata_t standard_meta) 
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_16_samples_outputs/issue270-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2-midend.p4
@@ -54,7 +54,7 @@ struct tuple_0 {
     bit<32> field_9;
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_16_samples_outputs/issue270-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2.p4
@@ -42,7 +42,7 @@ control Eg(inout H hdrs, inout M meta, inout standard_metadata_t standard_meta) 
 
 action drop() {
 }
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
         verify_checksum(hdr.inner_ipv4.ihl == 5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
         verify_checksum(hdr.ipv4.ihl == 5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);

--- a/testdata/p4_16_samples_outputs/issue272-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue272-1-bmv2-first.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue272-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue272-1-bmv2-frontend.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue272-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue272-1-bmv2-midend.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue272-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue272-1-bmv2.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue272-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue272-2-bmv2-first.p4
@@ -20,7 +20,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue272-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue272-2-bmv2-frontend.p4
@@ -20,7 +20,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue272-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue272-2-bmv2-midend.p4
@@ -20,7 +20,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue272-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue272-2-bmv2.p4
@@ -20,7 +20,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta)
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue281-first.p4
+++ b/testdata/p4_16_samples_outputs/issue281-first.p4
@@ -99,7 +99,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue281-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue281-frontend.p4
@@ -99,7 +99,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue281-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue281-midend.p4
@@ -92,7 +92,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue281.p4
+++ b/testdata/p4_16_samples_outputs/issue281.p4
@@ -99,7 +99,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-first.p4
@@ -58,7 +58,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
@@ -56,7 +56,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
@@ -63,7 +63,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue297-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2.p4
@@ -58,7 +58,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
@@ -99,7 +99,7 @@ control TopDeparser(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
@@ -94,7 +94,7 @@ control TopDeparser(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
@@ -113,7 +113,7 @@ struct tuple_0 {
     bit<32> field_9;
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2.p4
@@ -99,7 +99,7 @@ control TopDeparser(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue323-first.p4
+++ b/testdata/p4_16_samples_outputs/issue323-first.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue323-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue323-frontend.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue323-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue323-midend.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue323.p4
+++ b/testdata/p4_16_samples_outputs/issue323.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue355-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue355-bmv2-first.p4
@@ -36,7 +36,7 @@ control cEgress(inout H hdr, inout M meta, inout standard_metadata_t stdmeta) {
     }
 }
 
-control vc(in H hdr, inout M meta) {
+control vc(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue355-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue355-bmv2-frontend.p4
@@ -38,7 +38,7 @@ control cEgress(inout H hdr, inout M meta, inout standard_metadata_t stdmeta) {
     }
 }
 
-control vc(in H hdr, inout M meta) {
+control vc(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue355-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue355-bmv2-midend.p4
@@ -48,7 +48,7 @@ control cEgress(inout H hdr, inout M meta, inout standard_metadata_t stdmeta) {
     }
 }
 
-control vc(in H hdr, inout M meta) {
+control vc(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue355-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue355-bmv2.p4
@@ -36,7 +36,7 @@ control cEgress(inout H hdr, inout M meta, inout standard_metadata_t stdmeta) {
     }
 }
 
-control vc(in H hdr, inout M meta) {
+control vc(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue356-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue356-bmv2-first.p4
@@ -30,7 +30,7 @@ control cEgress(inout H hdr, inout M meta, inout standard_metadata_t stdmeta) {
     }
 }
 
-control vc(in H hdr, inout M meta) {
+control vc(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue356-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue356-bmv2-frontend.p4
@@ -32,7 +32,7 @@ control cEgress(inout H hdr, inout M meta, inout standard_metadata_t stdmeta) {
     }
 }
 
-control vc(in H hdr, inout M meta) {
+control vc(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue356-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue356-bmv2-midend.p4
@@ -37,7 +37,7 @@ control cEgress(inout H hdr, inout M meta, inout standard_metadata_t stdmeta) {
     }
 }
 
-control vc(in H hdr, inout M meta) {
+control vc(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue356-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue356-bmv2.p4
@@ -30,7 +30,7 @@ control cEgress(inout H hdr, inout M meta, inout standard_metadata_t stdmeta) {
     }
 }
 
-control vc(in H hdr, inout M meta) {
+control vc(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue361-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2-first.p4
@@ -26,7 +26,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue361-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2-frontend.p4
@@ -27,7 +27,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue361-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2-midend.p4
@@ -32,7 +32,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue361-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2.p4
@@ -26,7 +26,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue364-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2-first.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue364-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2-frontend.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue364-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2-midend.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue364-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue414-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2-first.p4
@@ -62,7 +62,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue414-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2-frontend.p4
@@ -53,7 +53,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue414-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2-midend.p4
@@ -53,7 +53,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue414-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2.p4
@@ -62,7 +62,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue420-first.p4
+++ b/testdata/p4_16_samples_outputs/issue420-first.p4
@@ -58,7 +58,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue420-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue420-frontend.p4
@@ -58,7 +58,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue420-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue420-midend.p4
@@ -56,7 +56,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue420.p4
+++ b/testdata/p4_16_samples_outputs/issue420.p4
@@ -58,7 +58,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue422-first.p4
+++ b/testdata/p4_16_samples_outputs/issue422-first.p4
@@ -56,7 +56,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue422-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue422-frontend.p4
@@ -52,7 +52,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue422-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue422-midend.p4
@@ -54,7 +54,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue422.p4
+++ b/testdata/p4_16_samples_outputs/issue422.p4
@@ -58,7 +58,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2-first.p4
@@ -38,7 +38,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2-frontend.p4
@@ -38,7 +38,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2-midend.p4
@@ -51,7 +51,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4
@@ -38,7 +38,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue430-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue430-bmv2-first.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue430-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue430-bmv2-frontend.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue430-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue430-bmv2-midend.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue430-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue430-bmv2.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-1-bmv2-first.p4
@@ -38,7 +38,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-1-bmv2-frontend.p4
@@ -38,7 +38,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-1-bmv2-midend.p4
@@ -38,7 +38,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-1-bmv2.p4
@@ -38,7 +38,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-2-bmv2-first.p4
@@ -42,7 +42,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-2-bmv2-frontend.p4
@@ -43,7 +43,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-2-bmv2-midend.p4
@@ -43,7 +43,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-2-bmv2.p4
@@ -42,7 +42,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-3-bmv2-first.p4
@@ -44,7 +44,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-3-bmv2-frontend.p4
@@ -45,7 +45,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-3-bmv2-midend.p4
@@ -45,7 +45,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-3-bmv2.p4
@@ -44,7 +44,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2-first.p4
@@ -43,7 +43,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2-frontend.p4
@@ -43,7 +43,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2-midend.p4
@@ -43,7 +43,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2.p4
@@ -43,7 +43,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-first.p4
@@ -48,7 +48,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-frontend.p4
@@ -48,7 +48,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-midend.p4
@@ -57,7 +57,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2.p4
@@ -48,7 +48,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-bmv2-first.p4
@@ -35,7 +35,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-bmv2-frontend.p4
@@ -35,7 +35,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-bmv2-midend.p4
@@ -35,7 +35,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-bmv2.p4
@@ -35,7 +35,7 @@ control egress(inout Parsed_packet hdr, inout Metadata meta, inout standard_meta
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue496-first.p4
+++ b/testdata/p4_16_samples_outputs/issue496-first.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue496-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue496-frontend.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue496-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue496-midend.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue496.p4
+++ b/testdata/p4_16_samples_outputs/issue496.p4
@@ -18,7 +18,7 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     }
 }
 
-control MyVerifyChecksum(in my_packet hdr, inout my_metadata meta) {
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue510-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue510-bmv2-first.p4
@@ -21,7 +21,7 @@ parser MyParser(packet_in packet, out my_headers_t hdr, inout my_metadata_t meta
     }
 }
 
-control MyVerifyChecksum(in my_headers_t hdr, inout my_metadata_t meta) {
+control MyVerifyChecksum(inout my_headers_t hdr, inout my_metadata_t meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue510-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue510-bmv2-frontend.p4
@@ -21,7 +21,7 @@ parser MyParser(packet_in packet, out my_headers_t hdr, inout my_metadata_t meta
     }
 }
 
-control MyVerifyChecksum(in my_headers_t hdr, inout my_metadata_t meta) {
+control MyVerifyChecksum(inout my_headers_t hdr, inout my_metadata_t meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue510-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue510-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser MyParser(packet_in packet, out my_headers_t hdr, inout my_metadata_t meta
     }
 }
 
-control MyVerifyChecksum(in my_headers_t hdr, inout my_metadata_t meta) {
+control MyVerifyChecksum(inout my_headers_t hdr, inout my_metadata_t meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue510-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue510-bmv2.p4
@@ -21,7 +21,7 @@ parser MyParser(packet_in packet, out my_headers_t hdr, inout my_metadata_t meta
     }
 }
 
-control MyVerifyChecksum(in my_headers_t hdr, inout my_metadata_t meta) {
+control MyVerifyChecksum(inout my_headers_t hdr, inout my_metadata_t meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue512-first.p4
+++ b/testdata/p4_16_samples_outputs/issue512-first.p4
@@ -58,7 +58,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue512-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue512-frontend.p4
@@ -58,7 +58,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue512-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue512-midend.p4
@@ -57,7 +57,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue512.p4
+++ b/testdata/p4_16_samples_outputs/issue512.p4
@@ -58,7 +58,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue635-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue635-bmv2-first.p4
@@ -35,7 +35,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue635-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue635-bmv2-frontend.p4
@@ -35,7 +35,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue635-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue635-bmv2-midend.p4
@@ -35,7 +35,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue635-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue635-bmv2.p4
@@ -35,7 +35,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-first.p4
@@ -39,7 +39,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 
 control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        verify_checksum<tuple<bit<16>, bit<16>>, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        verify_checksum<tuple<bit<16>>, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-first.p4
@@ -37,7 +37,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
         verify_checksum<tuple<bit<16>, bit<16>>, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-frontend.p4
@@ -39,7 +39,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 
 control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        verify_checksum<tuple<bit<16>, bit<16>>, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        verify_checksum<tuple<bit<16>>, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-frontend.p4
@@ -37,7 +37,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
         verify_checksum<tuple<bit<16>, bit<16>>, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-midend.p4
@@ -48,22 +48,17 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 
 struct tuple_0 {
     bit<16> field;
-    bit<16> field_0;
 }
 
 control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        verify_checksum<tuple_0, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        verify_checksum<tuple_0, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
-}
-
-struct tuple_1 {
-    bit<16> field_1;
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        update_checksum<tuple_1, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        update_checksum<tuple_0, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-midend.p4
@@ -51,7 +51,7 @@ struct tuple_0 {
     bit<16> field_0;
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
         verify_checksum<tuple_0, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue655-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2.p4
@@ -37,7 +37,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
         verify_checksum(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
     }

--- a/testdata/p4_16_samples_outputs/issue655-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2.p4
@@ -39,7 +39,7 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 
 control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        verify_checksum(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        verify_checksum(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-first.p4
+++ b/testdata/p4_16_samples_outputs/issue655-first.p4
@@ -37,9 +37,9 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        verify_checksum<tuple<bit<16>, bit<16>>, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        verify_checksum<tuple<bit<16>>, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-frontend.p4
@@ -37,9 +37,9 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        verify_checksum<tuple<bit<16>, bit<16>>, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        verify_checksum<tuple<bit<16>>, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-midend.p4
@@ -48,22 +48,17 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 
 struct tuple_0 {
     bit<16> field;
-    bit<16> field_0;
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        verify_checksum<tuple_0, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        verify_checksum<tuple_0, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
-}
-
-struct tuple_1 {
-    bit<16> field_1;
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        update_checksum<tuple_1, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        update_checksum<tuple_0, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655.p4
+++ b/testdata/p4_16_samples_outputs/issue655.p4
@@ -37,9 +37,9 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
     }
 }
 
-control vc(in Parsed_packet hdr, inout Metadata meta) {
+control vc(inout Parsed_packet hdr, inout Metadata meta) {
     apply {
-        verify_checksum(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        verify_checksum(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2-first.p4
@@ -38,7 +38,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2-frontend.p4
@@ -38,7 +38,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2-midend.p4
@@ -40,7 +40,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2.p4
@@ -38,7 +38,7 @@ control DeparserI(packet_out pk, in H hdr) {
     }
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/key-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2-first.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/key-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2-frontend.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/key-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2-midend.p4
@@ -20,7 +20,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/key-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/key1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/key1-bmv2-first.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/key1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/key1-bmv2-frontend.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/key1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/key1-bmv2-midend.p4
@@ -20,7 +20,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/key1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/key1-bmv2.p4
@@ -39,7 +39,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/mux-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2-first.p4
@@ -35,7 +35,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/mux-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2-frontend.p4
@@ -42,7 +42,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/mux-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2-midend.p4
@@ -55,7 +55,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/mux-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2.p4
@@ -35,7 +35,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-first.p4
@@ -101,7 +101,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
@@ -96,7 +96,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
@@ -100,7 +100,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2.p4
@@ -101,7 +101,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
     }
 }
 
-control verifyChecksum(in headers hdr, inout metadata meta) {
+control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/parser-locals2-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-locals2-first.p4
@@ -85,7 +85,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/parser-locals2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-locals2-frontend.p4
@@ -83,7 +83,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/parser-locals2-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-locals2-midend.p4
@@ -83,7 +83,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/parser-locals2.p4
+++ b/testdata/p4_16_samples_outputs/parser-locals2.p4
@@ -85,7 +85,7 @@ control cEgress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_me
     }
 }
 
-control vc(in Parsed_packet hdr, inout mystruct1 meta) {
+control vc(inout Parsed_packet hdr, inout mystruct1 meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/scalarmeta-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/scalarmeta-bmv2-first.p4
@@ -23,7 +23,7 @@ parser MyParser(packet_in b, out h hdrs, inout m meta, inout standard_metadata_t
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/scalarmeta-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/scalarmeta-bmv2-frontend.p4
@@ -20,7 +20,7 @@ parser MyParser(packet_in b, out h hdrs, inout m meta, inout standard_metadata_t
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/scalarmeta-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/scalarmeta-bmv2-midend.p4
@@ -20,7 +20,7 @@ parser MyParser(packet_in b, out h hdrs, inout m meta, inout standard_metadata_t
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/scalarmeta-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/scalarmeta-bmv2.p4
@@ -23,7 +23,7 @@ parser MyParser(packet_in b, out h hdrs, inout m meta, inout standard_metadata_t
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use-first.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use-first.p4
@@ -60,7 +60,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use-frontend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use-frontend.p4
@@ -61,7 +61,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use-midend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use-midend.p4
@@ -70,7 +70,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use.p4
@@ -60,7 +60,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use1-first.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1-first.p4
@@ -70,7 +70,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1-frontend.p4
@@ -70,7 +70,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use1-midend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1-midend.p4
@@ -70,7 +70,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use1.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1.p4
@@ -70,7 +70,7 @@ control DP(packet_out b, in Headers p) {
     }
 }
 
-control Verify(in Headers hdrs, inout Metadata meta) {
+control Verify(inout Headers hdrs, inout Metadata meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/stack-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2-first.p4
@@ -27,7 +27,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/stack-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2-frontend.p4
@@ -27,7 +27,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2-midend.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/stack-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2.p4
@@ -27,7 +27,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2-first.p4
@@ -26,7 +26,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2-frontend.p4
@@ -26,7 +26,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2-midend.p4
@@ -26,7 +26,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2.p4
@@ -26,7 +26,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-first.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,8 +61,10 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a();
         const entries = {
-            8w0x1 : a_with_control_params(9w1);
-            8w0x2 : a_with_control_params(9w2);
+                        8w0x1 : a_with_control_params(9w1);
+
+                        8w0x2 : a_with_control_params(9w2);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,8 +61,10 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            8w0x1 : a_with_control_params_0(9w1);
-            8w0x2 : a_with_control_params_0(9w2);
+                        8w0x1 : a_with_control_params_0(9w1);
+
+                        8w0x2 : a_with_control_params_0(9w2);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-midend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,8 +61,10 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            8w0x1 : a_with_control_params_0(9w1);
-            8w0x2 : a_with_control_params_0(9w2);
+                        8w0x1 : a_with_control_params_0(9w1);
+
+                        8w0x2 : a_with_control_params_0(9w2);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,8 +61,10 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         const entries = {
-            0x1 : a_with_control_params(1);
-            0x2 : a_with_control_params(2);
+                        0x1 : a_with_control_params(1);
+
+                        0x2 : a_with_control_params(2);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-first.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -62,10 +62,14 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a();
         const entries = {
-            (8w0x1, 16w0x1111 &&& 16w0xf) : a_with_control_params(9w1);
-            (8w0x2, 16w0x1181) : a_with_control_params(9w2);
-            (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params(9w3);
-            (8w0x4, default) : a_with_control_params(9w4);
+                        (8w0x1, 16w0x1111 &&& 16w0xf) : a_with_control_params(9w1);
+
+                        (8w0x2, 16w0x1181) : a_with_control_params(9w2);
+
+                        (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params(9w3);
+
+                        (8w0x4, default) : a_with_control_params(9w4);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -62,10 +62,14 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            (8w0x1, 16w0x1111 &&& 16w0xf) : a_with_control_params_0(9w1);
-            (8w0x2, 16w0x1181) : a_with_control_params_0(9w2);
-            (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params_0(9w3);
-            (8w0x4, default) : a_with_control_params_0(9w4);
+                        (8w0x1, 16w0x1111 &&& 16w0xf) : a_with_control_params_0(9w1);
+
+                        (8w0x2, 16w0x1181) : a_with_control_params_0(9w2);
+
+                        (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params_0(9w3);
+
+                        (8w0x4, default) : a_with_control_params_0(9w4);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-midend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -62,10 +62,14 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            (8w0x1, 16w0x1111 &&& 16w0xf) : a_with_control_params_0(9w1);
-            (8w0x2, 16w0x1181) : a_with_control_params_0(9w2);
-            (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params_0(9w3);
-            (8w0x4, default) : a_with_control_params_0(9w4);
+                        (8w0x1, 16w0x1111 &&& 16w0xf) : a_with_control_params_0(9w1);
+
+                        (8w0x2, 16w0x1181) : a_with_control_params_0(9w2);
+
+                        (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params_0(9w3);
+
+                        (8w0x4, default) : a_with_control_params_0(9w4);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -62,10 +62,14 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         const entries = {
-            (0x1, 0x1111 &&& 0xf) : a_with_control_params(1);
-            (0x2, 0x1181) : a_with_control_params(2);
-            (0x3, 0x1111 &&& 0xf000) : a_with_control_params(3);
-            (0x4, default) : a_with_control_params(4);
+                        (0x1, 0x1111 &&& 0xf) : a_with_control_params(1);
+
+                        (0x2, 0x1181) : a_with_control_params(2);
+
+                        (0x3, 0x1111 &&& 0xf000) : a_with_control_params(3);
+
+                        (0x4, default) : a_with_control_params(4);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-first.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a();
         const entries = {
-            8w0x11 &&& 8w0xf0 : a_with_control_params(9w11);
-            8w0x12 : a_with_control_params(9w12);
-            default : a_with_control_params(9w13);
+                        8w0x11 &&& 8w0xf0 : a_with_control_params(9w11);
+
+                        8w0x12 : a_with_control_params(9w12);
+
+                        default : a_with_control_params(9w13);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            8w0x11 &&& 8w0xf0 : a_with_control_params_0(9w11);
-            8w0x12 : a_with_control_params_0(9w12);
-            default : a_with_control_params_0(9w13);
+                        8w0x11 &&& 8w0xf0 : a_with_control_params_0(9w11);
+
+                        8w0x12 : a_with_control_params_0(9w12);
+
+                        default : a_with_control_params_0(9w13);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-midend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            8w0x11 &&& 8w0xf0 : a_with_control_params_0(9w11);
-            8w0x12 : a_with_control_params_0(9w12);
-            default : a_with_control_params_0(9w13);
+                        8w0x11 &&& 8w0xf0 : a_with_control_params_0(9w11);
+
+                        8w0x12 : a_with_control_params_0(9w12);
+
+                        default : a_with_control_params_0(9w13);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         const entries = {
-            0x11 &&& 0xf0 : a_with_control_params(11);
-            0x12 : a_with_control_params(12);
-            default : a_with_control_params(13);
+                        0x11 &&& 0xf0 : a_with_control_params(11);
+
+                        0x12 : a_with_control_params(12);
+
+                        default : a_with_control_params(13);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-first.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a();
         const entries = {
-            16w0x1111 &&& 16w0xf : a_with_control_params(9w1) @priority(3);
-            16w0x1181 : a_with_control_params(9w2);
-            16w0x1181 &&& 16w0xf00f : a_with_control_params(9w3) @priority(1);
+                        16w0x1111 &&& 16w0xf : a_with_control_params(9w1)@priority(3) ;
+
+                        16w0x1181 : a_with_control_params(9w2);
+
+                        16w0x1181 &&& 16w0xf00f : a_with_control_params(9w3)@priority(1) ;
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            16w0x1111 &&& 16w0xf : a_with_control_params_0(9w1) @priority(3);
-            16w0x1181 : a_with_control_params_0(9w2);
-            16w0x1181 &&& 16w0xf00f : a_with_control_params_0(9w3) @priority(1);
+                        16w0x1111 &&& 16w0xf : a_with_control_params_0(9w1)@priority(3) ;
+
+                        16w0x1181 : a_with_control_params_0(9w2);
+
+                        16w0x1181 &&& 16w0xf00f : a_with_control_params_0(9w3)@priority(1) ;
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-midend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            16w0x1111 &&& 16w0xf : a_with_control_params_0(9w1)@priority(3) ;
-            16w0x1181 : a_with_control_params_0(9w2);
-            16w0x1181 &&& 16w0xf00f : a_with_control_params_0(9w3)@priority(1) ;
+                        16w0x1111 &&& 16w0xf : a_with_control_params_0(9w1)@priority(3) ;
+
+                        16w0x1181 : a_with_control_params_0(9w2);
+
+                        16w0x1181 &&& 16w0xf00f : a_with_control_params_0(9w3)@priority(1) ;
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         const entries = {
-            0x1111 &&& 0xf : a_with_control_params(1) @priority(3);
-            0x1181 : a_with_control_params(2);
-            0x1181 &&& 0xf00f : a_with_control_params(3) @priority(1);
+                        0x1111 &&& 0xf : a_with_control_params(1)@priority(3) ;
+
+                        0x1181 : a_with_control_params(2);
+
+                        0x1181 &&& 0xf00f : a_with_control_params(3)@priority(1) ;
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-first.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a();
         const entries = {
-            8w1 .. 8w8 : a_with_control_params(9w21);
-            8w6 .. 8w12 : a_with_control_params(9w22);
-            default : a_with_control_params(9w23);
+                        8w1 .. 8w8 : a_with_control_params(9w21);
+
+                        8w6 .. 8w12 : a_with_control_params(9w22);
+
+                        default : a_with_control_params(9w23);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            8w1 .. 8w8 : a_with_control_params_0(9w21);
-            8w6 .. 8w12 : a_with_control_params_0(9w22);
-            default : a_with_control_params_0(9w23);
+                        8w1 .. 8w8 : a_with_control_params_0(9w21);
+
+                        8w6 .. 8w12 : a_with_control_params_0(9w22);
+
+                        default : a_with_control_params_0(9w23);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-midend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            8w1 .. 8w8 : a_with_control_params_0(9w21);
-            8w6 .. 8w12 : a_with_control_params_0(9w22);
-            default : a_with_control_params_0(9w23);
+                        8w1 .. 8w8 : a_with_control_params_0(9w21);
+
+                        8w6 .. 8w12 : a_with_control_params_0(9w22);
+
+                        default : a_with_control_params_0(9w23);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,9 +61,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         const entries = {
-            1 .. 8 : a_with_control_params(21);
-            6 .. 12 : a_with_control_params(22);
-            default : a_with_control_params(23);
+                        1 .. 8 : a_with_control_params(21);
+
+                        6 .. 12 : a_with_control_params(22);
+
+                        default : a_with_control_params(23);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-first.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,10 +61,14 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a();
         const entries = {
-            16w0x1111 &&& 16w0xf : a_with_control_params(9w1);
-            16w0x1187 : a_with_control_params(9w2);
-            16w0x1111 &&& 16w0xf000 : a_with_control_params(9w3);
-            default : a_with_control_params(9w4);
+                        16w0x1111 &&& 16w0xf : a_with_control_params(9w1);
+
+                        16w0x1187 : a_with_control_params(9w2);
+
+                        16w0x1111 &&& 16w0xf000 : a_with_control_params(9w3);
+
+                        default : a_with_control_params(9w4);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,10 +61,14 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            16w0x1111 &&& 16w0xf : a_with_control_params_0(9w1);
-            16w0x1187 : a_with_control_params_0(9w2);
-            16w0x1111 &&& 16w0xf000 : a_with_control_params_0(9w3);
-            default : a_with_control_params_0(9w4);
+                        16w0x1111 &&& 16w0xf : a_with_control_params_0(9w1);
+
+                        16w0x1187 : a_with_control_params_0(9w2);
+
+                        16w0x1111 &&& 16w0xf000 : a_with_control_params_0(9w3);
+
+                        default : a_with_control_params_0(9w4);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-midend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,10 +61,14 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a_0();
         const entries = {
-            16w0x1111 &&& 16w0xf : a_with_control_params_0(9w1);
-            16w0x1187 : a_with_control_params_0(9w2);
-            16w0x1111 &&& 16w0xf000 : a_with_control_params_0(9w3);
-            default : a_with_control_params_0(9w4);
+                        16w0x1111 &&& 16w0xf : a_with_control_params_0(9w1);
+
+                        16w0x1187 : a_with_control_params_0(9w2);
+
+                        16w0x1111 &&& 16w0xf000 : a_with_control_params_0(9w3);
+
+                        default : a_with_control_params_0(9w4);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }
@@ -61,10 +61,14 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         }
         default_action = a;
         const entries = {
-            0x1111 &&& 0xf : a_with_control_params(1);
-            0x1187 : a_with_control_params(2);
-            0x1111 &&& 0xf000 : a_with_control_params(3);
-            default : a_with_control_params(4);
+                        0x1111 &&& 0xf : a_with_control_params(1);
+
+                        0x1187 : a_with_control_params(2);
+
+                        0x1111 &&& 0xf000 : a_with_control_params(3);
+
+                        default : a_with_control_params(4);
+
         }
 
     }

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-first.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-midend.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4
@@ -23,7 +23,7 @@ parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t 
     }
 }
 
-control vrfy(in Header_t h, inout Meta_t m) {
+control vrfy(inout Header_t h, inout Meta_t m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-first.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out packet_t hdrs, inout Meta m, inout standard_metadata_t
     }
 }
 
-control vrfy(in packet_t h, inout Meta m) {
+control vrfy(inout packet_t h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-frontend.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out packet_t hdrs, inout Meta m, inout standard_metadata_t
     }
 }
 
-control vrfy(in packet_t h, inout Meta m) {
+control vrfy(inout packet_t h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-midend.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out packet_t hdrs, inout Meta m, inout standard_metadata_t
     }
 }
 
-control vrfy(in packet_t h, inout Meta m) {
+control vrfy(inout packet_t h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2.p4
@@ -37,7 +37,7 @@ parser p(packet_in b, out packet_t hdrs, inout Meta m, inout standard_metadata_t
     }
 }
 
-control vrfy(in packet_t h, inout Meta m) {
+control vrfy(inout packet_t h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union-bmv2-first.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union-bmv2-frontend.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union-bmv2-midend.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union-bmv2.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2-first.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2-frontend.p4
@@ -36,7 +36,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2-midend.p4
@@ -36,7 +36,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union1-bmv2-first.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union1-bmv2-frontend.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union1-bmv2-midend.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union1-bmv2.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union2-bmv2-first.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union2-bmv2-frontend.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union2-bmv2-midend.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union2-bmv2.p4
@@ -40,7 +40,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union3-bmv2-first.p4
@@ -41,7 +41,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union3-bmv2-frontend.p4
@@ -41,7 +41,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union3-bmv2-midend.p4
@@ -41,7 +41,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union3-bmv2.p4
@@ -41,7 +41,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union4-bmv2-first.p4
@@ -41,7 +41,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union4-bmv2-frontend.p4
@@ -41,7 +41,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union4-bmv2-midend.p4
@@ -41,7 +41,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/union4-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union4-bmv2.p4
@@ -41,7 +41,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2-first.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2-frontend.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2-midend.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4
@@ -19,7 +19,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-control vrfy(in Headers h, inout Meta m) {
+control vrfy(inout Headers h, inout Meta m) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/verify-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2-first.p4
@@ -21,7 +21,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/verify-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2-frontend.p4
@@ -22,7 +22,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/verify-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2-midend.p4
@@ -22,7 +22,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/verify-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2.p4
@@ -21,7 +21,7 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
     }
 }
 
-control MyVerifyChecksum(in h hdr, inout m meta) {
+control MyVerifyChecksum(inout h hdr, inout m meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/x-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/x-bmv2-first.p4
@@ -18,7 +18,7 @@ struct M {
     S s;
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/x-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/x-bmv2-frontend.p4
@@ -18,7 +18,7 @@ struct M {
     S s;
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/x-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/x-bmv2-midend.p4
@@ -18,7 +18,7 @@ struct M {
     S s;
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/x-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/x-bmv2.p4
@@ -18,7 +18,7 @@ struct M {
     S s;
 }
 
-control VerifyChecksumI(in H hdr, inout M meta) {
+control VerifyChecksumI(inout H hdr, inout M meta) {
     apply {
     }
 }


### PR DESCRIPTION
With this fix the BMv2 back-end also verifies checksums.
This PR also adds an intrinsic metadata field to be set by verify_checksum when verification fails. This will require BMv2 support; currently the field is unused.

Unfortunately, the BMv2 API for checksum verification requires a field for the checksum; it cannot be a constant. In consequence, to enforce this in P4-16 I had to change v1model.p4 to take an inout parameter for the checksum:
```
extern void verify_checksum<T, O>(in bool condition, in T data, inout O checksum, HashAlgorithm algo);
```

This requires the corresponding control headers to also be inout:

```
control VerifyChecksum<H, M>(inout H hdr, inout M meta);
```

This has caused a cascade of changes to all reference outputs and tests that use v1model.
