### PR TITLE
Allow options to have optional arguments

### DIFF
--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -120,31 +120,45 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
     registerOption("-o", "outfile",
                    [this](const char* arg) { outputFile = arg; return true; },
                    "Write output to outfile");
-    registerOption("--Wwarnings-as-errors", nullptr,
-                    [](const char*) {
-                        auto action = DiagnosticAction::Error;
-                        P4CContext::get().setDefaultWarningDiagnosticAction(action);
-                        return true;
-                    },
-                    "Treat all warnings as errors");
     registerOption("--Wdisable", "diagnostic",
         [this](const char *diagnostic) {
-            P4CContext::get().setDiagnosticAction(diagnostic,
-                                                  DiagnosticAction::Ignore);
+            if (diagnostic) {
+                P4CContext::get().setDiagnosticAction(diagnostic,
+                                                      DiagnosticAction::Ignore);
+            } else {
+                auto action = DiagnosticAction::Ignore;
+                P4CContext::get().setDefaultWarningDiagnosticAction(action);
+            }
             return true;
-        }, "Disable a compiler diagnostic");
+        }, "Disable a compiler diagnostic, or disable all warnings if no "
+           "diagnostic is specified.",
+        OptionFlags::OptionalArgument);
     registerOption("--Wwarn", "diagnostic",
         [this](const char *diagnostic) {
-            P4CContext::get().setDiagnosticAction(diagnostic,
-                                                  DiagnosticAction::Warn);
+            if (diagnostic) {
+                P4CContext::get().setDiagnosticAction(diagnostic,
+                                                      DiagnosticAction::Warn);
+            } else {
+                auto action = DiagnosticAction::Warn;
+                P4CContext::get().setDefaultWarningDiagnosticAction(action);
+            }
             return true;
-        }, "Report a warning for a compiler diagnostic");
+        }, "Report a warning for a compiler diagnostic, or treat all warnings "
+           "as warnings (the default) if no diagnostic is specified.",
+        OptionFlags::OptionalArgument);
     registerOption("--Werror", "diagnostic",
         [this](const char *diagnostic) {
-            P4CContext::get().setDiagnosticAction(diagnostic,
-                                                  DiagnosticAction::Error);
+            if (diagnostic) {
+                P4CContext::get().setDiagnosticAction(diagnostic,
+                                                      DiagnosticAction::Error);
+            } else {
+                auto action = DiagnosticAction::Error;
+                P4CContext::get().setDefaultWarningDiagnosticAction(action);
+            }
             return true;
-        }, "Report an error for a compiler diagnostic");
+        }, "Report an error for a compiler diagnostic, or treat all warnings as "
+           "errors if no diagnostic is specified.",
+        OptionFlags::OptionalArgument);
     registerOption("-T", "loglevel",
                    [](const char* arg) { Log::addDebugSpec(arg); return true; },
                    "[Compiler debugging] Adjust logging level per file (see below)");

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -64,12 +64,14 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                    [this](const char*) {
                        langVersion = CompilerOptions::FrontendVersion::P4_14;
                        return true; },
-                    "[Deprecated] Specify language version to compile", true);
+                    "[Deprecated] Specify language version to compile",
+                    OptionFlags::Hide);
     registerOption("--p4-16", nullptr,
                    [this](const char*) {
                        langVersion = CompilerOptions::FrontendVersion::P4_16;
                        return true; },
-                    "[Deprecated] Specify language version to compile", true);
+                    "[Deprecated] Specify language version to compile",
+                    OptionFlags::Hide);
     registerOption("--p4v", "{14|16}",
                    [this](const char* arg) {
                        if (!strcmp(arg, "1.0") || !strcmp(arg, "14")) {

--- a/lib/options.h
+++ b/lib/options.h
@@ -32,6 +32,21 @@ namespace Util {
 // Command-line options processing
 class Options {
  public:
+    enum OptionFlags {
+        /// The default option flags.
+        Default = 0,
+
+        /// Hide this option from --help message.
+        Hide = 1 << 0,
+
+        /// If this option requires an argument, it may be omitted. Options with
+        /// this flag set can only accept their argument with the syntax
+        /// `--foo=bar`; `--foo bar` will be treated as if the argument to
+        /// `--foo` were omitted. If the argument is omitted, null will be
+        /// passed to the OptionProcessor.
+        OptionalArgument = 1 << 1,
+    };
+
     // return true if processing is successful
     typedef std::function<bool(const char* optarg)> OptionProcessor;
 
@@ -41,7 +56,7 @@ class Options {
         const char* argName;  // nullptr if argument is not required
         const char* description;
         OptionProcessor processor;
-        bool hide;  // is true to hide option from help message
+        OptionFlags flags;
     };
     const char* binaryName;
     cstring message;
@@ -61,7 +76,7 @@ class Options {
                                               // nullptr if no argument expected
                         OptionProcessor processor,  // function to execute when option matches
                         const char* description,  // option help message
-                        bool hide = false);  // hide option from --help message
+                        OptionFlags flags = OptionFlags::Default);  // additional flags
 
     explicit Options(cstring message) : binaryName(nullptr), message(message) {}
 


### PR DESCRIPTION
As @mbudiu-vmw pointed out in #1074, when you forget the argument to an option, the error message that the compiler reports isn't very helpful. The ambiguity is unfortunately impossible to resolve in general, I think, but this specific case is fairly easy: in analogy with GCC, users expect that `--Werror` without an argument will be accepted and will make the compiler treat all warnings as errors, and we should make that work.

To that end, this PR adds a flag to `Util::Options::registerOption()` that lets you specify that an option's argument may be omitted. To avoid ambiguity, for such options we don't allow `--foo bar`; only `--foo=bar` is accepted. That means that you must use `--Werror=foo` and not `--Werror foo`. `--foo bar` still works for options with non-optional arguments, of course.

With that change in place, we can make `--Werror` and `--Wdisable` do what you might expect. `--Wwarn` also works and makes us treat all warnings as, well, warnings; this seems a bit silly but sometimes it's useful to do this kind of thing in Makefiles and the like to cancel flags introduced elsewhere.

Since it's now redundant, I also removed `--Wwarnings-as-errors`.