### PR TITLE
Only create aliases for metadata fields if compiling P4_16

### DIFF
--- a/backends/bmv2/backend.cpp
+++ b/backends/bmv2/backend.cpp
@@ -175,7 +175,7 @@ void Backend::convert(BMV2Options& options) {
 
     // if (psa) tlb->apply(new ConvertExterns());
     PassManager codegen_passes = {
-        new ConvertHeaders(this, scalarsName),
+        new ConvertHeaders(this, scalarsName, options),
         new ConvertExterns(this),  // only run when target == PSA
         new ConvertParser(this),
         new ConvertActions(this),

--- a/backends/bmv2/header.cpp
+++ b/backends/bmv2/header.cpp
@@ -28,8 +28,8 @@ Util::JsonArray* ConvertHeaders::pushNewArray(Util::JsonArray* parent) {
 }
 
 ConvertHeaders::ConvertHeaders(Backend* backend, cstring scalarsName, BMV2Options& options)
-        : backend(backend), scalarsName(scalarsName), options(options), refMap(backend->getRefMap()),
-          typeMap(backend->getTypeMap()), json(backend->json) {
+        : backend(backend), scalarsName(scalarsName), options(options),
+          refMap(backend->getRefMap()), typeMap(backend->getTypeMap()), json(backend->json) {
     setName("ConvertHeaders");
     CHECK_NULL(backend->json);
 }

--- a/backends/bmv2/header.h
+++ b/backends/bmv2/header.h
@@ -32,6 +32,7 @@ class Backend;
 class ConvertHeaders : public Inspector {
     Backend*             backend;
     cstring              scalarsName;
+    BMV2Options&         options;
     cstring              scalarsTypeName;
     P4::ReferenceMap*    refMap;
     P4::TypeMap*         typeMap;
@@ -58,7 +59,7 @@ class ConvertHeaders : public Inspector {
     bool preorder(const IR::PackageBlock* b) override;
     bool preorder(const IR::Parameter* param) override;
 
-    ConvertHeaders(Backend* backend, cstring scalarsName);
+    ConvertHeaders(Backend* backend, cstring scalarsName, BMV2Options& options);
 };
 
 }  // namespace BMV2


### PR DESCRIPTION
This is a fix for #718 and #1036.