### PR TITLE
Add egress timestamp to v1model's metadata fields

### DIFF
--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -53,6 +53,7 @@ struct standard_metadata_t {
     @alias("queueing_metadata.deq_qdepth")    bit<19> deq_qdepth;
     // intrinsic metadata
     @alias("intrinsic_metadata.ingress_global_timestamp") bit<48> ingress_global_timestamp;
+    @alias("intrinsic_metadata.egress_global_timestamp") bit<48> egress_global_timestamp;
     @alias("intrinsic_metadata.lf_field_list") bit<32> lf_field_list;
     @alias("intrinsic_metadata.mcast_grp")     bit<16> mcast_grp;
     @alias("intrinsic_metadata.resubmit_flag") bit<32> resubmit_flag;

--- a/testdata/p4_16_errors_outputs/issue584.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue584.p4-stderr
@@ -1,6 +1,6 @@
 issue584.p4(28): error: hash: cannot infer bitwidth for integer-valued type parameter M
         hash(var, HashAlgorithm.crc16, 16w0, hdr, 0xFFFF);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-v1model.p4(124)
+v1model.p4(125)
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
                           ^

--- a/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
@@ -30,6 +30,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         smeta.deq_timedelta = smeta_1.deq_timedelta;
         smeta.deq_qdepth = smeta_1.deq_qdepth;
         smeta.ingress_global_timestamp = smeta_1.ingress_global_timestamp;
+        smeta.egress_global_timestamp = smeta_1.egress_global_timestamp;
         smeta.lf_field_list = smeta_1.lf_field_list;
         smeta.mcast_grp = smeta_1.mcast_grp;
         smeta.resubmit_flag = smeta_1.resubmit_flag;

--- a/testdata/p4_16_samples_outputs/issue841.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue841.p4-stderr
@@ -1,6 +1,6 @@
 issue841.p4(39): warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
     Checksum16() checksum;
     ^^^^^^^^^^
-v1model.p4(136)
+v1model.p4(137)
 extern Checksum16 {
        ^^^^^^^^^^


### PR DESCRIPTION
This is to enable the implementation of INT with v1model. This metadata
field does exist in PSA, but until PSA becomes mainstream, it is nice to
have access to the same metadata in v1model.

The egress timestamp is the "time at which the packet began processing
in the egress parser".