### PR TITLE
Remove unreasonable cpplint casting check

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -4,6 +4,7 @@ filter=-build/include_what_you_use
 filter=-legal/copyright
 filter=-runtime/int
 filter=-runtime/references
+filter=-readability/completely_reasonable_casts
 filter=-readability/todo
 filter=-readability/function
 linelength=100

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -198,6 +198,7 @@ _ERROR_CATEGORIES = [
     'readability/alt_tokens',
     'readability/braces',
     'readability/casting',
+    'readability/completely_reasonable_casts',
     'readability/check',
     'readability/constructors',
     'readability/fn_size',
@@ -5287,7 +5288,7 @@ def CheckCasts(filename, clean_lines, linenum, error):
               matched_funcptr.startswith('(*)'))) and
         not Match(r'\s*using\s+\S+\s*=\s*' + matched_type, line) and
         not Search(r'new\(\S+\)\s*' + matched_type, line)):
-      error(filename, linenum, 'readability/casting', 4,
+      error(filename, linenum, 'readability/completely_reasonable_casts', 4,
             'Using deprecated casting style.  '
             'Use static_cast<%s>(...) instead' %
             matched_type)


### PR DESCRIPTION
Currently, cpplint forbids the construct `int(foo)`, insisting that you use `static_cast<int>(foo)`. This check really makes no sense. `int(foo)` is a perfectly good C++-style explicit conversion. It's quite distinct from the C-style cast `(int)foo`, which should indeed be banned. Banning this kind of explicit conversion is exactly the same thing as saying that you should write this:

```c++
auto vec_with_ten_elements = std::vector(10);
```

like this:

```c++
auto vec_with_ten_elements = static_cast<std::vector>(10);
```

Both of those work (believe it or not!) but I think few would argue that the latter is more readable.