### PR TITLE
support another blackbox primitive  in p4-14 type inference

### DIFF
--- a/ir/v1.cpp
+++ b/ir/v1.cpp
@@ -142,6 +142,8 @@ const IR::Type *IR::Primitive::inferOperandType(int operand) const {
         operand == 0) {
         return IR::Type::Bits::get(32);
     }
+    if ((name == "execute") && operand == 2)
+        return IR::Type::Bits::get(32);
     return IR::Type::Unknown::get();
 }
 


### PR DESCRIPTION
This is undoubtfully a hack, but we already have hacks in this file to support type inference on `execute_stateful_` primitives.