### PR TITLE
p4c driver refactoring

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -23,6 +23,7 @@ execute_process(COMMAND chmod a+x ${P4C_BINARY_DIR}/p4c)
 
 set (P4C_DRIVER_SRCS
   p4c_src/main.py
+  p4c_src/driver.py
   p4c_src/util.py
   p4c_src/config.py
   p4c_src/__init__.py

--- a/tools/driver/p4c_src/config.py
+++ b/tools/driver/p4c_src/config.py
@@ -27,10 +27,6 @@ class Config(object):
     def __init__(self, config_prefix):
         self.config_prefix = config_prefix or 'p4c'
         self.target = []
-        self.steps = {}
-        self.init_func = {}
-        self.options = {}
-        self.toolchain = {}
 
     def load_from_config(self, path, output_dir, source_file):
         cfg_globals = dict(globals())
@@ -60,68 +56,3 @@ class Config(object):
         except:
             import traceback
             print traceback.format_exc()
-
-    def add_preprocessor_option(self, backend, option):
-        if backend not in self.options:
-            self.options[backend] = {}
-        if 'preprocessor' not in self.options[backend]:
-            self.options[backend]['preprocessor'] = []
-        self.options[backend]['preprocessor'].append(option)
-
-    def add_compiler_option(self, backend, option):
-        if backend not in self.options:
-            self.options[backend] = {}
-        if 'compiler' not in self.options[backend]:
-            self.options[backend]['compiler'] = []
-        self.options[backend]['compiler'].append(option)
-
-    def add_assembler_option(self, backend, option):
-        if backend not in self.options:
-            self.options[backend] = {}
-        if 'assembler' not in self.options[backend]:
-            self.options[backend]['assembler'] = []
-        self.options[backend]['assembler'].append(option)
-
-    def add_linker_option(self, backend, option):
-        if backend not in self.options:
-            self.options[backend] = {}
-        if 'linker' not in self.options[backend]:
-            self.options[backend]['linker'] = []
-        self.options[backend]['linker'].append(option)
-
-    def add_toolchain(self, backend, toolchain):
-        if backend not in self.toolchain:
-            self.toolchain[backend] = {}
-        if not isinstance(toolchain, dict):
-            print "variable toolchain is not type dict"
-            sys.exit(1)
-        for k, v in toolchain.iteritems():
-            self.toolchain[backend][k] = v
-
-    def add_compilation_steps(self, backend, step):
-        self.steps[backend] = step
-
-
-    def get_compiler(self, backend):
-        if 'compiler' in self.toolchain[backend]:
-            return self.toolchain[backend]['compiler']
-        else:
-            return None
-
-    def get_preprocessor(self, backend):
-        if 'preprocessor' in self.toolchain[backend]:
-            return self.toolchain[backend]['preprocessor']
-        else:
-            return None
-
-    def get_assembler(self, backend):
-        if 'assembler' in self.toolchain[backend]:
-            return self.toolchain[backend]['assembler']
-        else:
-            return None
-
-    def get_linker(self, backend):
-        if 'linker' in self.toolchain[backend]:
-            return self.toolchain[backend]['linker']
-        else:
-            return None

--- a/tools/driver/p4c_src/config.py
+++ b/tools/driver/p4c_src/config.py
@@ -20,24 +20,20 @@ class Config(object):
     """
     Config - Configuration data for a 'p4c' tool chain.
 
-    The common configuration data include compiler/assembler name,
-    compiler/assembler installation path.
+    The common configuration includes the argument parser and the path to the
+    backend configuration file.
+
     """
 
     def __init__(self, config_prefix):
         self.config_prefix = config_prefix or 'p4c'
         self.target = []
 
-    def load_from_config(self, path, output_dir, source_file):
+    def load_from_config(self, path, argParser):
         cfg_globals = dict(globals())
         cfg_globals['config'] = self
         cfg_globals['__file__'] = path
-        cfg_globals['output_dir'] = output_dir
-        cfg_globals['source_fullname'] = source_file
-        if source_file is None:
-            cfg_globals['source_basename'] = None
-        else:
-            cfg_globals['source_basename'] = os.path.splitext(os.path.basename(source_file))[0]
+        cfg_globals['argParser'] = argParser
 
         data = None
         f = open(path)

--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -1,0 +1,148 @@
+# Copyright 2013-present Barefoot Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import shlex, subprocess
+import sys
+
+import p4c_src.util as util
+
+class Driver:
+    """A class that has a list of passes that need to be run.
+    Each backend instantiates this class and configures the commands
+    that wants to be run.
+
+    \TODO: the main program assumes that preprocessor, assembler,
+    compiler, and linker are predefined commands. We should move those
+    out of main and let the backend class configure its commands using
+    the options.
+
+    Each pass builds a command line that is invoked as a separate
+    process.  Each pass also allows invoking a pre and post processing
+    step to setup and cleanup after each command.
+
+    """
+
+    def __init__(self, backendName):
+        self._backend = backendName
+        self._commands = {}
+        self._commandsEnabled = []
+        self._preCmds = {}
+        self._postCmds = {}
+
+    def __str__(self):
+        return self._backend
+
+    def add_command(self, cmd_name, cmd):
+        """ Add a command
+
+        If the command was previously set, it is overwritten
+        """
+        if cmd_name in self._commands:
+            print >> sys.stderr, "Warning: overwriting command", cmd_name
+        self._commands[cmd_name] = []
+        self._commands[cmd_name].append(cmd)
+
+    def add_command_option(self, cmd_name, option):
+        """ Add an option to a command
+        """
+        if cmd_name not in self._commands:
+            print >> sys.stderr, "Command", "'" + cmd_name + "'", \
+                "was not set for target", self._backend
+            return
+        self._commands[cmd_name].append(option)
+
+    def enable_commands(self, cmdsEnabled):
+        """
+        Defines the order in which the steps are executed and which commands
+        are going to run
+        """
+        self._commandsEnabled = cmdsEnabled
+
+    def disable_commands(self, cmdsDisabled):
+        """
+        Disables the commands in cmdsDisabled
+        """
+        for c in cmdsDisabled:
+            if c in self._commandsEnabled:
+                self._commandsEnabled.remove(c)
+
+    def runCmd(self, cmd, opts):
+        """
+        Run a command, capture its output and print it
+        Also exit with the command error code if failed
+        """
+        # only dry-run
+        if opts.dry_run:
+            print " ".join(cmd)
+            return
+
+        args = shlex.split(" ".join(cmd))
+        try:
+            p = subprocess.Popen(args, stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT)
+        except:
+            import traceback
+            print >> sys.stderr, "error invoking {}".format(" ".join(cmd))
+            print >> sys.stderr, traceback.format_exc()
+            sys.exit(1)
+
+        if opts.debug: print 'running {}'.format(' '.join(cmd))
+        out, err = p.communicate() # now wait
+        if len(out) > 0: print out
+        if p.returncode != 0:
+            sys.exit(p.returncode)
+
+    def preRun(self, cmd_name, opts):
+        """
+        Preamble to a command to setup anything needed
+        """
+        if cmd_name not in self._preCmds:
+            return # nothing to do
+
+        cmd = self._preCmds[cmd_name]
+        self.runCmd(cmd, opts)
+
+    def postRun(self, cmd_name, opts):
+        """
+        Postamble to a command to cleanup
+        """
+        if cmd_name not in self._postCmds:
+            return # nothing to do
+
+        cmd = self._postCmds[cmd_name]
+        self.runCmd(cmd, opts)
+
+    def run(self, opts):
+        """
+        Run the set of commands required by this driver
+        """
+
+        # set output directory
+        if not os.path.exists(opts.output_directory):
+            os.makedirs(opts.output_directory)
+
+        for c in self._commandsEnabled:
+
+            # run the setup for the command
+            self.preRun(c, opts)
+
+            # run the command
+            cmd = self._commands[c]
+            if cmd[0].find('/') != 0 and (util.find_bin(cmd[0]) == None):
+                print >> sys.stderr, "{}: command not found".format(cmd[0])
+                sys.exit(1)
+            self.runCmd(cmd, opts)
+
+            # run the cleanup
+            self.postRun(c, opts)

--- a/tools/driver/p4c_src/p4c.bmv2.cfg
+++ b/tools/driver/p4c_src/p4c.bmv2.cfg
@@ -16,32 +16,43 @@
 
 from p4c_src.driver import BackendDriver
 
+class BMV2Backend(BackendDriver):
+    def __init__(self, target, argParser):
+        BackendDriver.__init__(self, target, argParser)
+
+        # commands
+        self.add_command('preprocessor', 'cc')
+        self.add_command('compiler',
+                         os.path.join(os.environ['P4C_BIN_DIR'],'p4c-bm2-ss'))
+        # order of invocation
+        self.enable_commands(['preprocessor', 'compiler'])
+
+        # options
+        self.add_command_option('preprocessor', "-E -x c")
+
+
+    def process_command_line_options(self, opts):
+        BackendDriver.process_command_line_options(self, opts)
+
+        # process the options related to source file
+        basepath = "{}/{}".format(opts.output_directory, self._source_basename)
+        # preprocessor
+        self.add_command_option('preprocessor', "-o")
+        self.add_command_option('preprocessor', "{}.p4i".format(basepath))
+        self.add_command_option('preprocessor', self._source_filename)
+
+        # compiler
+        self.add_command_option('compiler', "-o")
+        self.add_command_option('compiler', "{}.json".format(basepath))
+        self.add_command_option('compiler', "{}.p4i".format(basepath))
+
+        # generate api as part of the compilation
+        self.add_command_option('compiler', "--p4runtime-file");
+        self.add_command_option('compiler', "{}.p4rt".format(basepath))
+
+
 # target
-simple_switch_target = BackendDriver('bmv2-ss-p4org')
-
-# commands
-simple_switch_target.add_command('preprocessor', 'cc')
-simple_switch_target.add_command('compiler', os.path.join(os.environ['P4C_BIN_DIR'],'p4c-bm2-ss'))
-
-# options
-simple_switch_target.add_command_option('preprocessor', "-E -x c")
-
-if source_basename is not None:
-    basepath = "{}/{}".format(output_dir, source_basename)
-    # preprocessor
-    simple_switch_target.add_command_option('preprocessor', "-o")
-    simple_switch_target.add_command_option('preprocessor', "{}.p4i".format(basepath))
-    simple_switch_target.add_command_option('preprocessor', source_fullname)
-
-    # compiler
-    simple_switch_target.add_command_option('compiler', "-o")
-    simple_switch_target.add_command_option('compiler', "{}.json".format(basepath))
-    simple_switch_target.add_command_option('compiler', "{}.p4i".format(basepath))
-    # generate api has part of the compilation
-    simple_switch_target.add_command_option('compiler', "--p4runtime-file");
-    simple_switch_target.add_command_option('compiler', "{}.p4rt".format(basepath))
-
-simple_switch_target.enable_commands(['preprocessor', 'compiler'])
+simple_switch_target = BMV2Backend('bmv2-ss-p4org', argParser)
 config.target.append(simple_switch_target)
 
 # PSA implementation on BMv2

--- a/tools/driver/p4c_src/p4c.bmv2.cfg
+++ b/tools/driver/p4c_src/p4c.bmv2.cfg
@@ -14,38 +14,38 @@
 
 # -*- Python -*-
 
-simple_switch_target="bmv2-ss-p4org"
-def config_preprocessor():
-    config.add_preprocessor_option(simple_switch_target, "-E -x c")
-    if source_basename is not None:
-        config.add_preprocessor_option(simple_switch_target, "-o")
-        config.add_preprocessor_option(simple_switch_target, "{}/{}.p4i".format(output_dir, source_basename))
-        config.add_preprocessor_option(simple_switch_target, source_fullname)
+from p4c_src.driver import Driver
 
-def config_compiler():
-    if source_basename is None:
-        return
-    config.add_compiler_option(simple_switch_target, "-o")
-    config.add_compiler_option(simple_switch_target, "{}/{}.json".format(output_dir, source_basename))
-    config.add_compiler_option(simple_switch_target, "{}/{}.p4i".format(output_dir, source_basename))
+# target
+simple_switch_target = Driver('bmv2-ss-p4org')
+
+# commands
+simple_switch_target.add_command('preprocessor', 'cc')
+simple_switch_target.add_command('compiler', os.path.join(os.environ['P4C_BIN_DIR'],'p4c-bm2-ss'))
+
+# options
+simple_switch_target.add_command_option('preprocessor', "-E -x c")
+
+if source_basename is not None:
+    basepath = "{}/{}".format(output_dir, source_basename)
+    # preprocessor
+    simple_switch_target.add_command_option('preprocessor', "-o")
+    simple_switch_target.add_command_option('preprocessor', "{}.p4i".format(basepath))
+    simple_switch_target.add_command_option('preprocessor', source_fullname)
+
+    # compiler
+    simple_switch_target.add_command_option('compiler', "-o")
+    simple_switch_target.add_command_option('compiler', "{}.json".format(basepath))
+    simple_switch_target.add_command_option('compiler', "{}.p4i".format(basepath))
     # generate api has part of the compilation
-    config.add_compiler_option(simple_switch_target, "--p4runtime-file");
-    config.add_compiler_option(simple_switch_target, "{}/{}.p4rt".format(output_dir, source_basename))
+    simple_switch_target.add_command_option('compiler', "--p4runtime-file");
+    simple_switch_target.add_command_option('compiler', "{}.p4rt".format(basepath))
 
-config_preprocessor()
-config_compiler()
-config.add_toolchain(simple_switch_target, {
-    'preprocessor': 'cc',
-    'compiler': os.path.join(os.environ['P4C_BIN_DIR'],'p4c-bm2-ss')})
-config.add_compilation_steps(simple_switch_target, ["preprocessor", "compiler"])
-
+simple_switch_target.enable_commands(['preprocessor', 'compiler'])
 config.target.append(simple_switch_target)
 
 # PSA implementation on BMv2
-psa_target = 'bmv2-psa-p4org'
-config.add_compiler_option(psa_target, "")
-config.add_toolchain(psa_target, {
-    'compiler': 'echo "target ' + psa_target + ' not yet implemented"'
-})
-config.add_compilation_steps(psa_target, ['compiler'])
+psa_target = Driver('bmv2-psa-p4org')
+psa_target.add_command('none', '/bin/echo "target ' + str(psa_target) + ' not yet implemented"')
+psa_target.enable_commands(['none'])
 config.target.append(psa_target)

--- a/tools/driver/p4c_src/p4c.bmv2.cfg
+++ b/tools/driver/p4c_src/p4c.bmv2.cfg
@@ -14,10 +14,10 @@
 
 # -*- Python -*-
 
-from p4c_src.driver import Driver
+from p4c_src.driver import BackendDriver
 
 # target
-simple_switch_target = Driver('bmv2-ss-p4org')
+simple_switch_target = BackendDriver('bmv2-ss-p4org')
 
 # commands
 simple_switch_target.add_command('preprocessor', 'cc')
@@ -45,7 +45,8 @@ simple_switch_target.enable_commands(['preprocessor', 'compiler'])
 config.target.append(simple_switch_target)
 
 # PSA implementation on BMv2
-psa_target = Driver('bmv2-psa-p4org')
-psa_target.add_command('none', '/bin/echo "target ' + str(psa_target) + ' not yet implemented"')
+psa_target = BackendDriver('bmv2-psa-p4org')
+psa_target.add_command('none', \
+        '/bin/echo "target ' + str(psa_target) + ' not yet implemented"')
 psa_target.enable_commands(['none'])
 config.target.append(psa_target)

--- a/tools/driver/p4c_src/p4c.ebpf.cfg
+++ b/tools/driver/p4c_src/p4c.ebpf.cfg
@@ -16,27 +16,34 @@
 
 from p4c_src.driver import BackendDriver
 
+class EBPFBackend(BackendDriver):
+    def __init__(self, target, argParser):
+        BackendDriver.__init__(self, target, argParser)
+        # commands
+        self.add_command('preprocessor', 'cc')
+        self.add_command('compiler', os.path.join(os.environ['P4C_BIN_DIR'],'p4c-ebpf'))
+        # order of commands
+        self.enable_commands(['preprocessor', 'compiler'])
+
+        # options
+        self.add_command_option('preprocessor', "-E -x c")
+
+    def process_command_line_options(self, opts):
+        BackendDriver.process_command_line_options(self, opts)
+
+        # process the options related to source file
+        basepath = "{}/{}".format(self._output_directory, self._source_basename)
+        # preprocessor
+        ebpf_target.add_command_option('preprocessor', "-o")
+        ebpf_target.add_command_option('preprocessor', "{}.p4i".format(basepath))
+        ebpf_target.add_command_option('preprocessor', self._source_filename)
+
+        # compiler
+        ebpf_target.add_command_option('compiler', "-o")
+        ebpf_target.add_command_option('compiler', "{}.json".format(basepath))
+        ebpf_target.add_command_option('compiler', "{}.p4i".format(basepath))
+
+
 # target
-ebpf_target = BackendDriver('ebpf-v1model-p4org')
-
-# commands
-ebpf_target.add_command('preprocessor', 'cpp')
-ebpf_target.add_command('compiler', os.path.join(os.environ['P4C_BIN_DIR'],'p4c-ebpf'))
-
-# options
-ebpf_target.add_command_option('preprocessor', "-E -x c")
-
-if source_basename is not None:
-    basepath = "{}/{}".format(output_dir, source_basename)
-    # preprocessor
-    ebpf_target.add_command_option('preprocessor', "-o")
-    ebpf_target.add_command_option('preprocessor', "{}.p4i".format(basepath))
-    ebpf_target.add_command_option('preprocessor', source_fullname)
-
-    # compiler
-    ebpf_target.add_command_option('compiler', "-o")
-    ebpf_target.add_command_option('compiler', "{}.json".format(basepath))
-    ebpf_target.add_command_option('compiler', "{}.p4i".format(basepath))
-
-ebpf_target.enable_commands(['preprocessor', 'compiler'])
+ebpf_target = EBPFBackend('ebpf-v1model-p4org', argParser)
 config.target.append(ebpf_target)

--- a/tools/driver/p4c_src/p4c.ebpf.cfg
+++ b/tools/driver/p4c_src/p4c.ebpf.cfg
@@ -14,10 +14,10 @@
 
 # -*- Python -*-
 
-from p4c_src.driver import Driver
+from p4c_src.driver import BackendDriver
 
 # target
-ebpf_target = Driver('ebpf-v1model-p4org')
+ebpf_target = BackendDriver('ebpf-v1model-p4org')
 
 # commands
 ebpf_target.add_command('preprocessor', 'cpp')

--- a/tools/driver/p4c_src/p4c.ebpf.cfg
+++ b/tools/driver/p4c_src/p4c.ebpf.cfg
@@ -14,25 +14,29 @@
 
 # -*- Python -*-
 
-ebpf_target="ebpf-v1model-p4org"
-def config_preprocessor():
-    config.add_preprocessor_option(ebpf_target, "-E -x c")
-    if source_basename is not None:
-        config.add_preprocessor_option(ebpf_target, "-o")
-        config.add_preprocessor_option(ebpf_target, "{}/{}.p4i".format(output_dir, source_basename))
-        config.add_preprocessor_option(ebpf_target, source_fullname)
+from p4c_src.driver import Driver
 
-def config_compiler():
-    if source_basename is not None:
-        config.add_compiler_option(ebpf_target, "-o")
-        config.add_compiler_option(ebpf_target, "{}/{}.json".format(output_dir, source_basename))
-        config.add_compiler_option(ebpf_target, "{}/{}.p4i".format(output_dir, source_basename))
+# target
+ebpf_target = Driver('ebpf-v1model-p4org')
 
-config_preprocessor()
-config_compiler()
+# commands
+ebpf_target.add_command('preprocessor', 'cpp')
+ebpf_target.add_command('compiler', os.path.join(os.environ['P4C_BIN_DIR'],'p4c-ebpf'))
 
-config.add_toolchain(ebpf_target, {
-    'preprocessor': 'cpp',
-    'compiler': os.path.join(os.environ['P4C_BIN_DIR'], 'p4c-ebpf')})
-config.add_compilation_steps(ebpf_target, ['preprocessor', 'compiler'])
+# options
+ebpf_target.add_command_option('preprocessor', "-E -x c")
+
+if source_basename is not None:
+    basepath = "{}/{}".format(output_dir, source_basename)
+    # preprocessor
+    ebpf_target.add_command_option('preprocessor', "-o")
+    ebpf_target.add_command_option('preprocessor', "{}.p4i".format(basepath))
+    ebpf_target.add_command_option('preprocessor', source_fullname)
+
+    # compiler
+    ebpf_target.add_command_option('compiler', "-o")
+    ebpf_target.add_command_option('compiler', "{}.json".format(basepath))
+    ebpf_target.add_command_option('compiler', "{}.p4i".format(basepath))
+
+ebpf_target.enable_commands(['preprocessor', 'compiler'])
 config.target.append(ebpf_target)

--- a/tools/driver/p4c_src/util.py
+++ b/tools/driver/p4c_src/util.py
@@ -46,3 +46,39 @@ def find_bin(exe):
                     found_path = os.path.join(pp, ff)
     return found_path
 
+def find_file(directory, filename, binary=True):
+    """
+    Searches up the directory hierarchy for filename with prefix directory
+    starting from the current working directory.
+    If directory is an absolute path, just check for the file.
+    If binary == true, then check permissions that the file is executable
+    """
+    def check_file(f):
+        if os.path.isfile(f):
+            if binary:
+                if os.access(f, os.X_OK): return True
+            else:
+                return True
+        return False
+
+    executable = ""
+    if directory.startswith('/'):
+        executable = os.path.normpath(os.path.join(directory, filename))
+        if check_file(executable): return executable
+
+    # find the file up the hierarchy
+    dir	= os.path.abspath(os.getcwd())
+    if os.path.basename(filename) != filename:
+        directory = os.path.join(directory, os.path.dirname(filename))
+        filename = os.path.basename(filename)
+    while dir != "/":
+        path_to_file = os.path.join(dir, directory)
+        if os.path.isdir(path_to_file):
+	    files = os.listdir(path_to_file)
+            if filename in files:
+                executable = os.path.join(path_to_file, filename)
+                if check_file(executable): return executable
+
+	dir = os.path.dirname(dir)
+    print 'File', filename, 'Not found'
+    sys.exit(1)


### PR DESCRIPTION
Refactors the p4c driver code to allow more flexibility for backends.

Different backends may carry special configurations, flags, and
intermediate passes that were not captured in the current design.

To that end, we define a Driver class that each backend instantiates
and configures its commands, setup and cleanup steps, as well as the
options to pass to commands.

Since different backends may want to add options that are proprietary
we refactor the option processing such that they can add these options
as part of different argument groups.

Also, segregated the processing of generic options from the options that
require the source file to be present. The source dependent options are
typically backend dependent, so it is expected that backends will set them
in the subclass, just before the commands are run, rather than part of the
"configuration".