### PR TITLE
Emit extern functions with --emit-externs

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -149,6 +149,8 @@ set (XFAIL_TESTS
   testdata/p4_14_samples/issue604.p4
   # This test uses an incorrect model
   testdata/p4_16_samples/issue1205-bmv2.p4
+  # This test requires --emit-externs and extern support from BMv2
+  testdata/p4_16_samples/extern-funcs-bmv2.p4
   # These psa tests are not ready to run on bmv2 yet
   testdata/p4_16_samples/psa-example-counters-bmv2.p4
   testdata/p4_16_samples/psa-example-digest-bmv2.p4
@@ -158,6 +160,8 @@ set (XFAIL_TESTS
 
 if (HAVE_SIMPLE_SWITCH)
   p4c_add_tests("bmv2" ${BMV2_DRIVER} "${BMV2_V1MODEL_TEST_SUITES}" "${XFAIL_TESTS}")
+  add_library(extern_func_module MODULE EXCLUDE_FROM_ALL "${P4C_SOURCE_DIR}/testdata/extern_modules/extern-funcs-bmv2.cpp" )
+  p4c_add_test_with_args("bmv2" ${BMV2_DRIVER} FALSE "bmv2_emit_externs" "testdata/p4_16_samples/extern-funcs-bmv2.p4" "-a --emit-externs --target-specific-switch-arg \"--load-modules $<TARGET_FILE:extern_func_module>\" --init \"make extern_func_module\"")
 else()
   MESSAGE(WARNING "BMv2 simple switch is not available, not adding v1model BMv2 tests")
 endif()

--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -355,6 +355,8 @@ class RunBMV2(object):
         self.actions = []
         self.switchLogFile = "switch.log"  # .txt is added by BMv2
         self.readJson()
+        self.cmd_line_args = getattr(options, 'switchOptions', ())
+        self.target_specific_cmd_line_args = getattr(options, 'switchTargetSpecificOptions', ())
 
     def readJson(self):
         with open(self.jsonfile) as jf:
@@ -562,6 +564,10 @@ class RunBMV2(object):
                          "--log-file", self.switchLogFile, "--log-flush",
                          "--use-files", str(wait), "--thrift-port", thriftPort,
                          "--device-id", str(rand)] + self.interfaceArgs() + ["../" + self.jsonfile]
+            if self.cmd_line_args:
+                runswitch += self.cmd_line_args
+            if self.target_specific_cmd_line_args:
+                runswitch += ['--',] + self.target_specific_cmd_line_args
             if self.options.verbose:
                 print("Running", " ".join(runswitch))
             sw = subprocess.Popen(runswitch, cwd=self.folder)

--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -123,7 +123,7 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                 continue;
             } else if (mi->is<P4::ExternFunction>()) {
                 auto ef = mi->to<P4::ExternFunction>();
-                auto json = ExternConverter::cvtExternFunction(ctxt, ef, mc, s);
+                auto json = ExternConverter::cvtExternFunction(ctxt, ef, mc, s, emitExterns);
                 if (json)
                     result->append(json);
                 continue;

--- a/backends/bmv2/common/extern.cpp
+++ b/backends/bmv2/common/extern.cpp
@@ -53,8 +53,9 @@ Util::IJson*
 ExternConverter::cvtExternFunction(ConversionContext* ctxt,
                                    const P4::ExternFunction* ef,
                                    const IR::MethodCallExpression* mc,
-                                   const IR::StatOrDecl* s) {
-    return get(ef)->convertExternFunction(ctxt, ef, mc, s);
+                                   const IR::StatOrDecl* s,
+                                   const bool emitExterns) {
+    return get(ef)->convertExternFunction(ctxt, ef, mc, s, emitExterns);
 }
 
 Util::IJson*
@@ -75,12 +76,23 @@ ExternConverter::convertExternInstance(ConversionContext* ,
 }
 
 Util::IJson*
-ExternConverter::convertExternFunction(ConversionContext* ,
+ExternConverter::convertExternFunction(ConversionContext* ctxt,
                                        const P4::ExternFunction* ef,
-                                       const IR::MethodCallExpression* ,
-                                       const IR::StatOrDecl* ) {
-    ::error("Unknown extern function %1%", ef->method->name);
-    return nullptr;
+                                       const IR::MethodCallExpression* mc,
+                                       const IR::StatOrDecl* s,
+                                       const bool emitExterns) {
+    if (!emitExterns) {
+        ::error("Unknown extern function %1%", ef->method->name);
+        return nullptr;
+    }
+    auto primitive = mkPrimitive(ef->method->name);
+    primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
+    auto parameters = mkParameters(primitive);
+    for (auto arg : *mc->arguments) {
+        auto args = ctxt->conv->convert(arg->expression);
+        parameters->append(args);
+    }
+    return primitive;
 }
 
 void

--- a/backends/bmv2/common/extern.h
+++ b/backends/bmv2/common/extern.h
@@ -37,7 +37,8 @@ class ExternConverter {
                           const IR::ExternBlock* eb);
     virtual Util::IJson*
     convertExternFunction(ConversionContext* ctxt, const P4::ExternFunction* ef,
-                          const IR::MethodCallExpression* mc, const IR::StatOrDecl* s);
+                          const IR::MethodCallExpression* mc, const IR::StatOrDecl* s,
+                          const bool emitExterns);
 
     static ExternConverter* get(cstring type);
     static ExternConverter* get(const IR::Type_Extern* type) { return get(type->name); }
@@ -54,7 +55,8 @@ class ExternConverter {
                       const IR::ExternBlock* eb);
     static Util::IJson*
     cvtExternFunction(ConversionContext* ctxt, const P4::ExternFunction* ef,
-                      const IR::MethodCallExpression* mc, const IR::StatOrDecl* s);
+                      const IR::MethodCallExpression* mc, const IR::StatOrDecl* s,
+                      const bool emitExterns);
 
     // helper function for simple switch
     void modelError(const char* format, const IR::Node* place) const;
