### PR TITLE
Added Midend Pass to Optimize Complex Bitwise Operations

### DIFF
--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -31,6 +31,7 @@ set (MIDEND_SRCS
   removeParameters.cpp
   removeSelectBooleans.cpp
   removeUnusedParameters.cpp
+  simplifyBitwise.cpp
   simplifyKey.cpp
   simplifySelectCases.cpp
   simplifySelectList.cpp
@@ -62,6 +63,7 @@ set (MIDEND_HDRS
   removeParameters.h
   removeSelectBooleans.h
   removeUnusedParameters.h
+  simplifyBitwise.h
   simplifyKey.h
   simplifySelectCases.h
   simplifySelectList.h

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -320,6 +320,14 @@ bool DoLocalCopyPropagation::equiv(const IR::Expression *left, const IR::Express
     if (al && ar) {
         return equiv(al->left, ar->left) && equiv(al->right, ar->right);
     }
+    auto tl = left->to<IR::Operation_Ternary>();
+    auto tr = right->to<IR::Operation_Ternary>();
+    if (tl && tr) {
+        bool check = equiv(tl->e0, tr->e0) && equiv(tl->e1, tr->e1) && equiv(tl->e2, tr->e2) &&
+        typeid(*tl) == typeid(*tr);
+        return check;
+    }
+
     // Compare binary operations (array indices)
     auto bl = left->to<IR::Operation_Binary>();
     auto br = right->to<IR::Operation_Binary>();
@@ -340,6 +348,15 @@ bool DoLocalCopyPropagation::equiv(const IR::Expression *left, const IR::Express
         return equiv(ul->expr, ur->expr) &&
         typeid(*ul) == typeid(*ur);
     }
+
+    // Compare value and base of the constants, but do not include the type
+    auto cl = left->to<IR::Constant>();
+    auto cr = right->to<IR::Constant>();
+    if (cl && cr) {
+        return cl->base == cr->base && cl->value == cr->value &&
+        typeid(*cl) == typeid(*cr);
+    }
+
     // Compare literals (strings, booleans and integers)
     if (*left == *right)
       return true;

--- a/midend/simplifyBitwise.cpp
+++ b/midend/simplifyBitwise.cpp
@@ -2,7 +2,8 @@
 
 namespace P4 {
 
-bool SimplifyBitwise::Scan::preorder(const IR::Operation *) {
+bool SimplifyBitwise::Scan::preorder(const IR::Operation *op) {
+    LOG1("Are we here? " << op);
     can_be_changed = false;
     return false;
 }
@@ -10,20 +11,26 @@ bool SimplifyBitwise::Scan::preorder(const IR::Operation *) {
 bool SimplifyBitwise::Scan::preorder(const IR::AssignmentStatement *as) {
     if (!as->right->is<IR::BOr>())
         return false;
+    auto action = findContext<IR::P4Action>();
+    if (action)
+        LOG1("Action name " << action->name.name);
     can_be_changed = true;
     total_mask = 0;
     return true;
 }
 
 bool SimplifyBitwise::Scan::preorder(const IR::BOr *bor) {
+    LOG1("Bor");
     if (!findContext<IR::AssignmentStatement>())
         can_be_changed = false;
     if (!(bor->left->is<IR::BAnd>() && bor->right->is<IR::BAnd>()))
         can_be_changed = false;
+    LOG1("Tests " << bor->left->is<IR::BAnd>() << " " << bor->right->is<IR::BAnd>());
     return can_be_changed;
 }
 
 bool SimplifyBitwise::Scan::preorder(const IR::BAnd *band) {
+    LOG1("Band");
     if (!findContext<IR::BOr>())
         can_be_changed = false;
     if (!band->left->is<IR::Constant>() && !band->right->is<IR::Constant>())
@@ -34,6 +41,7 @@ bool SimplifyBitwise::Scan::preorder(const IR::BAnd *band) {
 }
 
 bool SimplifyBitwise::Scan::preorder(const IR::Constant *constant) {
+    LOG1("Constant");
     if (!findContext<IR::BAnd>()) {
         can_be_changed = false;
         return false;

--- a/midend/simplifyBitwise.cpp
+++ b/midend/simplifyBitwise.cpp
@@ -2,8 +2,7 @@
 
 namespace P4 {
 
-bool SimplifyBitwise::Scan::preorder(const IR::Operation *op) {
-    LOG1("Are we here? " << op);
+bool SimplifyBitwise::Scan::preorder(const IR::Operation *) {
     can_be_changed = false;
     return false;
 }
@@ -11,26 +10,20 @@ bool SimplifyBitwise::Scan::preorder(const IR::Operation *op) {
 bool SimplifyBitwise::Scan::preorder(const IR::AssignmentStatement *as) {
     if (!as->right->is<IR::BOr>())
         return false;
-    auto action = findContext<IR::P4Action>();
-    if (action)
-        LOG1("Action name " << action->name.name);
     can_be_changed = true;
     total_mask = 0;
     return true;
 }
 
 bool SimplifyBitwise::Scan::preorder(const IR::BOr *bor) {
-    LOG1("Bor");
     if (!findContext<IR::AssignmentStatement>())
         can_be_changed = false;
     if (!(bor->left->is<IR::BAnd>() && bor->right->is<IR::BAnd>()))
         can_be_changed = false;
-    LOG1("Tests " << bor->left->is<IR::BAnd>() << " " << bor->right->is<IR::BAnd>());
     return can_be_changed;
 }
 
 bool SimplifyBitwise::Scan::preorder(const IR::BAnd *band) {
-    LOG1("Band");
     if (!findContext<IR::BOr>())
         can_be_changed = false;
     if (!band->left->is<IR::Constant>() && !band->right->is<IR::Constant>())
@@ -41,7 +34,6 @@ bool SimplifyBitwise::Scan::preorder(const IR::BAnd *band) {
 }
 
 bool SimplifyBitwise::Scan::preorder(const IR::Constant *constant) {
-    LOG1("Constant");
     if (!findContext<IR::BAnd>()) {
         can_be_changed = false;
         return false;
@@ -63,8 +55,7 @@ void SimplifyBitwise::Scan::postorder(const IR::AssignmentStatement *as) {
 }
 
 const IR::Node *SimplifyBitwise::Update::preorder(IR::AssignmentStatement *as) {
-    auto orig_as = getOriginal()->to<IR::AssignmentStatement>();
-    if (self.changeable.count(orig_as) == 0) {
+    if (self.changeable.count(getOriginal<IR::AssignmentStatement>()) == 0) {
         prune();
     } else {
         slice_statements = new IR::Vector<IR::StatOrDecl>();

--- a/midend/simplifyBitwise.cpp
+++ b/midend/simplifyBitwise.cpp
@@ -1,0 +1,98 @@
+#include "simplifyBitwise.h"
+
+namespace P4 {
+
+bool SimplifyBitwise::Scan::preorder(const IR::AssignmentStatement *as) {
+    if (!as->right->is<IR::BOr>())
+        return false;
+    can_be_changed = true;
+    mpz_init(total_mask.get_mpz_t());
+    return true;
+}
+
+bool SimplifyBitwise::Scan::preorder(const IR::BOr *bor) {
+    if (!findContext<IR::AssignmentStatement>())
+        can_be_changed = false;
+    if (!(bor->left->is<IR::BAnd>() && bor->right->is<IR::BAnd>()))
+        can_be_changed = false;
+    return can_be_changed;
+}
+
+bool SimplifyBitwise::Scan::preorder(const IR::BAnd *band) {
+    if (!findContext<IR::BOr>())
+        can_be_changed = false;
+    if (!band->left->is<IR::Constant>() && !band->right->is<IR::Constant>())
+        can_be_changed = false;
+    if (band->left->is<IR::Constant>() && band->right->is<IR::Constant>())
+        can_be_changed = false;
+    return can_be_changed;
+}
+
+bool SimplifyBitwise::Scan::preorder(const IR::Constant *constant) {
+    if (!findContext<IR::BAnd>()) {
+        can_be_changed = false;
+        return false;
+    }
+    // Ensure that there are no collisions within the bitmask
+    mpz_class mask;
+    mpz_init(mask.get_mpz_t());
+    mpz_class zero;
+    mpz_init(zero.get_mpz_t());
+    mpz_and(mask.get_mpz_t(), total_mask.get_mpz_t(), constant->value.get_mpz_t());
+    if (mpz_cmp(mask.get_mpz_t(), zero.get_mpz_t()) == 0) {
+        mpz_ior(total_mask.get_mpz_t(), mask.get_mpz_t(), total_mask.get_mpz_t());
+    } else {
+        can_be_changed = false;
+    }
+    return false;
+}
+
+void SimplifyBitwise::Scan::postorder(const IR::AssignmentStatement *as) {
+    if (can_be_changed)
+        self.changeable.insert(as);
+}
+
+const IR::Node *SimplifyBitwise::Update::preorder(IR::AssignmentStatement *as) {
+    auto orig_as = getOriginal()->to<IR::AssignmentStatement>();
+    if (self.changeable.count(orig_as) == 0) {
+        prune();
+    } else {
+        slice_statements = new IR::Vector<IR::StatOrDecl>();
+        changing_as = as;
+    }
+    return as;
+}
+
+
+const IR::Node *SimplifyBitwise::Update::preorder(IR::BAnd *band) {
+    if (!findContext<IR::AssignmentStatement>())
+        return band;
+    const IR::Constant *constant = band->left->to<IR::Constant>();
+    const IR::Expression *rvalue = band->right;
+    if (constant == nullptr) {
+        constant = band->right->to<IR::Constant>();
+        rvalue = band->left;
+    }
+    BUG_CHECK(constant, "%s: No singular mask field in & compilation: %s", band->srcInfo, band);
+    mp_bitcnt_t zero_pos = 0;
+    mp_bitcnt_t one_pos = mpz_scan1(constant->value.get_mpz_t(), zero_pos);
+    while (static_cast<int>(one_pos) >= 0) {
+        zero_pos = mpz_scan0(constant->value.get_mpz_t(), one_pos);
+        auto left_slice = new IR::Slice(changing_as->left, static_cast<int>(zero_pos - 1),
+                                        static_cast<int>(one_pos));
+        auto right_slice = new IR::Slice(rvalue, static_cast<int>(zero_pos - 1),
+                                         static_cast<int>(one_pos));
+        auto new_as = new IR::AssignmentStatement(changing_as->srcInfo, left_slice, right_slice);
+        slice_statements->push_back(new_as);
+        one_pos = mpz_scan1(constant->value.get_mpz_t(), zero_pos);
+    }
+    return band;
+}
+
+const IR::Node *SimplifyBitwise::Update::postorder(IR::AssignmentStatement *as) {
+    BUG_CHECK(!slice_statements->empty(), "%s: Must have created separate assignment statements "
+              "for this statement: %s", as->srcInfo, as);
+    return slice_statements;
+}
+
+}  // namespace P4

--- a/midend/simplifyBitwise.h
+++ b/midend/simplifyBitwise.h
@@ -34,6 +34,10 @@ class SimplifyBitwise : public PassManager {
         using Inspector::postorder;
 
         bool preorder(const IR::Operation *op) override;
+        bool preorder(const IR::Member *) override { return false; }
+        bool preorder(const IR::Slice *) override { return false; }
+        bool preorder(const IR::ArrayIndex *) override { return false; }
+        bool preorder(const IR::Cast *) override { return false; }
         bool preorder(const IR::AssignmentStatement *as) override;
         bool preorder(const IR::BOr *bor) override;
         bool preorder(const IR::BAnd *band) override;

--- a/midend/simplifyBitwise.h
+++ b/midend/simplifyBitwise.h
@@ -2,6 +2,7 @@
 #define MIDEND_SIMPLIFYBITWISE_H_
 
 #include "ir/ir.h"
+#include "lib/ordered_set.h"
 
 namespace P4 {
 

--- a/midend/simplifyBitwise.h
+++ b/midend/simplifyBitwise.h
@@ -1,0 +1,71 @@
+#ifndef MIDEND_SIMPLIFYBITWISE_H_
+#define MIDEND_SIMPLIFYBITWISE_H_
+
+#include "ir/ir.h"
+
+namespace P4 {
+
+/**
+ * The purpose of this pass is to simplify the translation of the p4-16 translation of the
+ * following p4_14 primitive:
+ *     modify_field(hdr.field, parameter, mask);
+ *
+ * This gets translated to the following p4_16:
+ *     hdr.field = hdr.field & ~mask | parameter & mask;
+ *
+ * which in term could be further simplified to a vector of simple assignments over slices.
+ * This extensions could be folded to any combinations of Binary Ors and Binary Ands as long
+ * as the masks never have any collisions.
+ *
+ * @pre none
+ *
+ * @todo: Extend the optimization to handle multiple combinations of masks
+ */
+class SimplifyBitwise : public PassManager {
+    ordered_set<const IR::AssignmentStatement *> changeable;
+
+    class Scan : public Inspector {
+        SimplifyBitwise &self;
+        mpz_class total_mask;
+        bool can_be_changed = false;
+
+        using Inspector::preorder;
+        using Inspector::postorder;
+
+        bool preorder(const IR::AssignmentStatement *as) override;
+        bool preorder(const IR::BOr *bor) override;
+        bool preorder(const IR::BAnd *band) override;
+        bool preorder(const IR::Constant *cst) override;
+        void postorder(const IR::AssignmentStatement *as) override;
+
+     public:
+        explicit Scan(SimplifyBitwise &s) : self(s) { setName("SimplifyBitwise::Scan"); }
+    };
+
+    class Update : public Transform {
+        SimplifyBitwise &self;
+        IR::Vector<IR::StatOrDecl> *slice_statements;
+        const IR::AssignmentStatement *changing_as;
+
+     public:
+        using Transform::preorder;
+        using Transform::postorder;
+
+        const IR::Node *preorder(IR::AssignmentStatement *as) override;
+        const IR::Node *preorder(IR::BAnd *band) override;
+        const IR::Node *postorder(IR::AssignmentStatement *as) override;
+
+        explicit Update(SimplifyBitwise &s) : self(s) { setName("SimplifyBitwise::Update"); }
+    };
+
+
+ public:
+    SimplifyBitwise() {
+        setName("SimplifyBitwise");
+        addPasses({ new Scan(*this), new Update(*this) });
+    }
+};
+
+}  // namespace P4
+
+#endif /* MIDEND_SIMPLIFYBITWISE_H_ */

--- a/midend/simplifyBitwise.h
+++ b/midend/simplifyBitwise.h
@@ -27,12 +27,13 @@ class SimplifyBitwise : public PassManager {
 
     class Scan : public Inspector {
         SimplifyBitwise &self;
-        mpz_class total_mask;
+        mpz_class total_mask = 0;
         bool can_be_changed = false;
 
         using Inspector::preorder;
         using Inspector::postorder;
 
+        bool preorder(const IR::Operation *op) override;
         bool preorder(const IR::AssignmentStatement *as) override;
         bool preorder(const IR::BOr *bor) override;
         bool preorder(const IR::BAnd *band) override;
@@ -47,6 +48,7 @@ class SimplifyBitwise : public PassManager {
         SimplifyBitwise &self;
         IR::Vector<IR::StatOrDecl> *slice_statements;
         const IR::AssignmentStatement *changing_as;
+        mpz_class total_mask = 0;
 
      public:
         using Transform::preorder;


### PR DESCRIPTION
In the p4-14 to p4-16 translation, the following instruction:
modify_field(field, param, mask)

becomes:
field = field & ~mask | param & mask

which is correct, but could be simplified for a backend as a vector of assignments of slices, as long as the masks don't have any collisions.

This also required a change to the equivalency check of Constants in local_copyprop.