### PR TITLE
Fix for issue #961

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -100,13 +100,6 @@ set (BMV2_TEST_SUITES
   )
 
 set (XFAIL_TESTS
-  # The following tests are broken because of issue #961
-  testdata/p4_14_samples/counter1.p4
-  testdata/p4_14_samples/counter2.p4
-  testdata/p4_14_samples/counter3.p4
-  testdata/p4_14_samples/counter4.p4
-  testdata/p4_14_samples/07-MultiProtocol.p4
-
   # This test defines two lpm keys for a table.
   # Even though the P4 spec allows it, it doesn't really make sense in a switch
   # so we allow it to fail on BMv2.

--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -439,6 +439,10 @@ class RunBMV2(object):
             else:
                 # parsing table key
                 word, cmd = nextWord(cmd)
+                if cmd.find("=") >= 0:
+                    # This command retrieves a handle for the key
+                    # This feature is currently not supported, so we just ignore the handle part
+                    cmd = cmd.split("=")[0]
                 if word.find("(") >= 0:
                     # found action
                     actionName, arg = nextWord(word, "(")

--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -345,7 +345,8 @@ class RunBMV2(object):
         self.folder = folder
         self.pcapPrefix = "pcap"
         self.interfaces = {}
-        self.expected = {}
+        self.expected = {}  # for each interface number of packets expected
+        self.expectedAny = []  # interface on which any number of packets is fine
         self.packetDelay = 0
         self.options = options
         self.json = None
@@ -400,6 +401,8 @@ class RunBMV2(object):
             data = ''.join(data.split())
             if data != '':
                 self.expected.setdefault(interface, []).append(data)
+            else:
+                self.expectedAny.append(interface)
         else:
             if self.options.verbose:
                 print("ignoring stf command:", first, cmd)
@@ -650,6 +653,10 @@ class RunBMV2(object):
                 observationLog.close()
 
             # Check for expected packets.
+            if interface in self.expectedAny:
+                if interface in self.expected:
+                    reportError("Interface " + interface + " has both expected with packets and without")
+                continue
             if interface not in self.expected:
                 expected = []
             else:

--- a/testdata/p4_14_samples/07-MultiProtocol.p4
+++ b/testdata/p4_14_samples/07-MultiProtocol.p4
@@ -166,8 +166,11 @@ metadata ingress_metadata_t ing_metadata;
 
 action nop() {
 }
-action drop() {
+action _drop() {
     modify_field(ing_metadata.drop, 1);
+}
+action discard() {
+    drop();
 }
 
 action set_egress_port(egress_port) {
@@ -243,7 +246,7 @@ table tcp_check {
     }
     actions {
         nop;
-        drop;
+        _drop;
     }
 }
 table udp_check {
@@ -252,7 +255,7 @@ table udp_check {
     }
     actions {
         nop;
-        drop;
+        _drop;
     }
 }
 table icmp_check {
@@ -261,7 +264,7 @@ table icmp_check {
     }
     actions {
         nop;
-        drop;
+        _drop;
     }
 }
 
@@ -274,7 +277,7 @@ table set_egress {
         ing_metadata.drop : exact;
     }
     actions {
-        nop;
+        discard;
         send_packet;
     }
 }

--- a/testdata/p4_14_samples/07-MultiProtocol.stf
+++ b/testdata/p4_14_samples/07-MultiProtocol.stf
@@ -5,10 +5,10 @@ add ethertype_match etherType:0x8100 mpls_packet()
 add ethertype_match etherType:0x9100 mim_packet()
 
 add set_egress drop:0 send_packet()
-add set_egress drop:1 nop()
+add set_egress drop:1 discard()
 
 add ipv4_match dstAddr:0xa000002 set_egress_port(egress_port:3)
-add udp_check dstPort:0xaa drop()
+add udp_check dstPort:0xaa _drop()
 
 
 #        | ethernet header            | | IPv4 header                                  | | UDP header      | | payload ...

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
@@ -167,11 +167,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop() {
     }
-    @name(".drop") action drop() {
+    @name("._drop") action _drop() {
         meta.ing_metadata.drop = 1w1;
     }
     @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
         meta.ing_metadata.egress_port = egress_port;
+    }
+    @name(".discard") action discard() {
+        mark_to_drop();
     }
     @name(".send_packet") action send_packet() {
         standard_metadata.egress_spec = meta.ing_metadata.egress_port;
@@ -193,7 +196,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".icmp_check") table icmp_check {
         actions = {
             nop();
-            drop();
+            _drop();
             @defaultonly NoAction();
         }
         key = {
@@ -236,7 +239,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_egress") table set_egress {
         actions = {
-            nop();
+            discard();
             send_packet();
             @defaultonly NoAction();
         }
@@ -248,7 +251,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".tcp_check") table tcp_check {
         actions = {
             nop();
-            drop();
+            _drop();
             @defaultonly NoAction();
         }
         key = {
@@ -259,7 +262,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".udp_check") table udp_check {
         actions = {
             nop();
-            drop();
+            _drop();
             @defaultonly NoAction();
         }
         key = {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
@@ -167,11 +167,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_0() {
     }
-    @name(".drop") action drop_0() {
+    @name("._drop") action _drop_0() {
         meta.ing_metadata.drop = 1w1;
     }
     @name(".set_egress_port") action set_egress_port_0(bit<9> egress_port) {
         meta.ing_metadata.egress_port = egress_port;
+    }
+    @name(".discard") action discard_0() {
+        mark_to_drop();
     }
     @name(".send_packet") action send_packet_0() {
         standard_metadata.egress_spec = meta.ing_metadata.egress_port;
@@ -193,7 +196,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".icmp_check") table icmp_check_0 {
         actions = {
             nop_0();
-            drop_0();
+            _drop_0();
             @defaultonly NoAction();
         }
         key = {
@@ -236,7 +239,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_egress") table set_egress_0 {
         actions = {
-            nop_0();
+            discard_0();
             send_packet_0();
             @defaultonly NoAction();
         }
@@ -248,7 +251,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".tcp_check") table tcp_check_0 {
         actions = {
             nop_0();
-            drop_0();
+            _drop_0();
             @defaultonly NoAction();
         }
         key = {
@@ -259,7 +262,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".udp_check") table udp_check_0 {
         actions = {
             nop_0();
-            drop_0();
+            _drop_0();
             @defaultonly NoAction();
         }
         key = {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
@@ -183,6 +183,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_0() {
     }
+    @name(".nop") action nop_6() {
+    }
     @name(".nop") action nop_7() {
     }
     @name(".nop") action nop_8() {
@@ -191,17 +193,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_10() {
     }
-    @name(".nop") action nop_11() {
-    }
-    @name(".nop") action nop_12() {
-    }
-    @name(".drop") action drop_0() {
+    @name("._drop") action _drop_0() {
         meta.ing_metadata.drop = 1w1;
     }
-    @name(".drop") action drop_4() {
+    @name("._drop") action _drop_3() {
         meta.ing_metadata.drop = 1w1;
     }
-    @name(".drop") action drop_5() {
+    @name("._drop") action _drop_4() {
         meta.ing_metadata.drop = 1w1;
     }
     @name(".set_egress_port") action set_egress_port_0(bit<9> egress_port) {
@@ -212,6 +210,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_egress_port") action set_egress_port_4(bit<9> egress_port) {
         meta.ing_metadata.egress_port = egress_port;
+    }
+    @name(".discard") action discard_0() {
+        mark_to_drop();
     }
     @name(".send_packet") action send_packet_0() {
         standard_metadata.egress_spec = meta.ing_metadata.egress_port;
@@ -233,7 +234,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".icmp_check") table icmp_check {
         actions = {
             nop_0();
-            drop_0();
+            _drop_0();
             @defaultonly NoAction_9();
         }
         key = {
@@ -243,7 +244,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".ipv4_match") table ipv4_match {
         actions = {
-            nop_7();
+            nop_6();
             set_egress_port_0();
             @defaultonly NoAction_10();
         }
@@ -254,7 +255,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".ipv6_match") table ipv6_match {
         actions = {
-            nop_8();
+            nop_7();
             set_egress_port_3();
             @defaultonly NoAction_11();
         }
@@ -265,7 +266,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".l2_match") table l2_match {
         actions = {
-            nop_9();
+            nop_8();
             set_egress_port_4();
             @defaultonly NoAction_12();
         }
@@ -276,7 +277,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_egress") table set_egress {
         actions = {
-            nop_10();
+            discard_0();
             send_packet_0();
             @defaultonly NoAction_13();
         }
@@ -287,8 +288,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".tcp_check") table tcp_check {
         actions = {
-            nop_11();
-            drop_4();
+            nop_9();
+            _drop_3();
             @defaultonly NoAction_14();
         }
         key = {
@@ -298,8 +299,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".udp_check") table udp_check {
         actions = {
-            nop_12();
-            drop_5();
+            nop_10();
+            _drop_4();
             @defaultonly NoAction_15();
         }
         key = {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
@@ -167,11 +167,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop() {
     }
-    @name(".drop") action drop() {
+    @name("._drop") action _drop() {
         meta.ing_metadata.drop = 1w1;
     }
     @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
         meta.ing_metadata.egress_port = egress_port;
+    }
+    @name(".discard") action discard() {
+        mark_to_drop();
     }
     @name(".send_packet") action send_packet() {
         standard_metadata.egress_spec = meta.ing_metadata.egress_port;
@@ -191,7 +194,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".icmp_check") table icmp_check {
         actions = {
             nop;
-            drop;
+            _drop;
         }
         key = {
             hdr.icmp.typeCode: exact;
@@ -226,7 +229,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_egress") table set_egress {
         actions = {
-            nop;
+            discard;
             send_packet;
         }
         key = {
@@ -236,7 +239,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".tcp_check") table tcp_check {
         actions = {
             nop;
-            drop;
+            _drop;
         }
         key = {
             hdr.tcp.dstPort: exact;
@@ -245,7 +248,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".udp_check") table udp_check {
         actions = {
             nop;
-            drop;
+            _drop;
         }
         key = {
             hdr.udp.dstPort: exact;


### PR DESCRIPTION
This fixes the old stf file parser to ignore the key handle part of a command.
This makes the tests pass again, but the stf support in the old parser is still incomplete.
