### PR TITLE
Fix for issue #1107

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -51,8 +51,6 @@ const IR::Node* DoConstantFolding::postorder(IR::PathExpression* e) {
     if (auto dc = decl->to<IR::Declaration_Constant>()) {
         auto cst = get(constants, dc);
         if (cst == nullptr)
-            cst = getConstant(dc->initializer);
-        if (cst == nullptr)
             return e;
         if (!typesKnown && cst->is<IR::ListExpression>())
             return e;
@@ -62,7 +60,15 @@ const IR::Node* DoConstantFolding::postorder(IR::PathExpression* e) {
             // type unification, and thus we want to have different type
             // objects for different constant instances.
             auto cc = cst->to<IR::Constant>();
-            const IR::Type* type = cc->type->clone();
+            const IR::Type* type;
+            if (cc->type->is<IR::Type_Bits>()) {
+                type = cc->type->clone();
+            } else if (cc->type->is<IR::Type_InfInt>()) {
+                // You can't just clone a InfInt value, because
+                // you get the same declid.  We want a new declid.
+                auto ii = cc->type->to<IR::Type_InfInt>();
+                type = new IR::Type_InfInt(ii->srcInfo);
+            }
             return new IR::Constant(cc->srcInfo, type, cc->value, cc->base);
         }
         return cst;
@@ -89,6 +95,9 @@ const IR::Node* DoConstantFolding::postorder(IR::Declaration_Constant* d) {
                     (cst->type->is<IR::Type_Bits>() &&
                      !(*d->type->to<IR::Type_Bits>() == *cst->type->to<IR::Type_Bits>())))
                     init = new IR::Constant(init->srcInfo, d->type, cst->value, cst->base);
+            } else {
+                // Don't fold this yet, we can't evaluate the cast.
+                return d;
             }
         }
         if (init != d->initializer)

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -1199,7 +1199,7 @@ bool ToP4::preorder(const IR::EntriesList *l) {
     builder.append("{");
     builder.newline();
     builder.increaseIndent();
-    preorder(&l->entries);
+    visit(&l->entries);
     builder.decreaseIndent();
     builder.emitIndent();
     builder.append("}");
@@ -1208,6 +1208,7 @@ bool ToP4::preorder(const IR::EntriesList *l) {
 }
 
 bool ToP4::preorder(const IR::Entry *e) {
+    dump(2);
     builder.emitIndent();
     if (e->keys->components.size() == 1)
         setListTerm("", "");

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -209,7 +209,7 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
                             bool reportErrors) {
     // These are canonical types.
     CHECK_NULL(dest); CHECK_NULL(src);
-    LOG3("Unifying " << dest->toString() << " to " << src->toString());
+    LOG3("Unifying " << dest << " to " << src);
 
     if (src->is<IR::ITypeVar>())
         src = src->apply(constraints->replaceVariables)->to<IR::Type>();

--- a/testdata/p4_16_samples/issue1107.p4
+++ b/testdata/p4_16_samples/issue1107.p4
@@ -10,9 +10,6 @@ struct M {
 typedef bit<32> IPAddr;
 const IPAddr MyIP = 0xffffffff;
 
-// if the 2 lines above are replaced by this one, program compiles
-// const bit<32> MyIP = 0xffffffff;
-
 parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
     state start { transition accept; }
 }
@@ -29,7 +26,6 @@ control myc(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         }
         actions = { set_eg; }
         const entries = {
-            // if one entry instead of 2, program compiles
             (32w1, MyIP) : set_eg(9w1);
             (32w2, MyIP) : set_eg(9w2);
         }

--- a/testdata/p4_16_samples/issue1107.p4
+++ b/testdata/p4_16_samples/issue1107.p4
@@ -1,0 +1,66 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H { };
+struct M {
+    bit<32> f1;
+    bit<32> f2;
+}
+
+typedef bit<32> IPAddr;
+const IPAddr MyIP = 0xffffffff;
+
+// if the 2 lines above are replaced by this one, program compiles
+// const bit<32> MyIP = 0xffffffff;
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start { transition accept; }
+}
+
+action empty() { }
+
+control myc(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    action set_eg(bit<9> eg) { smeta.egress_spec = eg; }
+
+    table myt {
+        key = {
+            meta.f1 : exact;
+            meta.f2 : exact;
+        }
+        actions = { set_eg; }
+        const entries = {
+            // if one entry instead of 2, program compiles
+            (32w1, MyIP) : set_eg(9w1);
+            (32w2, MyIP) : set_eg(9w2);
+        }
+    }
+
+    apply {
+        myt.apply();
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+        myc.apply(hdr, meta, smeta);
+    }
+};
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply { }
+};
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply { }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(),
+         ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/issue1107-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1107-first.p4
@@ -1,0 +1,77 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> f1;
+    bit<32> f2;
+}
+
+typedef bit<32> IPAddr;
+const IPAddr MyIP = 32w0xffffffff;
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+action empty() {
+}
+control myc(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    action set_eg(bit<9> eg) {
+        smeta.egress_spec = eg;
+    }
+    table myt {
+        key = {
+            meta.f1: exact @name("meta.f1") ;
+            meta.f2: exact @name("meta.f2") ;
+        }
+        actions = {
+            set_eg();
+            @defaultonly NoAction();
+        }
+        const entries = {
+                        (32w1, 32w0xffffffff) : set_eg(9w1);
+
+                        (32w2, 32w0xffffffff) : set_eg(9w2);
+
+        }
+
+        default_action = NoAction();
+    }
+    apply {
+        myt.apply();
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("myc") myc() myc_inst;
+    apply {
+        myc_inst.apply(hdr, meta, smeta);
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1107-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1107-frontend.p4
@@ -1,0 +1,73 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> f1;
+    bit<32> f2;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control myc(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("set_eg") action set_eg_0(bit<9> eg) {
+        smeta.egress_spec = eg;
+    }
+    @name("myt") table myt_0 {
+        key = {
+            meta.f1: exact @name("meta.f1") ;
+            meta.f2: exact @name("meta.f2") ;
+        }
+        actions = {
+            set_eg_0();
+            @defaultonly NoAction();
+        }
+        const entries = {
+                        (32w1, 32w0xffffffff) : set_eg_0(9w1);
+
+                        (32w2, 32w0xffffffff) : set_eg_0(9w2);
+
+        }
+
+        default_action = NoAction();
+    }
+    apply {
+        myt_0.apply();
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("myc") myc() myc_inst_0;
+    apply {
+        myc_inst_0.apply(hdr, meta, smeta);
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1107-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1107-midend.p4
@@ -1,0 +1,68 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> f1;
+    bit<32> f2;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("NoAction") action NoAction_0() {
+    }
+    @name("myc.set_eg") action myc_set_eg(bit<9> eg) {
+        smeta.egress_spec = eg;
+    }
+    @name("myc.myt") table myc_myt_0 {
+        key = {
+            meta.f1: exact @name("meta.f1") ;
+            meta.f2: exact @name("meta.f2") ;
+        }
+        actions = {
+            myc_set_eg();
+            @defaultonly NoAction_0();
+        }
+        const entries = {
+                        (32w1, 32w0xffffffff) : myc_set_eg(9w1);
+
+                        (32w2, 32w0xffffffff) : myc_set_eg(9w2);
+
+        }
+
+        default_action = NoAction_0();
+    }
+    apply {
+        myc_myt_0.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1107.p4
+++ b/testdata/p4_16_samples_outputs/issue1107.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> f1;
+    bit<32> f2;
+}
+
+typedef bit<32> IPAddr;
+const IPAddr MyIP = 0xffffffff;
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+action empty() {
+}
+control myc(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    action set_eg(bit<9> eg) {
+        smeta.egress_spec = eg;
+    }
+    table myt {
+        key = {
+            meta.f1: exact;
+            meta.f2: exact;
+        }
+        actions = {
+            set_eg;
+        }
+        const entries = {
+                        (32w1, MyIP) : set_eg(9w1);
+
+                        (32w2, MyIP) : set_eg(9w2);
+
+        }
+
+    }
+    apply {
+        myt.apply();
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+        myc.apply(hdr, meta, smeta);
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+


### PR DESCRIPTION
There were two subtle bugs in constant folding
- the constant declaration value was substituted, but the type in the constant declaration was ignored.
- cloning an Type_InfInt does not produce a new Type_InfInt, just another copy of the same type. Here we really wanted a new type, which can be bound to a different value when performing unification.
