### PR TITLE
Move p4RuntimeSerializer invocation to right after frontend

### DIFF
--- a/backends/bmv2/bmv2.cpp
+++ b/backends/bmv2/bmv2.cpp
@@ -66,6 +66,10 @@ int main(int argc, char *const argv[]) {
     if (program == nullptr || ::errorCount() > 0)
         return 1;
 
+    P4::serializeP4RuntimeIfRequired(program, options);
+    if (::errorCount() > 0)
+        return 1;
+
     const IR::ToplevelBlock* toplevel = nullptr;
     BMV2::MidEnd midEnd(options);
     midEnd.addDebugHook(hook);
@@ -104,8 +108,6 @@ int main(int argc, char *const argv[]) {
             out->flush();
         }
     }
-
-    P4::serializeP4RuntimeIfRequired(program, options);
 
     return ::errorCount() > 0;
 }

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -99,6 +99,8 @@ int main(int argc, char *const argv[]) {
         }
         log_dump(program, "Initial program");
         if (program != nullptr && ::errorCount() == 0) {
+            P4::serializeP4RuntimeIfRequired(program, options);
+
             if (!options.parseOnly && !options.validateOnly) {
                 P4Test::MidEnd midEnd(options);
                 midEnd.addDebugHook(hook);
@@ -145,8 +147,6 @@ int main(int argc, char *const argv[]) {
             }
         }
     }
-
-    P4::serializeP4RuntimeIfRequired(program, options);
 
     if (Log::verbose())
         std::cerr << "Done." << std::endl;


### PR DESCRIPTION
For bmv2 and p4test backends. It is important to run the serializer
before some of the midend passes that could have an impact on the
contents of the P4Info message - such as the EliminateTuples pass.

Currently, the serializer seems to have a dependency on a few passes
usually run in the midend, which is why it has its own pass manager.

Note that if a given backend later runs some transformation pass like
EliminateTuples, it is the responsibility of this backend to provide the
P4Runtime server implementation with the necessary information to do
data transformation.