### PR TITLE
Proposed fix for issue #995

### DIFF
--- a/backends/bmv2/parser.cpp
+++ b/backends/bmv2/parser.cpp
@@ -232,15 +232,18 @@ unsigned ParserConverter::combine(const IR::Expression* keySet,
             int width = type->width_bits();
             BUG_CHECK(width > 0, "%1%: unknown width", e);
 
-            mpz_class key_value, mask_value;
+            mpz_class key_value, mask_value, mask_value2;
             convertSimpleKey(keyElement, key_value, mask_value);
             unsigned w = 8 * ROUNDUP(width, 8);
             totalWidth += ROUNDUP(width, 8);
             value = Util::shift_left(value, w) + key_value;
             if (mask_value != -1) {
-                mask = Util::shift_left(mask, w) + mask_value;
+                mask_value2 = mask_value;
                 noMask = false;
+            } else {
+                mask_value2 = Util::mask(width);
             }
+            mask = Util::shift_left(mask, w) + mask_value2;
             LOG3("Shifting " << " into key " << key_value << " &&& " << mask_value <<
                  " result is " << value << " &&& " << mask);
             index++;

--- a/backends/bmv2/parser.cpp
+++ b/backends/bmv2/parser.cpp
@@ -232,18 +232,23 @@ unsigned ParserConverter::combine(const IR::Expression* keySet,
             int width = type->width_bits();
             BUG_CHECK(width > 0, "%1%: unknown width", e);
 
-            mpz_class key_value, mask_value, mask_value2;
+            mpz_class key_value, mask_value;
             convertSimpleKey(keyElement, key_value, mask_value);
             unsigned w = 8 * ROUNDUP(width, 8);
             totalWidth += ROUNDUP(width, 8);
             value = Util::shift_left(value, w) + key_value;
             if (mask_value != -1) {
-                mask_value2 = mask_value;
                 noMask = false;
             } else {
-                mask_value2 = Util::mask(width);
+                // mask_value == -1 is a special value used to
+                // indicate an exact match on all bit positions.  When
+                // there is more than one keyElement, we must
+                // represent such an exact match with 'width' 1 bits,
+                // because it may be combined into a mask for other
+                // keyElements that have their own independent masks.
+                mask_value = Util::mask(width);
             }
-            mask = Util::shift_left(mask, w) + mask_value2;
+            mask = Util::shift_left(mask, w) + mask_value;
             LOG3("Shifting " << " into key " << key_value << " &&& " << mask_value <<
                  " result is " << value << " &&& " << mask);
             index++;

--- a/testdata/p4_16_samples/issue995-bmv2.p4
+++ b/testdata/p4_16_samples/issue995-bmv2.p4
@@ -1,0 +1,96 @@
+/*
+Copyright 2017 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+    bit<16> transition_taken;
+}
+
+struct headers {
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.srcAddr, hdr.ethernet.dstAddr) {
+            (0x12f_0000                , 0x456             ): a1;
+            (0x12f_0000 &&& 0xffff_0000, 0x456             ): a2;
+            (0x12f_0000                , 0x456 &&& 0xfff   ): a3;
+            (0x12f_0000 &&& 0xffff_0000, 0x456 &&& 0xfff   ): a4;
+            default: a5;
+        }
+    }
+    state a1 {
+        meta.transition_taken = 1;
+        transition accept;
+    }
+    state a2 {
+        meta.transition_taken = 2;
+        transition accept;
+    }
+    state a3 {
+        meta.transition_taken = 3;
+        transition accept;
+    }
+    state a4 {
+        meta.transition_taken = 4;
+        transition accept;
+    }
+    state a5 {
+        meta.transition_taken = 5;
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+        hdr.ethernet.etherType = meta.transition_taken;
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_16_samples/issue995-bmv2.stf
+++ b/testdata/p4_16_samples/issue995-bmv2.stf
@@ -1,0 +1,65 @@
+# Goals for test cases:
+
+# (1) Include several cases where the current buggy version of the
+# compiler causes the wrong transition to occur.
+
+# (2) Include at least two cases that take each of the transitions in
+# the correct version of the code, one with all 0s in don't-care bit
+# positions of fields, the other with all 1s in don't-care bit
+# positions of fields.
+
+
+# Category (1) tests:
+
+# Confirmed: bug takes transition a2, fix takes a5
+packet 0 000000000456 0000022E0000 0000
+expect 0 000000000456 0000022E0000 0005
+
+# Confirmed: bug takes transition a3, fix takes a4
+packet 0 FFFFFFFFF456 FFFF012FFFFF 0000
+expect 0 FFFFFFFFF456 FFFF012FFFFF 0004
+
+# In the bug version, I believe it is impossible to take transition
+# a4, because with the bug, the value/mask of a4 matches only a subset
+# of packets matched by a3.
+
+# Category (2) tests:
+
+# transition a1
+# All bits are exact match in the src and dst, so cannot make two
+# different packets for this transition.
+packet 0 000000000456 0000012F0000 0000
+expect 0 000000000456 0000012F0000 0001
+
+# transition a2, as many 1 bits in fields as possible
+packet 0 000000000456 FFFF012FFFFF 0000
+expect 0 000000000456 FFFF012FFFFF 0002
+# We have to make at least one of the bits in the src non-0 to avoid
+# taking transition a1 in the correct code.
+packet 0 000000000456 8000012F0000 0000
+expect 0 000000000456 8000012F0000 0002
+
+# transition a3, as many 1 bits in fields as possible
+packet 0 FFFFFFFFF456 0000012F0000 0000
+expect 0 FFFFFFFFF456 0000012F0000 0003
+# transition a3, as many 0 bits in fields as possible
+# We have to make at least one of the bits in the dst non-0 to avoid
+# taking transition a1 in the correct code.
+packet 0 800000000456 0000012F0000 0000
+expect 0 800000000456 0000012F0000 0003
+
+# transition a4, as many 1 bits in fields as possible
+packet 0 FFFFFFFFF456 FFFF012FFFFF 0000
+expect 0 FFFFFFFFF456 FFFF012FFFFF 0004
+# transition a4, as many 0 bits in fields as possible
+# We have to make at least one of the bits in the src, and the dst,
+# non-0 to avoid taking transitions a1, a2, or a3 in the correct code.
+packet 0 040000000456 0200012F0000 0000
+expect 0 040000000456 0200012F0000 0004
+
+# transition a5, as many 1 bits in fields as possible
+packet 0 FFFFFFFFF456 FFFF012EFFFF 0000
+expect 0 FFFFFFFFF456 FFFF012EFFFF 0005
+# transition a5, as many 0 bits in fields as possible
+packet 0 000000000476 0000012F0000 0000
+expect 0 000000000476 0000012F0000 0005

--- a/testdata/p4_16_samples_outputs/issue995-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue995-bmv2-first.p4
@@ -1,0 +1,81 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+    bit<16> transition_taken;
+}
+
+struct headers {
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.srcAddr, hdr.ethernet.dstAddr) {
+            (48w0x12f0000, 48w0x456): a1;
+            (48w0x12f0000 &&& 48w0xffff0000, 48w0x456): a2;
+            (48w0x12f0000, 48w0x456 &&& 48w0xfff): a3;
+            (48w0x12f0000 &&& 48w0xffff0000, 48w0x456 &&& 48w0xfff): a4;
+            default: a5;
+        }
+    }
+    state a1 {
+        meta.transition_taken = 16w1;
+        transition accept;
+    }
+    state a2 {
+        meta.transition_taken = 16w2;
+        transition accept;
+    }
+    state a3 {
+        meta.transition_taken = 16w3;
+        transition accept;
+    }
+    state a4 {
+        meta.transition_taken = 16w4;
+        transition accept;
+    }
+    state a5 {
+        meta.transition_taken = 16w5;
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+        hdr.ethernet.etherType = meta.transition_taken;
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue995-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue995-bmv2-frontend.p4
@@ -1,0 +1,78 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+    bit<16> transition_taken;
+}
+
+struct headers {
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.srcAddr, hdr.ethernet.dstAddr) {
+            (48w0x12f0000, 48w0x456): a1;
+            (48w0x12f0000 &&& 48w0xffff0000, 48w0x456): a2;
+            (48w0x12f0000, 48w0x456 &&& 48w0xfff): a3;
+            (48w0x12f0000 &&& 48w0xffff0000, 48w0x456 &&& 48w0xfff): a4;
+            default: a5;
+        }
+    }
+    state a1 {
+        meta.transition_taken = 16w1;
+        transition accept;
+    }
+    state a2 {
+        meta.transition_taken = 16w2;
+        transition accept;
+    }
+    state a3 {
+        meta.transition_taken = 16w3;
+        transition accept;
+    }
+    state a4 {
+        meta.transition_taken = 16w4;
+        transition accept;
+    }
+    state a5 {
+        meta.transition_taken = 16w5;
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+        hdr.ethernet.etherType = meta.transition_taken;
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue995-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue995-bmv2-midend.p4
@@ -1,0 +1,87 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+    bit<16> transition_taken;
+}
+
+struct headers {
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.srcAddr, hdr.ethernet.dstAddr) {
+            (48w0x12f0000, 48w0x456): a1;
+            (48w0x12f0000 &&& 48w0xffff0000, 48w0x456): a2;
+            (48w0x12f0000, 48w0x456 &&& 48w0xfff): a3;
+            (48w0x12f0000 &&& 48w0xffff0000, 48w0x456 &&& 48w0xfff): a4;
+            default: a5;
+        }
+    }
+    state a1 {
+        meta.transition_taken = 16w1;
+        transition accept;
+    }
+    state a2 {
+        meta.transition_taken = 16w2;
+        transition accept;
+    }
+    state a3 {
+        meta.transition_taken = 16w3;
+        transition accept;
+    }
+    state a4 {
+        meta.transition_taken = 16w4;
+        transition accept;
+    }
+    state a5 {
+        meta.transition_taken = 16w5;
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @hidden action act() {
+        hdr.ethernet.etherType = meta.transition_taken;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue995-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue995-bmv2.p4
@@ -1,0 +1,81 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+    bit<16> transition_taken;
+}
+
+struct headers {
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.srcAddr, hdr.ethernet.dstAddr) {
+            (0x12f0000, 0x456): a1;
+            (0x12f0000 &&& 0xffff0000, 0x456): a2;
+            (0x12f0000, 0x456 &&& 0xfff): a3;
+            (0x12f0000 &&& 0xffff0000, 0x456 &&& 0xfff): a4;
+            default: a5;
+        }
+    }
+    state a1 {
+        meta.transition_taken = 1;
+        transition accept;
+    }
+    state a2 {
+        meta.transition_taken = 2;
+        transition accept;
+    }
+    state a3 {
+        meta.transition_taken = 3;
+        transition accept;
+    }
+    state a4 {
+        meta.transition_taken = 4;
+        transition accept;
+    }
+    state a5 {
+        meta.transition_taken = 5;
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+        hdr.ethernet.etherType = meta.transition_taken;
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;


### PR DESCRIPTION
Correct the masks generated in bmv2 backend for select expressions
with multiple fields.