### PR TITLE
Change base Docker image to behavioral-model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM p4lang/pi:latest
+FROM p4lang/behavioral-model:latest
 MAINTAINER Seth Fowler <seth.fowler@barefootnetworks.com>
 
 # Default to using 2 make jobs, which is a good default for CI. If you're


### PR DESCRIPTION
The behavioral-model image now has pi as a base image, not the other way around.