### PR TITLE
Add serializeP4RuntimeIfRequired convenience wrapper

### DIFF
--- a/backends/bmv2/bmv2.cpp
+++ b/backends/bmv2/bmv2.cpp
@@ -101,19 +101,7 @@ int main(int argc, char *const argv[]) {
         }
     }
 
-    // Generate a PI control plane API for this program if requested.
-    if (!options.p4RuntimeFile.isNullOrEmpty()) {
-        std::ostream* out = openFile(options.p4RuntimeFile, false);
-        std::ostream* outEntries = nullptr;
-        if (!options.p4RuntimeEntriesFile.isNullOrEmpty())
-            outEntries = openFile(options.p4RuntimeEntriesFile, false);
-        if (out != nullptr) {
-            auto p4Runtime = P4::generateP4Runtime(program);
-            p4Runtime.serializeP4InfoTo(out, options.p4RuntimeFormat);
-            if (outEntries != nullptr)
-                p4Runtime.serializeEntriesTo(outEntries, options.p4RuntimeFormat);
-        }
-    }
+    P4::serializeP4RuntimeIfRequired(program, options);
 
     return ::errorCount() > 0;
 }

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include <fstream>
 #include <iostream>
 
+#include "control-plane/p4RuntimeSerializer.h"
 #include "ir/ir.h"
 #include "ir/json_loader.h"
 #include "lib/log.h"
@@ -129,6 +130,9 @@ int main(int argc, char *const argv[]) {
             }
         }
     }
+
+    P4::serializeP4RuntimeIfRequired(program, options);
+
     if (Log::verbose())
         std::cerr << "Done." << std::endl;
     return ::errorCount() > 0;

--- a/control-plane/p4RuntimeSerializer.h
+++ b/control-plane/p4RuntimeSerializer.h
@@ -30,6 +30,8 @@ namespace IR {
 class P4Program;
 }  // namespace IR
 
+class CompilerOptions;
+
 namespace P4 {
 
 /// P4Runtime serialization formats.
@@ -69,6 +71,18 @@ struct P4RuntimeAPI {
  * @return the generated P4Runtime API.
  */
 P4RuntimeAPI generateP4Runtime(const IR::P4Program* program);
+
+/**
+ * A convenience wrapper for P4::generateP4Runtime() which generates the
+ * P4RuntimeAPI structure for the provided program and serializes it according
+ * to the provided command-line options.
+ *
+ * @param program  The program to construct the control-plane API from. All
+ *                 frontend passes must have already run.
+ * @param options  The command-line options used to invoke the compiler.
+ */
+void serializeP4RuntimeIfRequired(const IR::P4Program* program,
+                                  const CompilerOptions& options);
 
 }  // namespace P4
 


### PR DESCRIPTION
A wrapper around generateP4Runtime, which can be used by all backends
which want to output the serialized control-plane API structures to
files.