@@ -75,7 +77,7 @@ class ExternConverter {
         static ExternConverter_##extern_name##__VA_ARGS__ singleton;            \
         Util::IJson* convertExternFunction(ConversionContext* ctxt,             \
             const P4::ExternFunction* ef, const IR::MethodCallExpression* mc,   \
-            const IR::StatOrDecl* s) override;  };
+            const IR::StatOrDecl* s, const bool emitExterns) override;  };
 
 #define EXTERN_CONVERTER_W_FUNCTION(extern_name, ...)                           \
     class ExternConverter_##extern_name##__VA_ARGS__ : public ExternConverter { \
@@ -84,7 +86,7 @@ class ExternConverter {
         static ExternConverter_##extern_name##__VA_ARGS__ singleton;            \
         Util::IJson* convertExternFunction(ConversionContext* ctxt,             \
             const P4::ExternFunction* ef, const IR::MethodCallExpression* mc,   \
-            const IR::StatOrDecl* s) override;  };
+            const IR::StatOrDecl* s, const bool emitExterns) override;  };
 
 #define EXTERN_CONVERTER_W_INSTANCE_AND_MODEL(extern_name, model_type, model_name, ...) \
     class ExternConverter_##extern_name##__VA_ARGS__ : public ExternConverter { \
@@ -147,7 +149,8 @@ class ExternConverter {
 #define CONVERT_EXTERN_FUNCTION(extern_name, ...)                                     \
     Util::IJson* ExternConverter_##extern_name##__VA_ARGS__::convertExternFunction(   \
         UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,          \
-        UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s)
+        UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,    \
+        UNUSED const bool emitExterns)
 
 }  // namespace BMV2
 

--- a/backends/bmv2/run-bmv2-test.py
+++ b/backends/bmv2/run-bmv2-test.py
@@ -51,10 +51,13 @@ class Options(object):
         self.verbose = False
         self.replace = False            # replace previous outputs
         self.compilerOptions = []
+        self.switchOptions = []
+        self.switchTargetSpecificOptions = []
         self.hasBMv2 = False            # Is the behavioral model installed?
         self.usePsa = False             # Use the psa switch behavioral model?
         self.runDebugger = False
         self.observationLog = None           # Log packets produced by the BMV2 model if path to log is supplied
+        self.initCommands = []
 
 def nextWord(text, sep = " "):
     # Split a text at the indicated separator.
@@ -112,9 +115,12 @@ def usage(options):
     print("          -p: use psa switch")
     print("          -f: replace reference outputs with newly generated ones")
     print("          -a option: pass this option to the compiler")
+    print("          --switch-arg option: pass this general option to the switch")
+    print("          --target-specific-switch-arg option: pass this target-specific option to the switch")
     print("          -gdb: run compiler under gdb")
     print("          --pp file: pass this option to the compiler")
     print("          -observation-log <file>: save packet output to <file>")
+    print("          --init <cmd>: Run <cmd> before the start of the test")
 
 
 def isError(p4filename):
@@ -183,9 +189,21 @@ def run_model(options, tmpdir, jsonfile):
     result = bmv2.checkOutputs()
     return result
 
+def run_init_commands(options):
+    if not options.initCommands:
+        return SUCCESS
+    for cmd in options.initCommands:
+        args = cmd.split()
+        result = run_timeout(options, args, timeout, None)
+        if result != SUCCESS:
+            return FAILURE
+    return SUCCESS
+
 def process_file(options, argv):
     assert isinstance(options, Options)
 
+    if (run_init_commands(options) != SUCCESS):
+        return FAILURE
     tmpdir = tempfile.mkdtemp(dir=".")
     basename = os.path.basename(options.p4filename)
     base, ext = os.path.splitext(basename)
@@ -276,6 +294,22 @@ def main(argv):
             else:
                 options.compilerOptions += argv[1].split();
                 argv = argv[1:]
