### PR TITLE
Fix resubmit in bmv2 backend

### DIFF
--- a/backends/bmv2/backend.cpp
+++ b/backends/bmv2/backend.cpp
@@ -257,6 +257,11 @@ void Backend::convert(BMV2Options& options) {
     jsonTop.emplace("header_unions", json->header_unions);
     jsonTop.emplace("header_union_stacks", json->header_union_stacks);
     field_lists = mkArrayField(&jsonTop, "field_lists");
+    // field list and learn list ids in bmv2 are not consistent with ids for
+    // other objects: they need to start at 1 (not 0) since the id is also used
+    // as a "flag" to indicate that a certain simple_switch primitive has been
+    // called (e.g. resubmit or generate_digest)
+    BMV2::nextId("field_lists");
     jsonTop.emplace("errors", json->errors);
     jsonTop.emplace("enums", json->enums);
     jsonTop.emplace("parsers", json->parsers);

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -55,7 +55,7 @@ struct standard_metadata_t {
     @alias("intrinsic_metadata.ingress_global_timestamp") bit<48> ingress_global_timestamp;
     @alias("intrinsic_metadata.lf_field_list") bit<32> lf_field_list;
     @alias("intrinsic_metadata.mcast_grp")     bit<16> mcast_grp;
-    @alias("intrinsic_metadata.resubmit_flag") bit<1>  resubmit_flag;
+    @alias("intrinsic_metadata.resubmit_flag") bit<32> resubmit_flag;
     @alias("intrinsic_metadata.egress_rid")    bit<16> egress_rid;
     /// Indicates that a verify_checksum() method has failed.
     bit<1>  checksum_error;


### PR DESCRIPTION
Just like for learn lists, field list ids (which are used for resubmit)
need to be non-zero, since the id is actually used as a flag to indicate
whether or not resubmit was invoked.

Given that the "resubmit_flag" v1model metadata field is supposed to
hold a field list id, its bitwidth was increased from 1 to 32.