### PR TITLE
make strength reduction pass in frontend optional

### DIFF
--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -106,7 +106,8 @@ class FrontEndDump : public PassManager {
 
 // TODO: remove skipSideEffectOrdering flag
 const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4Program* program,
-                                   bool skipSideEffectOrdering) {
+                                   bool skipSideEffectOrdering,
+                                   bool skipStrengthReduction) {
     if (program == nullptr)
         return nullptr;
 
@@ -140,6 +141,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new ClearTypeMap(&typeMap),
         new TableKeyNames(&refMap, &typeMap),
         new ConstantFolding(&refMap, &typeMap),
+        new StrengthReduction(skipStrengthReduction),
         new UselessCasts(&refMap, &typeMap),
         new SimplifyControlFlow(&refMap, &typeMap),
         new FrontEndDump(),  // used for testing the program at this point

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -140,7 +140,6 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new ClearTypeMap(&typeMap),
         new TableKeyNames(&refMap, &typeMap),
         new ConstantFolding(&refMap, &typeMap),
-        new StrengthReduction(),
         new UselessCasts(&refMap, &typeMap),
         new SimplifyControlFlow(&refMap, &typeMap),
         new FrontEndDump(),  // used for testing the program at this point

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -29,7 +29,8 @@ class FrontEnd {
     explicit FrontEnd(DebugHook hook) { hooks.push_back(hook); }
     void addDebugHook(DebugHook hook) { hooks.push_back(hook); }
     const IR::P4Program* run(const CompilerOptions& options, const IR::P4Program* program,
-                             bool skipSideEffectOrdering = false);
+                             bool skipSideEffectOrdering = false,
+                             bool skipStrengthReduction = false);
 };
 
 }  // namespace P4

