### PR TITLE
Support named arguments in frontend and midend

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -97,8 +97,8 @@ set(BMV2_DRIVER ${CMAKE_CURRENT_SOURCE_DIR}/run-bmv2-test.py)
 set (BMV2_TEST_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*-bmv2.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_bmv_errors/*-bmv2.p4"
-  "${P4C_SOURCE_DIR}/testdata/p4_14_samples/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_14_samples/switch_*/switch.p4"
+  "${P4C_SOURCE_DIR}/testdata/p4_14_samples/*.p4"
   )
 
 set (XFAIL_TESTS

--- a/backends/bmv2/backend.cpp
+++ b/backends/bmv2/backend.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/p4/unusedDeclarations.h"
 #include "midend/actionSynthesis.h"
+#include "midend/orderArguments.h"
 #include "midend/removeLeftSlices.h"
 #include "lower.h"
 #include "header.h"
@@ -237,6 +238,7 @@ Backend::process(const IR::ToplevelBlock* tlb, BMV2Options& options) {
     addPasses({
         new RenameUserMetadata(refMap, userMetaType, userMetaName),
         new P4::ClearTypeMap(typeMap),  // because the user metadata type has changed
+        new P4::OrderArguments(refMap, typeMap),
         new P4::SynthesizeActions(refMap, typeMap, new SkipControls(&non_pipeline_controls)),
         new P4::MoveActionsToTables(refMap, typeMap),
         new P4::TypeChecking(refMap, typeMap),

--- a/backends/bmv2/control.cpp
+++ b/backends/bmv2/control.cpp
@@ -266,8 +266,8 @@ ControlConverter::handleTableImplementation(const IR::Property* implementation,
             return false;
         }
         isSimpleTable = false;
-        auto eb = backend->getToplevelBlock()->getValue(decl->getNode());
-        if (eb) {
+        if (backend->getToplevelBlock()->hasValue(decl->getNode())) {
+            auto eb = backend->getToplevelBlock()->getValue(decl->getNode());
             BUG_CHECK(eb->is<IR::ExternBlock>(), "Not an extern block?");
             backend->getSimpleSwitch()->convertExternInstances(decl->to<IR::Declaration>(),
                         eb->to<IR::ExternBlock>(), action_profiles, selector_check, emitExterns); }

--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -191,7 +191,7 @@ bool CodeGenInspector::preorder(const IR::MethodCallExpression* expression) {
     visit(expression->method);
     builder->append("(");
     bool first = true;
-    for (auto p : *mcd.substitution.getParameters()) {
+    for (auto p : *mcd.substitution.getParametersInArgumentOrder()) {
         if (!first)
             builder->append(", ");
         first = false;

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -361,7 +361,7 @@ void EBPFTable::emitInitializer(CodeBuilder* builder) {
     CodeGenInspector cg(program->refMap, program->typeMap);
     cg.setBuilder(builder);
 
-    for (auto p : *mcd.substitution.getParameters()) {
+    for (auto p : *mcd.substitution.getParametersInArgumentOrder()) {
         builder->emitIndent();
         builder->appendFormat(".%s = ", p->name.name.c_str());
         auto arg = mcd.substitution.lookup(p);

--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -58,7 +58,7 @@ p4c_add_tests("p4" ${P4TEST_DRIVER} "${P4TEST_SUITES}" "${P4_XFAIL_TESTS}")
 
 set (P4_14_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_14_samples/*.p4"
-  "${P4C_SOURCE_DIR}/testdata/p4_14_errors/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_14_samples/switch_*/switch.p4"
+  "${P4C_SOURCE_DIR}/testdata/p4_14_errors/*.p4"
   )
 p4c_add_tests("p14_to_16" ${P4TEST_DRIVER} "${P4_14_SUITES}" "")

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -16,6 +16,7 @@ set (P4_FRONTEND_SRCS
   p4/actionsInlining.cpp
   p4/callGraph.cpp
   p4/checkConstants.cpp
+  p4/checkNamedArgs.cpp
   p4/createBuiltins.cpp
   p4/def_use.cpp
   p4/deprecated.cpp
@@ -68,6 +69,7 @@ set (P4_FRONTEND_HDRS
   p4/actionsInlining.h
   p4/callGraph.h
   p4/checkConstants.h
+  p4/checkNamedArgs.h
   p4/cloner.h
   p4/coreLibrary.h
   p4/createBuiltins.h

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -35,6 +35,7 @@ set (P4_FRONTEND_SRCS
   p4/modelInstances.cpp
   p4/moveConstructors.cpp
   p4/moveDeclarations.cpp
+  p4/parameterSubstitution.cpp
   p4/parserCallGraph.cpp
   p4/parserControlFlow.cpp
   p4/removeReturns.cpp

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -28,7 +28,7 @@ ResolutionContext::resolve(IR::ID name, P4::ResolutionType type, bool forwardOK)
 
     for (auto it = toTry.rbegin(); it != toTry.rend(); ++it) {
         const IR::INamespace* current = *it;
-        LOG2("Trying to resolve in " << current->toString());
+        LOG3("Trying to resolve in " << current->toString());
 
         if (current->is<IR::IGeneralNamespace>()) {
             auto gen = current->to<IR::IGeneralNamespace>();
@@ -61,7 +61,7 @@ ResolutionContext::resolve(IR::ID name, P4::ResolutionType type, bool forwardOK)
                     Util::SourceInfo nsi = name.srcInfo;
                     Util::SourceInfo dsi = d->getNode()->srcInfo;
                     bool before = dsi <= nsi;
-                    LOG2("\tPosition test:" << dsi << "<=" << nsi << "=" << before);
+                    LOG3("\tPosition test:" << dsi << "<=" << nsi << "=" << before);
                     return before;
                 };
                 decls = decls->where(locationFilter);
@@ -69,7 +69,7 @@ ResolutionContext::resolve(IR::ID name, P4::ResolutionType type, bool forwardOK)
 
             auto vector = decls->toVector();
             if (!vector->empty()) {
-                LOG2("Resolved in " << dbp(current->getNode()));
+                LOG3("Resolved in " << dbp(current->getNode()));
                 return vector;
             } else {
                 continue;
@@ -100,12 +100,12 @@ ResolutionContext::resolve(IR::ID name, P4::ResolutionType type, bool forwardOK)
                 Util::SourceInfo nsi = name.srcInfo;
                 Util::SourceInfo dsi = decl->getNode()->srcInfo;
                 bool before = dsi <= nsi;
-                LOG2("\tPosition test:" << dsi << "<=" << nsi << "=" << before);
+                LOG3("\tPosition test:" << dsi << "<=" << nsi << "=" << before);
                 if (!before)
                     continue;
             }
 
-            LOG2("Resolved in " << dbp(current->getNode()));
+            LOG3("Resolved in " << dbp(current->getNode()));
             auto result = new std::vector<const IR::IDeclaration*>();
             result->push_back(decl);
             return result;
@@ -177,7 +177,7 @@ ResolveReferences::ResolveReferences(ReferenceMap* refMap,
 }
 
 void ResolveReferences::addToContext(const IR::INamespace* ns) {
-    LOG1("Adding to context " << dbp(ns));
+    LOG2("Adding to context " << dbp(ns));
     BUG_CHECK(context != nullptr, "No resolution context; did not start at P4Program?");
     checkShadowing(ns);
     context->push(ns);
@@ -189,13 +189,13 @@ void ResolveReferences::addToGlobals(const IR::INamespace* ns) {
 }
 
 void ResolveReferences::removeFromContext(const IR::INamespace* ns) {
-    LOG1("Removing from context " << dbp(ns));
+    LOG2("Removing from context " << dbp(ns));
     BUG_CHECK(context != nullptr, "No resolution context; did not start at P4Program?");
     context->pop(ns);
 }
 
 void ResolveReferences::resolvePath(const IR::Path* path, bool isType) const {
-    LOG1("Resolving " << path << " " << (isType ? "as type" : "as identifier"));
+    LOG2("Resolving " << path << " " << (isType ? "as type" : "as identifier"));
     ResolutionContext* ctx = context;
     if (path->absolute)
         ctx = new ResolutionContext(rootNamespace);
@@ -271,7 +271,7 @@ void ResolveReferences::postorder(const IR::P4Program*) {
     resolveForward.pop_back();
     BUG_CHECK(resolveForward.empty(), "Expected empty resolvePath");
     context = nullptr;
-    LOG1("Reference map " << refMap);
+    LOG2("Reference map " << refMap);
 }
 
 bool ResolveReferences::preorder(const IR::This* pointer) {

--- a/frontends/p4/checkNamedArgs.cpp
+++ b/frontends/p4/checkNamedArgs.cpp
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "checkNamedArgs.h"
+
+namespace P4 {
+
+bool CheckNamedArgs::checkArguments(const IR::Vector<IR::Argument>* arguments) {
+    bool first = true;
+    bool hasName = false;
+    std::map<cstring, const IR::Argument*> found;
+
+    for (auto arg: *arguments) {
+        cstring argName = arg->name.name;
+        bool argHasName = !argName.isNullOrEmpty();
+        if (first) {
+            hasName = argHasName;
+            first = false;
+        } else {
+            if (argHasName != hasName)
+                ::error("%1%: all or none of the arguments of a call must be named", arg);
+            if (argHasName) {
+                auto it = found.find(argName);
+                if (it != found.end())
+                    ::error("%1% and %2%: same argument name", it->second, arg);
+            }
+        }
+        if (argHasName)
+            found.emplace(argName, arg);
+    }
+    return true;
+}
+
+}  // namespace P4

--- a/frontends/p4/checkNamedArgs.cpp
+++ b/frontends/p4/checkNamedArgs.cpp
@@ -44,4 +44,14 @@ bool CheckNamedArgs::checkArguments(const IR::Vector<IR::Argument>* arguments) {
     return true;
 }
 
+bool CheckNamedArgs::preorder(const IR::Parameter* parameter) {
+    if (parameter->defaultValue != nullptr) {
+        if (parameter->isOptional())
+            ::error("%1%: optional parameters cannot have default values", parameter);
+        if (parameter->hasOut())
+            ::error("%1%: out parameters cannot have default values", parameter);
+    }
+    return true;
+}
+
 }  // namespace P4

--- a/frontends/p4/checkNamedArgs.cpp
+++ b/frontends/p4/checkNamedArgs.cpp
@@ -23,7 +23,7 @@ bool CheckNamedArgs::checkArguments(const IR::Vector<IR::Argument>* arguments) {
     bool hasName = false;
     std::map<cstring, const IR::Argument*> found;
 
-    for (auto arg: *arguments) {
+    for (auto arg : *arguments) {
         cstring argName = arg->name.name;
         bool argHasName = !argName.isNullOrEmpty();
         if (first) {

--- a/frontends/p4/checkNamedArgs.h
+++ b/frontends/p4/checkNamedArgs.h
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _FRONTENDS_P4_CHECKNAMEDARGS_H_
+#define _FRONTENDS_P4_CHECKNAMEDARGS_H_
+
+#include "ir/ir.h"
+
+namespace P4 {
+
+/// A method call must have either all or none of the arguments named.
+class CheckNamedArgs : public Inspector {
+ public:
+    CheckNamedArgs() {
+        setName("CheckNamedArgs");
+    }
+
+    bool checkArguments(const IR::Vector<IR::Argument> *arguments);
+    bool preorder(const IR::MethodCallExpression* call) override
+    { return checkArguments(call->arguments); }
+    bool preorder(const IR::Declaration_Instance* call) override
+    { return checkArguments(call->arguments); }
+};
+
+}  // namespace P4
+
+#endif /* _FRONTENDS_P4_CHECKNAMEDARGS_H_ */

--- a/frontends/p4/checkNamedArgs.h
+++ b/frontends/p4/checkNamedArgs.h
@@ -22,6 +22,8 @@ limitations under the License.
 namespace P4 {
 
 /// A method call must have either all or none of the arguments named.
+/// We also check that no argument appears twice.
+/// We also check that no optional parameter has a default value.
 class CheckNamedArgs : public Inspector {
  public:
     CheckNamedArgs() {
@@ -33,6 +35,7 @@ class CheckNamedArgs : public Inspector {
     { return checkArguments(call->arguments); }
     bool preorder(const IR::Declaration_Instance* call) override
     { return checkArguments(call->arguments); }
+    bool preorder(const IR::Parameter* parameter) override;
 };
 
 }  // namespace P4

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -678,7 +678,7 @@ bool ComputeWriteSet::preorder(const IR::MethodCallExpression* expression) {
 
     auto result = LocationSet::empty;
     // For all methods out/inout arguments are written
-    for (auto p : *mcd.substitution.getParameters()) {
+    for (auto p : *mcd.substitution.getParametersInArgumentOrder()) {
         auto arg = mcd.substitution.lookup(p);
         bool save = lhs;
         // pretend we are on the lhs

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -679,14 +679,14 @@ bool ComputeWriteSet::preorder(const IR::MethodCallExpression* expression) {
     auto result = LocationSet::empty;
     // For all methods out/inout arguments are written
     for (auto p : *mcd.substitution.getParameters()) {
-        auto expr = mcd.substitution.lookup(p);
+        auto arg = mcd.substitution.lookup(p);
         bool save = lhs;
         // pretend we are on the lhs
         lhs = true;
-        visit(expr);
+        visit(arg);
         lhs = save;
         if (p->direction == IR::Direction::Out || p->direction == IR::Direction::InOut) {
-            auto val = get(expr);
+            auto val = get(arg->expression);
             result = result->join(val);
         }
     }

--- a/frontends/p4/dontcareArgs.cpp
+++ b/frontends/p4/dontcareArgs.cpp
@@ -23,7 +23,7 @@ const IR::Node* DontcareArgs::postorder(IR::MethodCallExpression* expression) {
     auto vec = new IR::Vector<IR::Argument>();
 
     MethodCallDescription mcd(expression, refMap, typeMap);
-    for (auto p : *mcd.substitution.getParameters()) {
+    for (auto p : *mcd.substitution.getParametersInArgumentOrder()) {
         auto a = mcd.substitution.lookup(p);
         if (a->expression->is<IR::DefaultExpression>()) {
             cstring name = refMap->newName("arg");

--- a/frontends/p4/dontcareArgs.cpp
+++ b/frontends/p4/dontcareArgs.cpp
@@ -25,15 +25,15 @@ const IR::Node* DontcareArgs::postorder(IR::MethodCallExpression* expression) {
     MethodCallDescription mcd(expression, refMap, typeMap);
     for (auto p : *mcd.substitution.getParameters()) {
         auto a = mcd.substitution.lookup(p);
-        if (a->is<IR::DefaultExpression>()) {
+        if (a->expression->is<IR::DefaultExpression>()) {
             cstring name = refMap->newName("arg");
             auto ptype = p->type;
             auto decl = new IR::Declaration_Variable(IR::ID(name), ptype, nullptr);
             toAdd.push_back(decl);
             changes = true;
-            vec->push_back(new IR::Argument(a->srcInfo, new IR::PathExpression(IR::ID(name))));
+            vec->push_back(new IR::Argument(a->srcInfo, a->name, new IR::PathExpression(IR::ID(name))));
         } else {
-            vec->push_back(new IR::Argument(a->srcInfo, a));
+            vec->push_back(a);
         }
     }
     if (changes)

--- a/frontends/p4/dontcareArgs.cpp
+++ b/frontends/p4/dontcareArgs.cpp
@@ -31,7 +31,8 @@ const IR::Node* DontcareArgs::postorder(IR::MethodCallExpression* expression) {
             auto decl = new IR::Declaration_Variable(IR::ID(name), ptype, nullptr);
             toAdd.push_back(decl);
             changes = true;
-            vec->push_back(new IR::Argument(a->srcInfo, a->name, new IR::PathExpression(IR::ID(name))));
+            vec->push_back(new IR::Argument(
+                a->srcInfo, a->name, new IR::PathExpression(IR::ID(name))));
         } else {
             vec->push_back(a);
         }

--- a/frontends/p4/evaluator/evaluator.cpp
+++ b/frontends/p4/evaluator/evaluator.cpp
@@ -120,8 +120,7 @@ Evaluator::evaluateArguments(
     for (auto p : parameters->parameters) {
         auto arg = substitution.lookup(p);
         if (arg == nullptr) {
-            BUG_CHECK(p->getAnnotations()->getSingle("optional") != nullptr,
-                      "Missing parameter %1%", p);
+            BUG_CHECK(p->isOptional(), "Missing parameter %1%", p);
             values->push_back(nullptr);
             continue;
         }

--- a/frontends/p4/evaluator/evaluator.cpp
+++ b/frontends/p4/evaluator/evaluator.cpp
@@ -49,21 +49,30 @@ void Evaluator::popBlock(IR::Block* block) {
 
 void Evaluator::setValue(const IR::Node* node, const IR::CompileTimeValue* constant) {
     CHECK_NULL(node);
-    CHECK_NULL(constant);
     auto block = currentBlock();
     LOG3("Set " << dbp(node) << " to " << dbp(constant) << " in " << dbp(block));
     block->setValue(node, constant);
 }
 
+bool Evaluator::hasValue(const IR::Node* node) const {
+    CHECK_NULL(node);
+    auto block = currentBlock();
+    return block->hasValue(node) || toplevelBlock->hasValue(node);
+}
+
 const IR::CompileTimeValue* Evaluator::getValue(const IR::Node* node) const {
     CHECK_NULL(node);
     auto block = currentBlock();
-    auto result = block->getValue(node);
-    LOG3("Looked up " << dbp(node) << " in " << dbp(block) << " got " << dbp(result));
-    if (result == nullptr && block != toplevelBlock) {
+    const IR::CompileTimeValue* result = nullptr;
+
+    if (block->hasValue(node)) {
+        result = block->getValue(node);
+        LOG3("Looked up " << dbp(node) << " in " << dbp(block) << " got " << dbp(result));
+    } else if (block != toplevelBlock) {
         // Try to lookup this value in the toplevel block:
         // this is needed for global declarations.
-        result = toplevelBlock->getValue(node);
+        if (toplevelBlock->hasValue(node))
+            result = toplevelBlock->getValue(node);
     }
     return result;
 }
@@ -92,27 +101,40 @@ bool Evaluator::preorder(const IR::Declaration_Constant* decl) {
     LOG2("Evaluating " << dbp(decl));
     visit(decl->initializer);
     auto value = getValue(decl);
-    if (value != nullptr)
-        setValue(decl, value);
+    setValue(decl, value);
     return false;
 }
 
 std::vector<const IR::CompileTimeValue*>*
-Evaluator::evaluateArguments(const IR::Vector<IR::Argument>* arguments, IR::Block* context) {
+Evaluator::evaluateArguments(
+    const IR::ParameterList* parameters,
+    const IR::Vector<IR::Argument>* arguments, IR::Block* context) {
     LOG2("Evaluating arguments in " << dbp(context));
     P4::DoConstantFolding cf(refMap, nullptr);
     auto values = new std::vector<const IR::CompileTimeValue*>();
     pushBlock(context);
-    for (auto e : *arguments) {
-        auto folded = e->expression->apply(cf);  // constant fold argument
+
+    ParameterSubstitution substitution;
+    substitution.populate(parameters, arguments);
+
+    for (auto p : parameters->parameters) {
+        auto arg = substitution.lookup(p);
+        if (arg == nullptr) {
+            BUG_CHECK(p->getAnnotations()->getSingle("optional") != nullptr,
+                      "Missing parameter %1%", p);
+            values->push_back(nullptr);
+            continue;
+        }
+
+        auto folded = arg->expression->apply(cf);  // constant fold argument
         CHECK_NULL(folded);
         visit(folded);  // recursive evaluation
-        auto value = getValue(folded);
-        if (value == nullptr) {
-            ::error("%1%: Cannot evaluate to a compile-time constant", e);
+        if (!hasValue(folded)) {
+            ::error("%1%: Cannot evaluate to a compile-time constant", arg->expression);
             popBlock(context);
             return nullptr;
         } else {
+            auto value = getValue(folded);
             values->push_back(value);
         }
     }
@@ -148,14 +170,13 @@ Evaluator::processConstructor(
         if (canon->is<IR::Type_SpecializedCanonical>())
             canon = canon->to<IR::Type_SpecializedCanonical>()->substituted->to<IR::Type>();
         BUG_CHECK(canon->is<IR::Type_Extern>(), "%1%: expected an extern", canon);
-        auto constructor = canon->to<IR::Type_Extern>()->lookupMethod(exttype->name.name,
-                                                                      arguments->size());
+        auto constructor = canon->to<IR::Type_Extern>()->lookupConstructor(arguments->size());
         BUG_CHECK(constructor != nullptr,
                   "Type %1% has no constructor with %2% arguments",
                   exttype, arguments->size());
         auto block = new IR::ExternBlock(node->srcInfo, node, instanceType, exttype, constructor);
         pushBlock(block);
-        auto values = evaluateArguments(arguments, current);
+        auto values = evaluateArguments(constructor->type->parameters, arguments, current);
         if (values != nullptr)
             block->instantiate(values);
         popBlock(block);
@@ -164,7 +185,7 @@ Evaluator::processConstructor(
         auto cont = decl->to<IR::P4Control>();
         auto block = new IR::ControlBlock(node->srcInfo, node, instanceType, cont);
         pushBlock(block);
-        auto values = evaluateArguments(arguments, current);
+        auto values = evaluateArguments(cont->getConstructorParameters(), arguments, current);
         if (values != nullptr) {
             block->instantiate(values);
             for (auto a : cont->controlLocals)
@@ -176,7 +197,7 @@ Evaluator::processConstructor(
         auto cont = decl->to<IR::P4Parser>();
         auto block = new IR::ParserBlock(node->srcInfo, node, instanceType, cont);
         pushBlock(block);
-        auto values = evaluateArguments(arguments, current);
+        auto values = evaluateArguments(cont->getConstructorParameters(), arguments, current);
         if (values != nullptr) {
             block->instantiate(values);
             for (auto a : cont->parserLocals)
@@ -187,10 +208,10 @@ Evaluator::processConstructor(
         popBlock(block);
         return block;
     } else if (decl->is<IR::Type_Package>()) {
-        auto block = new IR::PackageBlock(node->srcInfo, node, instanceType,
-                                          decl->to<IR::Type_Package>());
+        auto package = decl->to<IR::Type_Package>();
+        auto block = new IR::PackageBlock(node->srcInfo, node, instanceType, package);
         pushBlock(block);
-        auto values = evaluateArguments(arguments, current);
+        auto values = evaluateArguments(package->constructorParams, arguments, current);
         if (values != nullptr)
             block->instantiate(values);
         popBlock(block);
@@ -223,9 +244,10 @@ bool Evaluator::preorder(const IR::Member* expression) {
 bool Evaluator::preorder(const IR::PathExpression* expression) {
     LOG2("Evaluating " << dbp(expression));
     auto decl = refMap->getDeclaration(expression->path, true);
-    auto val = getValue(decl->getNode());
-    if (val != nullptr)
+    if (hasValue(decl->getNode())) {
+        auto val = getValue(decl->getNode());
         setValue(expression, val);
+    }
     return false;
 }
 
@@ -258,8 +280,7 @@ bool Evaluator::preorder(const IR::MethodCallExpression* expr) {
 bool Evaluator::preorder(const IR::P4Table* table) {
     LOG2("Evaluating " << dbp(table));
     auto block = new IR::TableBlock(table->srcInfo, table, table);
-    if (block != nullptr)
-        setValue(table, block);
+    setValue(table, block);
     pushBlock(block);
     visit(table->properties);
     popBlock(block);
@@ -269,9 +290,10 @@ bool Evaluator::preorder(const IR::P4Table* table) {
 bool Evaluator::preorder(const IR::Property* prop) {
     LOG2("Evaluating " << dbp(prop));
     visit(prop->value);
-    auto value = getValue(prop->value);
-    if (value != nullptr)
+    if (hasValue(prop->value)) {
+        auto value = getValue(prop->value);
         setValue(prop, value);
+    }
     return false;
 }
 

--- a/frontends/p4/evaluator/evaluator.h
+++ b/frontends/p4/evaluator/evaluator.h
@@ -45,11 +45,19 @@ class Evaluator final : public Inspector, public IHasBlock {
     IR::ToplevelBlock* getToplevelBlock() override { return toplevelBlock; }
 
     IR::Block* currentBlock() const;
+    /// Map a node to value.  The value can be nullptr, e.g., for an
+    /// optional parameter.
     void setValue(const IR::Node* node, const IR::CompileTimeValue* constant);
+    /// True if the node is mapped to a value, even if the value is
+    /// nullptr.
+    bool hasValue(const IR::Node* node) const;
     const IR::CompileTimeValue* getValue(const IR::Node* node) const;
 
+    /// Evaluates the arguments and returns a vector of parameter values
+    /// ordered in the parameter order.
     std::vector<const IR::CompileTimeValue*>*
-            evaluateArguments(const IR::Vector<IR::Argument>* arguments,
+            evaluateArguments(const IR::ParameterList* parameters,
+                              const IR::Vector<IR::Argument>* arguments,
                               IR::Block* context);
 
     profile_t init_apply(const IR::Node* node) override;

--- a/frontends/p4/evaluator/substituteParameters.cpp
+++ b/frontends/p4/evaluator/substituteParameters.cpp
@@ -28,7 +28,7 @@ const IR::Node* SubstituteParameters::postorder(IR::PathExpression* expr) {
     auto decl = refMap->getDeclaration(expr->path, true);
     auto param = decl->to<IR::Parameter>();
     if (param != nullptr && subst->contains(param)) {
-        auto value = subst->lookup(param);
+        auto value = subst->lookup(param)->expression;
         LOG1("Replaced " << dbp(expr) << " with " << dbp(value));
         return value;
     }

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 // Passes
 #include "actionsInlining.h"
 #include "createBuiltins.h"
+#include "checkNamedArgs.h"
 #include "deprecated.h"
 #include "directCalls.h"
 #include "dontcareArgs.h"
@@ -136,6 +137,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         // explicit casts where implicit casts exist.
         new ResolveReferences(&refMap),  // check shadowing
         new Deprecated(&refMap),
+        new CheckNamedArgs(),
         new TypeInference(&refMap, &typeMap, false),  // insert casts
         new BindTypeVariables(&typeMap),
         // Another round of constant folding, using type information.

--- a/frontends/p4/methodInstance.cpp
+++ b/frontends/p4/methodInstance.cpp
@@ -118,10 +118,11 @@ MethodInstance::resolve(const IR::MethodCallExpression* mce, ReferenceMap* refMa
 ConstructorCall*
 ConstructorCall::resolve(const IR::ConstructorCallExpression* cce,
                          ReferenceMap* refMap, TypeMap* typeMap) {
-    auto t = typeMap->getTypeType(cce->constructedType, true);
+    auto ct = typeMap->getTypeType(cce->constructedType, true);
     ConstructorCall* result;
-    const IR::Vector<IR::Type>* typeArguments = nullptr;
+    const IR::Vector<IR::Type>* typeArguments;
     const IR::Type_Name* type;
+    const IR::ParameterList* constructorParameters;
 
     if (cce->constructedType->is<IR::Type_Specialized>()) {
         auto spec = cce->constructedType->to<IR::Type_Specialized>();
@@ -133,24 +134,29 @@ ConstructorCall::resolve(const IR::ConstructorCallExpression* cce,
         typeArguments = new IR::Vector<IR::Type>();
     }
 
-    if (t->is<IR::Type_SpecializedCanonical>()) {
-        auto tsc = t->to<IR::Type_SpecializedCanonical>();
-        t = typeMap->getTypeType(tsc->baseType, true);
-    }
+    if (auto tsc = ct->to<IR::Type_SpecializedCanonical>())
+        ct = typeMap->getTypeType(tsc->baseType, true);
 
-    if (t->is<IR::Type_Extern>()) {
-        auto ext = refMap->getDeclaration(type->path, true);
-        BUG_CHECK(ext->is<IR::Type_Extern>(), "%1%: expected an extern type", dbp(ext));
-        result = new ExternConstructorCall(ext->to<IR::Type_Extern>());
-    } else if (t->is<IR::IContainer>()) {
-        auto cont = refMap->getDeclaration(type->path, true);
-        BUG_CHECK(cont->is<IR::IContainer>(), "%1%: expected a container", dbp(cont));
-        result = new ContainerConstructorCall(cont->to<IR::IContainer>());
+    if (ct->is<IR::Type_Extern>()) {
+        auto decl = refMap->getDeclaration(type->path, true);
+        auto ext = decl->to<IR::Type_Extern>();
+        BUG_CHECK(ext, "%1%: expected an extern type", dbp(decl));
+        auto constr = ext->lookupConstructor(cce->arguments->size());
+        result = new ExternConstructorCall(ext->to<IR::Type_Extern>(), constr);
+        BUG_CHECK(constr, "%1%: constructor not found", ext);
+        constructorParameters = constr->type->parameters;
+    } else if (ct->is<IR::IContainer>()) {
+        auto decl = refMap->getDeclaration(type->path, true);
+        auto cont = decl->to<IR::IContainer>();
+        BUG_CHECK(cont, "%1%: expected a container", dbp(decl));
+        result = new ContainerConstructorCall(cont);
+        constructorParameters = cont->getConstructorParameters();
     } else {
-        BUG("Unexpected constructor call %1%; type is %2%", dbp(cce), dbp(t));
+        BUG("Unexpected constructor call %1%; type is %2%", dbp(cce), dbp(ct));
     }
     result->cce = cce;
     result->typeArguments = typeArguments;
+    result->constructorParameters = constructorParameters;
     return result;
 }
 
@@ -159,6 +165,33 @@ MethodCallDescription::MethodCallDescription(const IR::MethodCallExpression* mce
     instance = MethodInstance::resolve(mce, refMap, typeMap);
     auto params = instance->getActualParameters();
     substitution.populate(params, mce->arguments);
+}
+
+Instantiation* Instantiation::resolve(const IR::Declaration_Instance* instance,
+                                      ReferenceMap* ,
+                                      TypeMap* typeMap) {
+    auto type = typeMap->getTypeType(instance->type, true);
+    auto simpleType = type;
+    const IR::Vector<IR::Type>* typeArguments;
+
+    if (auto st = type->to<IR::Type_SpecializedCanonical>()) {
+        simpleType = st->substituted;
+        typeArguments = st->arguments;
+    } else {
+        typeArguments = new IR::Vector<IR::Type>();
+    }
+
+    if (auto et = simpleType->to<IR::Type_Extern>()) {
+        return new ExternInstantiation(instance, typeArguments, et);
+    } else if (auto pt = simpleType->to<IR::Type_Package>()) {
+        return new PackageInstantiation(instance, typeArguments, pt);
+    } else if (auto pt = simpleType->to<IR::P4Parser>()) {
+        return new ParserInstantiation(instance, typeArguments, pt);
+    } else if (auto ct = simpleType->to<IR::P4Control>()) {
+        return new ControlInstantiation(instance, typeArguments, ct);
+    }
+    BUG("Unexpected instantiation %1%", instance);
+    return nullptr;  // unreachable
 }
 
 }  // namespace P4

--- a/frontends/p4/parameterSubstitution.cpp
+++ b/frontends/p4/parameterSubstitution.cpp
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "parameterSubstitution.h"
+
+namespace P4 {
+
+void ParameterSubstitution::add(
+    const IR::Parameter* parameter, const IR::Argument* value) {
+    LOG2("Mapping " << dbp(parameter) << " to " << dbp(value));
+    cstring name = parameter->name.name;
+    auto par = get(parametersByName, name);
+    BUG_CHECK(par == nullptr,
+              "Two parameters with the same name %1% in a substitution", name);
+    parameterValues.emplace(name, value);
+    parametersByName.emplace(name, parameter);
+    parameters.push_back(parameter);
+}
+
+void ParameterSubstitution::populate(const IR::ParameterList* params,
+                                     const IR::Vector<IR::Argument>* args) {
+    BUG_CHECK(paramList == nullptr, "Already populated");
+    paramList = params;
+    BUG_CHECK(params->size() >= args->size(),
+              "Incompatible number of arguments for parameter list: %1% and %2%",
+              params, args);
+
+    auto pe = params->getEnumerator();
+    for (auto a : *args) {
+        const IR::Parameter* p;
+        if (a->name) {
+            p = params->getParameter(a->name);
+            if (p == nullptr) {
+                ::error("No parameter named %1%", a->name);
+                continue;
+            }
+        } else {
+            bool success = pe->moveNext();
+            BUG_CHECK(success, "Enumerator finished too soon");
+            p = pe->getCurrent();
+        }
+        add(p, a);
+    }
+}
+
+}  // namespace P4

--- a/frontends/p4/parameterSubstitution.h
+++ b/frontends/p4/parameterSubstitution.h
@@ -33,9 +33,12 @@ class ParameterSubstitution : public IHasDbPrint {
     // Parameter names are unique for a procedure, so each name
     // should show up only once.
     std::map<cstring, const IR::Argument*> parameterValues;
-    // Map from parameter name to parameter.
+    /// Map from parameter name to parameter.
     std::map<cstring, const IR::Parameter*>  parametersByName;
+    /// Parameters in the order they were added.
     std::vector<const IR::Parameter*>        parameters;
+    /// If created using populate this is non-null.
+    const IR::ParameterList*                 paramList = nullptr;
 
     bool containsName(cstring name) const
     { return parameterValues.find(name) != parameterValues.end(); }
@@ -44,17 +47,7 @@ class ParameterSubstitution : public IHasDbPrint {
     ParameterSubstitution() = default;
     ParameterSubstitution(const ParameterSubstitution& other) = default;
 
-    void add(const IR::Parameter* parameter, const IR::Argument* value) {
-        LOG1("Mapping " << dbp(parameter) << " to " << dbp(value));
-        cstring name = parameter->name.name;
-        auto par = get(parametersByName, name);
-        BUG_CHECK(par == nullptr,
-                  "Two parameters with the same name %1% in a substitution", name);
-        parameterValues.emplace(name, value);
-        parametersByName.emplace(name, parameter);
-        parameters.push_back(parameter);
-    }
-
+    void add(const IR::Parameter* parameter, const IR::Argument* value);
     const IR::Argument* lookupByName(cstring name) const
     { return get(parameterValues, name); }
 
@@ -70,36 +63,23 @@ class ParameterSubstitution : public IHasDbPrint {
     bool empty() const
     { return parameterValues.empty(); }
 
+    /// Only the parameters which have corresponding arguments
+    /// will be bound.  PARAMETERS ARE ADDED IN THE ORDER OF THE ARGUMENTS.
+    // For actions only some parameters may be bound.
     void populate(const IR::ParameterList* params,
-                  const IR::Vector<IR::Argument>* args) {
-        // Allow for binding only some parameters: used for actions
-        BUG_CHECK(params->size() >= args->size(),
-                  "Incompatible number of arguments for parameter list: %1% and %2%",
-                  params, args);
+                  const IR::Vector<IR::Argument>* args);
 
-        std::map<cstring, const IR::Parameter*> byName;
-        for (auto p : params->parameters)
-            byName.emplace(p->name, p);
-
-        auto pe = params->getEnumerator();
-        for (auto a : *args) {
-            if (a->name) {
-                auto p = ::get(byName, a->name);
-                if (p == nullptr) {
-                    ::error("No parameter named %1%", a->name);
-                    continue;
-                }
-                add(p, a);
-            } else {
-                bool success = pe->moveNext();
-                BUG_CHECK(success, "Enumerator finished too soon");
-                add(pe->getCurrent(), a);
-            }
-        }
-    }
-
-    Util::Enumerator<const IR::Parameter*>* getParameters() const
+    /// Returns parameters in the order they were added
+    Util::Enumerator<const IR::Parameter*>* getParametersInArgumentOrder() const
     { return Util::Enumerator<const IR::Parameter*>::createEnumerator(parameters); }
+
+    /// Returns parameters in the order of the parameter list.
+    /// Only works if parameters were inserted using populate.
+    Util::Enumerator<const IR::Parameter*>* getParametersInOrder() const {
+        if (paramList == nullptr)
+            return nullptr;
+        return paramList->getEnumerator();
+    }
 
     void dbprint(std::ostream& out) const {
         for (auto s : parametersByName)

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -553,7 +553,7 @@ class DismantleExpression : public Transform {
         std::set<const IR::Parameter*> useTemporary;
 
         bool anyOut = false;
-        for (auto p : *desc.substitution.getParameters()) {
+        for (auto p : *desc.substitution.getParametersInArgumentOrder()) {
             if (p->direction == IR::Direction::None)
                 continue;
             if (p->hasOut())
@@ -588,9 +588,9 @@ class DismantleExpression : public Transform {
         if (anyOut) {
             // Check aliasing between all pairs of arguments where at
             // least one of them is out or inout.
-            for (auto p1 : *desc.substitution.getParameters()) {
+            for (auto p1 : *desc.substitution.getParametersInArgumentOrder()) {
                 auto arg1 = desc.substitution.lookup(p1);
-                for (auto p2 : *desc.substitution.getParameters()) {
+                for (auto p2 : *desc.substitution.getParametersInArgumentOrder()) {
                     if (p2 == p1)
                         break;
                     if (!p1->hasOut() && !p2->hasOut())
@@ -615,7 +615,7 @@ class DismantleExpression : public Transform {
         auto method = result->final;
 
         ClonePathExpressions cloner;  // a cheap version of deep copy
-        for (auto p : *desc.substitution.getParameters()) {
+        for (auto p : *desc.substitution.getParametersInArgumentOrder()) {
             auto arg = desc.substitution.lookup(p);
             if (p->direction == IR::Direction::None) {
                 args->push_back(arg);

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -561,7 +561,7 @@ class DismantleExpression : public Transform {
             auto arg = desc.substitution.lookup(p);
             // If an argument evaluation has side-effects then
             // always use a temporary to hold the argument value.
-            if (SideEffects::check(arg, refMap, typeMap)) {
+            if (SideEffects::check(arg->expression, refMap, typeMap)) {
                 LOG3("Using temporary for " << dbp(mce) <<
                      " param " << dbp(p) << " arg side effect");
                 useTemporary.emplace(p);
@@ -600,7 +600,7 @@ class DismantleExpression : public Transform {
                     if (useTemporary.find(p2) != useTemporary.end())
                         continue;
                     auto arg2 = desc.substitution.lookup(p2);
-                    if (mayAlias(arg1, arg2)) {
+                    if (mayAlias(arg1->expression, arg2->expression)) {
                         LOG3("Using temporary for " << dbp(mce) <<
                              " param " << dbp(p1) << " aliasing" << dbp(p2));
                         useTemporary.emplace(p1);
@@ -618,7 +618,7 @@ class DismantleExpression : public Transform {
         for (auto p : *desc.substitution.getParameters()) {
             auto arg = desc.substitution.lookup(p);
             if (p->direction == IR::Direction::None) {
-                args->push_back(new IR::Argument(arg));
+                args->push_back(arg);
                 continue;
             }
 
@@ -661,7 +661,7 @@ class DismantleExpression : public Transform {
                 copyBack->push_back(assign);
                 LOG3("Will copy out value " << dbp(assign));
             }
-            args->push_back(new IR::Argument(argValue));
+            args->push_back(new IR::Argument(arg->name, argValue));
         }
         leftValue = savelv;
         resultNotUsed = savenu;

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -386,7 +386,7 @@ class FindUninitialized : public Inspector {
             (void)callee->apply(fu);
         }
 
-        for (auto p : *mcd.substitution.getParameters()) {
+        for (auto p : *mcd.substitution.getParametersInArgumentOrder()) {
             auto expr = mcd.substitution.lookup(p);
             if (p->direction == IR::Direction::Out) {
                 // out parameters are not read; they behave as if they are on

--- a/frontends/p4/specialize.cpp
+++ b/frontends/p4/specialize.cpp
@@ -79,6 +79,9 @@ const IR::Argument* SpecializationMap::convertArgument(
 void SpecializationMap::addSpecialization(
     const IR::ConstructorCallExpression* invocation, const IR::IContainer* cont,
     const IR::Node* insertion) {
+    LOG2("Will specialize " << dbp(invocation) << " of " << dbp(cont->getNode())
+         << " " << cont->getNode() << " inserted after" << insertion);
+
     auto spec = new SpecializationInfo(invocation, cont, insertion);
     auto declaration = cont->to<IR::IDeclaration>();
     CHECK_NULL(declaration);
@@ -98,6 +101,9 @@ void SpecializationMap::addSpecialization(
 void SpecializationMap::addSpecialization(
     const IR::Declaration_Instance* invocation, const IR::IContainer* cont,
     const IR::Node* insertion) {
+    LOG2("Will specialize " << dbp(invocation) << " of " << dbp(cont->getNode()) <<
+         " inserted after" << insertion);
+
     auto spec = new SpecializationInfo(invocation, cont, insertion);
     auto declaration = cont->to<IR::IDeclaration>();
     CHECK_NULL(declaration);

--- a/frontends/p4/specialize.h
+++ b/frontends/p4/specialize.h
@@ -106,9 +106,9 @@ class FindSpecializations : public Inspector {
     bool isSimpleConstant(const IR::Expression* expression) const;
     Visitor::profile_t init_apply(const IR::Node* node) override
     { specMap->clear(); return Inspector::init_apply(node); }
-    // True if this container does not have constructor or type
-    // parameters i.e., we can look inside for invocations to
-    // specialize.
+    /// True if this container does not have constructor or type
+    /// parameters i.e., we can look inside for invocations to
+    /// specialize.
     bool noParameters(const IR::IContainer* container);
 
     bool preorder(const IR::P4Parser* parser) override
@@ -132,7 +132,7 @@ class FindSpecializations : public Inspector {
  * Instantiations with constructor arguments that are not constant values are
  * ignored---see SpecializeAll for details.
  *
- * Note that this pass handles type substition for instantiating generic Parser
+ * Note that this pass handles type substitution for instantiating generic Parser
  * or Control types, which is an experimental feature.
  *
  * For example:

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -970,7 +970,7 @@ TypeInference::containerInstantiation(
         auto argType = getType(arg);
         if (argType == nullptr)
             return std::pair<const IR::Type*, const IR::Vector<IR::Argument>*>(nullptr, nullptr);
-        auto argInfo = new IR::ArgumentInfo(arg->srcInfo, arg, true, argType);
+        auto argInfo = new IR::ArgumentInfo(arg->srcInfo, arg, true, argType, aarg->name);
         args->push_back(argInfo);
     }
     auto rettype = new IR::Type_Var(IR::ID(refMap->newName("R")));
@@ -2487,7 +2487,6 @@ TypeInference::actionCall(bool inActionList,
     auto baseType = methodType->to<IR::Type_Action>();
     LOG2("Action type " << baseType);
     BUG_CHECK(method->is<IR::PathExpression>(), "%1%: unexpected call", method);
-    auto arguments = actionCall->arguments;
     BUG_CHECK(baseType->returnType == nullptr,
               "%1%: action with return type?", baseType->returnType);
     if (!baseType->typeParameters->empty())
@@ -2498,47 +2497,75 @@ TypeInference::actionCall(bool inActionList,
 
     TypeConstraints constraints(typeMap->getSubstitutions());
     auto params = new IR::ParameterList;
-    auto it = arguments->begin();
-    for (auto p : baseType->parameters->parameters) {
-        LOG2("Action parameter " << dbp(p));
-        if (it == arguments->end()) {
-            params->parameters.push_back(p);
-            if ((p->direction != IR::Direction::None) || !inActionList)
-                typeError("%1%: parameter %2% must be bound", actionCall, p);
-        } else {
-            auto arg = (*it)->expression;
-            auto paramType = getType(p);
-            auto argType = getType(arg);
-            if (paramType == nullptr || argType == nullptr)
-                // type checking failed before
+
+    // keep track of parameters that have not been matched yet
+    std::map<cstring, const IR::Parameter*> left;
+    for (auto p: baseType->parameters->parameters)
+        left.emplace(p->name, p);
+
+    auto paramIt = baseType->parameters->parameters.begin();
+    for (auto arg: *actionCall->arguments) {
+        cstring argName = arg->name.name;
+        bool named = !argName.isNullOrEmpty();
+        const IR::Parameter* param;
+
+        if (named) {
+            param = baseType->parameters->getParameter(argName);
+            if (param == nullptr) {
+                typeError("%1%: No parameter named %2%", baseType->parameters, arg->name);
                 return actionCall;
-            constraints.addEqualityConstraint(paramType, argType);
-            if (p->direction == IR::Direction::None) {
-                if (inActionList) {
-                    typeError("%1%: parameter %2% cannot be bound: it is set by the control plane",
-                              arg, p);
-                } else if (inTable) {
-                    // For actions None parameters are treated as IN
-                    // parameters when the action is called directly.  We
-                    // don't require them to be bound to a compile-time
-                    // constant.  But if the action is instantiated in a
-                    // table (as default_action or entries), then the
-                    // arguments do have to be compile-time constants.
-                    if (!isCompileTimeConstant(arg))
-                        typeError("%1%: action argument must be a compile-time constant", arg);
-                }
-            } else if (p->direction == IR::Direction::Out ||
-                       p->direction == IR::Direction::InOut) {
-                if (!isLeftValue(arg))
-                    typeError("%1%: must be a left-value", arg);
             }
-            it++;
+        } else {
+            if (paramIt == baseType->parameters->parameters.end()) {
+                typeError("%1%: Too many arguments for action", actionCall);
+                return actionCall;
+            }
+            param = *paramIt;
+        }
+
+        LOG2("Action parameter " << dbp(param));
+        auto leftIt = left.find(param->name.name);
+        // This shold have been checked by the CheckNamedArgs pass.
+        BUG_CHECK(leftIt != left.end(), "%1%: Duplicate argument name?", param->name);
+        left.erase(leftIt);
+
+        auto paramType = getType(param);
+        auto argType = getType(arg);
+        if (paramType == nullptr || argType == nullptr)
+            // type checking failed before
+            return actionCall;
+        constraints.addEqualityConstraint(paramType, argType);
+        if (param->direction == IR::Direction::None) {
+            if (inActionList) {
+                typeError("%1%: parameter %2% cannot be bound: it is set by the control plane",
+                          arg, param);
+            } else if (inTable) {
+                // For actions None parameters are treated as IN
+                // parameters when the action is called directly.  We
+                // don't require them to be bound to a compile-time
+                // constant.  But if the action is instantiated in a
+                // table (as default_action or entries), then the
+                // arguments do have to be compile-time constants.
+                if (!isCompileTimeConstant(arg->expression))
+                    typeError("%1%: action argument must be a compile-time constant", arg->expression);
+            }
+        } else if (param->direction == IR::Direction::Out ||
+                   param->direction == IR::Direction::InOut) {
+            if (!isLeftValue(arg->expression))
+                typeError("%1%: must be a left-value", arg->expression);
+        }
+        if (!named)
+            ++paramIt;
+    }
+
+    // Check remaining parameters: they must be all non-directional
+    for (auto p: left) {
+        if (p.second->direction != IR::Direction::None) {
+            typeError("%1%: Parameter must be bound", p.second);
+            return actionCall;
         }
     }
-    if (it != arguments->end()) {
-        typeError("%1% Too many arguments for action", *it);
-        return actionCall;
-    }
+
     auto resultType = new IR::Type_Action(baseType->srcInfo, baseType->typeParameters, params);
 
     setType(getOriginal(), resultType);
@@ -2706,7 +2733,7 @@ const IR::Node* TypeInference::postorder(IR::MethodCallExpression* expression) {
             if (argType == nullptr)
                 return expression;
             auto argInfo = new IR::ArgumentInfo(arg->srcInfo, isLeftValue(arg),
-                                                isCompileTimeConstant(arg), argType);
+                                                isCompileTimeConstant(arg), argType, aarg->name);
             args->push_back(argInfo);
             constArgs &= isCompileTimeConstant(arg);
         }

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -762,7 +762,7 @@ TypeInference::checkExternConstructor(const IR::Node* errorPosition,
         typeError("%1%: Type parameters must be supplied for constructor", errorPosition);
         return nullptr;
     }
-    auto constructor = ext->lookupMethod(ext->name.name, arguments->size());
+    auto constructor = ext->lookupConstructor(arguments->size());
     if (constructor == nullptr) {
         typeError("%1%: type %2% has no constructor with %3% arguments",
                   errorPosition, ext, arguments->size());

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -2500,11 +2500,11 @@ TypeInference::actionCall(bool inActionList,
 
     // keep track of parameters that have not been matched yet
     std::map<cstring, const IR::Parameter*> left;
-    for (auto p: baseType->parameters->parameters)
+    for (auto p : baseType->parameters->parameters)
         left.emplace(p->name, p);
 
     auto paramIt = baseType->parameters->parameters.begin();
-    for (auto arg: *actionCall->arguments) {
+    for (auto arg : *actionCall->arguments) {
         cstring argName = arg->name.name;
         bool named = !argName.isNullOrEmpty();
         const IR::Parameter* param;
@@ -2547,7 +2547,8 @@ TypeInference::actionCall(bool inActionList,
                 // table (as default_action or entries), then the
                 // arguments do have to be compile-time constants.
                 if (!isCompileTimeConstant(arg->expression))
-                    typeError("%1%: action argument must be a compile-time constant", arg->expression);
+                    typeError(
+                        "%1%: action argument must be a compile-time constant", arg->expression);
             }
         } else if (param->direction == IR::Direction::Out ||
                    param->direction == IR::Direction::InOut) {
@@ -2559,12 +2560,15 @@ TypeInference::actionCall(bool inActionList,
     }
 
     // Check remaining parameters: they must be all non-directional
-    for (auto p: left) {
+    bool error = false;
+    for (auto p : left) {
         if (p.second->direction != IR::Direction::None) {
-            typeError("%1%: Parameter must be bound", p.second);
-            return actionCall;
+            typeError("%1%: Parameter %2% must be bound", actionCall, p.second);
+            error = true;
         }
     }
+    if (error)
+        return actionCall;
 
     auto resultType = new IR::Type_Action(baseType->srcInfo, baseType->typeParameters, params);
 

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -781,7 +781,7 @@ TypeInference::checkExternConstructor(const IR::Node* errorPosition,
     size_t i = 0;
     for (auto pi : *methodType->parameters->getEnumerator()) {
         if (i >= arguments->size()) {
-            BUG_CHECK(pi->getAnnotation("optional"), "Missing nonoptional arg %s", pi);
+            BUG_CHECK(pi->isOptional(), "Missing nonoptional arg %s", pi);
             break; }
         auto arg = arguments->at(i++);
         if (!isCompileTimeConstant(arg->expression))

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -63,10 +63,10 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
     auto paramIt = dest->parameters->begin();
     // keep track of parameters that have not been matched yet
     std::map<cstring, const IR::Parameter*> left;
-    for (auto p: dest->parameters->parameters)
+    for (auto p : dest->parameters->parameters)
         left.emplace(p->name, p);
 
-    for (auto arg: *src->arguments) {
+    for (auto arg : *src->arguments) {
         cstring argName = arg->name.name;
         bool named = !argName.isNullOrEmpty();
         const IR::Parameter* param;
@@ -100,11 +100,13 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
         if ((param->direction == IR::Direction::Out || param->direction == IR::Direction::InOut) &&
             (!arg->leftValue)) {
             if (reportErrors)
-                ::error("%1%: Read-only value used for out/inout parameter %2%", arg->srcInfo, param);
+                ::error("%1%: Read-only value used for out/inout parameter %2%",
+                        arg->srcInfo, param);
             return false;
         } else if (param->direction == IR::Direction::None && !arg->compileTimeConstant) {
             if (reportErrors)
-                ::error("%1%: not a compile-time constant when binding to %2%", arg->srcInfo, param);
+                ::error("%1%: not a compile-time constant when binding to %2%",
+                        arg->srcInfo, param);
             return false;
         }
 
@@ -120,7 +122,7 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
     }
 
     // Check remaining parameters: they must be all optional
-    for (auto p: left) {
+    for (auto p : left) {
         bool opt = p.second->getAnnotation("optional") != nullptr;
         if (opt) continue;
         if (reportErrors)

--- a/frontends/p4/typeChecking/typeUnification.h
+++ b/frontends/p4/typeChecking/typeUnification.h
@@ -36,10 +36,10 @@ Constraint solving can fail, which means that the program does not type-check.
 class TypeUnification final {
     TypeConstraints*  constraints;
 
-    bool unifyFunctions(const IR::Node* errorPosition,
-                        const IR::Type_MethodBase* dest,
-                        const IR::Type_MethodCall* src,
-                        bool reportErrors);
+    bool unifyCall(const IR::Node* errorPosition,
+                   const IR::Type_MethodBase* dest,
+                   const IR::Type_MethodCall* src,
+                   bool reportErrors);
     bool unifyFunctions(const IR::Node* errorPosition,
                         const IR::Type_MethodBase* dest,
                         const IR::Type_MethodBase* src,

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -317,7 +317,8 @@ nonEmptyParameterList
     ;
 
 parameter
-    : optAnnotations direction typeRef name { $$ = new IR::Parameter(@4, *$4, $1, $2, $3); }
+    : optAnnotations direction typeRef name { $$ = new IR::Parameter(@4, *$4, $1, $2, $3, nullptr); }
+    | optAnnotations direction typeRef name "=" expression { $$ = new IR::Parameter(@4, *$4, $1, $2, $3, $6); }
     ;
 
 direction

--- a/ir/base.def
+++ b/ir/base.def
@@ -189,6 +189,7 @@ class Annotation {
     static const cstring atomicAnnotation;  /// Code should be executed atomically.
     static const cstring hiddenAnnotation;  /// Object should not be exposed to the control-plane.
     static const cstring lengthAnnotation;  /// P4-14 annotation for varbit fields.
+    static const cstring optionalAnnotation;  /// Optional parameter annotation
     toString{ return cstring("@") + name; }
     validate{ BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name"); }
 

--- a/ir/dbprint.cpp
+++ b/ir/dbprint.cpp
@@ -63,6 +63,10 @@ void IR::Block::dbprint_recursive(std::ostream& out) const {
     out << dbp(this);
     out << indent;
     for (auto it : constantValue) {
+        if (it.second == nullptr) {
+            out << endl << dbp(it.first) << " => null";
+            continue;
+        }
         if (it.second->is<IR::Block>() && it.first->is<IR::IDeclaration>()) {
             auto block = it.second->to<IR::Block>();
             out << endl << dbp(it.first) << " => ";

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -159,7 +159,7 @@ void InstantiatedBlock::instantiate(std::vector<const CompileTimeValue*> *args) 
     auto it = args->begin();
     for (auto p : *getConstructorParameters()->getEnumerator()) {
         if (it == args->end()) {
-            BUG_CHECK(p->getAnnotation("optional"), "Missing nonoptional arg %s", p);
+            BUG_CHECK(p->isOptional(), "Missing nonoptional arg %s", p);
             continue; }
         LOG1("Set " << p << " to " << *it << " in " << id);
         setValue(p, *it);

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -489,31 +489,36 @@ class Function : Declaration {
 
 /////////////////////////////////////////////////////////////
 
-// Block is the base class for IR nodes produced by the evaluator.
-// A block represents a compile-time allocated resource.
-// Blocks are not visited using visitors, so the visit_children()
-// method is empty.  Users have to write custom visitors to
-// traverse the constantValue map.
+/**
+ * Block is the base class for IR nodes produced by the evaluator.
+ * A block represents a compile-time allocated resource.
+ * Blocks are not visited using visitors, so the visit_children()
+ * method is empty.  Users have to write custom visitors to
+ * traverse the constantValue map.
+ */
 abstract Block : CompileTimeValue {
-    Node node;  // Node that evaluates to this block.
-    // It's either a Declaration_Instance or a ConstructorCallExpression.
+    Node node;  /// Node that evaluates to this block.
+    /// This is either a Declaration_Instance or a ConstructorCallExpression.
 
-    // One value for each Node inside that evaluates to a compile-time constant.
-    // This includes all constructor parameters, and all inner nested blocks.
+    /// One value for each Node inside that evaluates to a compile-time constant.
+    /// This includes all constructor parameters, and all inner nested blocks.
     ordered_map<Node, CompileTimeValue> constantValue = {};
 
     virtual void dbprint(std::ostream& out) const override;
     virtual void dbprint_recursive(std::ostream& out) const;
+    /// value can be null for parameters which are optional
     void setValue(Node node, CompileTimeValue value) {
-        CHECK_NULL(node); CHECK_NULL(value);
+        CHECK_NULL(node);
         auto it = constantValue.find(node);
         BUG_CHECK(it == constantValue.end(), "%1% already set", node);
         constantValue[node] = value; }
+    bool hasValue(Node node) const {
+        return constantValue.find(node) != constantValue.end();
+    }
     CompileTimeValue getValue(Node node) const {
         CHECK_NULL(node);
         auto it = constantValue.find(node);
-        if (it == constantValue.end())
-            return nullptr;
+        BUG_CHECK(it != constantValue.end(), "%1%: No such node %2%", this, node);
         return it->second; }
     visit_children { (void)v; }
 }
@@ -523,8 +528,7 @@ class TableBlock : Block {
 #nodbprint
 }
 
-// An object that has been instantiated
-// The substitution holds the constructor arguments.
+/// An object that has been instantiated
 abstract InstantiatedBlock : Block {
     Type instanceType;  // May be a SpecializedType
 
@@ -574,11 +578,12 @@ class ExternBlock : InstantiatedBlock {
 #nodbprint
 }
 
-// Represents the program as a whole
+/// Represents the program as a whole
 class ToplevelBlock : Block {
     P4Program getProgram() const { return node->to<IR::P4Program>(); }
     PackageBlock getMain() const;
 #nodbprint
     validate { BUG_CHECK(node->is<IR::P4Program>(), "%1%: expected a P4Program", node); }
 }
+
 /** @} *//* end group irdefs */

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -37,6 +37,7 @@ const cstring IR::Annotation::defaultOnlyAnnotation = "defaultonly";
 const cstring IR::Annotation::atomicAnnotation = "atomic";
 const cstring IR::Annotation::hiddenAnnotation = "hidden";
 const cstring IR::Annotation::lengthAnnotation = "length";
+const cstring IR::Annotation::optionalAnnotation = "optional";
 
 std::map<int, const IR::Type_Bits*> *Type_Bits::signedTypes = nullptr;
 std::map<int, const IR::Type_Bits*> *Type_Bits::unsignedTypes = nullptr;
@@ -132,7 +133,7 @@ bool Type_ActionEnum::contains(cstring name) const {
 size_t Type_MethodBase::minParameterCount() const {
     size_t rv = 0;
     for (auto p : *parameters)
-        if (!p->getAnnotation("optional"))
+        if (!p->isOptional())
             ++rv;
     return rv;
 }

--- a/ir/type.def
+++ b/ir/type.def
@@ -459,6 +459,7 @@ class ArgumentInfo {
     bool leftValue;
     bool compileTimeConstant;
     Type type;
+    ID   name;  // only present if using named arguments
 #nodbprint
 }
 

--- a/ir/type.def
+++ b/ir/type.def
@@ -511,6 +511,8 @@ class Type_Extern : Type_Declaration, IGeneralNamespace, IMayBeGenericType, IAnn
             ->concat(attributes.valueEnumerator()->as<const IDeclaration*>()); }
     virtual TypeParameters getTypeParameters() const override { return typeParameters; }
     Method lookupMethod(cstring name, int argCount) const;
+    Method lookupConstructor(int argCount) const
+    { return lookupMethod(name.name, argCount); }
     validate{ methods.check_null(); }
     Annotations getAnnotations() const override { return annotations; }
 }

--- a/ir/type.def
+++ b/ir/type.def
@@ -104,8 +104,12 @@ class Parameter : Declaration, IAnnotated {
     optional Annotations annotations = Annotations::empty;
     Direction           direction;
     Type                type;
+    optional NullOK Expression defaultValue;
     Annotations getAnnotations() const override { return annotations; }
-    bool hasOut() const { return direction == IR::Direction::Out || direction == IR::Direction::InOut; }
+    bool hasOut() const
+    { return direction == IR::Direction::Out || direction == IR::Direction::InOut; }
+    bool isOptional() const {
+        return getAnnotation(Annotation::optionalAnnotation) != nullptr; }
     dbprint { out << annotations << direction << ' ' << type << ' ' << name; }
 }
 

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -24,6 +24,7 @@ set (MIDEND_SRCS
   local_copyprop.cpp
   nestedStructs.cpp
   noMatch.cpp
+  orderArguments.cpp
   parserUnroll.cpp
   predication.cpp
   removeExits.cpp
@@ -56,6 +57,7 @@ set (MIDEND_HDRS
   midEndLast.h
   nestedStructs.h
   noMatch.h
+  orderArguments.h
   parserUnroll.h
   predication.h
   removeExits.h

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -961,7 +961,7 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression* expression) 
 
     // For all other methods we act conservatively:
     // in arguments are unchanged, and the out arguments have an unknown value.
-    for (auto p : *mcd.substitution.getParameters()) {
+    for (auto p : *mcd.substitution.getParametersInArgumentOrder()) {
         if (p->direction == IR::Direction::Out || p->direction == IR::Direction::InOut) {
             auto arg = mcd.substitution.lookup(p);
             auto val = get(arg->expression);

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -963,8 +963,8 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression* expression) 
     // in arguments are unchanged, and the out arguments have an unknown value.
     for (auto p : *mcd.substitution.getParameters()) {
         if (p->direction == IR::Direction::Out || p->direction == IR::Direction::InOut) {
-            auto expr = mcd.substitution.lookup(p);
-            auto val = get(expr);
+            auto arg = mcd.substitution.lookup(p);
+            auto val = get(arg->expression);
             val->setAllUnknown();
         }
     }

--- a/midend/noMatch.h
+++ b/midend/noMatch.h
@@ -22,11 +22,11 @@ limitations under the License.
 
 namespace P4 {
 
-// Convert
-// state s { transition select (e) { ... } }
-// into
-// state s { transition select (e) { ... default: noMatch; }}
-// state noMatch { verify(false, error.NoMatch); transition reject; }
+/// Convert
+/// state s { transition select (e) { ... } }
+/// into
+/// state s { transition select (e) { ... default: noMatch; }}
+/// state noMatch { verify(false, error.NoMatch); transition reject; }
 class DoHandleNoMatch : public Transform {
     const IR::ParserState* noMatch = nullptr;
     NameGenerator* nameGen;

--- a/midend/orderArguments.cpp
+++ b/midend/orderArguments.cpp
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "orderArguments.h"
+#include "frontends/p4/methodInstance.h"
+
+namespace P4 {
+
+static IR::Vector<IR::Argument>* reorder(const ParameterSubstitution &substitution) {
+    auto reordered = new IR::Vector<IR::Argument>();
+
+    bool foundOptional = false;
+    for (auto p : *substitution.getParametersInOrder()) {
+        auto arg = substitution.lookup(p);
+        if (arg == nullptr) {
+            // This argument may be missing either because it is
+            // optional or because it is an argument for an action
+            // which has some control-plane arguments.
+            foundOptional = true;
+        } else {
+            BUG_CHECK(!foundOptional, "Not all optional parameters are at the end");
+            reordered->push_back(arg);
+        }
+    }
+    return reordered;
+}
+
+const IR::Node* DoOrderArguments::postorder(IR::MethodCallExpression* expression) {
+    MethodCallDescription mcd(expression, refMap, typeMap);
+    expression->arguments = reorder(mcd.substitution);
+    return expression;
+}
+
+const IR::Node* DoOrderArguments::postorder(IR::ConstructorCallExpression* expression) {
+    ConstructorCallDescription ccd(expression, refMap, typeMap);
+    expression->arguments = reorder(ccd.substitution);
+    return expression;
+}
+
+const IR::Node* DoOrderArguments::postorder(IR::Declaration_Instance* instance) {
+    auto inst = Instantiation::resolve(instance, refMap, typeMap);
+    instance->arguments = reorder(inst->substitution);
+    return instance;
+}
+
+
+}  // namespace P4

--- a/midend/orderArguments.h
+++ b/midend/orderArguments.h
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _MIDEND_ORDERARGUMENTS_H_
+#define _MIDEND_ORDERARGUMENTS_H_
+
+#include "ir/ir.h"
+#include "frontends/common/resolveReferences/resolveReferences.h"
+
+namespace P4 {
+
+/**
+ * Order the arguments of a call in the order that the parameters appear.
+ * This only works if all optional parameters are at the end.
+ */
+class DoOrderArguments : public Transform {
+    ReferenceMap* refMap;
+    TypeMap* typeMap;
+ public:
+    DoOrderArguments(ReferenceMap* refMap, TypeMap* typeMap):
+            refMap(refMap), typeMap(typeMap)
+    { CHECK_NULL(refMap); CHECK_NULL(typeMap); setName("DoOrderArguments"); }
+
+    const IR::Node* postorder(IR::MethodCallExpression* expression) override;
+    const IR::Node* postorder(IR::ConstructorCallExpression* expression) override;
+    const IR::Node* postorder(IR::Declaration_Instance* instance) override;
+};
+
+class OrderArguments : public PassManager {
+ public:
+    OrderArguments(ReferenceMap* refMap, TypeMap* typeMap) {
+        passes.push_back(new TypeChecking(refMap, typeMap));
+        passes.push_back(new DoOrderArguments(refMap, typeMap));
+        setName("OrderArguments");
+    }
+};
+
+}  // namespace P4
+
+#endif /* _MIDEND_ORDERARGUMENTS_H_ */

--- a/midend/removeParameters.cpp
+++ b/midend/removeParameters.cpp
@@ -102,7 +102,10 @@ const IR::Node* DoRemoveActionParameters::postorder(IR::P4Action* action) {
             LOG3("Added declaration " << decl << " annotations " << p->annotations);
             result->push_back(decl);
             auto arg = substitution.lookup(p);
-            BUG_CHECK(arg != nullptr, "%1%: too few arguments", invocation);
+            if (arg == nullptr) {
+                ::error("action %1%: parameter %2% must be bound", invocation, p);
+                continue;
+            }
 
             if (p->direction == IR::Direction::In ||
                 p->direction == IR::Direction::InOut ||

--- a/midend/removeParameters.cpp
+++ b/midend/removeParameters.cpp
@@ -89,7 +89,9 @@ const IR::Node* DoRemoveActionParameters::postorder(IR::P4Action* action) {
         return action;
     auto args = invocation->arguments;
 
-    auto argit = args->begin();
+    ParameterSubstitution substitution;
+    substitution.populate(action->parameters, args);
+
     bool removeAll = invocations->removeAllParameters(getOriginal<IR::P4Action>());
     for (auto p : action->parameters->parameters) {
         if (p->direction == IR::Direction::None && !removeAll) {
@@ -99,9 +101,9 @@ const IR::Node* DoRemoveActionParameters::postorder(IR::P4Action* action) {
                                                      p->annotations, p->type, nullptr);
             LOG3("Added declaration " << decl << " annotations " << p->annotations);
             result->push_back(decl);
-            BUG_CHECK(argit != args->end(), "%1%: too few arguments", invocation);
-            auto arg = *argit;
-            ++argit;
+            auto arg = substitution.lookup(p);
+            BUG_CHECK(arg != nullptr, "%1%: too few arguments", invocation);
+
             if (p->direction == IR::Direction::In ||
                 p->direction == IR::Direction::InOut ||
                 p->direction == IR::Direction::None) {

--- a/testdata/p4_16_errors/named-fail.p4
+++ b/testdata/p4_16_errors/named-fail.p4
@@ -1,0 +1,11 @@
+extern void f(in bit<16> x, in bool y);
+
+control c() {
+    apply {
+        bit<16> xv = 0;
+        bool    b  = true;
+
+        f(y = b, xv);  // not all arguments named
+        f(y = b, y = b); // same argument twice
+    }
+}

--- a/testdata/p4_16_errors/named-fail1.p4
+++ b/testdata/p4_16_errors/named-fail1.p4
@@ -1,0 +1,10 @@
+extern void f(in bit<16> x, in bool y);
+
+control c() {
+    apply {
+        bit<16> xv = 0;
+        bool    b  = true;
+
+        f(z = b, y = b); // No such parameter
+    }
+}

--- a/testdata/p4_16_errors_outputs/action-bind1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind1.p4-stderr
@@ -1,18 +1,6 @@
-action-bind1.p4(22): error: a: parameter b must be bound
+action-bind1.p4(22): error: a: Parameter b must be bound
         default_action = a(); // error: too few arguments
                          ^^^
 action-bind1.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                            ^
-action-bind1.p4(22): error: a: parameter d must be bound
-        default_action = a(); // error: too few arguments
-                         ^^^
-action-bind1.p4(17)
-    action a(inout bit<32> b, bit<32> d) {
-                                      ^
-action-bind1.p4(22): error: Action for ExpressionValue has some unbound arguments
-        default_action = a(); // error: too few arguments
-                         ^^^
-action-bind1.p4(22): error: a: not enough arguments
-        default_action = a(); // error: too few arguments
-                         ^^^

--- a/testdata/p4_16_errors_outputs/action-bind2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind2.p4-stderr
@@ -1,4 +1,4 @@
-action-bind2.p4(21): error: a: parameter b must be bound
+action-bind2.p4(21): error: a: Parameter b must be bound
         actions = { a; } // error: not enough arguments
                     ^
 action-bind2.p4(17)
@@ -7,9 +7,9 @@ action-bind2.p4(17)
 action-bind2.p4(22): error: 0: must be a left-value
         default_action = a(0);
                            ^
-action-bind2.p4(22): error: a: parameter d must be bound
-        default_action = a(0);
-                         ^^^^
+action-bind2.p4(21): error: a: Parameter b must be bound
+        actions = { a; } // error: not enough arguments
+                    ^
 action-bind2.p4(17)
     action a(inout bit<32> b, bit<32> d) {
-                                      ^
+                           ^

--- a/testdata/p4_16_errors_outputs/action-bind3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind3.p4-stderr
@@ -7,9 +7,3 @@ action-bind3.p4(17)
 action-bind3.p4(22): error: 0: must be a left-value
         default_action = a(0);
                            ^
-action-bind3.p4(22): error: a: parameter d must be bound
-        default_action = a(0);
-                         ^^^^
-action-bind3.p4(17)
-    action a(inout bit<32> b, bit<32> d) {
-                                      ^

--- a/testdata/p4_16_errors_outputs/function_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function_e.p4-stderr
@@ -1,6 +1,9 @@
-function_e.p4(22): error: f: Not enough arguments for call
+function_e.p4(22): error: f: No argument for parameter x
         f(); // not enough arguments
         ^^^
+function_e.p4(16)
+extern void f(in bit x);
+                     ^
 function_e.p4(23): error: f: Passing 2 arguments when 1 expected
         f(1w1, 1w0); // too many arguments
         ^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/named-fail.p4
+++ b/testdata/p4_16_errors_outputs/named-fail.p4
@@ -1,0 +1,10 @@
+extern void f(in bit<16> x, in bool y);
+control c() {
+    apply {
+        bit<16> xv = 0;
+        bool b = true;
+        f(y = b, xv);
+        f(y = b, y = b);
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/named-fail.p4-stderr
+++ b/testdata/p4_16_errors_outputs/named-fail.p4-stderr
@@ -1,0 +1,9 @@
+named-fail.p4(8): error: xv: all or none of the arguments of a call must be named
+        f(y = b, xv); // not all arguments named
+                 ^^
+named-fail.p4(9): error: y = b and y = b: same argument name
+        f(y = b, y = b); // same argument twice
+          ^
+named-fail.p4(9)
+        f(y = b, y = b); // same argument twice
+                 ^

--- a/testdata/p4_16_errors_outputs/named-fail1.p4
+++ b/testdata/p4_16_errors_outputs/named-fail1.p4
@@ -1,0 +1,9 @@
+extern void f(in bit<16> x, in bool y);
+control c() {
+    apply {
+        bit<16> xv = 0;
+        bool b = true;
+        f(z = b, y = b);
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/named-fail1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/named-fail1.p4-stderr
@@ -1,0 +1,6 @@
+named-fail1.p4(8): error: f: No parameter named z
+        f(z = b, y = b); // No such parameter
+        ^^^^^^^^^^^^^^^
+named-fail1.p4(8)
+        f(z = b, y = b); // No such parameter
+          ^

--- a/testdata/p4_16_errors_outputs/not_bound-first.p4
+++ b/testdata/p4_16_errors_outputs/not_bound-first.p4
@@ -1,0 +1,46 @@
+struct headers {
+}
+
+struct metadata {
+}
+
+#include <core.p4>
+#include <v1model.p4>
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    action set_nhop(bit<9> port) {
+        standard_metadata.egress_spec = port;
+    }
+    apply {
+        set_nhop();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_16_errors_outputs/not_bound-frontend.p4
+++ b/testdata/p4_16_errors_outputs/not_bound-frontend.p4
@@ -1,0 +1,46 @@
+struct headers {
+}
+
+struct metadata {
+}
+
+#include <core.p4>
+#include <v1model.p4>
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("ingress.set_nhop") action set_nhop_0(bit<9> port) {
+        standard_metadata.egress_spec = port;
+    }
+    apply {
+        set_nhop_0();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_16_errors_outputs/not_bound.p4-stderr
+++ b/testdata/p4_16_errors_outputs/not_bound.p4-stderr
@@ -1,4 +1,4 @@
-not_bound.p4(36): error: set_nhop: parameter port must be bound
+not_bound.p4(36): error: action set_nhop: parameter port must be bound
         set_nhop(); // parameter not bound
         ^^^^^^^^^^
 not_bound.p4(32)

--- a/testdata/p4_16_samples/basic_routing-bmv2.p4
+++ b/testdata/p4_16_samples/basic_routing-bmv2.p4
@@ -1,0 +1,192 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct ingress_metadata_t {
+    bit<12> vrf;
+    bit<16> bd;
+    bit<16> nexthop_index;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+    ingress_metadata_t ingress_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state parse_ethernet {
+        packet.extract(hdr = hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract(hdr = hdr.ipv4);
+        transition accept;
+    }
+    state start {
+        transition parse_ethernet;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    action on_miss() {
+    }
+    action rewrite_src_dst_mac(bit<48> smac, bit<48> dmac) {
+        hdr.ethernet.srcAddr = smac;
+        hdr.ethernet.dstAddr = dmac;
+    }
+    table rewrite_mac {
+        actions = {
+            on_miss;
+            rewrite_src_dst_mac;
+        }
+        key = {
+            meta.ingress_metadata.nexthop_index: exact;
+        }
+        size = 32768;
+    }
+    apply {
+        rewrite_mac.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    action set_vrf(bit<12> vrf) {
+        meta.ingress_metadata.vrf = vrf;
+    }
+    action on_miss() {
+    }
+    action fib_hit_nexthop(bit<16> nexthop_index) {
+        meta.ingress_metadata.nexthop_index = nexthop_index;
+        hdr.ipv4.ttl = hdr.ipv4.ttl - 8w1;
+    }
+    action set_egress_details(bit<9> egress_spec) {
+        standard_metadata.egress_spec = egress_spec;
+    }
+    action set_bd(bit<16> bd) {
+        meta.ingress_metadata.bd = bd;
+    }
+    table bd {
+        actions = {
+            set_vrf;
+        }
+        key = {
+            meta.ingress_metadata.bd: exact;
+        }
+        size = 65536;
+    }
+    table ipv4_fib {
+        actions = {
+            on_miss;
+            fib_hit_nexthop;
+        }
+        key = {
+            meta.ingress_metadata.vrf: exact;
+            hdr.ipv4.dstAddr         : exact;
+        }
+        size = 131072;
+    }
+    table ipv4_fib_lpm {
+        actions = {
+            on_miss;
+            fib_hit_nexthop;
+        }
+        key = {
+            meta.ingress_metadata.vrf: exact;
+            hdr.ipv4.dstAddr         : lpm;
+        }
+        size = 16384;
+    }
+    table nexthop {
+        actions = {
+            on_miss;
+            set_egress_details;
+        }
+        key = {
+            meta.ingress_metadata.nexthop_index: exact;
+        }
+        size = 32768;
+    }
+    table port_mapping {
+        actions = {
+            set_bd;
+        }
+        key = {
+            standard_metadata.ingress_port: exact;
+        }
+        size = 32768;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            port_mapping.apply();
+            bd.apply();
+            switch (ipv4_fib.apply().action_run) {
+                on_miss: {
+                    ipv4_fib_lpm.apply();
+                }
+            }
+
+            nexthop.apply();
+        }
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr = hdr.ethernet);
+        packet.emit(hdr = hdr.ipv4);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        verify_checksum(
+        data = { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr },
+        checksum = hdr.ipv4.hdrChecksum,
+        condition = true,
+        algo = HashAlgorithm.csum16);
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        update_checksum(
+        condition = true,
+        data = { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr },
+        algo = HashAlgorithm.csum16,
+        checksum = hdr.ipv4.hdrChecksum);
+    }
+}
+
+V1Switch(p = ParserImpl(),
+         ig = ingress(),
+         vr = verifyChecksum(),
+         eg = egress(),
+         ck = computeChecksum(),
+         dep = DeparserImpl()) main;

--- a/testdata/p4_16_samples/named-arg.p4
+++ b/testdata/p4_16_samples/named-arg.p4
@@ -1,0 +1,15 @@
+extern void f(in bit<16> x, in bool y);
+
+control c() {
+    apply {
+        bit<16> xv = 0;
+        bool    b  = true;
+
+        f(y = b, x = xv);
+    }
+}
+
+control empty();
+package top(empty _e);
+
+top(c()) main;

--- a/testdata/p4_16_samples/named-arg1.p4
+++ b/testdata/p4_16_samples/named-arg1.p4
@@ -1,0 +1,50 @@
+#include <core.p4>
+
+parser adder(in bit<32> y, out bit<32> x)(bit<32> add, bool ignore) {
+    state start {
+        x = y + add;
+        transition accept;
+    }
+}
+
+parser par(out bool b) {
+    adder(ignore = false, add = 6) p;
+    state start {
+        bit<32> x;
+        p.apply(x = x, y = 0);
+        b = x == 0;
+        transition accept;
+    }
+}
+
+control comp(inout bit<16> x, out bool b)(bit<16> compare, bit<2> ignore) {
+    apply {
+        b = x == compare;
+    }
+}
+
+control c(out bool b) {
+    comp(ignore = 1, compare = 0) c0;
+    comp(ignore = 2, compare = 1) c1;
+
+    action a(in bit<16> bi, out bit<16> mb) {
+        mb = -bi;
+    }
+
+    apply {
+        bit<16> xv = 0;
+        a(bi = 3, mb = xv);
+        a(mb = xv, bi = 0);
+        c0.apply(b = b, x = xv);
+        c1.apply(xv, b);
+        xv = 1;
+        c0.apply(x = xv, b = b);
+        c1.apply(b = b, x = xv);
+    }
+}
+
+control ce(out bool b);
+parser pe(out bool b);
+package top(pe _p, ce _e);
+
+top(par(), c()) main;

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2-first.p4
@@ -1,0 +1,192 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct ingress_metadata_t {
+    bit<12> vrf;
+    bit<16> bd;
+    bit<16> nexthop_index;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+    ingress_metadata_t ingress_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state parse_ethernet {
+        packet.extract<ethernet_t>(hdr = hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr = hdr.ipv4);
+        transition accept;
+    }
+    state start {
+        transition parse_ethernet;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    action on_miss() {
+    }
+    action rewrite_src_dst_mac(bit<48> smac, bit<48> dmac) {
+        hdr.ethernet.srcAddr = smac;
+        hdr.ethernet.dstAddr = dmac;
+    }
+    table rewrite_mac {
+        actions = {
+            on_miss();
+            rewrite_src_dst_mac();
+            @defaultonly NoAction();
+        }
+        key = {
+            meta.ingress_metadata.nexthop_index: exact @name("meta.ingress_metadata.nexthop_index") ;
+        }
+        size = 32768;
+        default_action = NoAction();
+    }
+    apply {
+        rewrite_mac.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    action set_vrf(bit<12> vrf) {
+        meta.ingress_metadata.vrf = vrf;
+    }
+    action on_miss() {
+    }
+    action fib_hit_nexthop(bit<16> nexthop_index) {
+        meta.ingress_metadata.nexthop_index = nexthop_index;
+        hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
+    }
+    action set_egress_details(bit<9> egress_spec) {
+        standard_metadata.egress_spec = egress_spec;
+    }
+    action set_bd(bit<16> bd) {
+        meta.ingress_metadata.bd = bd;
+    }
+    table bd {
+        actions = {
+            set_vrf();
+            @defaultonly NoAction();
+        }
+        key = {
+            meta.ingress_metadata.bd: exact @name("meta.ingress_metadata.bd") ;
+        }
+        size = 65536;
+        default_action = NoAction();
+    }
+    table ipv4_fib {
+        actions = {
+            on_miss();
+            fib_hit_nexthop();
+            @defaultonly NoAction();
+        }
+        key = {
+            meta.ingress_metadata.vrf: exact @name("meta.ingress_metadata.vrf") ;
+            hdr.ipv4.dstAddr         : exact @name("hdr.ipv4.dstAddr") ;
+        }
+        size = 131072;
+        default_action = NoAction();
+    }
+    table ipv4_fib_lpm {
+        actions = {
+            on_miss();
+            fib_hit_nexthop();
+            @defaultonly NoAction();
+        }
+        key = {
+            meta.ingress_metadata.vrf: exact @name("meta.ingress_metadata.vrf") ;
+            hdr.ipv4.dstAddr         : lpm @name("hdr.ipv4.dstAddr") ;
+        }
+        size = 16384;
+        default_action = NoAction();
+    }
+    table nexthop {
+        actions = {
+            on_miss();
+            set_egress_details();
+            @defaultonly NoAction();
+        }
+        key = {
+            meta.ingress_metadata.nexthop_index: exact @name("meta.ingress_metadata.nexthop_index") ;
+        }
+        size = 32768;
+        default_action = NoAction();
+    }
+    table port_mapping {
+        actions = {
+            set_bd();
+            @defaultonly NoAction();
+        }
+        key = {
+            standard_metadata.ingress_port: exact @name("standard_metadata.ingress_port") ;
+        }
+        size = 32768;
+        default_action = NoAction();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            port_mapping.apply();
+            bd.apply();
+            switch (ipv4_fib.apply().action_run) {
+                on_miss: {
+                    ipv4_fib_lpm.apply();
+                }
+            }
+
+            nexthop.apply();
+        }
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr = hdr.ethernet);
+        packet.emit<ipv4_t>(hdr = hdr.ipv4);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(data = { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, checksum = hdr.ipv4.hdrChecksum, condition = true, algo = HashAlgorithm.csum16);
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(condition = true, data = { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, algo = HashAlgorithm.csum16, checksum = hdr.ipv4.hdrChecksum);
+    }
+}
+
+V1Switch<headers, metadata>(p = ParserImpl(), ig = ingress(), vr = verifyChecksum(), eg = egress(), ck = computeChecksum(), dep = DeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2-frontend.p4
@@ -1,0 +1,209 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct ingress_metadata_t {
+    bit<12> vrf;
+    bit<16> bd;
+    bit<16> nexthop_index;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+    ingress_metadata_t ingress_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr = hdr.ipv4);
+        transition accept;
+    }
+    state start {
+        packet.extract<ethernet_t>(hdr = hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("egress.on_miss") action on_miss_0() {
+    }
+    @name("egress.rewrite_src_dst_mac") action rewrite_src_dst_mac_0(bit<48> smac, bit<48> dmac) {
+        hdr.ethernet.srcAddr = smac;
+        hdr.ethernet.dstAddr = dmac;
+    }
+    @name("egress.rewrite_mac") table rewrite_mac {
+        actions = {
+            on_miss_0();
+            rewrite_src_dst_mac_0();
+            @defaultonly NoAction_0();
+        }
+        key = {
+            meta.ingress_metadata.nexthop_index: exact @name("meta.ingress_metadata.nexthop_index") ;
+        }
+        size = 32768;
+        default_action = NoAction_0();
+    }
+    apply {
+        rewrite_mac.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".NoAction") action NoAction_1() {
+    }
+    @name(".NoAction") action NoAction_8() {
+    }
+    @name(".NoAction") action NoAction_9() {
+    }
+    @name(".NoAction") action NoAction_10() {
+    }
+    @name(".NoAction") action NoAction_11() {
+    }
+    @name("ingress.set_vrf") action set_vrf_0(bit<12> vrf) {
+        meta.ingress_metadata.vrf = vrf;
+    }
+    @name("ingress.on_miss") action on_miss_1() {
+    }
+    @name("ingress.on_miss") action on_miss_5() {
+    }
+    @name("ingress.on_miss") action on_miss_6() {
+    }
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_0(bit<16> nexthop_index) {
+        meta.ingress_metadata.nexthop_index = nexthop_index;
+        hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
+    }
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_2(bit<16> nexthop_index) {
+        meta.ingress_metadata.nexthop_index = nexthop_index;
+        hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
+    }
+    @name("ingress.set_egress_details") action set_egress_details_0(bit<9> egress_spec) {
+        standard_metadata.egress_spec = egress_spec;
+    }
+    @name("ingress.set_bd") action set_bd_0(bit<16> bd) {
+        meta.ingress_metadata.bd = bd;
+    }
+    @name("ingress.bd") table bd_1 {
+        actions = {
+            set_vrf_0();
+            @defaultonly NoAction_1();
+        }
+        key = {
+            meta.ingress_metadata.bd: exact @name("meta.ingress_metadata.bd") ;
+        }
+        size = 65536;
+        default_action = NoAction_1();
+    }
+    @name("ingress.ipv4_fib") table ipv4_fib {
+        actions = {
+            on_miss_1();
+            fib_hit_nexthop_0();
+            @defaultonly NoAction_8();
+        }
+        key = {
+            meta.ingress_metadata.vrf: exact @name("meta.ingress_metadata.vrf") ;
+            hdr.ipv4.dstAddr         : exact @name("hdr.ipv4.dstAddr") ;
+        }
+        size = 131072;
+        default_action = NoAction_8();
+    }
+    @name("ingress.ipv4_fib_lpm") table ipv4_fib_lpm {
+        actions = {
+            on_miss_5();
+            fib_hit_nexthop_2();
+            @defaultonly NoAction_9();
+        }
+        key = {
+            meta.ingress_metadata.vrf: exact @name("meta.ingress_metadata.vrf") ;
+            hdr.ipv4.dstAddr         : lpm @name("hdr.ipv4.dstAddr") ;
+        }
+        size = 16384;
+        default_action = NoAction_9();
+    }
+    @name("ingress.nexthop") table nexthop {
+        actions = {
+            on_miss_6();
+            set_egress_details_0();
+            @defaultonly NoAction_10();
+        }
+        key = {
+            meta.ingress_metadata.nexthop_index: exact @name("meta.ingress_metadata.nexthop_index") ;
+        }
+        size = 32768;
+        default_action = NoAction_10();
+    }
+    @name("ingress.port_mapping") table port_mapping {
+        actions = {
+            set_bd_0();
+            @defaultonly NoAction_11();
+        }
+        key = {
+            standard_metadata.ingress_port: exact @name("standard_metadata.ingress_port") ;
+        }
+        size = 32768;
+        default_action = NoAction_11();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            port_mapping.apply();
+            bd_1.apply();
+            switch (ipv4_fib.apply().action_run) {
+                on_miss_1: {
+                    ipv4_fib_lpm.apply();
+                }
+            }
+
+            nexthop.apply();
+        }
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr = hdr.ethernet);
+        packet.emit<ipv4_t>(hdr = hdr.ipv4);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        verify_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(data = { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, checksum = hdr.ipv4.hdrChecksum, condition = true, algo = HashAlgorithm.csum16);
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(condition = true, data = { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, algo = HashAlgorithm.csum16, checksum = hdr.ipv4.hdrChecksum);
+    }
+}
+
+V1Switch<headers, metadata>(p = ParserImpl(), ig = ingress(), vr = verifyChecksum(), eg = egress(), ck = computeChecksum(), dep = DeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2-midend.p4
@@ -1,0 +1,223 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct ingress_metadata_t {
+    bit<12> vrf;
+    bit<16> bd;
+    bit<16> nexthop_index;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+    ingress_metadata_t ingress_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr = hdr.ipv4);
+        transition accept;
+    }
+    state start {
+        packet.extract<ethernet_t>(hdr = hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("egress.on_miss") action on_miss_0() {
+    }
+    @name("egress.rewrite_src_dst_mac") action rewrite_src_dst_mac_0(bit<48> smac, bit<48> dmac) {
+        hdr.ethernet.srcAddr = smac;
+        hdr.ethernet.dstAddr = dmac;
+    }
+    @name("egress.rewrite_mac") table rewrite_mac {
+        actions = {
+            on_miss_0();
+            rewrite_src_dst_mac_0();
+            @defaultonly NoAction_0();
+        }
+        key = {
+            meta.ingress_metadata.nexthop_index: exact @name("meta.ingress_metadata.nexthop_index") ;
+        }
+        size = 32768;
+        default_action = NoAction_0();
+    }
+    apply {
+        rewrite_mac.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".NoAction") action NoAction_1() {
+    }
+    @name(".NoAction") action NoAction_8() {
+    }
+    @name(".NoAction") action NoAction_9() {
+    }
+    @name(".NoAction") action NoAction_10() {
+    }
+    @name(".NoAction") action NoAction_11() {
+    }
+    @name("ingress.set_vrf") action set_vrf_0(bit<12> vrf) {
+        meta.ingress_metadata.vrf = vrf;
+    }
+    @name("ingress.on_miss") action on_miss_1() {
+    }
+    @name("ingress.on_miss") action on_miss_5() {
+    }
+    @name("ingress.on_miss") action on_miss_6() {
+    }
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_0(bit<16> nexthop_index) {
+        meta.ingress_metadata.nexthop_index = nexthop_index;
+        hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
+    }
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_2(bit<16> nexthop_index) {
+        meta.ingress_metadata.nexthop_index = nexthop_index;
+        hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
+    }
+    @name("ingress.set_egress_details") action set_egress_details_0(bit<9> egress_spec) {
+        standard_metadata.egress_spec = egress_spec;
+    }
+    @name("ingress.set_bd") action set_bd_0(bit<16> bd) {
+        meta.ingress_metadata.bd = bd;
+    }
+    @name("ingress.bd") table bd_1 {
+        actions = {
+            set_vrf_0();
+            @defaultonly NoAction_1();
+        }
+        key = {
+            meta.ingress_metadata.bd: exact @name("meta.ingress_metadata.bd") ;
+        }
+        size = 65536;
+        default_action = NoAction_1();
+    }
+    @name("ingress.ipv4_fib") table ipv4_fib {
+        actions = {
+            on_miss_1();
+            fib_hit_nexthop_0();
+            @defaultonly NoAction_8();
+        }
+        key = {
+            meta.ingress_metadata.vrf: exact @name("meta.ingress_metadata.vrf") ;
+            hdr.ipv4.dstAddr         : exact @name("hdr.ipv4.dstAddr") ;
+        }
+        size = 131072;
+        default_action = NoAction_8();
+    }
+    @name("ingress.ipv4_fib_lpm") table ipv4_fib_lpm {
+        actions = {
+            on_miss_5();
+            fib_hit_nexthop_2();
+            @defaultonly NoAction_9();
+        }
+        key = {
+            meta.ingress_metadata.vrf: exact @name("meta.ingress_metadata.vrf") ;
+            hdr.ipv4.dstAddr         : lpm @name("hdr.ipv4.dstAddr") ;
+        }
+        size = 16384;
+        default_action = NoAction_9();
+    }
+    @name("ingress.nexthop") table nexthop {
+        actions = {
+            on_miss_6();
+            set_egress_details_0();
+            @defaultonly NoAction_10();
+        }
+        key = {
+            meta.ingress_metadata.nexthop_index: exact @name("meta.ingress_metadata.nexthop_index") ;
+        }
+        size = 32768;
+        default_action = NoAction_10();
+    }
+    @name("ingress.port_mapping") table port_mapping {
+        actions = {
+            set_bd_0();
+            @defaultonly NoAction_11();
+        }
+        key = {
+            standard_metadata.ingress_port: exact @name("standard_metadata.ingress_port") ;
+        }
+        size = 32768;
+        default_action = NoAction_11();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            port_mapping.apply();
+            bd_1.apply();
+            switch (ipv4_fib.apply().action_run) {
+                on_miss_1: {
+                    ipv4_fib_lpm.apply();
+                }
+            }
+
+            nexthop.apply();
+        }
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr = hdr.ethernet);
+        packet.emit<ipv4_t>(hdr = hdr.ipv4);
+    }
+}
+
+struct tuple_0 {
+    bit<4>  field;
+    bit<4>  field_0;
+    bit<8>  field_1;
+    bit<16> field_2;
+    bit<16> field_3;
+    bit<3>  field_4;
+    bit<13> field_5;
+    bit<8>  field_6;
+    bit<8>  field_7;
+    bit<32> field_8;
+    bit<32> field_9;
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        verify_checksum<tuple_0, bit<16>>(data = { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, checksum = hdr.ipv4.hdrChecksum, condition = true, algo = HashAlgorithm.csum16);
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        update_checksum<tuple_0, bit<16>>(condition = true, data = { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, algo = HashAlgorithm.csum16, checksum = hdr.ipv4.hdrChecksum);
+    }
+}
+
+V1Switch<headers, metadata>(p = ParserImpl(), ig = ingress(), vr = verifyChecksum(), eg = egress(), ck = computeChecksum(), dep = DeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2.p4
@@ -1,0 +1,180 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct ingress_metadata_t {
+    bit<12> vrf;
+    bit<16> bd;
+    bit<16> nexthop_index;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+    ingress_metadata_t ingress_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state parse_ethernet {
+        packet.extract(hdr = hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract(hdr = hdr.ipv4);
+        transition accept;
+    }
+    state start {
+        transition parse_ethernet;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    action on_miss() {
+    }
+    action rewrite_src_dst_mac(bit<48> smac, bit<48> dmac) {
+        hdr.ethernet.srcAddr = smac;
+        hdr.ethernet.dstAddr = dmac;
+    }
+    table rewrite_mac {
+        actions = {
+            on_miss;
+            rewrite_src_dst_mac;
+        }
+        key = {
+            meta.ingress_metadata.nexthop_index: exact;
+        }
+        size = 32768;
+    }
+    apply {
+        rewrite_mac.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    action set_vrf(bit<12> vrf) {
+        meta.ingress_metadata.vrf = vrf;
+    }
+    action on_miss() {
+    }
+    action fib_hit_nexthop(bit<16> nexthop_index) {
+        meta.ingress_metadata.nexthop_index = nexthop_index;
+        hdr.ipv4.ttl = hdr.ipv4.ttl - 8w1;
+    }
+    action set_egress_details(bit<9> egress_spec) {
+        standard_metadata.egress_spec = egress_spec;
+    }
+    action set_bd(bit<16> bd) {
+        meta.ingress_metadata.bd = bd;
+    }
+    table bd {
+        actions = {
+            set_vrf;
+        }
+        key = {
+            meta.ingress_metadata.bd: exact;
+        }
+        size = 65536;
+    }
+    table ipv4_fib {
+        actions = {
+            on_miss;
+            fib_hit_nexthop;
+        }
+        key = {
+            meta.ingress_metadata.vrf: exact;
+            hdr.ipv4.dstAddr         : exact;
+        }
+        size = 131072;
+    }
+    table ipv4_fib_lpm {
+        actions = {
+            on_miss;
+            fib_hit_nexthop;
+        }
+        key = {
+            meta.ingress_metadata.vrf: exact;
+            hdr.ipv4.dstAddr         : lpm;
+        }
+        size = 16384;
+    }
+    table nexthop {
+        actions = {
+            on_miss;
+            set_egress_details;
+        }
+        key = {
+            meta.ingress_metadata.nexthop_index: exact;
+        }
+        size = 32768;
+    }
+    table port_mapping {
+        actions = {
+            set_bd;
+        }
+        key = {
+            standard_metadata.ingress_port: exact;
+        }
+        size = 32768;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            port_mapping.apply();
+            bd.apply();
+            switch (ipv4_fib.apply().action_run) {
+                on_miss: {
+                    ipv4_fib_lpm.apply();
+                }
+            }
+
+            nexthop.apply();
+        }
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr = hdr.ethernet);
+        packet.emit(hdr = hdr.ipv4);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        verify_checksum(data = { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, checksum = hdr.ipv4.hdrChecksum, condition = true, algo = HashAlgorithm.csum16);
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        update_checksum(condition = true, data = { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, algo = HashAlgorithm.csum16, checksum = hdr.ipv4.hdrChecksum);
+    }
+}
+
+V1Switch(p = ParserImpl(), ig = ingress(), vr = verifyChecksum(), eg = egress(), ck = computeChecksum(), dep = DeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/named-arg-first.p4
+++ b/testdata/p4_16_samples_outputs/named-arg-first.p4
@@ -1,0 +1,13 @@
+extern void f(in bit<16> x, in bool y);
+control c() {
+    apply {
+        bit<16> xv = 16w0;
+        bool b = true;
+        f(y = b, x = xv);
+    }
+}
+
+control empty();
+package top(empty _e);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/named-arg-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named-arg-frontend.p4
@@ -1,0 +1,15 @@
+extern void f(in bit<16> x, in bool y);
+control c() {
+    bit<16> xv;
+    bool b;
+    apply {
+        xv = 16w0;
+        b = true;
+        f(y = b, x = xv);
+    }
+}
+
+control empty();
+package top(empty _e);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/named-arg-midend.p4
+++ b/testdata/p4_16_samples_outputs/named-arg-midend.p4
@@ -1,0 +1,20 @@
+extern void f(in bit<16> x, in bool y);
+control c() {
+    @hidden action act() {
+        f(y = true, x = 16w0);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control empty();
+package top(empty _e);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/named-arg.p4
+++ b/testdata/p4_16_samples_outputs/named-arg.p4
@@ -1,0 +1,13 @@
+extern void f(in bit<16> x, in bool y);
+control c() {
+    apply {
+        bit<16> xv = 0;
+        bool b = true;
+        f(y = b, x = xv);
+    }
+}
+
+control empty();
+package top(empty _e);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/named-arg1-first.p4
+++ b/testdata/p4_16_samples_outputs/named-arg1-first.p4
@@ -8,11 +8,11 @@ parser adder(in bit<32> y, out bit<32> x)(bit<32> add, bool ignore) {
 }
 
 parser par(out bool b) {
-    adder(ignore = false, add = 6) p;
+    adder(ignore = false, add = 32w6) p;
     state start {
         bit<32> x;
-        p.apply(x = x, y = 0);
-        b = x == 0;
+        p.apply(x = x, y = 32w0);
+        b = x == 32w0;
         transition accept;
     }
 }
@@ -24,20 +24,18 @@ control comp(inout bit<16> x, out bool b)(bit<16> compare, bit<2> ignore) {
 }
 
 control c(out bool b) {
-    comp(ignore = 1, compare = 0) c0;
-    comp(ignore = 2, compare = 1) c1;
-
+    comp(ignore = 2w1, compare = 16w0) c0;
+    comp(ignore = 2w2, compare = 16w1) c1;
     action a(in bit<16> bi, out bit<16> mb) {
         mb = -bi;
     }
-
     apply {
-        bit<16> xv = 0;
-        a(bi = 3, mb = xv);
-        a(mb = xv, bi = 0);
+        bit<16> xv = 16w0;
+        a(bi = 16w3, mb = xv);
+        a(mb = xv, bi = 16w0);
         c0.apply(b = b, x = xv);
         c1.apply(xv, b);
-        xv = 1;
+        xv = 16w1;
         c0.apply(x = xv, b = b);
         c1.apply(b = b, x = xv);
     }
@@ -46,6 +44,5 @@ control c(out bool b) {
 control ce(out bool b);
 parser pe(out bool b);
 package top(pe _p, ce _e, @optional ce _e1);
+top(_e = c(), _p = par()) main;
 
-top(_e = c(),
-    _p = par()) main;

--- a/testdata/p4_16_samples_outputs/named-arg1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named-arg1-frontend.p4
@@ -1,0 +1,61 @@
+#include <core.p4>
+
+parser par(out bool b) {
+    bit<32> x;
+    bit<32> y;
+    bit<32> x_4;
+    state start {
+        y = 32w0;
+        transition adder_0_start;
+    }
+    state adder_0_start {
+        x_4 = y + 32w6;
+        transition start_0;
+    }
+    state start_0 {
+        x = x_4;
+        b = x == 32w0;
+        transition accept;
+    }
+}
+
+control c(out bool b) {
+    bit<16> xv;
+    bit<16> x_5;
+    bool b_2;
+    bit<16> x_6;
+    bool b_3;
+    @name("c.a") action a_0(in bit<16> bi, out bit<16> mb) {
+        mb = -bi;
+    }
+    @name("c.a") action a_2(in bit<16> bi_1, out bit<16> mb_1) {
+        mb_1 = -bi_1;
+    }
+    apply {
+        a_0(bi = 16w3, mb = xv);
+        a_2(mb = xv, bi = 16w0);
+        x_5 = xv;
+        b_2 = x_5 == 16w0;
+        b = b_2;
+        xv = x_5;
+        x_6 = xv;
+        b_3 = x_6 == 16w1;
+        xv = x_6;
+        b = b_3;
+        xv = 16w1;
+        x_5 = xv;
+        b_2 = x_5 == 16w0;
+        xv = x_5;
+        b = b_2;
+        x_6 = xv;
+        b_3 = x_6 == 16w1;
+        b = b_3;
+        xv = x_6;
+    }
+}
+
+control ce(out bool b);
+parser pe(out bool b);
+package top(pe _p, ce _e, @optional ce _e1);
+top(_e = c(), _p = par()) main;
+

--- a/testdata/p4_16_samples_outputs/named-arg1-midend.p4
+++ b/testdata/p4_16_samples_outputs/named-arg1-midend.p4
@@ -1,0 +1,65 @@
+#include <core.p4>
+
+parser par(out bool b) {
+    bit<32> x;
+    bit<32> y;
+    bit<32> x_4;
+    state start {
+        y = 32w0;
+        x_4 = y + 32w6;
+        x = x_4;
+        b = x == 32w0;
+        transition accept;
+    }
+}
+
+control c(out bool b) {
+    bit<16> xv;
+    bool b_3;
+    @name("c.a") action a_0() {
+        xv = 16w65533;
+    }
+    @name("c.a") action a_2() {
+        xv = 16w0;
+    }
+    @hidden action act() {
+        b = xv == 16w0;
+        b_3 = xv == 16w1;
+        b = b_3;
+        xv = 16w1;
+        xv = 16w1;
+        b = false;
+        b_3 = true;
+        b = true;
+        xv = 16w1;
+    }
+    @hidden table tbl_a {
+        actions = {
+            a_0();
+        }
+        const default_action = a_0();
+    }
+    @hidden table tbl_a_0 {
+        actions = {
+            a_2();
+        }
+        const default_action = a_2();
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_a.apply();
+        tbl_a_0.apply();
+        tbl_act.apply();
+    }
+}
+
+control ce(out bool b);
+parser pe(out bool b);
+package top(pe _p, ce _e, @optional ce _e1);
+top(_e = c(), _p = par()) main;
+

--- a/testdata/p4_16_samples_outputs/named-arg1.p4
+++ b/testdata/p4_16_samples_outputs/named-arg1.p4
@@ -26,11 +26,9 @@ control comp(inout bit<16> x, out bool b)(bit<16> compare, bit<2> ignore) {
 control c(out bool b) {
     comp(ignore = 1, compare = 0) c0;
     comp(ignore = 2, compare = 1) c1;
-
     action a(in bit<16> bi, out bit<16> mb) {
         mb = -bi;
     }
-
     apply {
         bit<16> xv = 0;
         a(bi = 3, mb = xv);
@@ -46,6 +44,5 @@ control c(out bool b) {
 control ce(out bool b);
 parser pe(out bool b);
 package top(pe _p, ce _e, @optional ce _e1);
+top(_e = c(), _p = par()) main;
 
-top(_e = c(),
-    _p = par()) main;


### PR DESCRIPTION
This is the second PR in a series for supporting named arguments.
This should take care of most of the cases.

In an upcoming PR we will also fix the backends to properly handle named arguments.
The PR does not handle default values for parameters or overload resolution. These will be other future PRs.