### PR TITLE
Extend toString methods for Operation expressions

### DIFF
--- a/ir/expression.def
+++ b/ir/expression.def
@@ -12,6 +12,7 @@ abstract Operation_Unary : Operation {
         if (!srcInfo && expr) srcInfo = expr->srcInfo;
         if (type->is<Type::Unknown>() && expr) type = expr->type; }
     precedence = DBPrint::Prec_Prefix;
+    toString { return getStringOp() + expr->toString(); }
 }
 
 class Neg : Operation_Unary {
@@ -292,6 +293,7 @@ class Mux : Operation_Ternary {
         clone.visit(e2, "e2");
         v.flow_merge(clone); }
     Mux { if (type->is<Type::Unknown>() && e1 && e2 && e1->type == e2->type) type = e1->type; }
+    toString { return e0->toString() + " ? " + e1->toString() + " : " + e2->toString(); }
 }
 
 class DefaultExpression : Expression {}
@@ -311,7 +313,7 @@ class Cast : Operation_Unary {
     /// type, and 'type' will only be updated later when type inferencing occurs
     precedence = DBPrint::Prec_Prefix;
     stringOp = "(cast)";
-    toString{ return "cast"; }
+    toString{ return "(" + type->toString() + ")(" + expr->toString() + ")"; }
     validate{ BUG_CHECK(!destType->is<Type_Unknown>(), "%1%: Cannot cast to unknown type", this); }
 }
 

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -33,6 +33,7 @@ abstract Operation_Binary : Operation {
         if (!srcInfo && left && right) srcInfo = left->srcInfo + right->srcInfo;
         if (type->is<Type::Unknown>() && left && right && left->type == right->type)
             type = left->type; }
