### PR TITLE
change parser value_set to accept a size argument

### DIFF
--- a/backends/bmv2/parser.cpp
+++ b/backends/bmv2/parser.cpp
@@ -350,8 +350,7 @@ bool ParserConverter::preorder(const IR::P4Parser* parser) {
 
     for (auto s : parser->parserLocals) {
         if (auto inst = s->to<IR::P4ValueSet>()) {
-            auto value_set = inst->type->to<IR::Type_ValueSet>();
-            auto bitwidth = value_set->width_bits();
+            auto bitwidth = inst->elementType->width_bits();
             auto name = inst->controlPlaneName();
             json->add_parse_vset(name, bitwidth);
         }

--- a/backends/bmv2/parser.cpp
+++ b/backends/bmv2/parser.cpp
@@ -349,9 +349,7 @@ bool ParserConverter::preorder(const IR::P4Parser* parser) {
     auto parser_id = json->add_parser("parser");
 
     for (auto s : parser->parserLocals) {
-        if (auto inst = s->to<IR::Declaration_Variable>()) {
-            if (!inst->type->is<IR::Type_ValueSet>())
-                continue;
+        if (auto inst = s->to<IR::P4ValueSet>()) {
             auto value_set = inst->type->to<IR::Type_ValueSet>();
             auto bitwidth = value_set->width_bits();
             auto name = inst->controlPlaneName();

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1227,13 +1227,12 @@ class P4RuntimeAnalyzer {
         // guaranteed by caller
         CHECK_NULL(inst);
 
-        auto pvsType = inst->type->to<IR::Type_ValueSet>();
-        auto bitwidth = static_cast<uint32_t>(pvsType->width_bits());
+        auto bitwidth = static_cast<uint32_t>(inst->elementType->width_bits());
 
         auto name = inst->controlPlaneName();
 
         unsigned int size = 0;
-        auto sizeConstant = inst->expression->to<IR::Constant>();
+        auto sizeConstant = inst->size->to<IR::Constant>();
         if (sizeConstant == nullptr || !sizeConstant->fitsInt()) {
             ::error("@size should be an integer for declaration %1%", inst);
             return;
@@ -1593,9 +1592,7 @@ static void collectParserSymbols(P4RuntimeSymbolTable& symbols,
     CHECK_NULL(parser);
 
     for (auto s : parser->parserLocals) {
-        if (auto inst = s->to<IR::Declaration_Variable>()) {
-            if (!inst->type->is<IR::Type_ValueSet>())
-                continue;
+        if (auto inst = s->to<IR::P4ValueSet>()) {
             symbols.add(P4RuntimeSymbolType::VALUE_SET, inst);
         }
     }

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1223,11 +1223,9 @@ class P4RuntimeAnalyzer {
         addAnnotations(profile->mutable_preamble(), actionProfile.annotations);
     }
 
-    void addValueSet(const IR::Declaration_Variable* inst) {
+    void addValueSet(const IR::P4ValueSet* inst) {
         // guaranteed by caller
         CHECK_NULL(inst);
-        BUG_CHECK(inst->type->is<IR::Type_ValueSet>(),
-                  "variable %1% is not of type value_set", inst);
 
         auto pvsType = inst->type->to<IR::Type_ValueSet>();
         auto bitwidth = static_cast<uint32_t>(pvsType->width_bits());
@@ -1235,23 +1233,16 @@ class P4RuntimeAnalyzer {
         auto name = inst->controlPlaneName();
 
         unsigned int size = 0;
-        auto sizeAnnotation = inst->getAnnotation("size");
-        if (sizeAnnotation) {
-            if (sizeAnnotation->expr.size() != 1) {
-                ::error("@size should be an integer for declaration %1%", inst);
-                return;
-            }
-            auto sizeConstant = sizeAnnotation->expr[0]->to<IR::Constant>();
-            if (sizeConstant == nullptr || !sizeConstant->fitsInt()) {
-                ::error("@size should be an integer for declaration %1%", inst);
-                return;
-            }
-            if (sizeConstant->value < 0) {
-                ::error("@size should be a positive integer for declaration %1%", inst);
-                return;
-            }
-            size = sizeConstant->value.get_ui();
+        auto sizeConstant = inst->expression->to<IR::Constant>();
+        if (sizeConstant == nullptr || !sizeConstant->fitsInt()) {
+            ::error("@size should be an integer for declaration %1%", inst);
+            return;
         }
+        if (sizeConstant->value < 0) {
+            ::error("@size should be a positive integer for declaration %1%", inst);
+            return;
+        }
+        size = sizeConstant->value.get_ui();
 
         auto vs = p4Info->add_value_sets();
         auto id = symbols.getId(P4RuntimeSymbolType::VALUE_SET, name);
@@ -1805,9 +1796,7 @@ static void analyzeParser(P4RuntimeAnalyzer& analyzer,
     CHECK_NULL(parser);
 
     for (auto s : parser->parserLocals) {
-        if (auto inst = s->to<IR::Declaration_Variable>()) {
-            if (!inst->type->is<IR::Type_ValueSet>())
-                continue;
+        if (auto inst = s->to<IR::P4ValueSet>()) {
             analyzer.addValueSet(inst);
         }
     }

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1228,7 +1228,6 @@ class P4RuntimeAnalyzer {
         CHECK_NULL(inst);
 
         auto bitwidth = static_cast<uint32_t>(inst->elementType->width_bits());
-
         auto name = inst->controlPlaneName();
 
         unsigned int size = 0;

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -448,7 +448,7 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                     return nullptr;
                 }
 
-                auto type = new IR::Type_ValueSet(explodeType(sizes));
+                auto type = explodeType(sizes);
                 auto sizeAnnotation = value_set->getAnnotation("size");
                 const IR::Constant* sizeConstant;
                 if (sizeAnnotation) {

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -465,7 +465,9 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                     WARNING("parser_value_set has no @size annotation, default to @size(4).");
                     sizeConstant = new IR::Constant(4);
                 }
-                auto decl = new IR::P4ValueSet(value_set->name, type, sizeConstant);
+                auto annos = addGlobalNameAnnotation(value_set->name, value_set->annotations);
+                auto decl = new IR::P4ValueSet(value_set->name, annos, type, sizeConstant);
+                LOG1(decl);
                 stateful->push_back(decl);
             }
             for (auto v : c->values) {

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -265,20 +265,16 @@ bool ToP4::preorder(const IR::Type_Tuple* t) {
     return false;
 }
 
-bool ToP4::preorder(const IR::Type_ValueSet* t) {
-    dump(3);
+bool ToP4::preorder(const IR::P4ValueSet* t) {
+    dump(1);
     builder.append("value_set<");
     auto p4type = t->elementType->getP4Type();
     CHECK_NULL(p4type);
     visit(p4type);
     builder.append(">");
-    return false;
-}
-
-bool ToP4::preorder(const IR::P4ValueSet* t) {
-    dump(1);
-    visit(t->type);
-    visit(t->expression);
+    builder.append("(");
+    visit(t->size);
+    builder.append(")");
     builder.newline();
     return false;
 }

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -267,6 +267,7 @@ bool ToP4::preorder(const IR::Type_Tuple* t) {
 
 bool ToP4::preorder(const IR::P4ValueSet* t) {
     dump(1);
+    visit(t->annotations);
     builder.append("value_set<");
     auto p4type = t->elementType->getP4Type();
     CHECK_NULL(p4type);
@@ -275,7 +276,9 @@ bool ToP4::preorder(const IR::P4ValueSet* t) {
     builder.append("(");
     visit(t->size);
     builder.append(")");
-    builder.newline();
+    builder.spc();
+    builder.append(t->name);
+    builder.endOfStatement();
     return false;
 }
 

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -275,6 +275,14 @@ bool ToP4::preorder(const IR::Type_ValueSet* t) {
     return false;
 }
 
+bool ToP4::preorder(const IR::P4ValueSet* t) {
+    dump(1);
+    visit(t->type);
+    visit(t->expression);
+    builder.newline();
+    return false;
+}
+
 bool ToP4::preorder(const IR::Type_Enum* t) {
     dump(1);
     builder.append("enum ");

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -222,6 +222,7 @@ class ToP4 : public Inspector {
     bool preorder(const IR::EntriesList *l) override;
     bool preorder(const IR::Entry *e) override;
     bool preorder(const IR::P4Table* c) override;
+    bool preorder(const IR::P4ValueSet* c) override;
 
     // in case it is accidentally called on a V1Program
     bool preorder(const IR::V1Program*) override { return false; }

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -142,7 +142,6 @@ class ToP4 : public Inspector {
     bool preorder(const IR::Type_Extern* t) override;
     bool preorder(const IR::Type_Unknown* t) override;
     bool preorder(const IR::Type_Tuple* t) override;
-    bool preorder(const IR::Type_ValueSet* t) override;
 
     // declarations
     bool preorder(const IR::Declaration_Constant* cst) override;

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1166,6 +1166,18 @@ const IR::Node* TypeInference::postorder(IR::Type_ValueSet* type) {
     return type;
 }
 
+const IR::Node* TypeInference::postorder(IR::P4ValueSet* decl) {
+    if (done())
+        return decl;
+    auto type = getTypeType(decl->type);
+    if (type == nullptr)
+        return decl;
+    auto orig = getOriginal<IR::P4ValueSet>();
+    setType(decl, type);
+    setType(orig, type);
+    return decl;
+}
+
 const IR::Node* TypeInference::postorder(IR::Type_Extern* type) {
     if (done()) return type;
     auto canon = setTypeType(type);

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1147,36 +1147,24 @@ const IR::Node* TypeInference::postorder(IR::Type_Set* type) {
     return type;
 }
 
-#if 0
-const IR::Node* TypeInference::postorder(IR::Type_ValueSet* type) {
+const IR::Node* TypeInference::postorder(IR::P4ValueSet* decl) {
+    if (done())
+        return decl;
     // This is a specialized version of setTypeType
-    auto canon = canonicalize(type->elementType);
+    auto canon = canonicalize(decl->elementType);
     if (canon != nullptr) {
         // Learn the new type
-        if (canon != type->elementType) {
+        if (canon != decl->elementType) {
             TypeInference tc(refMap, typeMap, true);
             unsigned e = ::errorCount();
             (void)canon->apply(tc);
             if (::errorCount() > e)
                 return nullptr;
         }
-        auto tt = new IR::Type_Type(new IR::Type_Set(canon));
+        auto tt = new IR::Type_Set(canon);
         setType(getOriginal(), tt);
-        setType(type, tt);
+        setType(decl, tt);
     }
-    return type;
-}
-#endif
-
-const IR::Node* TypeInference::postorder(IR::P4ValueSet* decl) {
-    if (done())
-        return decl;
-    auto type = getTypeType(decl->elementType);
-    if (type == nullptr)
-        return decl;
-    auto orig = getOriginal<IR::P4ValueSet>();
-    setType(decl, type);
-    setType(orig, type);
     return decl;
 }
 

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1147,6 +1147,7 @@ const IR::Node* TypeInference::postorder(IR::Type_Set* type) {
     return type;
 }
 
+#if 0
 const IR::Node* TypeInference::postorder(IR::Type_ValueSet* type) {
     // This is a specialized version of setTypeType
     auto canon = canonicalize(type->elementType);
@@ -1165,11 +1166,12 @@ const IR::Node* TypeInference::postorder(IR::Type_ValueSet* type) {
     }
     return type;
 }
+#endif
 
 const IR::Node* TypeInference::postorder(IR::P4ValueSet* decl) {
     if (done())
         return decl;
-    auto type = getTypeType(decl->type);
+    auto type = getTypeType(decl->elementType);
     if (type == nullptr)
         return decl;
     auto orig = getOriginal<IR::P4ValueSet>();

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -210,6 +210,7 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::Type_ActionEnum* type) override;
     const IR::Node* postorder(IR::P4Table* type) override;
     const IR::Node* postorder(IR::P4Action* type) override;
+    const IR::Node* postorder(IR::P4ValueSet* type) override;
     const IR::Node* postorder(IR::Key* key) override;
     const IR::Node* postorder(IR::Entry* e) override;
 

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -204,7 +204,6 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::Type_SpecializedCanonical* type) override;
     const IR::Node* postorder(IR::Type_Tuple* type) override;
     const IR::Node* postorder(IR::Type_Set* type) override;
-    const IR::Node* postorder(IR::Type_ValueSet* type) override;
     const IR::Node* postorder(IR::Type_ArchBlock* type) override;
     const IR::Node* postorder(IR::Type_Package* type) override;
     const IR::Node* postorder(IR::Type_ActionEnum* type) override;

--- a/frontends/p4/uniqueNames.cpp
+++ b/frontends/p4/uniqueNames.cpp
@@ -89,10 +89,6 @@ IR::ID* RenameSymbols::getName() const {
 const IR::Node* RenameSymbols::postorder(IR::Declaration_Variable* decl) {
     auto name = getName();
     if (name != nullptr && *name != decl->name) {
-        if (decl->type->is<IR::Type_ValueSet>()) {
-            auto annos = addNameAnnotation(decl->name, decl->annotations);
-            decl->annotations = annos;
-        }
         decl->name = *name;
     }
     return decl;
@@ -147,6 +143,16 @@ const IR::Node* RenameSymbols::postorder(IR::P4Table* decl) {
 }
 
 const IR::Node* RenameSymbols::postorder(IR::P4Action* decl) {
+    auto name = getName();
+    if (name != nullptr && *name != decl->name) {
+        auto annos = addNameAnnotation(decl->name, decl->annotations);
+        decl->name = *name;
+        decl->annotations = annos;
+    }
+    return decl;
+}
+
+const IR::Node* RenameSymbols::postorder(IR::P4ValueSet* decl) {
     auto name = getName();
     if (name != nullptr && *name != decl->name) {
         auto annos = addNameAnnotation(decl->name, decl->annotations);

--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -91,6 +91,8 @@ class FindSymbols : public Inspector {
     { doDecl(decl); }
     void postorder(const IR::P4Action* decl) override
     { if (!isTopLevel()) doDecl(decl); }
+    void postorder(const IR::P4ValueSet* decl) override
+    { if (!isTopLevel()) doDecl(decl); }
 };
 
 class RenameSymbols : public Transform {

--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -108,6 +108,7 @@ class RenameSymbols : public Transform {
     const IR::Node* postorder(IR::Declaration_Instance* decl) override;
     const IR::Node* postorder(IR::P4Table* decl) override;
     const IR::Node* postorder(IR::P4Action* decl) override;
+    const IR::Node* postorder(IR::P4ValueSet* decl) override;
     const IR::Node* postorder(IR::Parameter* param) override;
 };
 

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -204,7 +204,6 @@ typedef const IR::Type ConstType;
 %type<IR::Node*>            declaration externDeclaration matchKindDeclaration
 %type<IR::Type_Parser*>     parserTypeDeclaration
 %type<IR::Type_Control*>    controlTypeDeclaration
-%type<IR::Type_ValueSet*>   valueSetType
 %type<IR::IndexedVector<IR::Declaration>*>  parserLocalElements controlLocalDeclarations
 %type<IR::StructField*>     structField
 %type<IR::IndexedVector<IR::StructField>*>  structFieldList
@@ -491,10 +490,17 @@ simpleKeysetExpression
     | "_"                         { $$ = new IR::DefaultExpression(@1); }
     ;
 
+// experimental
 valueSetDeclaration
     : optAnnotations
-        valueSetType "(" argument ")" name ";"
-        { $$ = new IR::P4ValueSet(@6, *$6, $1, $2, $4); }
+        VALUESET "<" baseType ">" "(" argument ")" name ";"
+        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
+    | optAnnotations
+        VALUESET "<" tupleType ">" "(" argument ")" name ";"
+        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
+    | optAnnotations
+        VALUESET "<" typeName ">" "(" argument ")" name ";"
+        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
     ;
 
 /*************************** CONTROL ************************/
@@ -600,13 +606,6 @@ typeName
 
 tupleType
     : TUPLE "<" typeArgumentList ">"    { $$ = new IR::Type_Tuple(@1+@4, *$3); }
-    ;
-
-// experimental
-valueSetType
-    : VALUESET "<" baseType ">"         { $$ = new IR::Type_ValueSet(@1, $3); }
-    | VALUESET "<" tupleType ">"        { $$ = new IR::Type_ValueSet(@1, $3); }
-    | VALUESET "<" typeName ">"         { $$ = new IR::Type_ValueSet(@1, $3); }
     ;
 
 headerStackType

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -164,7 +164,7 @@ typedef const IR::Type ConstType;
                             argument simpleKeysetExpression
                             transitionStatement switchLabel
 %type<ConstType*>           baseType typeOrVoid specializedType headerStackType
-                            typeRef tupleType typeArg realTypeArg valueSetType namedType
+                            typeRef tupleType typeArg realTypeArg namedType
 %type<IR::Type_Name*>       typeName
 %type<IR::Parameter*>       parameter
 %type<OptionalConst>        optCONST
@@ -195,7 +195,7 @@ typedef const IR::Type ConstType;
 %type<IR::Declaration*>     constantDeclaration actionDeclaration
                             variableDeclaration instantiation functionDeclaration
                             objDeclaration tableDeclaration controlLocalDeclaration
-                            parserLocalElement
+                            parserLocalElement valueSetDeclaration
 %type<IR::Type_Declaration*>  headerTypeDeclaration structTypeDeclaration
                               headerUnionDeclaration derivedTypeDeclaration
                               parserDeclaration controlDeclaration enumDeclaration
@@ -204,6 +204,7 @@ typedef const IR::Type ConstType;
 %type<IR::Node*>            declaration externDeclaration matchKindDeclaration
 %type<IR::Type_Parser*>     parserTypeDeclaration
 %type<IR::Type_Control*>    controlTypeDeclaration
+%type<IR::Type_ValueSet*>   valueSetType
 %type<IR::IndexedVector<IR::Declaration>*>  parserLocalElements controlLocalDeclarations
 %type<IR::StructField*>     structField
 %type<IR::IndexedVector<IR::StructField>*>  structFieldList
@@ -397,6 +398,7 @@ parserLocalElement
     : constantDeclaration             { $$ = $1; }
     | instantiation                   { $$ = $1; }
     | variableDeclaration             { $$ = $1; }
+    | valueSetDeclaration             { $$ = $1; }
     ;
 
 parserTypeDeclaration
@@ -489,6 +491,12 @@ simpleKeysetExpression
     | "_"                         { $$ = new IR::DefaultExpression(@1); }
     ;
 
+valueSetDeclaration
+    : optAnnotations
+        valueSetType "(" argument ")" name ";"
+        { $$ = new IR::P4ValueSet(@6, *$6, $1, $2, $4); }
+    ;
+
 /*************************** CONTROL ************************/
 
 controlDeclaration
@@ -573,7 +581,6 @@ typeRef
     | specializedType                  { $$ = $1; }
     | headerStackType                  { $$ = $1; }
     | tupleType                        { $$ = $1; }
-    | valueSetType                     { $$ = $1; }
     ;
 
 namedType

--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -203,7 +203,7 @@ void IR::P4Table::dbprint(std::ostream &out) const {
 
 void IR::P4ValueSet::dbprint(std::ostream &out) const {
     out << "value_set " << name;
-    out << " " << annotations << "(" << expression << ")";
+    out << " " << annotations << "(" << size << ")";
 }
 
 void IR::V1Control::dbprint(std::ostream &out) const {

--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -202,7 +202,7 @@ void IR::P4Table::dbprint(std::ostream &out) const {
 }
 
 void IR::P4ValueSet::dbprint(std::ostream &out) const {
-    out << "value_set " << name;
+    out << "value_set<" << elementType << "> " << name;
     out << " " << annotations << "(" << size << ")";
 }
 

--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -201,6 +201,11 @@ void IR::P4Table::dbprint(std::ostream &out) const {
     out << " }" << unindent;
 }
 
+void IR::P4ValueSet::dbprint(std::ostream &out) const {
+    out << "value_set " << name;
+    out << " " << annotations << "(" << expression << ")";
+}
+
 void IR::V1Control::dbprint(std::ostream &out) const {
     out << "control " << name << " {" << indent << code << unindent << " }";
 }

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -337,8 +337,8 @@ class P4Table : Declaration, IAnnotated, IApply {
 
 class P4ValueSet : Declaration, IAnnotated {
     optional Annotations        annotations = Annotations::empty;
-    Type_ValueSet               type;
-    Expression                  expression;
+    Type                        elementType;
+    Expression                  size;
     Annotations getAnnotations() const override { return annotations; }
 }
 

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -335,6 +335,13 @@ class P4Table : Declaration, IAnnotated, IApply {
     }
 }
 
+class P4ValueSet : Declaration, IAnnotated {
+    optional Annotations        annotations = Annotations::empty;
+    Type_ValueSet               type;
+    Expression                  expression;
+    Annotations getAnnotations() const override { return annotations; }
+}
+
 class Declaration_Variable : Declaration, IAnnotated {
     optional Annotations        annotations = Annotations::empty;
     Type                        type;

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -164,7 +164,4 @@ const Type* Type_SpecializedCanonical::getP4Type() const {
     return new IR::Type_Specialized(srcInfo, baseType->getP4Type()->to<IR::Type_Name>(), args);
 }
 
-const Type* Type_ValueSet::getP4Type() const {
-    return new IR::Type_ValueSet(srcInfo, elementType->getP4Type());
-}
 }  // namespace IR

--- a/ir/type.def
+++ b/ir/type.def
@@ -282,25 +282,6 @@ class Type_Tuple : Type {
     const Type* getP4Type() const override;
 }
 
-/// The type of a parser value set
-class Type_ValueSet : Type {
-    Type elementType;
-    dbprint{ out << "value_set<" << elementType << ">"; }
-    toString{ return cstring("value_set<") + elementType->toString() + ">"; }
-    const Type* getP4Type() const override;
-    int width_bits() const override {
-        int rv = 0;
-        if (auto tuple = elementType->to<IR::Type_Tuple>()) {
-            for (auto f : tuple->components) {
-                rv += f->width_bits();
-            }
-            return rv;
-        } else {
-            return elementType->width_bits();
-        }
-    }
-}
-
 /// The type of an architectural block.
 /// Abstract base for Type_Control, Type_Parser and Type_Package
 abstract Type_ArchBlock : Type_Declaration, IMayBeGenericType, IAnnotated {

--- a/ir/type.def
+++ b/ir/type.def
@@ -280,6 +280,13 @@ class Type_Tuple : Type {
     toString{ return "Tuple(" + Util::toString(components.size()) + ")"; }
     validate{ components.check_null(); }
     const Type* getP4Type() const override;
+    int width_bits() const override {
+        /// returning sum of the width of the tuple elements
+        int rv = 0;
+        for (auto f : components) {
+            rv += f->width_bits();
+        }
+        return rv; }
 }
 
 /// The type of an architectural block.

--- a/midend/eliminateTuples.h
+++ b/midend/eliminateTuples.h
@@ -84,7 +84,7 @@ class DoReplaceTuples final : public Transform {
     { return insertReplacements(ext); }
     const IR::Node* postorder(IR::Declaration_Instance* decl) override
     { return insertReplacements(decl); }
-    const IR::Node* preorder(IR::Type_ValueSet* set) override
+    const IR::Node* preorder(IR::P4ValueSet* set) override
     // Disable substitution of type parameters for value sets.
     // We want to keep these as tuples.
     { prune(); return set; }

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -749,7 +749,7 @@ TEST_F(P4Runtime, ValueSet) {
 
         parser parse(packet_in p, out Headers h, inout Metadata m,
                      inout standard_metadata_t sm) {
-            @size(16) value_set<tuple<bit<32>, bit<16>>> pvs;
+            value_set<tuple<bit<32>, bit<16>>>(16) pvs;
             state start {
                 p.extract(h.h);
                 transition select(h.h.hfA, h.h.hfB) {

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -749,7 +749,7 @@ TEST_F(P4Runtime, ValueSet) {
 
         parser parse(packet_in p, out Headers h, inout Metadata m,
                      inout standard_metadata_t sm) {
-            value_set<tuple<bit<32>, bit<16>>>(16) pvs;
+            @name("pvs") value_set<tuple<bit<32>, bit<16>>>(16) pvs;
             state start {
                 p.extract(h.h);
                 transition select(h.h.hfA, h.h.hfB) {

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -749,7 +749,7 @@ TEST_F(P4Runtime, ValueSet) {
 
         parser parse(packet_in p, out Headers h, inout Metadata m,
                      inout standard_metadata_t sm) {
-            @name("pvs") value_set<tuple<bit<32>, bit<16>>>(16) pvs;
+            value_set<tuple<bit<32>, bit<16>>>(16) pvs;
             state start {
                 p.extract(h.h);
                 transition select(h.h.hfA, h.h.hfB) {

--- a/testdata/p4_14_samples_outputs/issue946-first.p4
+++ b/testdata/p4_14_samples_outputs/issue946-first.p4
@@ -16,7 +16,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs") value_set<bit<16>> pvs;
+    @name(".pvs") value_set<bit<16>>(4) pvs;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/issue946-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue946-frontend.p4
@@ -16,7 +16,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs") value_set<bit<16>> pvs;
+    @name(".pvs") value_set<bit<16>>(4) pvs;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/issue946-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue946-midend.p4
@@ -16,7 +16,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs") value_set<bit<16>> pvs;
+    @name(".pvs") value_set<bit<16>>(4) pvs;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/issue946.p4
+++ b/testdata/p4_14_samples_outputs/issue946.p4
@@ -16,7 +16,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs") value_set<bit<16>> pvs;
+    @name(".pvs") value_set<bit<16>>(4) pvs;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set0-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0-first.p4
@@ -18,8 +18,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs0") value_set<bit<16>> pvs0;
-    @name(".pvs1") value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>>(4) pvs0;
+    @name(".pvs1") value_set<bit<16>>(4) pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set0-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0-frontend.p4
@@ -18,8 +18,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs0") value_set<bit<16>> pvs0;
-    @name(".pvs1") value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>>(4) pvs0;
+    @name(".pvs1") value_set<bit<16>>(4) pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set0-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0-midend.p4
@@ -18,8 +18,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs0") value_set<bit<16>> pvs0;
-    @name(".pvs1") value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>>(4) pvs0;
+    @name(".pvs1") value_set<bit<16>>(4) pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set0.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0.p4
@@ -18,8 +18,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs0") value_set<bit<16>> pvs0;
-    @name(".pvs1") value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>>(4) pvs0;
+    @name(".pvs1") value_set<bit<16>>(4) pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set1-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1-first.p4
@@ -35,8 +35,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs0") value_set<bit<16>> pvs0;
-    @name(".pvs1") value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>>(4) pvs0;
+    @name(".pvs1") value_set<bit<16>>(4) pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1-frontend.p4
@@ -35,8 +35,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs0") value_set<bit<16>> pvs0;
-    @name(".pvs1") value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>>(4) pvs0;
+    @name(".pvs1") value_set<bit<16>>(4) pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set1-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1-midend.p4
@@ -35,8 +35,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs0") value_set<bit<16>> pvs0;
-    @name(".pvs1") value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>>(4) pvs0;
+    @name(".pvs1") value_set<bit<16>>(4) pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set1.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1.p4
@@ -35,8 +35,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".pvs0") value_set<bit<16>> pvs0;
-    @name(".pvs1") value_set<bit<16>> pvs1;
+    @name(".pvs0") value_set<bit<16>>(4) pvs0;
+    @name(".pvs1") value_set<bit<16>>(4) pvs1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_14_samples_outputs/parser_value_set2-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2-first.p4
@@ -35,7 +35,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>> pvs0;
+    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>>(4) pvs0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType, hdr.ethernet.srcAddr) {

--- a/testdata/p4_14_samples_outputs/parser_value_set2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2-frontend.p4
@@ -35,7 +35,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>> pvs0;
+    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>>(4) pvs0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType, hdr.ethernet.srcAddr) {

--- a/testdata/p4_14_samples_outputs/parser_value_set2-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2-midend.p4
@@ -35,7 +35,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>> pvs0;
+    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>>(4) pvs0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType, hdr.ethernet.srcAddr) {

--- a/testdata/p4_14_samples_outputs/parser_value_set2.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2.p4
@@ -35,7 +35,7 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>> pvs0;
+    @parser_value_set_size(4) @name(".pvs0") value_set<tuple<bit<16>, bit<48>>>(4) pvs0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.etherType, hdr.ethernet.srcAddr) {

--- a/testdata/p4_16_samples/pvs.p4
+++ b/testdata/p4_16_samples/pvs.p4
@@ -5,7 +5,7 @@ header H {
 }
 
 parser p(packet_in pk) {
-    value_set<tuple<bit<32>, bit<2>>> vs;
+    value_set<tuple<bit<32>, bit<2>>>(4) vs;
     H h;
 
     state start {

--- a/testdata/p4_16_samples_outputs/pvs-first.p4
+++ b/testdata/p4_16_samples_outputs/pvs-first.p4
@@ -5,7 +5,7 @@ header H {
 }
 
 parser p(packet_in pk) {
-    value_set<tuple<bit<32>, bit<2>>> vs;
+    value_set<tuple<bit<32>, bit<2>>>(4) vs;
     H h;
     state start {
         pk.extract<H>(h);

--- a/testdata/p4_16_samples_outputs/pvs-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-frontend.p4
@@ -6,7 +6,7 @@ header H {
 
 parser p(packet_in pk) {
     H h;
-    value_set<tuple<bit<32>, bit<2>>>(4) vs;
+    @name("p.vs") value_set<tuple<bit<32>, bit<2>>>(4) vs;
     state start {
         pk.extract<H>(h);
         transition select(h.f, 2w2) {

--- a/testdata/p4_16_samples_outputs/pvs-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-frontend.p4
@@ -5,8 +5,8 @@ header H {
 }
 
 parser p(packet_in pk) {
-    @name("p.vs") value_set<tuple<bit<32>, bit<2>>> vs;
     H h;
+    value_set<tuple<bit<32>, bit<2>>>(4) vs;
     state start {
         pk.extract<H>(h);
         transition select(h.f, 2w2) {

--- a/testdata/p4_16_samples_outputs/pvs-midend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-midend.p4
@@ -6,7 +6,7 @@ header H {
 
 parser p(packet_in pk) {
     H h;
-    value_set<tuple<bit<32>, bit<2>>>(4) vs;
+    @name("p.vs") value_set<tuple<bit<32>, bit<2>>>(4) vs;
     state start {
         pk.extract<H>(h);
         transition select(h.f, 2w2) {

--- a/testdata/p4_16_samples_outputs/pvs-midend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-midend.p4
@@ -5,8 +5,8 @@ header H {
 }
 
 parser p(packet_in pk) {
-    @name("p.vs") value_set<tuple<bit<32>, bit<2>>> vs;
     H h;
+    value_set<tuple<bit<32>, bit<2>>>(4) vs;
     state start {
         pk.extract<H>(h);
         transition select(h.f, 2w2) {

--- a/testdata/p4_16_samples_outputs/pvs.p4
+++ b/testdata/p4_16_samples_outputs/pvs.p4
@@ -5,7 +5,7 @@ header H {
 }
 
 parser p(packet_in pk) {
-    value_set<tuple<bit<32>, bit<2>>> vs;
+    value_set<tuple<bit<32>, bit<2>>>(4) vs;
     H h;
     state start {
         pk.extract(h);


### PR DESCRIPTION
Follow up on issue https://github.com/p4lang/p4-spec/issues/565.

This PR implements the proposed syntax for value_set to take a size argument, instead of using `@size` annotation. 

```
value_set<tuple<bit<32>, bit<32>>> (4) pvs;
value_set<bit<32>> (8) pvs;
```