### PR TITLE
Fix generation of P4Info for v1model registers

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -196,7 +196,7 @@ struct Register {
          const TypeMap* typeMap,
          p4::P4TypeInfo* p4RtTypeInfo) {
         CHECK_NULL(instance);
-        auto declaration = instance->node->to<IR::IDeclaration>();
+        auto declaration = instance->node->to<IR::Declaration_Instance>();
 
         auto size = instance->getParameterValue("size")->to<IR::Constant>();
         if (!size->is<IR::Constant>()) {
@@ -210,13 +210,14 @@ struct Register {
         }
 
         // retrieve type parameter for the register instance and convert it to p4::P4DataTypeSpec
-        BUG_CHECK(instance->instanceType->is<IR::Type_SpecializedCanonical>(),
-                  "%1%: expected Type_SpecializedCanonical", instance->instanceType);
-        auto instanceType = instance->instanceType->to<IR::Type_SpecializedCanonical>();
-        BUG_CHECK(instanceType->arguments->size() == 1,
+        BUG_CHECK(declaration->type->is<IR::Type_Specialized>(),
+                  "%1%: expected Type_Specialized", declaration->type);
+        auto type = declaration->type->to<IR::Type_Specialized>();
+        BUG_CHECK(type->arguments->size() == 1,
                   "%1%: expected one type argument", instance);
-        auto typeArg = instanceType->arguments->at(0);
+        auto typeArg = type->arguments->at(0);
         auto typeSpec = TypeSpecConverter::convert(typeMap, refMap, typeArg, p4RtTypeInfo);
+        CHECK_NULL(typeSpec);
 
         return Register{declaration->controlPlaneName(),
                         declaration->to<IR::IAnnotated>(),

--- a/control-plane/typeSpecConverter.cpp
+++ b/control-plane/typeSpecConverter.cpp
@@ -101,6 +101,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Tuple* type) {
     for (auto cType : type->components) {
         visit(cType);
         auto cTypeSpec = map.at(cType);
+        CHECK_NULL(cTypeSpec);
         auto member = tupleTypeSpec->add_members();
         member->CopyFrom(*cTypeSpec);
     }
@@ -146,6 +147,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Struct* type) {
                 auto fType = f->type;
                 visit(fType);
                 auto fTypeSpec = map.at(fType);
+                CHECK_NULL(fTypeSpec);
                 auto member = structTypeSpec->add_members();
                 member->set_name(f->controlPlaneName());
                 member->mutable_type_spec()->CopyFrom(*fTypeSpec);
@@ -167,6 +169,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Header* type) {
                 auto fType = f->type;
                 visit(fType);
                 auto fTypeSpec = map.at(fType);
+                CHECK_NULL(fTypeSpec);
                 BUG_CHECK(fTypeSpec->has_bitstring(),
                           "Only bistring fields expected in header type declaration %1%", type);
                 auto member = headerTypeSpec->add_members();
@@ -190,6 +193,7 @@ bool TypeSpecConverter::preorder(const IR::Type_HeaderUnion* type) {
                 auto fType = f->type;
                 visit(fType);
                 auto fTypeSpec = map.at(fType);
+                CHECK_NULL(fTypeSpec);
                 BUG_CHECK(fTypeSpec->has_header(),
                           "Only header fields expected in header union declaration %1%", type);
                 auto member = headerUnionTypeSpec->add_members();


### PR DESCRIPTION
Use declaration instance type instead of evaluated block instance
type. The evaluated block instance type gives us a
Type_SpecializedCanonical node which doesn't use Type_Name and therefore
violates pre-condition for typeSpecConverter.