### PR TITLE
Simplify SimplifyBitwise by using a general pattern matcher for expressions

### DIFF
--- a/ir/expression.cpp
+++ b/ir/expression.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,6 +17,26 @@ limitations under the License.
 #include "ir.h"
 #include "dbprint.h"
 #include "lib/gmputil.h"
+
+const IR::Expression *IR::Slice::make(const IR::Expression *e, int lo, int hi) {
+    if (auto k = e->to<IR::Constant>()) {
+        auto rv = ((*k >> lo) & IR::Constant((1U << (hi-lo+1)) - 1)).clone();
+        rv->type = IR::Type::Bits::get(hi-lo+1);
+        return rv; }
+    if (auto src_width = e->type->width_bits()) {
+        if (lo >= src_width)
+            return new IR::Constant(IR::Type::Bits::get(hi-lo+1), 0);
+        if (hi >= src_width)
+            hi = src_width - 1;
+        if (lo == 0 && hi == src_width - 1)
+            return e; }
+    if (auto sl = e->to<IR::Slice>()) {
+        lo += sl->getL();
+        hi += sl->getL();
+        BUG_CHECK(lo >= sl->getL() && hi <= sl->getH(), "MakeSlice slice on slice type mismatch");
+        e = sl->e0; }
+    return new IR::Slice(e, hi, lo);
+}
 
 int IR::Member::offset_bits() const {
   // This assumes little-endian number for bits.

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -219,6 +219,8 @@ class Slice : Operation_Ternary {
     Slice {
         if (type->is<Type::Unknown>() && e1 && e1->is<Constant>() && e2 && e2->is<Constant>())
             type = IR::Type::Bits::get(getH() - getL() + 1); }
+    // make a slice, folding slices on slices and slices on constants automatically
+    static Expression make(Expression a, int hi, int lo);
 }
 
 class Member : Operation_Unary {

--- a/ir/pattern.h
+++ b/ir/pattern.h
@@ -37,6 +37,16 @@ class Pattern {
         bool match(const IR::Node *n) override { return (m = n->to<T>()); }
         Match(const T *&m) : m(m) {}
     };
+    class Const : public Base {
+        mpz_class       value;
+     public:
+        bool match(const IR::Node *n) override {
+            if (auto k = n->to<IR::Constant>())
+                return k->value == value;
+            return false; }
+        Const(mpz_class v) : value(v) {}
+        Const(int v) : value(v) {}
+    };
     template<class T> class Unary : public Base {
         Base *expr;
      public:
@@ -62,6 +72,8 @@ class Pattern {
 
  public:
     template <class T> Pattern(const T*&m) : pattern(new Match<T>(m)) {}
+    Pattern(mpz_class v) : pattern(new Const(v)) {}     // NOLINT(runtime/explicit)
+    Pattern(int v) : pattern(new Const(v)) {}           // NOLINT(runtime/explicit)
     Pattern operator-() const { return Pattern(new Unary<IR::Neg>(pattern)); }
     Pattern operator~() const { return Pattern(new Unary<IR::Cmpl>(pattern)); }
     Pattern operator!() const { return Pattern(new Unary<IR::LNot>(pattern)); }
@@ -104,5 +116,24 @@ class Pattern {
 
     bool match(const IR::Node *n) { return pattern->match(n); }
 };
+
+inline Pattern operator*(int v, const Pattern &a) { return Pattern(v) * a; }
+inline Pattern operator/(int v, const Pattern &a) { return Pattern(v) / a; }
+inline Pattern operator%(int v, const Pattern &a) { return Pattern(v) % a; }
+inline Pattern operator+(int v, const Pattern &a) { return Pattern(v) + a; }
+inline Pattern operator-(int v, const Pattern &a) { return Pattern(v) - a; }
+inline Pattern operator<<(int v, const Pattern &a) { return Pattern(v) << a; }
+inline Pattern operator>>(int v, const Pattern &a) { return Pattern(v) >> a; }
+inline Pattern operator==(int v, const Pattern &a) { return Pattern(v) == a; }
+inline Pattern operator!=(int v, const Pattern &a) { return Pattern(v) != a; }
+inline Pattern operator<(int v, const Pattern &a) { return Pattern(v) < a; }
+inline Pattern operator<=(int v, const Pattern &a) { return Pattern(v) <= a; }
+inline Pattern operator>(int v, const Pattern &a) { return Pattern(v) > a; }
+inline Pattern operator>=(int v, const Pattern &a) { return Pattern(v) >= a; }
+inline Pattern operator&(int v, const Pattern &a) { return Pattern(v) & a; }
+inline Pattern operator|(int v, const Pattern &a) { return Pattern(v) | a; }
+inline Pattern operator^(int v, const Pattern &a) { return Pattern(v) ^ a; }
+inline Pattern operator&&(int v, const Pattern &a) { return Pattern(v) && a; }
+inline Pattern operator||(int v, const Pattern &a) { return Pattern(v) || a; }
 
 #endif /* IR_PATTERN_H_ */

--- a/ir/pattern.h
+++ b/ir/pattern.h
@@ -1,0 +1,108 @@
+/*
+Copyright 2018-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef IR_PATTERN_H_
+#define IR_PATTERN_H_
+
+#include "ir/ir.h"
+
+/**
+ * Pattern matcher for IR::Expression trees.
+ *
+ * Build pattern expressions with `Pattern` to match subtrees or leaves, and combine
+ * them with C++ operators to build larger patterns that can match tree fragments
+ */
+class Pattern {
+    class Base {
+     public:
+        virtual bool match(const IR::Node *) = 0;
+    } *pattern;
+    Pattern(Base *p) : pattern(p) {}
+    template<class T> class Match : public Base {
+        const T *&m;
+     public:
+        bool match(const IR::Node *n) override { return (m = n->to<T>()); }
+        Match(const T *&m) : m(m) {}
+    };
+    template<class T> class Unary : public Base {
+        Base *expr;
+     public:
+        bool match(const IR::Node *n) override {
+            if (auto b = n->to<T>())
+                return expr->match(b->expr);
+            return false; }
+        Unary(Base *e) : expr(e) {}
+    };
+    template<class T> class Binary : public Base {
+        Base    *left, *right;
+        bool    commutative;
+     public:
+        bool match(const IR::Node *n) override {
+            if (auto b = n->to<T>()) {
+                if (left->match(b->left) && right->match(b->right))
+                    return true;
+                if (commutative && left->match(b->right) && right->match(b->left))
+                    return true; }
+            return false; }
+        Binary(Base *l, Base *r, bool commute = false) : left(l), right(r), commutative(commute) {}
+    };
+
+ public:
+    template <class T> Pattern(const T*&m) : pattern(new Match<T>(m)) {}
+    Pattern operator-() const { return Pattern(new Unary<IR::Neg>(pattern)); }
+    Pattern operator~() const { return Pattern(new Unary<IR::Cmpl>(pattern)); }
+    Pattern operator!() const { return Pattern(new Unary<IR::LNot>(pattern)); }
+    Pattern operator*(const Pattern &r) const {
+        return Pattern(new Binary<IR::Mul>(pattern, r.pattern, true)); }
+    Pattern operator/(const Pattern &r) const {
+        return Pattern(new Binary<IR::Div>(pattern, r.pattern)); }
+    Pattern operator%(const Pattern &r) const {
+        return Pattern(new Binary<IR::Mod>(pattern, r.pattern)); }
+    Pattern operator+(const Pattern &r) const {
+        return Pattern(new Binary<IR::Add>(pattern, r.pattern, true)); }
+    Pattern operator-(const Pattern &r) const {
+        return Pattern(new Binary<IR::Sub>(pattern, r.pattern)); }
+    Pattern operator<<(const Pattern &r) const {
+        return Pattern(new Binary<IR::Shl>(pattern, r.pattern)); }
+    Pattern operator>>(const Pattern &r) const {
+        return Pattern(new Binary<IR::Shr>(pattern, r.pattern)); }
+    Pattern operator==(const Pattern &r) const {
+        return Pattern(new Binary<IR::Equ>(pattern, r.pattern, true)); }
+    Pattern operator!=(const Pattern &r) const {
+        return Pattern(new Binary<IR::Neq>(pattern, r.pattern, true)); }
+    Pattern operator<(const Pattern &r) const {
+        return Pattern(new Binary<IR::Lss>(pattern, r.pattern)); }
+    Pattern operator<=(const Pattern &r) const {
+        return Pattern(new Binary<IR::Leq>(pattern, r.pattern)); }
+    Pattern operator>(const Pattern &r) const {
+        return Pattern(new Binary<IR::Grt>(pattern, r.pattern)); }
+    Pattern operator>=(const Pattern &r) const {
+        return Pattern(new Binary<IR::Geq>(pattern, r.pattern)); }
+    Pattern operator&(const Pattern &r) const {
+        return Pattern(new Binary<IR::BAnd>(pattern, r.pattern, true)); }
+    Pattern operator|(const Pattern &r) const {
+        return Pattern(new Binary<IR::BOr>(pattern, r.pattern, true)); }
+    Pattern operator^(const Pattern &r) const {
+        return Pattern(new Binary<IR::BXor>(pattern, r.pattern, true)); }
+    Pattern operator&&(const Pattern &r) const {
+        return Pattern(new Binary<IR::LAnd>(pattern, r.pattern)); }
+    Pattern operator||(const Pattern &r) const {
+        return Pattern(new Binary<IR::LOr>(pattern, r.pattern)); }
+
+    bool match(const IR::Node *n) { return pattern->match(n); }
+};
+
+#endif /* IR_PATTERN_H_ */

--- a/midend/simplifyBitwise.cpp
+++ b/midend/simplifyBitwise.cpp
@@ -9,8 +9,8 @@ void SimplifyBitwise::assignSlices(const IR::Expression *expr, mpz_class mask) {
     // Calculate the slices for this particular mask
     while (one_pos >= 0) {
         int zero_pos = mpz_scan0(mask.get_mpz_t(), one_pos);
-        auto left_slice = new IR::Slice(changing_as->left, zero_pos - 1, one_pos);
-        auto right_slice = new IR::Slice(expr, zero_pos - 1, one_pos);
+        auto left_slice = IR::Slice::make(changing_as->left, zero_pos - 1, one_pos);
+        auto right_slice = IR::Slice::make(expr, zero_pos - 1, one_pos);
         auto new_as = new IR::AssignmentStatement(changing_as->srcInfo, left_slice, right_slice);
         slice_statements->push_back(new_as);
         one_pos = mpz_scan1(mask.get_mpz_t(), zero_pos);

--- a/midend/simplifyBitwise.cpp
+++ b/midend/simplifyBitwise.cpp
@@ -1,118 +1,39 @@
 #include "simplifyBitwise.h"
+#include "ir/pattern.h"
 
 namespace P4 {
 
-bool SimplifyBitwise::Scan::preorder(const IR::Operation *) {
-    can_be_changed = false;
-    return false;
-}
-
-bool SimplifyBitwise::Scan::preorder(const IR::AssignmentStatement *as) {
-    if (!as->right->is<IR::BOr>())
-        return false;
-    can_be_changed = true;
-    total_mask = 0;
-    return true;
-}
-
-bool SimplifyBitwise::Scan::preorder(const IR::BOr *bor) {
-    if (!findContext<IR::AssignmentStatement>())
-        can_be_changed = false;
-    if (!(bor->left->is<IR::BAnd>() && bor->right->is<IR::BAnd>()))
-        can_be_changed = false;
-    return can_be_changed;
-}
-
-bool SimplifyBitwise::Scan::preorder(const IR::BAnd *band) {
-    if (!findContext<IR::BOr>())
-        can_be_changed = false;
-    if (!band->left->is<IR::Constant>() && !band->right->is<IR::Constant>())
-        can_be_changed = false;
-    if (band->left->is<IR::Constant>() && band->right->is<IR::Constant>())
-        can_be_changed = false;
-    return can_be_changed;
-}
-
-bool SimplifyBitwise::Scan::preorder(const IR::Constant *constant) {
-    if (!findContext<IR::BAnd>()) {
-        can_be_changed = false;
-        return false;
-    }
-    // Ensure that there are no collisions within the bitmask
-    mpz_class mask = 0;
-    mask = total_mask & constant->value;
-    if (mask == 0) {
-        total_mask |= constant->value;
-    } else {
-        can_be_changed = false;
-    }
-    return false;
-}
-
-void SimplifyBitwise::Scan::postorder(const IR::AssignmentStatement *as) {
-    if (can_be_changed)
-        self.changeable.insert(as);
-}
-
-const IR::Node *SimplifyBitwise::Update::preorder(IR::AssignmentStatement *as) {
-    if (self.changeable.count(getOriginal<IR::AssignmentStatement>()) == 0) {
-        prune();
-    } else {
-        slice_statements = new IR::Vector<IR::StatOrDecl>();
-        changing_as = as;
-        total_mask = 0;
-    }
-    return as;
-}
-
-
-const IR::Node *SimplifyBitwise::Update::preorder(IR::BAnd *band) {
-    if (!findContext<IR::AssignmentStatement>())
-        return band;
-    const IR::Constant *constant = band->left->to<IR::Constant>();
-    const IR::Expression *rvalue = band->right;
-    if (constant == nullptr) {
-        constant = band->right->to<IR::Constant>();
-        rvalue = band->left;
-    }
-    BUG_CHECK(constant, "%s: No singular mask field in & compilation: %s", band->srcInfo, band);
-    mp_bitcnt_t one_pos = mpz_scan1(constant->value.get_mpz_t(), 0);
+void SimplifyBitwise::assignSlices(const IR::Expression *expr, mpz_class mask) {
+    int one_pos = mpz_scan1(mask.get_mpz_t(), 0);
 
     // Calculate the slices for this particular mask
-    while (static_cast<int>(one_pos) >= 0) {
-        mp_bitcnt_t zero_pos = mpz_scan0(constant->value.get_mpz_t(), one_pos);
-        auto left_slice = new IR::Slice(changing_as->left, static_cast<int>(zero_pos - 1),
-                                        static_cast<int>(one_pos));
-        auto right_slice = new IR::Slice(rvalue, static_cast<int>(zero_pos - 1),
-                                         static_cast<int>(one_pos));
+    while (one_pos >= 0) {
+        int zero_pos = mpz_scan0(mask.get_mpz_t(), one_pos);
+        auto left_slice = new IR::Slice(changing_as->left, zero_pos - 1, one_pos);
+        auto right_slice = new IR::Slice(expr, zero_pos - 1, one_pos);
         auto new_as = new IR::AssignmentStatement(changing_as->srcInfo, left_slice, right_slice);
         slice_statements->push_back(new_as);
-        one_pos = mpz_scan1(constant->value.get_mpz_t(), zero_pos);
+        one_pos = mpz_scan1(mask.get_mpz_t(), zero_pos);
     }
-    total_mask |= constant->value;
-    return band;
 }
 
-const IR::Node *SimplifyBitwise::Update::postorder(IR::AssignmentStatement *as) {
-    mpz_class parameter_mask = 1;
-    parameter_mask << (as->left->type->width_bits());
-    mpz_class zero_mask = parameter_mask & ~total_mask;
-    mp_bitcnt_t one_pos = mpz_scan1(zero_mask.get_mpz_t(), 0);
+const IR::Node *SimplifyBitwise::preorder(IR::AssignmentStatement *as) {
+    const IR::Expression *a, *b;
+    const IR::Constant *maskA, *maskB;
 
-    // Calculate the slices for the holes in the entirety of that mask
-    while (static_cast<int>(one_pos) >= 0) {
-        mp_bitcnt_t zero_pos = mpz_scan0(zero_mask.get_mpz_t(), one_pos);
-        int width = static_cast<int>(one_pos - zero_pos);
-        auto left_slice = new IR::Slice(changing_as->left, static_cast<int>(zero_pos - 1),
-                                        static_cast<int>(one_pos));
-        auto rvalue = new IR::Constant(new IR::Type::Bits(width, false), 0);
-        auto new_as = new IR::AssignmentStatement(changing_as->srcInfo, left_slice, rvalue);
-        slice_statements->push_back(new_as);
-        one_pos = mpz_scan1(zero_mask.get_mpz_t(), zero_pos);
-    }
+    if (!((Pattern(a) & Pattern(maskA)) | (Pattern(b) & Pattern(maskB))).match(as->right))
+        return as;
+    if ((maskA->value & maskB->value) != 0)
+        return as;
 
-    BUG_CHECK(!slice_statements->empty(), "%s: Must have created separate assignment statements "
-              "for this statement: %s", as->srcInfo, as);
+    slice_statements = new IR::Vector<IR::StatOrDecl>();
+    assignSlices(a, maskA->value);
+    assignSlices(b, maskB->value);
+    mpz_class parameter_mask = (mpz_class(1) << (as->left->type->width_bits())) - 1;
+    parameter_mask &= ~maskA->value;
+    parameter_mask &= ~maskB->value;
+    if (parameter_mask != 0)
+        assignSlices(new IR::Constant(0), parameter_mask);
     return slice_statements;
 }
 


### PR DESCRIPTION

It seems so much simpler to do this with a basic pattern matcher that I couldn't resist refactoring it to use one...