### PR TITLE
Frontend support for parser_value_set

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -412,7 +412,7 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                     cases.push_back(sc);
                 } else if (auto first = v.first->to<IR::PathExpression>()) {
                     // XXX(hanw): handle parser_value_set
-                    P4C_UNIMPLEMENTED("parser_value_set is not yet implemented");
+                    ::warning("parser_value_set is not yet implemented");
                 } else {
                     ::error("Expected constant or parser value set in %1%", v.first);
                 }

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -414,7 +414,7 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                     // XXX(hanw): handle parser_value_set
                     P4C_UNIMPLEMENTED("parser_value_set is not yet implemented");
                 } else {
-                    BUG("Unknown type for select case", v.first);
+                    ::error("Expected constant or parser value set in %1%", v.first);
                 }
             }
         }

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -410,9 +410,11 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                     auto expr = explodeLabel(first, v.second, sizes);
                     auto sc = new IR::SelectCase(c->srcInfo, expr, deststate);
                     cases.push_back(sc);
-                }
-                if (auto first = v.first->to<IR::StringLiteral>()) {
+                } else if (auto first = v.first->to<IR::PathExpression>()) {
                     // XXX(hanw): handle parser_value_set
+                    P4C_UNIMPLEMENTED("parser_value_set is not yet implemented");
+                } else {
+                    BUG("Unknown type for select case", v.first);
                 }
             }
         }

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -406,9 +406,14 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
             if (deststate == nullptr)
                 return nullptr;
             for (auto v : c->values) {
-                auto expr = explodeLabel(v.first, v.second, sizes);
-                auto sc = new IR::SelectCase(c->srcInfo, expr, deststate);
-                cases.push_back(sc);
+                if (auto first = v.first->to<IR::Constant>()) {
+                    auto expr = explodeLabel(first, v.second, sizes);
+                    auto sc = new IR::SelectCase(c->srcInfo, expr, deststate);
+                    cases.push_back(sc);
+                }
+                if (auto first = v.first->to<IR::StringLiteral>()) {
+                    // XXX(hanw): handle parser_value_set
+                }
             }
         }
         select = new IR::SelectExpression(parser->select->srcInfo, list, std::move(cases));

--- a/frontends/parsers/v1/v1lexer.ll
+++ b/frontends/parsers/v1/v1lexer.ll
@@ -191,6 +191,8 @@ using Parser = V1::V1Parser;
                   return Parser::make_PARSE_ERROR(cstring(yytext), driver.yylloc); }
 "parser"        { BEGIN(driver.saveState);
                   return Parser::make_PARSER(cstring(yytext), driver.yylloc); }
