### PR TITLE
driver installs only the targets that were configured

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -27,26 +27,36 @@ set (P4C_DRIVER_SRCS
   p4c_src/util.py
   p4c_src/config.py
   p4c_src/__init__.py
-  p4c_src/p4c.bmv2.cfg
-  p4c_src/p4c.ebpf.cfg
   )
+
+set (P4C_TARGET_CFGS)
+if (ENABLE_BMV2)
+  list (APPEND P4C_TARGET_CFGS p4c_src/p4c.bmv2.cfg)
+endif()
+if (ENABLE_EBPF)
+  list (APPEND P4C_TARGET_CFGS p4c_src/p4c.ebpf.cfg)
+endif()
 
 install (PROGRAMS ${P4C_BINARY_DIR}/p4c
   DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})
 install (DIRECTORY p4c_src
   DESTINATION ${P4C_ARTIFACTS_OUTPUT_DIRECTORY}
-  FILES_MATCHING PATTERN "*.py" PATTERN "*.cfg")
+  FILES_MATCHING PATTERN "*.py")
+install (FILES ${P4C_TARGETS_CFGS}
+  DESTINATION ${P4C_ARTIFACTS_OUTPUT_DIRECTORY}/p4c_src)
 
 # p4cdir=$(pkgdatadir)/p4c_src
 
 set (P4C_DRIVER_DST)
-foreach (__f IN LISTS P4C_DRIVER_SRCS)
+foreach (__f IN LISTS P4C_DRIVER_SRCS P4C_TARGET_CFGS)
   list (APPEND P4C_DRIVER_DST "${P4C_BINARY_DIR}/${__f}")
 endforeach(__f)
 
+message ("targets: ${P4C_DRIVER_DST}")
+
 add_custom_command(OUTPUT ${P4C_DRIVER_DST}
   COMMAND ${CMAKE_COMMAND} -E make_directory ${P4C_BINARY_DIR}/p4c_src &&
-          for f in ${P4C_DRIVER_SRCS} \; do
+          for f in ${P4C_DRIVER_SRCS} ${P4C_TARGET_CFGS} \; do
           ${CMAKE_COMMAND} -E copy_if_different \$$f ${P4C_BINARY_DIR}/p4c_src \;
           done
   COMMAND chmod a+x ${P4C_BINARY_DIR}/p4c


### PR DESCRIPTION
The driver installed all the configurations available, even when
the target was not enabled, resulting in an error with a missing backend.
This patch installs only the targets that are enabled.