### PR TITLE
Fix some of the failing STF tests described in #961

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -105,10 +105,6 @@ set (XFAIL_TESTS
   testdata/p4_14_samples/counter2.p4
   testdata/p4_14_samples/counter3.p4
   testdata/p4_14_samples/counter4.p4
-  testdata/p4_14_samples/gateway1.p4
-  testdata/p4_14_samples/gateway2.p4
-  testdata/p4_14_samples/gateway3.p4
-  testdata/p4_14_samples/gateway4.p4
   testdata/p4_14_samples/07-MultiProtocol.p4
 
   # This test defines two lpm keys for a table.

--- a/testdata/p4_14_samples/gateway1.p4
+++ b/testdata/p4_14_samples/gateway1.p4
@@ -29,6 +29,15 @@ parser start {
     return ingress;
 }
 
+action _drop() { drop(); }
+
+table set_default_behavior_drop {
+    actions {
+        _drop;
+    }
+    default_action: _drop;
+}
+
 action noop() { }
 action setb1(val, port) {
     modify_field(data.b1, val);
@@ -56,6 +65,10 @@ table test2 {
 }
 
 control ingress {
+    // Unless some later action sets standard_metadata.egress_spec to
+    // the value corresponding to an output port, the packet will be
+    // dropped at the end of ingress.
+    apply(set_default_behavior_drop);
     if (data.b2 == 1) {
         apply(test1);
     } else {

--- a/testdata/p4_14_samples/gateway2.p4
+++ b/testdata/p4_14_samples/gateway2.p4
@@ -31,6 +31,15 @@ parser start {
     return ingress;
 }
 
+action _drop() { drop(); }
+
+table set_default_behavior_drop {
+    actions {
+        _drop;
+    }
+    default_action: _drop;
+}
+
 action noop() { }
 action setb1(val, port) {
     modify_field(data.b1, val);
@@ -57,6 +66,10 @@ table test2 {
 }
 
 control ingress {
+    // Unless some later action sets standard_metadata.egress_spec to
+    // the value corresponding to an output port, the packet will be
+    // dropped at the end of ingress.
+    apply(set_default_behavior_drop);
     if (data.b2 == data.b3 and data.b4 == 10) {
         apply(test1);
     } else {

--- a/testdata/p4_14_samples/gateway3.p4
+++ b/testdata/p4_14_samples/gateway3.p4
@@ -32,6 +32,15 @@ parser start {
     return ingress;
 }
 
+action _drop() { drop(); }
+
+table set_default_behavior_drop {
+    actions {
+        _drop;
+    }
+    default_action: _drop;
+}
+
 action noop() { }
 action setb1(val, port) {
     modify_field(data.b1, val);
@@ -58,6 +67,10 @@ table test2 {
 }
 
 control ingress {
+    // Unless some later action sets standard_metadata.egress_spec to
+    // the value corresponding to an output port, the packet will be
+    // dropped at the end of ingress.
+    apply(set_default_behavior_drop);
     if (data.b2 == data.b3 or data.b4 == 10) {
         if (data.b1 == data.b2 and data.b4 == 10) {
             apply(test1);

--- a/testdata/p4_14_samples/gateway4.p4
+++ b/testdata/p4_14_samples/gateway4.p4
@@ -42,6 +42,15 @@ parser start {
     }
 }
 
+action _drop() { drop(); }
+
+table set_default_behavior_drop {
+    actions {
+        _drop;
+    }
+    default_action: _drop;
+}
+
 parser parse_data2 {
     extract(data2);
     return ingress;
@@ -73,6 +82,10 @@ table test2 {
 }
 
 control ingress {
+    // Unless some later action sets standard_metadata.egress_spec to
+    // the value corresponding to an output port, the packet will be
+    // dropped at the end of ingress.
+    apply(set_default_behavior_drop);
     if (valid(data2)) {
         apply(test1); }
     apply(test2);

--- a/testdata/p4_14_samples_outputs/gateway1-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-first.p4
@@ -24,11 +24,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop();
+        }
+        default_action = _drop();
     }
     @name(".test1") table test1 {
         actions = {
@@ -53,6 +62,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction();
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data.b2 == 8w1) 
             test1.apply();
         else 

--- a/testdata/p4_14_samples_outputs/gateway1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-frontend.p4
@@ -24,11 +24,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop_0() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop_0() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop_0 {
+        actions = {
+            _drop_0();
+        }
+        default_action = _drop_0();
     }
     @name(".test1") table test1_0 {
         actions = {
@@ -53,6 +62,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction();
     }
     apply {
+        set_default_behavior_drop_0.apply();
         if (hdr.data.b2 == 8w1) 
             test1_0.apply();
         else 

--- a/testdata/p4_14_samples_outputs/gateway1-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-midend.p4
@@ -28,6 +28,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("NoAction") action NoAction_3() {
     }
+    @name("._drop") action _drop_0() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
@@ -39,6 +42,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".noop") action noop_0() {
     }
     @name(".noop") action noop_2() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop_0();
+        }
+        default_action = _drop_0();
     }
     @name(".test1") table test1 {
         actions = {
@@ -63,6 +72,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_3();
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data.b2 == 8w1) 
             test1.apply();
         else 

--- a/testdata/p4_14_samples_outputs/gateway1.p4
+++ b/testdata/p4_14_samples_outputs/gateway1.p4
@@ -24,11 +24,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop;
+        }
+        default_action = _drop();
     }
     @name(".test1") table test1 {
         actions = {
@@ -49,6 +58,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data.b2 == 8w1) {
             test1.apply();
         }

--- a/testdata/p4_14_samples_outputs/gateway2-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-first.p4
@@ -26,11 +26,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop();
+        }
+        default_action = _drop();
     }
     @name(".test1") table test1 {
         actions = {
@@ -55,6 +64,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction();
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data.b2 == hdr.data.b3 && hdr.data.b4 == 8w10) 
             test1.apply();
         else 

--- a/testdata/p4_14_samples_outputs/gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-frontend.p4
@@ -26,11 +26,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop_0() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop_0() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop_0 {
+        actions = {
+            _drop_0();
+        }
+        default_action = _drop_0();
     }
     @name(".test1") table test1_0 {
         actions = {
@@ -55,6 +64,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction();
     }
     apply {
+        set_default_behavior_drop_0.apply();
         if (hdr.data.b2 == hdr.data.b3 && hdr.data.b4 == 8w10) 
             test1_0.apply();
         else 

--- a/testdata/p4_14_samples_outputs/gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-midend.p4
@@ -30,6 +30,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("NoAction") action NoAction_3() {
     }
+    @name("._drop") action _drop_0() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
@@ -41,6 +44,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".noop") action noop_0() {
     }
     @name(".noop") action noop_2() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop_0();
+        }
+        default_action = _drop_0();
     }
     @name(".test1") table test1 {
         actions = {
@@ -65,6 +74,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_3();
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data.b2 == hdr.data.b3 && hdr.data.b4 == 8w10) 
             test1.apply();
         else 

--- a/testdata/p4_14_samples_outputs/gateway2.p4
+++ b/testdata/p4_14_samples_outputs/gateway2.p4
@@ -26,11 +26,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop;
+        }
+        default_action = _drop();
     }
     @name(".test1") table test1 {
         actions = {
@@ -51,6 +60,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data.b2 == hdr.data.b3 && hdr.data.b4 == 8w10) {
             test1.apply();
         }

--- a/testdata/p4_14_samples_outputs/gateway3-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-first.p4
@@ -26,11 +26,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop();
+        }
+        default_action = _drop();
     }
     @name(".test1") table test1 {
         actions = {
@@ -55,6 +64,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction();
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data.b2 == hdr.data.b3 || hdr.data.b4 == 8w10) 
             if (hdr.data.b1 == hdr.data.b2 && hdr.data.b4 == 8w10) 
                 test1.apply();

--- a/testdata/p4_14_samples_outputs/gateway3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-frontend.p4
@@ -26,11 +26,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop_0() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop_0() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop_0 {
+        actions = {
+            _drop_0();
+        }
+        default_action = _drop_0();
     }
     @name(".test1") table test1_0 {
         actions = {
@@ -55,6 +64,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction();
     }
     apply {
+        set_default_behavior_drop_0.apply();
         if (hdr.data.b2 == hdr.data.b3 || hdr.data.b4 == 8w10) 
             if (hdr.data.b1 == hdr.data.b2 && hdr.data.b4 == 8w10) 
                 test1_0.apply();

--- a/testdata/p4_14_samples_outputs/gateway3-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-midend.p4
@@ -30,6 +30,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("NoAction") action NoAction_3() {
     }
+    @name("._drop") action _drop_0() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
@@ -41,6 +44,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".noop") action noop_0() {
     }
     @name(".noop") action noop_2() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop_0();
+        }
+        default_action = _drop_0();
     }
     @name(".test1") table test1 {
         actions = {
@@ -65,6 +74,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_3();
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data.b2 == hdr.data.b3 || hdr.data.b4 == 8w10) 
             if (hdr.data.b1 == hdr.data.b2 && hdr.data.b4 == 8w10) 
                 test1.apply();

--- a/testdata/p4_14_samples_outputs/gateway3.p4
+++ b/testdata/p4_14_samples_outputs/gateway3.p4
@@ -26,11 +26,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop;
+        }
+        default_action = _drop();
     }
     @name(".test1") table test1 {
         actions = {
@@ -51,6 +60,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data.b2 == hdr.data.b3 || hdr.data.b4 == 8w10) {
             if (hdr.data.b1 == hdr.data.b2 && hdr.data.b4 == 8w10) {
                 test1.apply();

--- a/testdata/p4_14_samples_outputs/gateway4-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-first.p4
@@ -40,11 +40,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop();
+        }
+        default_action = _drop();
     }
     @name(".test1") table test1 {
         actions = {
@@ -69,6 +78,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction();
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data2.isValid()) 
             test1.apply();
         test2.apply();

--- a/testdata/p4_14_samples_outputs/gateway4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-frontend.p4
@@ -40,11 +40,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop_0() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop_0() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop_0 {
+        actions = {
+            _drop_0();
+        }
+        default_action = _drop_0();
     }
     @name(".test1") table test1_0 {
         actions = {
@@ -69,6 +78,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction();
     }
     apply {
+        set_default_behavior_drop_0.apply();
         if (hdr.data2.isValid()) 
             test1_0.apply();
         test2_0.apply();

--- a/testdata/p4_14_samples_outputs/gateway4-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-midend.p4
@@ -44,6 +44,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("NoAction") action NoAction_3() {
     }
+    @name("._drop") action _drop_0() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1_0(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
@@ -55,6 +58,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".noop") action noop_0() {
     }
     @name(".noop") action noop_2() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop_0();
+        }
+        default_action = _drop_0();
     }
     @name(".test1") table test1 {
         actions = {
@@ -79,6 +88,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_3();
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data2.isValid()) 
             test1.apply();
         test2.apply();

--- a/testdata/p4_14_samples_outputs/gateway4.p4
+++ b/testdata/p4_14_samples_outputs/gateway4.p4
@@ -40,11 +40,20 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {
+    }
+    @name(".set_default_behavior_drop") table set_default_behavior_drop {
+        actions = {
+            _drop;
+        }
+        default_action = _drop();
     }
     @name(".test1") table test1 {
         actions = {
@@ -65,6 +74,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
     }
     apply {
+        set_default_behavior_drop.apply();
         if (hdr.data2.isValid()) {
             test1.apply();
         }


### PR DESCRIPTION
These failures all are due to bmv2 sending packets out of port 0 for a
P4_14 program that never assigns a value to the egress_spec intrinsic
metadata field.

Chris Dodd suggested changing the programs so that if they do not
explicitly assign a value to egress_spec, then they drop the packet.
This makes the existing STF tests for these programs pass, so these
tests appear to have been written with this behavior in mind.