### PR TITLE
remove macro for PSA_SWITCH in psa.p4, update test case

### DIFF
--- a/p4include/psa.p4
+++ b/p4include/psa.p4
@@ -639,15 +639,4 @@ package PSA_Switch<IH, IM, EH, EM, NM, CI2EM, CE2EM, RESUBM, RECIRCM> (
 
 // END:Programmable_blocks
 
-// Macro enabling the PSA program author to more conveniently create a
-// PSA_Switch package instantiation, without having to type the
-// constructor calls for PacketReplicationEngine and
-// BufferingQueueingEngine.
-
-#define PSA_SWITCH(ip, ep) PSA_Switch(                           \
-                                      (ip),                      \
-                                      PacketReplicationEngine(), \
-                                      (ep),                      \
-                                      BufferingQueueingEngine())
-
 #endif  /* _PORTABLE_SWITCH_ARCHITECTURE_P4_ */

--- a/testdata/p4_16_samples/issue1208-1.p4
+++ b/testdata/p4_16_samples/issue1208-1.p4
@@ -65,6 +65,8 @@ control MyED(
     apply { }
 }
 
-PSA_SWITCH(
+PSA_Switch(
     IngressPipeline(MyIP(), MyIC(), MyID()),
-    EgressPipeline(MyEP(), MyEC(), MyED())) main;
+    PacketReplicationEngine(),
+    EgressPipeline(MyEP(), MyEC(), MyED()),
+    BufferingQueueingEngine()) main;


### PR DESCRIPTION
We already have a proposal with named argument to make the PacketReplicationEngine and BufferingQueueingEngine arguments optional. 

I would like to remove the PSA_SWITCH macro in psa.p4 to avoid creating more test cases that use a macro which is going to be retired later. 

Another reason to remove the macro is it does not play well with the gtest infrastructure, because gtest includes a raw string as test program which assumes the preprocessing is done, but there is no preprocessing support in the frontend, so all gtest cases that include psa.p4 is going to give a syntax error for the macro.
