### PR TITLE
Fix for issue #841 and #955

### DIFF
--- a/backends/bmv2/backend.cpp
+++ b/backends/bmv2/backend.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include "frontends/p4/unusedDeclarations.h"
 #include "midend/actionSynthesis.h"
 #include "midend/removeLeftSlices.h"
+#include "midend/synthesizeValidField.h"
 #include "lower.h"
 #include "header.h"
 #include "parser.h"
@@ -113,6 +114,9 @@ Backend::process(const IR::ToplevelBlock* tlb, BMV2Options& options) {
         new DiscoverStructure(&structure),
         new ErrorCodesVisitor(&errorCodesMap),
         new ExtractArchInfo(typeMap),
+#if 0
+        new P4::SynthesizeValidField(refMap, typeMap),
+#endif
         evaluator,
         new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
     });

--- a/backends/bmv2/backend.cpp
+++ b/backends/bmv2/backend.cpp
@@ -29,7 +29,6 @@ limitations under the License.
 #include "frontends/p4/unusedDeclarations.h"
 #include "midend/actionSynthesis.h"
 #include "midend/removeLeftSlices.h"
-#include "midend/synthesizeValidField.h"
 #include "lower.h"
 #include "header.h"
 #include "parser.h"
@@ -114,9 +113,6 @@ Backend::process(const IR::ToplevelBlock* tlb, BMV2Options& options) {
         new DiscoverStructure(&structure),
         new ErrorCodesVisitor(&errorCodesMap),
         new ExtractArchInfo(typeMap),
-#if 0
-        new P4::SynthesizeValidField(refMap, typeMap),
-#endif
         evaluator,
         new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
     });

