### PR TITLE
Allow named arguments in calls; first step: types and grammar

### DIFF
--- a/backends/bmv2/action.cpp
+++ b/backends/bmv2/action.cpp
@@ -76,12 +76,12 @@ ConvertActions::convertActionBody(const IR::Vector<IR::StatOrDecl>* body, Util::
                     prim = "remove_header";
                 } else if (builtin->name == IR::Type_Stack::push_front) {
                     BUG_CHECK(mc->arguments->size() == 1, "Expected 1 argument for %1%", mc);
-                    auto arg = conv->convert(mc->arguments->at(0));
+                    auto arg = conv->convert(mc->arguments->at(0)->expression);
                     prim = "push";
                     parameters->append(arg);
                 } else if (builtin->name == IR::Type_Stack::pop_front) {
                     BUG_CHECK(mc->arguments->size() == 1, "Expected 1 argument for %1%", mc);
-                    auto arg = conv->convert(mc->arguments->at(0));
+                    auto arg = conv->convert(mc->arguments->at(0)->expression);
                     prim = "pop";
                     parameters->append(arg);
                 } else {

--- a/backends/bmv2/deparser.cpp
+++ b/backends/bmv2/deparser.cpp
@@ -47,7 +47,7 @@ void ConvertDeparser::convertDeparserBody(const IR::Vector<IR::StatOrDecl>* body
                             // arrays are expanded into elements.
                             int size = type->to<IR::Type_Stack>()->getSize();
                             for (int i=0; i < size; i++) {
-                                auto j = conv->convert(arg);
+                                auto j = conv->convert(arg->expression);
                                 auto e = j->to<Util::JsonObject>()->get("value");
                                 BUG_CHECK(e->is<Util::JsonValue>(),
                                           "%1%: Expected a Json value", e->toString());
@@ -56,7 +56,7 @@ void ConvertDeparser::convertDeparserBody(const IR::Vector<IR::StatOrDecl>* body
                                 result->append(ref);
                             }
                         } else if (type->is<IR::Type_Header>()) {
-                            auto j = conv->convert(arg);
+                            auto j = conv->convert(arg->expression);
                             auto val = j->to<Util::JsonObject>()->get("value");
                             result->append(val);
                         } else {

--- a/backends/bmv2/extern.cpp
+++ b/backends/bmv2/extern.cpp
@@ -33,13 +33,13 @@ Extern::addExternAttributes(const IR::Declaration_Instance*,  // TODO: Unused pa
             } else {
                 BUG("%1%: unhandled constant constructor param", cVal->toString());
             }
-        } else if (pVal->is<IR::Declaration_ID>()) {
-            auto declId = pVal->to<IR::Declaration_ID>();
-            json->add_extern_attribute(name, "string", declId->name, attributes);
-        } else if (pVal->is<IR::Type_Enum>()) {
-            json->add_extern_attribute(name, "string", pVal->toString(), attributes);
+        } else if (argExpr->is<IR::Declaration_ID>()) {
+            auto declId = argExpr->to<IR::Declaration_ID>();
+            json->add_extern_attribute(name, "string", declId->toString(), attributes);
+        } else if (argExpr->type->is<IR::Type_Enum>()) {
+            json->add_extern_attribute(name, "string", argExpr->toString(), attributes);
         } else {
-            BUG("%1%: unknown constructor param type", p->type);
+            BUG("%1%: unknown constructor param type", argExpr->type);
         }
     }
     return attributes;

--- a/backends/bmv2/extern.cpp
+++ b/backends/bmv2/extern.cpp
@@ -33,13 +33,11 @@ Extern::addExternAttributes(const IR::Declaration_Instance*,  // TODO: Unused pa
             } else {
                 BUG("%1%: unhandled constant constructor param", cVal->toString());
             }
-        } else if (argExpr->is<IR::Declaration_ID>()) {
-            auto declId = argExpr->to<IR::Declaration_ID>();
+        } else if (pVal->is<IR::Declaration_ID>()) {
+            auto declId = pVal->to<IR::Declaration_ID>();
             json->add_extern_attribute(name, "string", declId->toString(), attributes);
-        } else if (argExpr->type->is<IR::Type_Enum>()) {
-            json->add_extern_attribute(name, "string", argExpr->toString(), attributes);
         } else {
-            BUG("%1%: unknown constructor param type", argExpr->type);
+            BUG("%1%: unexpected constructor argument", pVal);
         }
     }
     return attributes;

--- a/backends/bmv2/lower.cpp
+++ b/backends/bmv2/lower.cpp
@@ -166,7 +166,7 @@ RemoveComplexExpressions::createTemporary(const IR::Expression* expression) {
     auto assign = new IR::AssignmentStatement(
         expression->srcInfo, new IR::PathExpression(name), expression);
     assignments.push_back(assign);
-    return new IR::PathExpression(expression->srcInfo, name);
+    return new IR::PathExpression(expression->srcInfo, new IR::Path(name));
 }
 
 const IR::Vector<IR::Argument>*

--- a/backends/bmv2/lower.cpp
+++ b/backends/bmv2/lower.cpp
@@ -163,9 +163,10 @@ RemoveComplexExpressions::createTemporary(const IR::Expression* expression) {
     auto decl = new IR::Declaration_Variable(IR::ID(name), type->getP4Type());
     newDecls.push_back(decl);
     typeMap->setType(decl, type);
-    auto assign = new IR::AssignmentStatement(new IR::PathExpression(name), expression);
+    auto assign = new IR::AssignmentStatement(
+        expression->srcInfo, new IR::PathExpression(name), expression);
     assignments.push_back(assign);
-    return new IR::PathExpression(name);
+    return new IR::PathExpression(expression->srcInfo, name);
 }
 
 const IR::Vector<IR::Argument>*
