### PR TITLE
Make v1model 'random' extern type generic

### DIFF
--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -110,9 +110,7 @@ struct ActionSelector_Model : public ::Model::Extern_Model {
 
 struct Random_Model : public ::Model::Elem {
     Random_Model() : Elem("random"),
-                     resultType(IR::Type_Bits::get(32)),
                      modify_field_rng_uniform("modify_field_rng_uniform") {}
-    const IR::Type* resultType;
     ::Model::Elem   modify_field_rng_uniform;
 };
 

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -104,7 +104,7 @@ extern action_profile {
 }
 
 // Get a random number in the range lo..hi
-extern void random(out bit<32> result, in bit<32> lo, in bit<32> hi);
+extern void random<T>(out T result, in T lo, in T hi);
 // If the type T is a named struct, the name is used
 // to generate the control-plane API.
 extern void digest<T>(in bit<32> receiver, in T data);

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -3325,7 +3325,7 @@ control process_global_params(inout headers hdr, inout metadata meta, inout stan
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
         standard_metadata.egress_spec = 9w511;
-        random(meta.ingress_metadata.sflow_take_sample, 32w0, 32w0x7fffffff);
+        random<bit<32>>(meta.ingress_metadata.sflow_take_sample, 32w0, 32w0x7fffffff);
     }
     @name(".switch_config_params") table switch_config_params {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -3241,7 +3241,7 @@ control process_global_params(inout headers hdr, inout metadata meta, inout stan
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
         standard_metadata.egress_spec = 9w511;
-        random(meta.ingress_metadata.sflow_take_sample, 32w0, 32w0x7fffffff);
+        random<bit<32>>(meta.ingress_metadata.sflow_take_sample, 32w0, 32w0x7fffffff);
     }
     @name(".switch_config_params") table switch_config_params_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -3554,7 +3554,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
         standard_metadata.egress_spec = 9w511;
-        random(meta.ingress_metadata.sflow_take_sample, 32w0, 32w0x7fffffff);
+        random<bit<32>>(meta.ingress_metadata.sflow_take_sample, 32w0, 32w0x7fffffff);
     }
     @name(".switch_config_params") table _switch_config_params_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -3260,7 +3260,7 @@ control process_global_params(inout headers hdr, inout metadata meta, inout stan
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
         standard_metadata.egress_spec = 9w511;
-        random(meta.ingress_metadata.sflow_take_sample, (bit<32>)0, (bit<32>)32w0x7fffffff);
+        random(meta.ingress_metadata.sflow_take_sample, (bit<32>)0, 32w0x7fffffff);
     }
     @name(".switch_config_params") table switch_config_params {
         actions = {


### PR DESCRIPTION
- bmv2 allows any type up to the bmv2 word size
- makes it easier to convert/deal with programs that use random numbers
  of sizes other than 32 bits.