### PR TITLE
Add P4_14 frontend support for mulitple algorithms in a field list

### DIFF
--- a/backends/p4test/run-p4-sample.py
+++ b/backends/p4test/run-p4-sample.py
@@ -89,7 +89,7 @@ def run_timeout(options, args, timeout, stderr):
             # reason, even some character classes that the man page claims are
             # available don't seem to actually work.
             local.filter = Popen(['sed', '-E',
-                r's|^[-[:alnum:][:space:]_/]*/([-[:alnum:][:space:]_]+\.p4[:(][[:digit:]]+)|\1|'],
+                r's|^[-[:alnum:][:space:]_/]*/([-[:alnum:][:space:]_]+\.[ph]4?[:(][[:digit:]]+)|\1|'],
                 stdin=PIPE, stdout=outfile)
             procstderr = local.filter.stdin
         local.process = Popen(args, stderr=procstderr)

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -233,6 +233,7 @@ class ProgramStructure {
                                           const IR::Expression* right, const IR::Type* type);
     const IR::Expression* convertFieldList(const IR::Expression* expression);
     const IR::Expression* convertHashAlgorithm(IR::ID algorithm);
+    const IR::Expression* convertHashAlgorithms(const IR::NameList *algorithm);
     const IR::Declaration_Instance* convert(const IR::Register* reg, cstring newName,
                                             const IR::Type *elementType = nullptr);
     const IR::Type_Struct* createFieldListType(const IR::Expression* expression);

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -302,6 +302,8 @@ const IR::Type* TypeInference::canonicalize(const IR::Type* type) {
             return exists->to<IR::Type_Type>()->type;
         return exists;
     }
+    if (auto tt = type->to<IR::Type_Type>())
+        type = tt->type;
 
     if (type->is<IR::Type_SpecializedCanonical>() ||
         type->is<IR::Type_InfInt>() ||

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -404,7 +404,11 @@ field_list_calculation_body: /* epsilon */
     | field_list_calculation_body ALGORITHM ":" name ";"
       { if ($1->algorithm)
             ::error("%s: multiple 'algorithm' in field_list_calculation", @2);
-        ($$=$1)->algorithm = IR::ID(@4, $4); }
+        ($$=$1)->algorithm = new IR::NameList(@4, IR::ID(@4, $4)); }
+    | field_list_calculation_body ALGORITHM "{" action_list "}"
+      { if ($1->algorithm)
+            ::error("%s: multiple 'algorithm' in field_list_calculation", @2);
+        ($$=$1)->algorithm = $4; }
     | field_list_calculation_body OUTPUT_WIDTH ":" const_expression ";"
       { if ($1->output_width)
             ::error("%s: multiple 'output_width' in field_list_calculation", @2);
@@ -459,9 +463,9 @@ parser_statement_list: /* epsilon */
       { $$ = new IR::V1Parser(driver.takePragmasAsAnnotations()); }
     | parser_statement_list EXTRACT "(" header_ref ")" ";"
       { ($$=$1)->stmts.push_back(new IR::Primitive(@2+@5, $2, $4)); }
-    | parser_statement_list SET_METADATA "(" field_ref "," expression ")" ";"
+    | parser_statement_list SET_METADATA "(" expression "," expression ")" ";"
       { ($$=$1)->stmts.push_back(new IR::Primitive(@2+@7, $2, $4, $6)); }
-    | parser_statement_list field_ref "=" expression ";"
+    | parser_statement_list expression "=" expression ";"
       { ($$=$1)->stmts.push_back(new IR::Primitive(@3, "set_metadata", $2, $4)); }
     | parser_statement_list RETURN name ";"
       { ($$=$1)->default_return = IR::ID(@3, $3); }

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -226,7 +226,7 @@ class FieldListCalculation {
     optional ID          name;
     NullOK NameList      input = nullptr;
     NullOK FieldList     input_fields = nullptr;
-    ID                   algorithm = {};
+    NullOK NameList      algorithm = nullptr;
     int                  output_width = 0;
     optional Annotations annotations = Annotations::empty;
 }
@@ -340,6 +340,7 @@ class PrimitiveAction {}
 class NameList {
     safe_vector<ID>  names = {};
     NameList(Util::SourceInfo si, cstring n) { names.emplace_back(si, n); }
+    NameList(Util::SourceInfo si, ID n) { names.emplace_back(si, n); }
     dump_fields { out << "names=" << names; }
 }
 


### PR DESCRIPTION
- for now when converting to P4_16 we just use the first algorithm, as
  P4_16 architectures are not set up to handle more than one.