### PR TITLE
Mark tests as xfailed due issue #486 - to be fixed

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -108,6 +108,10 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/issue907-bmv2.p4
   # This test uses a table graph that is not implementable in BMv2
   testdata/p4_16_samples/issue986-bmv2.p4
+  # These tests fail due to issue #486
+  testdata/p4_16_samples/x-bmv2.p4
+  testdata/p4_16_samples/issue986-1-bmv2.p4
+  testdata/p4_14_samples/16-TwoReferences.p4
   )
 
 if (HAVE_SIMPLE_SWITCH)


### PR DESCRIPTION
This is required for the testsuite to pass with the latest build of the behavioral model.
