### PR TITLE
Fix for issue #870: support slice and concat in ebpf back-end

### DIFF
--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -27,6 +27,7 @@ set (P4C_EBPF_SRCS
   codeGen.cpp
   ebpfModel.cpp
   midend.cpp
+  lower.cpp
   )
 
 set (P4C_EBPF_HDRS
@@ -42,6 +43,7 @@ set (P4C_EBPF_HDRS
   ebpfType.h
   midend.h
   target.h
+  lower.h
   )
 
 add_cpplint_files(${CMAKE_CURRENT_SOURCE_DIR} "${P4C_EBPF_SRCS};${P4C_EBPF_HDRS}")

--- a/backends/ebpf/codeGen.h
+++ b/backends/ebpf/codeGen.h
@@ -72,9 +72,8 @@ class CodeGenInspector : public Inspector {
     { return notSupported(expression); }
     bool preorder(const IR::Mask* expression) override
     { return notSupported(expression); }
-    bool preorder(const IR::Slice* expression) override
+    bool preorder(const IR::Slice* expression) override  // should not happen
     { return notSupported(expression); }
-
     bool preorder(const IR::StringLiteral* expression) override;
     bool preorder(const IR::ListExpression* expression) override;
     bool preorder(const IR::PathExpression* expression) override;

--- a/backends/ebpf/lower.cpp
+++ b/backends/ebpf/lower.cpp
@@ -1,0 +1,118 @@
+/*
+Copyright 2017 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "lower.h"
+
+namespace EBPF {
+
+const IR::Expression* LowerExpressions::shift(const IR::Operation_Binary* expression) const {
+    auto rhs = expression->right;
+    auto rhstype = typeMap->getType(rhs, true);
+    if (rhstype->is<IR::Type_InfInt>()) {
+        auto cst = rhs->to<IR::Constant>();
+        mpz_class maxShift = Util::shift_left(1, LowerExpressions::maxShiftWidth);
+        if (cst->value > maxShift)
+            ::error("%1%: shift amount limited to %2% on this target", expression, maxShift);
+    } else {
+        BUG_CHECK(rhstype->is<IR::Type_Bits>(), "%1%: expected a bit<> type", rhstype);
+        auto bs = rhstype->to<IR::Type_Bits>();
+        if (bs->size > LowerExpressions::maxShiftWidth)
+            ::error("%1%: shift amount limited to %2% bits on this target",
+                    expression, LowerExpressions::maxShiftWidth);
+    }
+    auto ltype = typeMap->getType(getOriginal(), true);
+    typeMap->setType(expression, ltype);
+    return expression;
+}
+
+const IR::Node* LowerExpressions::postorder(IR::Expression* expression) {
+    // Just update the typeMap incrementally.
+    auto type = typeMap->getType(getOriginal(), true);
+    typeMap->setType(expression, type);
+    return expression;
+}
+
+const IR::Node* LowerExpressions::postorder(IR::Slice* expression) {
+    // This is in a RHS expression a[m:l]  ->  (cast)(a >> l)
+    int h = expression->getH();
+    int l = expression->getL();
+    const IR::Expression* expr;
+    if (l != 0) {
+        expr = new IR::Shr(expression->e0->srcInfo, expression->e0, new IR::Constant(l));
+        auto e0type = typeMap->getType(expression->e0, true);
+        typeMap->setType(expr, e0type);
+    } else {
+        expr = expression->e0;
+    }
+    auto type = IR::Type_Bits::get(h - l + 1);
+    auto result = new IR::Cast(expression->srcInfo, type, expr);
+    typeMap->setType(result, type);
+    LOG3("Replaced " << expression << " with " << result);
+    return result;
+}
+
+const IR::Node* LowerExpressions::postorder(IR::Concat* expression) {
+    // a ++ b  -> ((cast)a << sizeof(b)) | ((cast)b & mask)
+    auto type = typeMap->getType(expression->right, true);
+    auto resulttype = typeMap->getType(getOriginal(), true);
+    BUG_CHECK(type->is<IR::Type_Bits>(), "%1%: expected a bitstring got a %2%",
+              expression->right, type);
+    BUG_CHECK(resulttype->is<IR::Type_Bits>(), "%1%: expected a bitstring got a %2%",
+              expression->right, type);
+    unsigned sizeofb = type->to<IR::Type_Bits>()->size;
+    unsigned sizeofresult = resulttype->to<IR::Type_Bits>()->size;
+    auto cast0 = new IR::Cast(expression->left->srcInfo, resulttype, expression->left);
+    auto cast1 = new IR::Cast(expression->right->srcInfo, resulttype, expression->right);
+
+    auto sh = new IR::Shl(cast0->srcInfo, cast0, new IR::Constant(sizeofb));
+    mpz_class m = Util::maskFromSlice(sizeofb, 0);
+    auto mask = new IR::Constant(expression->right->srcInfo,
+                                 IR::Type_Bits::get(sizeofresult), m, 16);
+    auto and0 = new IR::BAnd(expression->right->srcInfo, cast1, mask);
+    auto result = new IR::BOr(expression->srcInfo, sh, and0);
+    typeMap->setType(cast0, resulttype);
+    typeMap->setType(cast1, resulttype);
+    typeMap->setType(result, resulttype);
+    typeMap->setType(sh, resulttype);
+    typeMap->setType(and0, resulttype);
+    LOG3("Replaced " << expression << " with " << result);
+    return result;
+}
+
+const IR::Node* LowerExpressions::postorder(IR::Cast* expression) {
+    auto destType = typeMap->getType(getOriginal(), true);
+    auto srcType = typeMap->getType(expression->expr, true);
+    if (destType->is<IR::Type_Boolean>() && srcType->is<IR::Type_Bits>()) {
+        auto zero = new IR::Constant(srcType, 0);
+        auto cmp = new IR::Equ(expression->srcInfo, expression->expr, zero);
+        typeMap->setType(cmp, destType);
+        LOG3("Replaced " << expression << " with " << cmp);
+        return cmp;
+    } else if (destType->is<IR::Type_Bits>() && srcType->is<IR::Type_Boolean>()) {
+        auto mux = new IR::Mux(expression->srcInfo, expression->expr,
+                               new IR::Constant(destType, 1),
+                               new IR::Constant(destType, 0));
+        typeMap->setType(mux, destType);
+        LOG3("Replaced " << expression << " with " << mux);
+        return mux;
+    }
+
+    // This may be a new expression
+    typeMap->setType(expression, destType);
+    return expression;
+}
+
+}  // namespace EBPF

--- a/backends/ebpf/lower.h
+++ b/backends/ebpf/lower.h
@@ -1,0 +1,59 @@
+/*
+Copyright 2017 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _BACKENDS_EBPF_LOWER_H_
+#define _BACKENDS_EBPF_LOWER_H_
+
+#include "ir/ir.h"
+#include "frontends/p4/typeChecking/typeChecker.h"
+#include "frontends/common/resolveReferences/resolveReferences.h"
+
+namespace EBPF {
+
+/**
+  This pass rewrites expressions which are not supported natively on EBPF.
+*/
+class LowerExpressions : public Transform {
+    P4::TypeMap* typeMap;
+    // Cannot shift with a value larger than 5 bits
+    const int maxShiftWidth = 5;
+    const IR::Expression* shift(const IR::Operation_Binary* expression) const;
+ public:
+    explicit LowerExpressions(P4::TypeMap* typeMap) : typeMap(typeMap)
+    { CHECK_NULL(typeMap); setName("Lower"); }
+
+    const IR::Node* postorder(IR::Shl* expression) override
+    { return shift(expression); }
+    const IR::Node* postorder(IR::Shr* expression) override
+    { return shift(expression); }
+    const IR::Node* postorder(IR::Expression* expression) override;
+    const IR::Node* postorder(IR::Slice* expression) override;
+    const IR::Node* postorder(IR::Concat* expression) override;
+    const IR::Node* postorder(IR::Cast* expression) override;
+};
+
+class Lower : public PassManager {
+ public:
+    Lower(P4::ReferenceMap* refMap, P4::TypeMap* typeMap) {
+        setName("Lower");
+        passes.push_back(new P4::TypeChecking(refMap, typeMap));
+        passes.push_back(new LowerExpressions(typeMap));
+    }
+};
+
+}  // namespace EBPF
+
+#endif  /* _BACKENDS_EBPF_LOWER_H_ */

--- a/backends/ebpf/midend.cpp
+++ b/backends/ebpf/midend.cpp
@@ -31,6 +31,7 @@ limitations under the License.
 #include "midend/noMatch.h"
 #include "midend/convertEnums.h"
 #include "midend/midEndLast.h"
+#include "midend/removeLeftSlices.h"
 #include "frontends/p4/uniqueNames.h"
 #include "frontends/p4/moveDeclarations.h"
 #include "frontends/p4/typeMap.h"
@@ -43,6 +44,7 @@ limitations under the License.
 #include "frontends/common/constantFolding.h"
 #include "frontends/p4/strengthReduction.h"
 #include "frontends/p4/simplifyParsers.h"
+#include "lower.h"
 
 namespace EBPF {
 
@@ -115,6 +117,8 @@ const IR::ToplevelBlock* MidEnd::run(EbpfOptions& options, const IR::P4Program* 
         new P4::MoveDeclarations(),  // more may have been introduced
         new P4::SimplifyControlFlow(&refMap, &typeMap),
         new P4::ValidateTableProperties({"implementation"}),
+        new P4::RemoveLeftSlices(&refMap, &typeMap),
+        new EBPF::Lower(&refMap, &typeMap),
         evaluator,
         new P4::MidEndLast()
     };

--- a/testdata/p4_16_samples/issue870_ebpf.p4
+++ b/testdata/p4_16_samples/issue870_ebpf.p4
@@ -1,0 +1,80 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <ebpf_model.p4>
+#include <core.p4>
+
+#include "ebpf_headers.p4"
+
+struct Headers_t
+{
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers)
+{
+    state start
+    {
+        p.extract(headers.ethernet);
+        transition select(headers.ethernet.etherType)
+        {
+            16w0x800 : ip;
+            default : reject;
+        }
+    }
+
+    state ip
+    {
+        p.extract(headers.ipv4);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass)
+{
+    action Reject(IPv4Address add)
+    {
+        pass = false;
+        headers.ipv4.srcAddr[31:0] = add[31:16] ++ add[15:0];
+    }
+
+    table Check_src_ip {
+        key = { headers.ipv4.srcAddr : exact; }
+        actions =
+        {
+            Reject;
+            NoAction;
+        }
+
+        implementation = hash_table(1024);
+        const default_action = NoAction;
+    }
+
+    apply {
+        pass = true;
+
+        if (!headers.ipv4.isValid())
+        {
+            pass = false;
+            return;
+        }
+
+        Check_src_ip.apply();
+    }
+}
+
+ebpfFilter(prs(), pipe()) main;

--- a/testdata/p4_16_samples_outputs/issue870_ebpf-first.p4
+++ b/testdata/p4_16_samples_outputs/issue870_ebpf-first.p4
@@ -1,0 +1,72 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    action Reject(IPv4Address add) {
+        pass = false;
+        headers.ipv4.srcAddr[31:0] = add[31:16] ++ add[15:0];
+    }
+    table Check_src_ip {
+        key = {
+            headers.ipv4.srcAddr: exact @name("headers.ipv4.srcAddr") ;
+        }
+        actions = {
+            Reject();
+            NoAction();
+        }
+        implementation = hash_table(32w1024);
+        const default_action = NoAction();
+    }
+    apply {
+        pass = true;
+        if (!headers.ipv4.isValid()) {
+            pass = false;
+            return;
+        }
+        Check_src_ip.apply();
+    }
+}
+
+ebpfFilter<Headers_t>(prs(), pipe()) main;

--- a/testdata/p4_16_samples_outputs/issue870_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue870_ebpf-frontend.p4
@@ -1,0 +1,72 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    @name("Reject") action Reject_0(IPv4Address add) {
+        pass = false;
+        headers.ipv4.srcAddr[31:0] = add[31:16] ++ add[15:0];
+    }
+    @name("Check_src_ip") table Check_src_ip_0 {
+        key = {
+            headers.ipv4.srcAddr: exact @name("headers.ipv4.srcAddr") ;
+        }
+        actions = {
+            Reject_0();
+            NoAction();
+        }
+        implementation = hash_table(32w1024);
+        const default_action = NoAction();
+    }
+    apply {
+        pass = true;
+        if (!headers.ipv4.isValid()) {
+            pass = false;
+            return;
+        }
+        Check_src_ip_0.apply();
+    }
+}
+
+ebpfFilter<Headers_t>(prs(), pipe()) main;

--- a/testdata/p4_16_samples_outputs/issue870_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue870_ebpf-midend.p4
@@ -1,0 +1,95 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    bool hasReturned_0;
+    @name("NoAction") action NoAction_0() {
+    }
+    @name("Reject") action Reject_0(IPv4Address add) {
+        pass = false;
+        headers.ipv4.srcAddr[31:0] = add[31:16] ++ add[15:0];
+    }
+    @name("Check_src_ip") table Check_src_ip {
+        key = {
+            headers.ipv4.srcAddr: exact @name("headers.ipv4.srcAddr") ;
+        }
+        actions = {
+            Reject_0();
+            NoAction_0();
+        }
+        implementation = hash_table(32w1024);
+        const default_action = NoAction_0();
+    }
+    @hidden action act() {
+        pass = false;
+        hasReturned_0 = true;
+    }
+    @hidden action act_0() {
+        hasReturned_0 = false;
+        pass = true;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+        if (!headers.ipv4.isValid()) {
+            tbl_act_0.apply();
+        }
+        if (!hasReturned_0) 
+            Check_src_ip.apply();
+    }
+}
+
+ebpfFilter<Headers_t>(prs(), pipe()) main;

--- a/testdata/p4_16_samples_outputs/issue870_ebpf.p4
+++ b/testdata/p4_16_samples_outputs/issue870_ebpf.p4
@@ -1,0 +1,72 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract(headers.ipv4);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    action Reject(IPv4Address add) {
+        pass = false;
+        headers.ipv4.srcAddr[31:0] = add[31:16] ++ add[15:0];
+    }
+    table Check_src_ip {
+        key = {
+            headers.ipv4.srcAddr: exact;
+        }
+        actions = {
+            Reject;
+            NoAction;
+        }
+        implementation = hash_table(1024);
+        const default_action = NoAction;
+    }
+    apply {
+        pass = true;
+        if (!headers.ipv4.isValid()) {
+            pass = false;
+            return;
+        }
+        Check_src_ip.apply();
+    }
+}
+
+ebpfFilter(prs(), pipe()) main;


### PR DESCRIPTION
Some of this code is copied from the bmv2 back-end.
Arguably, some of this code should be moved into a mid-end pass.