### PR TITLE
Handle "long long" primitive types in lib/json

### DIFF
--- a/test/gtest/json_test.cpp
+++ b/test/gtest/json_test.cpp
@@ -14,10 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <sstream>
+
 #include "gtest/gtest.h"
 #include "lib/json.h"
 
 namespace Util {
+
+template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+static std::string getNumStringRepr(T v) {
+    std::ostringstream sstream;
+    sstream << std::dec << v;
+    return sstream.str();
+}
 
 TEST(Util, Json) {
     IJson* value;
@@ -31,6 +40,15 @@ TEST(Util, Json) {
     EXPECT_EQ("\"5\"", value->toString());
     value = new JsonValue(5);
     EXPECT_EQ("5", value->toString());
+    value = new JsonValue(static_cast<unsigned long long>(123456789000ULL));
+    EXPECT_EQ("123456789000", value->toString());
+    value = new JsonValue(static_cast<long long>(123456789000LL));
+    EXPECT_EQ("123456789000", value->toString());
+    value = new JsonValue(static_cast<long long>(-123456789000LL));
+    EXPECT_EQ("-123456789000", value->toString());
+    auto smallestLongLong = static_cast<long long>(1LL << 63);
+    value = new JsonValue(smallestLongLong);
+    EXPECT_EQ(getNumStringRepr(smallestLongLong), value->toString());
 
     auto arr = new JsonArray();
     arr->append(5);


### PR DESCRIPTION
On some 64-bit sytems, int64 is a typedef to "long long" and not
"long". On those systems, trying to construct a JsonValue object from a
int64 or uint64 triggers a compiler error. In this commit, we add
support for constructing JsonValue objects from "long long" and
"unsigned long long" values. Note that the constructor for GMP's
mpz_class does not support "long long" values so we have to use a
workaround. This commit also makes handling of integral types in
lib/json more generic.

Note that this commit should also help for compiling on 32-bit systems,
where int64 is probably always a typedef to "long long".