### PR TITLE
allow CopyStructures pass to ignore methods

### DIFF
--- a/midend/copyStructures.cpp
+++ b/midend/copyStructures.cpp
@@ -22,7 +22,7 @@ const IR::Node* DoCopyStructures::postorder(IR::AssignmentStatement* statement) 
     auto ltype = typeMap->getType(statement->left, true);
     if (ltype->is<IR::Type_StructLike>()) {
         if (statement->right->is<IR::MethodCallExpression>()) {
-            if (!ignoreMethods)
+            if (errorOnMethodCall)
                 ::error("%1%: functions or methods returning structures "
                         "are not supported on this target",
                         statement->right);

--- a/midend/copyStructures.cpp
+++ b/midend/copyStructures.cpp
@@ -22,9 +22,10 @@ const IR::Node* DoCopyStructures::postorder(IR::AssignmentStatement* statement) 
     auto ltype = typeMap->getType(statement->left, true);
     if (ltype->is<IR::Type_StructLike>()) {
         if (statement->right->is<IR::MethodCallExpression>()) {
-            ::error("%1%: functions or methods returning structures "
-                    "are not supported on this target",
-                    statement->right);
+            if (!ignoreMethods)
+                ::error("%1%: functions or methods returning structures "
+                        "are not supported on this target",
+                        statement->right);
             return statement;
         }
 

--- a/midend/copyStructures.h
+++ b/midend/copyStructures.h
@@ -54,10 +54,14 @@ namespace P4 {
  */
 class DoCopyStructures : public Transform {
     TypeMap* typeMap;
-    bool ignoreMethods;
+    /* Specific targets may allow functions or methods to return structs.
+     * Such methods will not be converted in this pass. Setting the
+     * errorOnMethodCall flag will produce an error message if such a
+     * method is encountered. */
+    bool errorOnMethodCall;
  public:
-    explicit DoCopyStructures(TypeMap* typeMap, bool ignoreMethods) :
-            typeMap(typeMap), ignoreMethods(ignoreMethods)
+    explicit DoCopyStructures(TypeMap* typeMap, bool errorOnMethodCall) :
+            typeMap(typeMap), errorOnMethodCall(errorOnMethodCall)
     { CHECK_NULL(typeMap); setName("DoCopyStructures"); }
     const IR::Node* postorder(IR::AssignmentStatement* statement) override;
 };
@@ -65,11 +69,11 @@ class DoCopyStructures : public Transform {
 class CopyStructures : public PassRepeated {
  public:
     CopyStructures(ReferenceMap* refMap, TypeMap* typeMap,
-                   bool ignoreMethods = false) :
+                   bool errorOnMethodCall = true) :
             PassManager({}) {
         CHECK_NULL(refMap); CHECK_NULL(typeMap); setName("CopyStructures");
         passes.emplace_back(new TypeChecking(refMap, typeMap));
-        passes.emplace_back(new DoCopyStructures(typeMap, ignoreMethods));
+        passes.emplace_back(new DoCopyStructures(typeMap, errorOnMethodCall));
     }
 };
 

--- a/midend/copyStructures.h
+++ b/midend/copyStructures.h
@@ -54,19 +54,22 @@ namespace P4 {
  */
 class DoCopyStructures : public Transform {
     TypeMap* typeMap;
+    bool ignoreMethods;
  public:
-    explicit DoCopyStructures(TypeMap* typeMap) : typeMap(typeMap)
+    explicit DoCopyStructures(TypeMap* typeMap, bool ignoreMethods) :
+            typeMap(typeMap), ignoreMethods(ignoreMethods)
     { CHECK_NULL(typeMap); setName("DoCopyStructures"); }
     const IR::Node* postorder(IR::AssignmentStatement* statement) override;
 };
 
 class CopyStructures : public PassRepeated {
  public:
-    CopyStructures(ReferenceMap* refMap, TypeMap* typeMap) :
+    CopyStructures(ReferenceMap* refMap, TypeMap* typeMap,
+                   bool ignoreMethods = false) :
             PassManager({}) {
         CHECK_NULL(refMap); CHECK_NULL(typeMap); setName("CopyStructures");
         passes.emplace_back(new TypeChecking(refMap, typeMap));
-        passes.emplace_back(new DoCopyStructures(typeMap));
+        passes.emplace_back(new DoCopyStructures(typeMap, ignoreMethods));
     }
 };
 


### PR DESCRIPTION
In our back-end users have some leeway with writing their own functions/externs that get linked in later. Since they can choose to write a function that returns a struct I'd prefer not to reject the design outright. So I just put a conditional around the error call in this case.
