### PR TITLE
Fixed some small bugs in simplifyBitwise.

### DIFF
--- a/midend/simplifyBitwise.cpp
+++ b/midend/simplifyBitwise.cpp
@@ -12,7 +12,6 @@ void SimplifyBitwise::assignSlices(const IR::Expression *expr, mpz_class mask) {
         auto left_slice = IR::Slice::make(changing_as->left, one_pos, zero_pos - 1);
         auto right_slice = IR::Slice::make(expr, one_pos, zero_pos - 1);
         auto new_as = new IR::AssignmentStatement(changing_as->srcInfo, left_slice, right_slice);
-        LOG1("New as " << new_as);
         slice_statements->push_back(new_as);
         one_pos = mpz_scan1(mask.get_mpz_t(), zero_pos);
     }

--- a/midend/simplifyBitwise.cpp
+++ b/midend/simplifyBitwise.cpp
@@ -9,9 +9,10 @@ void SimplifyBitwise::assignSlices(const IR::Expression *expr, mpz_class mask) {
     // Calculate the slices for this particular mask
     while (one_pos >= 0) {
         int zero_pos = mpz_scan0(mask.get_mpz_t(), one_pos);
-        auto left_slice = IR::Slice::make(changing_as->left, zero_pos - 1, one_pos);
-        auto right_slice = IR::Slice::make(expr, zero_pos - 1, one_pos);
+        auto left_slice = IR::Slice::make(changing_as->left, one_pos, zero_pos - 1);
+        auto right_slice = IR::Slice::make(expr, one_pos, zero_pos - 1);
         auto new_as = new IR::AssignmentStatement(changing_as->srcInfo, left_slice, right_slice);
+        LOG1("New as " << new_as);
         slice_statements->push_back(new_as);
         one_pos = mpz_scan1(mask.get_mpz_t(), zero_pos);
     }
@@ -26,6 +27,7 @@ const IR::Node *SimplifyBitwise::preorder(IR::AssignmentStatement *as) {
     if ((maskA->value & maskB->value) != 0)
         return as;
 
+    changing_as = as;
     slice_statements = new IR::Vector<IR::StatOrDecl>();
     assignSlices(a, maskA->value);
     assignSlices(b, maskB->value);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/arch_test.cpp
   gtest/bitvec_test.cpp
   gtest/call_graph_test.cpp
+  gtest/complex_bitwise.cpp
   gtest/cstring.cpp
   gtest/diagnostics.cpp
   gtest/dumpjson.cpp

--- a/test/gtest/complex_bitwise.cpp
+++ b/test/gtest/complex_bitwise.cpp
@@ -106,7 +106,7 @@ TEST_F(SimplifyBitwiseTest, SimpleSplit) {
     std::string program_string = builder.toString();
     std::string value1 = "headers.h.f1[15:0] = headers.h.f2[15:0]";
     std::string value2 = "headers.h.f1[31:16] = headers.h.f1[31:16]";
-    EXPECT_FALSE(program_string.find(value1) == std::string::npos); 
+    EXPECT_FALSE(program_string.find(value1) == std::string::npos);
     EXPECT_FALSE(program_string.find(value2) == std::string::npos);
 }
 
@@ -170,7 +170,7 @@ TEST_F(SimplifyBitwiseTest, SplitWithZero) {
     std::string value2 = "headers.h.f1[31:24] = headers.h.f3[31:24]";
     std::string value3 = "headers.h.f1[23:8] = 16w0";
 
-    EXPECT_FALSE(program_string.find(value1) == std::string::npos); 
+    EXPECT_FALSE(program_string.find(value1) == std::string::npos);
     EXPECT_FALSE(program_string.find(value2) == std::string::npos);
     EXPECT_FALSE(program_string.find(value3) == std::string::npos);
 }

--- a/test/gtest/complex_bitwise.cpp
+++ b/test/gtest/complex_bitwise.cpp
@@ -1,0 +1,137 @@
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/optional.hpp>
+
+#include "gtest/gtest.h"
+#include "ir/ir.h"
+#include "helpers.h"
+#include "lib/log.h"
+
+#include "frontends/common/parseInput.h"
+#include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/p4/typeMap.h"
+#include "midend/simplifyBitwise.h"
+
+using namespace P4;
+
+
+namespace Test {
+
+namespace {
+
+boost::optional<FrontendTestCase>
+createSimplifyBitwiseTestCase(const std::string &ingressSource) {
+    std::string source = P4_SOURCE(P4Headers::V1MODEL, R"(
+header H
+{
+   bit<32> f1;
+   bit<32> f2;
+   bit<32> f3;
+}
+
+struct Headers { H h; }
+struct Metadata { }
+
+parser parse(packet_in packet, out Headers headers, inout Metadata meta,
+         inout standard_metadata_t sm) {
+    state start {
+        packet.extract(headers.h);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout Headers headers, inout Metadata meta) { apply { } }
+control ingress(inout Headers headers, inout Metadata meta,
+                inout standard_metadata_t sm) {
+    apply {
+%INGRESS%
+    }
+}
+
+control egress(inout Headers headers, inout Metadata meta,
+                inout standard_metadata_t sm) { apply { } }
+
+control computeChecksum(inout Headers headers, inout Metadata meta) { apply { } }
+
+control deparse(packet_out packet, in Headers headers) {
+    apply { packet.emit(headers.h); }
+}
+
+V1Switch(parse(), verifyChecksum(), ingress(), egress(),
+    computeChecksum(), deparse()) main;
+    )");
+
+    boost::replace_first(source, "%INGRESS%", ingressSource);
+    return FrontendTestCase::create(source, CompilerOptions::FrontendVersion::P4_16);
+}
+
+class CountAssignmentStatements : public Inspector {
+    int _as_total = 0;
+    bool preorder(const IR::AssignmentStatement *as) {
+        _as_total++;
+        LOG1("As " << as);
+        return true;
+    }
+
+ public:
+    int as_total() { return _as_total; }
+};
+
+}  // namespace
+
+class SimplifyBitwiseTest : public P4CTest { };
+
+TEST_F(SimplifyBitwiseTest, SimpleSplit) {
+    auto test = createSimplifyBitwiseTestCase(P4_SOURCE(R"(
+        headers.h.f1 = headers.h.f2 & 0xffff | headers.h.f1 & 0xffff0000;
+    )"));
+
+    ReferenceMap refMap;
+    TypeMap typeMap;
+    CountAssignmentStatements cas;
+    PassManager quick_midend = {
+        new TypeChecking(&refMap, &typeMap, true),
+        new SimplifyBitwise,
+        &cas
+    };
+
+    test->program->apply(quick_midend);
+    EXPECT_EQ(2, cas.as_total());
+}
+
+TEST_F(SimplifyBitwiseTest, ManySplit) {
+    auto test = createSimplifyBitwiseTestCase(P4_SOURCE(R"(
+        headers.h.f1 = headers.h.f2 & 0x55555555 | headers.h.f1 & 0xaaaaaaaa;
+    )"));
+
+    ReferenceMap refMap;
+    TypeMap typeMap;
+    CountAssignmentStatements cas;
+    PassManager quick_midend = {
+        new TypeChecking(&refMap, &typeMap, true),
+        new SimplifyBitwise,
+        &cas
+    };
+
+    test->program->apply(quick_midend);
+    EXPECT_EQ(32, cas.as_total());
+}
+
+TEST_F(SimplifyBitwiseTest, SplitWithZero) {
+    auto test = createSimplifyBitwiseTestCase(P4_SOURCE(R"(
+        headers.h.f1 = headers.h.f2 & 0xff | headers.h.f3 & 0xff000000;
+    )"));
+
+    ReferenceMap refMap;
+    TypeMap typeMap;
+    CountAssignmentStatements cas;
+    PassManager quick_midend = {
+        new TypeChecking(&refMap, &typeMap, true),
+        new SimplifyBitwise,
+        &cas
+    };
+
+    test->program->apply(quick_midend);
+    EXPECT_EQ(3, cas.as_total());
+}
+
+}  // namespace Test


### PR DESCRIPTION
IR::Slices were made in reverse and the assignment statement that was being adapted was never assigned, resulting in a SEGFAULT.