### PR TITLE
Use the gold linker if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required (VERSION 3.0.2 FATAL_ERROR)
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
-    MESSAGE("-- Enabling ccache")
+    MESSAGE(STATUS "Enabling ccache")
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif()
 
@@ -130,6 +130,21 @@ add_cxx_compiler_option ("-Wall")
 add_cxx_compiler_option ("-Wextra")
 add_cxx_compiler_option ("-Wno-overloaded-virtual")
 add_cxx_compiler_option ("-Wno-deprecated")
+
+# If we're on GCC, use the gold linker if available.
+if(CMAKE_COMPILER_IS_GNUCC)
+    execute_process(
+            COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version
+            ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
+    if ("${LD_VERSION}" MATCHES "GNU gold")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold")
+        message(STATUS "Using the GNU gold linker.")
+    else ()
+        message(STATUS "Using the default system linker.")
+    endif ()
+    unset(LD_VERSION)
+endif ()
 
 include_directories (
   ${P4C_SOURCE_DIR}/frontends

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -149,7 +149,18 @@ set (PARSER_HDRS
 macro(add_parser pname)
   add_custom_target (mk${pname}dirs
     ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname})
-  BISON_TARGET (${pname}Parser parsers/${pname}/${pname}parser.ypp ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}parser.cpp VERBOSE ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}parser.output)
+
+  # Versions of CMake before 3.7.2 require a filename argument to BISON_TARGET's
+  # VERBOSE option. Later versions "support" it, but they generate a file with
+  # the same name automatically anyway, and then issue a warning because the
+  # file gets overwritten, so we need this code to avoid warning spew during
+  # compilation.
+  if (CMAKE_VERSION VERSION_LESS "3.7.2")
+      BISON_TARGET (${pname}Parser parsers/${pname}/${pname}parser.ypp ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}parser.cpp VERBOSE ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}parser.output)
+  else ()
+      BISON_TARGET (${pname}Parser parsers/${pname}/${pname}parser.ypp ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}parser.cpp VERBOSE)
+  endif ()
+
   # regardless of the output name, flex puts out yy.lex.c, so we use a custom command to generate
   # the file to stdout and redirect to the desired name
   # FLEX_TARGET (${pname}Lexer parsers/${pname}/${pname}lexer.ll ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}lexer.cc)


### PR DESCRIPTION
On a build where ccache gets a lot of hits, the linker rapidly becomes the bottleneck. Let's use the gold linker when it's available; it's much faster than the standard ld. It comes with binutils, so all we really need to do is flip it on, at least on recent Linux distros.

Unfortunately the compatibility situation between gold and clang (and symmetrically, between lld and gcc) doesn't seem to be perfect, so I hesitate to enable it when building with clang. We can add support for lld in a future PR.