--- a/frontends/p4/strengthReduction.cpp
+++ b/frontends/p4/strengthReduction.cpp
@@ -20,34 +20,34 @@ namespace P4 {
 
 /// @section Helper methods
 
-bool StrengthReduction::isOne(const IR::Expression* expr) const {
+bool DoStrengthReduction::isOne(const IR::Expression* expr) const {
     auto cst = expr->to<IR::Constant>();
     if (cst == nullptr)
         return false;
     return cst->value == 1;
 }
 
-bool StrengthReduction::isZero(const IR::Expression* expr) const {
+bool DoStrengthReduction::isZero(const IR::Expression* expr) const {
     auto cst = expr->to<IR::Constant>();
     if (cst == nullptr)
         return false;
     return cst->value == 0;
 }
 
-bool StrengthReduction::isTrue(const IR::Expression* expr) const {
+bool DoStrengthReduction::isTrue(const IR::Expression* expr) const {
     auto cst = expr->to<IR::BoolLiteral>();
     if (cst == nullptr)
         return false;
     return cst->value;
 }
 
-bool StrengthReduction::isFalse(const IR::Expression* expr) const {
+bool DoStrengthReduction::isFalse(const IR::Expression* expr) const {
     auto cst = expr->to<IR::BoolLiteral>();
     if (cst == nullptr)
         return false;
     return !cst->value;
 }
-int StrengthReduction::isPowerOf2(const IR::Expression* expr) const {
+int DoStrengthReduction::isPowerOf2(const IR::Expression* expr) const {
     auto cst = expr->to<IR::Constant>();
     if (cst == nullptr)
         return -1;
@@ -64,13 +64,13 @@ int StrengthReduction::isPowerOf2(const IR::Expression* expr) const {
 
 /// @section Visitor Methods
 
-const IR::Node* StrengthReduction::postorder(IR::Cmpl* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::Cmpl* expr) {
     if (auto a = expr->expr->to<IR::Cmpl>())
         return a->expr;
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::BAnd* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::BAnd* expr) {
     if (isZero(expr->left))
         return expr->left;
     if (isZero(expr->right))
@@ -82,7 +82,7 @@ const IR::Node* StrengthReduction::postorder(IR::BAnd* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::BOr* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::BOr* expr) {
     if (isZero(expr->left))
         return expr->right;
     if (isZero(expr->right))
@@ -94,7 +94,7 @@ const IR::Node* StrengthReduction::postorder(IR::BOr* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::BXor* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::BXor* expr) {
     if (isZero(expr->left))
         return expr->right;
     if (isZero(expr->right))
@@ -111,7 +111,7 @@ const IR::Node* StrengthReduction::postorder(IR::BXor* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::LAnd* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::LAnd* expr) {
     if (isFalse(expr->left))
         return expr->left;
     if (isTrue(expr->left))
@@ -122,7 +122,7 @@ const IR::Node* StrengthReduction::postorder(IR::LAnd* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::LOr* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::LOr* expr) {
     if (isFalse(expr->left))
         return expr->right;
     if (isTrue(expr->left))
@@ -133,7 +133,7 @@ const IR::Node* StrengthReduction::postorder(IR::LOr* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::LNot* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::LNot* expr) {
     if (auto e = expr->expr->to<IR::Equ>())
         return new IR::Neq(e->left, e->right);
     if (auto e = expr->expr->to<IR::Neq>())
@@ -149,7 +149,7 @@ const IR::Node* StrengthReduction::postorder(IR::LNot* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::Sub* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::Sub* expr) {
     if (isZero(expr->right))
         return expr->left;
     if (isZero(expr->left))
@@ -164,7 +164,7 @@ const IR::Node* StrengthReduction::postorder(IR::Sub* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::Add* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::Add* expr) {
     if (isZero(expr->right))
         return expr->left;
     if (isZero(expr->left))
@@ -172,19 +172,19 @@ const IR::Node* StrengthReduction::postorder(IR::Add* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::Shl* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::Shl* expr) {
     if (isZero(expr->right) || isZero(expr->left))
         return expr->left;
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::Shr* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::Shr* expr) {
     if (isZero(expr->right) || isZero(expr->left))
         return expr->left;
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::Mul* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::Mul* expr) {
     if (isZero(expr->left))
         return expr->left;
     if (isZero(expr->right))
@@ -208,7 +208,7 @@ const IR::Node* StrengthReduction::postorder(IR::Mul* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::Div* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::Div* expr) {
     if (isZero(expr->right)) {
         ::error("%1%: Division by zero", expr);
         return expr;
@@ -226,7 +226,7 @@ const IR::Node* StrengthReduction::postorder(IR::Div* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::Mod* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::Mod* expr) {
     if (isZero(expr->right)) {
         ::error("%1%: Modulo by zero", expr);
         return expr;
@@ -244,7 +244,7 @@ const IR::Node* StrengthReduction::postorder(IR::Mod* expr) {
     return expr;
 }
 
-const IR::Node* StrengthReduction::postorder(IR::Slice* expr) {
+const IR::Node* DoStrengthReduction::postorder(IR::Slice* expr) {
     int shift_amt = 0;
     const IR::Expression *shift_of = nullptr;
     if (auto sh = expr->e0->to<IR::Shr>()) {

--- a/frontends/p4/strengthReduction.h
+++ b/frontends/p4/strengthReduction.h
@@ -41,7 +41,7 @@ namespace P4 {
   *    - Should this pass be merged with constant folding?
   *    - Should we store constant values in the IR instead of computing them explicitly?
   */
-class StrengthReduction final : public Transform {
+class DoStrengthReduction final : public Transform {
     /// @returns `true` if @p expr is the constant `1`.
     bool isOne(const IR::Expression* expr) const;
     /// @returns `true` if @p expr is the constant `0`.
@@ -55,7 +55,7 @@ class StrengthReduction final : public Transform {
     int isPowerOf2(const IR::Expression* expr) const;
 
  public:
-    StrengthReduction() { visitDagOnce = true; setName("StrengthReduction"); }
+    DoStrengthReduction() { visitDagOnce = true; setName("DoStrengthReduction"); }
 
     using Transform::postorder;
 
@@ -74,6 +74,16 @@ class StrengthReduction final : public Transform {
     const IR::Node* postorder(IR::Div* expr) override;
     const IR::Node* postorder(IR::Mod* expr) override;
     const IR::Node* postorder(IR::Slice* expr) override;
+};
+
+class StrengthReduction : public PassManager {
+ public:
+    StrengthReduction(bool skipStrengthReduction = false) {
+        if (!skipStrengthReduction) {
+            passes.push_back(new DoStrengthReduction());
+        }
+        setName("StrengthReduction");
+    }
 };
 
 }  // namespace P4


### PR DESCRIPTION
strength reduction causes an issue with certain midend when the midend is trying to perform an architecture translation. In particular, to translate the following expression.

```
standard_metadata.packet_length - 14 + 1 
```

to another architecture with meta.pkt_length of type bit<16>.

```
meta.pkt_length - 14 + 1
```

If the strength reduction is done at the frontend, then the transformation in frontend goes as follows.
```
standard_metadata.packet_length - 14 + 1
```
is first type inferred to 
```
standard_metadata.packet_length - 32w14 + 32w1
```
then, it is strength reduced to
```
standard_metadata.packet_length + 32w4294967282 + 32w1
```

However, if the target architecture contains a pkt_length metadata that has a different bit width, say bit<16>, the translation needs to go as follows.
```
standard_metadata.packet_length + 32w4294967282 + 32w1
```
is first translated to 
```
meta.pkt_length + 32w4294967282 + 32w1
```
then, the translation has to fix the type of the constants by inserting casts for all constants in an arbitrary expression.
```
meta.pkt_length + (bit<16>)32w4294967282 + (bit<16)32w1
```

Alternatively, an easier way to do the translation is to disable the strength reduction in the frontend. 
```
meta.pkt_length  - 32w14 + 32w1
```
converts the constants to InfInt
```
meta.pkt_length  - 14 + 1
```
then rerun typeinference
```
meta.pkt_length  - 16w14 + 16w1
```
and then strengthReduction
```
meta.pkt_length  + 16w65522 + 16w1
```

Making the StrengthReduction pass optional will make certain midend easier to write.