### PR TITLE
Better alias analysis in side-effects pass

### DIFF
--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -310,21 +310,193 @@ class DismantleExpression : public Transform {
     const IR::Node* preorder(IR::LAnd* expression) override { return shortCircuit(expression); }
     const IR::Node* preorder(IR::LOr* expression) override { return shortCircuit(expression); }
 
-    // We don't want to compute the full read/write set here so we
-    // overapproximate it as follows: all declarations that occur in
-    // an expression.
-    // TODO: this could be made more precise, perhaps using LocationSets.
-    class ReadsWrites : public Inspector {
-     public:
-        std::set<const IR::IDeclaration*> decls;
-        ReferenceMap* refMap;
+    /// This class represents the path to a location.
+    /// Given a struct S { bit a; bit b; } and a variable S x;
+    /// a path can be x.a, or just x.  An array index is represented as a
+    /// number (encoded as a string) or as "*", denoting an unknown index.
+    struct LocationPath : public IHasDbPrint {
+        const IR::IDeclaration* root;
+        std::vector<cstring> path;
 
-        explicit ReadsWrites(ReferenceMap* refMap) : refMap(refMap)
+        explicit LocationPath(const IR::IDeclaration* root): root(root) { CHECK_NULL(root); }
+
+        const LocationPath* append(cstring suffix) const {
+            auto result = new LocationPath(root);
+            result->path = path;
+            result->path.push_back(suffix);
+            return result;
+        }
+
+        /// True if this path is a prefix of other or the other way around
+        bool isPrefix(const LocationPath* other) const {
+            // Due to the structure of the P4 language, two distinct
+            // declarations can never alias.
+            if (root != other->root)
+                return false;
+            size_t len = std::min(path.size(), other->path.size());
+            for (size_t i = 0; i < len; i++) {
+                if (path.at(i) == "*" || other->path.at(i) == "*")
+                    continue;
+                if (path.at(i) != other->path.at(i))
+                    return false;
+            }
+            return true;
+        }
+
+        void dbprint(std::ostream& out) const override {
+            out << root->getName();
+            for (auto p : path)
+                out << "." << p;
+        }
+    };
+
+    /// We represent a set of location set as a set of LocationPath
+    /// objects.
+    class SetOfLocations : public IHasDbPrint {
+     public:
+        std::set<const LocationPath*> paths;
+
+        SetOfLocations() = default;
+        explicit SetOfLocations(const LocationPath* path) {
+            add(path);
+        }
+        explicit SetOfLocations(const SetOfLocations* set): paths(set->paths) {}
+
+        void add(const LocationPath* path) { paths.emplace(path); }
+        bool overlaps(const SetOfLocations* other) const {
+            // Normally one of these sets has only one element, because
+            // one of the two is a left-value, so this should be fast.
+            for (auto s : paths) {
+                for (auto so : other->paths) {
+                    if (s->isPrefix(so))
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        const SetOfLocations* join(const SetOfLocations* other) const {
+            auto result = new SetOfLocations(this);
+            for (auto p : other->paths)
+                result->add(p);
+            return result;
+        }
+
+        /// Append suffix to each location in the set
+        const SetOfLocations* append(cstring suffix) const {
+            auto result = new SetOfLocations();
+            for (auto p : paths) {
+                auto append = p->append(suffix);
+                result->add(append);
+            }
+            return result;
+        }
+
+        void dbprint(std::ostream& out) const override {
+            for (auto p : paths)
+                out << p << std::endl;
+        }
+    };
+
+    /// Computes the SetOfLocations read and written by an expression.
+    /// This is invoked only for expressions that appear as arguments
+    /// to method calls.
+    class ReadsWrites : public Inspector {
+        const ReferenceMap* refMap;
+        std::map<const IR::Expression*, const SetOfLocations*> rw;
+
+     public:
+        explicit ReadsWrites(const ReferenceMap* refMap) : refMap(refMap)
         { setName("ReadsWrites"); }
+
+        void postorder(const IR::Operation_Binary* expression) override {
+            auto left = ::get(rw, expression->left);
+            auto right = ::get(rw, expression->right);
+            rw.emplace(expression, left->join(right));
+        }
 
         void postorder(const IR::PathExpression* expression) override {
             auto decl = refMap->getDeclaration(expression->path);
-            decls.emplace(decl);
+            auto path = new LocationPath(decl);
+            auto locs = new SetOfLocations(path);
+            rw.emplace(expression, locs);
+        }
+
+        void postorder(const IR::Operation_Unary* expression) override {
+            auto e = ::get(rw, expression->expr);
+            rw.emplace(expression, e);
+        }
+
+        void postorder(const IR::Member* expression) override {
+            auto e = ::get(rw, expression->expr);
+            auto result = e->append(expression->member);
+            rw.emplace(expression, result);
+        }
+
+        void postorder(const IR::ArrayIndex* expression) override {
+            auto e = ::get(rw, expression->left);
+            const SetOfLocations* result;
+            if (expression->right->is<IR::Constant>()) {
+                int index = expression->right->to<IR::Constant>()->asInt();
+                result = e->append(Util::toString(index));
+            } else {
+                result = e->append("*");
+            }
+            rw.emplace(expression, result);
+        }
+
+        void postorder(const IR::Literal* expression) override {
+            rw.emplace(expression, new SetOfLocations());
+        }
+
+        void postorder(const IR::TypeNameExpression* expression) override {
+            rw.emplace(expression, new SetOfLocations());
+        }
+
+        void postorder(const IR::Operation_Ternary* expression) override {
+            auto e0 = ::get(rw, expression->e0);
+            auto e1 = ::get(rw, expression->e1);
+            auto e2 = ::get(rw, expression->e2);
+            rw.emplace(expression, e0->join(e1)->join(e2));
+        }
+
+        void postorder(const IR::MethodCallExpression* expression) override {
+            // The only expression that can appear here is h.isValid();
+            // The ReadsWrites analysis is not called for other methods that
+            // have side-effects -- these are always copied into temporaries.
+            BUG_CHECK(expression->method->is<IR::Member>(),
+                      "%1%: expected isValid()", expression);
+            auto member = expression->method->to<IR::Member>();
+            BUG_CHECK(member->member == "isValid", "%1%: expected isValid()", expression);
+            auto obj = member->expr;
+            auto e = ::get(rw, obj);
+            rw.emplace(expression, e->append("$valid"));
+        }
+
+        void postorder(const IR::ConstructorCallExpression* expression) override {
+            const SetOfLocations* result = new SetOfLocations();
+            for (auto e : *expression->arguments) {
+                auto s = ::get(rw, e);
+                result = result->join(s);
+            }
+            rw.emplace(expression, result);
+        }
+
+        void postorder(const IR::ListExpression* expression) override {
+            const SetOfLocations* result = new SetOfLocations();
+            for (auto e : expression->components) {
+                auto s = ::get(rw, e);
+                result = result->join(s);
+            }
+            rw.emplace(expression, result);
+        }
+
+        const SetOfLocations* get(const IR::Expression* expression) {
+            expression->apply(*this);
+            auto result = ::get(rw, expression);
+            CHECK_NULL(result);
+            LOG3("SetOfLocations(" << expression << ")=" << result);
+            return result;
         }
     };
 
@@ -332,18 +504,11 @@ class DismantleExpression : public Transform {
     // runs early in the front end, before enough information is present (eg.
     // def-use information) to do a precise alias analysis.
     bool mayAlias(const IR::Expression* left, const IR::Expression* right) const {
-        ReadsWrites rwleft(refMap);
-        (void)left->apply(rwleft);
-        ReadsWrites rwright(refMap);
-        (void)right->apply(rwright);
-
-        for (auto d : rwleft.decls) {
-            if (rwright.decls.count(d) > 0) {
-                LOG3(dbp(d) << " accessed by both " << dbp(left) << " and " << dbp(right));
-                return true;
-            }
-        }
-        return false;
+        ReadsWrites rw(refMap);
+        auto llocs = rw.get(left);
+        auto rlocs = rw.get(right);
+        LOG3("Checking overlap between " << llocs << " and " << rlocs);
+        return llocs->overlaps(rlocs);
     }
 
     /// Returns true if type is a header or a struct containing a header.
@@ -429,6 +594,10 @@ class DismantleExpression : public Transform {
                     if (p2 == p1)
                         break;
                     if (!p1->hasOut() && !p2->hasOut())
+                        continue;
+                    if (useTemporary.find(p1) != useTemporary.end())
+                        continue;
+                    if (useTemporary.find(p2) != useTemporary.end())
                         continue;
                     auto arg2 = desc.substitution.lookup(p2);
                     if (mayAlias(arg1, arg2)) {

--- a/midend/actionSynthesis.cpp
+++ b/midend/actionSynthesis.cpp
@@ -108,6 +108,8 @@ bool DoSynthesizeActions::mustMove(const IR::AssignmentStatement *assign) {
         if (!mi->is<ExternMethod>())
             return true;
         auto em = mi->to<ExternMethod>();
+        // TODO: this is wrong, there is no way a mid-end pass can depend on
+        // v1model.
         auto &v1model = P4V1::V1Model::instance;
         if (em->originalExternType->name.name == v1model.ck16.name)
             return false;

--- a/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
@@ -27,7 +27,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<8> tmp;
     @name(".copy2") action copy2_0(inout bit<8> dest_0, bit<8> val_0) {
         dest_0 = val_0;
     }
@@ -38,9 +37,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         copy_0(dest_2, val_2);
     }
     @name(".setb1") action setb1_0(bit<9> port) {
-        tmp = hdr.data.b1;
-        setbyte_0(tmp, hdr.data.b2);
-        hdr.data.b1 = tmp;
+        setbyte_0(hdr.data.b1, hdr.data.b2);
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop_0() {

--- a/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
@@ -117,21 +117,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<14> tmp;
-    tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>> tmp_0;
-    bit<16> tmp_1;
-    bit<32> tmp_2;
-    bit<32> tmp_3;
-    bit<32> tmp_4;
     @name(".flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
     @name(".flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
     @name("._drop") action _drop_1() {
         mark_to_drop();
     }
     @name(".set_ecmp_select") action set_ecmp_select_0(bit<8> ecmp_base, bit<8> ecmp_count) {
-        tmp_0 = { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id };
-        hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(tmp, HashAlgorithm.crc16, (bit<10>)ecmp_base, tmp_0, (bit<20>)ecmp_count);
-        meta.ingress_metadata.ecmp_offset = tmp;
+        hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);
     }
     @name(".set_nhop") action set_nhop_0(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;
@@ -140,13 +132,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".lookup_flowlet_map") action lookup_flowlet_map_0() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        tmp_2 = (bit<32>)meta.ingress_metadata.flowlet_map_index;
-        flowlet_id_0.read(tmp_1, tmp_2);
-        meta.ingress_metadata.flowlet_id = tmp_1;
+        flowlet_id_0.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
-        tmp_4 = (bit<32>)meta.ingress_metadata.flowlet_map_index;
-        flowlet_lasttime_0.read(tmp_3, tmp_4);
-        meta.ingress_metadata.flowlet_lasttime = tmp_3;
+        flowlet_lasttime_0.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
     }
@@ -226,23 +214,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
-    bit<16> tmp_5;
-    bool tmp_6;
+    bit<16> tmp;
+    bool tmp_0;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        tmp_5 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        tmp_6 = hdr.ipv4.hdrChecksum == tmp_5;
-        if (tmp_6) 
+        tmp = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_0 = hdr.ipv4.hdrChecksum == tmp;
+        if (tmp_0) 
             mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    bit<16> tmp_7;
+    bit<16> tmp_1;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        tmp_7 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        hdr.ipv4.hdrChecksum = tmp_7;
+        tmp_1 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_1;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -136,10 +136,6 @@ struct tuple_1 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<14> tmp_8;
-    tuple_0 tmp_9;
-    bit<16> tmp_10;
-    bit<32> tmp_12;
     @name("NoAction") action NoAction_1() {
     }
     @name("NoAction") action NoAction_8() {
@@ -162,14 +158,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop();
     }
     @name(".set_ecmp_select") action set_ecmp_select_0(bit<8> ecmp_base, bit<8> ecmp_count) {
-        tmp_9.field = hdr.ipv4.srcAddr;
-        tmp_9.field_0 = hdr.ipv4.dstAddr;
-        tmp_9.field_1 = hdr.ipv4.protocol;
-        tmp_9.field_2 = hdr.tcp.srcPort;
-        tmp_9.field_3 = hdr.tcp.dstPort;
-        tmp_9.field_4 = meta.ingress_metadata.flowlet_id;
-        hash<bit<14>, bit<10>, tuple_0, bit<20>>(tmp_8, HashAlgorithm.crc16, (bit<10>)ecmp_base, tmp_9, (bit<20>)ecmp_count);
-        meta.ingress_metadata.ecmp_offset = tmp_8;
+        hash<bit<14>, bit<10>, tuple_0, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);
     }
     @name(".set_nhop") action set_nhop_0(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;
@@ -178,12 +167,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".lookup_flowlet_map") action lookup_flowlet_map_0() {
         hash<bit<13>, bit<13>, tuple_1, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id_1.read(tmp_10, (bit<32>)meta.ingress_metadata.flowlet_map_index);
-        meta.ingress_metadata.flowlet_id = tmp_10;
+        flowlet_id_1.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
-        flowlet_lasttime_1.read(tmp_12, (bit<32>)meta.ingress_metadata.flowlet_map_index);
-        meta.ingress_metadata.flowlet_lasttime = tmp_12;
-        meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - tmp_12;
+        flowlet_lasttime_1.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime_1.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
     }
     @name(".set_dmac") action set_dmac_0(bit<48> dmac) {
@@ -276,21 +263,21 @@ struct tuple_2 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
-    bit<16> tmp_14;
+    bit<16> tmp_2;
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        tmp_14 = ipv4_checksum.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        if (hdr.ipv4.hdrChecksum == tmp_14) 
+        tmp_2 = ipv4_checksum.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_2) 
             mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    bit<16> tmp_16;
+    bit<16> tmp_4;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        tmp_16 = ipv4_checksum_2.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        hdr.ipv4.hdrChecksum = tmp_16;
+        tmp_4 = ipv4_checksum_2.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_4;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/issue894-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-frontend.p4
@@ -107,10 +107,6 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<16> tmp;
-    bit<32> tmp_0;
-    bit<16> tmp_1;
-    bit<32> tmp_2;
     @name(".heavy_hitter_counter1") register<bit<16>>(32w16) heavy_hitter_counter1_0;
     @name(".heavy_hitter_counter2") register<bit<16>>(32w16) heavy_hitter_counter2_0;
     @name("._drop") action _drop_1() {
@@ -126,15 +122,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_heavy_hitter_count") action set_heavy_hitter_count_0() {
         hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.custom_metadata.hash_val1, HashAlgorithm.csum16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        tmp_0 = (bit<32>)meta.custom_metadata.hash_val1;
-        heavy_hitter_counter1_0.read(tmp, tmp_0);
-        meta.custom_metadata.count_val1 = tmp;
+        heavy_hitter_counter1_0.read(meta.custom_metadata.count_val1, (bit<32>)meta.custom_metadata.hash_val1);
         meta.custom_metadata.count_val1 = meta.custom_metadata.count_val1 + 16w1;
         heavy_hitter_counter1_0.write((bit<32>)meta.custom_metadata.hash_val1, meta.custom_metadata.count_val1);
         hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.custom_metadata.hash_val2, HashAlgorithm.crc16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        tmp_2 = (bit<32>)meta.custom_metadata.hash_val2;
-        heavy_hitter_counter2_0.read(tmp_1, tmp_2);
-        meta.custom_metadata.count_val2 = tmp_1;
+        heavy_hitter_counter2_0.read(meta.custom_metadata.count_val2, (bit<32>)meta.custom_metadata.hash_val2);
         meta.custom_metadata.count_val2 = meta.custom_metadata.count_val2 + 16w1;
         heavy_hitter_counter2_0.write((bit<32>)meta.custom_metadata.hash_val2, meta.custom_metadata.count_val2);
     }
@@ -198,23 +190,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
-    bit<16> tmp_3;
-    bool tmp_4;
+    bit<16> tmp;
+    bool tmp_0;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        tmp_3 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        tmp_4 = hdr.ipv4.hdrChecksum == tmp_3;
-        if (tmp_4) 
+        tmp = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_0 = hdr.ipv4.hdrChecksum == tmp;
+        if (tmp_0) 
             mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    bit<16> tmp_5;
+    bit<16> tmp_1;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        tmp_5 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        hdr.ipv4.hdrChecksum = tmp_5;
+        tmp_1 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_1;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/issue894-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-midend.p4
@@ -117,8 +117,6 @@ struct tuple_0 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<16> tmp_6;
-    bit<16> tmp_8;
     @name("NoAction") action NoAction_1() {
     }
     @name("NoAction") action NoAction_7() {
@@ -148,15 +146,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_heavy_hitter_count") action set_heavy_hitter_count_0() {
         hash<bit<16>, bit<16>, tuple_0, bit<32>>(meta.custom_metadata.hash_val1, HashAlgorithm.csum16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter1.read(tmp_6, (bit<32>)meta.custom_metadata.hash_val1);
-        meta.custom_metadata.count_val1 = tmp_6;
-        meta.custom_metadata.count_val1 = tmp_6 + 16w1;
-        heavy_hitter_counter1.write((bit<32>)meta.custom_metadata.hash_val1, tmp_6 + 16w1);
+        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<32>)meta.custom_metadata.hash_val1);
+        meta.custom_metadata.count_val1 = meta.custom_metadata.count_val1 + 16w1;
+        heavy_hitter_counter1.write((bit<32>)meta.custom_metadata.hash_val1, meta.custom_metadata.count_val1);
         hash<bit<16>, bit<16>, tuple_0, bit<32>>(meta.custom_metadata.hash_val2, HashAlgorithm.crc16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter2.read(tmp_8, (bit<32>)meta.custom_metadata.hash_val2);
-        meta.custom_metadata.count_val2 = tmp_8;
-        meta.custom_metadata.count_val2 = tmp_8 + 16w1;
-        heavy_hitter_counter2.write((bit<32>)meta.custom_metadata.hash_val2, tmp_8 + 16w1);
+        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<32>)meta.custom_metadata.hash_val2);
+        meta.custom_metadata.count_val2 = meta.custom_metadata.count_val2 + 16w1;
+        heavy_hitter_counter2.write((bit<32>)meta.custom_metadata.hash_val2, meta.custom_metadata.count_val2);
     }
     @name(".drop_heavy_hitter_table") table drop_heavy_hitter_table {
         actions = {
@@ -232,21 +228,21 @@ struct tuple_1 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
-    bit<16> tmp_10;
+    bit<16> tmp_2;
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        tmp_10 = ipv4_checksum.get<tuple_1>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        if (hdr.ipv4.hdrChecksum == tmp_10) 
+        tmp_2 = ipv4_checksum.get<tuple_1>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_2) 
             mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    bit<16> tmp_12;
+    bit<16> tmp_4;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        tmp_12 = ipv4_checksum_2.get<tuple_1>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        hdr.ipv4.hdrChecksum = tmp_12;
+        tmp_4 = ipv4_checksum_2.get<tuple_1>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_4;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -4295,36 +4295,16 @@ control process_ingress_fabric(inout headers hdr, inout metadata meta, inout sta
 }
 
 control process_hashes(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<16> tmp_0;
-    tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>> tmp_1;
-    bit<16> tmp_2;
-    tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>> tmp_3;
-    bit<16> tmp_4;
-    tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>> tmp_5;
-    bit<16> tmp_6;
-    tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>> tmp_7;
-    bit<16> tmp_8;
-    tuple<bit<16>, bit<48>, bit<48>, bit<16>> tmp_9;
     @name(".compute_lkp_ipv4_hash") action compute_lkp_ipv4_hash_0() {
-        tmp_1 = { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
-        hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_0, HashAlgorithm.crc16, 16w0, tmp_1, 32w65536);
-        meta.hash_metadata.hash1 = tmp_0;
-        tmp_3 = { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
-        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_2, HashAlgorithm.crc16, 16w0, tmp_3, 32w65536);
-        meta.hash_metadata.hash2 = tmp_2;
+        hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
     }
     @name(".compute_lkp_ipv6_hash") action compute_lkp_ipv6_hash_0() {
-        tmp_5 = { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
-        hash<bit<16>, bit<16>, tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_4, HashAlgorithm.crc16, 16w0, tmp_5, 32w65536);
-        meta.hash_metadata.hash1 = tmp_4;
-        tmp_7 = { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
-        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_6, HashAlgorithm.crc16, 16w0, tmp_7, 32w65536);
-        meta.hash_metadata.hash2 = tmp_6;
+        hash<bit<16>, bit<16>, tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
     }
     @name(".compute_lkp_non_ip_hash") action compute_lkp_non_ip_hash_0() {
-        tmp_9 = { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type };
-        hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(tmp_8, HashAlgorithm.crc16, 16w0, tmp_9, 32w65536);
-        meta.hash_metadata.hash2 = tmp_8;
+        hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
     }
     @name(".computed_two_hashes") action computed_two_hashes_0() {
         meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
@@ -4907,49 +4887,49 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
-    bool tmp_10;
-    bit<16> tmp_11;
-    bool tmp_12;
-    bool tmp_13;
-    bit<16> tmp_14;
-    bool tmp_15;
+    bool tmp_0;
+    bit<16> tmp_1;
+    bool tmp_2;
+    bool tmp_3;
+    bit<16> tmp_4;
+    bool tmp_5;
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_0;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
         if (!(hdr.inner_ipv4.ihl == 4w5)) 
-            tmp_10 = false;
+            tmp_0 = false;
         else {
-            tmp_11 = inner_ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
-            tmp_12 = hdr.inner_ipv4.hdrChecksum == tmp_11;
-            tmp_10 = tmp_12;
+            tmp_1 = inner_ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_2 = hdr.inner_ipv4.hdrChecksum == tmp_1;
+            tmp_0 = tmp_2;
         }
-        if (tmp_10) 
+        if (tmp_0) 
             mark_to_drop();
         if (!(hdr.ipv4.ihl == 4w5)) 
-            tmp_13 = false;
+            tmp_3 = false;
         else {
-            tmp_14 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-            tmp_15 = hdr.ipv4.hdrChecksum == tmp_14;
-            tmp_13 = tmp_15;
+            tmp_4 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_5 = hdr.ipv4.hdrChecksum == tmp_4;
+            tmp_3 = tmp_5;
         }
-        if (tmp_13) 
+        if (tmp_3) 
             mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    bit<16> tmp_16;
-    bit<16> tmp_17;
+    bit<16> tmp_6;
+    bit<16> tmp_7;
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_1;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
         if (hdr.inner_ipv4.ihl == 4w5) {
-            tmp_16 = inner_ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
-            hdr.inner_ipv4.hdrChecksum = tmp_16;
+            tmp_6 = inner_ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_6;
         }
         if (hdr.ipv4.ihl == 4w5) {
-            tmp_17 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-            hdr.ipv4.hdrChecksum = tmp_17;
+            tmp_7 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_7;
         }
     }
 }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -763,7 +763,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<4> tmp_0;
+    bit<4> tmp_8;
     @name(".parse_all_int_meta_value_heders") state parse_all_int_meta_value_heders {
         packet.extract<int_switch_id_header_t>(hdr.int_switch_id_header);
         packet.extract<int_ingress_port_id_header_t>(hdr.int_ingress_port_id_header);
@@ -1017,8 +1017,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_mpls_bos") state parse_mpls_bos {
-        tmp_0 = packet.lookahead<bit<4>>();
-        transition select(tmp_0[3:0]) {
+        tmp_8 = packet.lookahead<bit<4>>();
+        transition select(tmp_8[3:0]) {
             4w0x4: parse_mpls_inner_ipv4;
             4w0x6: parse_mpls_inner_ipv6;
             default: parse_eompls;
@@ -2963,16 +2963,6 @@ struct tuple_7 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<16> _process_hashes_tmp_9;
-    tuple_2 _process_hashes_tmp_10;
-    bit<16> _process_hashes_tmp_11;
-    tuple_3 _process_hashes_tmp_12;
-    bit<16> _process_hashes_tmp_13;
-    tuple_4 _process_hashes_tmp_14;
-    bit<16> _process_hashes_tmp_15;
-    tuple_5 _process_hashes_tmp_16;
-    bit<16> _process_hashes_tmp_17;
-    tuple_6 _process_hashes_tmp_18;
     @name("NoAction") action NoAction_114() {
     }
     @name("NoAction") action NoAction_115() {
@@ -4443,48 +4433,15 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_152();
     }
     @name(".compute_lkp_ipv4_hash") action _compute_lkp_ipv4_hash() {
-        _process_hashes_tmp_10.field_5 = meta.ipv4_metadata.lkp_ipv4_sa;
-        _process_hashes_tmp_10.field_6 = meta.ipv4_metadata.lkp_ipv4_da;
-        _process_hashes_tmp_10.field_7 = meta.l3_metadata.lkp_ip_proto;
-        _process_hashes_tmp_10.field_8 = meta.l3_metadata.lkp_l4_sport;
-        _process_hashes_tmp_10.field_9 = meta.l3_metadata.lkp_l4_dport;
-        hash<bit<16>, bit<16>, tuple_2, bit<32>>(_process_hashes_tmp_9, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_10, 32w65536);
-        meta.hash_metadata.hash1 = _process_hashes_tmp_9;
-        _process_hashes_tmp_12.field_10 = meta.l2_metadata.lkp_mac_sa;
-        _process_hashes_tmp_12.field_11 = meta.l2_metadata.lkp_mac_da;
-        _process_hashes_tmp_12.field_12 = meta.ipv4_metadata.lkp_ipv4_sa;
-        _process_hashes_tmp_12.field_13 = meta.ipv4_metadata.lkp_ipv4_da;
-        _process_hashes_tmp_12.field_14 = meta.l3_metadata.lkp_ip_proto;
-        _process_hashes_tmp_12.field_15 = meta.l3_metadata.lkp_l4_sport;
-        _process_hashes_tmp_12.field_16 = meta.l3_metadata.lkp_l4_dport;
-        hash<bit<16>, bit<16>, tuple_3, bit<32>>(_process_hashes_tmp_11, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_12, 32w65536);
-        meta.hash_metadata.hash2 = _process_hashes_tmp_11;
+        hash<bit<16>, bit<16>, tuple_2, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_3, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
     }
     @name(".compute_lkp_ipv6_hash") action _compute_lkp_ipv6_hash() {
-        _process_hashes_tmp_14.field_17 = meta.ipv6_metadata.lkp_ipv6_sa;
-        _process_hashes_tmp_14.field_18 = meta.ipv6_metadata.lkp_ipv6_da;
-        _process_hashes_tmp_14.field_19 = meta.l3_metadata.lkp_ip_proto;
-        _process_hashes_tmp_14.field_20 = meta.l3_metadata.lkp_l4_sport;
-        _process_hashes_tmp_14.field_21 = meta.l3_metadata.lkp_l4_dport;
-        hash<bit<16>, bit<16>, tuple_4, bit<32>>(_process_hashes_tmp_13, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_14, 32w65536);
-        meta.hash_metadata.hash1 = _process_hashes_tmp_13;
-        _process_hashes_tmp_16.field_22 = meta.l2_metadata.lkp_mac_sa;
-        _process_hashes_tmp_16.field_23 = meta.l2_metadata.lkp_mac_da;
-        _process_hashes_tmp_16.field_24 = meta.ipv6_metadata.lkp_ipv6_sa;
-        _process_hashes_tmp_16.field_25 = meta.ipv6_metadata.lkp_ipv6_da;
-        _process_hashes_tmp_16.field_26 = meta.l3_metadata.lkp_ip_proto;
-        _process_hashes_tmp_16.field_27 = meta.l3_metadata.lkp_l4_sport;
-        _process_hashes_tmp_16.field_28 = meta.l3_metadata.lkp_l4_dport;
-        hash<bit<16>, bit<16>, tuple_5, bit<32>>(_process_hashes_tmp_15, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_16, 32w65536);
-        meta.hash_metadata.hash2 = _process_hashes_tmp_15;
+        hash<bit<16>, bit<16>, tuple_4, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_5, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
     }
     @name(".compute_lkp_non_ip_hash") action _compute_lkp_non_ip_hash() {
-        _process_hashes_tmp_18.field_29 = meta.ingress_metadata.ifindex;
-        _process_hashes_tmp_18.field_30 = meta.l2_metadata.lkp_mac_sa;
-        _process_hashes_tmp_18.field_31 = meta.l2_metadata.lkp_mac_da;
-        _process_hashes_tmp_18.field_32 = meta.l2_metadata.lkp_mac_type;
-        hash<bit<16>, bit<16>, tuple_6, bit<32>>(_process_hashes_tmp_17, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_18, 32w65536);
-        meta.hash_metadata.hash2 = _process_hashes_tmp_17;
+        hash<bit<16>, bit<16>, tuple_6, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
     }
     @name(".computed_two_hashes") action _computed_two_hashes() {
         meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
@@ -5045,45 +5002,45 @@ struct tuple_8 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
-    bool tmp_1;
-    bit<16> tmp_2;
-    bool tmp_4;
-    bit<16> tmp_5;
+    bool tmp_9;
+    bit<16> tmp_10;
+    bool tmp_12;
+    bit<16> tmp_13;
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
         if (hdr.inner_ipv4.ihl != 4w5) 
-            tmp_1 = false;
+            tmp_9 = false;
         else {
-            tmp_2 = inner_ipv4_checksum.get<tuple_8>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
-            tmp_1 = hdr.inner_ipv4.hdrChecksum == tmp_2;
+            tmp_10 = inner_ipv4_checksum.get<tuple_8>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_9 = hdr.inner_ipv4.hdrChecksum == tmp_10;
         }
-        if (tmp_1) 
+        if (tmp_9) 
             mark_to_drop();
         if (hdr.ipv4.ihl != 4w5) 
-            tmp_4 = false;
+            tmp_12 = false;
         else {
-            tmp_5 = ipv4_checksum.get<tuple_8>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-            tmp_4 = hdr.ipv4.hdrChecksum == tmp_5;
+            tmp_13 = ipv4_checksum.get<tuple_8>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_12 = hdr.ipv4.hdrChecksum == tmp_13;
         }
-        if (tmp_4) 
+        if (tmp_12) 
             mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    bit<16> tmp_7;
-    bit<16> tmp_8;
+    bit<16> tmp_15;
+    bit<16> tmp_16;
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_2;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
         if (hdr.inner_ipv4.ihl == 4w5) {
-            tmp_7 = inner_ipv4_checksum_2.get<tuple_8>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
-            hdr.inner_ipv4.hdrChecksum = tmp_7;
+            tmp_15 = inner_ipv4_checksum_2.get<tuple_8>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_15;
         }
         if (hdr.ipv4.ihl == 4w5) {
-            tmp_8 = ipv4_checksum_2.get<tuple_8>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-            hdr.ipv4.hdrChecksum = tmp_8;
+            tmp_16 = ipv4_checksum_2.get<tuple_8>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_16;
         }
     }
 }

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -5182,36 +5182,16 @@ control process_meter_index(inout headers hdr, inout metadata meta, inout standa
 }
 
 control process_hashes(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<16> tmp_0;
-    tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>> tmp_1;
-    bit<16> tmp_2;
-    tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>> tmp_3;
-    bit<16> tmp_4;
-    tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>> tmp_5;
-    bit<16> tmp_6;
-    tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>> tmp_7;
-    bit<16> tmp_8;
-    tuple<bit<16>, bit<48>, bit<48>, bit<16>> tmp_9;
     @name(".compute_lkp_ipv4_hash") action compute_lkp_ipv4_hash_0() {
-        tmp_1 = { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
-        hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_0, HashAlgorithm.crc16, 16w0, tmp_1, 32w65536);
-        meta.hash_metadata.hash1 = tmp_0;
-        tmp_3 = { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
-        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_2, HashAlgorithm.crc16, 16w0, tmp_3, 32w65536);
-        meta.hash_metadata.hash2 = tmp_2;
+        hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
     }
     @name(".compute_lkp_ipv6_hash") action compute_lkp_ipv6_hash_0() {
-        tmp_5 = { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
-        hash<bit<16>, bit<16>, tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_4, HashAlgorithm.crc16, 16w0, tmp_5, 32w65536);
-        meta.hash_metadata.hash1 = tmp_4;
-        tmp_7 = { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport };
-        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(tmp_6, HashAlgorithm.crc16, 16w0, tmp_7, 32w65536);
-        meta.hash_metadata.hash2 = tmp_6;
+        hash<bit<16>, bit<16>, tuple<bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        hash<bit<16>, bit<16>, tuple<bit<48>, bit<48>, bit<128>, bit<128>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
     }
     @name(".compute_lkp_non_ip_hash") action compute_lkp_non_ip_hash_0() {
-        tmp_9 = { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type };
-        hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(tmp_8, HashAlgorithm.crc16, 16w0, tmp_9, 32w65536);
-        meta.hash_metadata.hash2 = tmp_8;
+        hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
     }
     @name(".computed_two_hashes") action computed_two_hashes_0() {
         meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
@@ -5901,49 +5881,49 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
-    bool tmp_10;
-    bit<16> tmp_11;
-    bool tmp_12;
-    bool tmp_13;
-    bit<16> tmp_14;
-    bool tmp_15;
+    bool tmp_0;
+    bit<16> tmp_1;
+    bool tmp_2;
+    bool tmp_3;
+    bit<16> tmp_4;
+    bool tmp_5;
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_0;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
         if (!(hdr.inner_ipv4.ihl == 4w5)) 
-            tmp_10 = false;
+            tmp_0 = false;
         else {
-            tmp_11 = inner_ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
-            tmp_12 = hdr.inner_ipv4.hdrChecksum == tmp_11;
-            tmp_10 = tmp_12;
+            tmp_1 = inner_ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_2 = hdr.inner_ipv4.hdrChecksum == tmp_1;
+            tmp_0 = tmp_2;
         }
-        if (tmp_10) 
+        if (tmp_0) 
             mark_to_drop();
         if (!(hdr.ipv4.ihl == 4w5)) 
-            tmp_13 = false;
+            tmp_3 = false;
         else {
-            tmp_14 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-            tmp_15 = hdr.ipv4.hdrChecksum == tmp_14;
-            tmp_13 = tmp_15;
+            tmp_4 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_5 = hdr.ipv4.hdrChecksum == tmp_4;
+            tmp_3 = tmp_5;
         }
-        if (tmp_13) 
+        if (tmp_3) 
             mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    bit<16> tmp_16;
-    bit<16> tmp_17;
+    bit<16> tmp_6;
+    bit<16> tmp_7;
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_1;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
         if (hdr.inner_ipv4.ihl == 4w5) {
-            tmp_16 = inner_ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
-            hdr.inner_ipv4.hdrChecksum = tmp_16;
+            tmp_6 = inner_ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_6;
         }
         if (hdr.ipv4.ihl == 4w5) {
-            tmp_17 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-            hdr.ipv4.hdrChecksum = tmp_17;
+            tmp_7 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_7;
         }
     }
 }

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -807,7 +807,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<4> tmp_0;
+    bit<4> tmp_8;
     @name(".parse_arp_rarp") state parse_arp_rarp {
         packet.extract<arp_rarp_t>(hdr.arp_rarp);
         transition select(hdr.arp_rarp.protoType) {
@@ -1066,8 +1066,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_mpls_bos") state parse_mpls_bos {
-        tmp_0 = packet.lookahead<bit<4>>();
-        transition select(tmp_0[3:0]) {
+        tmp_8 = packet.lookahead<bit<4>>();
+        transition select(tmp_8[3:0]) {
             4w0x4: parse_mpls_inner_ipv4;
             4w0x6: parse_mpls_inner_ipv6;
             default: parse_eompls;
@@ -3120,56 +3120,56 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 struct tuple_2 {
-    bit<32> field_5;
-    bit<32> field_6;
-    bit<8>  field_7;
+    bit<1>  field_5;
+    bit<16> field_6;
+}
+
+struct tuple_3 {
+    tuple_1 field_7;
     bit<16> field_8;
     bit<16> field_9;
 }
 
-struct tuple_3 {
-    bit<48> field_10;
-    bit<48> field_11;
-    bit<32> field_12;
-    bit<32> field_13;
-    bit<8>  field_14;
-    bit<16> field_15;
-    bit<16> field_16;
-}
-
 struct tuple_4 {
-    bit<128> field_17;
-    bit<128> field_18;
-    bit<8>   field_19;
-    bit<16>  field_20;
-    bit<16>  field_21;
+    bit<32> field_10;
+    bit<32> field_11;
+    bit<8>  field_12;
+    bit<16> field_13;
+    bit<16> field_14;
 }
 
 struct tuple_5 {
-    bit<48>  field_22;
-    bit<48>  field_23;
-    bit<128> field_24;
-    bit<128> field_25;
-    bit<8>   field_26;
-    bit<16>  field_27;
-    bit<16>  field_28;
+    bit<48> field_15;
+    bit<48> field_16;
+    bit<32> field_17;
+    bit<32> field_18;
+    bit<8>  field_19;
+    bit<16> field_20;
+    bit<16> field_21;
 }
 
 struct tuple_6 {
-    bit<16> field_29;
-    bit<48> field_30;
-    bit<48> field_31;
-    bit<16> field_32;
+    bit<128> field_22;
+    bit<128> field_23;
+    bit<8>   field_24;
+    bit<16>  field_25;
+    bit<16>  field_26;
 }
 
 struct tuple_7 {
-    bit<1>  field_33;
-    bit<16> field_34;
+    bit<48>  field_27;
+    bit<48>  field_28;
+    bit<128> field_29;
+    bit<128> field_30;
+    bit<8>   field_31;
+    bit<16>  field_32;
+    bit<16>  field_33;
 }
 
 struct tuple_8 {
-    tuple_1 field_35;
-    bit<16> field_36;
+    bit<16> field_34;
+    bit<48> field_35;
+    bit<48> field_36;
     bit<16> field_37;
 }
 
@@ -3179,16 +3179,6 @@ struct tuple_9 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<16> _process_hashes_tmp_9;
-    tuple_2 _process_hashes_tmp_10;
-    bit<16> _process_hashes_tmp_11;
-    tuple_3 _process_hashes_tmp_12;
-    bit<16> _process_hashes_tmp_13;
-    tuple_4 _process_hashes_tmp_14;
-    bit<16> _process_hashes_tmp_15;
-    tuple_5 _process_hashes_tmp_16;
-    bit<16> _process_hashes_tmp_17;
-    tuple_6 _process_hashes_tmp_18;
     @name("NoAction") action NoAction_148() {
     }
     @name("NoAction") action NoAction_149() {
@@ -3674,7 +3664,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.int_metadata.insert_byte_cnt = meta.int_metadata.gpe_int_hdr_len << 2;
         meta.int_metadata_i2e.sink = 1w1;
         meta.i2e_metadata.mirror_session_id = (bit<16>)mirror_id;
-        clone3<tuple_7>(CloneType.I2E, mirror_id, { 1w1, (bit<16>)mirror_id });
+        clone3<tuple_2>(CloneType.I2E, mirror_id, { 1w1, (bit<16>)mirror_id });
         hdr.int_header.setInvalid();
         hdr.int_val[0].setInvalid();
         hdr.int_val[1].setInvalid();
@@ -4364,7 +4354,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         _sflow_ingress_session_pkt_counter_0.count();
         meta.fabric_metadata.reason_code = reason_code;
         meta.i2e_metadata.mirror_session_id = (bit<16>)sflow_i2e_mirror_id;
-        clone3<tuple_8>(CloneType.I2E, sflow_i2e_mirror_id, { { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, reason_code, meta.ingress_metadata.ingress_port }, meta.sflow_metadata.sflow_session_id, (bit<16>)sflow_i2e_mirror_id });
+        clone3<tuple_3>(CloneType.I2E, sflow_i2e_mirror_id, { { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, reason_code, meta.ingress_metadata.ingress_port }, meta.sflow_metadata.sflow_session_id, (bit<16>)sflow_i2e_mirror_id });
     }
     @name(".sflow_ing_take_sample") table _sflow_ing_take_sample_0 {
         actions = {
@@ -5267,48 +5257,15 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_208();
     }
     @name(".compute_lkp_ipv4_hash") action _compute_lkp_ipv4_hash() {
-        _process_hashes_tmp_10.field_5 = meta.ipv4_metadata.lkp_ipv4_sa;
-        _process_hashes_tmp_10.field_6 = meta.ipv4_metadata.lkp_ipv4_da;
-        _process_hashes_tmp_10.field_7 = meta.l3_metadata.lkp_ip_proto;
-        _process_hashes_tmp_10.field_8 = meta.l3_metadata.lkp_l4_sport;
-        _process_hashes_tmp_10.field_9 = meta.l3_metadata.lkp_l4_dport;
-        hash<bit<16>, bit<16>, tuple_2, bit<32>>(_process_hashes_tmp_9, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_10, 32w65536);
-        meta.hash_metadata.hash1 = _process_hashes_tmp_9;
-        _process_hashes_tmp_12.field_10 = meta.l2_metadata.lkp_mac_sa;
-        _process_hashes_tmp_12.field_11 = meta.l2_metadata.lkp_mac_da;
-        _process_hashes_tmp_12.field_12 = meta.ipv4_metadata.lkp_ipv4_sa;
-        _process_hashes_tmp_12.field_13 = meta.ipv4_metadata.lkp_ipv4_da;
-        _process_hashes_tmp_12.field_14 = meta.l3_metadata.lkp_ip_proto;
-        _process_hashes_tmp_12.field_15 = meta.l3_metadata.lkp_l4_sport;
-        _process_hashes_tmp_12.field_16 = meta.l3_metadata.lkp_l4_dport;
-        hash<bit<16>, bit<16>, tuple_3, bit<32>>(_process_hashes_tmp_11, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_12, 32w65536);
-        meta.hash_metadata.hash2 = _process_hashes_tmp_11;
+        hash<bit<16>, bit<16>, tuple_4, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_5, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv4_metadata.lkp_ipv4_sa, meta.ipv4_metadata.lkp_ipv4_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
     }
     @name(".compute_lkp_ipv6_hash") action _compute_lkp_ipv6_hash() {
-        _process_hashes_tmp_14.field_17 = meta.ipv6_metadata.lkp_ipv6_sa;
-        _process_hashes_tmp_14.field_18 = meta.ipv6_metadata.lkp_ipv6_da;
-        _process_hashes_tmp_14.field_19 = meta.l3_metadata.lkp_ip_proto;
-        _process_hashes_tmp_14.field_20 = meta.l3_metadata.lkp_l4_sport;
-        _process_hashes_tmp_14.field_21 = meta.l3_metadata.lkp_l4_dport;
-        hash<bit<16>, bit<16>, tuple_4, bit<32>>(_process_hashes_tmp_13, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_14, 32w65536);
-        meta.hash_metadata.hash1 = _process_hashes_tmp_13;
-        _process_hashes_tmp_16.field_22 = meta.l2_metadata.lkp_mac_sa;
-        _process_hashes_tmp_16.field_23 = meta.l2_metadata.lkp_mac_da;
-        _process_hashes_tmp_16.field_24 = meta.ipv6_metadata.lkp_ipv6_sa;
-        _process_hashes_tmp_16.field_25 = meta.ipv6_metadata.lkp_ipv6_da;
-        _process_hashes_tmp_16.field_26 = meta.l3_metadata.lkp_ip_proto;
-        _process_hashes_tmp_16.field_27 = meta.l3_metadata.lkp_l4_sport;
-        _process_hashes_tmp_16.field_28 = meta.l3_metadata.lkp_l4_dport;
-        hash<bit<16>, bit<16>, tuple_5, bit<32>>(_process_hashes_tmp_15, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_16, 32w65536);
-        meta.hash_metadata.hash2 = _process_hashes_tmp_15;
+        hash<bit<16>, bit<16>, tuple_6, bit<32>>(meta.hash_metadata.hash1, HashAlgorithm.crc16, 16w0, { meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_7, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.ipv6_metadata.lkp_ipv6_sa, meta.ipv6_metadata.lkp_ipv6_da, meta.l3_metadata.lkp_ip_proto, meta.l3_metadata.lkp_l4_sport, meta.l3_metadata.lkp_l4_dport }, 32w65536);
     }
     @name(".compute_lkp_non_ip_hash") action _compute_lkp_non_ip_hash() {
-        _process_hashes_tmp_18.field_29 = meta.ingress_metadata.ifindex;
-        _process_hashes_tmp_18.field_30 = meta.l2_metadata.lkp_mac_sa;
-        _process_hashes_tmp_18.field_31 = meta.l2_metadata.lkp_mac_da;
-        _process_hashes_tmp_18.field_32 = meta.l2_metadata.lkp_mac_type;
-        hash<bit<16>, bit<16>, tuple_6, bit<32>>(_process_hashes_tmp_17, HashAlgorithm.crc16, 16w0, _process_hashes_tmp_18, 32w65536);
-        meta.hash_metadata.hash2 = _process_hashes_tmp_17;
+        hash<bit<16>, bit<16>, tuple_8, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
     }
     @name(".computed_two_hashes") action _computed_two_hashes() {
         meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
@@ -6060,45 +6017,45 @@ struct tuple_10 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
-    bool tmp_1;
-    bit<16> tmp_2;
-    bool tmp_4;
-    bit<16> tmp_5;
+    bool tmp_9;
+    bit<16> tmp_10;
+    bool tmp_12;
+    bit<16> tmp_13;
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum;
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
         if (hdr.inner_ipv4.ihl != 4w5) 
-            tmp_1 = false;
+            tmp_9 = false;
         else {
-            tmp_2 = inner_ipv4_checksum.get<tuple_10>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
-            tmp_1 = hdr.inner_ipv4.hdrChecksum == tmp_2;
+            tmp_10 = inner_ipv4_checksum.get<tuple_10>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            tmp_9 = hdr.inner_ipv4.hdrChecksum == tmp_10;
         }
-        if (tmp_1) 
+        if (tmp_9) 
             mark_to_drop();
         if (hdr.ipv4.ihl != 4w5) 
-            tmp_4 = false;
+            tmp_12 = false;
         else {
-            tmp_5 = ipv4_checksum.get<tuple_10>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-            tmp_4 = hdr.ipv4.hdrChecksum == tmp_5;
+            tmp_13 = ipv4_checksum.get<tuple_10>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            tmp_12 = hdr.ipv4.hdrChecksum == tmp_13;
         }
-        if (tmp_4) 
+        if (tmp_12) 
             mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    bit<16> tmp_7;
-    bit<16> tmp_8;
+    bit<16> tmp_15;
+    bit<16> tmp_16;
     @name("inner_ipv4_checksum") Checksum16() inner_ipv4_checksum_2;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
         if (hdr.inner_ipv4.ihl == 4w5) {
-            tmp_7 = inner_ipv4_checksum_2.get<tuple_10>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
-            hdr.inner_ipv4.hdrChecksum = tmp_7;
+            tmp_15 = inner_ipv4_checksum_2.get<tuple_10>({ hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.diffserv, hdr.inner_ipv4.totalLen, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.protocol, hdr.inner_ipv4.srcAddr, hdr.inner_ipv4.dstAddr });
+            hdr.inner_ipv4.hdrChecksum = tmp_15;
         }
         if (hdr.ipv4.ihl == 4w5) {
-            tmp_8 = ipv4_checksum_2.get<tuple_10>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-            hdr.ipv4.hdrChecksum = tmp_8;
+            tmp_16 = ipv4_checksum_2.get<tuple_10>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+            hdr.ipv4.hdrChecksum = tmp_16;
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
@@ -117,21 +117,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<14> tmp;
-    tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>> tmp_0;
-    bit<16> tmp_1;
-    bit<32> tmp_2;
-    bit<32> tmp_3;
-    bit<32> tmp_4;
     @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
     @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
     @name("_drop") action _drop_1() {
         mark_to_drop();
     }
     @name("set_ecmp_select") action set_ecmp_select_0(bit<8> ecmp_base, bit<8> ecmp_count) {
-        tmp_0 = { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id };
-        hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(tmp, HashAlgorithm.crc16, (bit<10>)ecmp_base, tmp_0, (bit<20>)ecmp_count);
-        meta.ingress_metadata.ecmp_offset = tmp;
+        hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);
     }
     @name("set_nhop") action set_nhop_0(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;
@@ -140,13 +132,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("lookup_flowlet_map") action lookup_flowlet_map_0() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        tmp_2 = (bit<32>)meta.ingress_metadata.flowlet_map_index;
-        flowlet_id_0.read(tmp_1, tmp_2);
-        meta.ingress_metadata.flowlet_id = tmp_1;
+        flowlet_id_0.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
-        tmp_4 = (bit<32>)meta.ingress_metadata.flowlet_map_index;
-        flowlet_lasttime_0.read(tmp_3, tmp_4);
-        meta.ingress_metadata.flowlet_lasttime = tmp_3;
+        flowlet_lasttime_0.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
     }
@@ -228,23 +216,23 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
-    bit<16> tmp_5;
-    bool tmp_6;
+    bit<16> tmp;
+    bool tmp_0;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_0;
     apply {
-        tmp_5 = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        tmp_6 = hdr.ipv4.hdrChecksum == tmp_5;
-        if (tmp_6) 
+        tmp = ipv4_checksum_0.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        tmp_0 = hdr.ipv4.hdrChecksum == tmp;
+        if (tmp_0) 
             mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    bit<16> tmp_7;
+    bit<16> tmp_1;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_1;
     apply {
-        tmp_7 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        hdr.ipv4.hdrChecksum = tmp_7;
+        tmp_1 = ipv4_checksum_1.get<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -136,10 +136,6 @@ struct tuple_1 {
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<14> tmp_8;
-    tuple_0 tmp_9;
-    bit<16> tmp_10;
-    bit<32> tmp_12;
     @name("NoAction") action NoAction_1() {
     }
     @name("NoAction") action NoAction_8() {
@@ -162,14 +158,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop();
     }
     @name("set_ecmp_select") action set_ecmp_select_0(bit<8> ecmp_base, bit<8> ecmp_count) {
-        tmp_9.field = hdr.ipv4.srcAddr;
-        tmp_9.field_0 = hdr.ipv4.dstAddr;
-        tmp_9.field_1 = hdr.ipv4.protocol;
-        tmp_9.field_2 = hdr.tcp.srcPort;
-        tmp_9.field_3 = hdr.tcp.dstPort;
-        tmp_9.field_4 = meta.ingress_metadata.flowlet_id;
-        hash<bit<14>, bit<10>, tuple_0, bit<20>>(tmp_8, HashAlgorithm.crc16, (bit<10>)ecmp_base, tmp_9, (bit<20>)ecmp_count);
-        meta.ingress_metadata.ecmp_offset = tmp_8;
+        hash<bit<14>, bit<10>, tuple_0, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);
     }
     @name("set_nhop") action set_nhop_0(bit<32> nhop_ipv4, bit<9> port) {
         meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;
@@ -178,12 +167,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("lookup_flowlet_map") action lookup_flowlet_map_0() {
         hash<bit<13>, bit<13>, tuple_1, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id_1.read(tmp_10, (bit<32>)meta.ingress_metadata.flowlet_map_index);
-        meta.ingress_metadata.flowlet_id = tmp_10;
+        flowlet_id_1.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
-        flowlet_lasttime_1.read(tmp_12, (bit<32>)meta.ingress_metadata.flowlet_map_index);
-        meta.ingress_metadata.flowlet_lasttime = tmp_12;
-        meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - tmp_12;
+        flowlet_lasttime_1.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime_1.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
     }
     @name("set_dmac") action set_dmac_0(bit<48> dmac) {
@@ -278,21 +265,21 @@ struct tuple_2 {
 }
 
 control verifyChecksum(in headers hdr, inout metadata meta) {
-    bit<16> tmp_14;
+    bit<16> tmp_2;
     @name("ipv4_checksum") Checksum16() ipv4_checksum;
     apply {
-        tmp_14 = ipv4_checksum.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        if (hdr.ipv4.hdrChecksum == tmp_14) 
+        tmp_2 = ipv4_checksum.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        if (hdr.ipv4.hdrChecksum == tmp_2) 
             mark_to_drop();
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    bit<16> tmp_16;
+    bit<16> tmp_4;
     @name("ipv4_checksum") Checksum16() ipv4_checksum_2;
     apply {
-        tmp_16 = ipv4_checksum_2.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
-        hdr.ipv4.hdrChecksum = tmp_16;
+        tmp_4 = ipv4_checksum_2.get<tuple_2>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = tmp_4;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/hash-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2-frontend.p4
@@ -35,12 +35,8 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 }
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
-    bit<16> tmp;
-    tuple<bit<32>> tmp_0;
     @name("a") action a_0() {
-        tmp_0 = { meta.ipv4.lkp_ipv4_sa };
-        hash<bit<16>, bit<16>, tuple<bit<32>>, bit<32>>(tmp, HashAlgorithm.crc16, 16w0, tmp_0, 32w65536);
-        meta.hash.hash = tmp;
+        hash<bit<16>, bit<16>, tuple<bit<32>>, bit<32>>(meta.hash.hash, HashAlgorithm.crc16, 16w0, { meta.ipv4.lkp_ipv4_sa }, 32w65536);
     }
     apply {
         a_0();

--- a/testdata/p4_16_samples_outputs/hash-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2-midend.p4
@@ -39,12 +39,8 @@ struct tuple_0 {
 }
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
-    bit<16> tmp_1;
-    tuple_0 tmp_2;
     @name("a") action a_0() {
-        tmp_2.field = meta.ipv4.lkp_ipv4_sa;
-        hash<bit<16>, bit<16>, tuple_0, bit<32>>(tmp_1, HashAlgorithm.crc16, 16w0, tmp_2, 32w65536);
-        meta.hash.hash = tmp_1;
+        hash<bit<16>, bit<16>, tuple_0, bit<32>>(meta.hash.hash, HashAlgorithm.crc16, 16w0, { meta.ipv4.lkp_ipv4_sa }, 32w65536);
     }
     @hidden table tbl_a {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2-frontend.p4
@@ -19,13 +19,9 @@ struct Metadata {
 }
 
 parser parserI(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
-    H tmp;
-    bit<32> tmp_0;
     state start {
         pkt.extract<S>(hdr.s1);
-        tmp_0 = hdr.s1.size;
-        pkt.extract<H>(tmp, tmp_0);
-        hdr.h = tmp;
+        pkt.extract<H>(hdr.h, hdr.s1.size);
         pkt.extract<S>(hdr.s2);
         transition accept;
     }

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2-midend.p4
@@ -19,13 +19,9 @@ struct Metadata {
 }
 
 parser parserI(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
-    H tmp_1;
-    bit<32> tmp_2;
     state start {
         pkt.extract<S>(hdr.s1);
-        tmp_2 = hdr.s1.size;
-        pkt.extract<H>(tmp_1, tmp_2);
-        hdr.h = tmp_1;
+        pkt.extract<H>(hdr.h, hdr.s1.size);
         pkt.extract<S>(hdr.s2);
         transition accept;
     }

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-frontend.p4
@@ -19,18 +19,10 @@ struct Metadata {
 }
 
 parser parserI(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
-    H tmp;
-    bit<32> tmp_0;
-    H tmp_1;
-    bit<32> tmp_2;
     state start {
         pkt.extract<S>(hdr.s1);
-        tmp_0 = hdr.s1.size;
-        pkt.extract<H>(tmp, tmp_0);
-        hdr.h1 = tmp;
-        tmp_2 = hdr.s1.size;
-        pkt.extract<H>(tmp_1, tmp_2);
-        hdr.h2 = tmp_1;
+        pkt.extract<H>(hdr.h1, hdr.s1.size);
+        pkt.extract<H>(hdr.h2, hdr.s1.size);
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-midend.p4
@@ -19,18 +19,10 @@ struct Metadata {
 }
 
 parser parserI(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
-    H tmp_3;
-    bit<32> tmp_4;
-    H tmp_5;
-    bit<32> tmp_6;
     state start {
         pkt.extract<S>(hdr.s1);
-        tmp_4 = hdr.s1.size;
-        pkt.extract<H>(tmp_3, tmp_4);
-        hdr.h1 = tmp_3;
-        tmp_6 = hdr.s1.size;
-        pkt.extract<H>(tmp_5, tmp_6);
-        hdr.h2 = tmp_5;
+        pkt.extract<H>(hdr.h1, hdr.s1.size);
+        pkt.extract<H>(hdr.h2, hdr.s1.size);
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/side_effects-frontend.p4
+++ b/testdata/p4_16_samples_outputs/side_effects-frontend.p4
@@ -22,34 +22,27 @@ control my() {
     bit<1> tmp_9;
     bit<1> tmp_10;
     bit<1> tmp_11;
-    bit<1> tmp_12;
-    bit<1> tmp_13;
-    bit<1> tmp_14;
     apply {
         a_0 = 1w0;
-        tmp = a_0;
-        tmp_0 = g(a_0);
-        tmp_1 = tmp_0;
-        tmp_2 = f(tmp, tmp_1);
-        a_0 = tmp_2;
-        tmp_3 = s_0[a_0].z;
-        tmp_4 = g(a_0);
-        tmp_5 = tmp_4;
-        tmp_6 = f(tmp_3, tmp_5);
-        s_0[a_0].z = tmp_3;
-        a_0 = tmp_6;
-        tmp_7 = g(a_0);
-        tmp_8 = tmp_7;
-        tmp_9 = s_0[tmp_8].z;
-        tmp_10 = a_0;
-        tmp_11 = f(tmp_9, tmp_10);
-        s_0[tmp_8].z = tmp_9;
-        a_0 = tmp_11;
-        tmp_12 = g(a_0);
-        a_0 = tmp_12;
-        tmp_13 = g(a_0[0:0]);
-        a_0[0:0] = tmp_13;
-        tmp_14 = g(a_0);
+        tmp = g(a_0);
+        tmp_0 = tmp;
+        tmp_1 = f(a_0, tmp_0);
+        a_0 = tmp_1;
+        tmp_2 = g(a_0);
+        tmp_3 = tmp_2;
+        tmp_4 = f(s_0[a_0].z, tmp_3);
+        a_0 = tmp_4;
+        tmp_5 = g(a_0);
+        tmp_6 = tmp_5;
+        tmp_7 = s_0[tmp_6].z;
+        tmp_8 = f(tmp_7, a_0);
+        s_0[tmp_6].z = tmp_7;
+        a_0 = tmp_8;
+        tmp_9 = g(a_0);
+        a_0 = tmp_9;
+        tmp_10 = g(a_0[0:0]);
+        a_0[0:0] = tmp_10;
+        tmp_11 = g(a_0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/side_effects-midend.p4
+++ b/testdata/p4_16_samples_outputs/side_effects-midend.p4
@@ -9,37 +9,32 @@ package top(c _c);
 control my() {
     bit<1> a;
     H[2] s;
+    bit<1> tmp_12;
+    bit<1> tmp_14;
     bit<1> tmp_15;
-    bit<1> tmp_16;
+    bit<1> tmp_17;
     bit<1> tmp_18;
-    bit<1> tmp_19;
     bit<1> tmp_20;
+    bit<1> tmp_21;
     bit<1> tmp_22;
     bit<1> tmp_23;
-    bit<1> tmp_25;
-    bit<1> tmp_27;
-    bit<1> tmp_28;
-    bit<1> tmp_29;
     @hidden action act() {
         a = 1w0;
-        tmp_15 = 1w0;
-        tmp_16 = g(a);
-        tmp_18 = f(tmp_15, tmp_16);
-        a = tmp_18;
-        tmp_19 = s[tmp_18].z;
-        tmp_20 = g(a);
-        tmp_22 = f(tmp_19, tmp_20);
-        s[a].z = tmp_19;
+        tmp_12 = g(a);
+        tmp_14 = f(a, tmp_12);
+        a = tmp_14;
+        tmp_15 = g(a);
+        tmp_17 = f(s[a].z, tmp_15);
+        a = tmp_17;
+        tmp_18 = g(a);
+        tmp_20 = s[tmp_18].z;
+        tmp_21 = f(tmp_20, a);
+        s[tmp_18].z = tmp_20;
+        a = tmp_21;
+        tmp_22 = g(a);
         a = tmp_22;
-        tmp_23 = g(a);
-        tmp_25 = s[tmp_23].z;
-        tmp_27 = f(tmp_25, a);
-        s[tmp_23].z = tmp_25;
-        a = tmp_27;
-        tmp_28 = g(a);
-        a = tmp_28;
-        tmp_29 = g(a[0:0]);
-        a[0:0] = tmp_29;
+        tmp_23 = g(a[0:0]);
+        a[0:0] = tmp_23;
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/uninit-frontend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-frontend.p4
@@ -16,16 +16,15 @@ parser p1(packet_in p, out Header h) {
     bit<32> tmp_0;
     bit<32> tmp_1;
     bit<32> tmp_2;
-    bit<32> tmp_3;
     state start {
         h.data1 = 32w0;
         func(h);
         tmp = h.data2;
         tmp_0 = h.data2;
-        tmp_1 = h.data2;
-        tmp_2 = g(tmp_0, tmp_1);
-        tmp_3 = tmp_2;
-        g(tmp, tmp_3);
+        tmp_1 = g(tmp, tmp_0);
+        h.data2 = tmp;
+        tmp_2 = tmp_1;
+        g(h.data2, tmp_2);
         h.data2 = h.data3 + 32w1;
         stack_0[1].isValid();
         transition select(h.isValid()) {

--- a/testdata/p4_16_samples_outputs/uninit-midend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-midend.p4
@@ -12,20 +12,19 @@ parser p1(packet_in p, out Header h) {
     Header[2] stack;
     bool c_1;
     bool d;
+    bit<32> tmp_3;
     bit<32> tmp_4;
     bit<32> tmp_5;
     bit<32> tmp_6;
-    bit<32> tmp_7;
-    bit<32> tmp_8;
     state start {
         h.data1 = 32w0;
         func(h);
+        tmp_3 = h.data2;
         tmp_4 = h.data2;
-        tmp_5 = h.data2;
-        tmp_6 = h.data2;
-        tmp_7 = g(tmp_5, tmp_6);
-        tmp_8 = tmp_7;
-        g(tmp_4, tmp_8);
+        tmp_5 = g(tmp_3, tmp_4);
+        h.data2 = tmp_3;
+        tmp_6 = tmp_5;
+        g(h.data2, tmp_6);
         h.data2 = h.data3 + 32w1;
         stack[1].isValid();
         transition select((bit<1>)h.isValid()) {

--- a/testdata/p4_16_samples_outputs/uninit.p4-stderr
+++ b/testdata/p4_16_samples_outputs/uninit.p4-stderr
@@ -3,9 +3,6 @@ uninit.p4(35): warning: h may not be completely initialized
              ^
 uninit.p4(36): warning: h.data2 may be uninitialized
         g(h.data2, g(h.data2, h.data2)); // uninitialized
-          ^^^^^^^
-uninit.p4(36): warning: h.data2 may be uninitialized
-        g(h.data2, g(h.data2, h.data2)); // uninitialized
                      ^^^^^^^
 uninit.p4(36): warning: h.data2 may be uninitialized
         g(h.data2, g(h.data2, h.data2)); // uninitialized


### PR DESCRIPTION
This PR contains a subset of the changes from the reverted PR (which changed v1model).
This PR only contains the improved alias analysis, which is useful in itself.
The main effect is to create fewer unneeded temporaries in the side-effect pass.