--- a/backends/bmv2/control.cpp
+++ b/backends/bmv2/control.cpp
@@ -333,14 +333,7 @@ ControlConverter::convertTable(const CFG::TableNode* node,
             auto keyelement = new Util::JsonObject();
             keyelement->emplace("match_type", match_type);
 
-            // XXX(seth): Boolean variables are stored as data, so we normally
-            // cast them back to bool via the 'd2b' primitive when they're used
-            // in expressions. We don't want to do that when we match against
-            // them, though; they're already in the form we want. That's what
-            // convertLeftValue() does. The name is a bit misleading in this
-            // context.
-            auto jk = conv->convertLeftValue(expr);
-
+            auto jk = conv->convert(expr);
             keyelement->emplace("target", jk->to<Util::JsonObject>()->get("value"));
             if (mask != 0)
                 keyelement->emplace("mask", stringRepr(mask, (expr->type->width_bits() + 7) / 8));

--- a/backends/bmv2/control.cpp
+++ b/backends/bmv2/control.cpp
@@ -44,6 +44,9 @@ void ControlConverter::convertTableEntries(const IR::P4Table *table,
             if (matchType == backend->getCoreLibrary().exactMatch.name) {
                 if (k->is<IR::Constant>())
                     key->emplace("key", stringRepr(k->to<IR::Constant>()->value, k8));
+                else if (k->is<IR::BoolLiteral>())
+                    // booleans are converted to ints
+                    key->emplace("key", stringRepr(k->to<IR::BoolLiteral>()->value ? 1 : 0, k8));
                 else
                     ::error("%1% invalid exact key expression", k);
             } else if (matchType == backend->getCoreLibrary().ternaryMatch.name) {

--- a/backends/bmv2/expression.cpp
+++ b/backends/bmv2/expression.cpp
@@ -133,6 +133,18 @@ void ExpressionConverter::postorder(const IR::MethodCallExpression* expression) 
                 else
                     e->append(l);
                 e->append(V1ModelProperties::validField);
+                if (!simpleExpressionsOnly) {
+                    // This is set when converting table keys;
+                    // for table keys we don't need the casts.
+                    auto cast = new Util::JsonObject();
+                    auto value = new Util::JsonObject();
+                    cast->emplace("type", "expression");
+                    cast->emplace("value", value);
+                    value->emplace("op", "d2b");  // data to Boolean cast
+                    value->emplace("left", Util::JsonValue::null);
+                    value->emplace("right", result);
+                    result = cast;
+                }
             }
             map.emplace(expression, result);
             return;

--- a/backends/bmv2/expression.cpp
+++ b/backends/bmv2/expression.cpp
@@ -284,7 +284,8 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
                 CHECK_NULL(field);
                 auto name = ::get(backend->scalarMetadataFields, field);
                 CHECK_NULL(name);
-                if (type->is<IR::Type_Bits>() || type->is<IR::Type_Error>() || leftValue) {
+                if (type->is<IR::Type_Bits>() || type->is<IR::Type_Error>() ||
+                    leftValue || simpleExpressionsOnly) {
                     result->emplace("type", "field");
                     auto e = mkArrayField(result, "value");
                     e->append(scalarsName);
@@ -511,7 +512,7 @@ void ExpressionConverter::postorder(const IR::PathExpression* expression)  {
             result->emplace("type", "header");
             result->emplace("value", var->name);
         } else if (type->is<IR::Type_Bits>() ||
-                   (type->is<IR::Type_Boolean>() && leftValue)) {
+                   (type->is<IR::Type_Boolean>() && (leftValue || simpleExpressionsOnly))) {
             // no conversion d2b when writing (leftValue is true) to a boolean
             result->emplace("type", "field");
             auto e = mkArrayField(result, "value");

--- a/backends/bmv2/expression.h
+++ b/backends/bmv2/expression.h
@@ -72,7 +72,6 @@ class ExpressionConverter : public Inspector {
     Util::IJson* fixLocal(Util::IJson* json);
 
     // doFixup = true -> insert masking operations for proper arithmetic implementation
-    // see below for wrap
     Util::IJson* convert(const IR::Expression* e, bool doFixup = true,
                          bool wrap = true, bool convertBool = false);
     Util::IJson* convertLeftValue(const IR::Expression* e);

--- a/backends/bmv2/header.cpp
+++ b/backends/bmv2/header.cpp
@@ -175,13 +175,6 @@ void ConvertHeaders::addHeaderType(const IR::Type_StructLike *st) {
     }
 
     for (auto f : st->fields) {
-#if 0
-        if (f->name == V1ModelProperties::validField) {
-            // The valid bit is automatically added by BMV2. Skip it so that we
-            // don't confuse BMV2 or end up generating unnecessary padding.
-            continue;
-        }
-#endif
         auto ftype = typeMap->getType(f, true);
         if (ftype->to<IR::Type_StructLike>()) {
             BUG("%1%: nested structure", st);

--- a/backends/bmv2/header.cpp
+++ b/backends/bmv2/header.cpp
@@ -175,11 +175,13 @@ void ConvertHeaders::addHeaderType(const IR::Type_StructLike *st) {
     }
 
     for (auto f : st->fields) {
+#if 0
         if (f->name == V1ModelProperties::validField) {
             // The valid bit is automatically added by BMV2. Skip it so that we
             // don't confuse BMV2 or end up generating unnecessary padding.
             continue;
         }
+#endif
         auto ftype = typeMap->getType(f, true);
         if (ftype->to<IR::Type_StructLike>()) {
             BUG("%1%: nested structure", st);

--- a/backends/bmv2/midend.cpp
+++ b/backends/bmv2/midend.cpp
@@ -44,7 +44,6 @@ limitations under the License.
 #include "midend/simplifyKey.h"
 #include "midend/simplifySelectCases.h"
 #include "midend/simplifySelectList.h"
-#include "midend/synthesizeValidField.h"
 #include "midend/removeSelectBooleans.h"
 #include "midend/validateProperties.h"
 #include "midend/compileTimeOps.h"
@@ -100,9 +99,11 @@ MidEnd::MidEnd(BMV2Options& options) {
         new P4::UniqueParameters(&refMap, &typeMap),
         new P4::SimplifyControlFlow(&refMap, &typeMap),
         new P4::RemoveActionParameters(&refMap, &typeMap),
-        new P4::SynthesizeValidField(&refMap, &typeMap),
         new P4::TypeChecking(&refMap, &typeMap),
-        new P4::SimplifyKey(&refMap, &typeMap, new P4::NonMaskLeftValue(&typeMap)),
+        new P4::SimplifyKey(&refMap, &typeMap,
+                            new P4::OrPolicy(
+                                new P4::IsValid(&refMap, &typeMap),
+                                new P4::IsMask())),
         new P4::ConstantFolding(&refMap, &typeMap),
         new P4::StrengthReduction(),
         new P4::SimplifySelectCases(&refMap, &typeMap, true),  // require constant keysets

--- a/backends/ebpf/midend.cpp
+++ b/backends/ebpf/midend.cpp
@@ -104,7 +104,9 @@ const IR::ToplevelBlock* MidEnd::run(EbpfOptions& options, const IR::P4Program* 
         new P4::SimplifyControlFlow(&refMap, &typeMap),
         new P4::RemoveActionParameters(&refMap, &typeMap),
         new P4::SimplifyKey(&refMap, &typeMap,
-                            new P4::NonLeftValueOrIsValid(&refMap, &typeMap)),
+                            new P4::OrPolicy(
+                                new P4::IsValid(&refMap, &typeMap),
+                                new P4::IsLikeLeftValue())),
         new P4::RemoveExits(&refMap, &typeMap),
         new P4::ConstantFolding(&refMap, &typeMap),
         new P4::SimplifySelectCases(&refMap, &typeMap, false),  // accept non-constant keysets

--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -118,7 +118,9 @@ MidEnd::MidEnd(CompilerOptions& options) {
         new P4::SimplifyControlFlow(&refMap, &typeMap),
         new P4::RemoveActionParameters(&refMap, &typeMap),
         new P4::SimplifyKey(&refMap, &typeMap,
-                            new P4::NonLeftValueOrIsValid(&refMap, &typeMap)),
+                            new P4::OrPolicy(
+                                new P4::IsValid(&refMap, &typeMap),
+                                new P4::IsLikeLeftValue())),
         new P4::RemoveExits(&refMap, &typeMap),
         new P4::ConstantFolding(&refMap, &typeMap),
         new P4::SimplifySelectCases(&refMap, &typeMap, false),  // non-constant keysets

--- a/midend/simplifyKey.h
+++ b/midend/simplifyKey.h
@@ -24,55 +24,83 @@ limitations under the License.
 namespace P4 {
 
 /**
- * Policy used to decide whether a key expression is too complex.
+ * Policy used to decide whether a key expression is simple enough
+ * to be implemented directly.
  */
-class KeyIsComplex {
+class KeyIsSimple {
  public:
-    virtual ~KeyIsComplex() {}
-    virtual bool isTooComplex(const IR::Expression* expression) const = 0;
+    virtual ~KeyIsSimple() {}
+    virtual bool isSimple(const IR::Expression* expression) = 0;
 };
 
 /**
- * Policy that treats a key as complex if it's not an lvalue.
+ * Policy that treats a key as simple if it contains just
+ * PathExpression, member and ArrayIndex operations.
  */
-class NonLeftValue : public KeyIsComplex {
+class IsLikeLeftValue : public KeyIsSimple, public Inspector {
  protected:
-    TypeMap*      typeMap;
+    TypeMap* typeMap;
+    bool     simple = true;
  public:
-    explicit NonLeftValue(TypeMap* typeMap) : typeMap(typeMap)
-    { CHECK_NULL(typeMap); }
-    bool isTooComplex(const IR::Expression* expression) const {
-        return !typeMap->isLeftValue(expression);
+    IsLikeLeftValue()
+    { setName("IsLikeLeftValue"); }
+
+    void postorder(const IR::Expression*) override {
+        // all other expressions are complicated
+        simple = false;
+    }
+    void postorder(const IR::Member*) override {}
+    void postorder(const IR::PathExpression*) override {}
+    void postorder(const IR::ArrayIndex*) override {}
+
+    bool isSimple(const IR::Expression* expression) {
+        (void)expression->apply(*this);
+        return simple;
     }
 };
 
 /**
- * Policy that treats a key as complex if it's not either (1) an lvalue, or (2)
- * a call to isValid().
+ * Policy that treats a key as simple if it a call to isValid().
  */
-class NonLeftValueOrIsValid : public NonLeftValue {
+class IsValid : public KeyIsSimple {
     ReferenceMap* refMap;
+    TypeMap* typeMap;
  public:
-    NonLeftValueOrIsValid(ReferenceMap* refMap, TypeMap* typeMap)
-        : NonLeftValue(typeMap), refMap(refMap)
-    { CHECK_NULL(refMap); }
-    bool isTooComplex(const IR::Expression* expression) const;
+    IsValid(ReferenceMap* refMap, TypeMap* typeMap)
+            : refMap(refMap), typeMap(typeMap)
+    { CHECK_NULL(refMap); CHECK_NULL(typeMap); }
+    bool isSimple(const IR::Expression* expression);
 };
 
 /**
- * Policy that treats a key as complex if it's not either (1) a simple lvalue,
- * or (2) a mask applied to a simple lvalue.
+ * Policy that treats a key as simple if it is a mask applied to an lvalue
+ * or just an lvalue.
  */
-class NonMaskLeftValue : public NonLeftValue {
+class IsMask : public IsLikeLeftValue {
  public:
-    using NonLeftValue::NonLeftValue;
-    bool isTooComplex(const IR::Expression* expression) const {
+    bool isSimple(const IR::Expression* expression) {
         if (auto mask = expression->to<IR::BAnd>()) {
             if (mask->right->is<IR::Constant>())
                 expression = mask->left;
             else if (mask->left->is<IR::Constant>())
                 expression = mask->right; }
-        return NonLeftValue::isTooComplex(expression); }
+        return IsLikeLeftValue::isSimple(expression); }
+};
+
+/**
+    A KeyIsSimple policy formed by combining two
+    other policies with a logical 'or'.
+*/
+class OrPolicy : public KeyIsSimple {
+    KeyIsSimple* left;
+    KeyIsSimple* right;
+
+ public:
+    OrPolicy(KeyIsSimple* left, KeyIsSimple* right): left(left), right(right)
+    { CHECK_NULL(left); CHECK_NULL(right); }
+    bool isSimple(const IR::Expression* expression) {
+        return left->isSimple(expression) || right->isSimple(expression);
+    }
 };
 
 class TableInsertions {
@@ -112,12 +140,12 @@ class TableInsertions {
  * @post all complex table key expressions are replaced with a simpler expression.
  */
 class DoSimplifyKey : public Transform {
-    ReferenceMap*       refMap;
-    TypeMap*            typeMap;
-    const KeyIsComplex* policy;
+    ReferenceMap* refMap;
+    TypeMap*      typeMap;
+    KeyIsSimple*  policy;
     std::map<const IR::P4Table*, TableInsertions*> toInsert;
  public:
-    DoSimplifyKey(ReferenceMap* refMap, TypeMap* typeMap, const KeyIsComplex* policy) :
+    DoSimplifyKey(ReferenceMap* refMap, TypeMap* typeMap, KeyIsSimple* policy) :
             refMap(refMap), typeMap(typeMap), policy(policy)
     { CHECK_NULL(refMap); CHECK_NULL(typeMap); CHECK_NULL(policy); setName("DoSimplifyKey"); }
     const IR::Node* doStatement(const IR::Statement* statement, const IR::Expression* expression);
@@ -140,7 +168,7 @@ class DoSimplifyKey : public Transform {
  */
 class SimplifyKey : public PassManager {
  public:
-    SimplifyKey(ReferenceMap* refMap, TypeMap* typeMap, const KeyIsComplex* policy) {
+    SimplifyKey(ReferenceMap* refMap, TypeMap* typeMap, KeyIsSimple* policy) {
         passes.push_back(new TypeChecking(refMap, typeMap));
         passes.push_back(new DoSimplifyKey(refMap, typeMap, policy));
         setName("SimplifyKey");

--- a/midend/synthesizeValidField.cpp
+++ b/midend/synthesizeValidField.cpp
@@ -39,6 +39,7 @@ class AddValidField final : public Modifier {
             {new IR::Annotation(IR::Annotation::hiddenAnnotation, {})});
         auto field = new IR::StructField("$valid$", annotations, IR::Type::Bits::get(1));
         header->fields.push_back(field);
+        LOG2("Added field to " << header);
         return true;
     }
 };
@@ -82,6 +83,7 @@ RewriteIsValidCalls::postorder(IR::MethodCallExpression* expr) {
     // In other contexts, rewrite isValid() into a comparison with a constant.
     // This maintains a boolean type for the overall expression.
     auto constant = new IR::Constant(IR::Type::Bits::get(1), 1);
+    LOG2("Rewrote " << expr);
     return new IR::Equ(expr->srcInfo, member, constant);
 }
 
@@ -128,6 +130,7 @@ class RewriteIsValidTableEntries final : public Transform {
                 newKey->components[index] =
                     new IR::Constant(IR::Type::Bits::get(1), asBit);
             }
+            LOG2("Rewrote " << e);
             e->keys = newKey;
             return e;
         });

--- a/midend/synthesizeValidField.h
+++ b/midend/synthesizeValidField.h
@@ -33,9 +33,9 @@ namespace P4 {
  * validity is actually implemented on some backends, which can simplify later
  * passes.
  *
- * XXX(seth): *There are known problems with this approach.* We're working on a
- * better way to handle this. For now, you are advised against using this in new
- * backends.
+ * WARNING: This pass should be used carefully; it breaks invariants
+ * about the IR that are assumed by other passes.  It should only be
+ * used very late in the compilation tool-chain, if at all.
  *
  * In most situations, `foo.isValid()` is rewritten to `foo.$valid$ == 1`.
  * However, when `foo.isValid()` is a table key element (and isn't part of a

--- a/test/gtest/bmv2_isvalid.cpp
+++ b/test/gtest/bmv2_isvalid.cpp
@@ -366,7 +366,10 @@ TEST(BMV2_SynthesizeValidField, SimplifiedKeysHaveNoIsValid) {
         new P4::TypeChecking(&refMap, &typeMap),
         new P4::SynthesizeValidField(&refMap, &typeMap),
         new P4::TypeChecking(&refMap, &typeMap),
-        new P4::SimplifyKey(&refMap, &typeMap, new P4::NonMaskLeftValue(&typeMap)),
+        new P4::SimplifyKey(&refMap, &typeMap,
+                            new P4::OrPolicy(
+                                new P4::IsValid(&refMap, &typeMap),
+                                new P4::IsMask()))
     };
     program = program->apply(passes);
     ASSERT_TRUE(program != nullptr);

--- a/testdata/p4_16_samples/issue841.p4
+++ b/testdata/p4_16_samples/issue841.p4
@@ -1,0 +1,45 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header h_t {
+  bit<32> src;
+  bit<32> dst;
+  bit<16> csum;
+}
+
+struct metadata {
+}
+struct headers {
+  h_t h;
+}
+
+parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract(hdr.h);
+        transition accept;
+    }
+}
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() checksum;
+    h_t h = { hdr.h.src, hdr.h.dst, 16w0 };
+    apply {
+	hdr.h.csum = checksum.get(h);
+   }
+}
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples/issue955.p4
+++ b/testdata/p4_16_samples/issue955.p4
@@ -1,0 +1,52 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+header Header { bit<32> data; }
+struct H { Header h; };
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start { transition accept; }
+}
+
+action empty() { }
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply { bool b = hdr.h.isValid(); }
+};
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply { }
+};
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply { }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/issue841-first.p4
+++ b/testdata/p4_16_samples_outputs/issue841-first.p4
@@ -1,0 +1,52 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header h_t {
+    bit<32> src;
+    bit<32> dst;
+    bit<16> csum;
+}
+
+struct metadata {
+}
+
+struct headers {
+    h_t h;
+}
+
+parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<h_t>(hdr.h);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() checksum;
+    h_t h = { hdr.h.src, hdr.h.dst, 16w0 };
+    apply {
+        hdr.h.csum = checksum.get<h_t>(h);
+    }
+}
+
+V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue841-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue841-frontend.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header h_t {
+    bit<32> src;
+    bit<32> dst;
+    bit<16> csum;
+}
+
+struct metadata {
+}
+
+struct headers {
+    h_t h;
+}
+
+parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<h_t>(hdr.h);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    h_t h_0;
+    bit<16> tmp;
+    @name("checksum") Checksum16() checksum_0;
+    apply {
+        h_0.setValid();
+        h_0 = { hdr.h.src, hdr.h.dst, 16w0 };
+        tmp = checksum_0.get<h_t>(h_0);
+        hdr.h.csum = tmp;
+    }
+}
+
+V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue841-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue841-midend.p4
@@ -1,0 +1,58 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header h_t {
+    bit<32> src;
+    bit<32> dst;
+    bit<16> csum;
+}
+
+struct metadata {
+}
+
+struct headers {
+    h_t h;
+}
+
+parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<h_t>(hdr.h);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    h_t h_1;
+    bit<16> tmp_0;
+    @name("checksum") Checksum16() checksum;
+    apply {
+        h_1.setValid();
+        h_1.src = hdr.h.src;
+        h_1.dst = hdr.h.dst;
+        h_1.csum = 16w0;
+        tmp_0 = checksum.get<h_t>(h_1);
+        hdr.h.csum = tmp_0;
+    }
+}
+
+V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue841.p4
+++ b/testdata/p4_16_samples_outputs/issue841.p4
@@ -1,0 +1,52 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header h_t {
+    bit<32> src;
+    bit<32> dst;
+    bit<16> csum;
+}
+
+struct metadata {
+}
+
+struct headers {
+    h_t h;
+}
+
+parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract(hdr.h);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    Checksum16() checksum;
+    h_t h = { hdr.h.src, hdr.h.dst, 16w0 };
+    apply {
+        hdr.h.csum = checksum.get(h);
+    }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue841.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue841.p4-stderr
@@ -1,0 +1,6 @@
+issue841.p4(39): warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
+    Checksum16() checksum;
+    ^^^^^^^^^^
+v1model.p4(136)
+extern Checksum16 {
+       ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue955-first.p4
+++ b/testdata/p4_16_samples_outputs/issue955-first.p4
@@ -1,0 +1,50 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h;
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+action empty() {
+}
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+        bool b = hdr.h.isValid();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/issue955-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue955-frontend.p4
@@ -1,0 +1,48 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h;
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+        hdr.h.isValid();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/issue955-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue955-midend.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h;
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @hidden action act() {
+        hdr.h.isValid();
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/issue955.p4
+++ b/testdata/p4_16_samples_outputs/issue955.p4
@@ -1,0 +1,50 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h;
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+action empty() {
+}
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+        bool b = hdr.h.isValid();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;


### PR DESCRIPTION
This PR fixes these two issues by removing the SynthesizeValidBits pass from the normal compiler flow.
That pass breaks invariants about the semantics of the IR, and does not seem to be necessary anymore.

I have also changed the policies used when to simplify table keys: they were using double negation, now they are easier to read and to combine.