### PR TITLE
Match explicit END tokens after error in bison parser

### DIFF
--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -268,10 +268,13 @@ header_type_declaration: HEADER_TYPE name "{" header_dec_body "}"
                                 new IR::Annotations(*$4.annotations), *$4.fields),
             new IR::Type_Header(@1+@5, IR::ID(@2, $2),
                                 new IR::Annotations(*$4.annotations), *$4.fields))); }
+    | HEADER_TYPE name "{" header_dec_body error END
+          { driver.clearPragmas(); }
 ;
 
 header_dec_body: FIELDS "{" field_declarations "}" opt_length opt_max_length
       { $$ = $3; }
+    | FIELDS "{" field_declarations error END { $$ = $3; }
 ;
 
 field_declarations: /* epsilon */
@@ -393,6 +396,7 @@ field_list_entries:
 field_list_calculation_declaration:
       FIELD_LIST_CALCULATION name "{" field_list_calculation_body "}"
       { $4->name = IR::ID(@2, $2); $4->srcInfo = @1 + @5; driver.global->add($2, $4); }
+    | FIELD_LIST_CALCULATION name "{" field_list_calculation_body error END
 ;
 
 field_list_calculation_body: /* epsilon */
@@ -426,6 +430,7 @@ field_list_list: /* epsilon */
 calculated_field_declaration:
       CALCULATED_FIELD field_ref "{" update_verify_spec_list "}"
       { $4->field = $2; $4->srcInfo = @1 + @5; driver.global->add($2->toString(), $4); }
+    | CALCULATED_FIELD field_ref "{" update_verify_spec_list error END
 ;
 
 update_verify_spec_list: /* epsilon */
@@ -457,6 +462,7 @@ value_set_declaration:
 parser_function_declaration:
       PARSER name "{" parser_statement_list "}"
       { $4->name = IR::ID(@2, $2); $4->srcInfo = @1 + @5; driver.global->add($2, $4); }
+    | PARSER name "{" parser_statement_list error END
 ;
 
 parser_statement_list: /* epsilon */
@@ -508,7 +514,7 @@ case_value:
 
 parser_exception_declaration:
       PARSER_EXCEPTION name "{" parser_statement_list "}"
-        { driver.clearPragmas(); }
+    | PARSER_EXCEPTION name "{" parser_statement_list error END
 ;
 
 /*****************/
@@ -517,6 +523,7 @@ parser_exception_declaration:
 
 counter_declaration: COUNTER name "{" counter_spec_list "}"
       { $4->name = IR::ID(@2, $2); $4->srcInfo = @1 + @5; driver.global->add($2, $4); }
+    | COUNTER name "{" counter_spec_list error END
 ;
 
 counter_spec_list:
@@ -551,6 +558,7 @@ counter_spec_list:
 meter_declaration : METER name "{" meter_spec_list "}"
       { $4->name = IR::ID(@2, $2); $4->srcInfo = @1 + @5;
         driver.global->add($2, $4); }
+    | METER name "{" meter_spec_list error END
 ;
 
 meter_spec_list:
@@ -586,6 +594,7 @@ register_declaration: REGISTER name "{" register_spec_list "}"
       { $4->name = IR::ID(@2, $2);
         $4->srcInfo = @1 + @5;
         driver.global->add($2, $4); }
+    | REGISTER name "{" register_spec_list error END
 ;
 
 register_spec_list:
@@ -649,7 +658,7 @@ action_function_declaration:
 
 action_function_body:
       "{" action_statement_list "}"        { $$ = $2; }
-    | "{" action_statement_list error "}"  { $$ = $2; }
+    | "{" action_statement_list error END  { $$ = $2; }
 ;
 
 action_statement_list: /* epsilon */
@@ -661,6 +670,8 @@ action_statement_list: /* epsilon */
     | action_statement_list field_ref "(" opt_expression_list ")" ";"
       { ($$ = $1)->action.push_back(new IR::Primitive(@2+@5, $2->member, $2->expr, $4)); }
     | action_statement_list error ";"
+      { $$ = $1; }
+    | action_statement_list error
       { $$ = $1; }
 ;
 
@@ -701,11 +712,14 @@ table_declaration: TABLE name "{" table_body "}"
       { $4->name = IR::ID(@2, $2);
         $4->srcInfo = @1 + @5;
         driver.global->add($2, $4); }
+    | TABLE name "{" table_body error END
 ;
 
 table_body: /* epsilon */
       { $$ = new IR::V1Table(driver.takePragmasAsAnnotations()); }
     | table_body READS "{" field_match_list "}"
+      { ($$=$1)->reads = $4; }
+    | table_body READS "{" field_match_list error END
       { ($$=$1)->reads = $4; }
     | table_body ACTIONS "{" action_list "}"
       { ($$=$1)->actions = $4->names; $4 = nullptr; }
@@ -765,6 +779,7 @@ action_list: /* epsilon */ { $$ = new IR::NameList(); }
 control_function_declaration: CONTROL name "{" control_statement_list "}"
       { driver.global->add($2, new IR::V1Control(@1+@5, IR::ID(@2, $2), $4,
                                                  driver.takePragmasAsAnnotations())); }
+    | CONTROL name "{" control_statement_list error END
 ;
 
 control_statement_list: /* epsilon */ { $$ = new IR::Vector<IR::Expression>; }


### PR DESCRIPTION
bison C++ parser can't recover properly (automatically) from errors on eof, due to the explicit END token required.  Need to explicitly match END where it can occur in error recovery to avoid hang.

Fixes issue #1093