### PR TITLE
Fix for issue #871

### DIFF
--- a/frontends/p4/substitution.cpp
+++ b/frontends/p4/substitution.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 namespace P4 {
 bool TypeVariableSubstitution::compose(const IR::Node* errorLocation,
                                        const IR::ITypeVar* var, const IR::Type* substitution) {
-    LOG3("Adding " << var << "->" << substitution << " to substitution");
+    LOG3("Adding " << dbp(var) << "->" << dbp(substitution) << " to substitution");
     if (substitution->is<IR::Type_Dontcare>())
         return true;
 

--- a/frontends/p4/substitution.h
+++ b/frontends/p4/substitution.h
@@ -64,7 +64,7 @@ class TypeSubstitution : public IHasDbPrint {
         for (auto it : binding) {
             if (!first)
                 out << std::endl;
-            out << it.first << " -> " << it.second;
+            out << dbp(it.first) << " -> " << dbp(it.second);
             first = false;
         }
     }

--- a/frontends/p4/substitutionVisitor.h
+++ b/frontends/p4/substitutionVisitor.h
@@ -44,14 +44,17 @@ class TypeVariableSubstitutionVisitor : public Transform {
     bool  replace;  // If true variables that map to variables are just replaced
                     // in the ParameterList of the replaced object; else they
                     // are removed.
+    const IR::Node* replacement(IR::ITypeVar* typeVariable);
  public:
     explicit TypeVariableSubstitutionVisitor(const TypeVariableSubstitution *bindings,
                                              bool replace = false)
             : bindings(bindings), replace(replace) { setName("TypeVariableSubstitution"); }
 
     const IR::Node* preorder(IR::TypeParameters *tps) override;
-    const IR::Node* preorder(IR::Type_Var* typeVariable) override;
-    const IR::Node* preorder(IR::Type_InfInt* typeVariable) override;
+    const IR::Node* preorder(IR::Type_Var* typeVariable) override
+    { return replacement(typeVariable); }
+    const IR::Node* preorder(IR::Type_InfInt* typeVariable) override
+    { return replacement(typeVariable); }
 };
 
 /* Replaces TypeNames with other Types. */

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -2600,9 +2600,10 @@ const IR::Node* TypeInference::postorder(IR::MethodCallExpression* expression) {
         if (tvs == nullptr)
             return expression;
 
-        LOG2("Method type before specialization " << methodType);
+        LOG2("Method type before specialization " << methodType << " with " << tvs);
         TypeVariableSubstitutionVisitor substVisitor(tvs);
         auto specMethodType = methodType->apply(substVisitor);
+        LOG2("Method type after specialization " << specMethodType);
 
         // construct types for the specMethodType, use a new typeChecker
         // that uses the same tables!
@@ -2615,7 +2616,6 @@ const IR::Node* TypeInference::postorder(IR::MethodCallExpression* expression) {
 
         auto functionType = specMethodType->to<IR::Type_MethodBase>();
         BUG_CHECK(functionType != nullptr, "Method type is %1%", specMethodType);
-        LOG2("Method type after specialization " << specMethodType);
 
         if (!functionType->is<IR::Type_Method>())
             BUG("Unexpected type for function %1%", functionType);

--- a/testdata/p4_16_samples/issue871.p4
+++ b/testdata/p4_16_samples/issue871.p4
@@ -1,0 +1,18 @@
+//#include <core.p4>
+
+extern lpf<I> {
+    lpf(I instance_count);
+    T execute<T>(in T data, in I index);
+}
+
+control c() {
+    lpf<bit<32>>(32) lpf_0;
+    apply {
+        lpf_0.execute<bit<8>>(0, 0);
+    }
+}
+
+control e();
+package top(e _e);
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue871-first.p4
+++ b/testdata/p4_16_samples_outputs/issue871-first.p4
@@ -1,0 +1,15 @@
+extern lpf<I> {
+    lpf(I instance_count);
+    T execute<T>(in T data, in I index);
+}
+
+control c() {
+    lpf<bit<32>>(32w32) lpf_0;
+    apply {
+        lpf_0.execute<bit<8>>(8w0, 32w0);
+    }
+}
+
+control e();
+package top(e _e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue871-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue871-frontend.p4
@@ -1,0 +1,15 @@
+extern lpf<I> {
+    lpf(I instance_count);
+    T execute<T>(in T data, in I index);
+}
+
+control c() {
+    @name("lpf_0") lpf<bit<32>>(32w32) lpf_1;
+    apply {
+        lpf_1.execute<bit<8>>(8w0, 32w0);
+    }
+}
+
+control e();
+package top(e _e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue871-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue871-midend.p4
@@ -1,0 +1,24 @@
+extern lpf<I> {
+    lpf(I instance_count);
+    T execute<T>(in T data, in I index);
+}
+
+control c() {
+    @name("lpf_0") lpf<bit<32>>(32w32) lpf_0;
+    @hidden action act() {
+        lpf_0.execute<bit<8>>(8w0, 32w0);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control e();
+package top(e _e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue871.p4
+++ b/testdata/p4_16_samples_outputs/issue871.p4
@@ -1,0 +1,15 @@
+extern lpf<I> {
+    lpf(I instance_count);
+    T execute<T>(in T data, in I index);
+}
+
+control c() {
+    lpf<bit<32>>(32) lpf_0;
+    apply {
+        lpf_0.execute<bit<8>>(0, 0);
+    }
+}
+
+control e();
+package top(e _e);
+top(c()) main;


### PR DESCRIPTION
In a type variable substitution one has to look-up variables until reaching a fix-point; it is not enough to look up a variable once.