### PR TITLE
Generate a deep-compare "equiv" function for IR nodes

### DIFF
--- a/ir/expression.def
+++ b/ir/expression.def
@@ -337,6 +337,11 @@ class MethodCallExpression : Expression {
     MethodCallExpression(Util::SourceInfo si, Expression m,
                          const std::initializer_list<Argument> &a)
     : Expression(si), method(m), arguments(new Vector<Argument>(a)) {}
+    MethodCallExpression(Expression m, const std::initializer_list<const Expression *> &a)
+    : method(m), arguments(nullptr)  {
+        auto arguments = new Vector<Argument>;
+        for (auto arg : a) arguments->push_back(new Argument(arg));
+        this->arguments = arguments; }
 }
 
 class ConstructorCallExpression : Expression {

--- a/ir/namemap.h
+++ b/ir/namemap.h
@@ -113,6 +113,16 @@ class NameMap : public Node {
     IRNODE_SUBCLASS(NameMap)
     bool operator==(const Node &a) const override { return a == *this; }
     bool operator==(const NameMap &a) const { return symbols == a.symbols; }
+    bool equiv(const Node &a_) const override {
+        if (static_cast<const Node *>(this) == &a_) return true;
+        if (typeid(*this) != typeid(a_)) return false;
+        auto &a = static_cast<const NameMap<T, MAP, COMP, ALLOC> &>(a_);
+        if (size() != a.size()) return false;
+        auto it = a.begin();
+        for (auto &el : *this)
+            if (el.first != it->first || !el.second->equiv(*(it++)->second))
+                return false;
+        return true; }
     cstring node_type_name() const override {
         return "NameMap<" + T::static_type_name() + ">"; }
     static cstring static_type_name() {

--- a/ir/node.h
+++ b/ir/node.h
@@ -109,7 +109,11 @@ class Node : public virtual INode {
     void toJSON(JSONGenerator &json) const override;
     void sourceInfoToJSON(JSONGenerator &json) const;
     Util::JsonObject* sourceInfoJsonObj() const;
+    /* operator== does a 'shallow' comparison, comparing two Node subclass objects for equality,
+     * and comparing pointers in the Node directly for equality */
     virtual bool operator==(const Node &a) const { return typeid(*this) == typeid(a); }
+    /* 'equiv' does a deep-equals comparison, comparing all non-pointer fields and recursing
+     * though all Node subclass pointers to compare them with 'equiv' as well. */
     virtual bool equiv(const Node &a) const { return typeid(*this) == typeid(a); }
 #define DEFINE_OPEQ_FUNC(CLASS, BASE) \
     virtual bool operator==(const CLASS &) const { return false; }

--- a/ir/node.h
+++ b/ir/node.h
@@ -110,6 +110,7 @@ class Node : public virtual INode {
     void sourceInfoToJSON(JSONGenerator &json) const;
     Util::JsonObject* sourceInfoJsonObj() const;
     virtual bool operator==(const Node &a) const { return typeid(*this) == typeid(a); }
+    virtual bool equiv(const Node &a) const { return typeid(*this) == typeid(a); }
 #define DEFINE_OPEQ_FUNC(CLASS, BASE) \
     virtual bool operator==(const CLASS &) const { return false; }
     IRNODE_ALL_SUBCLASSES(DEFINE_OPEQ_FUNC)

--- a/ir/nodemap.h
+++ b/ir/nodemap.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -72,6 +72,16 @@ class NodeMap : public Node {
     IRNODE_SUBCLASS(NodeMap)
     bool operator==(const Node &a) const override { return a == *this; }
     bool operator==(const NodeMap &a) const { return symbols == a.symbols; }
+    bool equiv(const Node &a_) const override {
+        if (static_cast<const Node *>(this) == &a_) return true;
+        if (typeid(*this) != typeid(a_)) return false;
+        auto &a = static_cast<const NodeMap<KEY, VALUE, MAP, COMP, ALLOC> &>(a_);
+        if (size() != a.size()) return false;
+        auto it = a.begin();
+        for (auto &el : *this)
+            if (el.first != it->first || !el.second->equiv(*(it++)->second))
+                return false;
+        return true; }
     cstring node_type_name() const override {
         return "NodeMap<" + KEY::static_type_name() + "," + VALUE::static_type_name() + ">"; }
     static cstring static_type_name() {

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -165,7 +165,14 @@ class Vector : public VectorBase {
      * of IR::Vector that appear somewhere in a .def file -- you can usually make
      * it work by using an instantiation with an (abstract) base class rather
      * than a concrete class, as most of those appear in .def files. */
-
+    bool equiv(const Node &a_) const override {
+        if (static_cast<const Node *>(this) == &a_) return true;
+        if (typeid(*this) != typeid(a_)) return false;
+        auto &a = static_cast<const Vector<T> &>(a_);
+        if (size() != a.size()) return false;
+        auto it = a.begin();
+        for (auto *el : *this) if (!el->equiv(**it++)) return false;
+        return true; }
     cstring node_type_name() const override {
         return "Vector<" + T::static_type_name() + ">"; }
     static cstring static_type_name() {

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -100,7 +100,6 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
     void apply_function(FuncInfo *tbl);
     IR::P4Table *preorder(IR::P4Table *) override;
     IR::P4Table *postorder(IR::P4Table *) override;
-    bool equiv(const IR::Expression *left, const IR::Expression *right);
     class ElimDead;
     class RewriteTableKeys;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/diagnostics.cpp
   gtest/dumpjson.cpp
   gtest/enumerator_test.cpp
+  gtest/equiv_test.cpp
   gtest/exception_test.cpp
   gtest/expr_uses_test.cpp
   gtest/format_test.cpp

--- a/test/gtest/equiv_test.cpp
+++ b/test/gtest/equiv_test.cpp
@@ -1,0 +1,72 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc. 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "gtest/gtest.h"
+#include "ir/ir.h"
+#include "ir/visitor.h"
+#include "lib/exceptions.h"
+
+TEST(IR, Equiv) {
+    auto *t = IR::Type::Bits::get(16);
+    auto *a1 = new IR::Constant(t, 10);
+    auto *a2 = new IR::Constant(t, 10);
+    auto *b = new IR::Constant(IR::Type::Bits::get(10), 10);
+    auto *c = new IR::Constant(t, 20);
+    auto *d1 = new IR::PathExpression("d");
+    auto *d2 = new IR::PathExpression("d");
+    auto *e = new IR::PathExpression("e");
+    auto *d1m = new IR::Member(d1, "m");
+    auto *d2m = new IR::Member(d2, "m");
+    auto *em = new IR::Member(e, "m");
+    auto *d1f = new IR::Member(d1, "f");
+
+    EXPECT_TRUE(a1->equiv(*a2));
+    EXPECT_TRUE(d1->equiv(*d2));
+    EXPECT_FALSE(a1->equiv(*b));
+    EXPECT_FALSE(a1->equiv(*c));
+    EXPECT_FALSE(a1->equiv(*e));
+    EXPECT_FALSE(d1->equiv(*e));
+    EXPECT_TRUE(d1m->equiv(*d2m));
+    EXPECT_FALSE(d1m->equiv(*em));
+    EXPECT_FALSE(d1m->equiv(*d1f));
+
+    auto *call1 = new IR::MethodCallExpression(d1m, { a1, d1 });
+    auto *call2 = new IR::MethodCallExpression(d2m, { a2, d2 });
+    auto *call3 = new IR::MethodCallExpression(d1m, { b, d1 });
+
+    EXPECT_TRUE(call1->equiv(*call2));
+    EXPECT_FALSE(call1->equiv(*call3));
+
+    auto *list1 = new IR::ListExpression({ a1, b, d1 });
+    auto *list2 = new IR::ListExpression({ a1, b, d2 });
+    auto *list3 = new IR::ListExpression({ a1, b, e });
+
+    EXPECT_TRUE(list1->equiv(*list2));
+    EXPECT_FALSE(list1->equiv(*list3));
+
+    auto *pr1 = new IR::V1Program;
+    auto *pr2 = pr1->clone();
+    pr1->add("a", a1);
+    pr1->add("b", b);
+    pr1->add("call", call1);
+    pr2->add("a", a2);
+    pr2->add("b", b);
+    pr2->add("call", call2);
+    EXPECT_TRUE(pr1->equiv(*pr2));
+    pr1->add("lista", list1);
+    pr2->add("listb", list1);
+    EXPECT_FALSE(pr1->equiv(*pr2));
+}

--- a/tools/ir-generator/irclass.h
+++ b/tools/ir-generator/irclass.h
@@ -129,8 +129,10 @@ class IrField : public IrElement {
     : IrElement(info), type(type), name(name), initializer(init), nullOK(flags & NullOK),
       optional(flags & Optional), isInline(flags & Inline), isStatic(flags & Static),
       isConst(flags & Const) {}
-    IrField(const Type *type, cstring name, cstring init = cstring())
-    : type(type), name(name), initializer(init) {}
+    IrField(const Type *type, cstring name, cstring init = cstring(), int flags = 0)
+    : IrField(Util::SourceInfo(), type, name, init, flags) {}
+    IrField(const Type *type, cstring name, int flags)
+    : IrField(Util::SourceInfo(), type, name, cstring(), flags) {}
     void generate(std::ostream &out, bool asField) const;
     void generate_hdr(std::ostream &out) const override { generate(out, true); }
     void generate_impl(std::ostream &) const override;


### PR DESCRIPTION
I talked about this awhile back -- this has the ir-generator generate a deep-compare method `equiv` for all IR classes.  It recursively compares all pointed at IR classes, so it is potentially expensive, but when it's needed, it's needed.