+        elif argv[0] == "--switch-arg":
+            if len(argv) == 0:
+                reportError("Missing argument for --switch-arg option")
+                usage(options)
+                sys.exit(FAILURE)
+            else:
+                options.switchOptions += argv[1].split();
+                argv = argv[1:]
+        elif argv[0] == "--target-specific-switch-arg":
+            if len(argv) == 0:
+                reportError("Missing argument for --target-specific-switch-arg option")
+                usage(options)
+                sys.exit(FAILURE)
+            else:
+                options.switchTargetSpecificOptions += argv[1].split();
+                argv = argv[1:]
         elif argv[0][1] == 'D' or argv[0][1] == 'I' or argv[0][1] == 'T':
             options.compilerOptions.append(argv[0])
         elif argv[0] == "-gdb":
@@ -292,6 +326,14 @@ def main(argv):
             options.compilerOptions.append(argv[0])
             argv = argv[1:]
             options.compilerOptions.append(argv[0])
+        elif argv[0] == "--init":
+            if len(argv) == 0:
+                reportError("Missing argument for --init option")
+                usage(options)
+                sys.exit(FAILURE)
+            else:
+                options.initCommands.append(argv[1])
+                argv = argv[1:]
         else:
             reportError("Unknown option ", argv[0])
             usage(options)

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -828,7 +828,7 @@ SimpleSwitchBackend::convertChecksum(const IR::BlockStatement *block, Util::Json
 }
 
 void SimpleSwitchBackend::createActions(ConversionContext* ctxt, V1ProgramStructure* structure) {
-    auto cvt = new ActionConverter(ctxt, true);
+    auto cvt = new ActionConverter(ctxt, options.emitExterns);
     for (auto it : structure->actions) {
         auto action = it.first;
         action->apply(*cvt);

--- a/testdata/extern_modules/extern-funcs-bmv2.cpp
+++ b/testdata/extern_modules/extern-funcs-bmv2.cpp
@@ -1,0 +1,16 @@
+/*
+ * Create a simple extern function and register it. The test will load a P4
+ * program that calls this extern. It will verify the extern loads correctly,
+ * and that the described action is performed.
+ */
+#include <bm/bm_sim/data.h>
+#include <bm/bm_sim/extern.h>
+#include <bm/bm_sim/fields.h>
+
+/**
+ * Extern test funcion. Set f to d (f <- d).
+ */
+void extern_func(bm::Field & f, const bm::Data & d) {
+	f.set(d);
+}
+BM_REGISTER_EXTERN_FUNCTION(extern_func, bm::Field &, const bm::Data &);

--- a/testdata/p4_16_bmv_errors/no-externs-bmv2.p4
+++ b/testdata/p4_16_bmv_errors/no-externs-bmv2.p4
@@ -1,0 +1,77 @@
+/*
+Copyright 2016 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <v1model.p4>
+
+/** Test extern function. Set d <- s. Will cause compilation failure since
+ *  default compilation is without --emit-extern. */
+extern void extern_func(out bit<32> d, bit<32> s);
+
+header h {
+  bit<8> n;
+}
+
+struct s_h {
+  h h;
+}
+
+struct m {
+  bit<32> mf;
+}
+
+parser MyParser(packet_in b,
+                out s_h parsedHdr,
+                inout m meta,
+                inout standard_metadata_t standard_metadata) {
+  state start {
+    b.extract(parsedHdr.h);
+    transition accept;
+  }
+}
+
+control MyVerifyChecksum(inout s_h hdr,
+                       inout m meta) {
+  apply {}
+
+}
+control MyIngress(inout s_h hdr,
+                  inout m meta,
+                  inout standard_metadata_t standard_metadata) {
+  apply {
+    extern_func(meta.mf, 32);
+  }
+}
+control MyEgress(inout s_h hdr,
+               inout m meta,
+               inout standard_metadata_t standard_metadata) {
+  apply {}
+}
+
+control MyComputeChecksum(inout s_h hdr,
+                          inout m meta) {
+  apply {}
+}
+
+control MyDeparser(packet_out b, in s_h hdr) {
+  apply {}
+}
+
+V1Switch(MyParser(),
+         MyVerifyChecksum(),
+         MyIngress(),
+         MyEgress(),
+         MyComputeChecksum(),
+         MyDeparser()) main;

--- a/testdata/p4_16_samples/extern-funcs-bmv2.p4
+++ b/testdata/p4_16_samples/extern-funcs-bmv2.p4
@@ -1,0 +1,33 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+/** Test extern function. Set d <- s. */
+extern void extern_func(out bit<32> d, bit<32> s);
+
+header hdr {
+  bit<32> a;
+}
+
+control compute(inout hdr h)
+{
+    apply {
+        // Test enum lowering
+        extern_func(h.a, 0xff);
+    }
+}
+
+#include "arith-inline-skeleton.p4"

--- a/testdata/p4_16_samples/extern-funcs-bmv2.stf
+++ b/testdata/p4_16_samples/extern-funcs-bmv2.stf
@@ -1,0 +1,8 @@
+# header = { int<32> a }
+# In the output a = 0x000000ff
+
+packet 0 00000000 00000000
+expect 0 000000ff 00000000
+
+packet 0 beefca0e a5dffd5a
+expect 0 000000ff a5dffd5a


### PR DESCRIPTION
This change builds on top of pull request #1217 to also support emitting
extern functions (in addition to objects and methods).

It assumes extern functions have the __extern_ prefix, to avoid name
collision.