### PR TITLE
refactor resolveReferences to use visitor infracture rather than main…

### DIFF
--- a/frontends/common/resolveReferences/referenceMap.cpp
+++ b/frontends/common/resolveReferences/referenceMap.cpp
@@ -20,6 +20,10 @@ limitations under the License.
 
 namespace P4 {
 
+MinimalNameGenerator::MinimalNameGenerator() {
+    usedNames.insert(P4::reservedWords.begin(), P4::reservedWords.end());
+}
+
 ReferenceMap::ReferenceMap() : ProgramMap("ReferenceMap"), isv1(false) { clear(); }
 
 void ReferenceMap::clear() {
@@ -90,6 +94,25 @@ void ReferenceMap::dbprint(std::ostream &out) const {
 }
 
 cstring ReferenceMap::newName(cstring base) {
+    // Maybe in the future we'll maintain information with per-scope identifiers,
+    // but today we are content to generate globally-unique identifiers.
+
+    // If base has a suffix of the form _(\d+), then we discard the suffix.
+    // under the assumption that it is probably a generated suffix.
+    // This will not impact correctness.
+    unsigned len = base.size();
+    const char digits[] = "0123456789";
+    const char* s = base.c_str();
+    while (len > 0 && strchr(digits, s[len-1])) len--;
+    if (len > 0 && base[len - 1] == '_')
+        base = base.substr(0, len - 1);
+
+    cstring name = cstring::make_unique(usedNames, base, '_');
+    usedNames.insert(name);
+    return name;
+}
+
+cstring MinimalNameGenerator::newName(cstring base) {
     // Maybe in the future we'll maintain information with per-scope identifiers,
     // but today we are content to generate globally-unique identifiers.
 

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -31,72 +31,45 @@ enum class ResolutionType {
     TypeVariable
 };
 
-/// Data structure representing a stack of nested namespaces.
-class ResolutionContext : public IHasDbPrint {
-    /// Stack of nested namespaces
-    std::vector<const IR::INamespace*> stack;
-    /// Root namespace for the program.
-    const IR::INamespace* rootNamespace;
-    /// Stack of namespaces for global declarations (e.g., match_kind)
-    std::vector<const IR::INamespace*> globals;
+/// Visitor mixin for looking up names in enclosing scopes from the Visitor::Context
+class ResolutionContext : virtual public Visitor, public DeclarationLookup {
+ protected:
     // Note that all errors have been merged by the parser into
     // a single error { } namespace.
 
-    std::vector<const IR::Vector<IR::Argument>*> argumentStack;
+    const std::vector<const IR::IDeclaration*>*
+    lookup(const IR::INamespace *ns, IR::ID name, ResolutionType type) const;
 
- public:
-    explicit ResolutionContext(const IR::INamespace* rootNamespace) :
-            rootNamespace(rootNamespace)
-    { push(rootNamespace); }
+    // match kinds exist in their own special namespace, made from all the match_kind
+    // declarations in the global scope.  Unlike errors, we don't merge those scopes in
+    // the parser, so we have to find them and scan them here.
+    const std::vector<const IR::IDeclaration*>*
+    lookupMatchKind(IR::ID name) const;
 
-    void dbprint(std::ostream& out) const;
+    // P4_14 allows things to be used before their declaration while P4_16 (generally)
+    // does not, so we will resolve names to things declared later only when translating
+    // from P4_14 or Type_Vars or ParserStates
+    bool isv1;
 
-    /// Add name space @p e to `globals`.
-    void addGlobal(const IR::INamespace* e) {
-        globals.push_back(e);
-    }
+    ResolutionContext();
 
-    /// We are resolving a method call.  Remember the arguments.
-    void enterMethodCall(const IR::Vector<IR::Argument>* args) {
-        argumentStack.push_back(args);
-    }
-
-    /// We are done resolving a method call.
-    void exitMethodCall() {
-        argumentStack.pop_back();
-    }
-
-    /// Add name space @p element to `stack`.
-    void push(const IR::INamespace* element) {
-        CHECK_NULL(element);
-        stack.push_back(element);
-    }
-
-    /// Remove namespace @p element from `stack`
-    /// @pre: `stack` must not be empty and `element` must be back element
-    /// @post: first occurrence of `element` is removed from stack
-    void pop(const IR::INamespace* element) {
-        if (stack.empty())
-            BUG("Empty stack in ResolutionContext::pop");
-        const IR::INamespace* node = stack.back();
-        if (node != element)
-            BUG("Expected %1% on stack, found %2%", element, node);
-        stack.pop_back();
-    }
-    void done();
+    /// We are resolving a method call.  Find the arguments from the context.
+    const IR::Vector<IR::Argument> *methodArguments(cstring name) const;
 
     /// Resolve references for @p name, restricted to @p type declarations.
-    /// If @p forwardOK is `false`, the referenced location must precede the location of @p name.
-    std::vector<const IR::IDeclaration*>*
-    resolve(IR::ID name, ResolutionType type, bool forwardOK) const;
+    const std::vector<const IR::IDeclaration*> *resolve(IR::ID name, ResolutionType type) const;
 
     /// Resolve reference for @p name, restricted to @p type declarations, and expect one result.
-    /// If @p forwardOK is `false`, the referenced location must precede the location of @p name.
     const IR::IDeclaration*
-    resolveUnique(IR::ID name, ResolutionType type, bool forwardOK) const;
+    resolveUnique(IR::ID name, ResolutionType type, const IR::INamespace * = nullptr) const;
+
+    const IR::IDeclaration *resolvePath(const IR::Path *path, bool isType) const;
 
     // Resolve a refrence to a type @p type.
     const IR::Type *resolveType(const IR::Type *type) const;
+
+    const IR::IDeclaration *getDeclaration(const IR::Path *path, bool notNull = false) const;
+    const IR::IDeclaration *getDeclaration(const IR::This *, bool notNull = false) const;
 };
 
 /** Inspector that computes `refMap`: a map from paths to declarations.
@@ -105,20 +78,10 @@ class ResolutionContext : public IHasDbPrint {
  *
  * @post: produces an up-to-date `refMap`
  *
- * @todo: is @p rootNamespace redundant, since @p context always has it?
  */
-class ResolveReferences : public Inspector {
+class ResolveReferences : public Inspector, virtual public ResolutionContext {
     /// Reference map -- essentially from paths to declarations.
-    ReferenceMap* refMap;
-
-    /// Helper data structure that maintains current context.
-    ResolutionContext* context;
-
-    /// The program's root namespace.
-    const IR::INamespace* rootNamespace;
-
-    /// Tracks whether forward references are permitted in a context.
-    std::vector<bool> resolveForward;
+    ReferenceMap *refMap;
 
     /// Indicates if _all_ forward references are allowed
     bool anyOrder;
@@ -127,58 +90,42 @@ class ResolveReferences : public Inspector {
     bool checkShadow;
 
  private:
-    /// Add namespace @p ns to `context`
-    void addToContext(const IR::INamespace* ns);
-
-    /// Remove namespace @p ns from `context`
-    void removeFromContext(const IR::INamespace* ns);
-
-    /// Add namespace @p ns to `globals`
-    void addToGlobals(const IR::INamespace* ns);
-
     /// Resolve @p path; if @p isType is `true` then resolution will
     /// only return type nodes.
-    void resolvePath(const IR::Path* path, bool isType) const;
+    void resolvePath(const IR::Path *path, bool isType) const;
 
  public:
-    explicit ResolveReferences(/* out */ P4::ReferenceMap* refMap,
+    explicit ResolveReferences(/* out */ P4::ReferenceMap *refMap,
                                bool checkShadow = false);
 
-    Visitor::profile_t init_apply(const IR::Node* node) override;
-    void end_apply(const IR::Node* node) override;
-    using Inspector::preorder;
-    using Inspector::postorder;
+    Visitor::profile_t init_apply(const IR::Node *node) override;
+    void end_apply(const IR::Node *node) override;
 
-    bool preorder(const IR::Type_Name* type) override;
-    bool preorder(const IR::PathExpression* path) override;
-    bool preorder(const IR::This* pointer) override;
+    bool preorder(const IR::Type_Name *type) override;
+    bool preorder(const IR::PathExpression *path) override;
+    bool preorder(const IR::KeyElement *path) override;
+    bool preorder(const IR::This *pointer) override;
     bool preorder(const IR::Declaration_Instance *decl) override;
 
-#define DECLARE(TYPE)                           \
-    bool preorder(const IR::TYPE* t) override;  \
-    void postorder(const IR::TYPE* t) override; \
+    bool preorder(const IR::P4Program *t) override;
+    void postorder(const IR::P4Program *t) override;
+    bool preorder(const IR::P4Control *t) override;
+    bool preorder(const IR::P4Parser *t) override;
+    bool preorder(const IR::P4Action *t) override;
+    bool preorder(const IR::Function *t) override;
+    bool preorder(const IR::TableProperties *t) override;
+    bool preorder(const IR::Type_Method *t) override;
+    bool preorder(const IR::ParserState *t) override;
+    bool preorder(const IR::Type_Extern *t) override;
+    bool preorder(const IR::Type_ArchBlock *t) override;
+    void postorder(const IR::Type_ArchBlock *t) override;
+    bool preorder(const IR::Type_StructLike *t) override;
+    bool preorder(const IR::BlockStatement *t) override;
 
-    DECLARE(P4Program)
-    DECLARE(P4Control)
-    DECLARE(P4Parser)
-    DECLARE(P4Action)
-    DECLARE(Function)
-    DECLARE(Method)
-    DECLARE(TableProperties)
-    DECLARE(Type_Method)
-    DECLARE(ParserState)
-    DECLARE(Type_Extern)
-    DECLARE(Type_ArchBlock)
-    DECLARE(Type_StructLike)
-    DECLARE(BlockStatement)
-#undef DECLARE
-
-    bool preorder(const IR::MethodCallExpression* mce) override;
-    bool preorder(const IR::P4Table* table) override;
-    bool preorder(const IR::Declaration_MatchKind* d) override;
-    bool preorder(const IR::Declaration* d) override
+    bool preorder(const IR::P4Table *table) override;
+    bool preorder(const IR::Declaration *d) override
     { refMap->usedName(d->getName().name); return true; }
-    bool preorder(const IR::Type_Declaration* d) override
+    bool preorder(const IR::Type_Declaration *d) override
     { refMap->usedName(d->getName().name); return true; }
 
     void checkShadowing(const IR::INamespace*ns) const;

--- a/frontends/p4/methodInstance.h
+++ b/frontends/p4/methodInstance.h
@@ -84,11 +84,17 @@ class MethodInstance : public InstanceBase {
         and then mce->type is used.  For some technical reasons
         neither the refMap or the typeMap are const here.  */
     static MethodInstance* resolve(const IR::MethodCallExpression* mce,
-                                   ReferenceMap* refMap, TypeMap* typeMap,
-                                   bool useExpressionType = false);
+                                   DeclarationLookup* refMap, TypeMap* typeMap,
+                                   bool useExpressionType = false,
+                                   const Visitor::Context *ctxt = nullptr);
+    static MethodInstance* resolve(const IR::MethodCallExpression* mce,
+                                   DeclarationLookup* refMap, TypeMap* typeMap,
+                                   const Visitor::Context *ctxt)
+    { return resolve(mce, refMap, typeMap, false, ctxt); }
     static MethodInstance* resolve(const IR::MethodCallStatement* mcs,
-                                   ReferenceMap* refMap, TypeMap* typeMap)
-    { return resolve(mcs->methodCall, refMap, typeMap); }
+                                   DeclarationLookup* refMap, TypeMap* typeMap,
+                                   const Visitor::Context *ctxt = nullptr)
+    { return resolve(mcs->methodCall, refMap, typeMap, false, ctxt); }
     const IR::ParameterList* getOriginalParameters() const
     { return originalMethodType->parameters; }
     const IR::ParameterList* getActualParameters() const
@@ -220,7 +226,7 @@ class ConstructorCall : public InstanceBase {
     const IR::Vector<IR::Type>*          typeArguments;
     const IR::ParameterList*             constructorParameters;
     static ConstructorCall* resolve(const IR::ConstructorCallExpression* cce,
-                                    ReferenceMap* refMap,
+                                    DeclarationLookup* refMap,
                                     TypeMap* typeMap);
 };
 
@@ -269,7 +275,7 @@ class Instantiation : public InstanceBase {
     const IR::ParameterList*       constructorParameters;
     ParameterSubstitution          substitution;
     static Instantiation* resolve(const IR::Declaration_Instance* instance,
-                                  ReferenceMap* refMap,
+                                  DeclarationLookup* refMap,
                                   TypeMap* typeMap);
 };
 

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -229,12 +229,6 @@ InstantiatedBlock::findParameterValue(cstring paramName) const {
     return getValue(param->getNode());
 }
 
-Util::Enumerator<const IDeclaration*>* P4Action::getDeclarations() const
-{ return body->getDeclarations(); }
-
-const IDeclaration* P4Action::getDeclByName(cstring name) const
-{ return body->components.getDeclaration(name); }
-
 Util::Enumerator<const IDeclaration*>* P4Program::getDeclarations() const {
     return objects.getEnumerator()
             ->as<const IDeclaration*>()

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -89,12 +89,18 @@ class P4Parser : Type_Declaration, ISimpleNamespace, IApply, IContainer {
 
     TypeParameters getTypeParameters() const override { return type->getTypeParameters(); }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return parserLocals.getDeclarations()->concat(states.getDeclarations()); }
+        return type->typeParameters->getDeclarations()
+                ->concat(type->applyParams->getDeclarations())
+                ->concat(constructorParams->getDeclarations())
+                ->concat(parserLocals.getDeclarations())
+                ->concat(states.getDeclarations()); }
     IDeclaration getDeclByName(cstring name) const override {
         auto decl = parserLocals.getDeclaration(name);
-        if (decl != nullptr)
-            return decl;
-        return states.getDeclaration(name); }
+        if (!decl) decl = states.getDeclaration(name);
+        if (!decl) decl = type->applyParams->getDeclByName(name);
+        if (!decl) decl = constructorParams->getDeclByName(name);
+        if (!decl) decl = type->typeParameters->getDeclByName(name);
+        return decl; }
     Type_Method getApplyMethodType() const override { return type->getApplyMethodType(); }
     ParameterList getApplyParameters() const override { return type->getApplyParameters(); }
     Type_Method getConstructorMethodType() const override;
@@ -119,12 +125,19 @@ class P4Control : Type_Declaration, ISimpleNamespace, IApply, IContainer {
 
     TypeParameters getTypeParameters() const override { return type->getTypeParameters(); }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return controlLocals.getDeclarations(); }
+        return type->typeParameters->getDeclarations()
+                ->concat(type->applyParams->getDeclarations())
+                ->concat(constructorParams->getDeclarations())
+                ->concat(controlLocals.getDeclarations()); }
     Type_Method getApplyMethodType() const override { return type->getApplyMethodType(); }
     ParameterList getApplyParameters() const override { return type->getApplyParameters(); }
     Type_Method getConstructorMethodType() const override;
     IDeclaration getDeclByName(cstring name) const override {
-        return controlLocals.getDeclaration(name); }
+        auto decl = controlLocals.getDeclaration(name);
+        if (!decl) decl = type->applyParams->getDeclByName(name);
+        if (!decl) decl = constructorParams->getDeclByName(name);
+        if (!decl) decl = type->typeParameters->getDeclByName(name);
+        return decl; }
     ParameterList getConstructorParameters() const override { return constructorParams; }
 #apply
     validate {
@@ -140,8 +153,10 @@ class P4Action : Declaration, ISimpleNamespace, IAnnotated, IFunctional {
     optional Annotations        annotations = Annotations::empty;
     ParameterList               parameters;
     BlockStatement              body;
-    Util::Enumerator<IDeclaration>* getDeclarations() const override;
-    IDeclaration getDeclByName(cstring name) const override;
+    Util::Enumerator<IDeclaration>* getDeclarations() const override {
+        return parameters->getDeclarations(); }
+    IDeclaration getDeclByName(cstring name) const override {
+        return parameters->getDeclByName(name); }
     Annotations getAnnotations() const override { return annotations; }
     ParameterList getParameters() const override { return parameters; }
 }
@@ -488,12 +503,16 @@ class SwitchStatement : Statement {
         v.parallel_visit(cases, "cases"); }
 }
 
-class Function : Declaration, IFunctional {
+class Function : Declaration, IFunctional, ISimpleNamespace {
     Type_Method    type;
     BlockStatement body;
     ParameterList getParameters() const override {
         return type->parameters;
     }
+    Util::Enumerator<IDeclaration> *getDeclarations() const override {
+        return type->parameters->getDeclarations(); }
+    IDeclaration getDeclByName(cstring name) const override {
+        return type->parameters->getDeclByName(name); }
 }
 
 /////////////////////////////////////////////////////////////

--- a/ir/type.def
+++ b/ir/type.def
@@ -329,18 +329,28 @@ class Type_Tuple : Type_BaseList {
 
 /// The type of an architectural block.
 /// Abstract base for Type_Control, Type_Parser and Type_Package
-abstract Type_ArchBlock : Type_Declaration, IMayBeGenericType, IAnnotated {
+abstract Type_ArchBlock : Type_Declaration, IMayBeGenericType, IAnnotated, ISimpleNamespace {
     optional Annotations annotations = Annotations::empty;
     optional TypeParameters typeParameters = new TypeParameters;
     Annotations getAnnotations() const override { return annotations; }
     TypeParameters getTypeParameters() const override { return typeParameters; }
+    Util::Enumerator<IDeclaration>* getDeclarations() const override {
+        return typeParameters->getDeclarations(); }
+    IDeclaration getDeclByName(cstring name) const override {
+        return typeParameters->getDeclByName(name); }
 }
 
-class Type_Package : Type_ArchBlock, IContainer {
+class Type_Package : Type_ArchBlock, IContainer, ISimpleNamespace {
     ParameterList constructorParams;
     Type_Method getConstructorMethodType() const override;
     ParameterList getConstructorParameters() const override { return constructorParams; }
     toString{ return cstring("package ") + externalName(); }
+    Util::Enumerator<IDeclaration>* getDeclarations() const override {
+        return typeParameters->getDeclarations()->concat(constructorParams->getDeclarations()); }
+    IDeclaration getDeclByName(cstring name) const override {
+        auto decl = constructorParams->getDeclByName(name);
+        if (!decl) decl = typeParameters->getDeclByName(name);
+        return decl; }
 }
 
 class Type_Parser : Type_ArchBlock, IApply {
@@ -484,7 +494,7 @@ class Type_ActionEnum : Type {
     const IR::Type* getP4Type() const override { return nullptr; }
 }
 
-abstract Type_MethodBase : Type, IMayBeGenericType {
+abstract Type_MethodBase : Type, IMayBeGenericType, ISimpleNamespace {
     // we generally want type parameters visited first
     optional TypeParameters typeParameters = new TypeParameters();
     optional NullOK Type returnType = nullptr;
@@ -507,6 +517,12 @@ abstract Type_MethodBase : Type, IMayBeGenericType {
         return result;
     }
     const IR::Type* getP4Type() const override { return nullptr; }
+    Util::Enumerator<IDeclaration>* getDeclarations() const override {
+        return typeParameters->getDeclarations()->concat(parameters->getDeclarations()); }
+    IDeclaration getDeclByName(cstring name) const override {
+        auto decl = parameters->getDeclByName(name);
+        if (!decl) decl = typeParameters->getDeclByName(name);
+        return decl; }
 }
 
 /// Type for a method or function.
@@ -542,7 +558,7 @@ class Type_Action : Type_MethodBase {
 #nodbprint
 }
 
-class Method : Declaration, IAnnotated, IFunctional {
+class Method : Declaration, IAnnotated, IFunctional, ISimpleNamespace {
     Type_Method type;
     optional bool isAbstract = false;
     optional Annotations annotations = Annotations::empty;
@@ -551,6 +567,11 @@ class Method : Declaration, IAnnotated, IFunctional {
     void setAbstract() { isAbstract = true; }
     Annotations getAnnotations() const override { return annotations; }
     ParameterList getParameters() const override { return type->parameters; }
+    // annotations can refer to parameters, so need to look them up in scope
+    IDeclaration getDeclByName(cstring name) const {
+        return type->parameters->getDeclByName(name); }
+    Util::Enumerator<IDeclaration> *getDeclarations() const {
+        return type->parameters->getDeclarations(); }
 }
 
 class Type_Typedef : Type_Declaration, IAnnotated {
@@ -582,8 +603,9 @@ class Type_Extern : Type_Declaration, IGeneralNamespace, IMayBeGenericType, IAnn
     optional Annotations annotations = Annotations::empty;
 
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return methods.getEnumerator()->as<const IDeclaration*>()
-            ->concat(attributes.valueEnumerator()->as<const IDeclaration*>()); }
+        return typeParameters->getDeclarations()
+            ->concat(attributes.valueEnumerator()->as<const IDeclaration*>())
+            ->concat(methods.getEnumerator()->as<const IDeclaration*>()); }
     virtual TypeParameters getTypeParameters() const override { return typeParameters; }
     validate{ methods.check_null(); }
     Annotations getAnnotations() const override { return annotations; }

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -135,10 +135,14 @@ class Visitor::ChangeTracker {
 };
 
 Visitor::profile_t Visitor::init_apply(const IR::Node *root) {
-    if (ctxt) BUG("previous use of visitor did not clean up properly");
     ctxt = nullptr;
     if (joinFlows) init_join_flows(root);
     return profile_t(*this);
+}
+Visitor::profile_t Visitor::init_apply(const IR::Node *root, const Context *parent_ctxt) {
+    auto rv = init_apply(root);
+    ctxt = parent_ctxt;
+    return rv;
 }
 Visitor::profile_t Modifier::init_apply(const IR::Node *root) {
     auto rv = Visitor::init_apply(root);

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -23,19 +23,22 @@ limitations under the License.
 #include "ir/ir.h"
 #include "lib/exceptions.h"
 
+// declare this outside of Visitor so it can be forward declared in node.h
+struct Visitor_Context {
+    // We maintain a linked list of Context structures on the stack
+    // in the Visitor::apply_visitor functions as we do the recursive
+    // descent traversal.  pre/postorder function can access this
+    // context via getContext/findContext
+    const Visitor_Context       *parent;
+    const IR::Node              *node, *original;
+    mutable int                 child_index;
+    mutable const char          *child_name;
+    int                         depth;
+};
+
 class Visitor {
  public:
-    struct Context {
-        // We maintain a linked list of Context structures on the stack
-        // in the Visitor::apply_visitor functions as we do the recursive
-        // descent traversal.  pre/postorder function can access this
-        // context via getContext/findContext
-        const Context   *parent;
-        const IR::Node  *node, *original;
-        mutable int     child_index;
-        mutable const char *child_name;
-        int             depth;
-    };
+    typedef Visitor_Context Context;
     class profile_t {
         // for profiling -- a profile_t object is created when a pass
         // starts and destroyed when it ends.  Moveable but not copyable.
@@ -61,6 +64,7 @@ class Visitor {
     // to do any additional initialization they need.  They should call their
     // parent's init_apply to do further initialization
     virtual profile_t init_apply(const IR::Node *root);
+    profile_t init_apply(const IR::Node *root, const Context *parent_context);
     // End_apply is called symmetrically with init_apply, after the visit
     // is completed.  Both functions will be called in the event of a normal
     // completion, but only the 0-argument version will be called in the event

--- a/test/gtest/midend_test.cpp
+++ b/test/gtest/midend_test.cpp
@@ -71,6 +71,7 @@ TEST_F(P4CMidend, convertEnums_used_before_declare) {
         const bool a = E.A == E.B;
         enum E { A, B, C, D };
     )");
+    P4CContext::get().options().langVersion = CompilerOptions::FrontendVersion::P4_16;
     auto pgm = P4::parseP4String(program, CompilerOptions::FrontendVersion::P4_16);
     ASSERT_TRUE(pgm && ::errorCount() == 0);
 


### PR DESCRIPTION
…tining its ouw redundant stack

- should ultimately allow eliinating the refMap, as any pass can inherit
  from ResolutionContext and do the lookups itself

This is still WIP, but I thought I'd put it out there for comment.

The basic idea is to use the already existing support in the visitor infrastructure to do contextual name lookup in ResolveReferences rather than maintaining an extra stack object in the visitor.  This still needs more cleanup and reorganization.