### PR TITLE
list expression fixes

### DIFF
--- a/frontends/p4/evaluator/evaluator.cpp
+++ b/frontends/p4/evaluator/evaluator.cpp
@@ -267,6 +267,19 @@ bool Evaluator::preorder(const IR::Property* prop) {
     return false;
 }
 
+bool Evaluator::preorder(const IR::ListExpression *list) {
+    LOG2("Evaluating " << list);
+    visit(list->components);
+    IR::Vector<IR::Expression> comp;
+    for (auto e : list->components) {
+        if (auto value = getValue(e))
+            comp.push_back(value->to<IR::Expression>());
+        else
+            return false; }
+    setValue(list, new IR::ListLiteral(std::move(comp)));
+    return false;
+}
+
 //////////////////////////////////////
 
 EvaluatorPass::EvaluatorPass(ReferenceMap* refMap, TypeMap* typeMap) {

--- a/frontends/p4/evaluator/evaluator.h
+++ b/frontends/p4/evaluator/evaluator.h
@@ -67,6 +67,9 @@ class Evaluator final : public Inspector, public IHasBlock {
     { setValue(expression, expression); return false; }
     bool preorder(const IR::BoolLiteral* expression) override
     { setValue(expression, expression); return false; }
+    bool preorder(const IR::ListLiteral* expression) override
+    { setValue(expression, expression); return false; }
+    bool preorder(const IR::ListExpression* expression) override;
     bool preorder(const IR::Declaration_ID* expression) override
     { setValue(expression, expression); return false; }
 

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -336,10 +336,22 @@ class ConstructorCallExpression : Expression {
 /// Represents a list of expressions separated by commas
 class ListExpression : Expression {
     inline Vector<Expression> components;
-    validate {
-        components.check_null();
-    }
+    ListExpression {
+        if (type->is<Type::Unknown>()) {
+            Vector<Type> tup;
+            for (auto e : components)
+                tup.push_back(e->type);
+            type = new Type_Tuple(tup); } }
+    validate { components.check_null(); }
     void push_back(Expression e) { components.push_back(e); }
+}
+
+/// A ListExpression where all the components are compile-time values
+class ListLiteral : ListExpression, CompileTimeValue {
+    validate {
+        for (auto e : components)
+            BUG_CHECK(e->is<CompileTimeValue>(), "%1%: not a compile-time value", e); }
+#nodbprint
 }
 
 /** @} *//* end group irdefs */

--- a/ir/pass_manager.cpp
+++ b/ir/pass_manager.cpp
@@ -20,6 +20,12 @@ limitations under the License.
 
 const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *) {
     safe_vector<std::pair<safe_vector<Visitor *>::iterator, const IR::Node *>> backup;
+    static indent_t log_indent(-1);
+    struct indent_nesting {
+        indent_t &indent;
+        explicit indent_nesting(indent_t &i) : indent(i) { ++indent; }
+        ~indent_nesting() { --indent; }
+    } nest_log_indent(log_indent);
 
     early_exit_flag = false;
     BUG_CHECK(running, "not calling apply properly");
@@ -31,9 +37,9 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
         try {
             try {
                 size_t maxmem;
-                LOG1(name() << " invoking " << v->name());
+                LOG1(log_indent << name() << " invoking " << v->name());
                 program = program->apply(**it);
-                LOG3("heap after " << v->name() << ": in use " <<
+                LOG3(log_indent << "heap after " << v->name() << ": in use " <<
                      n4(gc_mem_inuse(&maxmem)) << "B, max " << n4(maxmem) << "B");
                 int errors = ErrorReporter::instance.getErrorCount();
                 if (stop_on_error && errors > 0)
@@ -43,7 +49,7 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
                 throw Backtrack::trigger(trig_type);
             }
         } catch (Backtrack::trigger &trig) {
-            LOG1("caught backtrack trigger " << trig);
+            LOG1(log_indent << "caught backtrack trigger " << trig);
             while (!backup.empty()) {
                 if (backup.back().first == it) {
                     backup.pop_back();
@@ -53,9 +59,9 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
                 program = backup.back().second;
                 if (b->backtrack(trig))
                     break;
-                LOG1("pass " << b->name() << " can't handle it"); }
+                LOG1(log_indent << "pass " << b->name() << " can't handle it"); }
             if (backup.empty()) {
-                LOG1("rethrow trigger");
+                LOG1(log_indent << "rethrow trigger");
                 throw trig; }
             continue; }
         runDebugHooks(v->name(), program);

--- a/midend/eliminateTuples.h
+++ b/midend/eliminateTuples.h
@@ -81,6 +81,8 @@ class DoReplaceTuples final : public Transform {
     { return insertReplacements(method); }
     const IR::Node* postorder(IR::Type_Extern* ext) override
     { return insertReplacements(ext); }
+    const IR::Node* postorder(IR::Declaration_Instance *decl) override
+    { return insertReplacements(decl); }
 };
 
 class EliminateTuples final : public PassManager {

--- a/testdata/p4_16_samples/register_w_init.p4
+++ b/testdata/p4_16_samples/register_w_init.p4
@@ -1,0 +1,30 @@
+/*
+Copyright 2017 Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+extern register_w_init<I, T> {
+    register_w_init(I size, T init);
+    void read(out T result, in I index);
+    void write(in I index, in T value);
+};
+
+struct foo {
+    bit<8>      field1;
+    bit<8>      field2;
+    bit<16>     field3;
+}
+
+register_w_init<bit<32>, foo>(32w16384, { 1, 1, 0 }) reg;
+

--- a/testdata/p4_16_samples_outputs/register_w_init-first.p4
+++ b/testdata/p4_16_samples_outputs/register_w_init-first.p4
@@ -1,0 +1,13 @@
+extern register_w_init<I, T> {
+    register_w_init(I size, T init);
+    void read(out T result, in I index);
+    void write(in I index, in T value);
+}
+
+struct foo {
+    bit<8>  field1;
+    bit<8>  field2;
+    bit<16> field3;
+}
+
+register_w_init<bit<32>, foo>(32w16384, { 8w1, 8w1, 16w0 }) reg;

--- a/testdata/p4_16_samples_outputs/register_w_init-frontend.p4
+++ b/testdata/p4_16_samples_outputs/register_w_init-frontend.p4
@@ -1,0 +1,13 @@
+extern register_w_init<I, T> {
+    register_w_init(I size, T init);
+    void read(out T result, in I index);
+    void write(in I index, in T value);
+}
+
+struct foo {
+    bit<8>  field1;
+    bit<8>  field2;
+    bit<16> field3;
+}
+
+register_w_init<bit<32>, foo>(32w16384, { 8w1, 8w1, 16w0 }) reg;

--- a/testdata/p4_16_samples_outputs/register_w_init.p4
+++ b/testdata/p4_16_samples_outputs/register_w_init.p4
@@ -1,0 +1,13 @@
+extern register_w_init<I, T> {
+    register_w_init(I size, T init);
+    void read(out T result, in I index);
+    void write(in I index, in T value);
+}
+
+struct foo {
+    bit<8>  field1;
+    bit<8>  field2;
+    bit<16> field3;
+}
+
+register_w_init<bit<32>, foo>(32w16384, { 1, 1, 0 }) reg;

--- a/testdata/p4_16_samples_outputs/register_w_init.p4-stderr
+++ b/testdata/p4_16_samples_outputs/register_w_init.p4-stderr
@@ -1,0 +1,4 @@
+register_w_init.p4(29): warning: reg: unused instance
+register_w_init<bit<32>, foo>(32w16384, { 1, 1, 0 }) reg;
+                                                     ^^^
+warning: Program does not contain a `main' module


### PR DESCRIPTION
This adds support for list expression constants in the front-end, for use with externs that need them in their constructors.  There's an issue with TypeInferencing around constructor arguments where it puts the wrong type in the typeMap when dealing with arguments that need to be inferenced (see the FIXME) that I'm not sure how to fix with the current typemap setup.