+    toString { return left->toString() + " " + getStringOp() + " " + right->toString(); }
 }
 
 abstract Operation_Ternary : Operation {
@@ -227,9 +228,9 @@ class Slice : Operation_Ternary {
     unsigned getH() const { return e1->to<IR::Constant>()->asUnsigned(); }
     unsigned getL() const { return e2->to<IR::Constant>()->asUnsigned(); }
     Slice(Expression a, int hi, int lo)
-    : Operation_Ternary(IR::Type::Bits::get(hi-lo+1), a, new Constant(hi), new Constant(lo)) {}
+    : Operation_Ternary(IR::Type::Bits::get(hi-lo+1), a, new Constant(hi), new Constant(lo)) { }
     Slice(Util::SourceInfo si, Expression a, int hi, int lo)
-    : Operation_Ternary(si, IR::Type::Bits::get(hi-lo+1), a, new Constant(hi), new Constant(lo)) {}
+    : Operation_Ternary(si, IR::Type::Bits::get(hi-lo+1), a, new Constant(hi), new Constant(lo)) { }
     Slice {
         if (type->is<Type::Unknown>() && e1 && e1->is<Constant>() && e2 && e2->is<Constant>())
             type = IR::Type::Bits::get(getH() - getL() + 1); }
@@ -263,10 +264,12 @@ class ArrayIndex : Operation_Binary {
     ArrayIndex {
         if (auto st = left ? left->type->to<IR::Type_Stack>() : nullptr)
             type = st->elementType; }
+    toString { return left->toString() + "[" + right->toString() + "]"; }
 }
 
 class Range : Operation_Binary {
     stringOp = "..";
+    toString { return left->toString() + getStringOp() + right->toString(); }
     precedence = DBPrint::Prec_Low;
     Range { if (left && type == left->type && !left->type->is<Type::Unknown>())
                 type = new Type_Set(left->type); }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/expr_uses_test.cpp
   gtest/format_test.cpp
   gtest/helpers.cpp
+  gtest/ir_tostring.cpp
   gtest/json_test.cpp
   gtest/midend_test.cpp
   gtest/opeq_test.cpp

--- a/test/gtest/ir_tostring.cpp
+++ b/test/gtest/ir_tostring.cpp
@@ -1,0 +1,65 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc. 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <iostream>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "ir/ir.h"
+
+TEST(IR, BinOpToString) {
+    auto c = new IR::Constant(2);
+    auto f = new IR::Member(new IR::PathExpression("obj"), "f");
+
+    EXPECT_STREQ("2", c->toString());
+    EXPECT_STREQ("obj.f", f->toString());
+
+    // Binary operations printed "x OP y".
+    std::vector<IR::Operation_Binary*> ops = {
+        new IR::Mul(f, c),
+        new IR::Div(f, c),
+        new IR::Mod(f, c),
+        new IR::Add(f, c),
+        new IR::Sub(f, c),
+        new IR::AddSat(f, c),
+        new IR::SubSat(f, c),
+        new IR::Shl(f, c),
+        new IR::Shr(f, c),
+        new IR::Equ(f, c),
+        new IR::Neq(f, c),
+        new IR::Lss(f, c),
+        new IR::Leq(f, c),
+        new IR::Grt(f, c),
+        new IR::Geq(f, c),
+        new IR::BAnd(f, c),
+        new IR::BOr(f, c),
+        new IR::BXor(f, c),
+        new IR::LAnd(f, c),
+        new IR::LOr(f, c),
+        new IR::Concat(f, c),
+        new IR::Mask(f, c),
+    };
+    for (auto* op : ops) {
+        std::string expected = "obj.f " + op->getStringOp() + " 2";
+        EXPECT_STREQ(expected.c_str(), op->toString());
+    }
+
+    // Array indexing is printed "left[right]".
+    EXPECT_STREQ("obj.f[2]", IR::ArrayIndex(f, c).toString());
+
+    // Range is printed "left..right".
+    EXPECT_STREQ("obj.f..2", IR::Range(f, c).toString());
+}

--- a/test/gtest/ir_tostring.cpp
+++ b/test/gtest/ir_tostring.cpp
@@ -20,6 +20,28 @@ limitations under the License.
 #include "gtest/gtest.h"
 #include "ir/ir.h"
 
+TEST(IR, UnOpToString) {
+    auto c = new IR::Constant(2);
+    auto f = new IR::Member(new IR::PathExpression("obj"), "f");
+
+    // Members are printed "parent.member".
+    EXPECT_STREQ("obj.f", f->toString());
+
+    // Unary operations printed "OPy".
+    std::vector<IR::Operation_Unary*> ops = {
+        new IR::Neg(f),
+        new IR::Cmpl(f),
+        new IR::LNot(f),
+    };
+    for (auto* op : ops) {
+        std::string expected = op->getStringOp() + "obj.f";
+        EXPECT_STREQ(expected.c_str(), op->toString());
+    }
+
+    // Casts are printed "(type)(expr)".
+    EXPECT_STREQ("(bit<8>)(2)", IR::Cast(IR::Type_Bits::get(8, false), c).toString());
+}
+
 TEST(IR, BinOpToString) {
     auto c = new IR::Constant(2);
     auto f = new IR::Member(new IR::PathExpression("obj"), "f");
@@ -63,3 +85,16 @@ TEST(IR, BinOpToString) {
     // Range is printed "left..right".
     EXPECT_STREQ("obj.f..2", IR::Range(f, c).toString());
 }
+
+TEST(IR, TernOpToString) {
+    auto c1 = new IR::Constant(1);
+    auto c2 = new IR::Constant(2);
+    auto f = new IR::Member(new IR::PathExpression("obj"), "f");
+
+    // Slices are printed "field[e1:e2]".
+    EXPECT_STREQ("obj.f[2:1]", IR::Slice(f, c2, c1).toString());
+
+    // Muxes are printed "e0 ? e1 : e2".
+    EXPECT_STREQ("obj.f ? 1 : 2", IR::Mux(f, c1, c2).toString());
+}
+


### PR DESCRIPTION
IR nodes are equipped with a toString method intended to pretty-print the node.
The IR::Operation nodes, however, mostly inherit toString from IR::Operation,
which simply prints the operation string encoding, eg. "+" for addition,
without including the operands.

This commit changes the toString methods for Operation nodes to include
operands, eg. "left + right" rather than "+", and adds a gtest confirming that the
toString methods work as expected.