### PR TITLE
remove -march=native for Travis optimized builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && \
     pip install tenjin && \
     mkdir build && \
     cd build && \
-    cmake .. '-DCMAKE_CXX_FLAGS:STRING=-O3 -march=native' && \
+    cmake .. '-DCMAKE_CXX_FLAGS:STRING=-O3' && \
     make && \
     make install && \
     /usr/local/bin/ccache -p -s && \


### PR DESCRIPTION
Since it is not guaranteed that the processor type in a docker VM is the same as the one that's actually running the container, we should not optimize for the native architecture. Several Travis builds are failing with illegal instruction.