@@ -274,7 +275,7 @@ RemoveComplexExpressions::postorder(IR::MethodCallExpression* expression) {
             if (arg1->is<IR::ListExpression>()) {
                 auto list = simplifyExpressions(&arg1->to<IR::ListExpression>()->components, true);
                 arg1 = new IR::ListExpression(arg1->srcInfo, *list);
-                vec->push_back(new IR::Argument(arg1->srcInfo, arg1));
+                vec->push_back(new IR::Argument(arg1));
             } else {
                 auto tmp = new IR::Argument(
                     expression->arguments->at(1)->srcInfo,

--- a/backends/bmv2/lower.h
+++ b/backends/bmv2/lower.h
@@ -76,8 +76,11 @@ class RemoveComplexExpressions : public Transform {
     IR::IndexedVector<IR::StatOrDecl>  assignments;
 
     const IR::PathExpression* createTemporary(const IR::Expression* expression);
+    const IR::Expression* simplifyExpression(const IR::Expression* expression, bool force);
     const IR::Vector<IR::Expression>* simplifyExpressions(
         const IR::Vector<IR::Expression>* vec, bool force = false);
+    const IR::Vector<IR::Argument>* simplifyExpressions(
+        const IR::Vector<IR::Argument>* vec);
 
  public:
     RemoveComplexExpressions(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,

--- a/backends/bmv2/parser.cpp
+++ b/backends/bmv2/parser.cpp
@@ -55,7 +55,7 @@ Util::IJson* ParserConverter::convertParserStatement(const IR::StatOrDecl* stat)
                     cstring ename = argCount == 1 ? "extract" : "extract_VL";
                     result->emplace("op", ename);
                     auto arg = mce->arguments->at(0);
-                    auto argtype = typeMap->getType(arg, true);
+                    auto argtype = typeMap->getType(arg->expression, true);
                     if (!argtype->is<IR::Type_Header>()) {
                         ::error("%1%: extract only accepts arguments with header types, not %2%",
                                 arg, argtype);
@@ -66,8 +66,8 @@ Util::IJson* ParserConverter::convertParserStatement(const IR::StatOrDecl* stat)
                     cstring type;
                     Util::IJson* j = nullptr;
 
-                    if (arg->is<IR::Member>()) {
-                        auto mem = arg->to<IR::Member>();
+                    if (arg->expression->is<IR::Member>()) {
+                        auto mem = arg->expression->to<IR::Member>();
                         auto baseType = typeMap->getType(mem->expr, true);
                         if (baseType->is<IR::Type_Stack>()) {
                             if (mem->member == IR::Type_Stack::next) {
@@ -80,7 +80,7 @@ Util::IJson* ParserConverter::convertParserStatement(const IR::StatOrDecl* stat)
                     }
                     if (j == nullptr) {
                         type = "regular";
-                        j = conv->convert(arg);
+                        j = conv->convert(arg->expression);
                     }
                     auto value = j->to<Util::JsonObject>()->get("value");
                     param->emplace("type", type);
@@ -88,7 +88,7 @@ Util::IJson* ParserConverter::convertParserStatement(const IR::StatOrDecl* stat)
 
                     if (argCount == 2) {
                         auto arg2 = mce->arguments->at(1);
-                        auto jexpr = conv->convert(arg2, true, false);
+                        auto jexpr = conv->convert(arg2->expression, true, false);
                         auto rwrap = new Util::JsonObject();
                         // The spec says that this must always be wrapped in an expression
                         rwrap->emplace("type", "expression");
@@ -107,14 +107,14 @@ Util::IJson* ParserConverter::convertParserStatement(const IR::StatOrDecl* stat)
                     auto cond = mce->arguments->at(0);
                     // false means don't wrap in an outer expression object, which is not needed
                     // here
-                    auto jexpr = conv->convert(cond, true, false);
+                    auto jexpr = conv->convert(cond->expression, true, false);
                     params->append(jexpr);
                 }
                 {
                     auto error = mce->arguments->at(1);
                     // false means don't wrap in an outer expression object, which is not needed
                     // here
-                    auto jexpr = conv->convert(error, true, false);
+                    auto jexpr = conv->convert(error->expression, true, false);
                     params->append(jexpr);
                 }
                 return result;
@@ -153,7 +153,7 @@ Util::IJson* ParserConverter::convertParserStatement(const IR::StatOrDecl* stat)
                     primitive = "pop";
 
                 BUG_CHECK(mce->arguments->size() == 1, "Expected 1 argument for %1%", mce);
-                auto arg = conv->convert(mce->arguments->at(0));
+                auto arg = conv->convert(mce->arguments->at(0)->expression);
                 pp->append(arg);
             } else {
                 BUG("%1%: Unexpected built-in method", bi->name);

--- a/backends/bmv2/simpleSwitch.cpp
+++ b/backends/bmv2/simpleSwitch.cpp
@@ -217,7 +217,7 @@ SimpleSwitch::convertExternObjects(Util::JsonArray *result,
             etr->emplace("value", em->object->getName());
             parameters->append(etr);
             for (auto arg : *mc->arguments) {
-                auto args = conv->convert(arg);
+                auto args = conv->convert(arg->expression);
                 parameters->append(args);
             }
         } else {

--- a/backends/bmv2/simpleSwitch.cpp
+++ b/backends/bmv2/simpleSwitch.cpp
@@ -139,7 +139,7 @@ SimpleSwitch::convertExternObjects(Util::JsonArray *result,
             ctr->emplace("type", "counter_array");
             ctr->emplace("value", em->object->controlPlaneName());
             parameters->append(ctr);
-            auto index = conv->convert(mc->arguments->at(0));
+            auto index = conv->convert(mc->arguments->at(0)->expression);
             parameters->append(index);
         }
     } else if (em->originalExternType->name == v1model.meter.name) {
@@ -155,9 +155,9 @@ SimpleSwitch::convertExternObjects(Util::JsonArray *result,
             mtr->emplace("type", "meter_array");
             mtr->emplace("value", em->object->controlPlaneName());
             parameters->append(mtr);
-            auto index = conv->convert(mc->arguments->at(0));
+            auto index = conv->convert(mc->arguments->at(0)->expression);
             parameters->append(index);
-            auto result = conv->convert(mc->arguments->at(1));
+            auto result = conv->convert(mc->arguments->at(1)->expression);
             parameters->append(result);
         }
     } else if (em->originalExternType->name == v1model.registers.name) {
@@ -173,19 +173,19 @@ SimpleSwitch::convertExternObjects(Util::JsonArray *result,
             auto primitive = mkPrimitive("register_read", result);
             auto parameters = mkParameters(primitive);
             primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
-            auto dest = conv->convert(mc->arguments->at(0));
+            auto dest = conv->convert(mc->arguments->at(0)->expression);
             parameters->append(dest);
             parameters->append(reg);
-            auto index = conv->convert(mc->arguments->at(1));
+            auto index = conv->convert(mc->arguments->at(1)->expression);
             parameters->append(index);
         } else if (em->method->name == v1model.registers.write.name) {
             auto primitive = mkPrimitive("register_write", result);
             auto parameters = mkParameters(primitive);
             primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
             parameters->append(reg);
-            auto index = conv->convert(mc->arguments->at(0));
+            auto index = conv->convert(mc->arguments->at(0)->expression);
             parameters->append(index);
-            auto value = conv->convert(mc->arguments->at(1));
+            auto value = conv->convert(mc->arguments->at(1)->expression);
             parameters->append(value);
         }
     } else if (em->originalExternType->name == v1model.directMeter.name) {
@@ -195,7 +195,7 @@ SimpleSwitch::convertExternObjects(Util::JsonArray *result,
                 return;
             }
             auto dest = mc->arguments->at(0);
-            backend->getMeterMap().setDestination(em->object, dest);
+            backend->getMeterMap().setDestination(em->object, dest->expression);
             // Do not generate any code for this operation
         }
     } else if (em->originalExternType->name == v1model.directCounter.name) {
@@ -252,18 +252,18 @@ SimpleSwitch::convertExternFunctions(Util::JsonArray *result,
                 return;
             }
             cstring name = refMap->newName("fl");
-            id = createFieldList(mc->arguments->at(2), "field_lists", name,
+            id = createFieldList(mc->arguments->at(2)->expression, "field_lists", name,
                                  backend->field_lists);
         }
         auto cloneType = mc->arguments->at(0);
-        auto ei = P4::EnumInstance::resolve(cloneType, typeMap);
+        auto ei = P4::EnumInstance::resolve(cloneType->expression, typeMap);
         if (ei == nullptr) {
             modelError("%1%: must be a constant on this target", cloneType);
             return;
         } else {
             cstring prim = ei->name == "I2E" ? "clone_ingress_pkt_to_egress" :
                     "clone_egress_pkt_to_egress";
-            auto session = conv->convert(mc->arguments->at(1));
+            auto session = conv->convert(mc->arguments->at(1)->expression);
             auto primitive = mkPrimitive(prim, result);
             auto parameters = mkParameters(primitive);
             // TODO(jafingerhut):
@@ -292,24 +292,24 @@ SimpleSwitch::convertExternFunctions(Util::JsonArray *result,
         auto primitive = mkPrimitive("modify_field_with_hash_based_offset", result);
         auto parameters = mkParameters(primitive);
         primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
-        auto dest = conv->convert(mc->arguments->at(0));
+        auto dest = conv->convert(mc->arguments->at(0)->expression);
         parameters->append(dest);
-        auto base = conv->convert(mc->arguments->at(2));
+        auto base = conv->convert(mc->arguments->at(2)->expression);
         parameters->append(base);
         auto calculation = new Util::JsonObject();
-        auto ei = P4::EnumInstance::resolve(mc->arguments->at(1), typeMap);
+        auto ei = P4::EnumInstance::resolve(mc->arguments->at(1)->expression, typeMap);
         CHECK_NULL(ei);
         if (supportedHashAlgorithms.find(ei->name) == supportedHashAlgorithms.end()) {
             ::error("%1%: unexpected algorithm", ei->name);
             return;
         }
         auto fields = mc->arguments->at(3);
-        auto calcName = createCalculation(ei->name, fields, backend->json->calculations,
+        auto calcName = createCalculation(ei->name, fields->expression, backend->json->calculations,
                                           false, nullptr);
         calculation->emplace("type", "calculation");
         calculation->emplace("value", calcName);
         parameters->append(calculation);
-        auto max = conv->convert(mc->arguments->at(4));
+        auto max = conv->convert(mc->arguments->at(4)->expression);
         parameters->append(max);
     } else if (ef->method->name == v1model.digest_receiver.name) {
         if (mc->arguments->size() != 2) {
@@ -320,7 +320,7 @@ SimpleSwitch::convertExternFunctions(Util::JsonArray *result,
         auto parameters = mkParameters(primitive);
         // TODO(jafingerhut):
         // primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
-        auto dest = conv->convert(mc->arguments->at(0));
+        auto dest = conv->convert(mc->arguments->at(0)->expression);
         parameters->append(dest);
         cstring listName = "digest";
         // If we are supplied a type argument that is a named type use
@@ -338,7 +338,7 @@ SimpleSwitch::convertExternFunctions(Util::JsonArray *result,
                 listName = st->controlPlaneName();
             }
         }
-        int id = createFieldList(mc->arguments->at(1), "learn_lists",
+        int id = createFieldList(mc->arguments->at(1)->expression, "learn_lists",
                                  listName, backend->learn_lists);
         auto cst = new IR::Constant(id);
         typeMap->setType(cst, IR::Type_Bits::get(32));
@@ -372,7 +372,7 @@ SimpleSwitch::convertExternFunctions(Util::JsonArray *result,
                 listName = st->controlPlaneName();
             }
         }
-        int id = createFieldList(mc->arguments->at(0), "field_lists",
+        int id = createFieldList(mc->arguments->at(0)->expression, "field_lists",
                                  listName, backend->field_lists);
         auto cst = new IR::Constant(id);
         typeMap->setType(cst, IR::Type_Bits::get(32));
@@ -396,9 +396,9 @@ SimpleSwitch::convertExternFunctions(Util::JsonArray *result,
         auto params = mkParameters(primitive);
         // TODO(jafingerhut):
         // primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
-        auto dest = conv->convert(mc->arguments->at(0));
-        auto lo = conv->convert(mc->arguments->at(1));
-        auto hi = conv->convert(mc->arguments->at(2));
+        auto dest = conv->convert(mc->arguments->at(0)->expression);
+        auto lo = conv->convert(mc->arguments->at(1)->expression);
+        auto hi = conv->convert(mc->arguments->at(2)->expression);
         params->append(dest);
         params->append(lo);
         params->append(hi);
@@ -411,7 +411,7 @@ SimpleSwitch::convertExternFunctions(Util::JsonArray *result,
         auto params = mkParameters(primitive);
         // TODO(jafingerhut):
         // primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
-        auto len = conv->convert(mc->arguments->at(0));
+        auto len = conv->convert(mc->arguments->at(0)->expression);
         params->append(len);
     }
 }
@@ -681,22 +681,25 @@ SimpleSwitch::convertChecksum(const IR::BlockStatement *block, Util::JsonArray* 
                         return;
                     }
                     auto cksum = new Util::JsonObject();
-                    auto ei = P4::EnumInstance::resolve(mi->expr->arguments->at(3), typeMap);
+                    auto ei = P4::EnumInstance::resolve(
+                        mi->expr->arguments->at(3)->expression, typeMap);
                     if (ei->name != "csum16") {
                         ::error("%1%: the only supported algorithm is csum16",
-                                mi->expr->arguments->at(3));
+                                mi->expr->arguments->at(3)->expression);
                         return;
                     }
-                    cstring calcName = createCalculation(ei->name, mi->expr->arguments->at(1),
-                                                         calculations, usePayload, mc);
+                    cstring calcName = createCalculation(
+                        ei->name, mi->expr->arguments->at(1)->expression,
+                        calculations, usePayload, mc);
                     cksum->emplace("name", refMap->newName("cksum_"));
                     cksum->emplace("id", nextId("checksums"));
                     // TODO(jafingerhut) - add line/col here?
-                    auto jleft = conv->convert(mi->expr->arguments->at(2));
+                    auto jleft = conv->convert(mi->expr->arguments->at(2)->expression);
                     cksum->emplace("target", jleft->to<Util::JsonObject>()->get("value"));
                     cksum->emplace("type", "generic");
                     cksum->emplace("calculation", calcName);
-                    auto ifcond = conv->convert(mi->expr->arguments->at(0), true, false);
+                    auto ifcond = conv->convert(
+                        mi->expr->arguments->at(0)->expression, true, false);
                     cksum->emplace("if_cond", ifcond);
                     checksums->append(cksum);
                     continue;

--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -180,10 +180,10 @@ void ControlBodyTranslator::compileEmitField(const IR::Expression* expr, cstring
     builder->endOfStatement(true);
 }
 
-void ControlBodyTranslator::compileEmit(const IR::Vector<IR::Expression>* args) {
+void ControlBodyTranslator::compileEmit(const IR::Vector<IR::Argument>* args) {
     BUG_CHECK(args->size() == 1, "%1%: expected 1 argument for emit", args);
 
-    auto expr = args->at(0);
+    auto expr = args->at(0)->expression;
     auto type = typeMap->getType(expr);
     auto ht = type->to<IR::Type_Header>();
     if (ht == nullptr) {

--- a/backends/ebpf/ebpfControl.h
+++ b/backends/ebpf/ebpfControl.h
@@ -35,7 +35,7 @@ class ControlBodyTranslator : public CodeGenInspector {
     // handle the packet_out.emit method
     virtual void compileEmitField(const IR::Expression* expr, cstring field,
                                   unsigned alignment, EBPFType* type);
-    virtual void compileEmit(const IR::Vector<IR::Expression>* args);
+    virtual void compileEmit(const IR::Vector<IR::Argument>* args);
     virtual void processMethod(const P4::ExternMethod* method);
     virtual void processApply(const P4::ApplyMethod* method);
     virtual void processFunction(const P4::ExternFunction* function);

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -30,7 +30,7 @@ class StateTranslationVisitor : public CodeGenInspector {
 
     void compileExtractField(const IR::Expression* expr, cstring name,
                              unsigned alignment, EBPFType* type);
-    void compileExtract(const IR::Vector<IR::Expression>* args);
+    void compileExtract(const IR::Vector<IR::Argument>* args);
 
  public:
     explicit StateTranslationVisitor(const EBPFParserState* state) :
@@ -211,13 +211,13 @@ StateTranslationVisitor::compileExtractField(
 }
 
 void
-StateTranslationVisitor::compileExtract(const IR::Vector<IR::Expression>* args) {
+StateTranslationVisitor::compileExtract(const IR::Vector<IR::Argument>* args) {
     if (args->size() != 1) {
         ::error("Variable-sized header fields not yet supported %1%", args);
         return;
     }
 
-    auto expr = args->at(0);
+    auto expr = args->at(0)->expression;
     auto type = state->parser->typeMap->getType(expr);
     auto ht = type->to<IR::Type_Header>();
     if (ht == nullptr) {

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -477,7 +477,7 @@ struct Counterlike {
             return boost::none;
         }
 
-        auto unitArgument = instance.arguments->at(0);
+        auto unitArgument = instance.arguments->at(0)->expression;
         if (unitArgument == nullptr) {
             ::error("Direct %1% instance %2% should take a constructor argument",
                     CounterlikeTraits<Kind>::name(), instance.expression);
@@ -1357,7 +1357,7 @@ getDigestCall(const IR::MethodCallExpression* call,
     }
 
     // The first argument is a numeric constant identifying the receiver.
-    auto receiver = call->arguments->at(0);
+    auto receiver = call->arguments->at(0)->expression;
     if (!receiver->is<IR::Constant>()) {
         ::error("%1%: Expected constant receiver", call);
         return boost::none;
@@ -1368,7 +1368,7 @@ getDigestCall(const IR::MethodCallExpression* call,
     // we could theoretically support passing more complicated expressions to
     // digest(), but it's not well supported right now.
     std::vector<Digest::Field> fields;
-    auto data = call->arguments->at(1);
+    auto data = call->arguments->at(1)->expression;
     auto dataType = typeMap->getType(data, true);
     if (data->is<IR::ListExpression>()) {
         for (auto expression : data->to<IR::ListExpression>()->components) {
@@ -1852,10 +1852,10 @@ getActionProfile(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMa
     const IR::Expression* sizeExpression;
     if (instance->type->name == P4V1::V1Model::instance.action_selector.name) {
         actionProfileType = ActionProfileType::INDIRECT_WITH_SELECTOR;
-        sizeExpression = instance->arguments->at(1);
+        sizeExpression = instance->arguments->at(1)->expression;
     } else if (instance->type->name == P4V1::V1Model::instance.action_profile.name) {
         actionProfileType = ActionProfileType::INDIRECT;
-        sizeExpression = instance->arguments->at(0);
+        sizeExpression = instance->arguments->at(0)->expression;
     } else {
         ::error("Table '%1%' has an implementation which doesn't resolve to an "
                 "action profile: %2%", table->controlPlaneName(),
@@ -1981,7 +1981,7 @@ class P4RuntimeEntriesConverter {
             protoParam->set_param_id(parameterId++);
             auto parameter = actionDecl->parameters->parameters.at(parameterIndex);
             auto width = parameter->type->width_bits();
-            auto value = stringRepr(arg->to<IR::Constant>()->value, ROUNDUP(width, 8));
+            auto value = stringRepr(arg->expression->to<IR::Constant>()->value, ROUNDUP(width, 8));
             if (value == boost::none) continue;
             protoParam->set_value(*value);
         }

--- a/frontends/p4/actionsInlining.cpp
+++ b/frontends/p4/actionsInlining.cpp
@@ -153,7 +153,7 @@ const IR::Node* ActionsInliner::preorder(IR::MethodCallStatement* statement) {
     // evaluate in and inout parameters in order
     auto it = statement->methodCall->arguments->begin();
     for (auto param : callee->parameters->parameters) {
-        auto initializer = *it;
+        auto initializer = (*it)->expression;
         cstring newName = refMap->newName(param->name);
         paramRename.emplace(param, newName);
         if (param->direction == IR::Direction::In || param->direction == IR::Direction::InOut) {
@@ -187,7 +187,7 @@ const IR::Node* ActionsInliner::preorder(IR::MethodCallStatement* statement) {
     // copy out and inout parameters
     it = statement->methodCall->arguments->begin();
     for (auto param : callee->parameters->parameters) {
-        auto left = *it;
+        auto left = (*it)->expression;
         if (param->direction == IR::Direction::InOut || param->direction == IR::Direction::Out) {
             cstring newName = ::get(paramRename, param);
             auto right = new IR::PathExpression(newName);

--- a/frontends/p4/checkConstants.cpp
+++ b/frontends/p4/checkConstants.cpp
@@ -26,7 +26,7 @@ void DoCheckConstants::postorder(const IR::MethodCallExpression* expression) {
             bi->name == IR::Type_Stack::pop_front) {
             BUG_CHECK(expression->arguments->size() == 1,
                       "Expected 1 argument for %1%", expression);
-            auto arg0 = expression->arguments->at(0);
+            auto arg0 = expression->arguments->at(0)->expression;
             if (!arg0->is<IR::Constant>())
                 ::error("%1%: argument must be a constant", arg0);
         }

--- a/frontends/p4/createBuiltins.cpp
+++ b/frontends/p4/createBuiltins.cpp
@@ -32,7 +32,7 @@ void CreateBuiltins::postorder(IR::ActionListElement* element) {
     if (element->expression->is<IR::PathExpression>())
         element->expression = new IR::MethodCallExpression(
             element->expression->srcInfo, element->expression,
-            new IR::Vector<IR::Type>(), new IR::Vector<IR::Expression>());
+            new IR::Vector<IR::Type>(), new IR::Vector<IR::Argument>());
 }
 
 void CreateBuiltins::postorder(IR::ExpressionValue* expression) {
@@ -44,7 +44,7 @@ void CreateBuiltins::postorder(IR::ExpressionValue* expression) {
         expression->expression->is<IR::PathExpression>())
         expression->expression = new IR::MethodCallExpression(
             expression->expression->srcInfo, expression->expression,
-            new IR::Vector<IR::Type>(), new IR::Vector<IR::Expression>());
+            new IR::Vector<IR::Type>(), new IR::Vector<IR::Argument>());
 }
 
 void CreateBuiltins::postorder(IR::ParserState* state) {
@@ -65,7 +65,7 @@ void CreateBuiltins::postorder(IR::ActionList* actions) {
             new IR::Annotations({new IR::Annotation(IR::Annotation::defaultOnlyAnnotation, {})}),
             new IR::MethodCallExpression(
                 new IR::PathExpression(P4::P4CoreLibrary::instance.noAction.Id(actions->srcInfo)),
-                new IR::Vector<IR::Type>(), new IR::Vector<IR::Expression>())));
+                new IR::Vector<IR::Type>(), new IR::Vector<IR::Argument>())));
 }
 
 bool CreateBuiltins::preorder(IR::P4Table* table) {
@@ -79,7 +79,7 @@ void CreateBuiltins::postorder(IR::TableProperties* properties) {
     if (!addNoAction)
         return;
     auto act = new IR::PathExpression(P4::P4CoreLibrary::instance.noAction.Id(properties->srcInfo));
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     auto methodCall = new IR::MethodCallExpression(act, args);
     auto prop = new IR::Property(
         IR::ID(IR::TableProperties::defaultActionPropertyName),

--- a/frontends/p4/directCalls.cpp
+++ b/frontends/p4/directCalls.cpp
@@ -38,7 +38,7 @@ const IR::Node* DoInstantiateCalls::postorder(IR::MethodCallExpression* expressi
                                   { new IR::StringLiteral(tn->typeName->path->toString()) }));
     auto inst = new IR::Declaration_Instance(
         expression->srcInfo, IR::ID(name), annos,
-        tn->typeName->clone(), new IR::Vector<IR::Expression>());
+        tn->typeName->clone(), new IR::Vector<IR::Argument>());
     insert.push_back(inst);
 
     auto path = new IR::PathExpression(expression->srcInfo,

--- a/frontends/p4/dontcareArgs.cpp
+++ b/frontends/p4/dontcareArgs.cpp
@@ -20,7 +20,7 @@ namespace P4 {
 
 const IR::Node* DontcareArgs::postorder(IR::MethodCallExpression* expression) {
     bool changes = false;
-    auto vec = new IR::Vector<IR::Expression>();
+    auto vec = new IR::Vector<IR::Argument>();
 
     MethodCallDescription mcd(expression, refMap, typeMap);
     for (auto p : *mcd.substitution.getParameters()) {
@@ -31,9 +31,9 @@ const IR::Node* DontcareArgs::postorder(IR::MethodCallExpression* expression) {
             auto decl = new IR::Declaration_Variable(IR::ID(name), ptype, nullptr);
             toAdd.push_back(decl);
             changes = true;
-            vec->push_back(new IR::PathExpression(IR::ID(name)));
+            vec->push_back(new IR::Argument(new IR::PathExpression(IR::ID(name))));
         } else {
-            vec->push_back(a);
+            vec->push_back(new IR::Argument(a->srcInfo, a));
         }
     }
     if (changes)

--- a/frontends/p4/dontcareArgs.cpp
+++ b/frontends/p4/dontcareArgs.cpp
@@ -31,7 +31,7 @@ const IR::Node* DontcareArgs::postorder(IR::MethodCallExpression* expression) {
             auto decl = new IR::Declaration_Variable(IR::ID(name), ptype, nullptr);
             toAdd.push_back(decl);
             changes = true;
-            vec->push_back(new IR::Argument(new IR::PathExpression(IR::ID(name))));
+            vec->push_back(new IR::Argument(a->srcInfo, new IR::PathExpression(IR::ID(name))));
         } else {
             vec->push_back(new IR::Argument(a->srcInfo, a));
         }

--- a/frontends/p4/evaluator/evaluator.cpp
+++ b/frontends/p4/evaluator/evaluator.cpp
@@ -98,13 +98,13 @@ bool Evaluator::preorder(const IR::Declaration_Constant* decl) {
 }
 
 std::vector<const IR::CompileTimeValue*>*
-Evaluator::evaluateArguments(const IR::Vector<IR::Expression>* arguments, IR::Block* context) {
+Evaluator::evaluateArguments(const IR::Vector<IR::Argument>* arguments, IR::Block* context) {
     LOG2("Evaluating arguments in " << dbp(context));
     P4::DoConstantFolding cf(refMap, nullptr);
     auto values = new std::vector<const IR::CompileTimeValue*>();
     pushBlock(context);
     for (auto e : *arguments) {
-        auto folded = e->apply(cf);  // constant fold argument
+        auto folded = e->expression->apply(cf);  // constant fold argument
         CHECK_NULL(folded);
         visit(folded);  // recursive evaluation
         auto value = getValue(folded);
@@ -126,7 +126,7 @@ Evaluator::processConstructor(
                            // could be a Declaration_Instance or a ConstructorCallExpression.
     const IR::Type* type,  // Type that appears in the program that is instantiated.
     const IR::Type* instanceType,  // Actual canonical type of generated instance.
-    const IR::Vector<IR::Expression>* arguments) {  // Constructor arguments
+    const IR::Vector<IR::Argument>* arguments) {  // Constructor arguments
     LOG2("Evaluating constructor " << dbp(type));
     if (type->is<IR::Type_Specialized>())
         type = type->to<IR::Type_Specialized>()->baseType;

--- a/frontends/p4/evaluator/evaluator.h
+++ b/frontends/p4/evaluator/evaluator.h
@@ -49,7 +49,7 @@ class Evaluator final : public Inspector, public IHasBlock {
     const IR::CompileTimeValue* getValue(const IR::Node* node) const;
 
     std::vector<const IR::CompileTimeValue*>*
-            evaluateArguments(const IR::Vector<IR::Expression>* arguments,
+            evaluateArguments(const IR::Vector<IR::Argument>* arguments,
                               IR::Block* context);
 
     profile_t init_apply(const IR::Node* node) override;
@@ -76,7 +76,7 @@ class Evaluator final : public Inspector, public IHasBlock {
 
     const IR::Block* processConstructor(const IR::Node* node,
                                         const IR::Type* type, const IR::Type* instanceType,
-                                        const IR::Vector<IR::Expression>* arguments);
+                                        const IR::Vector<IR::Argument>* arguments);
 };
 
 // A pass which "evaluates" the program

--- a/frontends/p4/externInstance.h
+++ b/frontends/p4/externInstance.h
@@ -49,7 +49,7 @@ struct ExternInstance final {
     const boost::optional<cstring> name;  // The instance's name, if any.
     const IR::Expression* expression;     // The original expression passed to resolve().
     const IR::Type_Extern* type;          // The type of the instance.
-    const IR::Vector<IR::Expression>* arguments;  // The instance's constructor arguments.
+    const IR::Vector<IR::Argument>* arguments;  // The instance's constructor arguments.
     const IR::IAnnotated* annotations;    // If non-null, the instance's annotations.
 
     /**

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -305,10 +305,16 @@ const IR::Node* StatementConverter::preorder(IR::Primitive* primitive) {
         auto instanceName = get(renameMap, control->name);
         auto ctrl = new IR::PathExpression(IR::ID(instanceName));
         auto method = new IR::Member(ctrl, IR::ID(IR::IApply::applyMethodName));
-        auto args = new IR::Vector<IR::Expression>();
-        args->push_back(structure->conversionContext.header->clone());
-        args->push_back(structure->conversionContext.userMetadata->clone());
-        args->push_back(structure->conversionContext.standardMetadata->clone());
+        auto args = new IR::Vector<IR::Argument>();
+        args->push_back(new IR::Argument(
+            structure->conversionContext.header->srcInfo,
+            structure->conversionContext.header->clone()));
+        args->push_back(new IR::Argument(
+            structure->conversionContext.userMetadata->srcInfo,
+            structure->conversionContext.userMetadata->clone()));
+        args->push_back(new IR::Argument(
+            structure->conversionContext.standardMetadata->srcInfo,
+            structure->conversionContext.standardMetadata->clone()));
         auto call = new IR::MethodCallExpression(primitive->srcInfo, method, args);
         auto stat = new IR::MethodCallStatement(primitive->srcInfo, call);
         return stat;
@@ -461,9 +467,11 @@ const IR::Statement *ExternConverter::convertExternCall(ProgramStructure *struct
     ExpressionConverter conv(structure);
     auto extref = new IR::PathExpression(structure->externs.get(ext));
     auto method = new IR::Member(prim->srcInfo, extref, prim->name);
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     for (unsigned i = 1; i < prim->operands.size(); ++i)
-        args->push_back(conv.convert(prim->operands.at(i)));
+        args->push_back(new IR::Argument(
+            prim->operands.at(i)->srcInfo,
+            conv.convert(prim->operands.at(i))));
     auto mc = new IR::MethodCallExpression(prim->srcInfo, method, args);
     return new IR::MethodCallStatement(prim->srcInfo, mc);
 }
@@ -925,14 +933,14 @@ class FixExtracts final : public Transform {
             auto var = new IR::Declaration_Variable(IR::ID(varName), t->to<IR::Type>());
             auto length = ::get(lengths, t);
             varDecls.push_back(var);
-            auto args = new IR::Vector<IR::Expression>();
-            args->push_back(new IR::PathExpression(IR::ID(varName)));
+            auto args = new IR::Vector<IR::Argument>();
+            args->push_back(new IR::Argument(new IR::PathExpression(IR::ID(varName))));
             if (length != nullptr) {
                 length = length->apply(rewrite);
                 auto type = IR::Type_Bits::get(
                     P4::P4CoreLibrary::instance.packetIn.extractSecondArgSize);
                 auto cast = new IR::Cast(Util::SourceInfo(), type, length);
-                args->push_back(cast);
+                args->push_back(new IR::Argument(cast));
             }
             auto expression = new IR::MethodCallExpression(
                 mce->srcInfo, mce->method->clone(), args);
@@ -940,15 +948,15 @@ class FixExtracts final : public Transform {
         }
 
         auto setValid = new IR::Member(
-            mce->srcInfo, arg, IR::Type_Header::setValid);
+            mce->srcInfo, arg->expression, IR::Type_Header::setValid);
         result->push_back(new IR::MethodCallStatement(
             new IR::MethodCallExpression(
-                mce->srcInfo, setValid, new IR::Vector<IR::Expression>())));
+                mce->srcInfo, setValid, new IR::Vector<IR::Argument>())));
         unsigned index = 0;
         for (auto t : typeDecls) {
             auto var = varDecls.at(index);
             for (auto f : t->fields) {
-                auto left = new IR::Member(mce->srcInfo, arg, f->name);
+                auto left = new IR::Member(mce->srcInfo, arg->expression, f->name);
                 auto right = new IR::Member(mce->srcInfo,
                                             new IR::PathExpression(var->name), f->name);
                 auto assign = new IR::AssignmentStatement(mce->srcInfo, left, right);

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -307,13 +307,10 @@ const IR::Node* StatementConverter::preorder(IR::Primitive* primitive) {
         auto method = new IR::Member(ctrl, IR::ID(IR::IApply::applyMethodName));
         auto args = new IR::Vector<IR::Argument>();
         args->push_back(new IR::Argument(
-            structure->conversionContext.header->srcInfo,
             structure->conversionContext.header->clone()));
         args->push_back(new IR::Argument(
-            structure->conversionContext.userMetadata->srcInfo,
             structure->conversionContext.userMetadata->clone()));
         args->push_back(new IR::Argument(
-            structure->conversionContext.standardMetadata->srcInfo,
             structure->conversionContext.standardMetadata->clone()));
         auto call = new IR::MethodCallExpression(primitive->srcInfo, method, args);
         auto stat = new IR::MethodCallStatement(primitive->srcInfo, call);
@@ -470,7 +467,6 @@ const IR::Statement *ExternConverter::convertExternCall(ProgramStructure *struct
     auto args = new IR::Vector<IR::Argument>();
     for (unsigned i = 1; i < prim->operands.size(); ++i)
         args->push_back(new IR::Argument(
-            prim->operands.at(i)->srcInfo,
             conv.convert(prim->operands.at(i))));
     auto mc = new IR::MethodCallExpression(prim->srcInfo, method, args);
     return new IR::MethodCallStatement(prim->srcInfo, mc);

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -321,7 +321,9 @@ const IR::Statement* ProgramStructure::convertParserStatement(const IR::Expressi
             const IR::Expression* method = new IR::Member(
                 paramReference(parserPacketIn),
                 p4lib.packetIn.extract.Id());
-            auto result = new IR::MethodCallStatement(expr->srcInfo, method, { dest });
+            auto result = new IR::MethodCallStatement(
+                expr->srcInfo, method,
+                { new IR::Argument(primitive->operands.at(0)->srcInfo, dest) });
 
             LOG3("Inserted extract " << dbp(result->methodCall) << " " << dbp(destType));
             extractsSynthesized.emplace(result->methodCall, destType->to<IR::Type_Header>());
@@ -695,8 +697,8 @@ void ProgramStructure::createDeparser() {
         if (exp->is<IR::StringLiteral>())
             // a "fake" header
             continue;
-        auto args = new IR::Vector<IR::Expression>();
-        args->push_back(exp);
+        auto args = new IR::Vector<IR::Argument>();
+        args->push_back(new IR::Argument(exp->srcInfo, exp));
         const IR::Expression* method = new IR::Member(
             paramReference(packetOut),
             p4lib.packetOut.emit.Id());
@@ -714,7 +716,7 @@ ProgramStructure::convertActionProfile(const IR::ActionProfile* action_profile, 
     if (!action_profile->selector.name.isNullOrEmpty() && !action_selector)
         ::error("Cannot locate action selector %1%", action_profile->selector);
     const IR::Type *type = nullptr;
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     auto annos = addGlobalNameAnnotation(action_profile->name);
     if (action_selector) {
         type = new IR::Type_Name(new IR::Path(v1model.action_selector.Id()));
@@ -722,11 +724,11 @@ ProgramStructure::convertActionProfile(const IR::ActionProfile* action_profile, 
         auto algorithm = convertHashAlgorithms(flc->algorithm);
         if (algorithm == nullptr)
             return nullptr;
-        args->push_back(algorithm);
+        args->push_back(new IR::Argument(flc->algorithm->srcInfo, algorithm));
         auto size = new IR::Constant(v1model.action_selector.sizeType, action_profile->size);
-        args->push_back(size);
+        args->push_back(new IR::Argument(action_profile->srcInfo, size));
         auto width = new IR::Constant(v1model.action_selector.widthType, flc->output_width);
-        args->push_back(width);
+        args->push_back(new IR::Argument(flc->srcInfo, width));
         if (action_selector->mode)
             annos = annos->addAnnotation("mode", new IR::StringLiteral(action_selector->mode));
         if (action_selector->type)
@@ -734,7 +736,7 @@ ProgramStructure::convertActionProfile(const IR::ActionProfile* action_profile, 
     } else {
         type = new IR::Type_Name(new IR::Path(v1model.action_profile.Id()));
         auto size = new IR::Constant(v1model.action_profile.sizeType, action_profile->size);
-        args->push_back(size); }
+        args->push_back(new IR::Argument(action_profile->srcInfo, size)); }
     auto decl = new IR::Declaration_Instance(newName, annos, type, args, nullptr);
     return decl;
 }
@@ -836,8 +838,13 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
 
     if (!table->default_action.name.isNullOrEmpty()) {
         auto act = new IR::PathExpression(actions.newname(table->default_action));
-        auto args = table->default_action_args ?
-                table->default_action_args : new IR::Vector<IR::Expression>();
+        auto args = new IR::Vector<IR::Argument>();
+        if (table->default_action_args != nullptr) {
+            for (auto e : *table->default_action_args) {
+                auto arg = new IR::Argument(e->srcInfo, e);
+                args->push_back(arg);
+            }
+        }
         auto methodCall = new IR::MethodCallExpression(act, args);
         auto prop = new IR::Property(
             IR::ID(IR::TableProperties::defaultActionPropertyName),
@@ -998,10 +1005,10 @@ const IR::Statement* ProgramStructure::convertPrimitive(const IR::Primitive* pri
     if (action != nullptr) {
         auto newname = actions.get(action);
         auto act = new IR::PathExpression(newname);
-        auto args = new IR::Vector<IR::Expression>();
+        auto args = new IR::Vector<IR::Argument>();
         for (auto a : primitive->operands) {
             auto e = conv.convert(a);
-            args->push_back(e);
+            args->push_back(new IR::Argument(e->srcInfo, e));
         }
         auto call = new IR::MethodCallExpression(primitive->srcInfo, act, args);
         auto stat = new IR::MethodCallStatement(primitive->srcInfo, call);
@@ -1226,11 +1233,13 @@ CONVERT_PRIMITIVE(copy_header) {
 }
 
 CONVERT_PRIMITIVE(drop) {
-    return new IR::MethodCallStatement(primitive->srcInfo, structure->v1model.drop.Id(), {});
+    return new IR::MethodCallStatement(
+        primitive->srcInfo, structure->v1model.drop.Id(), {});
 }
 
 CONVERT_PRIMITIVE(mark_for_drop) {
-    return new IR::MethodCallStatement(primitive->srcInfo, structure->v1model.drop.Id(), {});
+    return new IR::MethodCallStatement(
+        primitive->srcInfo, structure->v1model.drop.Id(), {});
 }
 
 static const IR::Constant *push_pop_size(ExpressionConverter &conv, const IR::Primitive *prim) {
@@ -1260,7 +1269,8 @@ CONVERT_PRIMITIVE(push) {
     IR::IndexedVector<IR::StatOrDecl> block;
     auto methodName = IR::Type_Stack::push_front;
     auto method = new IR::Member(hdr, IR::ID(methodName));
-    block.push_back(new IR::MethodCallStatement(primitive->srcInfo, method, { count }));
+    block.push_back(new IR::MethodCallStatement(primitive->srcInfo, method,
+                                                { new IR::Argument(count->srcInfo, count) }));
     for (int i = 0; i < count->asInt(); i++) {
         auto elemi = new IR::ArrayIndex(primitive->srcInfo, hdr, new IR::Constant(i));
         auto setValid = new IR::Member(elemi, IR::ID(IR::Type_Header::setValid));
@@ -1276,7 +1286,8 @@ CONVERT_PRIMITIVE(pop) {
     auto count = push_pop_size(conv, primitive);
     auto methodName = IR::Type_Stack::pop_front;
     auto method = new IR::Member(hdr, IR::ID(methodName));
-    return new IR::MethodCallStatement(primitive->srcInfo, method, { count });
+    return new IR::MethodCallStatement(primitive->srcInfo, method,
+                                       { new IR::Argument(count->srcInfo, count) });
 }
 
 CONVERT_PRIMITIVE(count) {
@@ -1297,7 +1308,9 @@ CONVERT_PRIMITIVE(count) {
     auto method = new IR::Member(counterref, methodName);
     auto arg = new IR::Cast(structure->v1model.counter.index_type,
                             conv.convert(primitive->operands.at(1)));
-    return new IR::MethodCallStatement(primitive->srcInfo, method, { arg });
+    return new IR::MethodCallStatement(
+        primitive->srcInfo, method,
+        { new IR::Argument(primitive->operands.at(1)->srcInfo, arg) });
 }
 
 CONVERT_PRIMITIVE(modify_field_from_rng) {
@@ -1315,13 +1328,16 @@ CONVERT_PRIMITIVE(modify_field_from_rng) {
         auto decl = new IR::Declaration_Variable(tmpvar, field->type);
         block->push_back(decl);
         dest = new IR::PathExpression(field->type, new IR::Path(tmpvar)); }
-    auto args = new IR::Vector<IR::Expression>();
-    args->push_back(dest);
-    args->push_back(new IR::Constant(primitive->operands.at(1)->srcInfo,
-                                     field->type, 0));
+    auto args = new IR::Vector<IR::Argument>();
+    args->push_back(new IR::Argument(primitive->operands.at(2)->srcInfo, dest));
+    args->push_back(
+        new IR::Argument(primitive->operands.at(1)->srcInfo,
+                         new IR::Constant(primitive->operands.at(1)->srcInfo, field->type, 0)));
     auto one = new IR::Constant(primitive->operands.at(1)->srcInfo, 1);
-    args->push_back(new IR::Cast(primitive->operands.at(1)->srcInfo, field->type,
-                                 new IR::Sub(new IR::Shl(one, logRange), one)));
+    args->push_back(
+        new IR::Argument(primitive->operands.at(1)->srcInfo,
+                         new IR::Cast(primitive->operands.at(1)->srcInfo, field->type,
+                                      new IR::Sub(new IR::Shl(one, logRange), one))));
     auto random = new IR::PathExpression(structure->v1model.random.Id());
     auto mc = new IR::MethodCallExpression(primitive->srcInfo, random, args);
     auto call = new IR::MethodCallStatement(primitive->srcInfo, mc);
@@ -1343,7 +1359,11 @@ CONVERT_PRIMITIVE(modify_field_rng_uniform) {
     if (hi->type != field->type)
         hi = new IR::Cast(primitive->operands.at(2)->srcInfo, field->type, hi);
     auto random = new IR::PathExpression(structure->v1model.random.Id());
-    auto mc = new IR::MethodCallExpression(primitive->srcInfo, random, { field, lo, hi });
+    auto mc = new IR::MethodCallExpression(
+        primitive->srcInfo, random, {
+            new IR::Argument(primitive->operands.at(0)->srcInfo, field),
+                    new IR::Argument(primitive->operands.at(1)->srcInfo, lo),
+                    new IR::Argument(primitive->operands.at(2)->srcInfo, hi) });
     auto call = new IR::MethodCallStatement(primitive->srcInfo, mc);
     return call;
 }
@@ -1354,8 +1374,8 @@ CONVERT_PRIMITIVE(recirculate) {
     auto right = structure->convertFieldList(primitive->operands.at(0));
     if (right == nullptr)
         return nullptr;
-    auto args = new IR::Vector<IR::Expression>();
-    args->push_back(right);
+    auto args = new IR::Vector<IR::Argument>();
+    args->push_back(new IR::Argument(primitive->operands.at(0)->srcInfo, right));
     auto path = new IR::PathExpression(structure->v1model.recirculate.Id());
     auto mc = new IR::MethodCallExpression(primitive->srcInfo, path, args);
     return new IR::MethodCallStatement(mc->srcInfo, mc);
@@ -1368,17 +1388,19 @@ convertClone(ProgramStructure *structure, const IR::Primitive *primitive, Model:
     ExpressionConverter conv(structure);
     auto session = conv.convert(primitive->operands.at(0));
 
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     auto enumref = new IR::TypeNameExpression(
         new IR::Type_Name(new IR::Path(structure->v1model.clone.cloneType.Id())));
     auto kindarg = new IR::Member(enumref, kind.Id());
-    args->push_back(kindarg);
-    args->push_back(new IR::Cast(primitive->operands.at(0)->srcInfo,
-                                 structure->v1model.clone.sessionType, session));
+    args->push_back(new IR::Argument(kindarg));
+    args->push_back(
+        new IR::Argument(primitive->operands.at(0)->srcInfo,
+                         new IR::Cast(primitive->operands.at(0)->srcInfo,
+                                      structure->v1model.clone.sessionType, session)));
     if (primitive->operands.size() == 2) {
         auto list = structure->convertFieldList(primitive->operands.at(1));
         if (list != nullptr)
-            args->push_back(list);
+            args->push_back(new IR::Argument(primitive->operands.at(1)->srcInfo, list));
     }
 
     auto id = primitive->operands.size() == 2 ? structure->v1model.clone.clone3.Id()
@@ -1401,12 +1423,15 @@ CONVERT_PRIMITIVE(resubmit) {
     ExpressionConverter conv(structure);
     BUG_CHECK(primitive->operands.size() <= 1, "Expected 0 or 1 operands for %1%", primitive);
     const IR::Expression *list = nullptr;
-    if (primitive->operands.size() > 0)
+    Util::SourceInfo srcInfo;
+    if (primitive->operands.size() > 0) {
         list = structure->convertFieldList(primitive->operands.at(0));
+        srcInfo = primitive->operands.at(0)->srcInfo;
+    }
     if (list == nullptr)
         list = new IR::ListExpression({});
     return new IR::MethodCallStatement(primitive->srcInfo, structure->v1model.resubmit.Id(),
-                                       { list });
+                                       { new IR::Argument(srcInfo, list) });
 }
 
 CONVERT_PRIMITIVE(execute_meter) {
@@ -1427,12 +1452,12 @@ CONVERT_PRIMITIVE(execute_meter) {
     auto meterref = new IR::PathExpression(newname);
     auto methodName = structure->v1model.meter.executeMeter.Id();
     auto method = new IR::Member(meterref, methodName);
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     auto arg = new IR::Cast(structure->v1model.meter.index_type,
                             conv.convert(primitive->operands.at(1)));
-    args->push_back(arg);
+    args->push_back(new IR::Argument(primitive->operands.at(1)->srcInfo, arg));
     auto dest = conv.convert(primitive->operands.at(2));
-    args->push_back(dest);
+    args->push_back(new IR::Argument(primitive->operands.at(2)->srcInfo, dest));
     auto mc = new IR::MethodCallExpression(primitive->srcInfo, method, args);
     return new IR::MethodCallStatement(primitive->srcInfo, mc);
 }
@@ -1444,7 +1469,7 @@ CONVERT_PRIMITIVE(modify_field_with_hash_based_offset) {
     auto dest = conv.convert(primitive->operands.at(0));
     auto base = conv.convert(primitive->operands.at(1));
     auto max = conv.convert(primitive->operands.at(3));
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
 
     auto nr = primitive->operands.at(2)->to<IR::PathExpression>();
     auto flc = structure->field_list_calculations.get(nr->path->name);
@@ -1459,11 +1484,13 @@ CONVERT_PRIMITIVE(modify_field_with_hash_based_offset) {
     auto list = conv.convert(fl);
 
     auto algorithm = structure->convertHashAlgorithms(flc->algorithm);
-    args->push_back(dest);
-    args->push_back(algorithm);
-    args->push_back(new IR::Cast(ttype, base));
-    args->push_back(list);
-    args->push_back(new IR::Cast(IR::Type_Bits::get(2 * flc->output_width), max));
+    args->push_back(new IR::Argument(primitive->operands.at(0)->srcInfo, dest));
+    args->push_back(new IR::Argument(flc->algorithm->srcInfo, algorithm));
+    args->push_back(new IR::Argument(
+        primitive->operands.at(1)->srcInfo, new IR::Cast(ttype, base)));
+    args->push_back(new IR::Argument(primitive->operands.at(2)->srcInfo, list));
+    args->push_back(new IR::Argument(
+        max->srcInfo, new IR::Cast(IR::Type_Bits::get(2 * flc->output_width), max)));
     auto hash = new IR::PathExpression(structure->v1model.hash.Id());
     auto mc = new IR::MethodCallExpression(primitive->srcInfo, hash, args);
     auto result = new IR::MethodCallStatement(primitive->srcInfo, mc);
@@ -1496,16 +1523,18 @@ CONVERT_PRIMITIVE(modify_field_with_shift) {
 CONVERT_PRIMITIVE(generate_digest) {
     ExpressionConverter conv(structure);
     OPS_CK(primitive, 2);
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     auto receiver = conv.convert(primitive->operands.at(0));
-    args->push_back(new IR::Cast(primitive->operands.at(1)->srcInfo,
-                                 structure->v1model.digest_receiver.receiverType, receiver));
+    args->push_back(
+        new IR::Argument(primitive->operands.at(0)->srcInfo,
+                         new IR::Cast(primitive->operands.at(0)->srcInfo,
+                                      structure->v1model.digest_receiver.receiverType, receiver)));
     auto list = structure->convertFieldList(primitive->operands.at(1));
     auto type = structure->createFieldListType(primitive->operands.at(1));
     // In P4 v1.0 programs we can have declarations out of order
     structure->declarations->push_back(type);
     if (list != nullptr)
-        args->push_back(list);
+        args->push_back(new IR::Argument(primitive->operands.at(1)->srcInfo, list));
     auto typeArgs = new IR::Vector<IR::Type>();
     auto typeName = new IR::Type_Name(new IR::Path(type->name));
     typeArgs->push_back(typeName);
@@ -1532,11 +1561,11 @@ CONVERT_PRIMITIVE(register_read) {
     auto registerref = new IR::PathExpression(newname);
     auto methodName = structure->v1model.registers.read.Id();
     auto method = new IR::Member(registerref, methodName);
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     auto arg = new IR::Cast(structure->v1model.registers.index_type,
                             conv.convert(primitive->operands.at(2)));
-    args->push_back(left);
-    args->push_back(arg);
+    args->push_back(new IR::Argument(primitive->operands.at(0)->srcInfo, left));
+    args->push_back(new IR::Argument(primitive->operands.at(2)->srcInfo, arg));
     auto mc = new IR::MethodCallExpression(primitive->srcInfo, method, args);
     return new IR::MethodCallStatement(mc->srcInfo, mc);
 }
@@ -1564,15 +1593,15 @@ CONVERT_PRIMITIVE(register_write) {
     auto registerref = new IR::PathExpression(newname);
     auto methodName = structure->v1model.registers.write.Id();
     auto method = new IR::Member(registerref, methodName);
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     auto arg0 = new IR::Cast(primitive->operands.at(1)->srcInfo,
                              structure->v1model.registers.index_type,
                              conv.convert(primitive->operands.at(1)));
     const IR::Expression* arg1 = conv.convert(primitive->operands.at(2));
     if (castType != nullptr)
         arg1 = new IR::Cast(primitive->operands.at(2)->srcInfo, castType, arg1);
-    args->push_back(arg0);
-    args->push_back(arg1);
+    args->push_back(new IR::Argument(primitive->operands.at(1)->srcInfo, arg0));
+    args->push_back(new IR::Argument(primitive->operands.at(2)->srcInfo, arg1));
     auto mc = new IR::MethodCallExpression(primitive->srcInfo, method, args);
     return new IR::MethodCallStatement(mc->srcInfo, mc);
 }
@@ -1583,10 +1612,10 @@ CONVERT_PRIMITIVE(truncate) {
     auto len = primitive->operands.at(0);
     auto methodName = structure->v1model.truncate.Id();
     auto method = new IR::PathExpression(methodName);
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     auto arg0 = new IR::Cast(len->srcInfo, structure->v1model.truncate.length_type,
                              conv.convert(len));
-    args->push_back(arg0);
+    args->push_back(new IR::Argument(primitive->operands.at(0)->srcInfo, arg0));
     auto mc = new IR::MethodCallExpression(primitive->srcInfo, method, args);
     return new IR::MethodCallStatement(mc->srcInfo, mc);
 }
@@ -1641,10 +1670,10 @@ ProgramStructure::convertAction(const IR::ActionFunction* action, cstring newNam
         CHECK_NULL(decl);
         auto extObj = new IR::PathExpression(decl->name);
         auto method = new IR::Member(extObj, v1model.directMeter.read.Id());
-        auto args = new IR::Vector<IR::Expression>();
+        auto args = new IR::Vector<IR::Argument>();
         auto arg = conv.convert(meterToAccess->result);
         if (arg != nullptr)
-            args->push_back(arg);
+            args->push_back(new IR::Argument(meterToAccess->result->srcInfo, arg));
         auto mc = new IR::MethodCallExpression(method, args);
         auto stat = new IR::MethodCallStatement(mc->srcInfo, mc);
         body->push_back(stat); }
@@ -1655,8 +1684,7 @@ ProgramStructure::convertAction(const IR::ActionFunction* action, cstring newNam
         CHECK_NULL(decl);
         auto extObj = new IR::PathExpression(decl->name);
         auto method = new IR::Member(extObj, v1model.directCounter.count.Id());
-        auto args = new IR::Vector<IR::Expression>();
-        auto mc = new IR::MethodCallExpression(method, args);
+        auto mc = new IR::MethodCallExpression(method, new IR::Vector<IR::Argument>());
         auto stat = new IR::MethodCallStatement(mc->srcInfo, mc);
         body->push_back(stat); }
 
@@ -1753,13 +1781,15 @@ ProgramStructure::convert(const IR::Register* reg, cstring newName,
     auto typeargs = new IR::Vector<IR::Type>();
     typeargs->push_back(regElementType);
     auto spectype = new IR::Type_Specialized(type, typeargs);
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     if (reg->direct) {
         // FIXME -- do we need a direct_register extern in v1model?  For now
         // using size of 0 to specify a direct register
-        args->push_back(new IR::Constant(v1model.registers.size_type, 0));
+        args->push_back(new IR::Argument(new IR::Constant(v1model.registers.size_type, 0)));
     } else {
-        args->push_back(new IR::Constant(v1model.registers.size_type, reg->instance_count)); }
+        args->push_back(
+            new IR::Argument(reg->srcInfo,
+                             new IR::Constant(v1model.registers.size_type, reg->instance_count))); }
     auto annos = addGlobalNameAnnotation(reg->name, reg->annotations);
     auto decl = new IR::Declaration_Instance(newName, annos, spectype, args, nullptr);
     return decl;
@@ -1775,10 +1805,12 @@ ProgramStructure::convert(const IR::CounterOrMeter* cm, cstring newName) {
         ext = v1model.meter.Id();
     auto typepath = new IR::Path(ext);
     auto type = new IR::Type_Name(typepath);
-    auto args = new IR::Vector<IR::Expression>();
-    args->push_back(new IR::Constant(v1model.counterOrMeter.size_type, cm->instance_count));
+    auto args = new IR::Vector<IR::Argument>();
+    args->push_back(
+        new IR::Argument(cm->srcInfo,
+            new IR::Constant(v1model.counterOrMeter.size_type, cm->instance_count)));
     auto kindarg = counterType(cm);
-    args->push_back(kindarg);
+    args->push_back(new IR::Argument(cm->srcInfo, kindarg));
     auto annos = addGlobalNameAnnotation(cm->name, cm->annotations);
     if (auto *c = cm->to<IR::Counter>()) {
         if (c->min_width >= 0)
@@ -1808,9 +1840,9 @@ ProgramStructure::convertDirectMeter(const IR::Meter* m, cstring newName) {
     auto vec = new IR::Vector<IR::Type>();
     vec->push_back(outputType);
     auto specType = new IR::Type_Specialized(type, vec);
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     auto kindarg = counterType(m);
-    args->push_back(kindarg);
+    args->push_back(new IR::Argument(m->srcInfo, kindarg));
     auto annos = addGlobalNameAnnotation(m->name, m->annotations);
     auto decl = new IR::Declaration_Instance(newName, annos, specType, args, nullptr);
     return decl;
@@ -1823,9 +1855,9 @@ ProgramStructure::convertDirectCounter(const IR::Counter* c, cstring newName) {
     IR::ID ext = v1model.directCounter.Id();
     auto typepath = new IR::Path(ext);
     auto type = new IR::Type_Name(typepath);
-    auto args = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
     auto kindarg = counterType(c);
-    args->push_back(kindarg);
+    args->push_back(new IR::Argument(c->srcInfo, kindarg));
     auto annos = addGlobalNameAnnotation(c->name, c->annotations);
     auto decl = new IR::Declaration_Instance(newName, annos, type, args, nullptr);
     return decl;
@@ -1972,8 +2004,8 @@ ProgramStructure::convertControl(const IR::V1Control* control, cstring newName) 
             auto typepath = new IR::Path(IR::ID(newname));
             auto type = new IR::Type_Name(typepath);
             auto annos = addGlobalNameAnnotation(cc);
-            auto decl = new IR::Declaration_Instance(IR::ID(iname), annos, type,
-                new IR::Vector<IR::Expression>(), nullptr);
+            auto decl = new IR::Declaration_Instance(
+                IR::ID(iname), annos, type, new IR::Vector<IR::Argument>(), nullptr);
             stateful.push_back(decl);
         }
     }
@@ -2048,39 +2080,38 @@ void ProgramStructure::createMain() {
     auto name = IR::ID(IR::P4Program::main);
     auto typepath = new IR::Path(v1model.sw.Id());
     auto type = new IR::Type_Name(typepath);
-    auto args = new IR::Vector<IR::Expression>();
-
-    auto emptyArgs = new IR::Vector<IR::Expression>();
+    auto args = new IR::Vector<IR::Argument>();
+    auto emptyArgs = new IR::Vector<IR::Argument>();
 
     auto parserPath = new IR::Path(v1model.parser.Id());
     auto parserType = new IR::Type_Name(parserPath);
     auto parserConstruct = new IR::ConstructorCallExpression(parserType, emptyArgs);
-    args->push_back(parserConstruct);
+    args->push_back(new IR::Argument(parserConstruct));
 
     auto verifyPath = new IR::Path(verifyChecksums->name);
     auto verifyType = new IR::Type_Name(verifyPath);
     auto verifyConstruct = new IR::ConstructorCallExpression(verifyType, emptyArgs);
-    args->push_back(verifyConstruct);
+    args->push_back(new IR::Argument(verifyConstruct));
 
     auto ingressPath = new IR::Path(ingressReference);
     auto ingressType = new IR::Type_Name(ingressPath);
     auto ingressConstruct = new IR::ConstructorCallExpression(ingressType, emptyArgs);
-    args->push_back(ingressConstruct);
+    args->push_back(new IR::Argument(ingressConstruct));
 
     auto egressPath = new IR::Path(v1model.egress.Id());
     auto egressType = new IR::Type_Name(egressPath);
     auto egressConstruct = new IR::ConstructorCallExpression(egressType, emptyArgs);
-    args->push_back(egressConstruct);
+    args->push_back(new IR::Argument(egressConstruct));
 
     auto updatePath = new IR::Path(updateChecksums->name);
     auto updateType = new IR::Type_Name(updatePath);
     auto updateConstruct = new IR::ConstructorCallExpression(updateType, emptyArgs);
-    args->push_back(updateConstruct);
+    args->push_back(new IR::Argument(updateConstruct));
 
     auto deparserPath = new IR::Path(deparser->name);
     auto deparserType = new IR::Type_Name(deparserPath);
     auto deparserConstruct = new IR::ConstructorCallExpression(deparserType, emptyArgs);
-    args->push_back(deparserConstruct);
+    args->push_back(new IR::Argument(deparserConstruct));
 
     auto result = new IR::Declaration_Instance(name, type, args, nullptr);
     declarations->push_back(result);
@@ -2153,17 +2184,17 @@ void ProgramStructure::createChecksumVerifications() {
             IR::ID methodName = fl->payload ? v1model.verify_checksum_with_payload.Id() :
                                 v1model.verify_checksum.Id();
             auto method = new IR::PathExpression(methodName);
-            auto args = new IR::Vector<IR::Expression>();
+            auto args = new IR::Vector<IR::Argument>();
             const IR::Expression* condition;
             if (uov.cond != nullptr)
                 condition = conv.convert(uov.cond);
             else
                 condition = new IR::BoolLiteral(true);
             auto algo = convertHashAlgorithms(flc->algorithm);
-            args->push_back(condition);
-            args->push_back(le);
-            args->push_back(dest);
-            args->push_back(algo);
+            args->push_back(new IR::Argument(condition->srcInfo, condition));
+            args->push_back(new IR::Argument(le->srcInfo, le));
+            args->push_back(new IR::Argument(dest->srcInfo, dest));
+            args->push_back(new IR::Argument(algo->srcInfo, algo));
 
             auto mc = new IR::MethodCallStatement(new IR::MethodCallExpression(method, args));
             body->push_back(mc);
@@ -2211,7 +2242,7 @@ void ProgramStructure::createChecksumUpdates() {
             IR::ID methodName = fl->payload ? v1model.update_checksum_with_payload.Id() :
                                 v1model.update_checksum.Id();
             auto method = new IR::PathExpression(methodName);
-            auto args = new IR::Vector<IR::Expression>();
+            auto args = new IR::Vector<IR::Argument>();
             const IR::Expression* condition;
             if (uov.cond != nullptr)
                 condition = conv.convert(uov.cond);
@@ -2219,10 +2250,10 @@ void ProgramStructure::createChecksumUpdates() {
                 condition = new IR::BoolLiteral(true);
             auto algo = convertHashAlgorithms(flc->algorithm);
 
-            args->push_back(condition);
-            args->push_back(le);
-            args->push_back(dest);
-            args->push_back(algo);
+            args->push_back(new IR::Argument(condition->srcInfo, condition));
+            args->push_back(new IR::Argument(le->srcInfo, le));
+            args->push_back(new IR::Argument(dest->srcInfo, dest));
+            args->push_back(new IR::Argument(algo->srcInfo, algo));
             auto mc = new IR::MethodCallStatement(new IR::MethodCallExpression(method, args));
             body->push_back(mc);
             LOG3("Converted " << flc);

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -238,7 +238,7 @@ class ProgramStructure {
     const IR::AssignmentStatement* assign(Util::SourceInfo srcInfo, const IR::Expression* left,
                                           const IR::Expression* right, const IR::Type* type);
     virtual const IR::Expression* convertFieldList(const IR::Expression* expression);
-    virtual const IR::Expression* convertHashAlgorithm(IR::ID algorithm);
+    virtual const IR::Expression* convertHashAlgorithm(Util::SourceInfo srcInfo, IR::ID algorithm);
     virtual const IR::Expression* convertHashAlgorithms(const IR::NameList *algorithm);
     virtual const IR::Declaration_Instance* convert(const IR::Register* reg, cstring newName,
                                                     const IR::Type *regElementType = nullptr);

--- a/frontends/p4/inlining.cpp
+++ b/frontends/p4/inlining.cpp
@@ -751,7 +751,7 @@ const IR::Node* GeneralInliner::preorder(IR::ParserState* state) {
         // Evaluate in and inout parameters in order.
         auto it = call->methodCall->arguments->begin();
         for (auto param : callee->getApplyParameters()->parameters) {
-            auto initializer = *it;
+            auto initializer = (*it)->expression;
             LOG3("Looking for " << param->name);
             if (param->direction == IR::Direction::In || param->direction == IR::Direction::InOut) {
                 auto expr = substs->paramSubst.lookupByName(param->name);
@@ -795,7 +795,7 @@ const IR::Node* GeneralInliner::preorder(IR::ParserState* state) {
         // Copy back out and inout parameters
         it = call->methodCall->arguments->begin();
         for (auto param : callee->getApplyParameters()->parameters) {
-            auto left = *it;
+            auto left = (*it)->expression;
             if (param->direction == IR::Direction::InOut ||
                 param->direction == IR::Direction::Out) {
                 auto expr = substs->paramSubst.lookupByName(param->name);

--- a/frontends/p4/resetHeaders.cpp
+++ b/frontends/p4/resetHeaders.cpp
@@ -32,7 +32,7 @@ void DoResetHeaders::generateResets(
         }
     } else if (type->is<IR::Type_Header>()) {
         auto method = new IR::Member(expr->srcInfo, expr, IR::Type_Header::setInvalid);
-        auto args = new IR::Vector<IR::Expression>();
+        auto args = new IR::Vector<IR::Argument>();
         auto mc = new IR::MethodCallExpression(expr->srcInfo, method, args);
         auto stat = new IR::MethodCallStatement(mc->srcInfo, mc);
         resets->push_back(stat);

--- a/frontends/p4/setHeaders.cpp
+++ b/frontends/p4/setHeaders.cpp
@@ -40,7 +40,7 @@ void DoSetHeaders::generateSetValid(
         LOG3("Inserting setValid for " << dest);
         auto method = new IR::Member(dest->srcInfo, dest, IR::Type_Header::setValid);
         auto mc = new IR::MethodCallExpression(
-            dest->srcInfo, method, new IR::Vector<IR::Expression>());
+            dest->srcInfo, method, new IR::Vector<IR::Argument>());
         auto stat = new IR::MethodCallStatement(mc->srcInfo, mc);
         insert->push_back(stat);
     }

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -618,7 +618,7 @@ class DismantleExpression : public Transform {
         for (auto p : *desc.substitution.getParameters()) {
             auto arg = desc.substitution.lookup(p);
             if (p->direction == IR::Direction::None) {
-                args->push_back(new IR::Argument(arg->srcInfo, arg));
+                args->push_back(new IR::Argument(arg));
                 continue;
             }
 
@@ -661,7 +661,7 @@ class DismantleExpression : public Transform {
                 copyBack->push_back(assign);
                 LOG3("Will copy out value " << dbp(assign));
             }
-            args->push_back(new IR::Argument(argValue->srcInfo, argValue));
+            args->push_back(new IR::Argument(argValue));
         }
         leftValue = savelv;
         resultNotUsed = savenu;

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -476,7 +476,7 @@ class DismantleExpression : public Transform {
         void postorder(const IR::ConstructorCallExpression* expression) override {
             const SetOfLocations* result = new SetOfLocations();
             for (auto e : *expression->arguments) {
-                auto s = ::get(rw, e);
+                auto s = ::get(rw, e->expression);
                 result = result->join(s);
             }
             rw.emplace(expression, result);
@@ -538,7 +538,7 @@ class DismantleExpression : public Transform {
         }
 
         auto copyBack = new IR::IndexedVector<IR::StatOrDecl>();
-        auto args = new IR::Vector<IR::Expression>();
+        auto args = new IR::Vector<IR::Argument>();
         MethodCallDescription desc(orig, refMap, typeMap);
         bool savelv = leftValue;
         bool savenu = resultNotUsed;
@@ -618,7 +618,7 @@ class DismantleExpression : public Transform {
         for (auto p : *desc.substitution.getParameters()) {
             auto arg = desc.substitution.lookup(p);
             if (p->direction == IR::Direction::None) {
-                args->push_back(arg);
+                args->push_back(new IR::Argument(arg->srcInfo, arg));
                 continue;
             }
 
@@ -661,7 +661,7 @@ class DismantleExpression : public Transform {
                 copyBack->push_back(assign);
                 LOG3("Will copy out value " << dbp(assign));
             }
-            args->push_back(argValue);
+            args->push_back(new IR::Argument(argValue->srcInfo, argValue));
         }
         leftValue = savelv;
         resultNotUsed = savenu;

--- a/frontends/p4/specialize.h
+++ b/frontends/p4/specialize.h
@@ -33,7 +33,7 @@ struct SpecializationInfo {
     /// Values to substitute for type arguments.
     const IR::Vector<IR::Type>*        typeArguments;
     /// Values to substitute for constructor arguments.
-    IR::Vector<IR::Expression>*        constructorArguments;
+    IR::Vector<IR::Argument>*          constructorArguments;
     /// Declarations to insert in the list of locals.
     IR::IndexedVector<IR::Declaration>* declarations;
     /// Invocation which causes this specialization.
@@ -44,7 +44,7 @@ struct SpecializationInfo {
     SpecializationInfo(const IR::Node* invocation, const IR::IContainer* cont,
                        const IR::Node* insertion) :
             specialized(cont), typeArguments(nullptr),
-            constructorArguments(new IR::Vector<IR::Expression>()),
+            constructorArguments(new IR::Vector<IR::Argument>()),
             declarations(new IR::IndexedVector<IR::Declaration>()),
             invocation(invocation), insertBefore(insertion)
     { CHECK_NULL(cont); CHECK_NULL(invocation); CHECK_NULL(insertion); }
@@ -55,7 +55,7 @@ struct SpecializationInfo {
 class SpecializationMap {
     /// Maps invocation to specialization info.
     ordered_map<const IR::Node*, SpecializationInfo*> specializations;
-    const IR::Expression* convertArgument(const IR::Expression* arg, SpecializationInfo* info);
+    const IR::Argument* convertArgument(const IR::Argument* arg, SpecializationInfo* info);
 
  public:
     TypeMap*      typeMap;
@@ -134,7 +134,7 @@ class FindSpecializations : public Inspector {
  *
  * Note that this pass handles type substition for instantiating generic Parser
  * or Control types, which is an experimental feature.
- * 
+ *
  * For example:
  *
 ```

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -238,6 +238,15 @@ bool ToP4::preorder(const IR::Type_Specialized* t) {
     return false;
 }
 
+bool ToP4::preorder(const IR::Argument* arg) {
+    if (!arg->name.name.isNullOrEmpty()) {
+        builder.append(arg->name.toString());
+        builder.append(" = ");
+    }
+    visit(arg->expression);
+    return false;
+}
+
 bool ToP4::preorder(const IR::Type_Typedef* t) {
     dump(2);
     visit(t->annotations);
@@ -636,6 +645,7 @@ VECTOR_VISIT(Vector, ActionListElement)
 VECTOR_VISIT(Vector, Annotation)
 VECTOR_VISIT(Vector, Entry)
 VECTOR_VISIT(Vector, Expression)
+VECTOR_VISIT(Vector, Argument)
 VECTOR_VISIT(Vector, KeyElement)
 VECTOR_VISIT(Vector, Method)
 VECTOR_VISIT(Vector, Node)

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -175,6 +175,7 @@ class ToP4 : public Inspector {
     bool preorder(const IR::Vector<IR::Annotation>* v) override;
     bool preorder(const IR::Vector<IR::Entry>* v) override;
     bool preorder(const IR::Vector<IR::Expression>* v) override;
+    bool preorder(const IR::Vector<IR::Argument>* v) override;
     bool preorder(const IR::Vector<IR::KeyElement>* v) override;
     bool preorder(const IR::Vector<IR::Method>* v) override;
     bool preorder(const IR::Vector<IR::Node>* v) override;
@@ -199,6 +200,7 @@ class ToP4 : public Inspector {
     bool preorder(const IR::IfStatement* s) override;
 
     // misc
+    bool preorder(const IR::Argument* arg) override;
     bool preorder(const IR::Path* p) override;
     bool preorder(const IR::Parameter* p) override;
     bool preorder(const IR::Annotation* a) override;

--- a/frontends/p4/typeChecking/syntacticEquivalence.cpp
+++ b/frontends/p4/typeChecking/syntacticEquivalence.cpp
@@ -34,6 +34,16 @@ bool SameExpression::sameExpressions(const IR::Vector<IR::Expression>* left,
     return true;
 }
 
+bool SameExpression::sameExpressions(const IR::Vector<IR::Argument>* left,
+                                     const IR::Vector<IR::Argument>* right) const {
+    if (left->size() != right->size())
+        return false;
+    for (unsigned i = 0; i < left->size(); i++)
+        if (!sameExpression(left->at(i)->expression, right->at(i)->expression))
+            return false;
+    return true;
+}
+
 bool SameExpression::sameExpression(const IR::Expression* left, const IR::Expression* right) const {
     CHECK_NULL(left); CHECK_NULL(right);
     if (left->node_type_name() != right->node_type_name())

--- a/frontends/p4/typeChecking/syntacticEquivalence.h
+++ b/frontends/p4/typeChecking/syntacticEquivalence.h
@@ -34,6 +34,8 @@ class SameExpression {
     bool sameExpression(const IR::Expression* left, const IR::Expression* right) const;
     bool sameExpressions(const IR::Vector<IR::Expression>* left,
                          const IR::Vector<IR::Expression>* right) const;
+    bool sameExpressions(const IR::Vector<IR::Argument>* left,
+                         const IR::Vector<IR::Argument>* right) const;
 };
 
 }  // namespace P4

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -140,17 +140,17 @@ class TypeInference : public Transform {
     const IR::Node* typeSet(const IR::Operation_Binary* op);
 
     const IR::Type* cloneWithFreshTypeVariables(const IR::IMayBeGenericType* type);
-    std::pair<const IR::Type*, const IR::Vector<IR::Expression>*>
+    std::pair<const IR::Type*, const IR::Vector<IR::Argument>*>
     containerInstantiation(const IR::Node* node,
-                           const IR::Vector<IR::Expression>* args,
+                           const IR::Vector<IR::Argument>* args,
                            const IR::IContainer* container);
     const IR::Expression* actionCall(
         bool inActionList,   // if true this "call" is in the action list of a table
         const IR::MethodCallExpression* actionCall);
-    const IR::Vector<IR::Expression>*
+    const IR::Vector<IR::Argument>*
             checkExternConstructor(const IR::Node* errorPosition,
                                    const IR::Type_Extern* ext,
-                                   const IR::Vector<IR::Expression> *arguments);
+                                   const IR::Vector<IR::Argument> *arguments);
 
     static constexpr bool forbidModules = true;
     static constexpr bool forbidPackages = true;
@@ -217,6 +217,7 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::Key* key) override;
     const IR::Node* postorder(IR::Entry* e) override;
 
+    const IR::Node* postorder(IR::Argument* arg) override;
     const IR::Node* postorder(IR::Parameter* param) override;
     const IR::Node* postorder(IR::Constant* expression) override;
     const IR::Node* postorder(IR::BoolLiteral* expression) override;

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -68,7 +68,7 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
             if (reportErrors)
                 ::error("%1%: Not enough arguments for call", errorPosition);
             return false; }
-        auto arg = *sit;
+        auto arg = (*sit);
         if (arg->type->is<IR::Type_Dontcare>() && dit->direction != IR::Direction::Out) {
             if (reportErrors)
                 ::error("%1%: don't care argument only allowed for out parameters", arg->srcInfo);

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -493,13 +493,13 @@ simpleKeysetExpression
 // experimental
 valueSetDeclaration
     : optAnnotations
-        VALUESET "<" baseType ">" "(" argument ")" name ";"
+        VALUESET "<" baseType ">" "(" expression ")" name ";"
         { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
     | optAnnotations
-        VALUESET "<" tupleType ">" "(" argument ")" name ";"
+        VALUESET "<" tupleType ">" "(" expression ")" name ";"
         { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
     | optAnnotations
-        VALUESET "<" typeName ">" "(" argument ")" name ";"
+        VALUESET "<" typeName ">" "(" expression ")" name ";"
         { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
     ;
 

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -158,14 +158,14 @@ typedef const IR::Type ConstType;
 %type<IR::Path*>            prefixedNonTypeName prefixedType
 %type<IR::IndexedVector<IR::Type_Var>*>  typeParameterList
 %type<IR::TypeParameters*>  optTypeParameters
-%type<IR::Expression*>      expression lvalue
-                            keysetExpression selectExpression
+%type<IR::Expression*>      expression lvalue keysetExpression selectExpression
                             stateExpression optInitializer initializer
-                            argument simpleKeysetExpression
-                            transitionStatement switchLabel
+                            simpleKeysetExpression transitionStatement switchLabel
 %type<ConstType*>           baseType typeOrVoid specializedType headerStackType
                             typeRef tupleType typeArg realTypeArg namedType
 %type<IR::Type_Name*>       typeName
+%type<IR::Argument*>        argument
+%type<IR::Vector<IR::Argument>*>  argumentList nonEmptyArgList
 %type<IR::Parameter*>       parameter
 %type<OptionalConst>        optCONST
 %type<IR::Annotations*>     optAnnotations
@@ -173,7 +173,7 @@ typedef const IR::Type ConstType;
 %type<IR::Annotation*>      annotation
 %type<IR::IndexedVector<IR::Parameter>*>  parameterList nonEmptyParameterList
                                           optConstructorParameters
-%type<IR::Vector<IR::Expression>*>        argumentList nonEmptyArgList expressionList
+%type<IR::Vector<IR::Expression>*>        expressionList
                                           simpleExpressionList tupleKeysetExpression
 %type<IR::IndexedVector<IR::Declaration_ID>*>  identifierList
 %type<IR::SelectCase*>      selectCase
@@ -967,19 +967,20 @@ functionDeclaration
     ;
 
 argumentList
-    : /* empty */                        { $$ = new IR::Vector<IR::Expression>(); }
+    : /* empty */                        { $$ = new IR::Vector<IR::Argument>(); }
     | nonEmptyArgList                    { $$ = $1; }
     ;
 
 nonEmptyArgList
-    : argument                           { $$ = new IR::Vector<IR::Expression>();
+    : argument                           { $$ = new IR::Vector<IR::Argument>();
                                            $$->push_back($1); }
     | nonEmptyArgList "," argument       { $$ = $1; $$->push_back($3); }
     ;
 
 argument
-    : expression                         { $$ = $1; }
-    | "_"                                { $$ = new IR::DefaultExpression(@1); }
+    : expression                         { $$ = new IR::Argument(@1, $1); }
+    | name "=" expression                { $$ = new IR::Argument(@1, *$1, $3); }
+    | "_"                                { $$ = new IR::Argument(@1, new IR::DefaultExpression(@1)); }
     ;
 
 expressionList

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -890,12 +890,12 @@ blackbox_instantiation:
         { driver.global->add($3,
             new IR::Declaration_Instance(@3, $3, driver.takePragmasAsAnnotations(),
                                          new IR::Type_Name($2),
-                                         new IR::Vector<IR::Expression>)); }
+                                         new IR::Vector<IR::Argument>)); }
     | BLACKBOX name name "{" blackbox_config "}"
         { auto instance =
             new IR::Declaration_Instance(@3, $3, driver.takePragmasAsAnnotations(),
                                          new IR::Type_Name($2),
-                                         new IR::Vector<IR::Expression>);
+                                         new IR::Vector<IR::Argument>);
           instance->properties = std::move(*$5);
           driver.global->add($3, instance); }
 ;

--- a/ir/base.def
+++ b/ir/base.def
@@ -260,6 +260,7 @@ class Argument {
     /// If an argument has no name the name.name is nullptr.
     optional ID name;
     Expression expression;
+    Argument { if (!srcInfo && expression) srcInfo = expression->srcInfo; }
     dbprint { out << (name.name.isNullOrEmpty() ? "" : name.name + " = ") << expression; }
     validate { CHECK_NULL(expression); }
     toString{

--- a/ir/base.def
+++ b/ir/base.def
@@ -147,8 +147,9 @@ abstract Operation : Expression {
     toString{ return getStringOp(); }
 }
 
-/// A Path is a vestige of a previous design.
-/// Today paths can only consist of a '.'
+/// Currently paths can be absolute (starting with a dot) or relative
+/// (just an identifier).  In a previous design paths could have
+/// multiple components.
 class Path {
     ID   name;
     optional bool absolute = false;
@@ -251,6 +252,22 @@ interface IAnnotated {
 interface IInstance {
     virtual cstring Name() const = 0;
     virtual Type getType() const = 0;
+}
+
+/// An argument to a function call (or constructor call)
+/// Arguments may have optional names
+class Argument {
+    /// If an argument has no name the name.name is nullptr.
+    optional ID name;
+    Expression expression;
+    dbprint { out << (name.name.isNullOrEmpty() ? "" : name.name + " = ") << expression; }
+    validate { CHECK_NULL(expression); }
+    toString{
+        cstring result = "";
+        if (!name.name.isNullOrEmpty())
+            result = name.toString() + " = ";
+        return result + expression->toString();
+    }
 }
 
 /** @} *//* end group irdefs */

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -315,19 +315,19 @@ class SelectExpression : Expression {
 class MethodCallExpression : Expression {
     Expression                  method;
     optional Vector<Type>       typeArguments = new Vector<Type>;
-    optional Vector<Expression> arguments = new Vector<Expression>;
+    optional Vector<Argument>   arguments = new Vector<Argument>;
     toString{ return method->toString(); }
     validate{ typeArguments->check_null(); arguments->check_null(); }
-    MethodCallExpression(Util::SourceInfo si, IR::ID m, const std::initializer_list<Expression> &a)
-    : Expression(si), method(new PathExpression(m)), arguments(new Vector<Expression>(a)) {}
+    MethodCallExpression(Util::SourceInfo si, IR::ID m, const std::initializer_list<Argument> &a)
+            : Expression(si), method(new PathExpression(m)), arguments(new Vector<Argument>(a)) {}
     MethodCallExpression(Util::SourceInfo si, Expression m,
-                         const std::initializer_list<Expression> &a)
-    : Expression(si), method(m), arguments(new Vector<Expression>(a)) {}
+                         const std::initializer_list<Argument> &a)
+    : Expression(si), method(m), arguments(new Vector<Argument>(a)) {}
 }
 
 class ConstructorCallExpression : Expression {
     Type               constructedType = type;  // Either a Type_Name or a Specialized_Type
-    Vector<Expression> arguments;
+    Vector<Argument>   arguments;
     toString{ return constructedType->toString(); }
     validate{ BUG_CHECK(constructedType->is<Type_Name>() ||
                         constructedType->is<Type_Specialized>(),

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -135,6 +135,7 @@ class P4Control : Type_Declaration, ISimpleNamespace, IApply, IContainer {
     toString { return cstring("control ") + externalName(); }
 }
 
+/// A P4-16 action
 class P4Action : Declaration, ISimpleNamespace, IAnnotated {
     optional Annotations        annotations = Annotations::empty;
     ParameterList               parameters;
@@ -164,10 +165,10 @@ class Declaration_MatchKind : ISimpleNamespace {
     validate{ members.check_null(); }
 }
 
-// Table property value abstract base class
+/// Table property value abstract base class
 abstract PropertyValue { }
 
-// A property whose value is an expression
+/// A table property whose value is an expression
 class ExpressionValue : PropertyValue {
     Expression expression;
     dbprint { out << expression; }
@@ -368,7 +369,7 @@ class Declaration_Constant : Declaration, IAnnotated {
 class Declaration_Instance : Declaration, IAnnotated, IInstance {
     optional Annotations  annotations = Annotations::empty;
     Type                  type;  // Either Type_Name or Type_Specialized or Type_Extern
-    Vector<Expression>    arguments;
+    Vector<Argument>      arguments;
     inline NameMap<Property> properties = {};  // P4_14 externs only, at the moment
     optional NullOK BlockStatement initializer = nullptr;
         // experimental only; contains just declarations, no code
@@ -445,10 +446,10 @@ class BlockStatement : Statement, ISimpleNamespace, IAnnotated {
 class MethodCallStatement : Statement {
     MethodCallExpression methodCall;
     MethodCallStatement { if (!srcInfo) srcInfo = methodCall->srcInfo; }
-    MethodCallStatement(Util::SourceInfo si, IR::ID m, const std::initializer_list<Expression> &a)
+    MethodCallStatement(Util::SourceInfo si, IR::ID m, const std::initializer_list<Argument> &a)
     : Statement(si), methodCall(new MethodCallExpression(si, m, a)) {}
     MethodCallStatement(Util::SourceInfo si, Expression m,
-                        const std::initializer_list<Expression> &a)
+                        const std::initializer_list<Argument> &a)
     : Statement(si), methodCall(new MethodCallExpression(si, m, a)) {}
 }
 

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -167,8 +167,8 @@ class JSONLoader {
     typename std::enable_if<std::is_integral<T>::value>::type
     unpack_json(T &v) { v = *json->to<JsonNumber>(); }
     void unpack_json(mpz_class &v) { v = json->to<JsonNumber>()->val; }
-    void unpack_json(cstring &v) { v = *json->to<std::string>(); }
-    void unpack_json(IR::ID &v) { v.name = *json->to<std::string>(); }
+    void unpack_json(cstring &v) { if (!json->is<JsonNull>()) v = *json->to<std::string>(); }
+    void unpack_json(IR::ID &v) { if (!json->is<JsonNull>()) v.name = *json->to<std::string>(); }
 
     void unpack_json(LTBitMatrix &m) {
         if (auto *s = json->to<std::string>())

--- a/ir/write_context.cpp
+++ b/ir/write_context.cpp
@@ -40,15 +40,16 @@ bool P4WriteContext::isWrite(bool root_value) {
         return prim->isOutput(ctxt->child_index);
     if (ctxt->node->is<IR::AssignmentStatement>())
         return ctxt->child_index == 0;
-    if (ctxt->node->is<IR::Vector<IR::Expression>>()) {
-        if (!ctxt->parent || !ctxt->parent->node)
+    if (ctxt->node->is<IR::Argument>()) {
+        // MethodCallExpression(Vector<Argument(Expression)>)
+        if (!ctxt->parent || !ctxt->parent->parent || !ctxt->parent->parent->node)
             return false;
-        if (auto *mc = ctxt->parent->node->to<IR::MethodCallExpression>()) {
+        if (auto *mc = ctxt->parent->parent->node->to<IR::MethodCallExpression>()) {
             auto type = mc->method->type->to<IR::Type_Method>();
             if (!type) {
                 /* FIXME -- can't find the type of the method -- should be a BUG? */
                 return true; }
-            auto param = type->parameters->getParameter(ctxt->child_index);
+            auto param = type->parameters->getParameter(ctxt->parent->child_index);
             return param->direction == IR::Direction::Out ||
                    param->direction == IR::Direction::InOut; }
         if (ctxt->parent->node->is<IR::ConstructorCallExpression>()) {
@@ -83,15 +84,16 @@ bool P4WriteContext::isRead(bool root_value) {
         return !prim->isOutput(ctxt->child_index);
     if (ctxt->node->is<IR::AssignmentStatement>())
         return ctxt->child_index != 0;
-    if (ctxt->node->is<IR::Vector<IR::Expression>>()) {
-        if (!ctxt->parent || !ctxt->parent->node)
+    if (ctxt->node->is<IR::Argument>()) {
+        // MethodCallExpression(Vector<Argument(Expression)>)
+        if (!ctxt->parent || !ctxt->parent->parent || !ctxt->parent->parent->node)
             return false;
-        if (auto *mc = ctxt->parent->node->to<IR::MethodCallExpression>()) {
+        if (auto *mc = ctxt->parent->parent->node->to<IR::MethodCallExpression>()) {
             auto type = mc->method->type->to<IR::Type_Method>();
             if (!type) {
                 /* FIXME -- can't find the type of the method -- should be a BUG? */
                 return true; }
-            auto param = type->parameters->getParameter(ctxt->child_index);
+            auto param = type->parameters->getParameter(ctxt->parent->child_index);
             return param->direction != IR::Direction::Out; } }
     if (ctxt->node->is<IR::IndexedVector<IR::StatOrDecl>>())
         return false;

--- a/midend/actionSynthesis.cpp
+++ b/midend/actionSynthesis.cpp
@@ -27,9 +27,10 @@ const IR::Node* DoMoveActionsToTables::postorder(IR::MethodCallStatement* statem
     auto ac = mi->to<ActionCall>();
 
     auto action = ac->action;
-    auto directionArgs = new IR::Vector<IR::Expression>();
+    auto directionArgs = new IR::Vector<IR::Argument>();
     auto mc = statement->methodCall;
 
+    // TODO: should use argument names
     auto it = action->parameters->parameters.begin();
     auto arg = mc->arguments->begin();
     for (; it != action->parameters->parameters.end(); ++it) {
@@ -53,7 +54,7 @@ const IR::Node* DoMoveActionsToTables::postorder(IR::MethodCallStatement* statem
         IR::ID(IR::TableProperties::actionsPropertyName, nullptr),
         actlist, false);
     // default action property
-    auto otherArgs = new IR::Vector<IR::Expression>();
+    auto otherArgs = new IR::Vector<IR::Argument>();
     for (; it != action->parameters->parameters.end(); ++it) {
         otherArgs->push_back(*arg);
         ++arg;
@@ -81,7 +82,7 @@ const IR::Node* DoMoveActionsToTables::postorder(IR::MethodCallStatement* statem
     auto method = new IR::Member(tblpath, IR::IApply::applyMethodName);
     auto mce = new IR::MethodCallExpression(
         statement->srcInfo, method, new IR::Vector<IR::Type>(),
-        new IR::Vector<IR::Expression>());
+        new IR::Vector<IR::Argument>());
     auto stat = new IR::MethodCallStatement(mce->srcInfo, mce);
     return stat;
 }

--- a/midend/expandEmit.cpp
+++ b/midend/expandEmit.cpp
@@ -20,8 +20,8 @@ limitations under the License.
 namespace P4 {
 
 bool DoExpandEmit::expandArg(
-    const IR::Type* type, const IR::Expression* arg,
-    std::vector<const IR::Expression*> *result, std::vector<const IR::Type*> *resultTypes) {
+    const IR::Type* type, const IR::Argument* arg,
+    std::vector<const IR::Argument*> *result, std::vector<const IR::Type*> *resultTypes) {
     if (type->is<IR::Type_Header>()) {
         result->push_back(arg);
         resultTypes->push_back(type);
@@ -30,7 +30,8 @@ bool DoExpandEmit::expandArg(
         int size = st->getSize();
         for (int i = 0; i < size; i++) {
             auto index = new IR::Constant(i);
-            auto element = new IR::ArrayIndex(arg, index);
+            auto element = new IR::Argument(
+                arg->srcInfo, arg->name, new IR::ArrayIndex(arg->expression, index));
             result->push_back(element);
             resultTypes->push_back(st->elementType);
         }
@@ -49,7 +50,8 @@ bool DoExpandEmit::expandArg(
                   "%1%: expected a struct or header_union type", type);
         auto strct = type->to<IR::Type_StructLike>();
         for (auto f : strct->fields) {
-            auto expr = new IR::Member(arg, f->name);
+            auto expr = new IR::Argument(
+                arg->srcInfo, arg->name, new IR::Member(arg->expression, f->name));
             auto type = typeMap->getTypeType(f->type, true);
             expandArg(type, expr, result, resultTypes);
         }
@@ -69,7 +71,7 @@ const IR::Node* DoExpandEmit::postorder(IR::MethodCallStatement* statement) {
 
             auto arg0 = em->expr->arguments->at(0);
             auto type = typeMap->getType(arg0, true);
-            std::vector<const IR::Expression*> expansion;
+            std::vector<const IR::Argument*> expansion;
             std::vector<const IR::Type*> expansionTypes;
             if (expandArg(type, arg0, &expansion, &expansionTypes)) {
                 auto vec = new IR::IndexedVector<IR::StatOrDecl>();
@@ -77,7 +79,7 @@ const IR::Node* DoExpandEmit::postorder(IR::MethodCallStatement* statement) {
                 for (auto e : expansion) {
                     auto method = statement->methodCall->method->clone();
                     auto argType = *it;
-                    auto args = new IR::Vector<IR::Expression>();
+                    auto args = new IR::Vector<IR::Argument>();
                     args->push_back(e);
                     auto typeArgs = new IR::Vector<IR::Type>();
                     typeArgs->push_back(argType->getP4Type());

--- a/midend/expandEmit.cpp
+++ b/midend/expandEmit.cpp
@@ -37,10 +37,10 @@ bool DoExpandEmit::expandArg(
         }
         return true;
     } else if (auto tup = type->to<IR::Type_Tuple>()) {
-        auto le = arg->to<IR::ListExpression>();
+        auto le = arg->expression->to<IR::ListExpression>();
         BUG_CHECK(le != nullptr && le->size() == tup->size(), "%1%: not a list?", arg);
         for (size_t i = 0; i < le->size(); i++) {
-            auto expr = le->components.at(i);
+            auto expr = new IR::Argument(arg->srcInfo, arg->name, le->components.at(i));
             auto type = tup->components.at(i);
             expandArg(type, expr, result, resultTypes);
         }

--- a/midend/expandEmit.h
+++ b/midend/expandEmit.h
@@ -49,8 +49,8 @@ class DoExpandEmit : public Transform {
             refMap(refMap), typeMap(typeMap)
     { CHECK_NULL(refMap); CHECK_NULL(typeMap); setName("DoExpandEmit"); }
     // return true if the expansion produced something "new"
-    bool expandArg(const IR::Type* type, const IR::Expression* expression,
-                   std::vector<const IR::Expression*> *result,
+    bool expandArg(const IR::Type* type, const IR::Argument* argument,
+                   std::vector<const IR::Argument*> *result,
                    std::vector<const IR::Type*> *resultTypes);
     const IR::Node* postorder(IR::MethodCallStatement* statement) override;
 };

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -836,7 +836,7 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression* expression) 
     auto mi = mcd.instance;
 
     for (auto arg : *expression->arguments) {
-        auto argValue = get(arg);
+        auto argValue = get(arg->expression);
         CHECK_NULL(argValue);
         if (argValue->is<SymbolicError>()) {
             set(expression, argValue);
@@ -861,7 +861,7 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression* expression) 
             BUG_CHECK(base->is<SymbolicArray>(), "%1%: expected an array", base);
             auto array = base->to<SymbolicArray>();
             BUG_CHECK(expression->arguments->size() == 1, "%1%: not one argument?", expression);
-            auto amount = get(expression->arguments->at(0));
+            auto amount = get(expression->arguments->at(0)->expression);
             BUG_CHECK(amount->is<SymbolicInteger>(), "%1%: expected an integer", amount);
             auto ac = amount->to<SymbolicInteger>();
             if (ac->isUnknown()) {
@@ -896,7 +896,7 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression* expression) 
                 // is always valid.
                 auto arg0 = expression->arguments->at(0);
                 auto argType = typeMap->getType(arg0, true);
-                auto hdr = get(arg0);
+                auto hdr = get(arg0->expression);
                 bool fixed = factory->isFixedWidth(argType);
                 unsigned width = factory->getWidth(argType);
                 // For variable-sized objects width is the "minimum" width.
@@ -921,7 +921,7 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression* expression) 
                         return;
                     }
                     auto arg1 = expression->arguments->at(1);
-                    auto sz = get(arg1);
+                    auto sz = get(arg1->expression);
                     if (sz->is<SymbolicInteger>()) {
                         auto szValue = sz->to<SymbolicInteger>();
                         if (szValue->isKnown())

--- a/midend/noMatch.cpp
+++ b/midend/noMatch.cpp
@@ -36,11 +36,11 @@ const IR::Node* DoHandleNoMatch::preorder(IR::P4Parser* parser) {
 
     cstring name = nameGen->newName("noMatch");
     LOG2("Inserting " << name << " state");
-    auto args = new IR::Vector<IR::Expression>();
-    args->push_back(new IR::BoolLiteral(false));
-    args->push_back(new IR::Member(
+    auto args = new IR::Vector<IR::Argument>();
+    args->push_back(new IR::Argument(new IR::BoolLiteral(false)));
+    args->push_back(new IR::Argument(new IR::Member(
         new IR::TypeNameExpression(IR::Type_Error::error),
-        lib.noMatch.Id()));
+        lib.noMatch.Id())));
     auto verify = new IR::MethodCallExpression(
         new IR::PathExpression(IR::ID(IR::ParserState::verify)), args);
     noMatch = new IR::ParserState(IR::ID(name), { new IR::MethodCallStatement(verify) },

--- a/midend/removeParameters.cpp
+++ b/midend/removeParameters.cpp
@@ -32,9 +32,9 @@ class RemoveMethodCallArguments : public Transform {
     { setName("RemoveMethodCallArguments"); }
     const IR::Node* postorder(IR::MethodCallExpression* expression) override {
         if (argumentsToRemove == -1) {
-            expression->arguments = new IR::Vector<IR::Expression>();
+            expression->arguments = new IR::Vector<IR::Argument>();
         } else {
-            auto args = new IR::Vector<IR::Expression>();
+            auto args = new IR::Vector<IR::Argument>();
             for (int i = 0; i < static_cast<int>(expression->arguments->size()); i++) {
                 if (i < argumentsToRemove)
                     continue;
@@ -106,13 +106,13 @@ const IR::Node* DoRemoveActionParameters::postorder(IR::P4Action* action) {
                 p->direction == IR::Direction::InOut ||
                 p->direction == IR::Direction::None) {
                 auto left = new IR::PathExpression(p->name);
-                auto assign = new IR::AssignmentStatement(arg->srcInfo, left, arg);
+                auto assign = new IR::AssignmentStatement(arg->srcInfo, left, arg->expression);
                 initializers->push_back(assign);
             }
             if (p->direction == IR::Direction::Out ||
                 p->direction == IR::Direction::InOut) {
                 auto right = new IR::PathExpression(p->name);
-                auto assign = new IR::AssignmentStatement(arg->srcInfo, arg, right);
+                auto assign = new IR::AssignmentStatement(arg->srcInfo, arg->expression, right);
                 postamble->push_back(assign);
             }
         }


### PR DESCRIPTION
This is the first step in implementing support for named arguments in function calls.
We introduce a new IR class called Argument, which packages the argument information. The argument has an optional name, which is an ID. If the name is missing we use in fact an id whose `name` is a cstring which is nullptr - which is unusual, nowhere else in the compiler we allow null names.

This PR just converts the code to use Argument everywhere instead of expecting an Expression for the arguments. 

The code still matches arguments in order to parameters, ignoring the argument names supplied. A second PR will augment this one to make that change.  

I have also updated the bison grammar to allow names for arguments, to make sure that there are no ambiguities. But if you use them the result will be incorrect.