### PR TITLE
adds support for saturating arithmetic in P4_16

### DIFF
--- a/backends/bmv2/JsonObjects.cpp
+++ b/backends/bmv2/JsonObjects.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 namespace BMV2 {
 
 const int JSON_MAJOR_VERSION = 2;
-const int JSON_MINOR_VERSION = 7;
+const int JSON_MINOR_VERSION = 18;
 
 JsonObjects::JsonObjects() {
     toplevel = new Util::JsonObject();

--- a/backends/bmv2/expression.cpp
+++ b/backends/bmv2/expression.cpp
@@ -450,7 +450,11 @@ void ExpressionConverter::postorder(const IR::IntMod* expression)  {
 }
 
 void ExpressionConverter::postorder(const IR::Operation_Binary* expression)  {
-    binary(expression);
+    cstring op = expression->getStringOp();
+    if (op == "|+|" || op == "|-|")
+        saturated_binary(expression);
+    else
+        binary(expression);
 }
 
 void ExpressionConverter::binary(const IR::Operation_Binary* expression) {
@@ -474,6 +478,40 @@ void ExpressionConverter::binary(const IR::Operation_Binary* expression) {
     e->emplace("left", fixLocal(l));
     auto r = get(expression->right);
     e->emplace("right", fixLocal(r));
+}
+
+void ExpressionConverter::saturated_binary(const IR::Operation_Binary* expression) {
+    // This should never happen if we correctly typecheck the program
+    BUG_CHECK(expression->type->is<IR::Type_Bits>(), "saturated arithmetic requires bit types");
+
+    std::cerr << "saturated arith: " << *expression << std::endl;
+
+    auto result = new Util::JsonObject();
+    map.emplace(expression, result);
+    result->emplace("type", "expression");
+    auto e = new Util::JsonObject();
+    result->emplace("value", e);
+    auto eType = expression->type->to<IR::Type_Bits>();
+    CHECK_NULL(eType);
+    auto opType = eType->isSigned ? "sat_cast" : "usat_cast";
+    e->emplace("op", opType);
+
+    // the left operand is the binary expression, but as a simple add/sub
+    auto eLeft = new Util::JsonObject();
+    eLeft->emplace("type", "expression");
+    auto e1 = new Util::JsonObject();
+    e1->emplace("op", expression->getStringOp() == "|+|" ? "+" : "-");
+    e1->emplace("left", fixLocal(get(expression->left)));
+    e1->emplace("right", fixLocal(get(expression->right)));
+    eLeft->emplace("value", e1);
+    e->emplace("left", eLeft);
+
+    // the right operand is the width of the type
+    auto r = new Util::JsonObject();
+    r->emplace("type", "hexstr");
+    cstring repr = stringRepr(eType->width_bits());
+    r->emplace("value", repr);
+    e->emplace("right", r);
 }
 
 void ExpressionConverter::postorder(const IR::ListExpression* expression)  {

--- a/backends/bmv2/expression.h
+++ b/backends/bmv2/expression.h
@@ -77,6 +77,7 @@ class ExpressionConverter : public Inspector {
     /// Non-null if the expression refers to a parameter from the enclosing control
     const IR::Parameter* enclosingParamReference(const IR::Expression* expression);
     void binary(const IR::Operation_Binary* expression);
+    void saturated_binary(const IR::Operation_Binary* expression);
     Util::IJson* get(const IR::Expression* expression) const;
     Util::IJson* fixLocal(Util::IJson* json);
 

--- a/backends/bmv2/expression.h
+++ b/backends/bmv2/expression.h
@@ -76,8 +76,6 @@ class ExpressionConverter : public Inspector {
 
     /// Non-null if the expression refers to a parameter from the enclosing control
     const IR::Parameter* enclosingParamReference(const IR::Expression* expression);
-    void binary(const IR::Operation_Binary* expression);
-    void saturated_binary(const IR::Operation_Binary* expression);
     Util::IJson* get(const IR::Expression* expression) const;
     Util::IJson* fixLocal(Util::IJson* json);
 
@@ -99,6 +97,8 @@ class ExpressionConverter : public Inspector {
     void postorder(const IR::BoolLiteral* expression) override;
     void postorder(const IR::MethodCallExpression* expression) override;
     void postorder(const IR::Cast* expression) override;
+    void postorder(const IR::AddSat* expression) override { saturated_binary(expression); }
+    void postorder(const IR::SubSat* expression) override { saturated_binary(expression); }
     void postorder(const IR::Constant* expression) override;
     void postorder(const IR::ArrayIndex* expression) override;
     void postorder(const IR::Member* expression) override;
@@ -110,6 +110,11 @@ class ExpressionConverter : public Inspector {
     void postorder(const IR::PathExpression* expression) override;
     void postorder(const IR::TypeNameExpression* expression) override;
     void postorder(const IR::Expression* expression) override;
+
+ private:
+    void binary(const IR::Operation_Binary* expression);
+    void saturated_binary(const IR::Operation_Binary* expression);
+
 };
 
 }  // namespace BMV2

--- a/backends/bmv2/expression.h
+++ b/backends/bmv2/expression.h
@@ -114,7 +114,6 @@ class ExpressionConverter : public Inspector {
  private:
     void binary(const IR::Operation_Binary* expression);
     void saturated_binary(const IR::Operation_Binary* expression);
-
 };
 
 }  // namespace BMV2

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -228,6 +228,8 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::LOr* expression) override { return binaryBool(expression); }
     const IR::Node* postorder(IR::Add* expression) override { return binaryArith(expression); }
     const IR::Node* postorder(IR::Sub* expression) override { return binaryArith(expression); }
+    const IR::Node* postorder(IR::AddSat* expression) override { return binaryArith(expression); }
+    const IR::Node* postorder(IR::SubSat* expression) override { return binaryArith(expression); }
     const IR::Node* postorder(IR::Mul* expression) override { return binaryArith(expression); }
     const IR::Node* postorder(IR::Div* expression) override { return unsBinaryArith(expression); }
     const IR::Node* postorder(IR::Mod* expression) override { return unsBinaryArith(expression); }

--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -168,7 +168,9 @@ using Parser = P4::P4Parser;
 "++"            { BEGIN(NORMAL); return Parser::make_PP(driver.yylloc); }
 
 "+"            { BEGIN(NORMAL); return Parser::make_PLUS(driver.yylloc); }
+"|+|"          { BEGIN(NORMAL); return Parser::make_PLUS_SAT(driver.yylloc); }
 "-"            { BEGIN(NORMAL); return Parser::make_MINUS(driver.yylloc); }
+"|-|"          { BEGIN(NORMAL); return Parser::make_MINUS_SAT(driver.yylloc); }
 "*"            { BEGIN(NORMAL); return Parser::make_MUL(driver.yylloc); }
 "/"            { BEGIN(NORMAL); return Parser::make_DIV(driver.yylloc); }
 "%"            { BEGIN(NORMAL); return Parser::make_MOD(driver.yylloc); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -117,6 +117,8 @@ typedef const IR::Type ConstType;
 %token      EQ "=="
 %token      PLUS "+"
 %token      MINUS "-"
+%token      PLUS_SAT "|+|"
+%token      MINUS_SAT "|-|"
 %token      MUL "*"
 %token      DIV "/"
 %token      MOD "%"
@@ -230,7 +232,7 @@ typedef const IR::Type ConstType;
 %left BIT_XOR
 %left BIT_AND
 %left SHL
-%left PP PLUS MINUS
+%left PP PLUS MINUS PLUS_SAT MINUS_SAT
 %left MUL DIV MOD
 %right PREFIX
 %nonassoc R_BRACKET L_PAREN L_BRACKET
@@ -1030,6 +1032,8 @@ expression
     | expression "%" expression          { $$ = new IR::Mod(@1 + @3, $1, $3); }
     | expression "+" expression          { $$ = new IR::Add(@1 + @3, $1, $3); }
     | expression "-" expression          { $$ = new IR::Sub(@1 + @3, $1, $3); }
+    | expression "|+|" expression        { $$ = new IR::AddSat(@1 + @3, $1, $3); }
+    | expression "|-|" expression        { $$ = new IR::SubSat(@1 + @3, $1, $3); }
     | expression "<<" expression         { $$ = new IR::Shl(@1 + @3, $1, $3); }
     | expression ">" ">" expression
         { driver.checkShift(@2, @3); $$ = new IR::Shr(@1 + @4, $1, $4); }

--- a/ir/dbprint-expression.cpp
+++ b/ir/dbprint-expression.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ limitations under the License.
     M(Mul, Binary, *, ##__VA_ARGS__)                                            \
     M(Div, Binary, /, ##__VA_ARGS__) M(Mod, Binary, %, ##__VA_ARGS__)           \
     M(Add, Binary, +, ##__VA_ARGS__) M(Sub, Binary, -, ##__VA_ARGS__)           \
+    M(AddSat, Binary, |+|, ##__VA_ARGS__) M(SubSat, Binary, |-|, ##__VA_ARGS__) \
     M(Shl, Binary, <<, ##__VA_ARGS__) M(Shr, Binary, >>, ##__VA_ARGS__)         \
     M(Equ, Relation, ==, ##__VA_ARGS__) M(Neq, Relation, !=, ##__VA_ARGS__)     \
     M(Lss, Relation, <, ##__VA_ARGS__) M(Leq, Relation, <=, ##__VA_ARGS__)      \

--- a/ir/dbprint.h
+++ b/ir/dbprint.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ enum dbprint_flags {
     Prec_Prefix = 14,
     Prec_Mul = 13, Prec_Div = 13, Prec_Mod = 13,
     Prec_Add = 12, Prec_Sub = 12,
+    Prec_AddSat = 12, Prec_SubSat = 12,
     Prec_Shl = 11, Prec_Shr = 11,
     Prec_BAnd = 10,
     Prec_BXor = 9,

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -67,6 +67,14 @@ class Sub : Operation_Binary {
     stringOp = "-";
     precedence = DBPrint::Prec_Sub;
 }
+class AddSat : Operation_Binary {
+    stringOp = "|+|";
+    precedence = DBPrint::Prec_AddSat;
+}
+class SubSat : Operation_Binary {
+    stringOp = "|-|";
+    precedence = DBPrint::Prec_SubSat;
+}
 class Shl : Operation_Binary {
     stringOp = "<<";
     precedence = DBPrint::Prec_Shl;

--- a/testdata/p4_16_samples/saturated-bmv2.p4
+++ b/testdata/p4_16_samples/saturated-bmv2.p4
@@ -1,0 +1,109 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<8> USat_t;
+typedef int<16> Sat_t;
+
+/// Test saturating arithmetic
+/// The header specifies the operation:
+/// op = 1 - usat_plus, 2 - usat_minus, 3 - sat_plus, 4 - sat_minus
+/// oprX_8 - unsigned 8-bit operands, res_8 contains the result
+/// oprX_16 - signed 16-bit operands, res_16 contains the result
+header hdr {
+    bit<8>  op;
+    USat_t  opr1_8;
+    USat_t  opr2_8;
+    USat_t  res_8;
+    Sat_t opr1_16;
+    Sat_t opr2_16;
+    Sat_t res_16;
+}
+
+struct Header_t {
+    hdr h;
+}
+struct Meta_t {}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+
+    action usat_plus() {
+        standard_meta.egress_spec = 0; // send to port 0
+        h.h.res_8 = h.h.opr1_8 |+| h.h.opr2_8;
+    }
+    action usat_minus() {
+        standard_meta.egress_spec = 0; // send to port 0
+        h.h.res_8 = h.h.opr1_8 |-| h.h.opr2_8;
+    }
+    action sat_plus() {
+        standard_meta.egress_spec = 0; // send to port 0
+        h.h.res_16 = h.h.opr1_16 |+| h.h.opr2_16;
+    }
+    action sat_minus() {
+        standard_meta.egress_spec = 0; // send to port 0
+        h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
+    }
+
+    action drop() { standard_meta.drop = 1; }
+
+    USat_t ru;
+    Sat_t r;
+
+    table t {
+
+  	key = {
+            h.h.op : exact;
+        }
+
+	actions = {
+            usat_plus;
+            usat_minus;
+            sat_plus;
+            sat_minus;
+            drop;
+        }
+
+	default_action = drop;
+
+        const entries = {
+            0x01 : usat_plus();
+            0x02 : usat_minus();
+            0x03 : sat_plus();
+            0x04 : sat_minus();
+        }
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples/saturated-bmv2.stf
+++ b/testdata/p4_16_samples/saturated-bmv2.stf
@@ -1,0 +1,33 @@
+# Test saturating arithmetic
+
+# unsigned: 1 + 1 = 2
+packet 0 01 01 01 00 0000 0000 0000
+expect 0 01 01 01 02 0000 0000 0000
+
+# unsigned: 2 - 1 = 1
+packet 0 02 02 01 00 0000 0000 0000
+expect 0 02 02 01 01 0000 0000 0000
+
+# unsigned: 254 + 2 = 255
+packet 0 01 fe 02 00 0000 0000 0000
+expect 0 01 fe 02 ff 0000 0000 0000
+
+# # unsigned: 8 - 10 = 0
+packet 0 02 08 0a aa 0000 0000 0000
+expect 0 02 08 0a 00 0000 0000 0000
+
+# signed: 10 + 10 = 20
+packet 0 03 00 00 00 000a 000a 0000
+expect 0 03 00 00 00 000a 000a 0014
+
+# signed: 32766 + 10 = 32767
+packet 0 03 00 00 00 7ffe 000a 0000
+expect 0 03 00 00 00 7ffe 000a 7fff
+
+# signed: 10 - 20 = -10
+packet 0 04 00 00 00 000a 0014 0000
+expect 0 04 00 00 00 000a 0014 fff6
+
+# signed: -32766 - 10 = -32768
+packet 0 04 00 00 00 8002 000a 0000
+expect 0 04 00 00 00 8002 000a 8000

--- a/testdata/p4_16_samples/saturated-bmv2.stf
+++ b/testdata/p4_16_samples/saturated-bmv2.stf
@@ -31,3 +31,11 @@ expect 0 04 00 00 00 000a 0014 fff6
 # signed: -32766 - 10 = -32768
 packet 0 04 00 00 00 8002 000a 0000
 expect 0 04 00 00 00 8002 000a 8000
+
+# signed: 1 + (-10) = -9
+packet 0 03 00 00 00 0001 fff6 0000
+expect 0 03 00 00 00 0001 fff6 fff7
+
+# signed: 1 - (-10) = 11
+packet 0 04 00 00 00 0001 fff6 0000
+expect 0 04 00 00 00 0001 fff6 000b

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
@@ -1,0 +1,103 @@
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<8> USat_t;
+typedef int<16> Sat_t;
+header hdr {
+    bit<8> op;
+    USat_t opr1_8;
+    USat_t opr2_8;
+    USat_t res_8;
+    Sat_t  opr1_16;
+    Sat_t  opr2_16;
+    Sat_t  res_16;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    action usat_plus() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_8 = h.h.opr1_8 + h.h.opr2_8;
+    }
+    action usat_minus() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_8 = h.h.opr1_8 |-| h.h.opr2_8;
+    }
+    action sat_plus() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_16 = h.h.opr1_16 |+| h.h.opr2_16;
+    }
+    action sat_minus() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
+    }
+    action drop() {
+        standard_meta.drop = 1w1;
+    }
+    USat_t ru;
+    Sat_t r;
+    table t {
+        key = {
+            h.h.op: exact @name("h.h.op") ;
+        }
+        actions = {
+            usat_plus();
+            usat_minus();
+            sat_plus();
+            sat_minus();
+            drop();
+        }
+        default_action = drop();
+        const entries = {
+                        8w0x1 : usat_plus();
+
+                        8w0x2 : usat_minus();
+
+                        8w0x3 : sat_plus();
+
+                        8w0x4 : sat_minus();
+
+        }
+
+    }
+    apply {
+        t.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
@@ -51,7 +51,7 @@ control deparser(packet_out b, in Header_t h) {
 control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
     action usat_plus() {
         standard_meta.egress_spec = 9w0;
-        h.h.res_8 = h.h.opr1_8 + h.h.opr2_8;
+        h.h.res_8 = h.h.opr1_8 |+| h.h.opr2_8;
     }
     action usat_minus() {
         standard_meta.egress_spec = 9w0;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
@@ -1,0 +1,101 @@
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<8> USat_t;
+typedef int<16> Sat_t;
+header hdr {
+    bit<8> op;
+    USat_t opr1_8;
+    USat_t opr2_8;
+    USat_t res_8;
+    Sat_t  opr1_16;
+    Sat_t  opr2_16;
+    Sat_t  res_16;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    @name("ingress.usat_plus") action usat_plus_0() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_8 = h.h.opr1_8 + h.h.opr2_8;
+    }
+    @name("ingress.usat_minus") action usat_minus_0() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_8 = h.h.opr1_8 |-| h.h.opr2_8;
+    }
+    @name("ingress.sat_plus") action sat_plus_0() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_16 = h.h.opr1_16 |+| h.h.opr2_16;
+    }
+    @name("ingress.sat_minus") action sat_minus_0() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
+    }
+    @name("ingress.drop") action drop_0() {
+        standard_meta.drop = 1w1;
+    }
+    @name("ingress.t") table t {
+        key = {
+            h.h.op: exact @name("h.h.op") ;
+        }
+        actions = {
+            usat_plus_0();
+            usat_minus_0();
+            sat_plus_0();
+            sat_minus_0();
+            drop_0();
+        }
+        default_action = drop_0();
+        const entries = {
+                        8w0x1 : usat_plus_0();
+
+                        8w0x2 : usat_minus_0();
+
+                        8w0x3 : sat_plus_0();
+
+                        8w0x4 : sat_minus_0();
+
+        }
+
+    }
+    apply {
+        t.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
@@ -51,7 +51,7 @@ control deparser(packet_out b, in Header_t h) {
 control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
     @name("ingress.usat_plus") action usat_plus_0() {
         standard_meta.egress_spec = 9w0;
-        h.h.res_8 = h.h.opr1_8 + h.h.opr2_8;
+        h.h.res_8 = h.h.opr1_8 |+| h.h.opr2_8;
     }
     @name("ingress.usat_minus") action usat_minus_0() {
         standard_meta.egress_spec = 9w0;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
@@ -1,0 +1,101 @@
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<8> USat_t;
+typedef int<16> Sat_t;
+header hdr {
+    bit<8> op;
+    USat_t opr1_8;
+    USat_t opr2_8;
+    USat_t res_8;
+    Sat_t  opr1_16;
+    Sat_t  opr2_16;
+    Sat_t  res_16;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    @name("ingress.usat_plus") action usat_plus_0() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_8 = h.h.opr1_8 + h.h.opr2_8;
+    }
+    @name("ingress.usat_minus") action usat_minus_0() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_8 = h.h.opr1_8 |-| h.h.opr2_8;
+    }
+    @name("ingress.sat_plus") action sat_plus_0() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_16 = h.h.opr1_16 |+| h.h.opr2_16;
+    }
+    @name("ingress.sat_minus") action sat_minus_0() {
+        standard_meta.egress_spec = 9w0;
+        h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
+    }
+    @name("ingress.drop") action drop_0() {
+        standard_meta.drop = 1w1;
+    }
+    @name("ingress.t") table t {
+        key = {
+            h.h.op: exact @name("h.h.op") ;
+        }
+        actions = {
+            usat_plus_0();
+            usat_minus_0();
+            sat_plus_0();
+            sat_minus_0();
+            drop_0();
+        }
+        default_action = drop_0();
+        const entries = {
+                        8w0x1 : usat_plus_0();
+
+                        8w0x2 : usat_minus_0();
+
+                        8w0x3 : sat_plus_0();
+
+                        8w0x4 : sat_minus_0();
+
+        }
+
+    }
+    apply {
+        t.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
@@ -51,7 +51,7 @@ control deparser(packet_out b, in Header_t h) {
 control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
     @name("ingress.usat_plus") action usat_plus_0() {
         standard_meta.egress_spec = 9w0;
-        h.h.res_8 = h.h.opr1_8 + h.h.opr2_8;
+        h.h.res_8 = h.h.opr1_8 |+| h.h.opr2_8;
     }
     @name("ingress.usat_minus") action usat_minus_0() {
         standard_meta.egress_spec = 9w0;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4
@@ -51,7 +51,7 @@ control deparser(packet_out b, in Header_t h) {
 control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
     action usat_plus() {
         standard_meta.egress_spec = 0;
-        h.h.res_8 = h.h.opr1_8 + h.h.opr2_8;
+        h.h.res_8 = h.h.opr1_8 |+| h.h.opr2_8;
     }
     action usat_minus() {
         standard_meta.egress_spec = 0;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4
@@ -1,0 +1,103 @@
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<8> USat_t;
+typedef int<16> Sat_t;
+header hdr {
+    bit<8> op;
+    USat_t opr1_8;
+    USat_t opr2_8;
+    USat_t res_8;
+    Sat_t  opr1_16;
+    Sat_t  opr2_16;
+    Sat_t  res_16;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    action usat_plus() {
+        standard_meta.egress_spec = 0;
+        h.h.res_8 = h.h.opr1_8 + h.h.opr2_8;
+    }
+    action usat_minus() {
+        standard_meta.egress_spec = 0;
+        h.h.res_8 = h.h.opr1_8 |-| h.h.opr2_8;
+    }
+    action sat_plus() {
+        standard_meta.egress_spec = 0;
+        h.h.res_16 = h.h.opr1_16 |+| h.h.opr2_16;
+    }
+    action sat_minus() {
+        standard_meta.egress_spec = 0;
+        h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
+    }
+    action drop() {
+        standard_meta.drop = 1;
+    }
+    USat_t ru;
+    Sat_t r;
+    table t {
+        key = {
+            h.h.op: exact;
+        }
+        actions = {
+            usat_plus;
+            usat_minus;
+            sat_plus;
+            sat_minus;
+            drop;
+        }
+        default_action = drop;
+        const entries = {
+                        0x1 : usat_plus();
+
+                        0x2 : usat_minus();
+
+                        0x3 : sat_plus();
+
+                        0x4 : sat_minus();
+
+        }
+
+    }
+    apply {
+        t.apply();
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+


### PR DESCRIPTION
We add support for |+| and |-| in the frontend of the compiler, as
well as bmv2 backend support. This includes defining two binary
operation IR nodes for saturating addition and subtraction, and
generating the json for bmv2 as defined in
https://github.com/p4lang/behavioral-model/pull/590. For that, we
update the json version to 2.18.

We also added a test that ensures that saturating arithmetic properly
bounds the min and max values for signed and unsigned integer
operations.

Still to do:
- translate P4_14 saturating operations to the new IR expression nodes.

Fixes #1229