### PR TITLE
Do not eliminate annotated states.

### DIFF
--- a/frontends/p4/simplifyParsers.cpp
+++ b/frontends/p4/simplifyParsers.cpp
@@ -55,6 +55,12 @@ class RemoveUnreachableStates : public Transform {
         if (state->name == IR::ParserState::start ||
             state->name == IR::ParserState::reject)
             return state;
+
+        // Do not eliminate states with annotations other than name.
+        for (const auto* anno : state->getAnnotations()->annotations) {
+            if (anno->name.name != "name") {
+                return state; } }
+
         auto orig = getOriginal<IR::ParserState>();
         if (reachable.find(orig) == reachable.end()) {
             if (state->name == IR::ParserState::accept) {

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -127,6 +127,12 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::ParserState* state) {
         state->name == IR::ParserState::reject ||
         state->name == IR::ParserState::start)
         return state;
+
+    // Do not eliminate states with annotations other than name.
+    for (const auto* anno : state->getAnnotations()->annotations) {
+        if (anno->name.name != "name") {
+            return state; } }
+
     if (refMap->isUsed(getOriginal<IR::ParserState>()))
         return state;
     LOG3("Removing " << state);

--- a/testdata/p4_14_samples/parser_pragma.p4
+++ b/testdata/p4_14_samples/parser_pragma.p4
@@ -1,0 +1,24 @@
+parser start {
+    return ingress;
+}
+
+@pragma packet_entry
+parser start_i2e_mirrored {
+    return ingress;
+}
+
+@pragma packet_entry
+parser start_e2e_mirrored {
+    return ingress;
+}
+
+action nop() { }
+
+table exact {
+    reads { standard_metadata.egress_spec: exact; }
+    actions { nop; }
+}
+
+control ingress {
+    apply(exact);
+}

--- a/testdata/p4_14_samples_outputs/parser_pragma-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-first.p4
@@ -1,0 +1,61 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct metadata {
+}
+
+struct headers {
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start {
+        transition accept;
+    }
+    @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {
+        transition accept;
+    }
+    @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".nop") action nop() {
+    }
+    @name(".exact") table exact_0 {
+        actions = {
+            nop();
+            @defaultonly NoAction();
+        }
+        key = {
+            standard_metadata.egress_spec: exact @name("standard_metadata.egress_spec") ;
+        }
+        default_action = NoAction();
+    }
+    apply {
+        exact_0.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/parser_pragma-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-frontend.p4
@@ -1,0 +1,63 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct metadata {
+}
+
+struct headers {
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start {
+        transition accept;
+    }
+    @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {
+        transition accept;
+    }
+    @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name(".nop") action nop_0() {
+    }
+    @name(".exact") table exact_0 {
+        actions = {
+            nop_0();
+            @defaultonly NoAction_0();
+        }
+        key = {
+            standard_metadata.egress_spec: exact @name("standard_metadata.egress_spec") ;
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        exact_0.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/parser_pragma-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-midend.p4
@@ -1,0 +1,63 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct metadata {
+}
+
+struct headers {
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start {
+        transition accept;
+    }
+    @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {
+        transition accept;
+    }
+    @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name(".nop") action nop_0() {
+    }
+    @name(".exact") table exact_0 {
+        actions = {
+            nop_0();
+            @defaultonly NoAction_0();
+        }
+        key = {
+            standard_metadata.egress_spec: exact @name("standard_metadata.egress_spec") ;
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        exact_0.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/parser_pragma.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma.p4
@@ -1,0 +1,59 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct metadata {
+}
+
+struct headers {
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start {
+        transition accept;
+    }
+    @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {
+        transition accept;
+    }
+    @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".nop") action nop() {
+    }
+    @name(".exact") table exact_0 {
+        actions = {
+            nop;
+        }
+        key = {
+            standard_metadata.egress_spec: exact;
+        }
+    }
+    apply {
+        exact_0.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+


### PR DESCRIPTION
Annotations on parser state may be useful for certain midend and backend. Do not eliminate the parser state that has an annotation other than `name`(because it is always added), but not invoked by any other parser state. 