### PR TITLE
Fix def_use/SimplifyDefUse to deal with extern methods properly

### DIFF
--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -404,10 +404,15 @@ void ResolveReferences::postorder(const IR::Type_Method *t) {
 
 bool ResolveReferences::preorder(const IR::Type_Extern *t) {
     refMap->usedName(t->name.name);
-    addToContext(t->typeParameters); return true; }
+    // FIXME -- should the typeParamters be part of the extern's scope?
+    addToContext(t->typeParameters);
+    addToContext(t);
+    return true; }
 
 void ResolveReferences::postorder(const IR::Type_Extern *t) {
-    removeFromContext(t->typeParameters); }
+    removeFromContext(t);
+    removeFromContext(t->typeParameters);
+    }
 
 bool ResolveReferences::preorder(const IR::ParserState *s) {
     refMap->usedName(s->name.name);

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -656,26 +656,29 @@ bool ComputeWriteSet::preorder(const IR::MethodCallExpression* expression) {
     }
 
     // Symbolically call some apply methods (actions and tables)
-    const IR::Node* callee = nullptr;
+    std::vector<const IR::IDeclaration *> callee;
     if (mi->is<ActionCall>()) {
         auto action = mi->to<ActionCall>()->action;
-        callee = action;
+        callee.push_back(action);
     } else if (mi->isApply()) {
         auto am = mi->to<ApplyMethod>();
         if (am->isTableApply()) {
             auto table = am->object->to<IR::P4Table>();
-            callee = table;
+            callee.push_back(table);
         }
-    }
-
-    if (callee != nullptr) {
-        LOG3("Analyzing " << dbp(callee));
+    } else if (auto em = mi->to<ExternMethod>()) {
+        // symbolically call all the methods that might be called via this extern method
+        callee = em->mayCall(); }
+    if (!callee.empty()) {
+        LOG3("Analyzing " << DBPrint::Brief << callee << DBPrint::Reset);
         ProgramPoint pt(callingContext, expression);
         ComputeWriteSet cw(this, pt, currentDefinitions);
-        (void)callee->apply(cw);
+        for (auto c : callee)
+            (void)c->getNode()->apply(cw);
         currentDefinitions = cw.currentDefinitions;
         exitDefinitions = exitDefinitions->joinDefinitions(cw.exitDefinitions);
-        LOG3("Definitions after call of " << expression << ": " << currentDefinitions);
+        LOG3("Definitions after call of " << DBPrint::Brief << expression << ": " <<
+             currentDefinitions << DBPrint::Reset);
     }
 
     auto result = LocationSet::empty;
@@ -752,11 +755,10 @@ bool ComputeWriteSet::preorder(const IR::P4Control* control) {
     enterScope(control->getApplyParameters(), &control->controlLocals, startPoint);
     exitDefinitions = new Definitions();
     returnedDefinitions = new Definitions();
-    for (auto l : control->controlLocals) {
-        if (l->is<IR::Declaration_Instance>())
-            visit(l);  // process virtual Functions if any
-    }
+    BUG_CHECK(controlLocals == nullptr, "Nested controls?");
+    controlLocals = &control->controlLocals;
     visit(control->body);
+    controlLocals = nullptr;;
     auto returned = currentDefinitions->joinDefinitions(returnedDefinitions);
     auto exited = returned->joinDefinitions(exitDefinitions);
     return setDefinitions(exited, control->body);
@@ -932,3 +934,13 @@ bool ComputeWriteSet::preorder(const IR::MethodCallStatement* statement) {
 }
 
 }  // namespace P4
+
+// functions for calling from gdb
+void dump(const P4::StorageLocation *s) { std::cout << *s << std::endl; }
+void dump(const P4::LocationSet *s) { std::cout << *s << std::endl; }
+void dump(const P4::ProgramPoint *p) { std::cout << *p << std::endl; }
+void dump(const P4::ProgramPoint &p) { std::cout << p << std::endl; }
+void dump(const P4::ProgramPoints *p) { std::cout << *p << std::endl; }
+void dump(const P4::ProgramPoints &p) { std::cout << p << std::endl; }
+void dump(const P4::Definitions *d) { std::cout << *d << std::endl; }
+void dump(const P4::AllDefinitions *d) { std::cout << *d << std::endl; }

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -276,6 +276,8 @@ class ProgramPoint : public IHasDbPrint {
     { return stack.empty() ? nullptr : stack.back(); }
     bool isBeforeStart() const
     { return stack.empty(); }
+    std::vector<const IR::Node*>::const_iterator begin() const { return stack.begin(); }
+    std::vector<const IR::Node*>::const_iterator end() const { return stack.end(); }
 };
 }  // namespace P4
 
