### PR TITLE
Make P4Runtime generation backend independent

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -39,7 +39,6 @@ set (BMV2_BACKEND_SRCS
   portableSwitch.cpp
   sharedActionSelectorCheck.cpp
   simpleSwitch.cpp
-  synthesizeValidField.cpp
   )
 
 set (BMV2_BACKEND_HDRS
@@ -63,7 +62,6 @@ set (BMV2_BACKEND_HDRS
   portableSwitch.h
   sharedActionSelectorCheck.h
   simpleSwitch.h
-  synthesizeValidField.h
   )
 
 set (IR_DEF_FILES ${IR_DEF_FILES} ${CMAKE_CURRENT_SOURCE_DIR}/bmv2.def PARENT_SCOPE)
@@ -122,11 +120,6 @@ endif()
 
 set (GTEST_BMV2_SOURCES
   ${P4C_SOURCE_DIR}/test/gtest/bmv2_isvalid.cpp
-
-  # XXX(seth): This should not depend on BMV2. The source of the dependency is
-  # the SynthesizeValidField pass; we should either promote it to a midend pass
-  # or remove the dependency in the P4Runtime code.
-  ${P4C_SOURCE_DIR}/test/gtest/p4runtime.cpp
   )
 
 set (GTEST_SOURCES ${GTEST_SOURCES} ${GTEST_BMV2_SOURCES} PARENT_SCOPE)

--- a/backends/bmv2/bmv2.cpp
+++ b/backends/bmv2/bmv2.cpp
@@ -104,12 +104,11 @@ int main(int argc, char *const argv[]) {
     // Generate a PI control plane API for this program if requested.
     if (!options.p4RuntimeFile.isNullOrEmpty()) {
         std::ostream* out = openFile(options.p4RuntimeFile, false);
-        std::ostream *outEntries = nullptr;
+        std::ostream* outEntries = nullptr;
         if (!options.p4RuntimeEntriesFile.isNullOrEmpty())
             outEntries = openFile(options.p4RuntimeEntriesFile, false);
         if (out != nullptr) {
-            auto p4Runtime =
-              generateP4Runtime(program, toplevel, &midEnd.refMap, &midEnd.typeMap);
+            auto p4Runtime = P4::generateP4Runtime(program);
             p4Runtime.serializeP4InfoTo(out, options.p4RuntimeFormat);
             if (outEntries != nullptr)
                 p4Runtime.serializeEntriesTo(outEntries, options.p4RuntimeFormat);

--- a/backends/bmv2/midend.cpp
+++ b/backends/bmv2/midend.cpp
@@ -44,6 +44,7 @@ limitations under the License.
 #include "midend/simplifyKey.h"
 #include "midend/simplifySelectCases.h"
 #include "midend/simplifySelectList.h"
+#include "midend/synthesizeValidField.h"
 #include "midend/removeSelectBooleans.h"
 #include "midend/validateProperties.h"
 #include "midend/compileTimeOps.h"
@@ -53,7 +54,6 @@ limitations under the License.
 #include "midend/tableHit.h"
 #include "midend/midEndLast.h"
 #include "midend/dontcareArgs.h"
-#include "synthesizeValidField.h"
 
 namespace BMV2 {
 
@@ -100,7 +100,7 @@ MidEnd::MidEnd(BMV2Options& options) {
         new P4::UniqueParameters(&refMap, &typeMap),
         new P4::SimplifyControlFlow(&refMap, &typeMap),
         new P4::RemoveActionParameters(&refMap, &typeMap),
-        new SynthesizeValidField(&refMap, &typeMap),
+        new P4::SynthesizeValidField(&refMap, &typeMap),
         new P4::TypeChecking(&refMap, &typeMap),
         new P4::SimplifyKey(&refMap, &typeMap, new P4::NonMaskLeftValue(&typeMap)),
         new P4::ConstantFolding(&refMap, &typeMap),

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1700,7 +1700,7 @@ static void analyzeTable(P4RuntimeAnalyzer& analyzer,
 template <typename Func>
 static void forAllEvaluatedBlocks(const IR::ToplevelBlock* aToplevelBlock,
                                   Func function) {
-    set<const IR::Block*> visited;
+    std::set<const IR::Block*> visited;
     ordered_set<const IR::Block*> frontier{aToplevelBlock};
 
     while (!frontier.empty()) {

--- a/control-plane/p4RuntimeSerializer.h
+++ b/control-plane/p4RuntimeSerializer.h
@@ -28,13 +28,9 @@ class WriteRequest;
 
 namespace IR {
 class P4Program;
-class ToplevelBlock;
 }  // namespace IR
 
 namespace P4 {
-
-class ReferenceMap;
-class TypeMap;
 
 /// P4Runtime serialization formats.
 enum class P4RuntimeFormat {
@@ -68,23 +64,11 @@ struct P4RuntimeAPI {
  * constructs may be excluded from the API. In this case, a program error will
  * be reported.
  *
- * XXX(seth): Ideally this should only depend on the frontend, but currently
- * some midend passes are also required. We depend on at least EliminateTuples,
- * SynthesizeValidField, and LocalizeAllActions.  That list is probably not
- * exhaustive.
- *
  * @param program  The program to construct the control-plane API from. All
  *                 frontend passes must have already run.
- * @param evaluatedProgram  An up-to-date version of the program with
- *                          compile-time evaluation performed.
- * @param refMap  An up-to-date reference map.
- * @param typeMap An up-to-date type map.
  * @return the generated P4Runtime API.
  */
-P4RuntimeAPI generateP4Runtime(const IR::P4Program* program,
-                               const IR::ToplevelBlock* evaluatedProgram,
-                               ReferenceMap* refMap,
-                               TypeMap* typeMap);
+P4RuntimeAPI generateP4Runtime(const IR::P4Program* program);
 
 }  // namespace P4
 

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -508,10 +508,10 @@ const IR::Statement *PrimitiveConverter::cvtPrimitive(ProgramStructure *structur
     return nullptr;
 }
 
-vector<const IR::Expression *>
+safe_vector<const IR::Expression *>
 PrimitiveConverter::convertArgs(ProgramStructure *structure, const IR::Primitive *prim) {
     ExpressionConverter conv(structure);
-    vector<const IR::Expression *> rv;
+    safe_vector<const IR::Expression *> rv;
     for (auto arg : prim->operands)
         rv.push_back(conv.convert(arg));
     return rv;

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define _FRONTENDS_P4_FROMV1_0_CONVERTERS_H_
 
 #include "ir/ir.h"
+#include "lib/safe_vector.h"
 #include "frontends/p4/coreLibrary.h"
 #include "programStructure.h"
 
@@ -120,7 +121,7 @@ class PrimitiveConverter {
     virtual ~PrimitiveConverter();
 
     // helper functions
-    vector<const IR::Expression *> convertArgs(ProgramStructure *, const IR::Primitive *);
+    safe_vector<const IR::Expression *> convertArgs(ProgramStructure *, const IR::Primitive *);
 
  public:
     virtual const IR::Statement *convert(ProgramStructure *, const IR::Primitive *) = 0;

--- a/ir/CMakeLists.txt
+++ b/ir/CMakeLists.txt
@@ -47,7 +47,6 @@ set (IR_HDRS
   node.h
   nodemap.h
   pass_manager.h
-  std.h
   vector.h
   visitor.h
 )

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -20,8 +20,9 @@ limitations under the License.
 
 #include "dbprint.h"
 #include "lib/enumerator.h"
-#include "lib/null.h"
 #include "lib/error.h"
+#include "lib/null.h"
+#include "lib/safe_vector.h"
 #include "vector.h"
 #include "id.h"
 
@@ -97,7 +98,7 @@ class IndexedVector : public Vector<T> {
     IndexedVector &operator=(IndexedVector &&) = default;
     explicit IndexedVector(const T *a) {
         push_back(std::move(a)); }
-    explicit IndexedVector(const vector<const T *> &a) {
+    explicit IndexedVector(const safe_vector<const T *> &a) {
         insert(typename Vector<T>::end(), a.begin(), a.end()); }
     explicit IndexedVector(const Vector<T> &a) {
         insert(typename Vector<T>::end(), a.begin(), a.end()); }

--- a/ir/json_generator.h
+++ b/ir/json_generator.h
@@ -21,9 +21,11 @@ limitations under the License.
 #include <boost/optional.hpp>
 #include <gmpxx.h>
 #include <string>
+#include <unordered_set>
 #include "lib/cstring.h"
 #include "lib/indent.h"
 #include "lib/match.h"
+#include "lib/safe_vector.h"
 
 #include "ir.h"
 class JSONGenerator {
@@ -49,7 +51,7 @@ class JSONGenerator {
         out(out), dumpSourceInfo(dumpSourceInfo) {}
 
     template<typename T>
-    void generate(const vector<T> &v) {
+    void generate(const safe_vector<T> &v) {
         out << "[";
         if (v.size() > 0) {
             out << std::endl << ++indent;

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "lib/cstring.h"
 #include "lib/indent.h"
 #include "lib/match.h"
+#include "lib/safe_vector.h"
 #include "ir.h"
 #include "json_parser.h"
 
@@ -74,7 +75,7 @@ class JSONLoader {
     }
 
     template<typename T>
-    void unpack_json(vector<T> &v) {
+    void unpack_json(safe_vector<T> &v) {
         T temp;
         for (auto e : *json->to<JsonVector>()) {
             load(e, temp);

--- a/ir/node.h
+++ b/ir/node.h
@@ -18,7 +18,6 @@ limitations under the License.
 #define _IR_NODE_H_
 
 #include <memory>
-#include "std.h"
 #include "lib/cstring.h"
 #include "lib/stringify.h"
 #include "lib/indent.h"

--- a/ir/pass_manager.cpp
+++ b/ir/pass_manager.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 #include "lib/n4.h"
 
 const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *) {
-    vector<std::pair<vector<Visitor *>::iterator, const IR::Node *>> backup;
+    safe_vector<std::pair<safe_vector<Visitor *>::iterator, const IR::Node *>> backup;
 
     early_exit_flag = false;
     BUG_CHECK(running, "not calling apply properly");

--- a/ir/pass_manager.h
+++ b/ir/pass_manager.h
@@ -27,8 +27,8 @@ class PassManager : virtual public Visitor, virtual public Backtrack {
     mutable int never_backtracks_cache = -1;
 
  protected:
-    vector<DebugHook>   debugHooks;  // called after each pass
-    vector<Visitor *>   passes;
+    safe_vector<DebugHook>   debugHooks;  // called after each pass
+    safe_vector<Visitor *>   passes;
     // if true stops compilation after first pass that signals an error
     bool                stop_on_error = true;
     bool                running = false;

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -164,7 +164,7 @@ class Apply : Expression {
         // HACK -- temp sort actions into program (source) order, so that condition names are
         // generated in the same order as p4-hlir
         typedef std::remove_reference<decltype(actions.at("any"))>::type action_t;
-        vector<action_t *> sort_actions;
+        safe_vector<action_t *> sort_actions;
         for (auto &p : Values(actions)) sort_actions.push_back(&p);
         std::sort(sort_actions.begin(), sort_actions.end(),
             [](action_t *a, action_t *b) {
@@ -244,7 +244,7 @@ class CalculatedField {
         update_or_verify(bool u, ID n, const Expression *c) : update(u), name(n), cond(c) {}
         update_or_verify() {}
     }
-    vector<update_or_verify>    specs = {};
+    safe_vector<update_or_verify> specs = {};
     Annotations                 annotations;
     visit_children {
         v.visit(field, "field");
@@ -253,7 +253,7 @@ class CalculatedField {
 }
 
 class CaseEntry {
-    vector<std::pair<Constant, Constant>>       values = {};
+    safe_vector<std::pair<Constant, Constant>>  values = {};
     optional ID                                 action;
 }
 
@@ -331,7 +331,7 @@ class Register : Stateful {
 class PrimitiveAction {}
 
 class NameList {
-    vector<ID>  names = {};
+    safe_vector<ID>  names = {};
     NameList(Util::SourceInfo si, cstring n) { names.emplace_back(si, n); }
     dump_fields { out << "names=" << names; }
 }
@@ -350,7 +350,7 @@ class ActionArg : Expression {
 class ActionFunction {
     optional ID                 name;
     inline Vector<Primitive>    action = {};
-    vector<ActionArg>           args = {};
+    safe_vector<ActionArg>      args = {};
     optional Annotations        annotations = Annotations::empty;
 
     ActionArg arg(cstring n) const {
@@ -373,7 +373,7 @@ class ActionFunction {
 
 class ActionProfile : Attached {
     ID          selector = {};
-    vector<ID>  actions = {};
+    safe_vector<ID> actions = {};
     int         size = 0;
     const char *kind() const override { return "action_profile"; }
     bool indexed() const override { return true; }
@@ -390,12 +390,12 @@ class ActionSelector : Attached {
 class V1Table : IInstance {
     optional ID                 name;
     NullOK Vector<Expression>   reads = 0;
-    vector<ID>                  reads_types = {};
+    safe_vector<ID>             reads_types = {};
     int                         min_size = 0;
     int                         max_size = 0;
     int                         size = 0;
     ID                          action_profile = {};
-    vector<ID>                  actions = {};
+    safe_vector<ID>             actions = {};
     ID                          default_action = {};
     NullOK Vector<Expression>   default_action_args = 0;
     inline TableProperties      properties = {};  // non-standard properties

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "dbprint.h"
 #include "lib/enumerator.h"
 #include "lib/null.h"
+#include "lib/safe_vector.h"
 
 class JSONLoader;
 
@@ -51,7 +52,7 @@ class VectorBase : public Node {
 // User-level code should use regular std::vector
 template<class T>
 class Vector : public VectorBase {
-    vector<const T *>   vec;
+    safe_vector<const T *>   vec;
 
  public:
     typedef const T* value_type;
@@ -63,12 +64,12 @@ class Vector : public VectorBase {
     Vector &operator=(Vector &&) = default;
     explicit Vector(const T *a) {
         vec.emplace_back(std::move(a)); }
-    explicit Vector(const vector<const T *> &a) {
+    explicit Vector(const safe_vector<const T *> &a) {
         vec.insert(vec.end(), a.begin(), a.end()); }
     Vector(const std::initializer_list<const T *> &a) : vec(a) {}
     static Vector<T>* fromJSON(JSONLoader &json);
-    typedef typename vector<const T *>::iterator        iterator;
-    typedef typename vector<const T *>::const_iterator  const_iterator;
+    typedef typename safe_vector<const T *>::iterator        iterator;
+    typedef typename safe_vector<const T *>::const_iterator  const_iterator;
     iterator begin() { return vec.begin(); }
     const_iterator begin() const { return vec.begin(); }
     VectorBase::iterator VectorBase_begin() const override {

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -32,7 +32,7 @@ class Visitor::ChangeTracker {
         bool            visitOnce;
         const IR::Node  *result;
     };
-    typedef unordered_map<const IR::Node *, visit_info_t>  visited_t;
+    typedef std::unordered_map<const IR::Node *, visit_info_t>  visited_t;
     visited_t           visited;
 
  public:
@@ -374,7 +374,7 @@ IRNODE_ALL_SUBCLASSES(DEFINE_VISIT_FUNCTIONS)
 #undef DEFINE_VISIT_FUNCTIONS
 
 class SetupJoinPoints : public Inspector {
-    map<const IR::Node *, std::pair<ControlFlowVisitor *, int>> &join_points;
+    std::map<const IR::Node *, std::pair<ControlFlowVisitor *, int>> &join_points;
     bool preorder(const IR::Node *n) override {
         return ++join_points[n].second == 1; }
  public:

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -18,7 +18,7 @@ limitations under the License.
 #define _IR_VISITOR_H_
 
 #include <stdexcept>
-#include "std.h"
+#include <unordered_map>
 #include "lib/cstring.h"
 #include "ir/ir.h"
 #include "lib/exceptions.h"
@@ -234,7 +234,7 @@ class Modifier : public virtual Visitor {
 
 class Inspector : public virtual Visitor {
     struct info_t { bool done, visitOnce; };
-    typedef unordered_map<const IR::Node *, info_t>       visited_t;
+    typedef std::unordered_map<const IR::Node *, info_t>       visited_t;
     visited_t   *visited = nullptr;
     bool check_clone(const Visitor *) override;
  public:
@@ -282,7 +282,7 @@ class Transform : public virtual Visitor {
 };
 
 class ControlFlowVisitor : public virtual Visitor {
-    map<const IR::Node *, std::pair<ControlFlowVisitor *, int>> *flow_join_points = 0;
+    std::map<const IR::Node *, std::pair<ControlFlowVisitor *, int>> *flow_join_points = 0;
  protected:
     virtual ControlFlowVisitor *clone() const = 0;
     void init_join_flows(const IR::Node *root) override;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -59,6 +59,7 @@ set (LIBP4CTOOLKIT_HDRS
 	ordered_set.h
 	path.h
 	range.h
+	safe_vector.h
 	set.h
 	source_file.h
 	sourceCodeBuilder.h

--- a/lib/safe_vector.h
+++ b/lib/safe_vector.h
@@ -14,26 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef IR_STD_H_
-#define IR_STD_H_
-#include <array>
-#include <map>
-#include <memory>
-#include <set>
-#include <unordered_map>
-#include <unordered_set>
+#ifndef P4C_LIB_SAFE_VECTOR_H_
+#define P4C_LIB_SAFE_VECTOR_H_
+
 #include <vector>
 
-using std::const_pointer_cast;
-using std::map;
-using std::set;
-using std::unordered_map;
-using std::unordered_set;
-// using std::vector;
-// using std::array;
-
+/// An enhanced version of std::vector that performs bounds checking for
+/// operator[].
 template<class T, class _Alloc = std::allocator<T>>
-class vector : public std::vector<T, _Alloc> {
+class safe_vector : public std::vector<T, _Alloc> {
  public:
     using std::vector<T, _Alloc>::vector;
     typedef typename std::vector<T, _Alloc>::reference reference;
@@ -44,15 +33,4 @@ class vector : public std::vector<T, _Alloc> {
     const_reference operator[](size_type n) const { return this->at(n); }
 };
 
-template<class T, size_t N>
-class array : public std::array<T, N> {
- public:
-    using std::array<T, N>::array;
-    typedef typename std::array<T, N>::reference reference;
-    typedef typename std::array<T, N>::const_reference const_reference;
-    typedef typename std::array<T, N>::size_type size_type;
-    reference operator[](size_type n) { return this->at(n); }
-    const_reference operator[](size_type n) const { return this->at(n); }
-};
-
-#endif /* IR_STD_H_ */
+#endif /* P4C_LIB_SAFE_VECTOR_H_ */

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -33,6 +33,7 @@ set (MIDEND_SRCS
   simplifyKey.cpp
   simplifySelectCases.cpp
   simplifySelectList.cpp
+  synthesizeValidField.cpp
   removeSelectBooleans.cpp
   validateProperties.cpp
   expandLookahead.cpp
@@ -71,6 +72,7 @@ set (MIDEND_HDRS
   simplifyKey.h
   simplifySelectCases.h
   simplifySelectList.h
+  synthesizeValidField.h
   tableHit.h
   validateProperties.h
   dontcareArgs.h

--- a/midend/synthesizeValidField.h
+++ b/midend/synthesizeValidField.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_BMV2_SYNTHESIZEVALIDFIELD_H_
-#define _BACKENDS_BMV2_SYNTHESIZEVALIDFIELD_H_
+#ifndef _MIDEND_SYNTHESIZEVALIDFIELD_H_
+#define _MIDEND_SYNTHESIZEVALIDFIELD_H_
 
 #include "ir/ir.h"
 #include "ir/pass_manager.h"
@@ -25,12 +25,17 @@ class ReferenceMap;
 class TypeMap;
 }  // namespace P4
 
-namespace BMV2 {
+namespace P4 {
 
 /**
  * Adds an explicit valid bit to each header type and replaces calls to
  * isValid() with references to the new field. This better reflects how header
- * validity is actually implemented on BMV2, which simplifies later passes.
+ * validity is actually implemented on some backends, which can simplify later
+ * passes.
+ *
+ * XXX(seth): *There are known problems with this approach.* We're working on a
+ * better way to handle this. For now, you are advised against using this in new
+ * backends.
  *
  * In most situations, `foo.isValid()` is rewritten to `foo.$valid$ == 1`.
  * However, when `foo.isValid()` is a table key element (and isn't part of a
@@ -43,8 +48,10 @@ namespace BMV2 {
  * to a simple read of a hidden field.
  *
  * XXX(seth): It would be cleaner to rewrite setValid() and setInvalid() too,
- * but we currently can't. Those compile down into special BMV2 primitives that
- * are needed for certain features (e.g. header unions) to work correctly.
+ * but we currently can't if we want to use this pass with BMV2 (or at least,
+ * we'd need to make it optional). Those compile down into special BMV2
+ * primitives that are needed for certain features (e.g. header unions) to work
+ * correctly.
  *
  * Example:
  *
@@ -88,6 +95,6 @@ class SynthesizeValidField final : public PassManager {
     SynthesizeValidField(P4::ReferenceMap* refMap, P4::TypeMap* typeMap);
 };
 
-}  // namespace BMV2
+}  // namespace P4
 
-#endif  /* _BACKENDS_BMV2_SYNTHESIZEVALIDFIELD_H_ */
+#endif  /* _MIDEND_SYNTHESIZEVALIDFIELD_H_ */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/midend_test.cpp
   gtest/opeq_test.cpp
   gtest/path_test.cpp
+  gtest/p4runtime.cpp
   gtest/source_file_test.cpp
   gtest/transforms.cpp
   )

--- a/test/gtest/bmv2_isvalid.cpp
+++ b/test/gtest/bmv2_isvalid.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 
 #include "gtest/gtest.h"
 #include "backends/bmv2/helpers.h"
-#include "backends/bmv2/synthesizeValidField.h"
 #include "frontends/common/parseInput.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/createBuiltins.h"
@@ -28,6 +27,7 @@ limitations under the License.
 #include "helpers.h"
 #include "ir/ir.h"
 #include "midend/simplifyKey.h"
+#include "midend/synthesizeValidField.h"
 
 namespace BMV2 {
 
@@ -49,7 +49,7 @@ TEST(BMV2_SynthesizeValidField, ValidField) {
     P4::TypeMap typeMap;
     PassManager passes = {
         new P4::TypeChecking(&refMap, &typeMap),
-        new SynthesizeValidField(&refMap, &typeMap),
+        new P4::SynthesizeValidField(&refMap, &typeMap),
     };
     program = program->apply(passes);
     ASSERT_TRUE(program != nullptr);
@@ -98,7 +98,7 @@ TEST(BMV2_SynthesizeValidField, Expressions) {
     PassManager passes = {
         new P4::CreateBuiltins(),
         new P4::TypeChecking(&refMap, &typeMap),
-        new SynthesizeValidField(&refMap, &typeMap),
+        new P4::SynthesizeValidField(&refMap, &typeMap),
     };
     program = program->apply(passes);
     ASSERT_TRUE(program != nullptr);
@@ -184,7 +184,7 @@ TEST(BMV2_SynthesizeValidField, MatchKeys) {
     PassManager passes = {
         new P4::CreateBuiltins(),
         new P4::TypeChecking(&refMap, &typeMap),
-        new SynthesizeValidField(&refMap, &typeMap),
+        new P4::SynthesizeValidField(&refMap, &typeMap),
     };
     program = program->apply(passes);
     ASSERT_TRUE(program != nullptr);
@@ -286,7 +286,7 @@ TEST(BMV2_SynthesizeValidField, ConstTableEntries) {
     PassManager passes = {
         new P4::CreateBuiltins(),
         new P4::TypeChecking(&refMap, &typeMap),
-        new SynthesizeValidField(&refMap, &typeMap),
+        new P4::SynthesizeValidField(&refMap, &typeMap),
     };
     program = program->apply(passes);
     ASSERT_TRUE(program != nullptr);
@@ -364,7 +364,7 @@ TEST(BMV2_SynthesizeValidField, SimplifiedKeysHaveNoIsValid) {
     PassManager passes = {
         new P4::CreateBuiltins(),
         new P4::TypeChecking(&refMap, &typeMap),
-        new SynthesizeValidField(&refMap, &typeMap),
+        new P4::SynthesizeValidField(&refMap, &typeMap),
         new P4::TypeChecking(&refMap, &typeMap),
         new P4::SimplifyKey(&refMap, &typeMap, new P4::NonMaskLeftValue(&typeMap)),
     };


### PR DESCRIPTION
We're at the point now where we're ready to make P4Runtime generation backend independent. This PR eliminates all remaining dependencies on post-frontend passes. This is accomplished by moving the passes that *are* required inside `generateP4Runtime()`. This is a funny definition of "eliminate", I'll grant you. =) The point is that the users of the API don't need to know about these dependencies anymore, though. I've triaged them all; now that we have the full list, we can start gradually whittling it down until there's nothing left.

To make this work, we do have to move the `BMV2::SynthesizeValidField` pass into the midend code, because we need this available on all backends. Everyone, including me, has concerns about that pass, so I can understand some discomfort at making this move, but consider it a temporary matter until we can get something better in place. I added a warning to the documentation for that pass telling people that they shouldn't write new backends that use it.

I have really wanted for a while now to fix the cpplint and unified build woes that result from `ir/std.h` placing a `vector` class in the global namespace; that vector class triggers issues in the generated protobuf headers that we've been working around in various ways for a while. As part of this PR I went ahead and solved the root of the problem by renaming that `vector` class to `safe_vector` and moving it to `lib/safe_vector.h`. It turns out that if you make that change and add a few missing `std::`s and `#include`s here and there, we don't need `ir/std.h` at all anymore, so I went ahead and removed it as part of this patch. It pulled in a lot of STL headers, so that should improve compilation speed a little for translation units that otherwise didn't need them.