### PR TITLE
P4_14->alternate architecture conversion

### DIFF
--- a/frontends/p4/evaluator/evaluator.cpp
+++ b/frontends/p4/evaluator/evaluator.cpp
@@ -247,6 +247,14 @@ bool Evaluator::preorder(const IR::ConstructorCallExpression* expr) {
     return false;
 }
 
+bool Evaluator::preorder(const IR::MethodCallExpression* expr) {
+    // Experimental: extern function or method call with constant arguments that
+    // returns an extern instance as a factory method
+    LOG2("Evaluating " << dbp(expr));
+    setValue(expr, new IR::CompileTimeMethodCall(expr));
+    return false;
+}
+
 bool Evaluator::preorder(const IR::P4Table* table) {
     LOG2("Evaluating " << dbp(table));
     auto block = new IR::TableBlock(table->srcInfo, table, table);

--- a/frontends/p4/evaluator/evaluator.h
+++ b/frontends/p4/evaluator/evaluator.h
@@ -60,6 +60,7 @@ class Evaluator final : public Inspector, public IHasBlock {
     bool preorder(const IR::P4Table* table) override;
     bool preorder(const IR::Declaration_Instance* inst) override;
     bool preorder(const IR::ConstructorCallExpression* inst) override;
+    bool preorder(const IR::MethodCallExpression* inst) override;
     bool preorder(const IR::PathExpression* expression) override;
     bool preorder(const IR::Property* prop) override;
     bool preorder(const IR::Member* expression) override;

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -1073,9 +1073,16 @@ class RemoveAnnotatedFields : public Transform {
 
 ///////////////////////////////////////////////////////////////
 
+static ProgramStructure *defaultCreateProgramStructure() {
+    return new ProgramStructure();
+}
+
+ProgramStructure *(*Converter::createProgramStructure)() = defaultCreateProgramStructure;
+
 Converter::Converter() {
     setStopOnError(true); setName("Converter");
-    structure.populateOutputNames();
+    structure = createProgramStructure();
+    structure->populateOutputNames();
 
     // Discover types using P4-14 type-checker
     passes.emplace_back(new DetectDuplicates());
@@ -1084,11 +1091,11 @@ Converter::Converter() {
     passes.emplace_back(new AdjustLengths());
     passes.emplace_back(new TypeCheck());
     // Convert
-    passes.emplace_back(new DiscoverStructure(&structure));
-    passes.emplace_back(new ComputeCallGraph(&structure));
-    passes.emplace_back(new ComputeTableCallGraph(&structure));
-    passes.emplace_back(new Rewriter(&structure));
-    passes.emplace_back(new FixExtracts(&structure));
+    passes.emplace_back(new DiscoverStructure(structure));
+    passes.emplace_back(new ComputeCallGraph(structure));
+    passes.emplace_back(new ComputeTableCallGraph(structure));
+    passes.emplace_back(new Rewriter(structure));
+    passes.emplace_back(new FixExtracts(structure));
     passes.emplace_back(new RemoveAnnotatedFields);
 }
 

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -153,11 +153,12 @@ class PrimitiveConverter {
 
 // Is fed a P4-14 program and outputs an equivalent P4-16 program
 class Converter : public PassManager {
-    ProgramStructure structure;
+    ProgramStructure *structure;
 
  public:
+    static ProgramStructure *(*createProgramStructure)();
     Converter();
-    void loadModel() { structure.loadModel(); }
+    void loadModel() { structure->loadModel(); }
     Visitor::profile_t init_apply(const IR::Node* node) override;
 };
 

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -168,7 +168,7 @@ class ProgramStructure {
     IR::IndexedVector<IR::Node>* declarations;
 
  protected:
-    const IR::Statement* convertPrimitive(const IR::Primitive* primitive);
+    virtual const IR::Statement* convertPrimitive(const IR::Primitive* primitive);
     void checkHeaderType(const IR::Type_StructLike* hrd, bool toStruct);
 
     /**
@@ -199,31 +199,34 @@ class ProgramStructure {
     static const IR::Annotations*
     addGlobalNameAnnotation(cstring name, const IR::Annotations* annos = nullptr);
 
-    const IR::ParserState* convertParser(const IR::V1Parser*, IR::IndexedVector<IR::Declaration>*);
-    const IR::Statement* convertParserStatement(const IR::Expression* expr);
-    const IR::P4Control* convertControl(const IR::V1Control* control, cstring newName);
-    const IR::Declaration_Instance* convertDirectMeter(const IR::Meter* m, cstring newName);
-    const IR::Declaration_Instance* convertDirectCounter(const IR::Counter* m, cstring newName);
-    const IR::Declaration_Instance* convert(const IR::CounterOrMeter* cm, cstring newName);
-    const IR::Declaration_Instance* convertActionProfile(const IR::ActionProfile *,
+    virtual const IR::ParserState*
+        convertParser(const IR::V1Parser*, IR::IndexedVector<IR::Declaration>*);
+    virtual const IR::Statement* convertParserStatement(const IR::Expression* expr);
+    virtual const IR::P4Control* convertControl(const IR::V1Control* control, cstring newName);
+    virtual const IR::Declaration_Instance* convertDirectMeter(const IR::Meter* m, cstring newName);
+    virtual const IR::Declaration_Instance*
+        convertDirectCounter(const IR::Counter* m, cstring newName);
+    virtual const IR::Declaration_Instance* convert(const IR::CounterOrMeter* cm, cstring newName);
+    virtual const IR::Declaration_Instance* convertActionProfile(const IR::ActionProfile *,
                                                          cstring newName);
-    const IR::P4Table*
-    convertTable(const IR::V1Table* table, cstring newName,
-                 IR::IndexedVector<IR::Declaration> &stateful, std::map<cstring, cstring> &);
-    const IR::P4Action* convertAction(const IR::ActionFunction* action, cstring newName,
-                                      const IR::Meter* meterToAccess, cstring counterToAccess);
+    virtual const IR::P4Table*
+        convertTable(const IR::V1Table* table, cstring newName,
+                     IR::IndexedVector<IR::Declaration> &stateful, std::map<cstring, cstring> &);
+    virtual const IR::P4Action*
+        convertAction(const IR::ActionFunction* action, cstring newName,
+                      const IR::Meter* meterToAccess, cstring counterToAccess);
     const IR::Type_Control* controlType(IR::ID name);
     const IR::PathExpression* getState(IR::ID dest);
     const IR::Expression* counterType(const IR::CounterOrMeter* cm) const;
-    void createChecksumVerifications();
-    void createChecksumUpdates();
-    void createStructures();
-    cstring createType(const IR::Type_StructLike* type, bool header,
+    virtual void createChecksumVerifications();
+    virtual void createChecksumUpdates();
+    virtual void createStructures();
+    virtual cstring createType(const IR::Type_StructLike* type, bool header,
                        std::unordered_set<const IR::Type*> *converted);
-    void createParser();
-    void createControls();
-    void createDeparser();
-    void createMain();
+    virtual void createParser();
+    virtual void createControls();
+    virtual void createDeparser();
+    virtual void createMain();
 
  public:
     void include(cstring filename, cstring ppoptions = cstring());
@@ -232,14 +235,14 @@ class ProgramStructure {
     void populateOutputNames();
     const IR::AssignmentStatement* assign(Util::SourceInfo srcInfo, const IR::Expression* left,
                                           const IR::Expression* right, const IR::Type* type);
-    const IR::Expression* convertFieldList(const IR::Expression* expression);
-    const IR::Expression* convertHashAlgorithm(IR::ID algorithm);
-    const IR::Expression* convertHashAlgorithms(const IR::NameList *algorithm);
-    const IR::Declaration_Instance* convert(const IR::Register* reg, cstring newName,
-                                            const IR::Type *elementType = nullptr);
-    const IR::Type_Struct* createFieldListType(const IR::Expression* expression);
-    const IR::FieldList* getFieldLists(const IR::FieldListCalculation* flc);
-    const IR::Expression* paramReference(const IR::Parameter* param);
+    virtual const IR::Expression* convertFieldList(const IR::Expression* expression);
+    virtual const IR::Expression* convertHashAlgorithm(IR::ID algorithm);
+    virtual const IR::Expression* convertHashAlgorithms(const IR::NameList *algorithm);
+    virtual const IR::Declaration_Instance* convert(const IR::Register* reg, cstring newName,
+                                                    const IR::Type *elementType = nullptr);
+    virtual const IR::Type_Struct* createFieldListType(const IR::Expression* expression);
+    virtual const IR::FieldList* getFieldLists(const IR::FieldListCalculation* flc);
+    virtual const IR::Expression* paramReference(const IR::Parameter* param);
     const IR::Statement* sliceAssign(Util::SourceInfo srcInfo, const IR::Expression* left,
                                      const IR::Expression* right, const IR::Expression* mask);
     void tablesReferred(const IR::V1Control* control, std::vector<const IR::V1Table*> &out);

--- a/frontends/p4/methodInstance.cpp
+++ b/frontends/p4/methodInstance.cpp
@@ -70,7 +70,12 @@ MethodInstance::resolve(const IR::MethodCallExpression* mce, ReferenceMap* refMa
             } else if (auto pe = mem->expr->to<IR::PathExpression>()) {
                 decl = refMap->getDeclaration(pe->path, true);
                 type = typeMap->getType(decl->getNode());
-            }
+            } else if (auto mc = mem->expr->to<IR::MethodCallExpression>()) {
+                auto mi = resolve(mc, refMap, typeMap, useExpressionType);
+                decl = mi->object;
+                type = mi->actualMethodType->returnType;
+            } else {
+                BUG("unexpected expression %1% resolving method instance", mem->expr); }
             if (type->is<IR::Type_SpecializedCanonical>())
                 type = type->to<IR::Type_SpecializedCanonical>()->substituted->to<IR::Type>();
             BUG_CHECK(type != nullptr, "Could not resolve type for %1%", decl);

--- a/frontends/p4/methodInstance.cpp
+++ b/frontends/p4/methodInstance.cpp
@@ -74,6 +74,10 @@ MethodInstance::resolve(const IR::MethodCallExpression* mce, ReferenceMap* refMa
                 auto mi = resolve(mc, refMap, typeMap, useExpressionType);
                 decl = mi->object;
                 type = mi->actualMethodType->returnType;
+            } else if (auto cce = mem->expr->to<IR::ConstructorCallExpression>()) {
+                auto cc = ConstructorCall::resolve(cce, refMap, typeMap);
+                decl = cc->to<ExternConstructorCall>()->type;
+                type = typeMap->getTypeType(cce->constructedType, true);
             } else {
                 BUG("unexpected expression %1% resolving method instance", mem->expr); }
             if (type->is<IR::Type_SpecializedCanonical>())

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -192,6 +192,10 @@ TypeVariableSubstitution* TypeInference::unify(const IR::Node* errorPosition,
 
     TypeConstraints constraints(typeMap->getSubstitutions());
     constraints.addEqualityConstraint(destType, srcType);
+    if (auto itv = destType->to<IR::ITypeVar>())
+        constraints.addUnifiableTypeVariable(itv);
+    if (auto itv = srcType->to<IR::ITypeVar>())
+        constraints.addUnifiableTypeVariable(itv);
     auto tvs = constraints.solve(errorPosition, reportErrors);
     addSubstitutions(tvs);
     return tvs;

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -192,10 +192,6 @@ TypeVariableSubstitution* TypeInference::unify(const IR::Node* errorPosition,
 
     TypeConstraints constraints(typeMap->getSubstitutions());
     constraints.addEqualityConstraint(destType, srcType);
-    if (auto itv = destType->to<IR::ITypeVar>())
-        constraints.addUnifiableTypeVariable(itv);
-    if (auto itv = srcType->to<IR::ITypeVar>())
-        constraints.addUnifiableTypeVariable(itv);
     auto tvs = constraints.solve(errorPosition, reportErrors);
     addSubstitutions(tvs);
     return tvs;

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -164,7 +164,7 @@ typedef const IR::Type ConstType;
                             argument simpleKeysetExpression
                             transitionStatement switchLabel
 %type<ConstType*>           baseType typeOrVoid specializedType headerStackType
-                            typeRef tupleType typeArg valueSetType
+                            typeRef tupleType typeArg realTypeArg valueSetType
 %type<IR::Type_Name*>       typeName
 %type<IR::Parameter*>       parameter
 %type<OptionalConst>        optCONST
@@ -189,7 +189,7 @@ typedef const IR::Type ConstType;
                                            parserStatements
 %type<IR::SwitchCase*>      switchCase
 %type<IR::Vector<IR::SwitchCase>*>  switchCases
-%type<IR::Vector<IR::Type>*>  typeArgumentList
+%type<IR::Vector<IR::Type>*>  typeArgumentList realTypeArgumentList
 %type<IR::ParserState*>     parserState
 %type<IR::IndexedVector<IR::ParserState>*>  parserStates
 %type<IR::Declaration*>     constantDeclaration actionDeclaration
@@ -637,12 +637,26 @@ typeParameterList
 
 typeArg
     : typeRef                     { $$ = $1; }
+    | nonTypeName                      { $$ = new IR::Type_Name(@1, new IR::Path(*$1)); }
+        // This is necessary because template arguments may introduce the return type
     | "_"                         { $$ = new IR::Type_Dontcare(@1); }
     ;
 
 typeArgumentList
     : typeArg                        { $$ = new IR::Vector<IR::Type>(); $$->push_back($1); }
     | typeArgumentList "," typeArg   { $$ = $1; $$->push_back($3); }
+    ;
+
+realTypeArg
+    : typeRef                     { $$ = $1; }
+    | "_"                         { $$ = new IR::Type_Dontcare(@1); }
+    ;
+
+// For use in contexts where the `<` might be a less-than rather than introducing a type
+// argument list -- we only allow the token after `<` to be a TYPE, not an ID
+realTypeArgumentList
+    : realTypeArg                        { $$ = new IR::Vector<IR::Type>(); $$->push_back($1); }
+    | realTypeArgumentList "," typeArg   { $$ = $1; $$->push_back($3); }
     ;
 
 typeDeclaration
@@ -1021,7 +1035,7 @@ expression
     | expression "&&" expression         { $$ = new IR::LAnd(@1 + @2 + @3, $1, $3); }
     | expression "||" expression         { $$ = new IR::LOr(@1 + @2 + @3, $1, $3); }
     | expression "?" expression ":" expression { $$ = new IR::Mux(@1 + @5, $1, $3, $5); }
-    | expression "<" typeArgumentList ">" "(" argumentList ")"
+    | expression "<" realTypeArgumentList ">" "(" argumentList ")"
         { $$ = new IR::MethodCallExpression(@1 + @4, $1, $3, $6); }
     // FIXME: the previous rule has the wrong precedence, and parses with
     // precedence weaker than casts.  There is no easy way to fix this in bison.

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -359,4 +359,14 @@ class ListCompileTimeValue : CompileTimeValue {
 #nodbprint
 }
 
+/// Experimental: an extern methond/function call with constant arguments to be
+/// evaluated at compile time
+class CompileTimeMethodCall : MethodCallExpression, CompileTimeValue {
+    CompileTimeMethodCall(MethodCallExpression e) : MethodCallExpression(*e) {}
+    validate {
+        for (auto v : *arguments)
+            BUG_CHECK(v->is<CompileTimeValue>(), "%1%: not a compile-time value", v); }
+#nodbprint
+}
+
 /** @} *//* end group irdefs */

--- a/lib/log.cpp
+++ b/lib/log.cpp
@@ -78,6 +78,20 @@ static bool match(const char *pattern, const char *name) {
         if (pattern == pend) {
             if (!strcmp(name, ".cpp")) return true;
             return *name == 0; }
+        if (*pattern == '[') {
+            bool negate = false;
+            if (pattern[1] == '^') {
+                negate = true;
+                ++pattern; }
+            while ((*++pattern != *name || pattern[1] == '-') && *pattern != ']' && *pattern) {
+                if (pattern[1] == '-' && pattern[2] != ']') {
+                    if (*name >= pattern[0] && *name <= pattern[2]) break;
+                    pattern += 2; } }
+            if ((*pattern == ']' || !*pattern) ^ negate) return false;
+            while (*pattern && *pattern++ != ']') continue;
+            if (pattern > pend) pend = pattern + strcspn(pattern, ",:");
+            name++;
+            continue; }
         if (*pattern++ != '*') return false;
         if (pattern == pend) return true;
         while (*name && *name != *pattern) {

--- a/testdata/p4_16_errors/factory-err2.p4
+++ b/testdata/p4_16_errors/factory-err2.p4
@@ -13,28 +13,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#include <core.p4>
 
-extern hash_function<O, T> {
-    // FIXME -- needs to be a way to do this with T a type param of hash
-    // instead of hash_function
-    O hash(in T data);
+extern widget<T> { }
+
+extern widget<T> createWidget<T, U>(U a, T b);
+
+header hdr_t {
+    bit<16>     f1;
+    bit<16>     f2;
+    bit<16>     f3;
 }
 
-extern hash_function<O, T> crc_poly<O, T>(O poly);
+control c1<T>(inout hdr_t hdr)(widget<T> w) { apply {} }
 
-header h1_t {
-    bit<32>     f1;
-    bit<32>     f2;
-    bit<32>     f3;
-}
-
-struct hdrs {
-    h1_t        h1;
-    bit<16>     crc;
-}
-
-control test(inout hdrs hdr) {
+control c2(inout hdr_t hdr) {
+    c1<bit<16>>(createWidget(hdr.f1, hdr.f2)) c;  // factory args must be constants
     apply {
-        hdr.crc = crc_poly<bit<16>, h1_t>(16w0x801a).hash(hdr.h1);
+        c.apply(hdr);
     }
 }

--- a/testdata/p4_16_errors_outputs/constructor1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor1_e.p4-stderr
@@ -1,4 +1,4 @@
-constructor1_e.p4(18):syntax error, unexpected IDENTIFIER "T"
-    Y<T
-      ^
+constructor1_e.p4(18):syntax error, unexpected (
+    Y<T>(
+        ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/factory-err2.p4
+++ b/testdata/p4_16_errors_outputs/factory-err2.p4
@@ -1,0 +1,24 @@
+#include <core.p4>
+
+extern widget<T> {
+}
+
+extern widget<T> createWidget<T, U>(U a, T b);
+header hdr_t {
+    bit<16> f1;
+    bit<16> f2;
+    bit<16> f3;
+}
+
+control c1<T>(inout hdr_t hdr)(widget<T> w) {
+    apply {
+    }
+}
+
+control c2(inout hdr_t hdr) {
+    c1<bit<16>>(createWidget(hdr.f1, hdr.f2)) c;
+    apply {
+        c.apply(hdr);
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/factory-err2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/factory-err2.p4-stderr
@@ -1,0 +1,9 @@
+factory-err2.p4(31): error: : not a compile-time constant when binding to a
+    c1<bit<16>>(createWidget(hdr.f1, hdr.f2)) c; // factory args must be constants
+                             ^^^^^^
+factory-err2.p4(20)
+extern widget<T> createWidget<T, U>(U a, T b);
+                                      ^
+factory-err2.p4(31): error: createWidget: cannot evaluate to a compile-time constant
+    c1<bit<16>>(createWidget(hdr.f1, hdr.f2)) c; // factory args must be constants
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue345.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue345.p4-stderr
@@ -1,4 +1,4 @@
-issue345.p4(19): error: h: Cannot unify type int with H
+issue345.p4(19): error: h: Cannot unify type H with int
         H h = 0;
         ^^^^^^^^
 issue345.p4(17)

--- a/testdata/p4_16_errors_outputs/issue345.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue345.p4-stderr
@@ -1,4 +1,4 @@
-issue345.p4(19): error: h: Cannot unify type H with int
+issue345.p4(19): error: h: Cannot unify type int with H
         H h = 0;
         ^^^^^^^^
 issue345.p4(17)

--- a/testdata/p4_16_errors_outputs/type-params_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-params_e.p4-stderr
@@ -1,4 +1,3 @@
-type-params_e.p4(18):syntax error, unexpected IDENTIFIER "D"
-package m(p<D
+type-params_e.p4(18): error: Could not find declaration for D
+package m(p<D> m);
             ^
-error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_samples/extern2.p4
+++ b/testdata/p4_16_samples/extern2.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Barefoot Networks, Inc.
+Copyright 2018 Barefoot Networks, Inc. 
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,27 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-extern hash_function<O, T> {
-    // FIXME -- needs to be a way to do this with T a type param of hash
-    // instead of hash_function
-    O hash(in T data);
+extern ext<H> {
+    ext(H v);
+    void method<T>(H h, T t);
 }
 
-extern hash_function<O, T> crc_poly<O, T>(O poly);
-
-header h1_t {
-    bit<32>     f1;
-    bit<32>     f2;
-    bit<32>     f3;
-}
-
-struct hdrs {
-    h1_t        h1;
-    bit<16>     crc;
-}
-
-control test(inout hdrs hdr) {
+control c() {
+    ext<bit<16>>(16w0) x;
     apply {
-        hdr.crc = crc_poly<bit<16>, h1_t>(16w0x801a).hash(hdr.h1);
+        x.method(0, 8w0);
     }
 }

--- a/testdata/p4_16_samples/factory1.p4
+++ b/testdata/p4_16_samples/factory1.p4
@@ -1,0 +1,28 @@
+/*
+Copyright 2018 Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <core.p4>
+
+extern widget { }
+
+extern widget createWidget<T, U>(U a, T b);
+
+parser P();
+parser p1()(widget w) {
+    state start { transition accept; } }
+
+package sw0(P p);
+
+sw0(p1(createWidget(16w0, 8w0))) main;

--- a/testdata/p4_16_samples/factory2.p4
+++ b/testdata/p4_16_samples/factory2.p4
@@ -13,28 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#include <core.p4>
 
-extern hash_function<O, T> {
-    // FIXME -- needs to be a way to do this with T a type param of hash
-    // instead of hash_function
-    O hash(in T data);
-}
+extern widget<T> { }
 
-extern hash_function<O, T> crc_poly<O, T>(O poly);
+extern widget<T> createWidget<T, U>(U a, T b);
 
-header h1_t {
-    bit<32>     f1;
-    bit<32>     f2;
-    bit<32>     f3;
-}
+parser P();
+parser p1()(widget<bit<8>> w) {
+    state start { transition accept; } }
 
-struct hdrs {
-    h1_t        h1;
-    bit<16>     crc;
-}
+package sw0(P p);
 
-control test(inout hdrs hdr) {
-    apply {
-        hdr.crc = crc_poly<bit<16>, h1_t>(16w0x801a).hash(hdr.h1);
-    }
-}
+sw0(p1(createWidget(16w0, 8w0))) main;

--- a/testdata/p4_16_samples/hashext.p4
+++ b/testdata/p4_16_samples/hashext.p4
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+extern hash_function<O> {
+    O hash<T>(in T data);
+}
+
+extern hash_function<T> crc_poly<T>(T poly);
+
+header h1_t {
+    bit<32>     f1;
+    bit<32>     f2;
+    bit<32>     f3;
+}
+
+struct hdrs {
+    h1_t        h1;
+    bit<16>     crc;
+}
+
+control test(inout hdrs hdr) {
+    apply {
+        hdr.crc = crc_poly(16w0x801a).hash(hdr.h1);
+    }
+}

--- a/testdata/p4_16_samples/hashext2.p4
+++ b/testdata/p4_16_samples/hashext2.p4
@@ -14,13 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-extern hash_function<O, T> {
-    // FIXME -- needs to be a way to do this with T a type param of hash
-    // instead of hash_function
-    O hash(in T data);
+extern crc_poly<O> {
+    crc_poly(O poly);
+    O hash<T>(in T data);
 }
-
-extern hash_function<O, T> crc_poly<O, T>(O poly);
 
 header h1_t {
     bit<32>     f1;
@@ -35,6 +32,6 @@ struct hdrs {
 
 control test(inout hdrs hdr) {
     apply {
-        hdr.crc = crc_poly<bit<16>, h1_t>(16w0x801a).hash(hdr.h1);
+        hdr.crc = crc_poly<bit<16>>(16w0x801a).hash(hdr.h1);
     }
 }

--- a/testdata/p4_16_samples_outputs/factory1-first.p4
+++ b/testdata/p4_16_samples_outputs/factory1-first.p4
@@ -1,0 +1,16 @@
+#include <core.p4>
+
+extern widget {
+}
+
+extern widget createWidget<T, U>(U a, T b);
+parser P();
+parser p1()(widget w) {
+    state start {
+        transition accept;
+    }
+}
+
+package sw0(P p);
+sw0(p1(createWidget<bit<8>, bit<16>>(16w0, 8w0))) main;
+

--- a/testdata/p4_16_samples_outputs/factory1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/factory1-frontend.p4
@@ -1,0 +1,16 @@
+#include <core.p4>
+
+extern widget {
+}
+
+extern widget createWidget<T, U>(U a, T b);
+parser P();
+parser p1()(widget w) {
+    state start {
+        transition accept;
+    }
+}
+
+package sw0(P p);
+sw0(p1(createWidget<bit<8>, bit<16>>(16w0, 8w0))) main;
+

--- a/testdata/p4_16_samples_outputs/factory1-midend.p4
+++ b/testdata/p4_16_samples_outputs/factory1-midend.p4
@@ -1,0 +1,16 @@
+#include <core.p4>
+
+extern widget {
+}
+
+extern widget createWidget<T, U>(U a, T b);
+parser P();
+parser p1()(widget w) {
+    state start {
+        transition accept;
+    }
+}
+
+package sw0(P p);
+sw0(p1(createWidget<bit<8>, bit<16>>(16w0, 8w0))) main;
+

--- a/testdata/p4_16_samples_outputs/factory1.p4
+++ b/testdata/p4_16_samples_outputs/factory1.p4
@@ -1,0 +1,16 @@
+#include <core.p4>
+
+extern widget {
+}
+
+extern widget createWidget<T, U>(U a, T b);
+parser P();
+parser p1()(widget w) {
+    state start {
+        transition accept;
+    }
+}
+
+package sw0(P p);
+sw0(p1(createWidget(16w0, 8w0))) main;
+

--- a/testdata/p4_16_samples_outputs/hashext-first.p4
+++ b/testdata/p4_16_samples_outputs/hashext-first.p4
@@ -1,8 +1,8 @@
-extern hash_function<O> {
-    O hash<T>(in T data);
+extern hash_function<O, T> {
+    O hash(in T data);
 }
 
-extern hash_function<T> crc_poly<T>(T poly);
+extern hash_function<O, T> crc_poly<O, T>(O poly);
 header h1_t {
     bit<32> f1;
     bit<32> f2;
@@ -16,7 +16,7 @@ struct hdrs {
 
 control test(inout hdrs hdr) {
     apply {
-        hdr.crc = (crc_poly<bit<16>>(16w0x801a)).hash<h1_t>(hdr.h1);
+        hdr.crc = (crc_poly<bit<16>, h1_t>(16w0x801a)).hash(hdr.h1);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/hashext-first.p4
+++ b/testdata/p4_16_samples_outputs/hashext-first.p4
@@ -1,0 +1,22 @@
+extern hash_function<O> {
+    O hash<T>(in T data);
+}
+
+extern hash_function<T> crc_poly<T>(T poly);
+header h1_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<32> f3;
+}
+
+struct hdrs {
+    h1_t    h1;
+    bit<16> crc;
+}
+
+control test(inout hdrs hdr) {
+    apply {
+        hdr.crc = (crc_poly<bit<16>>(16w0x801a)).hash<h1_t>(hdr.h1);
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/hashext-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hashext-frontend.p4
@@ -1,0 +1,15 @@
+extern hash_function<O> {
+    O hash<T>(in T data);
+}
+
+header h1_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<32> f3;
+}
+
+struct hdrs {
+    h1_t    h1;
+    bit<16> crc;
+}
+

--- a/testdata/p4_16_samples_outputs/hashext.p4
+++ b/testdata/p4_16_samples_outputs/hashext.p4
@@ -1,0 +1,22 @@
+extern hash_function<O> {
+    O hash<T>(in T data);
+}
+
+extern hash_function<T> crc_poly<T>(T poly);
+header h1_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<32> f3;
+}
+
+struct hdrs {
+    h1_t    h1;
+    bit<16> crc;
+}
+
+control test(inout hdrs hdr) {
+    apply {
+        hdr.crc = crc_poly(16w0x801a).hash(hdr.h1);
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/hashext.p4
+++ b/testdata/p4_16_samples_outputs/hashext.p4
@@ -1,8 +1,8 @@
-extern hash_function<O> {
-    O hash<T>(in T data);
+extern hash_function<O, T> {
+    O hash(in T data);
 }
 
-extern hash_function<T> crc_poly<T>(T poly);
+extern hash_function<O, T> crc_poly<O, T>(O poly);
 header h1_t {
     bit<32> f1;
     bit<32> f2;
@@ -16,7 +16,7 @@ struct hdrs {
 
 control test(inout hdrs hdr) {
     apply {
-        hdr.crc = crc_poly(16w0x801a).hash(hdr.h1);
+        hdr.crc = (crc_poly<bit<16>, h1_t>(16w0x801a)).hash(hdr.h1);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/hashext.p4-stderr
+++ b/testdata/p4_16_samples_outputs/hashext.p4-stderr
@@ -1,0 +1,1 @@
+warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/hashext2-first.p4
+++ b/testdata/p4_16_samples_outputs/hashext2-first.p4
@@ -1,0 +1,22 @@
+extern crc_poly<O> {
+    crc_poly(O poly);
+    O hash<T>(in T data);
+}
+
+header h1_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<32> f3;
+}
+
+struct hdrs {
+    h1_t    h1;
+    bit<16> crc;
+}
+
+control test(inout hdrs hdr) {
+    apply {
+        hdr.crc = crc_poly<bit<16>>(16w0x801a).hash<h1_t>(hdr.h1);
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/hashext2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hashext2-frontend.p4
@@ -1,5 +1,6 @@
-extern hash_function<O, T> {
-    O hash(in T data);
+extern crc_poly<O> {
+    crc_poly(O poly);
+    O hash<T>(in T data);
 }
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/hashext2.p4
+++ b/testdata/p4_16_samples_outputs/hashext2.p4
@@ -1,0 +1,22 @@
+extern crc_poly<O> {
+    crc_poly(O poly);
+    O hash<T>(in T data);
+}
+
+header h1_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<32> f3;
+}
+
+struct hdrs {
+    h1_t    h1;
+    bit<16> crc;
+}
+
+control test(inout hdrs hdr) {
+    apply {
+        hdr.crc = crc_poly<bit<16>>(16w0x801a).hash(hdr.h1);
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/hashext2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/hashext2.p4-stderr
@@ -1,0 +1,1 @@
+warning: Program does not contain a `main' module


### PR DESCRIPTION
- initial work to split P4_14->16 conversion into a base converted with architecture specific subclass conversion, to allow for eventual P4_14->PSA conversion as well as target-specific architectures
- experimental support for extern functions with constant args returning extern instances (factory methods)