### PR TITLE
Add #ifdef __clang__ around diagnostic pragma

### DIFF
--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -18,7 +18,9 @@ using Parser = P4::P4Parser;
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wtautological-undefined-compare"
+#ifdef __clang__
 #pragma clang diagnostic ignored "-Wnull-conversion"
+#endif
 
 %}
 

--- a/frontends/parsers/v1/v1lexer.ll
+++ b/frontends/parsers/v1/v1lexer.ll
@@ -20,7 +20,9 @@ using Parser = V1::V1Parser;
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wtautological-undefined-compare"
+#ifdef __clang__
 #pragma clang diagnostic ignored "-Wnull-conversion"
+#endif
 
 %}
 


### PR DESCRIPTION
Makes frontends/parsers/*/*.ll consistent with
tools/ir-generator/ir-generator-lex.l