### PR TITLE
Use 1LL << 32, instead of 1U << 32

### DIFF
--- a/midend/convertEnums.cpp
+++ b/midend/convertEnums.cpp
@@ -7,10 +7,10 @@ const IR::Node* DoConvertEnums::preorder(IR::Type_Enum* type) {
     bool convert = policy->convert(type);
     if (!convert)
         return type;
-    unsigned count = type->members.size();
-    unsigned width = policy->enumSize(count);
+    unsigned long long count = type->members.size();
+    unsigned long long width = policy->enumSize(count);
     LOG1("Converting enum " << type->name << " to " << "bit<" << width << ">");
-    BUG_CHECK(count >= (1U << width),
+    BUG_CHECK(count <= (1LL << width),
               "%1%: not enough bits to represent %2%", width, type);
     auto r = new EnumRepresentation(type->srcInfo, width);
     auto canontype = typeMap->getTypeType(getOriginal(), true);


### PR DESCRIPTION
1U << 32 is 0, we should use 1LL << 32.

Also, the BUG_CHECK condition is reversed, we were lucky to not hit on that check.