### PR TITLE
Revert "New checksum APIs in v1model; better alias analysis in side-e…

### DIFF
--- a/backends/bmv2/backend.cpp
+++ b/backends/bmv2/backend.cpp
@@ -106,6 +106,7 @@ Backend::process(const IR::ToplevelBlock* tlb, BMV2Options& options) {
         new P4::ConstantFolding(refMap, typeMap, false),
         new P4::TypeChecking(refMap, typeMap),
         new RemoveComplexExpressions(refMap, typeMap, new ProcessControls(&pipeline_controls)),
+        new FixupChecksum(&update_checksum_controls),
         new P4::SimplifyControlFlow(refMap, typeMap),
         new P4::RemoveAllUnusedDeclarations(refMap),
         new DiscoverStructure(&structure),

--- a/backends/bmv2/lower.cpp
+++ b/backends/bmv2/lower.cpp
@@ -137,6 +137,248 @@ const IR::Node* LowerExpressions::postorder(IR::Concat* expression) {
 namespace {
 
 /**
+A list of assignments that all write to a "variable".
+This really only handles scalar variables.
+It is customized for the needs of FixupChecksum.
+*/
+struct VariableWriters {
+    std::set<const IR::AssignmentStatement*> writers;
+    VariableWriters() = default;
+    explicit VariableWriters(const IR::AssignmentStatement* writer)
+    { writers.emplace(writer); }
+    VariableWriters* join(const VariableWriters* other) const {
+        auto result = new VariableWriters();
+        result->writers = writers;
+        for (auto e : other->writers)
+            result->writers.emplace(e);
+        return result;
+    }
+    /**
+       This function returns a non-null value only if there is exaclty one writer statement.
+       In that case it returns the RHS of the assignment
+    */
+    const IR::Expression* substitution() const {
+        if (writers.size() != 1)
+            return nullptr;
+        auto first = *writers.begin();
+        return first->right;
+    }
+};
+
+/**
+Maintains a map from variable names to VariableWriters
+It is customized for the needs of FixupChecksum.
+*/
+struct VariableDefinitions {
+    std::map<cstring, const VariableWriters*> writers;
+    VariableDefinitions(const VariableDefinitions& other) = default;
+    VariableDefinitions() = default;
+    VariableDefinitions* clone() const {
+        return new VariableDefinitions(*this);
+    }
+    VariableDefinitions* join(const VariableDefinitions* other) const {
+        auto result = clone();
+        for (auto e : other->writers) {
+            auto &prev = result->writers[e.first];
+            prev = prev ? prev->join(e.second) : e.second;
+        }
+        return result;
+    }
+    void declare(const IR::Declaration_Variable* decl) {
+        writers.emplace(decl->getName().name, new VariableWriters());
+    }
+    const VariableWriters* getWriters(const IR::Path* path) {
+        if (path->absolute)
+            return nullptr;
+        return ::get(writers, path->name.name);
+    }
+    VariableDefinitions* setDefinition(const IR::Path* path,
+                                       const IR::AssignmentStatement* statement) {
+        auto w = getWriters(path);
+        if (w == nullptr)
+            // Path does not represent a variable
+            return this;
+        auto result = clone();
+        result->writers[path->name.name] = new VariableWriters(statement);
+        return result;
+    }
+};
+
+/**
+Maintain def-use information.
+It is customized for the needs of FixupChecksum.
+*/
+struct PathSubstitutions {
+    std::map<const IR::PathExpression*, const IR::Expression*> definitions;
+    std::set<const IR::AssignmentStatement*> haveUses;
+    PathSubstitutions() = default;
+    void add(const IR::PathExpression* path, const IR::Expression* expression) {
+        definitions.emplace(path, expression);
+        LOG3("Will substitute " << dbp(path) << " with " << expression);
+    }
+    const IR::Expression* get(const IR::PathExpression* path) const {
+        return ::get(definitions, path);
+    }
+    void foundUses(const VariableWriters* writers) {
+        for (auto w : writers->writers)
+            haveUses.emplace(w);
+    }
+    void foundUses(const IR::AssignmentStatement* statement) {
+        haveUses.emplace(statement);
+    }
+    bool hasUses(const IR::AssignmentStatement* statement) const {
+        return haveUses.find(statement) != haveUses.end();
+    }
+};
+
+/**
+See the SimpleCopyProp pass below for the context in which this
+analysis is run.  We take advantage that some more complex code
+patterns have already been eliminated.
+*/
+class Accesses : public Inspector {
+    PathSubstitutions* substitutions;
+    VariableDefinitions* currentDefinitions;
+
+    bool notSupported(const IR::Node* node) {
+        ::error("%1%: not supported in checksum update control", node);
+        return false;
+    }
+
+ public:
+    explicit Accesses(PathSubstitutions* substitutions): substitutions(substitutions) {
+        CHECK_NULL(substitutions); setName("Accesses");
+        currentDefinitions = new VariableDefinitions();
+    }
+
+    bool preorder(const IR::Declaration_Variable* decl) override {
+        // we assume all variable declarations are at the beginning
+        currentDefinitions->declare(decl);
+        return false;
+    }
+
+    // This is only invoked for read expressions
+    bool preorder(const IR::PathExpression* expression) override {
+        auto writers = currentDefinitions->getWriters(expression->path);
+        if (writers != nullptr) {
+            if (auto s = writers->substitution())
+                substitutions->add(expression, s);
+            else
+                substitutions->foundUses(writers);
+        }
+        return false;
+    }
+
+    bool preorder(const IR::AssignmentStatement* statement) override {
+        visit(statement->right);
+        if (statement->left->is<IR::PathExpression>()) {
+            auto pe = statement->left->to<IR::PathExpression>();
+            currentDefinitions = currentDefinitions->setDefinition(pe->path, statement);
+        } else {
+            substitutions->foundUses(statement);
+        }
+        return false;
+    }
+
+    bool preorder(const IR::IfStatement* statement) override {
+        visit(statement->condition);
+        auto defs = currentDefinitions->clone();
+        visit(statement->ifTrue);
+        auto afterTrue = currentDefinitions;
+        if (statement->ifFalse != nullptr) {
+            currentDefinitions = defs;
+            visit(statement->ifFalse);
+            currentDefinitions = afterTrue->join(currentDefinitions);
+        } else {
+            currentDefinitions = defs->join(afterTrue);
+        }
+        return false;
+    }
+
+    bool preorder(const IR::SwitchStatement* statement) override
+    { return notSupported(statement); }
+
+    bool preorder(const IR::P4Action* action) override
+    { return notSupported(action); }
+
+    bool preorder(const IR::P4Table* table) override
+    { return notSupported(table); }
+
+    bool preorder(const IR::ReturnStatement* statement) override
+    { return notSupported(statement); }
+
+    bool preorder(const IR::ExitStatement* statement) override
+    { return notSupported(statement); }
+};
+
+class Replace : public Transform {
+    const PathSubstitutions* substitutions;
+ public:
+    explicit Replace(const PathSubstitutions* substitutions): substitutions(substitutions) {
+        CHECK_NULL(substitutions); setName("Replace"); }
+
+    const IR::Node* postorder(IR::AssignmentStatement* statement) override {
+        if (!substitutions->hasUses(getOriginal<IR::AssignmentStatement>()))
+            return new IR::EmptyStatement();
+        return statement;
+    }
+
+    const IR::Node* postorder(IR::PathExpression* expression) override {
+        auto repl = substitutions->get(getOriginal<IR::PathExpression>());
+        if (repl != nullptr) {
+            Replace rpl(substitutions);
+            auto recurse = repl->apply(rpl);
+            return recurse;
+        }
+        return expression;
+    }
+};
+
+/**
+This analysis is only executed on the control which performs
+checksum update computations.
+
+This is a simpler variant of copy propagation; it just finds
+patterns of the form:
+tmp = X;
+...
+out = tmp;
+
+then it substitutes the definition into the use.
+The LocalCopyPropagation pass does not do this, because
+it won't consider replacing definitions where the RHS has side-effects.
+Since the only method call we accept in the checksum update block
+is a checksum unit "get" method (this is not checked here, but
+in the json code generator), we know that this method has no side-effects,
+so we can safely reorder calls to methods.
+Also, this is run after eliminating struct and tuple operations,
+so we know that all assignments operate on scalar values.
+*/
+class SimpleCopyProp : public PassManager {
+    PathSubstitutions substitutions;
+ public:
+    SimpleCopyProp() {
+        setName("SimpleCopyProp");
+        passes.push_back(new Accesses(&substitutions));
+        passes.push_back(new Replace(&substitutions));
+    }
+};
+
+}  // namespace
+
+const IR::Node* FixupChecksum::preorder(IR::P4Control* control) {
+    if (updateChecksumBlocks->find(control->name) != updateChecksumBlocks->end()) {
+        SimpleCopyProp scp;
+        return control->apply(scp);
+    }
+    return control;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+/**
 Detect whether a Select expression is too complicated for BMv2.
 Also used to detect complex expressions that are arguments
 to method calls.

--- a/backends/bmv2/lower.h
+++ b/backends/bmv2/lower.h
@@ -50,6 +50,24 @@ class LowerExpressions : public Transform {
 };
 
 /**
+This pass is a hack to work around current BMv2 limitations:
+checksum computations must be expressed in a restricted way, since
+the JSON code generator uses simple pattern-matching.
+
+The real solution to this problem is to have the BMv2 simulator use a
+real extern for computing and verifying checksums.  Then this hack
+would not be necessary anymore.
+*/
+class FixupChecksum : public Transform {
+    const std::set<cstring>* updateChecksumBlocks;
+ public:
+    explicit FixupChecksum(const std::set<cstring>* updateChecksumBlocks) :
+            updateChecksumBlocks(updateChecksumBlocks)
+    { setName("FixupChecksum"); }
+    const IR::Node* preorder(IR::P4Control* control) override;
+};
+
+/**
 Policy which selects the control blocks where remove
 complex expression is applied.
 */

--- a/backends/bmv2/simpleSwitch.cpp
+++ b/backends/bmv2/simpleSwitch.cpp
@@ -100,10 +100,6 @@ SimpleSwitch::convertHashAlgorithm(cstring algorithm) {
         result = "random";
     else if (algorithm == v1model.algorithm.identity.name)
         result = "identity";
-    else if (algorithm == v1model.algorithm.csum16.name)
-        result = "csum16";
-    else if (algorithm == v1model.algorithm.xor16.name)
-        result = "xor16";
     else
         ::error("%1%: unexpected algorithm", algorithm);
     return result;
@@ -251,9 +247,7 @@ SimpleSwitch::convertExternFunctions(Util::JsonArray *result,
         static std::set<cstring> supportedHashAlgorithms = {
             v1model.algorithm.crc32.name, v1model.algorithm.crc32_custom.name,
             v1model.algorithm.crc16.name, v1model.algorithm.crc16_custom.name,
-            v1model.algorithm.random.name, v1model.algorithm.identity.name,
-            v1model.algorithm.csum16.name, v1model.algorithm.xor16.name
-        };
+            v1model.algorithm.random.name, v1model.algorithm.identity.name };
 
         if (mc->arguments->size() != 5) {
             modelError("Expected 5 arguments for %1%", mc);
@@ -606,38 +600,47 @@ SimpleSwitch::generateUpdate(const IR::BlockStatement *block,
     auto typeMap = backend->getTypeMap();
     auto refMap = backend->getRefMap();
     auto conv = backend->getExpressionConverter();
+    // Currently this is very hacky to target the very limited support
+    // for checksums in BMv2 This will work much better when BMv2
+    // offers a checksum extern.
     for (auto stat : block->components) {
+        if (stat->is<IR::IfStatement>()) {
+            // The way checksums work in Json, they always ignore the condition!
+            stat = stat->to<IR::IfStatement>()->ifTrue;
+        }
         if (auto blk = stat->to<IR::BlockStatement>()) {
             generateUpdate(blk, checksums, calculations);
             continue;
-        } else if (auto mc = stat->to<IR::MethodCallStatement>()) {
-            auto mi = P4::MethodInstance::resolve(mc->methodCall, refMap, typeMap);
-            if (auto em = mi->to<P4::ExternFunction>()) {
-                if (em->method->name.name == v1model.update_checksum.name) {
-                    BUG_CHECK(mi->expr->arguments->size() == 4, "%1%: Expected 4 arguments", mc);
-                    auto cksum = new Util::JsonObject();
-                    auto ei = P4::EnumInstance::resolve(mi->expr->arguments->at(3), typeMap);
-                    if (ei->name != "csum16") {
-                        ::error("%1%: the only supported algorithm is csum16",
-                                mi->expr->arguments->at(3));
-                        return;
+        } else if (auto assign = stat->to<IR::AssignmentStatement>()) {
+            if (auto mc = assign->right->to<IR::MethodCallExpression>()) {
+                auto mi = P4::MethodInstance::resolve(mc, refMap, typeMap);
+                if (auto em = mi->to<P4::ExternMethod>()) {
+                    if (em->method->name.name == v1model.ck16.get.name &&
+                        em->originalExternType->name.name == v1model.ck16.name) {
+                        if (mi->expr->arguments->size() != 1) {
+                            modelError("%1%: Expected 1 argument", assign->right);
+                            return;
+                        }
+                        auto cksum = new Util::JsonObject();
+                        cstring calcName = createCalculation("csum16", mi->expr->arguments->at(0),
+                                                             calculations, mc);
+                        cksum->emplace("name", refMap->newName("cksum_"));
+                        cksum->emplace("id", nextId("checksums"));
+                        // TODO(jafingerhut) - add line/col here?
+                        auto jleft = conv->convert(assign->left);
+                        cksum->emplace("target", jleft->to<Util::JsonObject>()->get("value"));
+                        cksum->emplace("type", "generic");
+                        cksum->emplace("calculation", calcName);
+                        checksums->append(cksum);
+                        continue;
                     }
-                    cstring calcName = createCalculation(ei->name, mi->expr->arguments->at(1),
-                                                         calculations, mc);
-                    cksum->emplace("name", refMap->newName("cksum_"));
-                    cksum->emplace("id", nextId("checksums"));
-                    // TODO(jafingerhut) - add line/col here?
-                    auto jleft = conv->convert(mi->expr->arguments->at(2));
-                    cksum->emplace("target", jleft->to<Util::JsonObject>()->get("value"));
-                    cksum->emplace("type", "generic");
-                    cksum->emplace("calculation", calcName);
-                    checksums->append(cksum);
-                    continue;
                 }
             }
+        } else if (auto mc = stat->to<IR::MethodCallStatement>()) {
+            auto mi = P4::MethodInstance::resolve(mc->methodCall, refMap, typeMap, true);
+            BUG_CHECK(mi && mi->isApply(), "Call of something other than an apply method");
         }
-        ::error("%1%: Only calls to %2% allowed", stat, v1model.update_checksum);
-        return;
+        BUG("%1%: not handled yet", stat);
     }
 }
 

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -970,8 +970,6 @@ class FixExtracts final : public Transform {
   do much better than this.
 */
 class AdjustLengths : public Transform {
- public:
-    AdjustLengths() { setName("AdjustLengths"); }
     const IR::Node* postorder(IR::PathExpression* expression) override {
         auto anno = findContext<IR::Annotation>();
         if (anno == nullptr)

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -89,7 +89,7 @@ bool ProgramStructure::isHeader(const IR::ConcreteHeaderRef* nhr) const {
 }
 
 void ProgramStructure::checkHeaderType(const IR::Type_StructLike* hdr, bool metadata) {
-    LOG3("Checking " << hdr << " " << (metadata ? "M" : "H"));
+    LOG1("Checking " << hdr << " " << (metadata ? "M" : "H"));
     for (auto f : hdr->fields) {
         if (f->type->is<IR::Type_Varbits>()) {
             if (metadata)
@@ -1518,7 +1518,7 @@ const IR::P4Action*
 ProgramStructure::convertAction(const IR::ActionFunction* action, cstring newName,
                                 const IR::Meter* meterToAccess,
                                 cstring counterToAccess) {
-    LOG3("Converting action " << action->name);
+    LOG1("Converting action " << action->name);
     auto body = new IR::BlockStatement;
     auto params = new IR::ParameterList;
     bool isCalled = calledActions.isCallee(action->name.name);
@@ -1537,7 +1537,7 @@ ProgramStructure::convertAction(const IR::ActionFunction* action, cstring newNam
             type = new IR::Type_Name(path);
         }
         auto param = new IR::Parameter(p->srcInfo, p->name, direction, type);
-        LOG3("  " << p << " is " << direction << " " << param);
+        LOG2("  " << p << " is " << direction << " " << param);
         params->push_back(param); }
 
     if (meterToAccess != nullptr) {
@@ -1635,7 +1635,7 @@ const IR::Expression* ProgramStructure::counterType(const IR::CounterOrMeter* cm
 
 const IR::Declaration_Instance*
 ProgramStructure::convert(const IR::Register* reg, cstring newName) {
-    LOG3("Synthesizing " << reg);
+    LOG1("Synthesizing " << reg);
     const IR::Type *regElementType = nullptr;
     if (reg->width > 0) {
         regElementType = IR::Type_Bits::get(reg->width);
@@ -1669,7 +1669,7 @@ ProgramStructure::convert(const IR::Register* reg, cstring newName) {
 
 const IR::Declaration_Instance*
 ProgramStructure::convert(const IR::CounterOrMeter* cm, cstring newName) {
-    LOG3("Synthesizing " << cm);
+    LOG1("Synthesizing " << cm);
     IR::ID ext;
     if (cm->is<IR::Counter>())
         ext = v1model.counter.Id();
@@ -1695,7 +1695,7 @@ ProgramStructure::convert(const IR::CounterOrMeter* cm, cstring newName) {
 
 const IR::Declaration_Instance*
 ProgramStructure::convertDirectMeter(const IR::Meter* m, cstring newName) {
-    LOG3("Synthesizing " << m);
+    LOG1("Synthesizing " << m);
     auto meterOutput = m->result;
     if (meterOutput == nullptr) {
         ::error("%1%: direct meter with no result", m);
@@ -1720,7 +1720,7 @@ ProgramStructure::convertDirectMeter(const IR::Meter* m, cstring newName) {
 
 const IR::Declaration_Instance*
 ProgramStructure::convertDirectCounter(const IR::Counter* c, cstring newName) {
-    LOG3("Synthesizing " << c);
+    LOG1("Synthesizing " << c);
 
     IR::ID ext = v1model.directCounter.Id();
     auto typepath = new IR::Path(ext);
@@ -1962,6 +1962,27 @@ void ProgramStructure::createMain() {
     declarations->push_back(result);
 }
 
+cstring ProgramStructure::mapAlgorithm(IR::ID algorithm) const {
+    if (algorithm.name == "csum16")
+        return v1model.ck16.name;
+    ::error("Unsupported algorithm %1%", algorithm);
+    return nullptr;
+}
+
+const IR::Declaration_Instance*
+ProgramStructure::checksumUnit(const IR::FieldListCalculation* flc) {
+    auto ext = mapAlgorithm(flc->algorithm);
+    if (ext == nullptr)
+        return nullptr;
+    auto typePath = new IR::Path(IR::ID(ext));
+    auto extType = new IR::Type_Name(typePath);
+    auto newName = field_list_calculations.get(flc);
+    auto inst = new IR::Declaration_Instance(
+        flc->srcInfo, newName, flc->annotations, extType,
+        new IR::Vector<IR::Expression>(), nullptr);
+    return inst;
+}
+
 // if a FieldListCalculation contains multiple field lists concatenate them all
 // into a temporary field list
 const IR::FieldList* ProgramStructure::getFieldLists(const IR::FieldListCalculation* flc) {
@@ -1995,6 +2016,7 @@ const IR::FieldList* ProgramStructure::getFieldLists(const IR::FieldListCalculat
 void ProgramStructure::createChecksumVerifications() {
     ExpressionConverter conv(this);
 
+    // verify
     auto params = new IR::ParameterList;
     auto headpath = new IR::Path(v1model.headersType.Id());
     auto headtype = new IR::Type_Name(headpath);
@@ -2007,43 +2029,68 @@ void ProgramStructure::createChecksumVerifications() {
     auto metatype = new IR::Type_Name(metapath);
     auto meta = new IR::Parameter(v1model.parser.metadataParam.Id(),
                                   IR::Direction::InOut, metatype);
-    auto body = new IR::BlockStatement;
     params->push_back(meta);
     conversionContext.userMetadata = paramReference(meta);
 
     conversionContext.standardMetadata = nullptr;
 
     auto type = new IR::Type_Control(v1model.verify.Id(), params);
+
+    std::map<const IR::FieldListCalculation*, const IR::Declaration_Instance*> map;
+    IR::IndexedVector<IR::Declaration> stateful;
     for (auto cf : calculated_fields) {
-        LOG3("Converting " << cf);
+        // FIXME -- do something with cf->annotations?
+        for (auto uov : cf->specs) {
+            if (uov.update) continue;
+            auto flc = field_list_calculations.get(uov.name.name);
+            if (flc == nullptr) {
+                ::error("Cannot find field_list_calculation %1%", uov.name);
+                continue;
+            }
+            if (map.find(flc) != map.end())
+                continue;
+            auto inst = checksumUnit(flc);
+            if (inst == nullptr)
+                continue;
+            stateful.push_back(inst);
+            map.emplace(flc, inst);
+        }
+    }
+
+    auto body = new IR::BlockStatement;
+    for (auto cf : calculated_fields) {
+        LOG1("Converting " << cf);
         auto dest = conv.convert(cf->field);
 
         for (auto uov : cf->specs) {
             if (uov.update) continue;
             auto flc = field_list_calculations.get(uov.name.name);
+            auto inst = get(map, flc);
+
             auto fl = getFieldLists(flc);
             if (fl == nullptr) continue;
             auto le = conv.convert(fl);
-            auto method = new IR::PathExpression(v1model.verify_checksum.Id());
+            auto extObj = new IR::PathExpression(inst->name);
+            // The only method we currently know about is v1model.ck16.get
+            auto method = new IR::Member(extObj, v1model.ck16.get.Id());
             auto args = new IR::Vector<IR::Expression>();
-            const IR::Expression* condition;
-            if (uov.cond != nullptr)
-                condition = conv.convert(uov.cond);
-            else
-                condition = new IR::BoolLiteral(true);
-            auto algo = convertHashAlgorithm(flc->algorithm);
-            args->push_back(condition);
             args->push_back(le);
-            args->push_back(dest);
-            args->push_back(algo);
-            auto mc = new IR::MethodCallStatement(new IR::MethodCallExpression(method, args));
-            body->push_back(mc);
-            LOG3("Converted " << flc);
+            auto mc = new IR::MethodCallExpression(method, args);
+            const IR::Expression* cond = new IR::Equ(uov.srcInfo, dest, mc);
+            if (uov.cond != nullptr) {
+                auto cond2 = conv.convert(uov.cond);
+                // cond2 is evaluated first
+                cond = new IR::LAnd(cond2, cond);
+            }
+            auto dropmethod = new IR::PathExpression(v1model.drop.Id());
+            auto dropmc = new IR::MethodCallExpression(dropmethod);
+            auto drop = new IR::MethodCallStatement(mc->srcInfo, dropmc);
+            auto ifstate = new IR::IfStatement(cond, drop, nullptr);
+            body->push_back(ifstate);
+            LOG1("Converted " << flc);
         }
     }
-
-    verifyChecksums = new IR::P4Control(
-        v1model.verify.Id(), type, *new IR::IndexedVector<IR::Declaration>(), body);
+    verifyChecksums = new IR::P4Control(v1model.verify.Id(), type, stateful, body);
     declarations->push_back(verifyChecksums);
     conversionContext.clear();
 }
@@ -2069,37 +2116,57 @@ void ProgramStructure::createChecksumUpdates() {
 
     auto type = new IR::Type_Control(v1model.update.Id(), params);
 
+    IR::IndexedVector<IR::Declaration> stateful;
     auto body = new IR::BlockStatement;
+
+    std::map<const IR::FieldListCalculation*, const IR::Declaration_Instance*> map;
     for (auto cf : calculated_fields) {
-        LOG3("Converting " << cf);
+        for (auto uov : cf->specs) {
+            if (!uov.update) continue;
+            auto flc = field_list_calculations.get(uov.name.name);
+            if (flc == nullptr) {
+                ::error("Cannot find field_list_calculation %1%", uov.name);
+                continue;
+            }
+            if (map.find(flc) != map.end())
+                continue;
+            auto inst = checksumUnit(flc);
+            if (inst == nullptr)
+                continue;
+            stateful.push_back(inst);
+            map.emplace(flc, inst);
+        }
+    }
+
+    for (auto cf : calculated_fields) {
+        LOG1("Converting " << cf);
         auto dest = conv.convert(cf->field);
 
         for (auto uov : cf->specs) {
             if (!uov.update) continue;
             auto flc = field_list_calculations.get(uov.name.name);
+            auto inst = get(map, flc);
+
             auto fl = getFieldLists(flc);
             if (fl == nullptr) continue;
             auto le = conv.convert(fl);
 
-            auto method = new IR::PathExpression(v1model.update_checksum.Id());
+            auto extObj = new IR::PathExpression(inst->name);
+            // The only method we currently know about is v1model.ck16.get
+            auto method = new IR::Member(extObj, v1model.ck16.get.Id());
             auto args = new IR::Vector<IR::Expression>();
-            const IR::Expression* condition;
-            if (uov.cond != nullptr)
-                condition = conv.convert(uov.cond);
-            else
-                condition = new IR::BoolLiteral(true);
-            auto algo = convertHashAlgorithm(flc->algorithm);
-            args->push_back(condition);
             args->push_back(le);
-            args->push_back(dest);
-            args->push_back(algo);
-            auto mc = new IR::MethodCallStatement(new IR::MethodCallExpression(method, args));
-            body->push_back(mc);
-            LOG3("Converted " << flc);
+            auto mc = new IR::MethodCallExpression(method, args);
+            const IR::Statement* set = new IR::AssignmentStatement(flc->srcInfo, dest, mc);
+            if (uov.cond != nullptr) {
+                auto cond = conv.convert(uov.cond);
+                set = new IR::IfStatement(cond, set, nullptr);
+            }
+            body->push_back(set);
+            LOG1("Converted " << flc);
         }
     }
-    updateChecksums = new IR::P4Control(
-        v1model.update.Id(), type, *new IR::IndexedVector<IR::Declaration>(), body);
+    updateChecksums = new IR::P4Control(v1model.update.Id(), type, stateful, body);
     declarations->push_back(updateChecksums);
     conversionContext.clear();
 }
@@ -2127,7 +2194,7 @@ const IR::P4Program* ProgramStructure::create(Util::SourceInfo info) {
 void
 ProgramStructure::tablesReferred(const IR::V1Control* control,
                                  std::vector<const IR::V1Table*> &out) {
-    LOG3("Inspecting " << control->name);
+    LOG1("Inspecting " << control->name);
     for (auto it : tableMapping) {
         if (it.second == control)
             out.push_back(it.first);
@@ -2151,8 +2218,7 @@ void ProgramStructure::populateOutputNames() {
         "range",
         "selector",
         // v1model externs
-        "verify_checksum",
-        "update_checksum",
+        "Checksum16",
         "CounterType",
         "MeterType",
         "HashAlgorithm",

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -212,7 +212,9 @@ class ProgramStructure {
                                       const IR::Meter* meterToAccess, cstring counterToAccess);
     const IR::Type_Control* controlType(IR::ID name);
     const IR::PathExpression* getState(IR::ID dest);
+    const IR::Declaration_Instance* checksumUnit(const IR::FieldListCalculation* flc);
     const IR::Expression* counterType(const IR::CounterOrMeter* cm) const;
+    cstring mapAlgorithm(IR::ID algorithm) const;
     void createChecksumVerifications();
     void createChecksumUpdates();
     void createStructures();

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -90,6 +90,13 @@ struct MeterType_Model : public ::Model::Enum_Model {
     ::Model::Elem bytes;
 };
 
+struct Checksum16_Model : public ::Model::Extern_Model {
+    Checksum16_Model() : Extern_Model("Checksum16"), get("get"),
+                         resultType(IR::Type_Bits::get(32)) {}
+    ::Model::Elem get;
+    const IR::Type* resultType;
+};
+
 struct ActionProfile_Model : public ::Model::Extern_Model {
     ActionProfile_Model() : Extern_Model("action_profile"),
                             sizeType(IR::Type_Bits::get(32)), sizeParam("size") {}
@@ -192,16 +199,13 @@ struct Algorithm_Model : public ::Model::Enum_Model {
     Algorithm_Model() : ::Model::Enum_Model("HashAlgorithm"),
                         crc32("crc32"), crc32_custom("crc32_custom"),
                         crc16("crc16"), crc16_custom("crc16_custom"),
-                        random("random"), identity("identity"),
-                        csum16("csum16"), xor16("xor16") {}
+                        random("random"), identity("identity") {}
     ::Model::Elem crc32;
     ::Model::Elem crc32_custom;
     ::Model::Elem crc16;
     ::Model::Elem crc16_custom;
     ::Model::Elem random;
     ::Model::Elem identity;
-    ::Model::Elem csum16;
-    ::Model::Elem xor16;
 };
 
 struct Hash_Model : public ::Model::Elem {
@@ -257,10 +261,9 @@ class V1Model : public ::Model::Model {
             action_selector(), clone(), resubmit("resubmit"),
             tableAttributes(), rangeMatchType("range"), selectorMatchType("selector"),
             verify("verifyChecksum", headersType), update("computeChecksum", headersType),
-            digest_receiver(), hash(), algorithm(),
+            ck16(), digest_receiver(), hash(), algorithm(),
             registers(), drop("mark_to_drop"),
-            recirculate("recirculate"), verify_checksum("verify_checksum"),
-            update_checksum("update_checksum"), directMeter(), directCounter()
+            recirculate("recirculate"), directMeter(), directCounter()
     {}
 
  public:
@@ -288,14 +291,13 @@ class V1Model : public ::Model::Model {
     ::Model::Elem       selectorMatchType;
     VerifyUpdate_Model  verify;
     VerifyUpdate_Model  update;
+    Checksum16_Model    ck16;
     DigestReceiver_Model digest_receiver;
     Hash_Model          hash;
     Algorithm_Model     algorithm;
     Register_Model      registers;
     ::Model::Elem       drop;
     ::Model::Elem       recirculate;
-    ::Model::Elem       verify_checksum;
-    ::Model::Elem       update_checksum;
     DirectMeter_Model   directMeter;
     DirectCounter_Model directCounter;
 

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -310,206 +310,40 @@ class DismantleExpression : public Transform {
     const IR::Node* preorder(IR::LAnd* expression) override { return shortCircuit(expression); }
     const IR::Node* preorder(IR::LOr* expression) override { return shortCircuit(expression); }
 
-    /// This class represents the path to a location.
-    /// Given a struct S { bit a; bit b; } and a variable S x;
-    /// a path can be x.a, or just x.  An array index is represented as a
-    /// number (encoded as a string) or as "*", denoting an unknown index.
-    struct LocationPath : public IHasDbPrint {
-        const IR::IDeclaration* root;
-        std::vector<cstring> path;
-
-        explicit LocationPath(const IR::IDeclaration* root): root(root) { CHECK_NULL(root); }
-
-        const LocationPath* append(cstring suffix) const {
-            auto result = new LocationPath(root);
-            result->path = path;
-            result->path.push_back(suffix);
-            return result;
-        }
-
-        /// True if this path is a prefix of other or the other way around
-        bool isPrefix(const LocationPath* other) const {
-            // Due to the structure of the P4 language, two distinct
-            // declarations can never alias.
-            if (root != other->root)
-                return false;
-            size_t len = std::min(path.size(), other->path.size());
-            for (size_t i = 0; i < len; i++) {
-                if (path.at(i) == "*" || other->path.at(i) == "*")
-                    continue;
-                if (path.at(i) != other->path.at(i))
-                    return false;
-            }
-            return true;
-        }
-
-        void dbprint(std::ostream& out) const override {
-            out << root->getName();
-            for (auto p : path)
-                out << "." << p;
-        }
-    };
-
-    /// We represent a set of location set as a set of LocationPath
-    /// objects.
-    class SetOfLocations : public IHasDbPrint {
-     public:
-        std::set<const LocationPath*> paths;
-
-        SetOfLocations() = default;
-        explicit SetOfLocations(const LocationPath* path) {
-            add(path);
-        }
-        explicit SetOfLocations(const SetOfLocations* set): paths(set->paths) {}
-
-        void add(const LocationPath* path) { paths.emplace(path); }
-        bool overlaps(const SetOfLocations* other) const {
-            // Normally one of these sets has only one element, because
-            // one of the two is a left-value, so this should be fast.
-            for (auto s : paths) {
-                for (auto so : other->paths) {
-                    if (s->isPrefix(so))
-                        return true;
-                }
-            }
-            return false;
-        }
-
-        const SetOfLocations* join(const SetOfLocations* other) const {
-            auto result = new SetOfLocations(this);
-            for (auto p : other->paths)
-                result->add(p);
-            return result;
-        }
-
-        /// Append suffix to each location in the set
-        const SetOfLocations* append(cstring suffix) const {
-            auto result = new SetOfLocations();
-            for (auto p : paths) {
-                auto append = p->append(suffix);
-                result->add(append);
-            }
-            return result;
-        }
-
-        void dbprint(std::ostream& out) const override {
-            for (auto p : paths)
-                out << p << std::endl;
-        }
-    };
-
-    /// Computes the SetOfLocations read and written by an expression.
-    /// This is invoked only for expressions that appear as arguments
-    /// to method calls.
+    // We don't want to compute the full read/write set here so we
+    // overapproximate it as follows: all declarations that occur in
+    // an expression.
+    // TODO: this could be made more precise, perhaps using LocationSets.
     class ReadsWrites : public Inspector {
-        const ReferenceMap* refMap;
-        std::map<const IR::Expression*, const SetOfLocations*> rw;
-
      public:
-        explicit ReadsWrites(const ReferenceMap* refMap) : refMap(refMap)
-        { setName("ReadsWrites"); }
+        std::set<const IR::IDeclaration*> decls;
+        ReferenceMap* refMap;
 
-        void postorder(const IR::Operation_Binary* expression) override {
-            auto left = ::get(rw, expression->left);
-            auto right = ::get(rw, expression->right);
-            rw.emplace(expression, left->join(right));
-        }
+        explicit ReadsWrites(ReferenceMap* refMap) : refMap(refMap)
+        { setName("ReadsWrites"); }
 
         void postorder(const IR::PathExpression* expression) override {
             auto decl = refMap->getDeclaration(expression->path);
-            auto path = new LocationPath(decl);
-            auto locs = new SetOfLocations(path);
-            rw.emplace(expression, locs);
-        }
-
-        void postorder(const IR::Operation_Unary* expression) override {
-            auto e = ::get(rw, expression->expr);
-            rw.emplace(expression, e);
-        }
-
-        void postorder(const IR::Member* expression) override {
-            auto e = ::get(rw, expression->expr);
-            auto result = e->append(expression->member);
-            rw.emplace(expression, result);
-        }
-
-        void postorder(const IR::ArrayIndex* expression) override {
-            auto e = ::get(rw, expression->left);
-            const SetOfLocations* result;
-            if (expression->right->is<IR::Constant>()) {
-                int index = expression->right->to<IR::Constant>()->asInt();
-                result = e->append(Util::toString(index));
-            } else {
-                result = e->append("*");
-            }
-            rw.emplace(expression, result);
-        }
-
-        void postorder(const IR::Literal* expression) override {
-            rw.emplace(expression, new SetOfLocations());
-        }
-
-        void postorder(const IR::TypeNameExpression* expression) override {
-            rw.emplace(expression, new SetOfLocations());
-        }
-
-        void postorder(const IR::Operation_Ternary* expression) override {
-            auto e0 = ::get(rw, expression->e0);
-            auto e1 = ::get(rw, expression->e1);
-            auto e2 = ::get(rw, expression->e2);
-            rw.emplace(expression, e0->join(e1)->join(e2));
-        }
-
-        void postorder(const IR::MethodCallExpression* expression) override {
-            // The only expression that can appear here is h.isValid();
-            // The ReadsWrites analysis is not called for other methods that
-            // have side-effects -- these are always copied into temporaries.
-            BUG_CHECK(expression->method->is<IR::Member>(),
-                      "%1%: expected isValid()", expression);
-            auto member = expression->method->to<IR::Member>();
-            BUG_CHECK(member->member == "isValid", "%1%: expected isValid()", expression);
-            auto obj = member->expr;
-            auto e = ::get(rw, obj);
-            rw.emplace(expression, e->append("$valid"));
-        }
-
-        void postorder(const IR::ConstructorCallExpression* expression) override {
-            const SetOfLocations* result = new SetOfLocations();
-            for (auto e : *expression->arguments) {
-                auto s = ::get(rw, e);
-                result = result->join(s);
-            }
-            rw.emplace(expression, result);
-        }
-
-        void postorder(const IR::ListExpression* expression) override {
-            const SetOfLocations* result = new SetOfLocations();
-            for (auto e : expression->components) {
-                auto s = ::get(rw, e);
-                result = result->join(s);
-            }
-            rw.emplace(expression, result);
-        }
-
-        const SetOfLocations* get(const IR::Expression* expression) {
-            expression->apply(*this);
-            auto result = ::get(rw, expression);
-            CHECK_NULL(result);
-            LOG3("SetOfLocations(" << expression << ")=" << result);
-            return result;
+            decls.emplace(decl);
         }
     };
 
-    // Conservative simple alias analysis.  We implement this here
-    // because this pass runs early in the front end, before enough
-    // information is present (eg.  def-use information) to do a
-    // precise alias analysis.
+    // Conservative alias analysis.  We implement this here because this pass
+    // runs early in the front end, before enough information is present (eg.
+    // def-use information) to do a precise alias analysis.
     bool mayAlias(const IR::Expression* left, const IR::Expression* right) const {
-        ReadsWrites rw(refMap);
-        auto llocs = rw.get(left);
-        auto rlocs = rw.get(right);
-        LOG3("Checking overlap between " << llocs << " and " << rlocs);
-        return llocs->overlaps(rlocs);
+        ReadsWrites rwleft(refMap);
+        (void)left->apply(rwleft);
+        ReadsWrites rwright(refMap);
+        (void)right->apply(rwright);
+
+        for (auto d : rwleft.decls) {
+            if (rwright.decls.count(d) > 0) {
+                LOG3(dbp(d) << " accessed by both " << dbp(left) << " and " << dbp(right));
+                return true;
+            }
+        }
+        return false;
     }
 
     /// Returns true if type is a header or a struct containing a header.
@@ -595,10 +429,6 @@ class DismantleExpression : public Transform {
                     if (p2 == p1)
                         break;
                     if (!p1->hasOut() && !p2->hasOut())
-                        continue;
-                    if (useTemporary.find(p1) != useTemporary.end())
-                        continue;
-                    if (useTemporary.find(p2) != useTemporary.end())
                         continue;
                     auto arg2 = desc.substitution.lookup(p2);
                     if (mayAlias(arg1, arg2)) {

--- a/midend/actionSynthesis.cpp
+++ b/midend/actionSynthesis.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "actionSynthesis.h"
 #include "frontends/p4/methodInstance.h"
 #include "frontends/p4/coreLibrary.h"
+#include "frontends/p4/fromv1.0/v1model.h"
 
 namespace P4 {
 
@@ -106,6 +107,10 @@ bool DoSynthesizeActions::mustMove(const IR::AssignmentStatement *assign) {
         auto mi = MethodInstance::resolve(mc, refMap, typeMap);
         if (!mi->is<ExternMethod>())
             return true;
+        auto em = mi->to<ExternMethod>();
+        auto &v1model = P4V1::V1Model::instance;
+        if (em->originalExternType->name.name == v1model.ck16.name)
+            return false;
     }
     return true;
 }

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-midend.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-midend.p4
@@ -82,7 +82,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = NoAction_8();
     }
-    @name(".D") table D {
+    @name(".D") table D_1 {
         actions = {
             nop_6();
             @defaultonly NoAction_9();
@@ -110,7 +110,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 C.apply();
             }
             do_d_0: {
-                D.apply();
+                D_1.apply();
                 C.apply();
             }
             do_e_0: {

--- a/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
@@ -205,8 +205,9 @@ control verifyChecksum(in headers hdr, inout metadata meta) {
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>, ipv4_option_security_t, ipv4_option_EOL_t, ipv4_option_timestamp_t>, bit<16>>(true, { hdr.ipv4_base.version, hdr.ipv4_base.ihl, hdr.ipv4_base.diffserv, hdr.ipv4_base.totalLen, hdr.ipv4_base.identification, hdr.ipv4_base.flags, hdr.ipv4_base.fragOffset, hdr.ipv4_base.ttl, hdr.ipv4_base.protocol, hdr.ipv4_base.srcAddr, hdr.ipv4_base.dstAddr, hdr.ipv4_option_security, hdr.ipv4_option_NOP[0], hdr.ipv4_option_timestamp }, hdr.ipv4_base.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4_base.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>, ipv4_option_security_t, ipv4_option_EOL_t, ipv4_option_timestamp_t>>({ hdr.ipv4_base.version, hdr.ipv4_base.ihl, hdr.ipv4_base.diffserv, hdr.ipv4_base.totalLen, hdr.ipv4_base.identification, hdr.ipv4_base.flags, hdr.ipv4_base.fragOffset, hdr.ipv4_base.ttl, hdr.ipv4_base.protocol, hdr.ipv4_base.srcAddr, hdr.ipv4_base.dstAddr, hdr.ipv4_option_security, hdr.ipv4_option_NOP[0], hdr.ipv4_option_timestamp });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
@@ -207,8 +207,11 @@ control verifyChecksum(in headers hdr, inout metadata meta) {
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>, ipv4_option_security_t, ipv4_option_EOL_t, ipv4_option_timestamp_t>, bit<16>>(true, { hdr.ipv4_base.version, hdr.ipv4_base.ihl, hdr.ipv4_base.diffserv, hdr.ipv4_base.totalLen, hdr.ipv4_base.identification, hdr.ipv4_base.flags, hdr.ipv4_base.fragOffset, hdr.ipv4_base.ttl, hdr.ipv4_base.protocol, hdr.ipv4_base.srcAddr, hdr.ipv4_base.dstAddr, hdr.ipv4_option_security, hdr.ipv4_option_NOP[0], hdr.ipv4_option_timestamp }, hdr.ipv4_base.hdrChecksum, HashAlgorithm.csum16);
+        tmp_0 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>, ipv4_option_security_t, ipv4_option_EOL_t, ipv4_option_timestamp_t>>({ hdr.ipv4_base.version, hdr.ipv4_base.ihl, hdr.ipv4_base.diffserv, hdr.ipv4_base.totalLen, hdr.ipv4_base.identification, hdr.ipv4_base.flags, hdr.ipv4_base.fragOffset, hdr.ipv4_base.ttl, hdr.ipv4_base.protocol, hdr.ipv4_base.srcAddr, hdr.ipv4_base.dstAddr, hdr.ipv4_option_security, hdr.ipv4_option_NOP[0], hdr.ipv4_option_timestamp });
+        hdr.ipv4_base.hdrChecksum = tmp_0;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
@@ -88,7 +88,7 @@ struct headers {
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     ipv4_option_timestamp_t_1 tmp_hdr;
     ipv4_option_timestamp_t_2 tmp_hdr_0;
-    bit<8> tmp_0;
+    bit<8> tmp_1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {
@@ -130,8 +130,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition parse_ipv4_options;
     }
     @name(".parse_ipv4_options") state parse_ipv4_options {
-        tmp_0 = packet.lookahead<bit<8>>();
-        transition select(meta.my_metadata.parse_ipv4_counter, tmp_0[7:0]) {
+        tmp_1 = packet.lookahead<bit<8>>();
+        transition select(meta.my_metadata.parse_ipv4_counter, tmp_1[7:0]) {
             (8w0x0 &&& 8w0xff, 8w0x0 &&& 8w0x0): accept;
             (8w0x0 &&& 8w0x0, 8w0x0 &&& 8w0xff): parse_ipv4_option_EOL;
             (8w0x0 &&& 8w0x0, 8w0x1 &&& 8w0xff): parse_ipv4_option_NOP;
@@ -235,8 +235,11 @@ struct tuple_0 {
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple_0, bit<16>>(true, { hdr.ipv4_base.version, hdr.ipv4_base.ihl, hdr.ipv4_base.diffserv, hdr.ipv4_base.totalLen, hdr.ipv4_base.identification, hdr.ipv4_base.flags, hdr.ipv4_base.fragOffset, hdr.ipv4_base.ttl, hdr.ipv4_base.protocol, hdr.ipv4_base.srcAddr, hdr.ipv4_base.dstAddr, hdr.ipv4_option_security, hdr.ipv4_option_NOP[0], hdr.ipv4_option_timestamp }, hdr.ipv4_base.hdrChecksum, HashAlgorithm.csum16);
+        tmp_2 = ipv4_checksum.get<tuple_0>({ hdr.ipv4_base.version, hdr.ipv4_base.ihl, hdr.ipv4_base.diffserv, hdr.ipv4_base.totalLen, hdr.ipv4_base.identification, hdr.ipv4_base.flags, hdr.ipv4_base.fragOffset, hdr.ipv4_base.ttl, hdr.ipv4_base.protocol, hdr.ipv4_base.srcAddr, hdr.ipv4_base.dstAddr, hdr.ipv4_option_security, hdr.ipv4_option_NOP[0], hdr.ipv4_option_timestamp });
+        hdr.ipv4_base.hdrChecksum = tmp_2;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/TLV_parsing.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing.p4
@@ -203,8 +203,9 @@ control verifyChecksum(in headers hdr, inout metadata meta) {
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4_base.version, hdr.ipv4_base.ihl, hdr.ipv4_base.diffserv, hdr.ipv4_base.totalLen, hdr.ipv4_base.identification, hdr.ipv4_base.flags, hdr.ipv4_base.fragOffset, hdr.ipv4_base.ttl, hdr.ipv4_base.protocol, hdr.ipv4_base.srcAddr, hdr.ipv4_base.dstAddr, hdr.ipv4_option_security, hdr.ipv4_option_NOP[0], hdr.ipv4_option_timestamp }, hdr.ipv4_base.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4_base.hdrChecksum = ipv4_checksum.get({ hdr.ipv4_base.version, hdr.ipv4_base.ihl, hdr.ipv4_base.diffserv, hdr.ipv4_base.totalLen, hdr.ipv4_base.identification, hdr.ipv4_base.flags, hdr.ipv4_base.fragOffset, hdr.ipv4_base.ttl, hdr.ipv4_base.protocol, hdr.ipv4_base.srcAddr, hdr.ipv4_base.dstAddr, hdr.ipv4_option_security, hdr.ipv4_option_NOP[0], hdr.ipv4_option_timestamp });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/TLV_parsing.p4-stderr
+++ b/testdata/p4_14_samples_outputs/TLV_parsing.p4-stderr
@@ -2,6 +2,3 @@ TLV_parsing.p4(118): warning: 20: value does not fit in 4 bits
     set_metadata(my_metadata.parse_ipv4_counter, ipv4_base.ihl * 4 - 20);
                                                                      ^^
 warning: The order of headers in deparser is not uniquely determined by parser!
-TLV_parsing.p4(186): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^

--- a/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
@@ -27,6 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<8> tmp;
     @name(".copy2") action copy2_0(inout bit<8> dest_0, bit<8> val_0) {
         dest_0 = val_0;
     }
@@ -37,7 +38,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         copy_0(dest_2, val_2);
     }
     @name(".setb1") action setb1_0(bit<9> port) {
-        setbyte_0(hdr.data.b1, hdr.data.b2);
+        tmp = hdr.data.b1;
+        setbyte_0(tmp, hdr.data.b2);
+        hdr.data.b1 = tmp;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop_0() {

--- a/testdata/p4_14_samples_outputs/basic_routing-first.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-first.p4
@@ -180,14 +180,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/basic_routing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-frontend.p4
@@ -180,14 +180,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp;
+    bool tmp_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_0 = hdr.ipv4.hdrChecksum == tmp;
+        if (tmp_0) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_1 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_1;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/basic_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-midend.p4
@@ -214,14 +214,21 @@ struct tuple_0 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_2 = ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_2) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_4;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_4 = ipv4_checksum_2.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_4;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/basic_routing.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing.p4
@@ -168,14 +168,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/basic_routing.p4-stderr
+++ b/testdata/p4_14_samples_outputs/basic_routing.p4-stderr
@@ -1,9 +1,3 @@
-basic_routing.p4(78): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-basic_routing.p4(78): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
 basic_routing.p4(117): warning: bd shadows .bd
 action set_bd(bd) {
               ^^

--- a/testdata/p4_14_samples_outputs/checksum-first.p4
+++ b/testdata/p4_14_samples_outputs/checksum-first.p4
@@ -72,14 +72,18 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/checksum-frontend.p4
+++ b/testdata/p4_14_samples_outputs/checksum-frontend.p4
@@ -72,14 +72,31 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp;
+    bit<16> tmp_0;
+    bool tmp_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (!(hdr.ipv4.ihl == 4w5)) 
+            tmp = false;
+        else {
+            tmp_0 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_1 = hdr.ipv4.hdrChecksum == tmp_0;
+            tmp = tmp_1;
+        }
+        if (tmp) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_2 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_2;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/checksum-midend.p4
+++ b/testdata/p4_14_samples_outputs/checksum-midend.p4
@@ -86,14 +86,29 @@ struct tuple_0 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp_3;
+    bit<16> tmp_4;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl != 4w5) 
+            tmp_3 = false;
+        else {
+            tmp_4 = ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_3 = hdr.ipv4.hdrChecksum == tmp_4;
+        }
+        if (tmp_3) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_6;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_6 = ipv4_checksum_2.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_6;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/checksum.p4
+++ b/testdata/p4_14_samples_outputs/checksum.p4
@@ -72,14 +72,18 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/checksum.p4-stderr
+++ b/testdata/p4_14_samples_outputs/checksum.p4-stderr
@@ -1,6 +1,0 @@
-checksum.p4(78): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-checksum.p4(78): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^

--- a/testdata/p4_14_samples_outputs/checksum1-first.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-first.p4
@@ -117,14 +117,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/checksum1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-frontend.p4
@@ -117,14 +117,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp;
+    bool tmp_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_0 = hdr.ipv4.hdrChecksum == tmp;
+        if (tmp_0) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_1 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_1;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/checksum1-midend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-midend.p4
@@ -135,14 +135,21 @@ struct tuple_0 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_2 = ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_2) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_4;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_4 = ipv4_checksum_2.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_4;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/checksum1.p4
+++ b/testdata/p4_14_samples_outputs/checksum1.p4
@@ -113,14 +113,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/checksum1.p4-stderr
+++ b/testdata/p4_14_samples_outputs/checksum1.p4-stderr
@@ -1,9 +1,3 @@
 checksum1.p4(122): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-checksum1.p4(77): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-checksum1.p4(77): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^

--- a/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
@@ -214,14 +214,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
@@ -117,13 +117,21 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<14> tmp;
+    tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>> tmp_0;
+    bit<16> tmp_1;
+    bit<32> tmp_2;
+    bit<32> tmp_3;
+    bit<32> tmp_4;
     @name(".flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
     @name(".flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
     @name("._drop") action _drop_1() {
         mark_to_drop();
     }
     @name(".set_ecmp_select") action set_ecmp_select_0(bit<8> ecmp_base, bit<8> ecmp_count) {
-        hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);
+        tmp_0 = { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id };
+        hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(tmp, HashAlgorithm.crc16, (bit<10>)ecmp_base, tmp_0, (bit<20>)ecmp_count);
+        meta.ingress_metadata.ecmp_offset = tmp;
     }
     @name(".set_nhop") action set_nhop_0(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;
@@ -132,9 +140,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".lookup_flowlet_map") action lookup_flowlet_map_0() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id_0.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        tmp_2 = (bit<32>)meta.ingress_metadata.flowlet_map_index;
+        flowlet_id_0.read(tmp_1, tmp_2);
+        meta.ingress_metadata.flowlet_id = tmp_1;
         meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
-        flowlet_lasttime_0.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        tmp_4 = (bit<32>)meta.ingress_metadata.flowlet_map_index;
+        flowlet_lasttime_0.read(tmp_3, tmp_4);
+        meta.ingress_metadata.flowlet_lasttime = tmp_3;
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
     }
@@ -214,14 +226,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_5;
+    bool tmp_6;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_5 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_6 = hdr.ipv4.hdrChecksum == tmp_5;
+        if (tmp_6) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_7;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_7 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_7;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -136,6 +136,10 @@ struct tuple_1 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<14> tmp_8;
+    tuple_0 tmp_9;
+    bit<16> tmp_10;
+    bit<32> tmp_12;
     @name("NoAction") action NoAction_1() {
     }
     @name("NoAction") action NoAction_8() {
@@ -158,7 +162,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop();
     }
     @name(".set_ecmp_select") action set_ecmp_select_0(bit<8> ecmp_base, bit<8> ecmp_count) {
-        hash<bit<14>, bit<10>, tuple_0, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);
+        tmp_9.field = hdr.ipv4.srcAddr;
+        tmp_9.field_0 = hdr.ipv4.dstAddr;
+        tmp_9.field_1 = hdr.ipv4.protocol;
+        tmp_9.field_2 = hdr.tcp.srcPort;
+        tmp_9.field_3 = hdr.tcp.dstPort;
+        tmp_9.field_4 = meta.ingress_metadata.flowlet_id;
+        hash<bit<14>, bit<10>, tuple_0, bit<20>>(tmp_8, HashAlgorithm.crc16, (bit<10>)ecmp_base, tmp_9, (bit<20>)ecmp_count);
+        meta.ingress_metadata.ecmp_offset = tmp_8;
     }
     @name(".set_nhop") action set_nhop_0(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;
@@ -167,9 +178,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".lookup_flowlet_map") action lookup_flowlet_map_0() {
         hash<bit<13>, bit<13>, tuple_1, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id_1.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_id_1.read(tmp_10, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        meta.ingress_metadata.flowlet_id = tmp_10;
         meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
-        flowlet_lasttime_1.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime_1.read(tmp_12, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        meta.ingress_metadata.flowlet_lasttime = tmp_12;
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime_1.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
     }
@@ -263,14 +276,21 @@ struct tuple_2 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_14;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_2, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_14 = ipv4_checksum.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_14) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_16;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_2, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_16 = ipv4_checksum_2.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_16;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/flowlet_switching.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching.p4
@@ -203,14 +203,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/flowlet_switching.p4-stderr
+++ b/testdata/p4_14_samples_outputs/flowlet_switching.p4-stderr
@@ -7,9 +7,3 @@ action set_ecmp_select(ecmp_base, ecmp_count) {
 flowlet_switching.p4(72): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-parser.p4(53): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-parser.p4(53): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^

--- a/testdata/p4_14_samples_outputs/parser_dc_full-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-first.p4
@@ -685,16 +685,24 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid() && hdr.inner_ipv4.hdrChecksum == (inner_ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }))) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid()) 
+            hdr.inner_ipv4.hdrChecksum = inner_ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_dc_full-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-frontend.p4
@@ -681,16 +681,50 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp_1;
+    bit<16> tmp_2;
+    bool tmp_3;
+    bool tmp_4;
+    bit<16> tmp_5;
+    bool tmp_6;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (!hdr.ipv4.isValid()) 
+            tmp_1 = false;
+        else {
+            tmp_2 = inner_ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_3 = hdr.inner_ipv4.hdrChecksum == tmp_2;
+            tmp_1 = tmp_3;
+        }
+        if (tmp_1) 
+            mark_to_drop();
+        if (!(hdr.ipv4.ihl == 4w5)) 
+            tmp_4 = false;
+        else {
+            tmp_5 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_6 = hdr.ipv4.hdrChecksum == tmp_5;
+            tmp_4 = tmp_6;
+        }
+        if (tmp_4) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_7;
+    bit<16> tmp_8;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid()) {
+            tmp_7 = inner_ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_7;
+        }
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_8 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_8;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_dc_full-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-midend.p4
@@ -362,8 +362,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<24> tmp_1;
-    bit<4> tmp_2;
+    bit<24> tmp_9;
+    bit<4> tmp_10;
     @name(".parse_arp_rarp") state parse_arp_rarp {
         packet.extract<arp_rarp_t>(hdr.arp_rarp);
         transition select(hdr.arp_rarp.protoType) {
@@ -529,8 +529,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_mpls") state parse_mpls {
-        tmp_1 = packet.lookahead<bit<24>>();
-        transition select(tmp_1[0:0]) {
+        tmp_9 = packet.lookahead<bit<24>>();
+        transition select(tmp_9[0:0]) {
             1w0: parse_mpls_not_bos;
             1w1: parse_mpls_bos;
             default: parse_payload;
@@ -538,8 +538,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_mpls_bos") state parse_mpls_bos {
         packet.extract<mpls_t>(hdr.mpls_bos);
-        tmp_2 = packet.lookahead<bit<4>>();
-        transition select(tmp_2[3:0]) {
+        tmp_10 = packet.lookahead<bit<4>>();
+        transition select(tmp_10[3:0]) {
             4w0x4: parse_inner_ipv4;
             4w0x6: parse_inner_ipv6;
             default: parse_eompls;
@@ -698,16 +698,46 @@ struct tuple_0 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp_11;
+    bit<16> tmp_12;
+    bool tmp_14;
+    bit<16> tmp_15;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (!hdr.ipv4.isValid()) 
+            tmp_11 = false;
+        else {
+            tmp_12 = inner_ipv4_checksum.get<tuple_0>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_11 = hdr.inner_ipv4.hdrChecksum == tmp_12;
+        }
+        if (tmp_11) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl != 4w5) 
+            tmp_14 = false;
+        else {
+            tmp_15 = ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_14 = hdr.ipv4.hdrChecksum == tmp_15;
+        }
+        if (tmp_14) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_17;
+    bit<16> tmp_18;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid()) {
+            tmp_17 = inner_ipv4_checksum_2.get<tuple_0>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_17;
+        }
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_18 = ipv4_checksum_2.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_18;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_dc_full.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full.p4
@@ -685,16 +685,24 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid() && hdr.inner_ipv4.hdrChecksum == inner_ipv4_checksum.get({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr })) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid()) 
+            hdr.inner_ipv4.hdrChecksum = inner_ipv4_checksum.get({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_dc_full.p4-stderr
+++ b/testdata/p4_14_samples_outputs/parser_dc_full.p4-stderr
@@ -1,13 +1,1 @@
 warning: The order of headers in deparser is not uniquely determined by parser!
-parser_dc_full.p4(744): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-parser_dc_full.p4(554): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-parser_dc_full.p4(744): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-parser_dc_full.p4(554): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-first.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-first.p4
@@ -907,16 +907,24 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid() && hdr.inner_ipv4.hdrChecksum == (inner_ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }))) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid()) 
+            hdr.inner_ipv4.hdrChecksum = inner_ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-frontend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-frontend.p4
@@ -903,16 +903,50 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp_1;
+    bit<16> tmp_2;
+    bool tmp_3;
+    bool tmp_4;
+    bit<16> tmp_5;
+    bool tmp_6;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (!hdr.ipv4.isValid()) 
+            tmp_1 = false;
+        else {
+            tmp_2 = inner_ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_3 = hdr.inner_ipv4.hdrChecksum == tmp_2;
+            tmp_1 = tmp_3;
+        }
+        if (tmp_1) 
+            mark_to_drop();
+        if (!(hdr.ipv4.ihl == 4w5)) 
+            tmp_4 = false;
+        else {
+            tmp_5 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_6 = hdr.ipv4.hdrChecksum == tmp_5;
+            tmp_4 = tmp_6;
+        }
+        if (tmp_4) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_7;
+    bit<16> tmp_8;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid()) {
+            tmp_7 = inner_ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_7;
+        }
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_8 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_8;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
@@ -474,8 +474,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<24> tmp_1;
-    bit<4> tmp_2;
+    bit<24> tmp_9;
+    bit<4> tmp_10;
     @name(".parse_arp_rarp") state parse_arp_rarp {
         packet.extract<arp_rarp_t>(hdr.arp_rarp);
         transition select(hdr.arp_rarp.protoType) {
@@ -641,8 +641,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_mpls") state parse_mpls {
-        tmp_1 = packet.lookahead<bit<24>>();
-        transition select(tmp_1[0:0]) {
+        tmp_9 = packet.lookahead<bit<24>>();
+        transition select(tmp_9[0:0]) {
             1w0: parse_mpls_not_bos;
             1w1: parse_mpls_bos;
             default: accept;
@@ -650,8 +650,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_mpls_bos") state parse_mpls_bos {
         packet.extract<mpls_t>(hdr.mpls_bos);
-        tmp_2 = packet.lookahead<bit<4>>();
-        transition select(tmp_2[3:0]) {
+        tmp_10 = packet.lookahead<bit<4>>();
+        transition select(tmp_10[3:0]) {
             4w0x4: parse_inner_ipv4;
             4w0x6: parse_inner_ipv6;
             default: parse_eompls;
@@ -922,16 +922,46 @@ struct tuple_0 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp_11;
+    bit<16> tmp_12;
+    bool tmp_14;
+    bit<16> tmp_15;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (!hdr.ipv4.isValid()) 
+            tmp_11 = false;
+        else {
+            tmp_12 = inner_ipv4_checksum.get<tuple_0>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_11 = hdr.inner_ipv4.hdrChecksum == tmp_12;
+        }
+        if (tmp_11) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl != 4w5) 
+            tmp_14 = false;
+        else {
+            tmp_15 = ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_14 = hdr.ipv4.hdrChecksum == tmp_15;
+        }
+        if (tmp_14) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_17;
+    bit<16> tmp_18;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid()) {
+            tmp_17 = inner_ipv4_checksum_2.get<tuple_0>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_17;
+        }
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_18 = ipv4_checksum_2.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_18;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping.p4
@@ -905,16 +905,24 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid() && hdr.inner_ipv4.hdrChecksum == inner_ipv4_checksum.get({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr })) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(hdr.ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.isValid()) 
+            hdr.inner_ipv4.hdrChecksum = inner_ipv4_checksum.get({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping.p4-stderr
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping.p4-stderr
@@ -1,13 +1,1 @@
 warning: The order of headers in deparser is not uniquely determined by parser!
-port_vlan_mapping.p4(744): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-port_vlan_mapping.p4(554): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-port_vlan_mapping.p4(744): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-port_vlan_mapping.p4(554): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^

--- a/testdata/p4_14_samples_outputs/sai_p4-first.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-first.p4
@@ -366,14 +366,18 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.checksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.checksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
@@ -349,14 +349,31 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp;
+    bit<16> tmp_0;
+    bool tmp_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        if (!(hdr.ipv4.ihl == 4w5)) 
+            tmp = false;
+        else {
+            tmp_0 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_1 = hdr.ipv4.checksum == tmp_0;
+            tmp = tmp_1;
+        }
+        if (tmp) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_2 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.checksum = tmp_2;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/sai_p4-midend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-midend.p4
@@ -378,14 +378,29 @@ struct tuple_0 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp_3;
+    bit<16> tmp_4;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl != 4w5) 
+            tmp_3 = false;
+        else {
+            tmp_4 = ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_3 = hdr.ipv4.checksum == tmp_4;
+        }
+        if (tmp_3) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_6;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_6 = ipv4_checksum_2.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.checksum = tmp_6;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/sai_p4.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4.p4
@@ -354,14 +354,18 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.checksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.checksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.ipv4_length, hdr.ipv4.id, hdr.ipv4.flags, hdr.ipv4.offset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
+++ b/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
@@ -103,12 +103,6 @@ action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, d
 sai_p4.p4(282): warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(192): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-sai_p4.p4(192): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
 sai_p4.p4(282): warning: port shadows .port
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                    ^^^^

--- a/testdata/p4_14_samples_outputs/simple_nat-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-first.p4
@@ -279,16 +279,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
+    Checksum16() tcp_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<32>, bit<32>, bit<8>, bit<8>, bit<16>, bit<16>, bit<16>, bit<32>, bit<32>, bit<4>, bit<4>, bit<8>, bit<16>, bit<16>>, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
+        if (hdr.tcp.isValid() && hdr.tcp.checksum == (tcp_checksum.get<tuple<bit<32>, bit<32>, bit<8>, bit<8>, bit<16>, bit<16>, bit<16>, bit<32>, bit<32>, bit<4>, bit<4>, bit<8>, bit<16>, bit<16>>>({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
+    Checksum16() tcp_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<32>, bit<32>, bit<8>, bit<8>, bit<16>, bit<16>, bit<16>, bit<32>, bit<32>, bit<4>, bit<4>, bit<8>, bit<16>, bit<16>>, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.tcp.isValid()) 
+            hdr.tcp.checksum = tcp_checksum.get<tuple<bit<32>, bit<32>, bit<8>, bit<8>, bit<16>, bit<16>, bit<16>, bit<32>, bit<32>, bit<4>, bit<4>, bit<8>, bit<16>, bit<16>>>({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
@@ -281,16 +281,42 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_0;
+    bool tmp_1;
+    bool tmp_2;
+    bit<16> tmp_3;
+    bool tmp_4;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
+    @name("tcp_checksum") Checksum16() tcp_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<32>, bit<32>, bit<8>, bit<8>, bit<16>, bit<16>, bit<16>, bit<32>, bit<32>, bit<4>, bit<4>, bit<8>, bit<16>, bit<16>>, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
+        tmp_0 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_1 = hdr.ipv4.hdrChecksum == tmp_0;
+        if (tmp_1) 
+            mark_to_drop();
+        if (!hdr.tcp.isValid()) 
+            tmp_2 = false;
+        else {
+            tmp_3 = tcp_checksum_0.get<tuple<bit<32>, bit<32>, bit<8>, bit<8>, bit<16>, bit<16>, bit<16>, bit<32>, bit<32>, bit<4>, bit<4>, bit<8>, bit<16>, bit<16>>>({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr });
+            tmp_4 = hdr.tcp.checksum == tmp_3;
+            tmp_2 = tmp_4;
+        }
+        if (tmp_2) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_5;
+    bit<16> tmp_6;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
+    @name("tcp_checksum") Checksum16() tcp_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<32>, bit<32>, bit<8>, bit<8>, bit<16>, bit<16>, bit<16>, bit<32>, bit<32>, bit<4>, bit<4>, bit<8>, bit<16>, bit<16>>, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
+        tmp_5 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_5;
+        if (hdr.tcp.isValid()) {
+            tmp_6 = tcp_checksum_1.get<tuple<bit<32>, bit<32>, bit<8>, bit<8>, bit<16>, bit<16>, bit<16>, bit<32>, bit<32>, bit<4>, bit<4>, bit<8>, bit<16>, bit<16>>>({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr });
+            hdr.tcp.checksum = tmp_6;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_nat-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-midend.p4
@@ -82,7 +82,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<64> tmp_0;
+    bit<64> tmp_7;
     @name(".parse_cpu_header") state parse_cpu_header {
         packet.extract<cpu_header_t>(hdr.cpu_header);
         meta.meta.if_index = hdr.cpu_header.if_index;
@@ -113,8 +113,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".start") state start {
         meta.meta.if_index = (bit<8>)standard_metadata.ingress_port;
-        tmp_0 = packet.lookahead<bit<64>>();
-        transition select(tmp_0[63:0]) {
+        tmp_7 = packet.lookahead<bit<64>>();
+        transition select(tmp_7[63:0]) {
             64w0: parse_cpu_header;
             default: parse_ethernet;
         }
@@ -337,16 +337,38 @@ struct tuple_2 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_8;
+    bool tmp_10;
+    bit<16> tmp_11;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
+    @name("tcp_checksum") Checksum16() tcp_checksum;
     apply {
-        verify_checksum<tuple_1, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple_2, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
+        tmp_8 = ipv4_checksum.get<tuple_1>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_8) 
+            mark_to_drop();
+        if (!hdr.tcp.isValid()) 
+            tmp_10 = false;
+        else {
+            tmp_11 = tcp_checksum.get<tuple_2>({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr });
+            tmp_10 = hdr.tcp.checksum == tmp_11;
+        }
+        if (tmp_10) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_13;
+    bit<16> tmp_14;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
+    @name("tcp_checksum") Checksum16() tcp_checksum_2;
     apply {
-        update_checksum<tuple_1, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple_2, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
+        tmp_13 = ipv4_checksum_2.get<tuple_1>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_13;
+        if (hdr.tcp.isValid()) {
+            tmp_14 = tcp_checksum_2.get<tuple_2>({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr });
+            hdr.tcp.checksum = tmp_14;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_nat.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat.p4
@@ -269,16 +269,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
+    Checksum16() tcp_checksum;
     apply {
-        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
+        if (hdr.tcp.isValid() && hdr.tcp.checksum == tcp_checksum.get({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
+    Checksum16() tcp_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.tcp.isValid()) 
+            hdr.tcp.checksum = tcp_checksum.get({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta.meta.tcpLength, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_nat.p4-stderr
+++ b/testdata/p4_14_samples_outputs/simple_nat.p4-stderr
@@ -1,15 +1,3 @@
 simple_nat.p4(280): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-simple_nat.p4(99): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-simple_nat.p4(167): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-simple_nat.p4(99): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-simple_nat.p4(167): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^

--- a/testdata/p4_14_samples_outputs/simple_router-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-first.p4
@@ -131,14 +131,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_router-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-frontend.p4
@@ -131,14 +131,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp;
+    bool tmp_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_0 = hdr.ipv4.hdrChecksum == tmp;
+        if (tmp_0) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_1 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_1;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_router-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-midend.p4
@@ -154,14 +154,21 @@ struct tuple_0 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_2 = ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_2) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_4;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_4 = ipv4_checksum_2.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_4;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_router.p4
+++ b/testdata/p4_14_samples_outputs/simple_router.p4
@@ -125,14 +125,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_router.p4-stderr
+++ b/testdata/p4_14_samples_outputs/simple_router.p4-stderr
@@ -1,9 +1,3 @@
 simple_router.p4(108): warning: -1: negative value with unsigned type
     add_to_field(ipv4.ttl, -1);
                             ^
-simple_router.p4(78): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-simple_router.p4(78): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
@@ -4977,16 +4977,24 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5 && hdr.inner_ipv4.hdrChecksum == (inner_ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }))) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5) 
+            hdr.inner_ipv4.hdrChecksum = inner_ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -4295,16 +4295,36 @@ control process_ingress_fabric(inout headers hdr, inout metadata meta, inout sta
 }
 
 control process_hashes(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<16> tmp_0;
+    tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>> tmp_1;
+    bit<16> tmp_2;
+    tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>> tmp_3;
+    bit<16> tmp_4;
+    tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>> tmp_5;
+    bit<16> tmp_6;
+    tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>> tmp_7;
+    bit<16> tmp_8;
+    tuple<bit<16>, bit<48>, bit<48>, bit<16>> tmp_9;
     @name(".compute_lkp_ipv4_hash") action compute_lkp_ipv4_hash_0() {
-        hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
-        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        tmp_1 = { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
+        hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_0, HashAlgorithm.crc16, 16w0, tmp_1, 32w65536);
+        meta.hash_metadata.hash1 = tmp_0;
+        tmp_3 = { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
+        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_2, HashAlgorithm.crc16, 16w0, tmp_3, 32w65536);
+        meta.hash_metadata.hash2 = tmp_2;
     }
     @name(".compute_lkp_ipv6_hash") action compute_lkp_ipv6_hash_0() {
-        hash<bit<16>, bit<16>, tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
-        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        tmp_5 = { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
+        hash<bit<16>, bit<16>, tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_4, HashAlgorithm.crc16, 16w0, tmp_5, 32w65536);
+        meta.hash_metadata.hash1 = tmp_4;
+        tmp_7 = { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
+        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_6, HashAlgorithm.crc16, 16w0, tmp_7, 32w65536);
+        meta.hash_metadata.hash2 = tmp_6;
     }
     @name(".compute_lkp_non_ip_hash") action compute_lkp_non_ip_hash_0() {
-        hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
+        tmp_9 = { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type };
+        hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(tmp_8, HashAlgorithm.crc16, 16w0, tmp_9, 32w65536);
+        meta.hash_metadata.hash2 = tmp_8;
     }
     @name(".computed_two_hashes") action computed_two_hashes_0() {
         meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
@@ -4887,16 +4907,50 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp_10;
+    bit<16> tmp_11;
+    bool tmp_12;
+    bool tmp_13;
+    bit<16> tmp_14;
+    bool tmp_15;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (!(hdr.inner_ipv4.ihl == 4w5)) 
+            tmp_10 = false;
+        else {
+            tmp_11 = inner_ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_12 = hdr.inner_ipv4.hdrChecksum == tmp_11;
+            tmp_10 = tmp_12;
+        }
+        if (tmp_10) 
+            mark_to_drop();
+        if (!(hdr.ipv4.ihl == 4w5)) 
+            tmp_13 = false;
+        else {
+            tmp_14 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_15 = hdr.ipv4.hdrChecksum == tmp_14;
+            tmp_13 = tmp_15;
+        }
+        if (tmp_13) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_16;
+    bit<16> tmp_17;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5) {
+            tmp_16 = inner_ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_16;
+        }
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_17 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_17;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -2963,6 +2963,16 @@ struct tuple_7 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<16> _process_hashes_tmp_9;
+    tuple_2 _process_hashes_tmp_10;
+    bit<16> _process_hashes_tmp_11;
+    tuple_3 _process_hashes_tmp_12;
+    bit<16> _process_hashes_tmp_13;
+    tuple_4 _process_hashes_tmp_14;
+    bit<16> _process_hashes_tmp_15;
+    tuple_5 _process_hashes_tmp_16;
+    bit<16> _process_hashes_tmp_17;
+    tuple_6 _process_hashes_tmp_18;
     @name("NoAction") action NoAction_114() {
     }
     @name("NoAction") action NoAction_115() {
@@ -4433,15 +4443,48 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_152();
     }
     @name(".compute_lkp_ipv4_hash") action _compute_lkp_ipv4_hash() {
-        hash<bit<16>, bit<16>, tuple_2, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
-        hash<bit<16>, bit<16>, tuple_3, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        _process_hashes_tmp_10.field_5 = meta.ipv4_metadata.lkp_ipv4_sa;
+        _process_hashes_tmp_10.field_6 = meta.ipv4_metadata.lkp_ipv4_da;
+        _process_hashes_tmp_10.field_7 = meta.l3_metadata.lkp_ip_proto;
+        _process_hashes_tmp_10.field_8 = meta.l3_metadata.lkp_l4_sport;
+        _process_hashes_tmp_10.field_9 = meta.l3_metadata.lkp_l4_dport;
+        hash<bit<16>, bit<16>, tuple_2, bit<32>>(_process_hashes_tmp_9, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_10, 32w65536);
+        meta.hash_metadata.hash1 = _process_hashes_tmp_9;
+        _process_hashes_tmp_12.field_10 = meta.l2_metadata.lkp_mac_sa;
+        _process_hashes_tmp_12.field_11 = meta.l2_metadata.lkp_mac_da;
+        _process_hashes_tmp_12.field_12 = meta.ipv4_metadata.lkp_ipv4_sa;
+        _process_hashes_tmp_12.field_13 = meta.ipv4_metadata.lkp_ipv4_da;
+        _process_hashes_tmp_12.field_14 = meta.l3_metadata.lkp_ip_proto;
+        _process_hashes_tmp_12.field_15 = meta.l3_metadata.lkp_l4_sport;
+        _process_hashes_tmp_12.field_16 = meta.l3_metadata.lkp_l4_dport;
+        hash<bit<16>, bit<16>, tuple_3, bit<32>>(_process_hashes_tmp_11, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_12, 32w65536);
+        meta.hash_metadata.hash2 = _process_hashes_tmp_11;
     }
     @name(".compute_lkp_ipv6_hash") action _compute_lkp_ipv6_hash() {
-        hash<bit<16>, bit<16>, tuple_4, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
-        hash<bit<16>, bit<16>, tuple_5, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        _process_hashes_tmp_14.field_17 = meta.ipv6_metadata.lkp_ipv6_sa;
+        _process_hashes_tmp_14.field_18 = meta.ipv6_metadata.lkp_ipv6_da;
+        _process_hashes_tmp_14.field_19 = meta.l3_metadata.lkp_ip_proto;
+        _process_hashes_tmp_14.field_20 = meta.l3_metadata.lkp_l4_sport;
+        _process_hashes_tmp_14.field_21 = meta.l3_metadata.lkp_l4_dport;
+        hash<bit<16>, bit<16>, tuple_4, bit<32>>(_process_hashes_tmp_13, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_14, 32w65536);
+        meta.hash_metadata.hash1 = _process_hashes_tmp_13;
+        _process_hashes_tmp_16.field_22 = meta.l2_metadata.lkp_mac_sa;
+        _process_hashes_tmp_16.field_23 = meta.l2_metadata.lkp_mac_da;
+        _process_hashes_tmp_16.field_24 = meta.ipv6_metadata.lkp_ipv6_sa;
+        _process_hashes_tmp_16.field_25 = meta.ipv6_metadata.lkp_ipv6_da;
+        _process_hashes_tmp_16.field_26 = meta.l3_metadata.lkp_ip_proto;
+        _process_hashes_tmp_16.field_27 = meta.l3_metadata.lkp_l4_sport;
+        _process_hashes_tmp_16.field_28 = meta.l3_metadata.lkp_l4_dport;
+        hash<bit<16>, bit<16>, tuple_5, bit<32>>(_process_hashes_tmp_15, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_16, 32w65536);
+        meta.hash_metadata.hash2 = _process_hashes_tmp_15;
     }
     @name(".compute_lkp_non_ip_hash") action _compute_lkp_non_ip_hash() {
-        hash<bit<16>, bit<16>, tuple_6, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
+        _process_hashes_tmp_18.field_29 = meta.ingress_metadata.ifindex;
+        _process_hashes_tmp_18.field_30 = meta.l2_metadata.lkp_mac_sa;
+        _process_hashes_tmp_18.field_31 = meta.l2_metadata.lkp_mac_da;
+        _process_hashes_tmp_18.field_32 = meta.l2_metadata.lkp_mac_type;
+        hash<bit<16>, bit<16>, tuple_6, bit<32>>(_process_hashes_tmp_17, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_18, 32w65536);
+        meta.hash_metadata.hash2 = _process_hashes_tmp_17;
     }
     @name(".computed_two_hashes") action _computed_two_hashes() {
         meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
@@ -5002,16 +5045,46 @@ struct tuple_8 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp_1;
+    bit<16> tmp_2;
+    bool tmp_4;
+    bit<16> tmp_5;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_8, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple_8, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl != 4w5) 
+            tmp_1 = false;
+        else {
+            tmp_2 = inner_ipv4_checksum.get<tuple_8>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_1 = hdr.inner_ipv4.hdrChecksum == tmp_2;
+        }
+        if (tmp_1) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl != 4w5) 
+            tmp_4 = false;
+        else {
+            tmp_5 = ipv4_checksum.get<tuple_8>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_4 = hdr.ipv4.hdrChecksum == tmp_5;
+        }
+        if (tmp_4) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_7;
+    bit<16> tmp_8;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_8, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple_8, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5) {
+            tmp_7 = inner_ipv4_checksum_2.get<tuple_8>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_7;
+        }
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_8 = ipv4_checksum_2.get<tuple_8>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_8;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
@@ -4855,16 +4855,24 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5 && hdr.inner_ipv4.hdrChecksum == inner_ipv4_checksum.get({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr })) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5) 
+            hdr.inner_ipv4.hdrChecksum = inner_ipv4_checksum.get({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4-stderr
@@ -20,15 +20,3 @@ fabric.p4(230): warning: Could not infer type for fabric_mgid, using bit<8>
 action set_fabric_multicast(fabric_mgid) {
                             ^^^^^^^^^^^
 warning: The order of headers in deparser is not uniquely determined by parser!
-parser.p4(571): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-parser.p4(280): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-parser.p4(571): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-parser.p4(280): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -6021,16 +6021,24 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5 && hdr.inner_ipv4.hdrChecksum == (inner_ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }))) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5) 
+            hdr.inner_ipv4.hdrChecksum = inner_ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -5182,16 +5182,36 @@ control process_meter_index(inout headers hdr, inout metadata meta, inout standa
 }
 
 control process_hashes(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<16> tmp_0;
+    tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>> tmp_1;
+    bit<16> tmp_2;
+    tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>> tmp_3;
+    bit<16> tmp_4;
+    tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>> tmp_5;
+    bit<16> tmp_6;
+    tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>> tmp_7;
+    bit<16> tmp_8;
+    tuple<bit<16>, bit<48>, bit<48>, bit<16>> tmp_9;
     @name(".compute_lkp_ipv4_hash") action compute_lkp_ipv4_hash_0() {
-        hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
-        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        tmp_1 = { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
+        hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_0, HashAlgorithm.crc16, 16w0, tmp_1, 32w65536);
+        meta.hash_metadata.hash1 = tmp_0;
+        tmp_3 = { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
+        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_2, HashAlgorithm.crc16, 16w0, tmp_3, 32w65536);
+        meta.hash_metadata.hash2 = tmp_2;
     }
     @name(".compute_lkp_ipv6_hash") action compute_lkp_ipv6_hash_0() {
-        hash<bit<16>, bit<16>, tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
-        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        tmp_5 = { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
+        hash<bit<16>, bit<16>, tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_4, HashAlgorithm.crc16, 16w0, tmp_5, 32w65536);
+        meta.hash_metadata.hash1 = tmp_4;
+        tmp_7 = { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
+        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_6, HashAlgorithm.crc16, 16w0, tmp_7, 32w65536);
+        meta.hash_metadata.hash2 = tmp_6;
     }
     @name(".compute_lkp_non_ip_hash") action compute_lkp_non_ip_hash_0() {
-        hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
+        tmp_9 = { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type };
+        hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(tmp_8, HashAlgorithm.crc16, 16w0, tmp_9, 32w65536);
+        meta.hash_metadata.hash2 = tmp_8;
     }
     @name(".computed_two_hashes") action computed_two_hashes_0() {
         meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
@@ -5881,16 +5901,50 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp_10;
+    bit<16> tmp_11;
+    bool tmp_12;
+    bool tmp_13;
+    bit<16> tmp_14;
+    bool tmp_15;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (!(hdr.inner_ipv4.ihl == 4w5)) 
+            tmp_10 = false;
+        else {
+            tmp_11 = inner_ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_12 = hdr.inner_ipv4.hdrChecksum == tmp_11;
+            tmp_10 = tmp_12;
+        }
+        if (tmp_10) 
+            mark_to_drop();
+        if (!(hdr.ipv4.ihl == 4w5)) 
+            tmp_13 = false;
+        else {
+            tmp_14 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_15 = hdr.ipv4.hdrChecksum == tmp_14;
+            tmp_13 = tmp_15;
+        }
+        if (tmp_13) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_16;
+    bit<16> tmp_17;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5) {
+            tmp_16 = inner_ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_16;
+        }
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_17 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_17;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -3120,56 +3120,56 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 struct tuple_2 {
-    bit<1>  field_5;
-    bit<16> field_6;
-}
-
-struct tuple_3 {
-    tuple_1 field_7;
+    bit<32> field_5;
+    bit<32> field_6;
+    bit<8>  field_7;
     bit<16> field_8;
     bit<16> field_9;
 }
 
+struct tuple_3 {
+    bit<48> field_10;
+    bit<48> field_11;
+    bit<32> field_12;
+    bit<32> field_13;
+    bit<8>  field_14;
+    bit<16> field_15;
+    bit<16> field_16;
+}
+
 struct tuple_4 {
-    bit<32> field_10;
-    bit<32> field_11;
-    bit<8>  field_12;
-    bit<16> field_13;
-    bit<16> field_14;
+    bit<128> field_17;
+    bit<128> field_18;
+    bit<8>   field_19;
+    bit<16>  field_20;
+    bit<16>  field_21;
 }
 
 struct tuple_5 {
-    bit<48> field_15;
-    bit<48> field_16;
-    bit<32> field_17;
-    bit<32> field_18;
-    bit<8>  field_19;
-    bit<16> field_20;
-    bit<16> field_21;
+    bit<48>  field_22;
+    bit<48>  field_23;
+    bit<128> field_24;
+    bit<128> field_25;
+    bit<8>   field_26;
+    bit<16>  field_27;
+    bit<16>  field_28;
 }
 
 struct tuple_6 {
-    bit<128> field_22;
-    bit<128> field_23;
-    bit<8>   field_24;
-    bit<16>  field_25;
-    bit<16>  field_26;
+    bit<16> field_29;
+    bit<48> field_30;
+    bit<48> field_31;
+    bit<16> field_32;
 }
 
 struct tuple_7 {
-    bit<48>  field_27;
-    bit<48>  field_28;
-    bit<128> field_29;
-    bit<128> field_30;
-    bit<8>   field_31;
-    bit<16>  field_32;
-    bit<16>  field_33;
+    bit<1>  field_33;
+    bit<16> field_34;
 }
 
 struct tuple_8 {
-    bit<16> field_34;
-    bit<48> field_35;
-    bit<48> field_36;
+    tuple_1 field_35;
+    bit<16> field_36;
     bit<16> field_37;
 }
 
@@ -3179,6 +3179,16 @@ struct tuple_9 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<16> _process_hashes_tmp_9;
+    tuple_2 _process_hashes_tmp_10;
+    bit<16> _process_hashes_tmp_11;
+    tuple_3 _process_hashes_tmp_12;
+    bit<16> _process_hashes_tmp_13;
+    tuple_4 _process_hashes_tmp_14;
+    bit<16> _process_hashes_tmp_15;
+    tuple_5 _process_hashes_tmp_16;
+    bit<16> _process_hashes_tmp_17;
+    tuple_6 _process_hashes_tmp_18;
     @name("NoAction") action NoAction_148() {
     }
     @name("NoAction") action NoAction_149() {
@@ -3664,7 +3674,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.int_metadata.insert_byte_cnt = meta.int_metadata.gpe_int_hdr_len << 2;
         meta.int_metadata_i2e.sink = 1w1;
         meta.i2e_metadata.mirror_session_id = (bit<16>)mirror_id;
-        clone3<tuple_2>(CloneType.I2E, mirror_id, { meta.int_metadata_i2e.sink, meta.i2e_metadata.mirror_session_id });
+        clone3<tuple_7>(CloneType.I2E, mirror_id, { meta.int_metadata_i2e.sink, meta.i2e_metadata.mirror_session_id });
         hdr.int_header.setInvalid();
         hdr.int_val[0].setInvalid();
         hdr.int_val[1].setInvalid();
@@ -4354,7 +4364,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         _sflow_ingress_session_pkt_counter_0.count();
         meta.fabric_metadata.reason_code = reason_code;
         meta.i2e_metadata.mirror_session_id = (bit<16>)sflow_i2e_mirror_id;
-        clone3<tuple_3>(CloneType.I2E, sflow_i2e_mirror_id, { { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port }, meta.sflow_metadata.sflow_session_id, meta.i2e_metadata.mirror_session_id });
+        clone3<tuple_8>(CloneType.I2E, sflow_i2e_mirror_id, { { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port }, meta.sflow_metadata.sflow_session_id, meta.i2e_metadata.mirror_session_id });
     }
     @name(".sflow_ing_take_sample") table _sflow_ing_take_sample_0 {
         actions = {
@@ -5257,15 +5267,48 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_208();
     }
     @name(".compute_lkp_ipv4_hash") action _compute_lkp_ipv4_hash() {
-        hash<bit<16>, bit<16>, tuple_4, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
-        hash<bit<16>, bit<16>, tuple_5, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        _process_hashes_tmp_10.field_5 = meta.ipv4_metadata.lkp_ipv4_sa;
+        _process_hashes_tmp_10.field_6 = meta.ipv4_metadata.lkp_ipv4_da;
+        _process_hashes_tmp_10.field_7 = meta.l3_metadata.lkp_ip_proto;
+        _process_hashes_tmp_10.field_8 = meta.l3_metadata.lkp_l4_sport;
+        _process_hashes_tmp_10.field_9 = meta.l3_metadata.lkp_l4_dport;
+        hash<bit<16>, bit<16>, tuple_2, bit<32>>(_process_hashes_tmp_9, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_10, 32w65536);
+        meta.hash_metadata.hash1 = _process_hashes_tmp_9;
+        _process_hashes_tmp_12.field_10 = meta.l2_metadata.lkp_mac_sa;
+        _process_hashes_tmp_12.field_11 = meta.l2_metadata.lkp_mac_da;
+        _process_hashes_tmp_12.field_12 = meta.ipv4_metadata.lkp_ipv4_sa;
+        _process_hashes_tmp_12.field_13 = meta.ipv4_metadata.lkp_ipv4_da;
+        _process_hashes_tmp_12.field_14 = meta.l3_metadata.lkp_ip_proto;
+        _process_hashes_tmp_12.field_15 = meta.l3_metadata.lkp_l4_sport;
+        _process_hashes_tmp_12.field_16 = meta.l3_metadata.lkp_l4_dport;
+        hash<bit<16>, bit<16>, tuple_3, bit<32>>(_process_hashes_tmp_11, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_12, 32w65536);
+        meta.hash_metadata.hash2 = _process_hashes_tmp_11;
     }
     @name(".compute_lkp_ipv6_hash") action _compute_lkp_ipv6_hash() {
-        hash<bit<16>, bit<16>, tuple_6, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
-        hash<bit<16>, bit<16>, tuple_7, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        _process_hashes_tmp_14.field_17 = meta.ipv6_metadata.lkp_ipv6_sa;
+        _process_hashes_tmp_14.field_18 = meta.ipv6_metadata.lkp_ipv6_da;
+        _process_hashes_tmp_14.field_19 = meta.l3_metadata.lkp_ip_proto;
+        _process_hashes_tmp_14.field_20 = meta.l3_metadata.lkp_l4_sport;
+        _process_hashes_tmp_14.field_21 = meta.l3_metadata.lkp_l4_dport;
+        hash<bit<16>, bit<16>, tuple_4, bit<32>>(_process_hashes_tmp_13, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_14, 32w65536);
+        meta.hash_metadata.hash1 = _process_hashes_tmp_13;
+        _process_hashes_tmp_16.field_22 = meta.l2_metadata.lkp_mac_sa;
+        _process_hashes_tmp_16.field_23 = meta.l2_metadata.lkp_mac_da;
+        _process_hashes_tmp_16.field_24 = meta.ipv6_metadata.lkp_ipv6_sa;
+        _process_hashes_tmp_16.field_25 = meta.ipv6_metadata.lkp_ipv6_da;
+        _process_hashes_tmp_16.field_26 = meta.l3_metadata.lkp_ip_proto;
+        _process_hashes_tmp_16.field_27 = meta.l3_metadata.lkp_l4_sport;
+        _process_hashes_tmp_16.field_28 = meta.l3_metadata.lkp_l4_dport;
+        hash<bit<16>, bit<16>, tuple_5, bit<32>>(_process_hashes_tmp_15, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_16, 32w65536);
+        meta.hash_metadata.hash2 = _process_hashes_tmp_15;
     }
     @name(".compute_lkp_non_ip_hash") action _compute_lkp_non_ip_hash() {
-        hash<bit<16>, bit<16>, tuple_8, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
+        _process_hashes_tmp_18.field_29 = meta.ingress_metadata.ifindex;
+        _process_hashes_tmp_18.field_30 = meta.l2_metadata.lkp_mac_sa;
+        _process_hashes_tmp_18.field_31 = meta.l2_metadata.lkp_mac_da;
+        _process_hashes_tmp_18.field_32 = meta.l2_metadata.lkp_mac_type;
+        hash<bit<16>, bit<16>, tuple_6, bit<32>>(_process_hashes_tmp_17, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_18, 32w65536);
+        meta.hash_metadata.hash2 = _process_hashes_tmp_17;
     }
     @name(".computed_two_hashes") action _computed_two_hashes() {
         meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
@@ -6017,16 +6060,46 @@ struct tuple_10 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bool tmp_1;
+    bit<16> tmp_2;
+    bool tmp_4;
+    bit<16> tmp_5;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_10, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple_10, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl != 4w5) 
+            tmp_1 = false;
+        else {
+            tmp_2 = inner_ipv4_checksum.get<tuple_10>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_1 = hdr.inner_ipv4.hdrChecksum == tmp_2;
+        }
+        if (tmp_1) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl != 4w5) 
+            tmp_4 = false;
+        else {
+            tmp_5 = ipv4_checksum.get<tuple_10>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_4 = hdr.ipv4.hdrChecksum == tmp_5;
+        }
+        if (tmp_4) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_7;
+    bit<16> tmp_8;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_10, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple_10, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5) {
+            tmp_7 = inner_ipv4_checksum_2.get<tuple_10>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_7;
+        }
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_8 = ipv4_checksum_2.get<tuple_10>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_8;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -5865,16 +5865,24 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5 && hdr.inner_ipv4.hdrChecksum == inner_ipv4_checksum.get({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr })) 
+            mark_to_drop();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.inner_ipv4.ihl == 4w5) 
+            hdr.inner_ipv4.hdrChecksum = inner_ipv4_checksum.get({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
@@ -20,18 +20,6 @@ fabric.p4(210): warning: Could not infer type for fabric_mgid, using bit<8>
 action set_fabric_multicast(fabric_mgid) {
                             ^^^^^^^^^^^
 warning: The order of headers in deparser is not uniquely determined by parser!
-parser.p4(586): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-parser.p4(278): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-parser.p4(586): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
-parser.p4(278): warning: csum16: unexpected algorithm
-    algorithm : csum16;
-                ^^^^^^
 parser.p4(487): warning: SelectCase: unreachable
         default: parse_all_int_meta_value_heders;
         ^^^^^^^

--- a/testdata/p4_16_errors/issue532.p4
+++ b/testdata/p4_16_errors/issue532.p4
@@ -54,14 +54,15 @@ control deparser(packet_out b, in parsed_packet_t hdr) {
   apply { }
 }
 
-control verify_ck(in parsed_packet_t hdr,
+control verify_checksum(in parsed_packet_t hdr,
                         inout my_meta_t my_meta) {
   apply { }
 }
 
-control compute_ck(inout parsed_packet_t hdr,
+control compute_checksum(inout parsed_packet_t hdr,
                          inout my_meta_t my_meta) {
   apply { }
 }
 
-V1Switch(parse(), verify_ck(), ingress(), egress(), compute_ck(), deparser()) main;
+V1Switch(parse(), verify_checksum(), ingress(), egress(),
+         compute_checksum(), deparser()) main;

--- a/testdata/p4_16_errors_outputs/issue532-first.p4
+++ b/testdata/p4_16_errors_outputs/issue532-first.p4
@@ -52,14 +52,14 @@ control deparser(packet_out b, in parsed_packet_t hdr) {
     }
 }
 
-control verify_ck(in parsed_packet_t hdr, inout my_meta_t my_meta) {
+control verify_checksum(in parsed_packet_t hdr, inout my_meta_t my_meta) {
     apply {
     }
 }
 
-control compute_ck(inout parsed_packet_t hdr, inout my_meta_t my_meta) {
+control compute_checksum(inout parsed_packet_t hdr, inout my_meta_t my_meta) {
     apply {
     }
 }
 
-V1Switch<parsed_packet_t, my_meta_t>(parse(), verify_ck(), ingress(), egress(), compute_ck(), deparser()) main;
+V1Switch<parsed_packet_t, my_meta_t>(parse(), verify_checksum(), ingress(), egress(), compute_checksum(), deparser()) main;

--- a/testdata/p4_16_errors_outputs/issue532-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue532-frontend.p4
@@ -54,14 +54,14 @@ control deparser(packet_out b, in parsed_packet_t hdr) {
     }
 }
 
-control verify_ck(in parsed_packet_t hdr, inout my_meta_t my_meta) {
+control verify_checksum(in parsed_packet_t hdr, inout my_meta_t my_meta) {
     apply {
     }
 }
 
-control compute_ck(inout parsed_packet_t hdr, inout my_meta_t my_meta) {
+control compute_checksum(inout parsed_packet_t hdr, inout my_meta_t my_meta) {
     apply {
     }
 }
 
-V1Switch<parsed_packet_t, my_meta_t>(parse(), verify_ck(), ingress(), egress(), compute_ck(), deparser()) main;
+V1Switch<parsed_packet_t, my_meta_t>(parse(), verify_checksum(), ingress(), egress(), compute_checksum(), deparser()) main;

--- a/testdata/p4_16_errors_outputs/issue532.p4
+++ b/testdata/p4_16_errors_outputs/issue532.p4
@@ -52,14 +52,14 @@ control deparser(packet_out b, in parsed_packet_t hdr) {
     }
 }
 
-control verify_ck(in parsed_packet_t hdr, inout my_meta_t my_meta) {
+control verify_checksum(in parsed_packet_t hdr, inout my_meta_t my_meta) {
     apply {
     }
 }
 
-control compute_ck(inout parsed_packet_t hdr, inout my_meta_t my_meta) {
+control compute_checksum(inout parsed_packet_t hdr, inout my_meta_t my_meta) {
     apply {
     }
 }
 
-V1Switch(parse(), verify_ck(), ingress(), egress(), compute_ck(), deparser()) main;
+V1Switch(parse(), verify_checksum(), ingress(), egress(), compute_checksum(), deparser()) main;

--- a/testdata/p4_16_errors_outputs/issue584.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue584.p4-stderr
@@ -1,6 +1,6 @@
 issue584.p4(28): error: hash: cannot infer bitwidth for integer-valued type parameter T
         hash(var, HashAlgorithm.crc16, 0, hdr, 0xFFFF);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-v1model.p4(122)
+v1model.p4(125)
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
                     ^

--- a/testdata/p4_16_samples/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples/flowlet_switching-bmv2.p4
@@ -216,14 +216,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_16_samples/issue134-bmv2.p4
+++ b/testdata/p4_16_samples/issue134-bmv2.p4
@@ -49,8 +49,12 @@ control VerifyChecksumI(in H hdr, inout M meta) {
 }
 
 control ComputeChecksumI(inout H hdr, inout M meta) {
+    Checksum16() c16;
+
     apply {
-        update_checksum(hdr.ipv4.ihl == 5, { 16w0 }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 5) {
+            hdr.ipv4.hdrChecksum = c16.get({ 1w0 });; // c16 invoked conditionally
+        }
     }
 }
 

--- a/testdata/p4_16_samples/issue249.p4
+++ b/testdata/p4_16_samples/issue249.p4
@@ -54,14 +54,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_16_samples/issue270-bmv2.p4
+++ b/testdata/p4_16_samples/issue270-bmv2.p4
@@ -67,8 +67,11 @@ control Eg(inout H hdrs,
 action drop() {}
 
 control VerifyChecksumI(in H hdr, inout M meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
+
     apply {
-        verify_checksum(hdr.inner_ipv4.ihl == 5, {
+        bit<16> inner_cksum = inner_ipv4_checksum.get({
             // all inner_ipv4 fields, except checksum itself
             hdr.inner_ipv4.version,
             hdr.inner_ipv4.ihl,
@@ -81,9 +84,9 @@ control VerifyChecksumI(in H hdr, inout M meta) {
             hdr.inner_ipv4.protocol,
             hdr.inner_ipv4.srcAddr,
             hdr.inner_ipv4.dstAddr
-        }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
+        });
 
-        verify_checksum(hdr.ipv4.ihl == 5, {
+        bit<16> cksum = ipv4_checksum.get({
             // all ipv4 fields, except checksum itself
             hdr.ipv4.version,
             hdr.ipv4.ihl,
@@ -96,13 +99,29 @@ control VerifyChecksumI(in H hdr, inout M meta) {
             hdr.ipv4.protocol,
             hdr.ipv4.srcAddr,
             hdr.ipv4.dstAddr
-        }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        });
+
+        if (hdr.inner_ipv4.ihl == 5 &&
+            hdr.inner_ipv4.hdrChecksum != inner_cksum) {
+            // SJS / FIXME: make sure that's what we're supposed to do here!
+            drop();
+        }
+
+        if (hdr.ipv4.ihl == 5 &&
+            hdr.ipv4.hdrChecksum != cksum) {
+            // SJS / FIXME: make sure that's what we're supposed to do here!
+            drop();
+        }
     }
+
 }
 
 control ComputeChecksumI(inout H hdr, inout M meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
+
     apply {
-        update_checksum(hdr.inner_ipv4.ihl == 5, {
+        bit<16> inner_cksum = inner_ipv4_checksum.get({
             // all inner_ipv4 fields, except checksum itself
             hdr.inner_ipv4.version,
             hdr.inner_ipv4.ihl,
@@ -115,9 +134,9 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
             hdr.inner_ipv4.protocol,
             hdr.inner_ipv4.srcAddr,
             hdr.inner_ipv4.dstAddr
-        }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
+        });
 
-        update_checksum(hdr.ipv4.ihl == 5, {
+        bit<16> cksum = ipv4_checksum.get({
             // all ipv4 fields, except checksum itself
             hdr.ipv4.version,
             hdr.ipv4.ihl,
@@ -130,7 +149,15 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
             hdr.ipv4.protocol,
             hdr.ipv4.srcAddr,
             hdr.ipv4.dstAddr
-        }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        });
+
+        if (hdr.inner_ipv4.ihl == 5) {
+            hdr.inner_ipv4.hdrChecksum = inner_cksum;
+        }
+
+        if (hdr.ipv4.ihl == 5) {
+            hdr.ipv4.hdrChecksum = cksum;
+        }
     }
 }
 

--- a/testdata/p4_16_samples/issue298-bmv2.p4
+++ b/testdata/p4_16_samples/issue298-bmv2.p4
@@ -133,14 +133,17 @@ control TopDeparser(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(true, {hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, {hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_16_samples/issue655-bmv2.p4
+++ b/testdata/p4_16_samples/issue655-bmv2.p4
@@ -38,14 +38,19 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 }
 
 control vc(in Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        verify_checksum(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get({ hdr.h.d, hdr.h.c });
+        if (0 != tmp)
+            mark_to_drop();
     }
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        update_checksum(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get({ hdr.h.d });
+        hdr.h.c = tmp;
     }
 }
 

--- a/testdata/p4_16_samples/issue655.p4
+++ b/testdata/p4_16_samples/issue655.p4
@@ -38,14 +38,19 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 }
 
 control vc(in Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        verify_checksum(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get({ hdr.h.d, hdr.h.c });
+        if (0 != tmp)
+            mark_to_drop();
     }
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        update_checksum(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get({ hdr.h.d });
+        hdr.h.c = tmp;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
@@ -216,14 +216,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
@@ -117,13 +117,21 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<14> tmp;
+    tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>> tmp_0;
+    bit<16> tmp_1;
+    bit<32> tmp_2;
+    bit<32> tmp_3;
+    bit<32> tmp_4;
     @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
     @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
     @name("_drop") action _drop_1() {
         mark_to_drop();
     }
     @name("set_ecmp_select") action set_ecmp_select_0(bit<8> ecmp_base, bit<8> ecmp_count) {
-        hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);
+        tmp_0 = { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id };
+        hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(tmp, HashAlgorithm.crc16, (bit<10>)ecmp_base, tmp_0, (bit<20>)ecmp_count);
+        meta.ingress_metadata.ecmp_offset = tmp;
     }
     @name("set_nhop") action set_nhop_0(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;
@@ -132,9 +140,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("lookup_flowlet_map") action lookup_flowlet_map_0() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id_0.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        tmp_2 = (bit<32>)meta.ingress_metadata.flowlet_map_index;
+        flowlet_id_0.read(tmp_1, tmp_2);
+        meta.ingress_metadata.flowlet_id = tmp_1;
         meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
-        flowlet_lasttime_0.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        tmp_4 = (bit<32>)meta.ingress_metadata.flowlet_map_index;
+        flowlet_lasttime_0.read(tmp_3, tmp_4);
+        meta.ingress_metadata.flowlet_lasttime = tmp_3;
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
     }
@@ -216,14 +228,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_5;
+    bool tmp_6;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_5 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_6 = hdr.ipv4.hdrChecksum == tmp_5;
+        if (tmp_6) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_7;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_7 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_7;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -136,6 +136,10 @@ struct tuple_1 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<14> tmp_8;
+    tuple_0 tmp_9;
+    bit<16> tmp_10;
+    bit<32> tmp_12;
     @name("NoAction") action NoAction_1() {
     }
     @name("NoAction") action NoAction_8() {
@@ -158,7 +162,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop();
     }
     @name("set_ecmp_select") action set_ecmp_select_0(bit<8> ecmp_base, bit<8> ecmp_count) {
-        hash<bit<14>, bit<10>, tuple_0, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);
+        tmp_9.field = hdr.ipv4.srcAddr;
+        tmp_9.field_0 = hdr.ipv4.dstAddr;
+        tmp_9.field_1 = hdr.ipv4.protocol;
+        tmp_9.field_2 = hdr.tcp.srcPort;
+        tmp_9.field_3 = hdr.tcp.dstPort;
+        tmp_9.field_4 = meta.ingress_metadata.flowlet_id;
+        hash<bit<14>, bit<10>, tuple_0, bit<20>>(tmp_8, HashAlgorithm.crc16, (bit<10>)ecmp_base, tmp_9, (bit<20>)ecmp_count);
+        meta.ingress_metadata.ecmp_offset = tmp_8;
     }
     @name("set_nhop") action set_nhop_0(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;
@@ -167,9 +178,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("lookup_flowlet_map") action lookup_flowlet_map_0() {
         hash<bit<13>, bit<13>, tuple_1, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id_1.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_id_1.read(tmp_10, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        meta.ingress_metadata.flowlet_id = tmp_10;
         meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
-        flowlet_lasttime_1.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime_1.read(tmp_12, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        meta.ingress_metadata.flowlet_lasttime = tmp_12;
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime_1.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
     }
@@ -265,14 +278,21 @@ struct tuple_2 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_14;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_2, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_14 = ipv4_checksum.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_14) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_16;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_2, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_16 = ipv4_checksum_2.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_16;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
@@ -216,14 +216,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_16_samples_outputs/hash-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2-frontend.p4
@@ -35,8 +35,12 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 }
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
+    bit<16> tmp;
+    tuple<bit<32>> tmp_0;
     @name("a") action a_0() {
-        hash<bit<16>, bit<16>, tuple<bit<32>>, bit<32>>(meta.hash.hash, HashAlgorithm.crc16, 16w0, { meta.ipv4.lkp_ipv4_sa }, 32w65536);
+        tmp_0 = { meta.ipv4.lkp_ipv4_sa };
+        hash<bit<16>, bit<16>, tuple<bit<32>>, bit<32>>(tmp, HashAlgorithm.crc16, 16w0, tmp_0, 32w65536);
+        meta.hash.hash = tmp;
     }
     apply {
         a_0();

--- a/testdata/p4_16_samples_outputs/hash-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2-midend.p4
@@ -39,8 +39,12 @@ struct tuple_0 {
 }
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
+    bit<16> tmp_1;
+    tuple_0 tmp_2;
     @name("a") action a_0() {
-        hash<bit<16>, bit<16>, tuple_0, bit<32>>(meta.hash.hash, HashAlgorithm.crc16, 16w0, { meta.ipv4.lkp_ipv4_sa }, 32w65536);
+        tmp_2.field = meta.ipv4.lkp_ipv4_sa;
+        hash<bit<16>, bit<16>, tuple_0, bit<32>>(tmp_1, HashAlgorithm.crc16, 16w0, tmp_2, 32w65536);
+        meta.hash.hash = tmp_1;
     }
     @hidden table tbl_a {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue134-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2-first.p4
@@ -40,8 +40,10 @@ control VerifyChecksumI(in H hdr, inout M meta) {
 }
 
 control ComputeChecksumI(inout H hdr, inout M meta) {
+    Checksum16() c16;
     apply {
-        update_checksum<tuple<bit<16>>, bit<16>>(hdr.ipv4.ihl == 4w5, { 16w0 }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = c16.get<tuple<bit<1>>>({ 1w0 });
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue134-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2-frontend.p4
@@ -40,8 +40,13 @@ control VerifyChecksumI(in H hdr, inout M meta) {
 }
 
 control ComputeChecksumI(inout H hdr, inout M meta) {
+    bit<16> tmp;
+    @name("c16") Checksum16() c16_0;
     apply {
-        update_checksum<tuple<bit<16>>, bit<16>>(hdr.ipv4.ihl == 4w5, { 16w0 }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp = c16_0.get<tuple<bit<1>>>({1w0});
+            hdr.ipv4.hdrChecksum = tmp;
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue134-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2-midend.p4
@@ -40,12 +40,17 @@ control VerifyChecksumI(in H hdr, inout M meta) {
 }
 
 struct tuple_0 {
-    bit<16> field;
+    bit<1> field;
 }
 
 control ComputeChecksumI(inout H hdr, inout M meta) {
+    bit<16> tmp_0;
+    @name("c16") Checksum16() c16;
     apply {
-        update_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { 16w0 }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 4w5) {
+            tmp_0 = c16.get<tuple_0>({ 1w0 });
+            hdr.ipv4.hdrChecksum = tmp_0;
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue134-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2.p4
@@ -40,8 +40,12 @@ control VerifyChecksumI(in H hdr, inout M meta) {
 }
 
 control ComputeChecksumI(inout H hdr, inout M meta) {
+    Checksum16() c16;
     apply {
-        update_checksum(hdr.ipv4.ihl == 5, { 16w0 }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.ihl == 5) {
+            hdr.ipv4.hdrChecksum = c16.get({1w0});
+            ;
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue249-first.p4
+++ b/testdata/p4_16_samples_outputs/issue249-first.p4
@@ -57,14 +57,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue249-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue249-frontend.p4
@@ -57,14 +57,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp;
+    bool tmp_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_0 = hdr.ipv4.hdrChecksum == tmp;
+        if (tmp_0) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_1 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue249-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue249-midend.p4
@@ -71,14 +71,21 @@ struct tuple_0 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_2 = ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_2) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_4;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_4 = ipv4_checksum_2.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_4;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue249.p4
+++ b/testdata/p4_16_samples_outputs/issue249.p4
@@ -57,14 +57,17 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue270-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2-first.p4
@@ -43,16 +43,28 @@ control Eg(inout H hdrs, inout M meta, inout standard_metadata_t standard_meta) 
 action drop() {
 }
 control VerifyChecksumI(in H hdr, inout M meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        bit<16> inner_cksum = inner_ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        bit<16> cksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.inner_ipv4.ihl == 4w5 && hdr.inner_ipv4.hdrChecksum != inner_cksum) 
+            drop();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum != cksum) 
+            drop();
     }
 }
 
 control ComputeChecksumI(inout H hdr, inout M meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        bit<16> inner_cksum = inner_ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        bit<16> cksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.inner_ipv4.ihl == 4w5) 
+            hdr.inner_ipv4.hdrChecksum = inner_cksum;
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = cksum;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue270-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2-frontend.p4
@@ -40,17 +40,43 @@ control Eg(inout H hdrs, inout M meta, inout standard_metadata_t standard_meta) 
     }
 }
 
+action drop() {
+}
 control VerifyChecksumI(in H hdr, inout M meta) {
+    bit<16> inner_cksum_0;
+    bit<16> cksum_0;
+    bit<16> tmp;
+    bit<16> tmp_0;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp = inner_ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        inner_cksum_0 = tmp;
+        tmp_0 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        cksum_0 = tmp_0;
+        if (hdr.inner_ipv4.ihl == 4w5 && hdr.inner_ipv4.hdrChecksum != inner_cksum_0) 
+            drop();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum != cksum_0) 
+            drop();
     }
 }
 
 control ComputeChecksumI(inout H hdr, inout M meta) {
+    bit<16> inner_cksum_1;
+    bit<16> cksum_1;
+    bit<16> tmp_1;
+    bit<16> tmp_2;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_1 = inner_ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        inner_cksum_1 = tmp_1;
+        tmp_2 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        cksum_1 = tmp_2;
+        if (hdr.inner_ipv4.ihl == 4w5) 
+            hdr.inner_ipv4.hdrChecksum = inner_cksum_1;
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = cksum_1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue270-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2-midend.p4
@@ -55,16 +55,48 @@ struct tuple_0 {
 }
 
 control VerifyChecksumI(in H hdr, inout M meta) {
+    bit<16> tmp_3;
+    bit<16> tmp_4;
+    @name(".drop") action drop_0() {
+    }
+    @name(".drop") action drop_3() {
+    }
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
+    @hidden table tbl_drop {
+        actions = {
+            drop_0();
+        }
+        const default_action = drop_0();
+    }
+    @hidden table tbl_drop_0 {
+        actions = {
+            drop_3();
+        }
+        const default_action = drop_3();
+    }
     apply {
-        verify_checksum<tuple_0, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_3 = inner_ipv4_checksum.get<tuple_0>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        tmp_4 = ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.inner_ipv4.ihl == 4w5 && hdr.inner_ipv4.hdrChecksum != tmp_3) 
+            tbl_drop.apply();
+        if (hdr.ipv4.ihl == 4w5 && hdr.ipv4.hdrChecksum != tmp_4) 
+            tbl_drop_0.apply();
     }
 }
 
 control ComputeChecksumI(inout H hdr, inout M meta) {
+    bit<16> tmp_5;
+    bit<16> tmp_6;
+    @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_0, bit<16>>(hdr.inner_ipv4.ihl == 4w5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum<tuple_0, bit<16>>(hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_5 = inner_ipv4_checksum_2.get<tuple_0>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        tmp_6 = ipv4_checksum_2.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.inner_ipv4.ihl == 4w5) 
+            hdr.inner_ipv4.hdrChecksum = tmp_5;
+        if (hdr.ipv4.ihl == 4w5) 
+            hdr.ipv4.hdrChecksum = tmp_6;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue270-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2.p4
@@ -43,16 +43,32 @@ control Eg(inout H hdrs, inout M meta, inout standard_metadata_t standard_meta) 
 action drop() {
 }
 control VerifyChecksumI(in H hdr, inout M meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(hdr.inner_ipv4.ihl == 5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum(hdr.ipv4.ihl == 5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        bit<16> inner_cksum = inner_ipv4_checksum.get({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        bit<16> cksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.inner_ipv4.ihl == 5 && hdr.inner_ipv4.hdrChecksum != inner_cksum) {
+            drop();
+        }
+        if (hdr.ipv4.ihl == 5 && hdr.ipv4.hdrChecksum != cksum) {
+            drop();
+        }
     }
 }
 
 control ComputeChecksumI(inout H hdr, inout M meta) {
+    Checksum16() inner_ipv4_checksum;
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(hdr.inner_ipv4.ihl == 5, { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr }, hdr.inner_ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum(hdr.ipv4.ihl == 5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        bit<16> inner_cksum = inner_ipv4_checksum.get({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+        bit<16> cksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.inner_ipv4.ihl == 5) {
+            hdr.inner_ipv4.hdrChecksum = inner_cksum;
+        }
+        if (hdr.ipv4.ihl == 5) {
+            hdr.ipv4.hdrChecksum = cksum;
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
@@ -100,14 +100,17 @@ control TopDeparser(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == (ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }))) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
@@ -95,14 +95,23 @@ control TopDeparser(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp;
+    bool tmp_0;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_0 = hdr.ipv4.hdrChecksum == tmp;
+        if (tmp_0) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_1;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_1 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
@@ -114,14 +114,21 @@ struct tuple_0 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    bit<16> tmp_2;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        verify_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_2 = ipv4_checksum.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_2) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    bit<16> tmp_4;
+    @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        update_checksum<tuple_0, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        tmp_4 = ipv4_checksum_2.get<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_4;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue298-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2.p4
@@ -100,14 +100,17 @@ control TopDeparser(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        verify_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        if (hdr.ipv4.hdrChecksum == ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr })) 
+            mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() ipv4_checksum;
     apply {
-        update_checksum(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        hdr.ipv4.hdrChecksum = ipv4_checksum.get({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2-frontend.p4
@@ -19,9 +19,13 @@ struct Metadata {
 }
 
 parser parserI(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    H tmp;
+    bit<32> tmp_0;
     state start {
         pkt.extract<S>(hdr.s1);
-        pkt.extract<H>(hdr.h, hdr.s1.size);
+        tmp_0 = hdr.s1.size;
+        pkt.extract<H>(tmp, tmp_0);
+        hdr.h = tmp;
         pkt.extract<S>(hdr.s2);
         transition accept;
     }

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2-midend.p4
@@ -19,9 +19,13 @@ struct Metadata {
 }
 
 parser parserI(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    H tmp_1;
+    bit<32> tmp_2;
     state start {
         pkt.extract<S>(hdr.s1);
-        pkt.extract<H>(hdr.h, hdr.s1.size);
+        tmp_2 = hdr.s1.size;
+        pkt.extract<H>(tmp_1, tmp_2);
+        hdr.h = tmp_1;
         pkt.extract<S>(hdr.s2);
         transition accept;
     }

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-frontend.p4
@@ -19,10 +19,18 @@ struct Metadata {
 }
 
 parser parserI(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    H tmp;
+    bit<32> tmp_0;
+    H tmp_1;
+    bit<32> tmp_2;
     state start {
         pkt.extract<S>(hdr.s1);
-        pkt.extract<H>(hdr.h1, hdr.s1.size);
-        pkt.extract<H>(hdr.h2, hdr.s1.size);
+        tmp_0 = hdr.s1.size;
+        pkt.extract<H>(tmp, tmp_0);
+        hdr.h1 = tmp;
+        tmp_2 = hdr.s1.size;
+        pkt.extract<H>(tmp_1, tmp_2);
+        hdr.h2 = tmp_1;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-midend.p4
@@ -19,10 +19,18 @@ struct Metadata {
 }
 
 parser parserI(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    H tmp_3;
+    bit<32> tmp_4;
+    H tmp_5;
+    bit<32> tmp_6;
     state start {
         pkt.extract<S>(hdr.s1);
-        pkt.extract<H>(hdr.h1, hdr.s1.size);
-        pkt.extract<H>(hdr.h2, hdr.s1.size);
+        tmp_4 = hdr.s1.size;
+        pkt.extract<H>(tmp_3, tmp_4);
+        hdr.h1 = tmp_3;
+        tmp_6 = hdr.s1.size;
+        pkt.extract<H>(tmp_5, tmp_6);
+        hdr.h2 = tmp_5;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-first.p4
@@ -38,14 +38,19 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 }
 
 control vc(in Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        verify_checksum<tuple<bit<16>, bit<16>>, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get<tuple<bit<16>, bit<16>>>({ hdr.h.d, hdr.h.c });
+        if (16w0 != tmp) 
+            mark_to_drop();
     }
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        update_checksum<tuple<bit<16>>, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get<tuple<bit<16>>>({ hdr.h.d });
+        hdr.h.c = tmp;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-frontend.p4
@@ -38,14 +38,25 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 }
 
 control vc(in Parsed_packet hdr, inout Metadata meta) {
+    bit<16> tmp_0;
+    bit<16> tmp;
+    @name("ck") Checksum16() ck_0;
     apply {
-        verify_checksum<tuple<bit<16>, bit<16>>, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        tmp = ck_0.get<tuple<bit<16>, bit<16>>>({ hdr.h.d, hdr.h.c });
+        tmp_0 = tmp;
+        if (16w0 != tmp_0) 
+            mark_to_drop();
     }
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
+    bit<16> tmp_1;
+    bit<16> tmp_2;
+    @name("ck") Checksum16() ck_1;
     apply {
-        update_checksum<tuple<bit<16>>, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        tmp_2 = ck_1.get<tuple<bit<16>>>({ hdr.h.d });
+        tmp_1 = tmp_2;
+        hdr.h.c = tmp_1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-midend.p4
@@ -52,8 +52,12 @@ struct tuple_0 {
 }
 
 control vc(in Parsed_packet hdr, inout Metadata meta) {
+    bit<16> tmp_4;
+    @name("ck") Checksum16() ck_2;
     apply {
-        verify_checksum<tuple_0, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        tmp_4 = ck_2.get<tuple_0>({ hdr.h.d, hdr.h.c });
+        if (16w0 != tmp_4) 
+            mark_to_drop();
     }
 }
 
@@ -62,8 +66,11 @@ struct tuple_1 {
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
+    bit<16> tmp_6;
+    @name("ck") Checksum16() ck_3;
     apply {
-        update_checksum<tuple_1, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        tmp_6 = ck_3.get<tuple_1>({ hdr.h.d });
+        hdr.h.c = tmp_6;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2.p4
@@ -38,14 +38,19 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 }
 
 control vc(in Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        verify_checksum(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get({ hdr.h.d, hdr.h.c });
+        if (0 != tmp) 
+            mark_to_drop();
     }
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        update_checksum(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get({ hdr.h.d });
+        hdr.h.c = tmp;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-first.p4
+++ b/testdata/p4_16_samples_outputs/issue655-first.p4
@@ -38,14 +38,19 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 }
 
 control vc(in Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        verify_checksum<tuple<bit<16>, bit<16>>, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get<tuple<bit<16>, bit<16>>>({ hdr.h.d, hdr.h.c });
+        if (16w0 != tmp) 
+            mark_to_drop();
     }
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        update_checksum<tuple<bit<16>>, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get<tuple<bit<16>>>({ hdr.h.d });
+        hdr.h.c = tmp;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-frontend.p4
@@ -38,14 +38,25 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 }
 
 control vc(in Parsed_packet hdr, inout Metadata meta) {
+    bit<16> tmp_0;
+    bit<16> tmp;
+    @name("ck") Checksum16() ck_0;
     apply {
-        verify_checksum<tuple<bit<16>, bit<16>>, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        tmp = ck_0.get<tuple<bit<16>, bit<16>>>({ hdr.h.d, hdr.h.c });
+        tmp_0 = tmp;
+        if (16w0 != tmp_0) 
+            mark_to_drop();
     }
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
+    bit<16> tmp_1;
+    bit<16> tmp_2;
+    @name("ck") Checksum16() ck_1;
     apply {
-        update_checksum<tuple<bit<16>>, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        tmp_2 = ck_1.get<tuple<bit<16>>>({ hdr.h.d });
+        tmp_1 = tmp_2;
+        hdr.h.c = tmp_1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-midend.p4
@@ -52,8 +52,12 @@ struct tuple_0 {
 }
 
 control vc(in Parsed_packet hdr, inout Metadata meta) {
+    bit<16> tmp_4;
+    @name("ck") Checksum16() ck_2;
     apply {
-        verify_checksum<tuple_0, bit<16>>(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        tmp_4 = ck_2.get<tuple_0>({ hdr.h.d, hdr.h.c });
+        if (16w0 != tmp_4) 
+            mark_to_drop();
     }
 }
 
@@ -62,8 +66,11 @@ struct tuple_1 {
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
+    bit<16> tmp_6;
+    @name("ck") Checksum16() ck_3;
     apply {
-        update_checksum<tuple_1, bit<16>>(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        tmp_6 = ck_3.get<tuple_1>({ hdr.h.d });
+        hdr.h.c = tmp_6;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655.p4
+++ b/testdata/p4_16_samples_outputs/issue655.p4
@@ -38,14 +38,19 @@ control cEgress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
 }
 
 control vc(in Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        verify_checksum(true, { hdr.h.d, hdr.h.c }, 16w0, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get({ hdr.h.d, hdr.h.c });
+        if (0 != tmp) 
+            mark_to_drop();
     }
 }
 
 control uc(inout Parsed_packet hdr, inout Metadata meta) {
+    Checksum16() ck;
     apply {
-        update_checksum(true, { hdr.h.d }, hdr.h.c, HashAlgorithm.csum16);
+        bit<16> tmp = ck.get({ hdr.h.d });
+        hdr.h.c = tmp;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/side_effects-frontend.p4
+++ b/testdata/p4_16_samples_outputs/side_effects-frontend.p4
@@ -22,27 +22,34 @@ control my() {
     bit<1> tmp_9;
     bit<1> tmp_10;
     bit<1> tmp_11;
+    bit<1> tmp_12;
+    bit<1> tmp_13;
+    bit<1> tmp_14;
     apply {
         a_0 = 1w0;
-        tmp = g(a_0);
-        tmp_0 = tmp;
-        tmp_1 = f(a_0, tmp_0);
-        a_0 = tmp_1;
-        tmp_2 = g(a_0);
-        tmp_3 = tmp_2;
-        tmp_4 = f(s_0[a_0].z, tmp_3);
-        a_0 = tmp_4;
-        tmp_5 = g(a_0);
-        tmp_6 = tmp_5;
-        tmp_7 = s_0[tmp_6].z;
-        tmp_8 = f(tmp_7, a_0);
-        s_0[tmp_6].z = tmp_7;
-        a_0 = tmp_8;
-        tmp_9 = g(a_0);
-        a_0 = tmp_9;
-        tmp_10 = g(a_0[0:0]);
-        a_0[0:0] = tmp_10;
-        tmp_11 = g(a_0);
+        tmp = a_0;
+        tmp_0 = g(a_0);
+        tmp_1 = tmp_0;
+        tmp_2 = f(tmp, tmp_1);
+        a_0 = tmp_2;
+        tmp_3 = s_0[a_0].z;
+        tmp_4 = g(a_0);
+        tmp_5 = tmp_4;
+        tmp_6 = f(tmp_3, tmp_5);
+        s_0[a_0].z = tmp_3;
+        a_0 = tmp_6;
+        tmp_7 = g(a_0);
+        tmp_8 = tmp_7;
+        tmp_9 = s_0[tmp_8].z;
+        tmp_10 = a_0;
+        tmp_11 = f(tmp_9, tmp_10);
+        s_0[tmp_8].z = tmp_9;
+        a_0 = tmp_11;
+        tmp_12 = g(a_0);
+        a_0 = tmp_12;
+        tmp_13 = g(a_0[0:0]);
+        a_0[0:0] = tmp_13;
+        tmp_14 = g(a_0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/side_effects-midend.p4
+++ b/testdata/p4_16_samples_outputs/side_effects-midend.p4
@@ -9,32 +9,37 @@ package top(c _c);
 control my() {
     bit<1> a;
     H[2] s;
-    bit<1> tmp_12;
-    bit<1> tmp_14;
     bit<1> tmp_15;
-    bit<1> tmp_17;
+    bit<1> tmp_16;
     bit<1> tmp_18;
+    bit<1> tmp_19;
     bit<1> tmp_20;
-    bit<1> tmp_21;
     bit<1> tmp_22;
     bit<1> tmp_23;
+    bit<1> tmp_25;
+    bit<1> tmp_27;
+    bit<1> tmp_28;
+    bit<1> tmp_29;
     @hidden action act() {
         a = 1w0;
-        tmp_12 = g(a);
-        tmp_14 = f(a, tmp_12);
-        a = tmp_14;
-        tmp_15 = g(a);
-        tmp_17 = f(s[a].z, tmp_15);
-        a = tmp_17;
-        tmp_18 = g(a);
-        tmp_20 = s[tmp_18].z;
-        tmp_21 = f(tmp_20, a);
-        s[tmp_18].z = tmp_20;
-        a = tmp_21;
-        tmp_22 = g(a);
+        tmp_15 = 1w0;
+        tmp_16 = g(a);
+        tmp_18 = f(tmp_15, tmp_16);
+        a = tmp_18;
+        tmp_19 = s[tmp_18].z;
+        tmp_20 = g(a);
+        tmp_22 = f(tmp_19, tmp_20);
+        s[a].z = tmp_19;
         a = tmp_22;
-        tmp_23 = g(a[0:0]);
-        a[0:0] = tmp_23;
+        tmp_23 = g(a);
+        tmp_25 = s[tmp_23].z;
+        tmp_27 = f(tmp_25, a);
+        s[tmp_23].z = tmp_25;
+        a = tmp_27;
+        tmp_28 = g(a);
+        a = tmp_28;
+        tmp_29 = g(a[0:0]);
+        a[0:0] = tmp_29;
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/uninit-frontend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-frontend.p4
@@ -16,15 +16,16 @@ parser p1(packet_in p, out Header h) {
     bit<32> tmp_0;
     bit<32> tmp_1;
     bit<32> tmp_2;
+    bit<32> tmp_3;
     state start {
         h.data1 = 32w0;
         func(h);
         tmp = h.data2;
         tmp_0 = h.data2;
-        tmp_1 = g(tmp, tmp_0);
-        h.data2 = tmp;
-        tmp_2 = tmp_1;
-        g(h.data2, tmp_2);
+        tmp_1 = h.data2;
+        tmp_2 = g(tmp_0, tmp_1);
+        tmp_3 = tmp_2;
+        g(tmp, tmp_3);
         h.data2 = h.data3 + 32w1;
         stack_0[1].isValid();
         transition select(h.isValid()) {

--- a/testdata/p4_16_samples_outputs/uninit-midend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-midend.p4
@@ -12,19 +12,20 @@ parser p1(packet_in p, out Header h) {
     Header[2] stack;
     bool c_1;
     bool d;
-    bit<32> tmp_3;
     bit<32> tmp_4;
     bit<32> tmp_5;
     bit<32> tmp_6;
+    bit<32> tmp_7;
+    bit<32> tmp_8;
     state start {
         h.data1 = 32w0;
         func(h);
-        tmp_3 = h.data2;
         tmp_4 = h.data2;
-        tmp_5 = g(tmp_3, tmp_4);
-        h.data2 = tmp_3;
-        tmp_6 = tmp_5;
-        g(h.data2, tmp_6);
+        tmp_5 = h.data2;
+        tmp_6 = h.data2;
+        tmp_7 = g(tmp_5, tmp_6);
+        tmp_8 = tmp_7;
+        g(tmp_4, tmp_8);
         h.data2 = h.data3 + 32w1;
         stack[1].isValid();
         transition select((bit<1>)h.isValid()) {

--- a/testdata/p4_16_samples_outputs/uninit.p4-stderr
+++ b/testdata/p4_16_samples_outputs/uninit.p4-stderr
@@ -3,6 +3,9 @@ uninit.p4(35): warning: h may not be completely initialized
              ^
 uninit.p4(36): warning: h.data2 may be uninitialized
         g(h.data2, g(h.data2, h.data2)); // uninitialized
+          ^^^^^^^
+uninit.p4(36): warning: h.data2 may be uninitialized
+        g(h.data2, g(h.data2, h.data2)); // uninitialized
                      ^^^^^^^
 uninit.p4(36): warning: h.data2 may be uninitialized
         g(h.data2, g(h.data2, h.data2)); // uninitialized


### PR DESCRIPTION
…ffects; … (#858)"

This reverts commit f09a95dcda68ca18a1528be6a63a16f2b8074d46.

This commit breaks all existing programs using checksums. This is a
change that needs to be staged more carefully, announced on the
mailing list and deprecate the old way in a more graceful manner,
giving people the chance of transitioning their programs.