### PR TITLE
fix for #1150: implement |= in a naive way

### DIFF
--- a/lib/bitvec.h
+++ b/lib/bitvec.h
@@ -217,6 +217,8 @@ class bitvec {
         return false; }
     void clrrange(size_t idx, size_t sz) {
         if (sz == 0) return;
+        if (size < sz/bits_per_unit)  // To avoid sz + idx overflow
+            sz = size * bits_per_unit;
         if (idx >= size * bits_per_unit) return;
         if (size == 1) {
             if (idx + sz < bits_per_unit)

--- a/lib/ltbitmatrix.h
+++ b/lib/ltbitmatrix.h
@@ -57,7 +57,10 @@ class LTBitMatrix : private bitvec {
      public:
         friend class LTBitMatrix;
         using rowref<LTBitMatrix>::rowref;
-        void operator|=(bitvec a) const { a.clrrange(row+1, ~0); self |= a << (row*row+row)/2; }
+        void operator|=(bitvec a) const {
+            for (size_t v : a) {
+                if (v > row) break;
+                self(row, v) = 1; } }
         nonconst_bitref operator[](unsigned col) const { return self(row, col); }
     };
     class const_rowref : public rowref<const LTBitMatrix> {

--- a/lib/symbitmatrix.h
+++ b/lib/symbitmatrix.h
@@ -70,9 +70,8 @@ class SymBitMatrix : private bitvec {
         friend class SymBitMatrix;
         using rowref<SymBitMatrix>::rowref;
         void operator|=(bitvec a) const {
-            for (auto col = a[row]; ++col != a.end();)
-                self(row, *col) = 1;
-            a.clrrange(row+1, ~0); self |= a << (row*row+row)/2; }
+            for (size_t v : a) {
+                self(row, v) = 1; } }
         nonconst_bitref operator[](unsigned col) const { return self(row, col); }
     };
     class const_rowref : public rowref<const SymBitMatrix> {


### PR DESCRIPTION
This implementation is slower, but has larger valid range and fixed the #1150 .