### PR TITLE
Support value_set in P4Info generation

### DIFF
--- a/backends/bmv2/parser.cpp
+++ b/backends/bmv2/parser.cpp
@@ -351,14 +351,9 @@ bool ParserConverter::preorder(const IR::P4Parser* parser) {
             if (!inst->type->is<IR::Type_ValueSet>())
                 continue;
             auto value_set = inst->type->to<IR::Type_ValueSet>();
-            unsigned size = 0;
-            if (value_set->elementType->is<IR::Type_Name>()) {
-                auto type = typeMap->getTypeType(value_set->elementType, true);
-                size = type->width_bits();
-            } else {
-                size = value_set->elementType->width_bits();
-            }
-            json->add_parse_vset(s->name, size);
+            auto bitwidth = value_set->width_bits();
+            auto name = inst->controlPlaneName();
+            json->add_parse_vset(name, bitwidth);
         }
     }
 

--- a/backends/bmv2/parser.cpp
+++ b/backends/bmv2/parser.cpp
@@ -259,8 +259,10 @@ unsigned ParserConverter::combine(const IR::Expression* keySet,
             mask = -1;
         return totalWidth;
     } else if (keySet->is<IR::PathExpression>()) {
+        auto pe = keySet->to<IR::PathExpression>();
+        auto decl = refMap->getDeclaration(pe->path, true);
+        vset_name = decl->controlPlaneName();
         is_vset = true;
-        vset_name = keySet->to<IR::PathExpression>()->path->name;
         return totalWidth;
     } else {
         BUG_CHECK(select->components.size() == 1, "%1%: mismatched select/label", select);

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -449,8 +449,8 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                 }
 
                 auto type = new IR::Type_ValueSet(explodeType(sizes));
-                auto decl = new IR::Declaration_Variable(value_set->name,
-                                                         value_set->annotations, type);
+                auto annos = addGlobalNameAnnotation(value_set->name, value_set->annotations);
+                auto decl = new IR::Declaration_Variable(value_set->name, annos, type);
                 stateful->push_back(decl);
             }
             for (auto v : c->values) {

--- a/frontends/p4/hierarchicalNames.cpp
+++ b/frontends/p4/hierarchicalNames.cpp
@@ -33,7 +33,7 @@ const IR::Node* HierarchicalNames::postorder(IR::Annotation* annotation) {
     for (cstring s : stack)
         newName += s + ".";
     newName += name;
-    LOG2("Chaging " << name << " to " << newName);
+    LOG2("Changing " << name << " to " << newName);
     annotation = new IR::Annotation(annotation->name, { new IR::StringLiteral(newName) });
     return annotation;
 }

--- a/frontends/p4/uniqueNames.cpp
+++ b/frontends/p4/uniqueNames.cpp
@@ -88,8 +88,13 @@ IR::ID* RenameSymbols::getName() const {
 
 const IR::Node* RenameSymbols::postorder(IR::Declaration_Variable* decl) {
     auto name = getName();
-    if (name != nullptr && *name != decl->name)
+    if (name != nullptr && *name != decl->name) {
+        if (decl->type->is<IR::Type_ValueSet>()) {
+            auto annos = addNameAnnotation(decl->name, decl->annotations);
+            decl->annotations = annos;
+        }
         decl->name = *name;
+    }
     return decl;
 }
 

--- a/testdata/p4_14_samples_outputs/issue946-first.p4
+++ b/testdata/p4_14_samples_outputs/issue946-first.p4
@@ -16,7 +16,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs;
+    @name(".pvs") value_set<bit<16>> pvs;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/issue946-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue946-frontend.p4
@@ -16,7 +16,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs;
+    @name(".pvs") value_set<bit<16>> pvs;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/issue946-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue946-midend.p4
@@ -16,7 +16,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs;
+    @name(".pvs") value_set<bit<16>> pvs;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/issue946.p4
+++ b/testdata/p4_14_samples_outputs/issue946.p4
@@ -16,7 +16,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs;
+    @name(".pvs") value_set<bit<16>> pvs;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set0-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0-first.p4
@@ -18,8 +18,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs0;
-    value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>> pvs0;
+    @name(".pvs1") value_set<bit<16>> pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set0-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0-frontend.p4
@@ -18,8 +18,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs0;
-    value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>> pvs0;
+    @name(".pvs1") value_set<bit<16>> pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set0-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0-midend.p4
@@ -18,8 +18,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs0;
-    value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>> pvs0;
+    @name(".pvs1") value_set<bit<16>> pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set0.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0.p4
@@ -18,8 +18,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs0;
-    value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>> pvs0;
+    @name(".pvs1") value_set<bit<16>> pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set1-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1-first.p4
@@ -35,8 +35,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs0;
-    value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>> pvs0;
+    @name(".pvs1") value_set<bit<16>> pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1-frontend.p4
@@ -35,8 +35,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs0;
-    value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>> pvs0;
+    @name(".pvs1") value_set<bit<16>> pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set1-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1-midend.p4
@@ -35,8 +35,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs0;
-    value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>> pvs0;
+    @name(".pvs1") value_set<bit<16>> pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set1.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1.p4
@@ -35,8 +35,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    value_set<bit<16>> pvs0;
-    value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>> pvs0;
+    @name(".pvs1") value_set<bit<16>> pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set2-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2-first.p4
@@ -35,7 +35,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @parser_value_set_size(4) value_set<tuple<bit<16>, bit<48>>> pvs0;
+    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>> pvs0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType, hdr.ethernet.srcAddr) {

--- a/testdata/p4_14_samples_outputs/parser_value_set2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2-frontend.p4
@@ -35,7 +35,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @parser_value_set_size(4) value_set<tuple<bit<16>, bit<48>>> pvs0;
+    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>> pvs0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType, hdr.ethernet.srcAddr) {

--- a/testdata/p4_14_samples_outputs/parser_value_set2-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2-midend.p4
@@ -35,7 +35,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @parser_value_set_size(4) value_set<tuple<bit<16>, bit<48>>> pvs0;
+    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>> pvs0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType, hdr.ethernet.srcAddr) {

--- a/testdata/p4_14_samples_outputs/parser_value_set2.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2.p4
@@ -35,7 +35,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @parser_value_set_size(4) value_set<tuple<bit<16>, bit<48>>> pvs0;
+    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>> pvs0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.etherType, hdr.ethernet.srcAddr) {

--- a/testdata/p4_16_samples_outputs/pvs-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-frontend.p4
@@ -5,7 +5,7 @@ header H {
 }
 
 parser p(packet_in pk) {
-    value_set<tuple<bit<32>, bit<2>>> vs;
+    @name("p.vs") value_set<tuple<bit<32>, bit<2>>> vs;
     H h;
     state start {
         pk.extract<H>(h);

--- a/testdata/p4_16_samples_outputs/pvs-midend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-midend.p4
@@ -5,7 +5,7 @@ header H {
 }
 
 parser p(packet_in pk) {
-    value_set<tuple<bit<32>, bit<2>>> vs;
+    @name("p.vs") value_set<tuple<bit<32>, bit<2>>> vs;
     H h;
     state start {
         pk.extract<H>(h);


### PR DESCRIPTION
The P4 syntax may not be set in stone, but people are starting to use parser value sets and require support from the compiler to include the correct information in the P4Info message.