### PR TITLE
propagate -g only to "known" tools

### DIFF
--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -97,7 +97,8 @@ class BackendDriver:
         # set debug info
         if opts.debug_info:
             for c in self._commands:
-                if c != 'none': self.add_command_option(c, "-g")
+                if c == 'assembler' or c == 'compiler' or c == 'linker':
+                    self.add_command_option(c, "-g")
 
         # set assembler options
         if 'assembler' in self._commands:


### PR DESCRIPTION
In debug mode, propagate the -g only to the known commands, rather
than all commands. Different backends may chose to add -g to these
commands on a case-by-case basis.