@@ -408,14 +410,16 @@ class ComputeWriteSet : public Inspector {
     bool                lhs;
     /// For each expression the location set it writes
     std::map<const IR::Expression*, const LocationSet*> writes;
+    const IR::IndexedVector<IR::Declaration>    *controlLocals = nullptr;
 
     /// Creates new visitor, but with same underlying data structures.
     /// Needed to visit some program fragments repeatedly.
     ComputeWriteSet(const ComputeWriteSet* source, ProgramPoint context, Definitions* definitions) :
             allDefinitions(source->allDefinitions), currentDefinitions(definitions),
             returnedDefinitions(nullptr), exitDefinitions(source->exitDefinitions),
-            callingContext(context), storageMap(source->storageMap), lhs(false) {
-        setName("ComputeWriteSet");
+            callingContext(context), storageMap(source->storageMap), lhs(false),
+            controlLocals(source->controlLocals) {
+        visitDagOnce = false;
     }
     void enterScope(const IR::ParameterList* parameters,
                     const IR::IndexedVector<IR::Declaration>* locals,
@@ -438,9 +442,9 @@ class ComputeWriteSet : public Inspector {
  public:
     explicit ComputeWriteSet(AllDefinitions* allDefinitions) :
             allDefinitions(allDefinitions), currentDefinitions(nullptr),
-            returnedDefinitions(nullptr), exitDefinitions(nullptr),
+            returnedDefinitions(nullptr), exitDefinitions(new Definitions()),
             storageMap(allDefinitions->storageMap), lhs(false)
-    { CHECK_NULL(allDefinitions); setName("ComputeWriteSet"); }
+    { CHECK_NULL(allDefinitions); visitDagOnce = false; }
 
     // expressions
     bool preorder(const IR::Literal* expression) override;

--- a/frontends/p4/methodInstance.h
+++ b/frontends/p4/methodInstance.h
@@ -129,6 +129,11 @@ class ExternMethod final : public MethodInstance {
     const IR::Method*      method;
     const IR::Type_Extern* originalExternType;    // type of object method is applied to
     const IR::Type_Extern* actualExternType;      // with type variables substituted
+
+    /// Set of IR::Method and IR::Function objects that may be called by this method.
+    // If this method is abstract, will consist of (just) the concrete implementation,
+    // otherwise will consist of those methods that are @synchronous with this
+    std::vector<const IR::IDeclaration *> mayCall() const;
 };
 
 /** Represents the call of an extern function */

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -36,7 +36,10 @@ ParseAnnotations::HandlerMap ParseAnnotations::standardHandlers() {
             PARSE(IR::Annotation::lengthAnnotation, Expression),
 
             // @pkginfo has a key-value list argument.
-            PARSE_KV_LIST(IR::Annotation::pkginfoAnnotation)
+            PARSE_KV_LIST(IR::Annotation::pkginfoAnnotation),
+
+            // @synchronous has a list of method names
+            PARSE_EXPRESSION_LIST(IR::Annotation::synchronousAnnotation)
         };
 }
 

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -69,6 +69,7 @@ class FindUninitialized : public Inspector {
     // This does not include location sets read by subexpressions.
     std::map<const IR::Expression*, const LocationSet*> readLocations;
     HasUses*        hasUses;  // output
+    const IR::IndexedVector<IR::Declaration>    *controlLocals = nullptr;
 
     const LocationSet* getReads(const IR::Expression* expression, bool nonNull = false) const {
         auto result = ::get(readLocations, expression);
@@ -78,7 +79,7 @@ class FindUninitialized : public Inspector {
     }
     // 'expression' is reading the 'loc' location set
     void reads(const IR::Expression* expression, const LocationSet* loc) {
-        LOG3(dbp(expression) << " reads " << loc);
+        LOG3(expression << " reads " << loc);
         CHECK_NULL(expression);
         CHECK_NULL(loc);
         readLocations.emplace(expression, loc);
@@ -92,8 +93,8 @@ class FindUninitialized : public Inspector {
             context(context), refMap(parent->definitions->storageMap->refMap),
             typeMap(parent->definitions->storageMap->typeMap),
             definitions(parent->definitions), lhs(false), currentPoint(context),
-            hasUses(parent->hasUses)
-    { setName("FindUninitialized"); }
+            hasUses(parent->hasUses), controlLocals(parent->controlLocals)
+    { visitDagOnce = false; }
 
  public:
     FindUninitialized(AllDefinitions* definitions, HasUses* hasUses) :
@@ -103,13 +104,13 @@ class FindUninitialized : public Inspector {
             hasUses(hasUses) {
         CHECK_NULL(refMap); CHECK_NULL(typeMap); CHECK_NULL(definitions);
         CHECK_NULL(hasUses);
-        setName("FindUninitialized"); }
+        visitDagOnce = false; }
 
     // we control the traversal order manually, so we always 'prune()'
     // (return false from preorder)
 
     bool preorder(const IR::ParserState* state) override {
-        LOG3("FU Visiting " << dbp(state));
+        LOG3("FU Visiting state " << state->name);
         context = ProgramPoint(state);
         currentPoint = ProgramPoint(state);  // point before the first statement
         visit(state->components, "components");
@@ -159,20 +160,19 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::P4Control* control) override {
-        LOG3("FU Visiting " << dbp(control));
+        LOG3("FU Visiting control " << control->name);
         currentPoint = ProgramPoint(control);
-        for (auto d : control->controlLocals)
-            if (d->is<IR::Declaration_Instance>())
-                // visit virtual Function implementation if any
-                visit(d);
+        controlLocals = &control->controlLocals;
         visit(control->body);
         checkOutParameters(
             control, control->getApplyMethodType()->parameters, getCurrentDefinitions());
+        controlLocals = nullptr;
         return false;
     }
 
     bool preorder(const IR::Function* func) override {
-        LOG3("FU Visiting " << dbp(func));
+        LOG3("FU Visiting function " << func->name);
+        LOG5(func);
         currentPoint = ProgramPoint(func);
         visit(func->body);
         bool checkReturn = !func->type->returnType->is<IR::Type_Void>();
@@ -181,7 +181,7 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::P4Parser* parser) override {
-        LOG3("FU Visiting " << dbp(parser));
+        LOG3("FU Visiting parser " << parser->name);
         visit(parser->states, "states");
         auto accept = ProgramPoint(parser->getDeclByName(IR::ParserState::accept)->getNode());
         auto acceptdefs = definitions->getDefinitions(accept, true);
@@ -202,26 +202,26 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::ReturnStatement* statement) override {
-        LOG3("FU Visiting " << dbp(statement));
+        LOG3("FU Visiting " << statement);
         if (statement->expression != nullptr)
             visit(statement->expression);
         return setCurrent(statement);
     }
 
     bool preorder(const IR::MethodCallStatement* statement) override {
-        LOG3("FU Visiting " << dbp(statement));
+        LOG3("FU Visiting " << statement);
         visit(statement->methodCall);
         return setCurrent(statement);
     }
 
     bool preorder(const IR::BlockStatement* statement) override {
-        LOG3("FU Visiting " << dbp(statement));
+        LOG3("FU Visiting " << statement);
         visit(statement->components, "components");
         return setCurrent(statement);
     }
 
     bool preorder(const IR::IfStatement* statement) override {
-        LOG3("FU Visiting " << dbp(statement));
+        LOG3("FU Visiting " << statement);
         visit(statement->condition);
         auto saveCurrent = currentPoint;
         visit(statement->ifTrue);
@@ -233,13 +233,13 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::SwitchStatement* statement) override {
-        LOG3("FU Visiting " << dbp(statement));
+        LOG3("FU Visiting " << statement);
         visit(statement->expression);
         currentPoint = ProgramPoint(statement->expression);
         auto saveCurrent = currentPoint;
         for (auto c : statement->cases) {
             if (c->statement != nullptr) {
-                LOG3("Visiting " << dbp(c));
+                LOG3("Visiting " << c);
                 currentPoint = saveCurrent;
                 visit(c);
             }
@@ -315,7 +315,7 @@ class FindUninitialized : public Inspector {
     // For the following we compute the read set and save it.
     // We check the read set later.
     bool preorder(const IR::PathExpression* expression) override {
-        LOG3("FU Visiting " << dbp(expression));
+        LOG3("FU Visiting [" << expression->id << "]: " << expression);
         if (lhs) {
             reads(expression, LocationSet::empty);
             return false;
@@ -333,7 +333,7 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::P4Action* action) override {
-        LOG3("FU Visiting " << dbp(action));
+        LOG3("FU Visiting " << action);
         currentPoint = ProgramPoint(context, action);
         visit(action->body);
         checkOutParameters(action, action->parameters, getCurrentDefinitions());
@@ -341,7 +341,7 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::P4Table* table) override {
-        LOG3("FU Visiting " << dbp(table));
+        LOG3("FU Visiting " << table->name);
         auto savePoint = ProgramPoint(context, table);
         currentPoint = savePoint;
         auto key = table->getKey();
@@ -358,7 +358,7 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::MethodCallExpression* expression) override {
-        LOG3("FU Visiting " << dbp(expression));
+        LOG3("FU Visiting [" << expression->id << "]: " << expression);
         visit(expression->method);
         auto mi = MethodInstance::resolve(expression, refMap, typeMap);
         if (auto bim = mi->to<BuiltInMethod>()) {
@@ -378,23 +378,25 @@ class FindUninitialized : public Inspector {
             }
         }
 
-        // Symbolically call some methods (actions and tables)
-        const IR::Node* callee = nullptr;
-        if (mi->is<ActionCall>()) {
-            auto action = mi->to<ActionCall>()->action;
-            callee = action;
+        // Symbolically call some methods (actions and tables, extern methods)
+        std::vector <const IR::IDeclaration *> callee;
+        if (auto ac = mi->to<ActionCall>()) {
+            callee.push_back(ac->action);
         } else if (mi->isApply()) {
             auto am = mi->to<ApplyMethod>();
             if (am->isTableApply()) {
                 auto table = am->object->to<IR::P4Table>();
-                callee = table;
+                callee.push_back(table);
             }
-        }
-        if (callee != nullptr) {
-            LOG3("Analyzing " << dbp(callee));
+        } else if (auto em = mi->to<ExternMethod>()) {
+            LOG4("##call to extern " << expression);
+            callee = em->mayCall(); }
+        if (!callee.empty()) {
+            LOG3("Analyzing " << callee);
             ProgramPoint pt(context, expression);
             FindUninitialized fu(this, pt);
-            (void)callee->apply(fu);
+            for (auto c : callee)
+                (void)c->getNode()->apply(fu);
         }
 
         for (auto p : *mi->substitution.getParametersInArgumentOrder()) {
@@ -415,7 +417,7 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::Member* expression) override {
-        LOG3("FU Visiting " << dbp(expression));
+        LOG3("FU Visiting [" << expression->id << "]: " << expression);
         visit(expression->expr);
         if (expression->expr->is<IR::TypeNameExpression>()) {
             // this is a constant
@@ -455,7 +457,7 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::Slice* expression) override {
-        LOG3("FU Visiting " << dbp(expression));
+        LOG3("FU Visiting [" << expression->id << "]: " << expression);
         bool save = lhs;
         lhs = false;  // slices on the LHS also read the data
         visit(expression->e0);
@@ -467,7 +469,7 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::ArrayIndex* expression) override {
-        LOG3("FU Visiting " << dbp(expression));
+        LOG3("FU Visiting [" << expression->id << "]: " << expression);
         if (expression->right->is<IR::Constant>()) {
             if (lhs) {
                 reads(expression, LocationSet::empty);
@@ -527,7 +529,7 @@ class RemoveUnused : public Transform {
     { CHECK_NULL(hasUses); setName("RemoveUnused"); }
     const IR::Node* postorder(IR::AssignmentStatement* statement) override {
         if (!hasUses->hasUses(getOriginal())) {
-            LOG3("Removing statement " << dbp(getOriginal()) << " " << statement);
+            LOG3("Removing statement " << getOriginal() << " " << statement);
             SideEffects se(nullptr, nullptr);
             (void)statement->right->apply(se);
 
@@ -564,6 +566,7 @@ class ProcessDefUse : public PassManager {
 
 const IR::Node* DoSimplifyDefUse::process(const IR::Node* node) {
     ProcessDefUse process(refMap, typeMap);
+    LOG5("ProcessDefUse of:\n" << node);
     return node->apply(process);
 }
 

--- a/ir/base.def
+++ b/ir/base.def
@@ -250,6 +250,7 @@ class Annotation {
     static const cstring optionalAnnotation;  /// Optional parameter annotation
     static const cstring pkginfoAnnotation;  /// Package documentation annotation.
     static const cstring deprecatedAnnotation;  /// Deprecation annotation.
+    static const cstring synchronousAnnotation;  /// Synchronous annotation.
     toString{ return cstring("@") + name; }
     validate{
         BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name");

--- a/ir/dbprint-stmt.cpp
+++ b/ir/dbprint-stmt.cpp
@@ -24,7 +24,7 @@ void IR::ReturnStatement::dbprint(std::ostream &out) const {
     int prec = getprec(out);
     out << "return";
     if (expression) {
-        out << Prec_Low << expression << setprec(prec); }
+        out << " " << Prec_Low << expression << setprec(prec); }
     if (!prec) out << ';';
 }
 

--- a/ir/dbprint-type.cpp
+++ b/ir/dbprint-type.cpp
@@ -45,6 +45,7 @@ void IR::Type_MethodBase::dbprint(std::ostream& out) const {
 
 void IR::Method::dbprint(std::ostream& out) const {
     int flags = dbgetflags(out);
+    out << annotations;
     if (isAbstract) out << "abstract ";
     out << Brief << type->returnType << " " << name;
     if (type->typeParameters != nullptr)

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -41,6 +41,7 @@ const cstring IR::Annotation::lengthAnnotation = "length";
 const cstring IR::Annotation::optionalAnnotation = "optional";
 const cstring IR::Annotation::pkginfoAnnotation = "pkginfo";
 const cstring IR::Annotation::deprecatedAnnotation = "deprecated";
+const cstring IR::Annotation::synchronousAnnotation = "synchronous";
 
 int Type_Declaration::nextId = 0;
 int Type_InfInt::nextId = 0;

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -49,6 +49,8 @@ if legal to do so.
 
  */
 class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteContext {
+    ReferenceMap                *refMap;
+    TypeMap                     *typeMap;
     bool                        working = false;
     struct VarInfo {
         bool                    local = false;
@@ -109,12 +111,11 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
     DoLocalCopyPropagation(const DoLocalCopyPropagation &) = default;
 
  public:
-    explicit DoLocalCopyPropagation(
+    DoLocalCopyPropagation(ReferenceMap* refMap, TypeMap* typeMap,
         std::function<bool(const Context *, const IR::Expression *)> policy)
-    : tables(*new std::map<cstring, TableInfo>), actions(*new std::map<cstring, FuncInfo>),
-      methods(*new std::map<cstring, FuncInfo>), states(*new std::map<cstring, FuncInfo>),
-      policy(policy)
-    { setName("DoLocalCopyPropagation"); }
+    : refMap(refMap), typeMap(typeMap), tables(*new std::map<cstring, TableInfo>),
+      actions(*new std::map<cstring, FuncInfo>), methods(*new std::map<cstring, FuncInfo>),
+      states(*new std::map<cstring, FuncInfo>), policy(policy) {}
 };
 
 class LocalCopyPropagation : public PassManager {
@@ -124,7 +125,7 @@ class LocalCopyPropagation : public PassManager {
             [](const Context *, const IR::Expression *) -> bool { return true; }
     ) {
         passes.push_back(new TypeChecking(refMap, typeMap, true));
-        passes.push_back(new DoLocalCopyPropagation(policy));
+        passes.push_back(new DoLocalCopyPropagation(refMap, typeMap, policy));
         setName("LocalCopyPropagation");
     }
 };

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -172,7 +172,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
-        meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
+        meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {

--- a/testdata/p4_16_errors_outputs/virtual3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual3.p4-stderr
@@ -1,3 +1,3 @@
-virtual3.p4(24): error: return: return with no expression in a function returning bit<16>
+virtual3.p4(24): error: return : return with no expression in a function returning bit<16>
             return;
             ^^^^^^

--- a/testdata/p4_16_samples_outputs/array_field1-midend.p4
+++ b/testdata/p4_16_samples_outputs/array_field1-midend.p4
@@ -6,22 +6,18 @@ extern bit<1> f(inout bit<1> x, in bit<1> b);
 control c(out H[2] h);
 package top(c _c);
 control my(out H[2] s) {
-    bit<32> tmp_2;
     bit<1> tmp_3;
-    bit<32> tmp_5;
     bit<1> tmp_6;
     bit<1> tmp_8;
     @name("my.act") action act() {
         s[32w0].z = 1w1;
         s[32w1].z = 1w0;
-        tmp_2 = 32w0;
         tmp_3 = s[32w0].z;
         tmp_8 = f(tmp_3, 1w0);
-        s[tmp_2].z = tmp_3;
-        tmp_5 = (bit<32>)tmp_8;
+        s[32w0].z = tmp_3;
         tmp_6 = s[(bit<32>)tmp_8].z;
         f(tmp_6, 1w1);
-        s[tmp_5].z = tmp_6;
+        s[(bit<32>)tmp_8].z = tmp_6;
     }
     @name("my.tbl_act") table tbl_act_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -170,7 +170,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         flowlet_id_0.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         flowlet_lasttime_0.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
-        meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
+        meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
     }
     @name("ingress.set_dmac") action set_dmac(bit<48> dmac) {

--- a/testdata/p4_16_samples_outputs/issue242-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-midend.p4
@@ -70,24 +70,19 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 }
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    Value val_0;
-    bit<32> inc_0;
     bit<32> tmp;
     bit<32> tmp_0;
     @name("Eg.debug") register<bit<32>>(32w100) debug_0;
     @name("Eg.reg") register<bit<32>>(32w1) reg_0;
     @name("Eg.test") action test() {
-        val_0.field1 = 32w0;
         tmp = tmp;
         tmp = 32w0;
-        inc_0 = tmp;
         tmp_0 = tmp_0;
         tmp_0 = 32w0;
         debug_0.write(32w0, tmp_0);
-        debug_0.write(32w1, inc_0);
-        val_0.field1 = 32w1;
-        debug_0.write(32w2, inc_0);
-        reg_0.write(32w0, val_0.field1);
+        debug_0.write(32w1, tmp);
+        debug_0.write(32w2, tmp);
+        reg_0.write(32w0, 32w1);
     }
     @hidden table tbl_test {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-midend.p4
@@ -74,22 +74,17 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 }
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    Value val_0;
-    bit<32> inc_0;
     bit<32> tmp;
     bit<32> tmp_0;
     @name("Eg.test") action test() {
-        val_0.field1 = 32w0;
         tmp = tmp;
         tmp = 32w0;
-        inc_0 = tmp;
         tmp_0 = tmp_0;
         tmp_0 = 32w0;
         debug.write(32w0, tmp_0);
-        debug.write(32w1, inc_0);
-        val_0.field1 = 32w1;
-        debug.write(32w2, inc_0);
-        reg.write(32w0, val_0.field1);
+        debug.write(32w1, tmp);
+        debug.write(32w2, tmp);
+        reg.write(32w0, 32w1);
     }
     @hidden table tbl_test {
         actions = {

--- a/testdata/p4_16_samples_outputs/nested-tuple-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-midend.p4
@@ -22,14 +22,12 @@ extern void f<T>(in T data);
 control c(inout bit<1> r) {
     T s_0_f1_field;
     T s_0_f1_field_0;
-    T s_0_f2;
     @hidden action act() {
         s_0_f1_field.f = 1w0;
         s_0_f1_field_0.f = 1w1;
-        s_0_f2.f = 1w0;
         f<tuple_1>({ s_0_f1_field, s_0_f1_field_0 });
         f<tuple_0>({{1w0},{1w1}});
-        r = s_0_f2.f & 1w1;
+        r = 1w0;
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/nested-tuple1-first.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple1-first.p4
@@ -13,7 +13,7 @@ control c(inout bit<1> r) {
     S s_0;
     bit<1> tmp;
     apply {
-        s_0 = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
+        s_0 = {{ {1w0}, {1w1} },{1w0},1w1};
         f<tuple<T, T>>(s_0.f1);
         tmp = s_0.f2.f & s_0.z;
         r = tmp;

--- a/testdata/p4_16_samples_outputs/nested-tuple1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple1-frontend.p4
@@ -13,7 +13,7 @@ control c(inout bit<1> r) {
     S s;
     bit<1> tmp_0;
     apply {
-        s = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
+        s = {{ {1w0}, {1w1} },{1w0},1w1};
         f<tuple<T, T>>(s.f1);
         tmp_0 = s.f2.f & s.z;
         r = tmp_0;

--- a/testdata/p4_16_samples_outputs/nested-tuple1-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple1-midend.p4
@@ -17,13 +17,11 @@ extern void f<D>(in D data);
 control c(inout bit<1> r) {
     T s_f1_field;
     T s_f1_field_0;
-    T s_f2;
     @hidden action act() {
         s_f1_field.f = 1w0;
         s_f1_field_0.f = 1w1;
-        s_f2.f = 1w0;
         f<tuple_0>({ s_f1_field, s_f1_field_0 });
-        r = s_f2.f & 1w1;
+        r = 1w0;
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-midend.p4
@@ -35,9 +35,7 @@ struct metadata {
 }
 
 parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
-    h1_t hdr_0_h1;
     h2_t[5] hdr_0_h2;
-    h3_t hdr_0_h3;
     state start {
         pkt.extract<h1_t>(hdr.h1);
         verify(hdr.h1.hdr_type == 8w1, error.BadHeaderType);
@@ -48,14 +46,10 @@ parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standa
         }
     }
     state parse_first_h2 {
-        hdr_0_h1 = hdr.h1;
         hdr_0_h2 = hdr.h2;
-        hdr_0_h3 = hdr.h3;
         pkt.extract<h2_t>(hdr_0_h2.next);
         verify(hdr_0_h2.last.hdr_type == 8w2, error.BadHeaderType);
-        hdr.h1 = hdr_0_h1;
         hdr.h2 = hdr_0_h2;
-        hdr.h3 = hdr_0_h3;
         transition select(hdr_0_h2.last.next_hdr_type) {
             8w2: parse_other_h2;
             8w3: parse_h3;

--- a/testdata/p4_16_samples_outputs/virtual2-first.p4
+++ b/testdata/p4_16_samples_outputs/virtual2-first.p4
@@ -1,7 +1,7 @@
 extern Virtual {
     Virtual();
-    abstract bit<16> f(in bit<16> ix);
     void run(in bit<16> ix);
+    @synchronous(run) abstract bit<16> f(in bit<16> ix);
 }
 
 extern State {

--- a/testdata/p4_16_samples_outputs/virtual2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/virtual2-frontend.p4
@@ -1,7 +1,7 @@
 extern Virtual {
     Virtual();
-    abstract bit<16> f(in bit<16> ix);
     void run(in bit<16> ix);
+    @synchronous(run) abstract bit<16> f(in bit<16> ix);
 }
 
 extern State {

--- a/testdata/p4_16_samples_outputs/virtual2-midend.p4
+++ b/testdata/p4_16_samples_outputs/virtual2-midend.p4
@@ -1,7 +1,7 @@
 extern Virtual {
     Virtual();
-    abstract bit<16> f(in bit<16> ix);
     void run(in bit<16> ix);
+    @synchronous(run) abstract bit<16> f(in bit<16> ix);
 }
 
 extern State {

--- a/testdata/p4_16_samples_outputs/virtual2.p4
+++ b/testdata/p4_16_samples_outputs/virtual2.p4
@@ -1,7 +1,7 @@
 extern Virtual {
     Virtual();
-    abstract bit<16> f(in bit<16> ix);
     void run(in bit<16> ix);
+    @synchronous(run) abstract bit<16> f(in bit<16> ix);
 }
 
 extern State {

--- a/testdata/p4_16_samples_outputs/virtual3-first.p4
+++ b/testdata/p4_16_samples_outputs/virtual3-first.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+
+extern Virtual {
+    Virtual();
+    void increment();
+    @synchronous(increment) abstract bit<16> f(in bit<16> ix);
+    bit<16> total();
+}
+
+control c(inout bit<16> p) {
+    bit<16> local;
+    Virtual() cntr = {
+        bit<16> f(in bit<16> ix) {
+            return ix + local;
+        }
+    };
+    action final_ctr() {
+        p = cntr.total();
+    }
+    action add_ctr() {
+        cntr.increment();
+    }
+    table run_ctr {
+        key = {
+            p: exact @name("p") ;
+        }
+        actions = {
+            add_ctr();
+            final_ctr();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        local = 16w4;
+        run_ctr.apply();
+    }
+}
+
+control ctr(inout bit<16> x);
+package top(ctr ctrl);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/virtual3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/virtual3-frontend.p4
@@ -1,0 +1,47 @@
+#include <core.p4>
+
+extern Virtual {
+    Virtual();
+    void increment();
+    @synchronous(increment) abstract bit<16> f(in bit<16> ix);
+    bit<16> total();
+}
+
+control c(inout bit<16> p) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    bit<16> local_0;
+    bit<16> tmp;
+    @name("c.cntr") Virtual() cntr_0 = {
+        bit<16> f(in bit<16> ix) {
+            return ix + local_0;
+        }
+    };
+    @name("c.final_ctr") action final_ctr() {
+        tmp = cntr_0.total();
+        p = tmp;
+    }
+    @name("c.add_ctr") action add_ctr() {
+        cntr_0.increment();
+    }
+    @name("c.run_ctr") table run_ctr_0 {
+        key = {
+            p: exact @name("p") ;
+        }
+        actions = {
+            add_ctr();
+            final_ctr();
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        local_0 = 16w4;
+        run_ctr_0.apply();
+    }
+}
+
+control ctr(inout bit<16> x);
+package top(ctr ctrl);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/virtual3-midend.p4
+++ b/testdata/p4_16_samples_outputs/virtual3-midend.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+
+extern Virtual {
+    Virtual();
+    void increment();
+    @synchronous(increment) abstract bit<16> f(in bit<16> ix);
+    bit<16> total();
+}
+
+control c(inout bit<16> p) {
+    bit<16> local_0;
+    bit<16> tmp;
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("c.cntr") Virtual() cntr_0 = {
+        bit<16> f(in bit<16> ix) {
+            return ix + local_0;
+        }
+    };
+    @name("c.final_ctr") action final_ctr() {
+        tmp = cntr_0.total();
+        p = tmp;
+    }
+    @name("c.add_ctr") action add_ctr() {
+        cntr_0.increment();
+    }
+    @name("c.run_ctr") table run_ctr_0 {
+        key = {
+            p: exact @name("p") ;
+        }
+        actions = {
+            add_ctr();
+            final_ctr();
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    @hidden action act() {
+        local_0 = 16w4;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+        run_ctr_0.apply();
+    }
+}
+
+control ctr(inout bit<16> x);
+package top(ctr ctrl);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/virtual3.p4
+++ b/testdata/p4_16_samples_outputs/virtual3.p4
@@ -1,0 +1,41 @@
+#include <core.p4>
+
+extern Virtual {
+    Virtual();
+    void increment();
+    @synchronous(increment) abstract bit<16> f(in bit<16> ix);
+    bit<16> total();
+}
+
+control c(inout bit<16> p) {
+    bit<16> local;
+    Virtual() cntr = {
+        bit<16> f(in bit<16> ix) {
+            return ix + local;
+        }
+    };
+    action final_ctr() {
+        p = cntr.total();
+    }
+    action add_ctr() {
+        cntr.increment();
+    }
+    table run_ctr {
+        key = {
+            p: exact;
+        }
+        actions = {
+            add_ctr;
+            final_ctr;
+        }
+    }
+    apply {
+        local = 4;
+        run_ctr.apply();
+    }
+}
+
+control ctr(inout bit<16> x);
+package top(ctr ctrl);
+top(c()) main;
+


### PR DESCRIPTION
- Track extern method calls, assuming that any call to any
  non-abstract method might trigger any abstract method implementation
- local_copyprop fixed for the same assumption.