### PR TITLE
remove alias fields from standard_metadata when translating p4-14

### DIFF
--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -1034,7 +1034,7 @@ class RemoveAnnotatedFields : public Transform {
                     fields->push_back(f);
                 }
             }
-            return new IR::Type_Struct(node->srcInfo, node->name, *fields);
+            return new IR::Type_Struct(node->srcInfo, node->name, node->annotations, *fields);
         }
         return node;
     }

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -1020,6 +1020,26 @@ class DetectDuplicates: public Inspector {
     }
 };
 
+// The fields in standard_metadata in v1model.p4 should only be used if
+// the source program is written in P4-16. Therefore we remove those
+// fields from the translated P4-14 program.
+class RemoveAnnotatedFields : public Transform {
+ public:
+    RemoveAnnotatedFields() { setName("RemoveAnnotatedFields"); }
+    const IR::Node* postorder(IR::Type_Struct* node) override {
+        if (node->name == "standard_metadata_t") {
+            auto fields = new IR::IndexedVector<IR::StructField>();
+            for (auto f : node->fields) {
+                if (!f->getAnnotation("alias")) {
+                    fields->push_back(f);
+                }
+            }
+            return new IR::Type_Struct(node->srcInfo, node->name, *fields);
+        }
+        return node;
+    }
+};
+
 }  // namespace
 
 
@@ -1041,6 +1061,7 @@ Converter::Converter() {
     passes.emplace_back(new ComputeCallGraph(&structure));
     passes.emplace_back(new Rewriter(&structure));
     passes.emplace_back(new FixExtracts(&structure));
+    passes.emplace_back(new RemoveAnnotatedFields);
 }
 
 Visitor::profile_t Converter::init_apply(const IR::Node* node) {

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -161,6 +161,8 @@ class Converter : public PassManager {
     Visitor::profile_t init_apply(const IR::Node* node) override;
 };
 
+
+
 }  // namespace P4V1
 
 #endif /* _FRONTENDS_P4_FROMV1_0_CONVERTERS_H_ */


### PR DESCRIPTION
This is a fix for #718 and #1036.

The fix is to remove the fields in v1model.p4 standard_metadata_t that are marked with `@alias`, which is only supposed to be used in P4-16 programs. If a P4-16 program is generated from a P4-14 program, these annotated fields should be removed, so they don't show up in the JSON file.
