### PR TITLE
P4_14->16 conversion hooks for register/stateful conversion

### DIFF
--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -439,7 +439,8 @@ const IR::Type_Extern *ExternConverter::convertExternType(ProgramStructure *stru
 }
 
 const IR::Declaration_Instance *ExternConverter::convertExternInstance(ProgramStructure *structure,
-            const IR::Declaration_Instance *ext, cstring name) {
+            const IR::Declaration_Instance *ext, cstring name,
+            IR::IndexedVector<IR::Declaration> *) {
     auto *rv = ext->clone();
     auto *et = rv->type->to<IR::Type_Extern>();
     BUG_CHECK(et, "Extern %s is not extern type, but %s", ext, ext->type);

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -89,7 +89,7 @@ class ExternConverter {
     virtual const IR::Type_Extern *convertExternType(ProgramStructure *,
                 const IR::Type_Extern *, cstring);
     virtual const IR::Declaration_Instance *convertExternInstance(ProgramStructure *,
-                const IR::Declaration_Instance *, cstring);
+                const IR::Declaration_Instance *, cstring, IR::IndexedVector<IR::Declaration> *);
     virtual const IR::Statement *convertExternCall(ProgramStructure *,
                 const IR::Declaration_Instance *, const IR::Primitive *);
     ExternConverter() {}
@@ -104,8 +104,9 @@ class ExternConverter {
                 const IR::Type_Extern *e, cstring name) {
         return get(e)->convertExternType(s, e, name); }
     static const IR::Declaration_Instance *cvtExternInstance(ProgramStructure *s,
-                const IR::Declaration_Instance *di, cstring name) {
-        return get(di)->convertExternInstance(s, di, name); }
+                const IR::Declaration_Instance *di, cstring name,
+                IR::IndexedVector<IR::Declaration> *scope) {
+        return get(di)->convertExternInstance(s, di, name, scope); }
     static const IR::Statement *cvtExternCall(ProgramStructure *s,
                 const IR::Declaration_Instance *di, const IR::Primitive *p) {
         return get(di)->convertExternCall(s, di, p); }

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -1629,10 +1629,14 @@ const IR::Expression* ProgramStructure::counterType(const IR::CounterOrMeter* cm
 }
 
 const IR::Declaration_Instance*
-ProgramStructure::convert(const IR::Register* reg, cstring newName) {
+ProgramStructure::convert(const IR::Register* reg, cstring newName,
+                          const IR::Type *regElementType) {
     LOG3("Synthesizing " << reg);
-    const IR::Type *regElementType = nullptr;
-    if (reg->width > 0) {
+    if (regElementType) {
+        if (auto str = regElementType->to<IR::Type_StructLike>())
+            regElementType = new IR::Type_Name(new IR::Path(str->name));
+        // use provided type
+    } else if (reg->width > 0) {
         regElementType = IR::Type_Bits::get(reg->width);
     } else if (reg->layout) {
         cstring newName = ::get(registerLayoutType, reg->layout);
@@ -1831,7 +1835,7 @@ ProgramStructure::convertControl(const IR::V1Control* control, cstring newName) 
 
     for (auto c : externsToDo) {
         auto ext = externs.get(c);
-        ext = ExternConverter::cvtExternInstance(this, ext, externs.get(ext));
+        ext = ExternConverter::cvtExternInstance(this, ext, externs.get(ext), &stateful);
         stateful.push_back(ext);
     }
 

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -204,7 +204,6 @@ class ProgramStructure {
     const IR::Declaration_Instance* convertDirectMeter(const IR::Meter* m, cstring newName);
     const IR::Declaration_Instance* convertDirectCounter(const IR::Counter* m, cstring newName);
     const IR::Declaration_Instance* convert(const IR::CounterOrMeter* cm, cstring newName);
-    const IR::Declaration_Instance* convert(const IR::Register* reg, cstring newName);
     const IR::P4Table*
     convertTable(const IR::V1Table* table, cstring newName,
                  IR::IndexedVector<IR::Declaration> &stateful, std::map<cstring, cstring> &);
@@ -232,6 +231,8 @@ class ProgramStructure {
                                           const IR::Expression* right, const IR::Type* type);
     const IR::Expression* convertFieldList(const IR::Expression* expression);
     const IR::Expression* convertHashAlgorithm(IR::ID algorithm);
+    const IR::Declaration_Instance* convert(const IR::Register* reg, cstring newName,
+                                            const IR::Type *elementType = nullptr);
     const IR::Type_Struct* createFieldListType(const IR::Expression* expression);
     const IR::FieldList* getFieldLists(const IR::FieldListCalculation* flc);
     const IR::Expression* paramReference(const IR::Parameter* param);

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -336,6 +336,12 @@ class ConstructorCallExpression : Expression {
 /// Represents a list of expressions separated by commas
 class ListExpression : Expression {
     inline Vector<Expression> components;
+    ListExpression {
+        if (type->is<Type::Unknown>()) {
+            Vector<Type> tuple;
+            for (auto e : components)
+                tuple.push_back(e->type);
+            type = new Type_Tuple(tuple); } }
     validate { components.check_null(); }
     void push_back(Expression e) { components.push_back(e); }
 }

--- a/ir/pass_manager.cpp
+++ b/ir/pass_manager.cpp
@@ -20,6 +20,12 @@ limitations under the License.
 
 const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *) {
     safe_vector<std::pair<safe_vector<Visitor *>::iterator, const IR::Node *>> backup;
+    static indent_t log_indent(-1);
+    struct indent_nesting {
+        indent_t &indent;
+        explicit indent_nesting(indent_t &i) : indent(i) { ++indent; }
+        ~indent_nesting() { --indent; }
+    } nest_log_indent(log_indent);
 
     early_exit_flag = false;
     BUG_CHECK(running, "not calling apply properly");
@@ -31,9 +37,9 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
         try {
             try {
                 size_t maxmem;
-                LOG1(name() << " invoking " << v->name());
+                LOG1(log_indent << name() << " invoking " << v->name());
                 program = program->apply(**it);
-                LOG3("heap after " << v->name() << ": in use " <<
+                LOG3(log_indent << "heap after " << v->name() << ": in use " <<
                      n4(gc_mem_inuse(&maxmem)) << "B, max " << n4(maxmem) << "B");
                 int errors = ErrorReporter::instance.getErrorCount();
                 if (stop_on_error && errors > 0)
@@ -43,7 +49,7 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
                 throw Backtrack::trigger(trig_type);
             }
         } catch (Backtrack::trigger &trig) {
-            LOG1("caught backtrack trigger " << trig);
+            LOG1(log_indent << "caught backtrack trigger " << trig);
             while (!backup.empty()) {
                 if (backup.back().first == it) {
                     backup.pop_back();
@@ -53,9 +59,9 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
                 program = backup.back().second;
                 if (b->backtrack(trig))
                     break;
-                LOG1("pass " << b->name() << " can't handle it"); }
+                LOG1(log_indent << "pass " << b->name() << " can't handle it"); }
             if (backup.empty()) {
-                LOG1("rethrow trigger");
+                LOG1(log_indent << "rethrow trigger");
                 throw trig; }
             continue; }
         runDebugHooks(v->name(), program);


### PR DESCRIPTION
This adds some hooks so that convertExternInstance can add additional declarations to the scope of the control in which is being converted and/or get at other previously converted objects in the scope (registers is the particular need).