### PR TITLE
Fix for spec issue 563

### DIFF
--- a/frontends/p4/inlining.cpp
+++ b/frontends/p4/inlining.cpp
@@ -401,8 +401,11 @@ void DiscoverInlining::postorder(const IR::MethodCallStatement* statement) {
         !am->applyObject->is<IR::Type_Parser>())
         return;
     auto instantiation = am->object->to<IR::Declaration_Instance>();
-    BUG_CHECK(instantiation != nullptr, "%1% expected an instance declaration", am->object);
-    inlineList->addInvocation(instantiation, statement);
+    if (instantiation != nullptr)
+        inlineList->addInvocation(instantiation, statement);
+    else
+        BUG_CHECK(am->object->is<IR::Parameter>(),
+                  "%1% expected a constructor parameter", am->object);
 }
 
 void DiscoverInlining::visit_all(const IR::Block* block) {

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1310,6 +1310,11 @@ const IR::Node* TypeInference::postorder(IR::Parameter* param) {
         return param;
     BUG_CHECK(!paramType->is<IR::Type_Type>(), "%1%: unexpected type", paramType);
 
+    if (paramType->is<IR::P4Control>() || paramType->is<IR::P4Parser>()) {
+        typeError("%1%: parameter cannot have type %2%", param, paramType);
+        return param;
+    }
+
     // The parameter type cannot have free type variables
     if (paramType->is<IR::IMayBeGenericType>()) {
         auto gen = paramType->to<IR::IMayBeGenericType>();

--- a/test/gtest/arch_test.cpp
+++ b/test/gtest/arch_test.cpp
@@ -190,11 +190,12 @@ TEST_F(P4CArchitecture, psa_control_in_control) {
         struct Metadata {
             bit<32> hdr;
         }
+        control E();
         control MyIngress(inout ParsedHeaders h, inout Metadata m) {
             apply {
             }
         }
-        control MyEgress(inout Metadata m) (MyIngress ig) {
+        control MyEgress(inout Metadata m)(E ig) {
             apply {}
         }
         //MyEgress(ig) eg;

--- a/testdata/p4_16_errors/spec-issue563.p4
+++ b/testdata/p4_16_errors/spec-issue563.p4
@@ -1,0 +1,14 @@
+// User Program
+
+control X();
+
+control A() {
+    apply {
+    }
+}
+control B()(X x) {
+    apply {}
+}
+control C()(A a) {
+    apply {}
+}

--- a/testdata/p4_16_errors_outputs/spec-issue563.p4
+++ b/testdata/p4_16_errors_outputs/spec-issue563.p4
@@ -1,0 +1,16 @@
+control X();
+control A() {
+    apply {
+    }
+}
+
+control B()(X x) {
+    apply {
+    }
+}
+
+control C()(A a) {
+    apply {
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/spec-issue563.p4-stderr
+++ b/testdata/p4_16_errors_outputs/spec-issue563.p4-stderr
@@ -1,0 +1,6 @@
+spec-issue563.p4(12): error: a: parameter cannot have type control A
+control C()(A a) {
+              ^
+spec-issue563.p4(5)
+control A() {
+        ^

--- a/testdata/p4_16_samples/control-as-param.p4
+++ b/testdata/p4_16_samples/control-as-param.p4
@@ -1,0 +1,36 @@
+#include <core.p4>
+
+control E(out bit b);
+
+control D(out bit b) {
+    apply {
+        b = 1;
+    }
+}
+
+control F(out bit b) {
+    apply {
+        b = 0;
+    }
+}
+
+control C(out bit b)(E d) {
+    apply {
+        d.apply(b);
+    }
+}
+
+control Ingress(out bit b) {
+    D() d;
+    F() f;
+    C(d) c0;
+    C(f) c1;
+    apply {
+        c0.apply(b);
+        c1.apply(b);
+    }
+}
+
+package top(E _e);
+
+top(Ingress()) main;

--- a/testdata/p4_16_samples/issue496.p4
+++ b/testdata/p4_16_samples/issue496.p4
@@ -20,11 +20,13 @@ control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
   apply { }
 }
 
+control E();
+
 control D() {
   apply { }
 }
 
-control C()(D d) {
+control C()(E d) {
   apply {
     d.apply();
   }

--- a/testdata/p4_16_samples_outputs/control-as-param-first.p4
+++ b/testdata/p4_16_samples_outputs/control-as-param-first.p4
@@ -1,0 +1,35 @@
+#include <core.p4>
+
+control E(out bit<1> b);
+control D(out bit<1> b) {
+    apply {
+        b = 1w1;
+    }
+}
+
+control F(out bit<1> b) {
+    apply {
+        b = 1w0;
+    }
+}
+
+control C(out bit<1> b)(E d) {
+    apply {
+        d.apply(b);
+    }
+}
+
+control Ingress(out bit<1> b) {
+    D() d;
+    F() f;
+    C(d) c0;
+    C(f) c1;
+    apply {
+        c0.apply(b);
+        c1.apply(b);
+    }
+}
+
+package top(E _e);
+top(Ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/control-as-param-frontend.p4
+++ b/testdata/p4_16_samples_outputs/control-as-param-frontend.p4
@@ -1,0 +1,13 @@
+#include <core.p4>
+
+control E(out bit<1> b);
+control Ingress(out bit<1> b) {
+    apply {
+        b = 1w1;
+        b = 1w0;
+    }
+}
+
+package top(E _e);
+top(Ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/control-as-param-midend.p4
+++ b/testdata/p4_16_samples_outputs/control-as-param-midend.p4
@@ -1,0 +1,22 @@
+#include <core.p4>
+
+control E(out bit<1> b);
+control Ingress(out bit<1> b) {
+    @hidden action act() {
+        b = 1w1;
+        b = 1w0;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+package top(E _e);
+top(Ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/control-as-param.p4
+++ b/testdata/p4_16_samples_outputs/control-as-param.p4
@@ -1,0 +1,35 @@
+#include <core.p4>
+
+control E(out bit<1> b);
+control D(out bit<1> b) {
+    apply {
+        b = 1;
+    }
+}
+
+control F(out bit<1> b) {
+    apply {
+        b = 0;
+    }
+}
+
+control C(out bit<1> b)(E d) {
+    apply {
+        d.apply(b);
+    }
+}
+
+control Ingress(out bit<1> b) {
+    D() d;
+    F() f;
+    C(d) c0;
+    C(f) c1;
+    apply {
+        c0.apply(b);
+        c1.apply(b);
+    }
+}
+
+package top(E _e);
+top(Ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue496-first.p4
+++ b/testdata/p4_16_samples_outputs/issue496-first.p4
@@ -23,12 +23,13 @@ control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     }
 }
 
+control E();
 control D() {
     apply {
     }
 }
 
-control C()(D d) {
+control C()(E d) {
     apply {
         d.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue496.p4
+++ b/testdata/p4_16_samples_outputs/issue496.p4
@@ -23,12 +23,13 @@ control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
     }
 }
 
+control E();
 control D() {
     apply {
     }
 }
 
-control C()(D d) {
+control C()(E d) {
     apply {
         d.apply();
     }


### PR DESCRIPTION
With this commit we distinguish a control from the type of the control. So you cannot use a control as the type of a parameter.