### PR TITLE
swap precedence of bitwise and relational operators in P4_14 parser

### DIFF
--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -177,11 +177,11 @@ typedef const IR::Type ConstType;
 %right ASSIGN
 %left OR
 %left AND
+%left EQ NE
+%left L_ANGLE R_ANGLE LE GE
 %left BIT_OR
 %left BIT_XOR
 %left BIT_AND
-%left EQ NE
-%left L_ANGLE R_ANGLE LE GE
 %left SHL SHR
 %left PLUS MINUS
 %left MUL DIV MOD


### PR DESCRIPTION
Despite the fact that the P4_14 spec says that expressions have "syntax, semantics, precedence, and associtivity matching that of C", if you look closely at th egrammar in the spec, you find that the precedence of bitwise operators (`&`, `|`, and `^`) has been swapped with that of relations (`==`, `!=`, `<`, `<=`, `>`, `>=`).  The old p4-hlir (python) frontend follows the precedence as specified in the grammar, giving the bitwise operators higher precedence.

Turns out there are existing P4_14 programs that depend on this, and they fail when using our frontend.  In the interest of backwards compatibility, this change swaps the precedence to match the spec grammar and the old implementation.

Arguably, the precedence in C is a mistake -- a historical accident due to the language originally conflating bitwise and logical operations.  Changing this in P4_16 is a discussion for the language committee.