### PR TITLE
Support inferring which architecture file to include from --target command line option.

### DIFF
--- a/backends/bmv2/bmv2.cpp
+++ b/backends/bmv2/bmv2.cpp
@@ -48,16 +48,17 @@ int main(int argc, char *const argv[]) {
 
     auto hook = options.getDebugHook();
 
-    cstring device, arch, vendor;
-    std::tie(device, arch, vendor) = options.parseTarget();
-    // BMV2 is required for compatibility with the previous compiler.
-    options.preprocessor_options += " -D__TARGET_BMV2__";
-    if (arch == "ss") {
-        options.preprocessor_options += " -D__ARCH_V1MODEL__";
-    } else if (arch == "psa") {
-        options.preprocessor_options += " -D__ARCH_PSA__";
+    if (options.target != nullptr) {
+        cstring device, arch, vendor;
+        std::tie(device, arch, vendor) = options.parseTarget();
+        // BMV2 is required for compatibility with the previous compiler.
+        options.preprocessor_options += " -D__TARGET_BMV2__";
+        if (arch == "ss") {
+            options.preprocessor_options += " -D__ARCH_V1MODEL__";
+        } else if (arch == "psa") {
+            options.preprocessor_options += " -D__ARCH_PSA__";
+        }
     }
-
     auto program = P4::parseP4File(options);
     if (program == nullptr || ::errorCount() > 0)
         return 1;

--- a/backends/bmv2/bmv2.cpp
+++ b/backends/bmv2/bmv2.cpp
@@ -48,8 +48,16 @@ int main(int argc, char *const argv[]) {
 
     auto hook = options.getDebugHook();
 
+    cstring device, arch, vendor;
+    std::tie(device, arch, vendor) = options.parseTarget();
     // BMV2 is required for compatibility with the previous compiler.
     options.preprocessor_options += " -D__TARGET_BMV2__";
+    if (arch == "ss") {
+        options.preprocessor_options += " -D__ARCH_V1MODEL__";
+    } else if (arch == "psa") {
+        options.preprocessor_options += " -D__ARCH_PSA__";
+    }
+
     auto program = P4::parseP4File(options);
     if (program == nullptr || ::errorCount() > 0)
         return 1;

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -39,14 +39,17 @@ void compile(EbpfOptions& options) {
         ::error("This compiler only handles P4-16");
         return;
     }
-    cstring device, arch, vendor;
-    std::tie(device, arch, vendor) = options.parseTarget();
 
-    options.preprocessor_options += " -D__TARGET_FRONTEND__";
-    if (arch == "ss") {
-        options.preprocessor_options += " -D__ARCH_V1MODEL__";
-    } else if (arch == "psa") {
-        options.preprocessor_options += " -D__ARCH_PSA__";
+    if (options.target != nullptr) {
+        cstring device, arch, vendor;
+        std::tie(device, arch, vendor) = options.parseTarget();
+
+        options.preprocessor_options += " -D__TARGET_FRONTEND__";
+        if (arch == "ss") {
+            options.preprocessor_options += " -D__ARCH_V1MODEL__";
+        } else if (arch == "psa") {
+            options.preprocessor_options += " -D__ARCH_PSA__";
+        }
     }
 
     auto program = P4::parseP4File(options);

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -44,7 +44,7 @@ void compile(EbpfOptions& options) {
         cstring device, arch, vendor;
         std::tie(device, arch, vendor) = options.parseTarget();
 
-        options.preprocessor_options += " -D__TARGET_FRONTEND__";
+        options.preprocessor_options += " -D__TARGET_EBPF__";
         if (arch == "ss") {
             options.preprocessor_options += " -D__ARCH_V1MODEL__";
         } else if (arch == "psa") {

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -39,6 +39,16 @@ void compile(EbpfOptions& options) {
         ::error("This compiler only handles P4-16");
         return;
     }
+    cstring device, arch, vendor;
+    std::tie(device, arch, vendor) = options.parseTarget();
+
+    options.preprocessor_options += " -D__TARGET_FRONTEND__";
+    if (arch == "ss") {
+        options.preprocessor_options += " -D__ARCH_V1MODEL__";
+    } else if (arch == "psa") {
+        options.preprocessor_options += " -D__ARCH_PSA__";
+    }
+
     auto program = P4::parseP4File(options);
     if (::errorCount() > 0)
         return;

--- a/backends/graphs/p4c-graphs.cpp
+++ b/backends/graphs/p4c-graphs.cpp
@@ -88,13 +88,15 @@ int main(int argc, char *const argv[]) {
 
     auto hook = options.getDebugHook();
 
-    cstring device, arch, vendor;
-    std::tie(device, arch, vendor) = options.parseTarget();
-    options.preprocessor_options += " -D__TARGET_GRAPH__";
-    if (arch == "ss") {
-        options.preprocessor_options += " -D__ARCH_V1MODEL__";
-    } else if (arch == "psa") {
-        options.preprocessor_options += " -D__ARCH_PSA__";
+    if (options.target != nullptr) {
+        cstring device, arch, vendor;
+        std::tie(device, arch, vendor) = options.parseTarget();
+        options.preprocessor_options += " -D__TARGET_GRAPH__";
+        if (arch == "ss") {
+            options.preprocessor_options += " -D__ARCH_V1MODEL__";
+        } else if (arch == "psa") {
+            options.preprocessor_options += " -D__ARCH_PSA__";
+        }
     }
 
     auto program = P4::parseP4File(options);

--- a/backends/graphs/p4c-graphs.cpp
+++ b/backends/graphs/p4c-graphs.cpp
@@ -88,6 +88,15 @@ int main(int argc, char *const argv[]) {
 
     auto hook = options.getDebugHook();
 
+    cstring device, arch, vendor;
+    std::tie(device, arch, vendor) = options.parseTarget();
+    options.preprocessor_options += " -D__TARGET_GRAPH__";
+    if (arch == "ss") {
+        options.preprocessor_options += " -D__ARCH_V1MODEL__";
+    } else if (arch == "psa") {
+        options.preprocessor_options += " -D__ARCH_PSA__";
+    }
+
     auto program = P4::parseP4File(options);
     if (program == nullptr || ::errorCount() > 0)
         return 1;

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -81,14 +81,16 @@ int main(int argc, char *const argv[]) {
     if (::errorCount() > 0)
         return 1;
 
-    cstring device, arch, vendor;
-    std::tie(device, arch, vendor) = options.parseTarget();
+    if (options.target != nullptr) {
+        cstring device, arch, vendor;
+        std::tie(device, arch, vendor) = options.parseTarget();
 
-    options.preprocessor_options += " -D__TARGET_FRONTEND__";
-    if (arch == "ss") {
-        options.preprocessor_options += " -D__ARCH_V1MODEL__";
-    } else if (arch == "psa") {
-        options.preprocessor_options += " -D__ARCH_PSA__";
+        options.preprocessor_options += " -D__TARGET_FRONTEND__";
+        if (arch == "ss") {
+            options.preprocessor_options += " -D__ARCH_V1MODEL__";
+        } else if (arch == "psa") {
+            options.preprocessor_options += " -D__ARCH_PSA__";
+        }
     }
 
     auto program = P4::parseP4File(options);

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <fstream>
 #include <iostream>
+#include <boost/algorithm/string.hpp>
 
 #include "control-plane/p4RuntimeSerializer.h"
 #include "ir/ir.h"
@@ -79,6 +80,16 @@ int main(int argc, char *const argv[]) {
         options.setInputFile();
     if (::errorCount() > 0)
         return 1;
+
+    cstring device, arch, vendor;
+    std::tie(device, arch, vendor) = options.parseTarget();
+
+    options.preprocessor_options += " -D__TARGET_FRONTEND__";
+    if (arch == "ss") {
+        options.preprocessor_options += " -D__ARCH_V1MODEL__";
+    } else if (arch == "psa") {
+        options.preprocessor_options += " -D__ARCH_PSA__";
+    }
 
     auto program = P4::parseP4File(options);
     auto hook = options.getDebugHook();

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 
 #include <fstream>
 #include <iostream>
-#include <boost/algorithm/string.hpp>
 
 #include "control-plane/p4RuntimeSerializer.h"
 #include "ir/ir.h"

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -374,6 +374,20 @@ void CompilerOptions::dumpPass(const char* manager, unsigned seq, const char* pa
     }
 }
 
+std::tuple<cstring, cstring, cstring> CompilerOptions::parseTarget() {
+    std::vector<std::string> splits;
+    std::string target_str(target.c_str());
+    boost::split(splits, target_str, [](char c){return c == '-';});
+    if (splits.size() != 3)
+        BUG("Invalid target %s", target);
+
+    auto device = splits[0];
+    auto arch   = splits[1];
+    auto vendor = splits[2];
+
+    return {device, arch, vendor};
+}
+
 DebugHook CompilerOptions::getDebugHook() const {
     using namespace std::placeholders;
     auto dp = std::bind(&CompilerOptions::dumpPass, this, _1, _2, _3, _4);

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -284,6 +284,7 @@ FILE* CompilerOptions::preprocess() {
 #else
         std::string cmd("cpp");
 #endif
+        const std::string arch = "-include arch.p4";
         // the p4c driver sets environment variables for include
         // paths.  check the environment and add these to the command
         // line for the preprocessor
@@ -291,7 +292,8 @@ FILE* CompilerOptions::preprocess() {
           isv1() ? getenv("P4C_14_INCLUDE_PATH") : getenv("P4C_16_INCLUDE_PATH");
         cmd += cstring(" -C -undef -nostdinc") + " " + preprocessor_options
             + (driverP4IncludePath ? " -I" + cstring(driverP4IncludePath) : "")
-            + " -I" + (isv1() ? p4_14includePath : p4includePath) + " " + file;
+            + " -I" + (isv1() ? p4_14includePath : p4includePath)
+            + " " + (isv1() ? "" : arch) + " " + file;
 
         if (Log::verbose())
             std::cerr << "Invoking preprocessor " << std::endl << cmd << std::endl;

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -385,7 +385,7 @@ std::tuple<cstring, cstring, cstring> CompilerOptions::parseTarget() {
     auto arch   = splits[1];
     auto vendor = splits[2];
 
-    return {device, arch, vendor};
+    return std::make_tuple(device, arch, vendor);
 }
 
 DebugHook CompilerOptions::getDebugHook() const {

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -20,6 +20,7 @@ limitations under the License.
 #define FRONTENDS_COMMON_OPTIONS_H_
 
 #include <unordered_map>
+#include <boost/algorithm/string.hpp>
 #include "lib/compile_context.h"
 #include "lib/cstring.h"
 #include "lib/options.h"
@@ -93,6 +94,9 @@ class CompilerOptions : public Util::Options {
 
     // Compiler target architecture
     cstring target = nullptr;
+    // parse target architecture to tuple(device, arch, vendor)
+    std::tuple<cstring, cstring, cstring> parseTarget();
+
     // substrings matched agains pass names
     std::vector<cstring> top4;
 

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -19,8 +19,8 @@ limitations under the License.
 #ifndef FRONTENDS_COMMON_OPTIONS_H_
 #define FRONTENDS_COMMON_OPTIONS_H_
 
-#include <unordered_map>
 #include <boost/algorithm/string.hpp>
+#include <unordered_map>
 #include "lib/compile_context.h"
 #include "lib/cstring.h"
 #include "lib/options.h"

--- a/p4include/arch.p4
+++ b/p4include/arch.p4
@@ -1,0 +1,22 @@
+#ifndef __INCLUDE_ARCH_P4__
+#define __INCLUDE_ARCH_P4__
+
+#ifdef __TARGET_BMV2__
+ #ifdef __ARCH_V1MODEL__
+  #include "v1model.p4"
+ #endif
+ #ifdef __ARCH_PSA__
+  #include "psa.p4"
+ #endif
+#endif
+
+#ifdef __TARGET_FRONTEND__
+ #ifdef __ARCH_V1MODEL__
+  #include "v1model.p4"
+ #endif
+ #ifdef __ARCH_PSA__
+  #include "psa.p4"
+ #endif
+#endif
+
+#endif

--- a/p4include/arch.p4
+++ b/p4include/arch.p4
@@ -19,4 +19,22 @@
  #endif
 #endif
 
+#ifdef __TARGET_GRAPH__
+ #ifdef __ARCH_V1MODEL__
+  #include "v1model.p4"
+ #endif
+ #ifdef __ARCH_PSA__
+  #include "psa.p4"
+ #endif
+#endif
+
+#ifdef __TARGET_EBPF__
+ #ifdef __ARCH_V1MODEL__
+  #include "v1model.p4"
+ #endif
+ #ifdef __ARCH_PSA__
+  #include "psa.p4"
+ #endif
+#endif
+
 #endif


### PR DESCRIPTION
Users don't have to include `core.p4` or `v1model.p4` in their program, as long as they specify which target the program should be compiled to, the compiler should be smart enough to include the correct file.