### PR TITLE
Fix parse error reporting in the ir generator

### DIFF
--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -395,6 +395,8 @@ void yyerror(const char *fmt, ...) {
 
 IrDefinitions *parse(char** files, int count) {
     int errors = 0;
+    class IrgenCompileContext : public BaseCompileContext { } ctxt;
+    AutoCompileContext ctxt_ctl(&ctxt);
 #ifdef YYDEBUG
     if (const char *p = getenv("YYDEBUG"))
         yydebug = atoi(p);


### PR DESCRIPTION
- parse errors in the ir generator were causing a BUG_CHECK crash (and
  not reporting the actual error) due the lack of a BaseCompileContext
  for error reporing.