### PR TITLE
fixes includes and class definitions for non-unified build

### DIFF
--- a/backends/graphs/graphs.cpp
+++ b/backends/graphs/graphs.cpp
@@ -25,74 +25,6 @@ limitations under the License.
 
 namespace graphs {
 
-class Graphs::GraphAttributeSetter {
- public:
-  void operator()(Graph &g) const {
-      auto vertices = boost::vertices(g);
-      for (auto vit = vertices.first; vit != vertices.second; ++vit) {
-          const auto &vinfo = g[*vit];
-          auto attrs = boost::get(boost::vertex_attribute, g);
-          attrs[*vit]["label"] = vinfo.name;
-          attrs[*vit]["style"] = vertexTypeGetStyle(vinfo.type);
-          attrs[*vit]["shape"] = vertexTypeGetShape(vinfo.type);
-          attrs[*vit]["margin"] = vertexTypeGetMargin(vinfo.type);
-      }
-      auto edges = boost::edges(g);
-      for (auto eit = edges.first; eit != edges.second; ++eit) {
-          auto attrs = boost::get(boost::edge_attribute, g);
-          attrs[*eit]["label"] = boost::get(boost::edge_name, g, *eit);
-      }
-  }
-
- private:
-    static cstring vertexTypeGetShape(VertexType type) {
-        switch (type) {
-          case VertexType::TABLE:
-              return "ellipse";
-          case VertexType::HEADER:
-              return "box";
-          case VertexType::START:
-              return "circle";
-          case VertexType::DEFAULT:
-              return "doublecircle";
-          default:
-              return "rectangle";
-        }
-        BUG("unreachable");
-        return "";
-    }
-
-    static cstring vertexTypeGetStyle(VertexType type) {
-        switch (type) {
-          case VertexType::CONTROL:
-              return "dashed";
-          case VertexType::HEADER:
-              return "solid";
-          case VertexType::START:
-              return "solid";
-          case VertexType::DEFAULT:
-              return "solid";
-          default:
-              return "solid";
-        }
-        BUG("unreachable");
-        return "";
-    }
-
-    static cstring vertexTypeGetMargin(VertexType type) {
-        switch (type) {
-          case VertexType::HEADER:
-              return "0.05,0";
-          case VertexType::START:
-              return "0,0";
-          case VertexType::DEFAULT:
-              return "0,0";
-          default:
-              return "";
-        }
-    }
-};
-
 Graphs::vertex_t Graphs::add_vertex(const cstring &name, VertexType type) {
     auto v = boost::add_vertex(*g);
     boost::put(&Vertex::name, *g, v, name);
@@ -136,4 +68,3 @@ Graphs::vertex_t Graphs::add_and_connect_vertex(const cstring &name, VertexType 
 }
 
 }  // namespace graphs
-

--- a/backends/graphs/graphs.h
+++ b/backends/graphs/graphs.h
@@ -125,7 +125,6 @@ class Graphs : public Inspector {
         VertexType type;
     };
 
-    class GraphAttributeSetter;
     // The boost graph support for graphviz subgraphs is not very intuitive. In
     // particular the write_graphviz code assumes the existence of a lot of
     // properties. See
@@ -161,7 +160,7 @@ class Graphs : public Inspector {
     void add_edge(const vertex_t &from, const vertex_t &to, const cstring &name);
 
     class GraphAttributeSetter {
-    public:
+     public:
         void operator()(Graph &g) const {
             auto vertices = boost::vertices(g);
             for (auto vit = vertices.first; vit != vertices.second; ++vit) {
@@ -179,7 +178,7 @@ class Graphs : public Inspector {
             }
         }
 
-    private:
+     private:
         static cstring vertexTypeGetShape(VertexType type) {
             switch (type) {
             case VertexType::TABLE:
@@ -226,8 +225,7 @@ class Graphs : public Inspector {
                 return "";
             }
         }
-    };
-
+    };  // end class GraphAttributeSetter
 
  protected:
     Graph *g{nullptr};

--- a/backends/graphs/graphs.h
+++ b/backends/graphs/graphs.h
@@ -160,6 +160,75 @@ class Graphs : public Inspector {
     vertex_t add_and_connect_vertex(const cstring &name, VertexType type);
     void add_edge(const vertex_t &from, const vertex_t &to, const cstring &name);
 
+    class GraphAttributeSetter {
+    public:
+        void operator()(Graph &g) const {
+            auto vertices = boost::vertices(g);
+            for (auto vit = vertices.first; vit != vertices.second; ++vit) {
+                const auto &vinfo = g[*vit];
+                auto attrs = boost::get(boost::vertex_attribute, g);
+                attrs[*vit]["label"] = vinfo.name;
+                attrs[*vit]["style"] = vertexTypeGetStyle(vinfo.type);
+                attrs[*vit]["shape"] = vertexTypeGetShape(vinfo.type);
+                attrs[*vit]["margin"] = vertexTypeGetMargin(vinfo.type);
+            }
+            auto edges = boost::edges(g);
+            for (auto eit = edges.first; eit != edges.second; ++eit) {
+                auto attrs = boost::get(boost::edge_attribute, g);
+                attrs[*eit]["label"] = boost::get(boost::edge_name, g, *eit);
+            }
+        }
+
+    private:
+        static cstring vertexTypeGetShape(VertexType type) {
+            switch (type) {
+            case VertexType::TABLE:
+                return "ellipse";
+            case VertexType::HEADER:
+                return "box";
+            case VertexType::START:
+                return "circle";
+            case VertexType::DEFAULT:
+                return "doublecircle";
+            default:
+                return "rectangle";
+            }
+            BUG("unreachable");
+            return "";
+        }
+
+        static cstring vertexTypeGetStyle(VertexType type) {
+            switch (type) {
+            case VertexType::CONTROL:
+                return "dashed";
+            case VertexType::HEADER:
+                return "solid";
+            case VertexType::START:
+                return "solid";
+            case VertexType::DEFAULT:
+                return "solid";
+            default:
+                return "solid";
+            }
+            BUG("unreachable");
+            return "";
+        }
+
+        static cstring vertexTypeGetMargin(VertexType type) {
+            switch (type) {
+            case VertexType::HEADER:
+                return "0.05,0";
+            case VertexType::START:
+                return "0,0";
+            case VertexType::DEFAULT:
+                return "0,0";
+            default:
+                return "";
+            }
+        }
+    };
+
+
  protected:
     Graph *g{nullptr};
     vertex_t start_v{};

--- a/backends/graphs/parser.cpp
+++ b/backends/graphs/parser.cpp
@@ -20,6 +20,8 @@ limitations under the License.
 
 #include "graphs.h"
 
+#include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/p4/typeMap.h"
 #include "lib/log.h"
 #include "lib/nullstream.h"
 #include "lib/path.h"


### PR DESCRIPTION
The GraphAttributeSetter is used also in both controls.cpp and parser.cpp and thus it needs to be fully defined -- the forward declaration in graphs.h is not sufficient.

Also, the typeMap and referenceMap headers need to be explicitly included.