### PR TITLE
Remove incorrect expansion of array copy

### DIFF
--- a/midend/copyStructures.cpp
+++ b/midend/copyStructures.cpp
@@ -57,20 +57,6 @@ const IR::Node* DoCopyStructures::postorder(IR::AssignmentStatement* statement) 
             }
         }
         return new IR::BlockStatement(statement->srcInfo, *retval);
-    } else if (ltype->is<IR::Type_Stack>()) {
-        auto retval = new IR::IndexedVector<IR::StatOrDecl>();
-        auto stack = ltype->to<IR::Type_Stack>();
-        for (unsigned i = 0; i < stack->getSize(); i++) {
-            auto index = new IR::Constant(i);
-            BUG_CHECK(statement->right->is<IR::PathExpression>() ||
-                      statement->right->is<IR::Member>(),
-                      "%1%: Unexpected operation when eliminating struct copying",
-                      statement->right);
-            auto right = new IR::ArrayIndex(statement->right, index);
-            auto left = new IR::ArrayIndex(statement->left, index->clone());
-            retval->push_back(new IR::AssignmentStatement(statement->srcInfo, left, right));
-        }
-        return new IR::BlockStatement(statement->srcInfo, *retval);
     }
 
     return statement;

--- a/testdata/p4_16_samples/inline-stack-bmv2.p4
+++ b/testdata/p4_16_samples/inline-stack-bmv2.p4
@@ -23,7 +23,7 @@ header h_t {
     bit<1> f;
 }
 struct H { h_t[1] stack; }
-struct M { }
+struct M {}
 
 parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta) {
     state start {

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2-midend.p4
@@ -30,18 +30,7 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 }
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
-    @hidden action act() {
-        hdr.stack[0] = hdr.stack[0];
-        hdr.stack[0] = hdr.stack[0];
-    }
-    @hidden table tbl_act {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
     apply {
-        tbl_act.apply();
     }
 }
 


### PR DESCRIPTION
As @jafingerhut pointed out, the removed code was incorrect, since it was assuming that copying all elements of an array is the same as copying the array. This would actually be correct within a control block only, where the .next and .last fields are not accessible. But that code was not really necessary for removing nested structures, which is the point of copyStructures. I don't think this is enough to solve issue #1128.