### PR TITLE
Fix ClangTidy complaints about parameter name differences

### DIFF
--- a/frontends/p4/evaluator/evaluator.h
+++ b/frontends/p4/evaluator/evaluator.h
@@ -60,7 +60,7 @@ class Evaluator final : public Inspector, public IHasBlock {
     bool preorder(const IR::P4Table* table) override;
     bool preorder(const IR::Declaration_Instance* inst) override;
     bool preorder(const IR::ConstructorCallExpression* inst) override;
-    bool preorder(const IR::MethodCallExpression* inst) override;
+    bool preorder(const IR::MethodCallExpression* expr) override;
     bool preorder(const IR::PathExpression* expression) override;
     bool preorder(const IR::Property* prop) override;
     bool preorder(const IR::Member* expression) override;

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -207,7 +207,7 @@ class ProgramStructure {
     virtual const IR::P4Control* convertControl(const IR::V1Control* control, cstring newName);
     virtual const IR::Declaration_Instance* convertDirectMeter(const IR::Meter* m, cstring newName);
     virtual const IR::Declaration_Instance*
-        convertDirectCounter(const IR::Counter* m, cstring newName);
+        convertDirectCounter(const IR::Counter* c, cstring newName);
     virtual const IR::Declaration_Instance* convert(const IR::CounterOrMeter* cm, cstring newName);
     virtual const IR::Declaration_Instance* convertActionProfile(const IR::ActionProfile *,
                                                          cstring newName);
@@ -241,7 +241,7 @@ class ProgramStructure {
     virtual const IR::Expression* convertHashAlgorithm(IR::ID algorithm);
     virtual const IR::Expression* convertHashAlgorithms(const IR::NameList *algorithm);
     virtual const IR::Declaration_Instance* convert(const IR::Register* reg, cstring newName,
-                                                    const IR::Type *elementType = nullptr);
+                                                    const IR::Type *regElementType = nullptr);
     virtual const IR::Type_Struct* createFieldListType(const IR::Expression* expression);
     virtual const IR::FieldList* getFieldLists(const IR::FieldListCalculation* flc);
     virtual const IR::Expression* paramReference(const IR::Parameter* param);


### PR DESCRIPTION
Make the .h parameter names match the corresponding .cpp implementation per ClangTidy output.