### PR TITLE
experimental: Allow @optional on abstract methods

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -443,7 +443,8 @@ const IR::Type* TypeInference::canonicalize(const IR::Type* type) {
 
             if (fpType != method->type) {
                 method = new IR::Method(method->srcInfo, method->name,
-                                        fpType->to<IR::Type_Method>(), method->isAbstract);
+                                        fpType->to<IR::Type_Method>(), method->isAbstract,
+                                        method->annotations);
                 changes = true;
                 setType(method, fpType);
             }
@@ -855,13 +856,12 @@ bool TypeInference::checkAbstractMethods(const IR::Declaration_Instance* inst,
             BUG_CHECK(tvs->isIdentity(), "%1%: expected no type variables", tvs);
         }
     }
-
-    if (virt.size() != 0) {
-        typeError("%1%: %2% abstract method not implemented",
-                  inst, virt.begin()->second);
-        return false;
-    }
-    return true;
+    bool rv = true;
+    for (auto &vm : virt) {
+        if (!vm.second->annotations->getSingle("optional")) {
+            typeError("%1%: %2% abstract method not implemented", inst, vm.second);
+            rv = false; } }
+    return rv;
 }
 
 const IR::Node* TypeInference::preorder(IR::Declaration_Instance* decl) {


### PR DESCRIPTION
- abstract methods may not all be required for every instantiation of an
  extern with abstract methods.
- avoid losing annotations on methods when canonicalizing them