### PR TITLE
Add 'policy' argument for local_copyprop

### DIFF
--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -156,6 +156,7 @@ class Visitor {
                   ctxt->original, typeid(T).name());
         return ctxt->original->to<T>();
     }
+    const Context *getChildContext() const { return ctxt; }
     const Context *getContext() const { return ctxt->parent; }
     template <class T>
     const T* getParent() const {


### PR DESCRIPTION
- allows backends fine-grained control over what values should be
  copy-propagated and which should not