+"parser_value_set" { BEGIN(driver.saveState);
+                     return Parser::make_PARSER_VALUE_SET(cstring(yytext), driver.yylloc); }
 "parser_exception" { BEGIN(driver.saveState);
                      return Parser::make_PARSER_EXCEPTION(cstring(yytext), driver.yylloc); }
 "payload"       { BEGIN(driver.saveState);

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -60,7 +60,7 @@ inline std::ostream& operator<<(std::ostream& out, const V1::HeaderType& headerT
     return out;
 }
 
-typedef std::pair<const IR::Constant*, const IR::Constant*> CaseValue;
+typedef std::pair<const IR::Literal*, const IR::Constant*> CaseValue;
 
 inline std::ostream& operator<<(std::ostream& out, const CaseValue& caseValue) {
     out << "CaseValue(" << caseValue.first << ',' << caseValue.second << ')';
@@ -166,7 +166,7 @@ typedef const IR::Type ConstType;
                 FIELDS HEADER HEADER_TYPE IF IMPLEMENTATION IN INPUT INSTANCE_COUNT
                 INT LATEST LAYOUT LENGTH MASK MAX_LENGTH MAX_SIZE MAX_WIDTH METADATA
                 METER METHOD MIN_SIZE MIN_WIDTH OPTIONAL OUT OUTPUT_WIDTH PARSE_ERROR
-                PARSER PARSER_EXCEPTION PAYLOAD PRAGMA PREFIX PRE_COLOR
+                PARSER PARSER_VALUE_SET PARSER_EXCEPTION PAYLOAD PRAGMA PREFIX PRE_COLOR
                 PRIMITIVE_ACTION READS REGISTER RESULT RETURN SATURATING SELECT
                 SELECTION_KEY SELECTION_MODE SELECTION_TYPE SET_METADATA SIGNED SIZE
                 STATIC STRING TABLE TRUE TYPE UPDATE VALID VERIFY WIDTH WRITES
@@ -237,6 +237,7 @@ input: /* epsilon */
     | input field_list_declaration
     | input field_list_calculation_declaration
     | input calculated_field_declaration
+    | input value_set_declaration
     | input parser_function_declaration
     | input parser_exception_declaration
     | input counter_declaration
@@ -257,7 +258,7 @@ input: /* epsilon */
 ;
 
 /********************************/
-/* 5.1 Header Type Declarations */
+/* 2.1 Header Type Declarations */
 /********************************/
 
 header_type_declaration: HEADER_TYPE name "{" header_dec_body "}"
@@ -337,7 +338,7 @@ type: BIT { $$ = IR::Type::Bits::get(@1, 1); }
 ;
 
 /************************************/
-/* 5.2 Header and Metadata instance */
+/* 2.2 Header and Metadata instance */
 /************************************/
 
 header_instance:
@@ -367,7 +368,7 @@ metadata_field_init_list: /* empty */
     ;
 
 /*******************/
-/* 5.4 Field Lists */
+/* 2.4 Field Lists */
 /*******************/
 
 field_list_declaration:
@@ -386,7 +387,7 @@ field_list_entries:
     ;
 
 /***************************************************/
-/* 6  Checksums and Hash-based Selection Functions */
+/* 3  Checksums and Hash-based Selection Functions */
 /***************************************************/
 
 field_list_calculation_declaration:
@@ -437,8 +438,16 @@ opt_condition: /* epsilon */ { $$ = nullptr; }
     | IF "(" expression ")" { $$ = $3; }
 ;
 
+/********************************/
+/* 4.3 Value Sets */
+/********************************/
+
+value_set_declaration:
+    PARSER_VALUE_SET name ";"
+    { driver.global->add($2, new IR::ParserValueSet(@1, IR::ID(@2, $2), driver.takePragmasAsAnnotations())); }
+
 /************************/
-/* 7.4 Parser Functions */
+/* 4.4 Parser Functions */
 /************************/
 
 parser_function_declaration:
@@ -485,12 +494,14 @@ case_value:
       { $$ = CaseValue($1 ? $1 : new IR::Constant(-1), new IR::Constant(-1)); }
     | const_expression MASK const_expression
       { $$ = CaseValue($1 ? $1 : new IR::Constant(-1), $3 ? $3 : new IR::Constant(0)); }
+    | name
+      { $$ = CaseValue(new IR::StringLiteral(@1, $1), new IR::Constant(-1)); }
     | DEFAULT
       { $$ = CaseValue(new IR::Constant(0), new IR::Constant(0)); }
     ;
 
 /*************************/
-/* 7.6 Parser Exceptions */
+/* 4.6 Parser Exceptions */
 /*************************/
 
 parser_exception_declaration:
@@ -499,7 +510,7 @@ parser_exception_declaration:
 ;
 
 /*****************/
-/* 10.1 Counters */
+/* 7.1 Counters */
 /*****************/
 
 counter_declaration: COUNTER name "{" counter_spec_list "}"
@@ -532,7 +543,7 @@ counter_spec_list:
 ;
 
 /***************/
-/* 10.2 Meters */
+/* 7.2 Meters */
 /***************/
 
 meter_declaration : METER name "{" meter_spec_list "}"
@@ -566,7 +577,7 @@ meter_spec_list:
 ;
 
 /******************/
-/* 10.2 Registers */
+/* 7.3 Registers */
 /******************/
 
 register_declaration: REGISTER name "{" register_spec_list "}"
@@ -603,7 +614,7 @@ register_spec_list:
 ;
 
 /**************************/
-/* 12.1 Primitive Actions */
+/* 9.1 Primitive Actions */
 /**************************/
 
 primitive_action_declaration:
@@ -621,7 +632,7 @@ opt_name_list: /* epsilon */ { $$ = nullptr; }
     ;
 
 /***************************/
-/* 12.2 Action Definitions */
+/* 9.2 Action Definitions */
 /***************************/
 
 action_function_declaration:
@@ -652,7 +663,7 @@ action_statement_list: /* epsilon */
 ;
 
 /***************************/
-/* Action Profile Definitions */
+/* 10 Action Profile Definitions */
 /***************************/
 
 action_profile_declaration: ACTION_PROFILE name "{" action_profile_body "}"
@@ -681,7 +692,7 @@ action_selector_body: /* epsilon */
     ;
 
 /*************************/
-/* 13 Table Declarations */
+/* 11 Table Declarations */
 /*************************/
 
 table_declaration: TABLE name "{" table_body "}"
@@ -746,7 +757,7 @@ action_list: /* epsilon */ { $$ = new IR::NameList(); }
 ;
 
 /*****************************************/
-/* 14 Packet Processing and Control Flow */
+/* 12 Packet Processing and Control Flow */
 /*****************************************/
 
 control_function_declaration: CONTROL name "{" control_statement_list "}"
@@ -961,7 +972,6 @@ field_ref: header_ref "." name
          { $$ = new IR::Member(@1+@3, $1, IR::ID(@3, $3)); }
 ;
 
-
 const_expression: expression
         { if (!($$ = driver.constantFold(&*$1)))
                 ::error("%s: Non constant expression", @1); }
@@ -1022,6 +1032,7 @@ name: IDENTIFIER { $$ = $1; }
     | OUT { $$ = $1; }
     | OUTPUT_WIDTH { $$ = $1; }
     | PARSER { $$ = $1; }
+    | PARSER_VALUE_SET { $$ = $1; }
     | PARSER_EXCEPTION { $$ = $1; }
     | PRE_COLOR { $$ = $1; }
     | PRIMITIVE_ACTION { $$ = $1; }

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -490,12 +490,10 @@ case_value_list:
     ;
 
 case_value:
-      const_expression
+      expression
       { $$ = CaseValue($1 ? $1 : new IR::Constant(-1), new IR::Constant(-1)); }
-    | const_expression MASK const_expression
+    | expression MASK const_expression
       { $$ = CaseValue($1 ? $1 : new IR::Constant(-1), $3 ? $3 : new IR::Constant(0)); }
-    | name
-      { $$ = CaseValue(new IR::PathExpression(IR::ID(@1, $1)), new IR::Constant(-1)); }
     | DEFAULT
       { $$ = CaseValue(new IR::Constant(0), new IR::Constant(0)); }
     ;

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -60,7 +60,7 @@ inline std::ostream& operator<<(std::ostream& out, const V1::HeaderType& headerT
     return out;
 }
 
-typedef std::pair<const IR::Literal*, const IR::Constant*> CaseValue;
+typedef std::pair<const IR::Expression*, const IR::Constant*> CaseValue;
 
 inline std::ostream& operator<<(std::ostream& out, const CaseValue& caseValue) {
     out << "CaseValue(" << caseValue.first << ',' << caseValue.second << ')';
@@ -495,7 +495,7 @@ case_value:
     | const_expression MASK const_expression
       { $$ = CaseValue($1 ? $1 : new IR::Constant(-1), $3 ? $3 : new IR::Constant(0)); }
     | name
-      { $$ = CaseValue(new IR::StringLiteral(@1, $1), new IR::Constant(-1)); }
+      { $$ = CaseValue(new IR::PathExpression(IR::ID(@1, $1)), new IR::Constant(-1)); }
     | DEFAULT
       { $$ = CaseValue(new IR::Constant(0), new IR::Constant(0)); }
     ;

--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -58,12 +58,16 @@ void IR::CaseEntry::dbprint(std::ostream &out) const {
     int prec = getprec(out);
     out << setprec(Prec_Low);
     for (auto &val : values) {
-        if (val.second->asLong() == -1)
+        if (val.first->is<IR::Constant>()) {
+            if (val.second->asLong() == -1)
+                out << sep << *val.first;
+            else if (val.second->asLong() == 0)
+                out << sep << "default";
+            else
+                out << sep << *val.first << " &&& " << *val.second;
+        } else if (val.first->is<IR::StringLiteral>()) {
             out << sep << *val.first;
-        else if (val.second->asLong() == 0)
-            out << sep << "default";
-        else
-            out << sep << *val.first << " &&& " << *val.second;
+        }
         sep = ", "; }
     out << ':' << setprec(prec) << " " << action;
 }

--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -65,8 +65,8 @@ void IR::CaseEntry::dbprint(std::ostream &out) const {
                 out << sep << "default";
             else
                 out << sep << *val.first << " &&& " << *val.second;
-        } else if (val.first->is<IR::StringLiteral>()) {
-            out << sep << *val.first;
+        } else if (val.first->is<IR::PathExpression>()) {
+            out << sep << *val.first->to<IR::PathExpression>();
         }
         sep = ", "; }
     out << ':' << setprec(prec) << " " << action;

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -260,8 +260,8 @@ class ParserValueSet {
 }
 
 class CaseEntry {
-    safe_vector<std::pair<Literal, Constant>>    values = {};
-    optional ID                                 action;
+    safe_vector<std::pair<Expression, Constant>>    values = {};
+    optional ID                                     action;
 }
 
 class V1Parser {

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -252,8 +252,15 @@ class CalculatedField {
         v.visit(annotations, "annotations"); }
 }
 
+class ParserValueSet {
+    optional ID                 name;
+    Annotations                 annotations;
+    dbprint { out << node_type_name() << " " << name; }
+    toString { return node_type_name() + " " + name; }
+}
+
 class CaseEntry {
-    safe_vector<std::pair<Constant, Constant>>  values = {};
+    safe_vector<std::pair<Literal, Constant>>    values = {};
     optional ID                                 action;
 }
 

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -142,6 +142,14 @@ extern void clone3<T>(in CloneType type, in bit<32> session, in T data);
 
 extern void truncate(in bit<32> length);
 
+// Parser value set
+// The parser value set implements a run-time updatable values that is used to
+// determine parser transition
+extern value_set<D> {
+    value_set(bit<8> size);
+    bool is_member(in D data);
+}
+
 // The name 'standard_metadata' is reserved
 
 // Architecture.

--- a/testdata/p4_14_samples/issue946.p4
+++ b/testdata/p4_14_samples/issue946.p4
@@ -1,0 +1,41 @@
+header_type ethernet_t {
+    fields {
+        dstAddr : 48;
+        srcAddr : 48;
+        etherType : 16;
+    }
+}
+header ethernet_t ethernet;
+
+parser start {
+    return parse_ethernet;
+}
+
+parser_value_set pvs;
+
+parser parse_ethernet {
+    extract(ethernet);
+    return select(latest.etherType) {
+        pvs : ingress;
+        default : ingress;
+    }
+}
+
+table dummy {
+    reads {
+        ethernet.dstAddr : exact;
+    }
+    actions {
+        noop;
+    }
+    size : 512;
+}
+
+
+action noop() {
+    no_op();
+}
+
+control ingress {
+    apply(dummy);
+}

--- a/testdata/p4_14_samples_outputs/issue946-first.p4
+++ b/testdata/p4_14_samples_outputs/issue946-first.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_ethernet") state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            default: accept;
+        }
+    }
+    @name(".start") state start {
+        transition parse_ethernet;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".noop") action noop() {
+    }
+    @name(".dummy") table dummy {
+        actions = {
+            noop();
+            @defaultonly NoAction();
+        }
+        key = {
+            hdr.ethernet.dstAddr: exact @name("ethernet.dstAddr") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    apply {
+        dummy.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/issue946-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue946-frontend.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_ethernet") state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            default: accept;
+        }
+    }
+    @name(".start") state start {
+        transition parse_ethernet;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".noop") action noop_0() {
+    }
+    @name(".dummy") table dummy_0 {
+        actions = {
+            noop_0();
+            @defaultonly NoAction();
+        }
+        key = {
+            hdr.ethernet.dstAddr: exact @name("ethernet.dstAddr") ;
+        }
+        size = 512;
+        default_action = NoAction();
+    }
+    apply {
+        dummy_0.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/issue946-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue946-midend.p4
@@ -1,0 +1,72 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_ethernet") state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            default: accept;
+        }
+    }
+    @name(".start") state start {
+        transition parse_ethernet;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("NoAction") action NoAction_0() {
+    }
+    @name(".noop") action noop_0() {
+    }
+    @name(".dummy") table dummy {
+        actions = {
+            noop_0();
+            @defaultonly NoAction_0();
+        }
+        key = {
+            hdr.ethernet.dstAddr: exact @name("ethernet.dstAddr") ;
+        }
+        size = 512;
+        default_action = NoAction_0();
+    }
+    apply {
+        dummy.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/issue946.p4
+++ b/testdata/p4_14_samples_outputs/issue946.p4
@@ -1,0 +1,69 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_ethernet") state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            default: accept;
+        }
+    }
+    @name(".start") state start {
+        transition parse_ethernet;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".noop") action noop() {
+        ;
+    }
+    @name(".dummy") table dummy {
+        actions = {
+            noop;
+        }
+        key = {
+            hdr.ethernet.dstAddr: exact;
+        }
+        size = 512;
+    }
+    apply {
+        dummy.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_14_samples_outputs/issue946.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue946.p4-stderr
@@ -1,0 +1,1 @@
+warning: parser_value_set is not yet implemented


### PR DESCRIPTION
This PR implements the frontend support for parser_value_set. 

The backend support for bmv2 is TBD. There is a placeholder for it.

I also corrected the section number in v1parser.ypp to correspond to the P14 v1.0.4 spec.

Related to #946 