### PR TITLE
Alternate cleaner way of specifying pattern matches.

### DIFF
--- a/midend/simplifyBitwise.cpp
+++ b/midend/simplifyBitwise.cpp
@@ -18,10 +18,10 @@ void SimplifyBitwise::assignSlices(const IR::Expression *expr, mpz_class mask) {
 }
 
 const IR::Node *SimplifyBitwise::preorder(IR::AssignmentStatement *as) {
-    const IR::Expression *a, *b;
-    const IR::Constant *maskA, *maskB;
+    Pattern::Match<IR::Expression> a, b;
+    Pattern::Match<IR::Constant> maskA, maskB;
 
-    if (!((Pattern(a) & Pattern(maskA)) | (Pattern(b) & Pattern(maskB))).match(as->right))
+    if (!((a & maskA) | (b & maskB)).match(as->right))
         return as;
     if ((maskA->value & maskB->value) != 0)
         return as;


### PR DESCRIPTION
I think this little bit of syntactic sugar makes the patterns being matched against a bit clearer.