### PR TITLE
A framework for P4Info generation for arbitrary architectures

### DIFF
--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -70,6 +70,8 @@ add_custom_command(OUTPUT ${P4RUNTIME_GEN_SRCS} ${P4RUNTIME_GEN_HDRS}
 #PROTOBUF_GENERATE_PYTHON (P4RUNTIME_GEN_PYTHON P4RUNTIME_INFO_GEN_HDRS ${P4RUNTIME_INFO_PROTO})
 
 set (CONTROLPLANE_SRCS
+  p4RuntimeArchHandler.cpp
+  p4RuntimeArchStandard.cpp
   p4RuntimeSerializer.cpp
   typeSpecConverter.cpp
   )
@@ -79,6 +81,7 @@ set (CONTROLPLANE_SOURCES
   )
 
 set (CONTROLPLANE_HDRS
+  p4RuntimeArchHandler.h
   p4RuntimeSerializer.h
   typeSpecConverter.h
   )

--- a/control-plane/p4RuntimeArchHandler.cpp
+++ b/control-plane/p4RuntimeArchHandler.cpp
@@ -1,0 +1,118 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <boost/optional.hpp>
+
+#include "frontends/common/resolveReferences/referenceMap.h"
+// TODO(antonin): this include should go away when we cleanup getTableSize
+// implementation.
+#include "frontends/p4/fromv1.0/v1model.h"
+#include "frontends/p4/externInstance.h"
+#include "frontends/p4/typeMap.h"
+#include "ir/ir.h"
+
+#include "p4RuntimeArchHandler.h"
+
+namespace P4 {
+
+/** \addtogroup control_plane
+ *  @{
+ */
+namespace ControlPlaneAPI {
+
+namespace Helpers {
+
+boost::optional<ExternInstance>
+getExternInstanceFromProperty(const IR::P4Table* table,
+                              const cstring& propertyName,
+                              ReferenceMap* refMap,
+                              TypeMap* typeMap,
+                              bool *isConstructedInPlace) {
+    auto property = table->properties->getProperty(propertyName);
+    if (property == nullptr) return boost::none;
+    if (!property->value->is<IR::ExpressionValue>()) {
+        ::error("Expected %1% property value for table %2% to be an expression: %3%",
+                propertyName, table->controlPlaneName(), property);
+        return boost::none;
+    }
+
+    auto expr = property->value->to<IR::ExpressionValue>()->expression;
+    if (isConstructedInPlace) *isConstructedInPlace = expr->is<IR::ConstructorCallExpression>();
+    if (expr->is<IR::ConstructorCallExpression>()
+        && property->getAnnotation(IR::Annotation::nameAnnotation) == nullptr) {
+        ::error("Table '%1%' has an anonymous table property '%2%' with no name annotation, "
+                "which is not supported by P4Runtime", table->controlPlaneName(), propertyName);
+        return boost::none;
+    }
+    auto name = property->controlPlaneName();
+    auto externInstance = ExternInstance::resolve(expr, refMap, typeMap, name);
+    if (!externInstance) {
+        ::error("Expected %1% property value for table %2% to resolve to an "
+                "extern instance: %3%", propertyName, table->controlPlaneName(),
+                property);
+        return boost::none;
+    }
+
+    return externInstance;
+}
+
+bool isExternPropertyConstructedInPlace(const IR::P4Table* table,
+                                        const cstring& propertyName) {
+    auto property = table->properties->getProperty(propertyName);
+    if (property == nullptr) return false;
+    if (!property->value->is<IR::ExpressionValue>()) {
+        ::error("Expected %1% property value for table %2% to be an expression: %3%",
+                propertyName, table->controlPlaneName(), property);
+        return false;
+    }
+
+    auto expr = property->value->to<IR::ExpressionValue>()->expression;
+    return expr->is<IR::ConstructorCallExpression>();
+}
+
+int64_t getTableSize(const IR::P4Table* table) {
+    // TODO(antonin): we should not be referring to v1model in this
+    // architecture-independent code; each architecture may have a different
+    // default table size.
+    const int64_t defaultTableSize =
+        P4V1::V1Model::instance.tableAttributes.defaultTableSize;
+
+    auto sizeProperty = table->properties->getProperty("size");
+    if (sizeProperty == nullptr) {
+        return defaultTableSize;
+    }
+
+    if (!sizeProperty->value->is<IR::ExpressionValue>()) {
+        ::error("Expected an expression for table size property: %1%", sizeProperty);
+        return defaultTableSize;
+    }
+
+    auto expression = sizeProperty->value->to<IR::ExpressionValue>()->expression;
+    if (!expression->is<IR::Constant>()) {
+        ::error("Expected a constant for table size property: %1%", sizeProperty);
+        return defaultTableSize;
+    }
+
+    const int64_t tableSize = expression->to<IR::Constant>()->asInt();
+    return tableSize == 0 ? defaultTableSize : tableSize;
+}
+
+}  // namespace Helpers
+
+}  // namespace ControlPlaneAPI
+
+/** @} */  /* end group control_plane */
+}  // namespace P4

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -1,0 +1,384 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef CONTROL_PLANE_P4RUNTIMEARCHHANDLER_H_
+#define CONTROL_PLANE_P4RUNTIMEARCHHANDLER_H_
+
+#include <boost/optional.hpp>
+
+#include <set>
+
+#include "p4/config/v1/p4info.pb.h"
+
+#include "frontends/p4/externInstance.h"
+#include "frontends/p4/methodInstance.h"
+#include "ir/ir.h"
+#include "lib/ordered_set.h"
+
+namespace P4 {
+
+/** \addtogroup control_plane
+ *  @{
+ */
+namespace ControlPlaneAPI {
+
+using p4rt_id_t = uint32_t;
+
+/// Base class for the different types introduced by the P4 architecture. The
+/// class includes static factory methods for all the built-in P4 types common
+/// to all architectures. When defining the P4Info serialization logic for a new
+/// architecture, the first step is to inherit from this class and add factory
+/// methods for architecture-specific types. The class is used to separate all
+/// symbols by type in the symbol table which is responsible for control-plane
+/// id assignment.
+class P4RuntimeSymbolType {
+ public:
+    virtual ~P4RuntimeSymbolType() { }
+
+    /// An explicit conversion operator that is useful when building the P4Info
+    /// message. It returns the id prefix for that type, as defined in the
+    /// p4info.proto file.
+    explicit operator p4rt_id_t() const { return id; }
+
+    static P4RuntimeSymbolType ACTION() {
+        return P4RuntimeSymbolType(::p4::config::v1::P4Ids::ACTION);
+    }
+    static P4RuntimeSymbolType TABLE() {
+        return P4RuntimeSymbolType(::p4::config::v1::P4Ids::TABLE);
+    }
+    static P4RuntimeSymbolType VALUE_SET() {
+        return P4RuntimeSymbolType(::p4::config::v1::P4Ids::VALUE_SET);
+    }
+    static P4RuntimeSymbolType CONTROLLER_HEADER() {
+        return P4RuntimeSymbolType(::p4::config::v1::P4Ids::CONTROLLER_HEADER);
+    }
+
+    bool operator==(const P4RuntimeSymbolType& other) const {
+        return id == other.id;
+    }
+
+    bool operator!=(const P4RuntimeSymbolType& other) const {
+        return !(*this == other);
+    }
+
+    bool operator<(const P4RuntimeSymbolType& other) const {
+        return id < other.id;
+    }
+
+ protected:
+    static P4RuntimeSymbolType make(p4rt_id_t id) {
+        return P4RuntimeSymbolType(id);
+    }
+
+ private:
+    // even if the constructor is protected, the static functions in the derived
+    // classes cannot access it, which is why we use the make factory function
+    constexpr P4RuntimeSymbolType(p4rt_id_t id) noexcept
+        : id(id) { }
+
+    /// The 8-bit id prefix for that type, as per the p4info.proto file.
+    p4rt_id_t id;
+};
+
+/// A table which tracks the symbols which are visible to P4Runtime and their
+/// ids.
+class P4RuntimeSymbolTableIface {
+ public:
+    virtual ~P4RuntimeSymbolTableIface() { }
+    /// Add a @type symbol, extracting the name and id from @declaration.
+    virtual void add(P4RuntimeSymbolType type, const IR::IDeclaration* declaration) = 0;
+    /// Add a @type symbol with @name and possibly an explicit P4 '@id'.
+    virtual void add(P4RuntimeSymbolType type, cstring name,
+                     boost::optional<p4rt_id_t> id = boost::none) = 0;
+    /// @return the P4Runtime id for the symbol of @type corresponding to
+    /// @declaration.
+    virtual p4rt_id_t getId(P4RuntimeSymbolType type,
+                            const IR::IDeclaration* declaration) const = 0;
+    /// @return the P4Runtime id for the symbol of @type with name @name.
+    virtual p4rt_id_t getId(P4RuntimeSymbolType type, cstring name) const = 0;
+    /// @return the alias for the given fully qualified external name. P4Runtime
+    /// defines an alias for each object to make referring to objects easier.
+    /// By default, the alias is the shortest unique suffix of path components
+    /// in the name.
+    virtual cstring getAlias(cstring name) const = 0;
+};
+
+/// The interface for defining the P4Info serialization logic for a specific P4
+/// architecture. The goal is to reduce code duplication between
+/// architectures. The @ref P4RuntimeSerializer will call these methods when
+/// generating the P4Info message to handle architecture-specific parts. @ref
+/// P4RuntimeSerializer generates the P4Info in two passes: first it collects
+/// all the control-plane visible symbols from the program into the symbol
+/// table, then it builds the P4Info message by adding each collected entity to
+/// the Protobuf message. The collect* methods are called in the first pass, the
+/// add* methods are called in the second pass.
+class P4RuntimeArchHandlerIface {
+ public:
+    virtual ~P4RuntimeArchHandlerIface() { }
+    /// Collects architecture-specific properties for @tableBlock in @symbols
+    /// table.
+    virtual void collectTableProperties(P4RuntimeSymbolTableIface* symbols,
+                                        const IR::TableBlock* tableBlock) = 0;
+    /// Collects architecture-specific @externBlock instance in @symbols table.
+    virtual void collectExternInstance(P4RuntimeSymbolTableIface* symbols,
+                                       const IR::ExternBlock* externBlock) = 0;
+    /// Collects extern method call @externFunction in @symbols table in case it
+    /// needs to be exposed to the control-plane (e.g. digest call for v1model).
+    virtual void collectExternFunction(P4RuntimeSymbolTableIface* symbols,
+                                       const P4::ExternFunction* externFunction) = 0;
+    /// This method is called between the two passes (collect and add) in case
+    /// the architecture requires some logic to be performed then.
+    virtual void postCollect(const P4RuntimeSymbolTableIface& symbols) = 0;
+    /// Adds architecture-specific properties for @tableBlock to the @table
+    /// Protobuf message.
+    virtual void addTableProperties(const P4RuntimeSymbolTableIface& symbols,
+                                    ::p4::config::v1::P4Info* p4info,
+                                    ::p4::config::v1::Table* table,
+                                    const IR::TableBlock* tableBlock) = 0;
+    /// Adds relevant information about @externBlock instance to the @p4info
+    /// message.
+    virtual void addExternInstance(const P4RuntimeSymbolTableIface& symbols,
+                                   ::p4::config::v1::P4Info* p4info,
+                                   const IR::ExternBlock* externBlock) = 0;
+    /// Adds relevant information about @externFunction method call - if it
+    /// needs to be exposed to the control-plane - to @p4info message.
+    virtual void addExternFunction(const P4RuntimeSymbolTableIface& symbols,
+                                   ::p4::config::v1::P4Info* p4info,
+                                   const P4::ExternFunction* externFunction) = 0;
+};
+
+/// A functor interface that needs to be implemented for each
+/// architecture-specific handler in charge of generating the appropriate P4Info
+/// message.
+struct P4RuntimeArchHandlerBuilderIface {
+    virtual ~P4RuntimeArchHandlerBuilderIface() { }
+
+    /// Called by the @ref P4RuntimeSerializer to build an instance of the
+    /// appropriate @ref P4RuntimeArchHandlerIface implementation for the
+    /// architecture, with the appropriate @refMap, @typeMap and
+    /// @evaluatedProgram.
+    virtual P4RuntimeArchHandlerIface* operator()(
+        ReferenceMap* refMap,
+        TypeMap* typeMap,
+        const IR::ToplevelBlock* evaluatedProgram) const = 0;
+};
+
+/// A collection of helper functions which can be used to implement @ref
+/// P4RuntimeArchHandlerIface for different architectures.
+namespace Helpers {
+
+/// @return an extern instance defined or referenced by the value of @table's
+/// @propertyName property, or boost::none if no extern was referenced.
+boost::optional<ExternInstance>
+getExternInstanceFromProperty(const IR::P4Table* table,
+                              const cstring& propertyName,
+                              ReferenceMap* refMap,
+                              TypeMap* typeMap,
+                              bool *isConstructedInPlace = nullptr);
+
+/// @return true if the extern instance assigned to property @propertyName for
+/// the @table was constructed in-place or outside of teh @table declaration.
+bool isExternPropertyConstructedInPlace(const IR::P4Table* table,
+                                        const cstring& propertyName);
+
+/// Visit evaluated blocks under the provided top-level block. Guarantees that
+/// each block is visited only once, even if multiple paths to reach it exist.
+template <typename Func>
+void forAllEvaluatedBlocks(const IR::ToplevelBlock* aToplevelBlock, Func function) {
+    std::set<const IR::Block*> visited;
+    ordered_set<const IR::Block*> frontier{aToplevelBlock};
+
+    while (!frontier.empty()) {
+        // Pop a block off the frontier of blocks we haven't yet visited.
+        auto evaluatedBlock = *frontier.begin();
+        frontier.erase(frontier.begin());
+        visited.insert(evaluatedBlock);
+
+        function(evaluatedBlock);
+
+        // Add child blocks to the frontier if we haven't already visited them.
+        for (auto evaluatedChild : evaluatedBlock->constantValue) {
+            // child block may be nullptr due to optional argument.
+            if (!evaluatedChild.second) continue;
+            if (!evaluatedChild.second->is<IR::Block>()) continue;
+            auto evaluatedChildBlock = evaluatedChild.second->to<IR::Block>();
+            if (visited.find(evaluatedChildBlock) != visited.end()) continue;
+            frontier.insert(evaluatedChildBlock);
+        }
+    }
+}
+
+/// Serialize @annotated's P4 annotations and attach them to a P4Info message
+/// with an 'annotations' field. '@name' and '@id' are ignored, as well as
+/// annotations whose name satisfies predicate @p.
+template <typename Message, typename UnaryPredicate>
+void addAnnotations(Message* message, const IR::IAnnotated* annotated, UnaryPredicate p) {
+    CHECK_NULL(message);
+
+    // Synthesized resources may have no annotations.
+    if (annotated == nullptr) return;
+
+    for (const IR::Annotation* annotation : annotated->getAnnotations()->annotations) {
+        // Don't output the @name or @id annotations; they're represented
+        // elsewhere in P4Info messages.
+        if (annotation->name == IR::Annotation::nameAnnotation) continue;
+        if (annotation->name == "id") continue;
+        if (p(annotation->name)) continue;
+
+        // Serialize the annotation.
+        // XXX(unknown): Might be nice to do something better than rely on
+        // toString().
+        std::string serializedAnnotation = "@" + annotation->name + "(";
+        auto expressions = annotation->expr;
+        for (unsigned i = 0; i < expressions.size(); ++i) {
+            serializedAnnotation.append(expressions[i]->toString());
+            if (i + 1 < expressions.size()) serializedAnnotation.append(", ");
+        }
+        serializedAnnotation.append(")");
+
+        message->add_annotations(serializedAnnotation);
+    }
+}
+
+/// calls addAnnotations with a unconditionally false predicate.
+template <typename Message>
+void addAnnotations(Message* message, const IR::IAnnotated* annotated) {
+    addAnnotations(message, annotated, [](cstring){ return false; });
+}
+
+/// @return @table's size property if available, falling back to the
+/// architecture's default size.
+int64_t getTableSize(const IR::P4Table* table);
+
+/// A traits class describing the properties of "counterlike" things.
+template <typename Kind> struct CounterlikeTraits;
+
+/// The information about a counter or meter instance which is necessary to
+/// serialize it. @Kind must be a class with a CounterlikeTraits<>
+/// specialization. This can be useful for different architectures as many
+/// define extern types for counter / meter. The architecture-specific code must
+/// specialize CounterlikeTraits<> appropriately.
+template <typename Kind>
+struct Counterlike {
+    /// The name of the instance.
+    const cstring name;
+    /// If non-null, the instance's annotations.
+    const IR::IAnnotated* annotations;
+    /// The units parameter to the instance; valid values vary depending on @Kind.
+    const cstring unit;
+    /// The size parameter to the instance.
+    const int64_t size;
+    /// If not none, the instance is a direct resource associated with @table.
+    const boost::optional<cstring> table;
+
+    /// @return the information required to serialize an explicit @instance of
+    /// @Kind, which is defined inside a control block.
+    static boost::optional<Counterlike<Kind>>
+    from(const IR::ExternBlock* instance) {
+        CHECK_NULL(instance);
+        auto declaration = instance->node->to<IR::IDeclaration>();
+
+        // Counter and meter externs refer to their unit as a "type"; this is
+        // (confusingly) unrelated to the "type" field of a counter or meter in
+        // P4Info.
+        auto unit = instance->getParameterValue("type");
+        if (!unit->is<IR::Declaration_ID>()) {
+            ::error("%1% '%2%' has a unit type which is not an enum constant: %3%",
+                    CounterlikeTraits<Kind>::name(), declaration, unit);
+            return boost::none;
+        }
+
+        auto size = instance->getParameterValue("size")->to<IR::Constant>();
+        if (!size->is<IR::Constant>()) {
+            ::error("%1% '%2%' has a non-constant size: %3%",
+                    CounterlikeTraits<Kind>::name(), declaration, size);
+            return boost::none;
+        }
+
+        return Counterlike<Kind>{declaration->controlPlaneName(),
+                                 declaration->to<IR::IAnnotated>(),
+                                 unit->to<IR::Declaration_ID>()->name,
+                                 size->to<IR::Constant>()->value.get_si(),
+                                 boost::none};
+    }
+
+    /// @return the information required to serialize an @instance of @Kind which
+    /// is either defined in or referenced by a property value of @table. (This
+    /// implies that @instance is a direct resource of @table.)
+    static boost::optional<Counterlike<Kind>>
+    fromDirect(const ExternInstance& instance, const IR::P4Table* table) {
+        CHECK_NULL(table);
+        BUG_CHECK(instance.name != boost::none,
+                  "Caller should've ensured we have a name");
+
+        if (instance.type->name != CounterlikeTraits<Kind>::directTypeName()) {
+            ::error("Expected a direct %1%: %2%", CounterlikeTraits<Kind>::name(),
+                    instance.expression);
+            return boost::none;
+        }
+
+        auto unitArgument = instance.arguments->at(0)->expression;
+        if (unitArgument == nullptr) {
+            ::error("Direct %1% instance %2% should take a constructor argument",
+                    CounterlikeTraits<Kind>::name(), instance.expression);
+            return boost::none;
+        }
+        if (!unitArgument->is<IR::Member>()) {
+            ::error("Direct %1% instance %2% has an unexpected constructor argument",
+                    CounterlikeTraits<Kind>::name(), instance.expression);
+            return boost::none;
+        }
+
+        auto unit = unitArgument->to<IR::Member>()->member.name;
+        return Counterlike<Kind>{*instance.name, instance.annotations,
+                                 unit, Helpers::getTableSize(table),
+                                 table->controlPlaneName()};
+    }
+};
+
+/// @return the direct counter associated with @table, if it has one, or
+/// boost::none otherwise.
+template <typename Kind>
+boost::optional<Counterlike<Kind>>
+getDirectCounterlike(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMap) {
+    auto propertyName = CounterlikeTraits<Kind>::directPropertyName();
+    auto instance =
+      getExternInstanceFromProperty(table, propertyName, refMap, typeMap);
+    if (!instance) return boost::none;
+    return Counterlike<Kind>::fromDirect(*instance, table);
+}
+
+}  // namespace Helpers
+
+/// Declarations specific to standard architectures (v1model & PSA).
+namespace Standard {
+
+/// The architecture handler builder implementation for v1model.
+struct V1ModelArchHandlerBuilder : public P4RuntimeArchHandlerBuilderIface {
+    P4RuntimeArchHandlerIface* operator()(
+        ReferenceMap* refMap,
+        TypeMap* typeMap,
+        const IR::ToplevelBlock* evaluatedProgram) const override;
+};
+
+}  // namespace Standard
+
+}  // namespace ControlPlaneAPI
+
+/** @} */  /* end group control_plane */
+}  // namespace P4
+
+#endif  /* CONTROL_PLANE_P4RUNTIMEARCHHANDLER_H_ */

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -1,0 +1,715 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <set>
+#include <unordered_map>
+
+#include <boost/optional.hpp>
+
+#include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/p4/fromv1.0/v1model.h"
+#include "frontends/p4/typeMap.h"
+#include "ir/ir.h"
+#include "lib/log.h"
+#include "typeSpecConverter.h"
+
+#include "p4RuntimeArchHandler.h"
+
+using ::P4::ControlPlaneAPI::Helpers::getExternInstanceFromProperty;
+using ::P4::ControlPlaneAPI::Helpers::addAnnotations;
+
+namespace p4configv1 = ::p4::config::v1;
+
+namespace P4 {
+
+/** \addtogroup control_plane
+ *  @{
+ */
+namespace ControlPlaneAPI {
+
+namespace Standard {
+
+/// v1model counter extern type
+struct CounterExtern { };
+/// v1model meter extern type
+struct MeterExtern { };
+
+}  // namespace Standard
+
+namespace Helpers {
+
+// According to the C++11 standard: An explicit specialization shall be declared
+// in a namespace enclosing the specialized template. An explicit specialization
+// whose declarator-id is not qualified shall be declared in the nearest
+// enclosing namespace of the template, or, if the namespace is inline (7.3.1),
+// any namespace from its enclosing namespace set. Such a declaration may also
+// be a definition. If the declaration is not a definition, the specialization
+// may be defined later (7.3.1.2).
+//
+// gcc reports an error when trying so specialize CounterlikeTraits<> for
+// Standard::CounterExtern & Standard::MeterExtern outside of the Helpers
+// namespace, even when qualifying CounterlikeTraits<> with Helpers::. It seems
+// to be related to thsi bug:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480.
+
+/// @ref CounterlikeTraits<> specialization for @ref CounterExtern
+template<> struct CounterlikeTraits<Standard::CounterExtern> {
+    static const cstring name() { return "counter"; }
+    static const cstring directPropertyName() {
+        return P4V1::V1Model::instance.tableAttributes.counters.name;
+    }
+    static const cstring typeName() {
+        return P4V1::V1Model::instance.counter.name;
+    }
+    static const cstring directTypeName() {
+        return P4V1::V1Model::instance.directCounter.name;
+    }
+};
+
+/// @ref CounterlikeTraits<> specialization for @ref MeterExtern
+template<> struct CounterlikeTraits<Standard::MeterExtern> {
+    static const cstring name() { return "meter"; }
+    static const cstring directPropertyName() {
+        return P4V1::V1Model::instance.tableAttributes.meters.name;
+    }
+    static const cstring typeName() {
+        return P4V1::V1Model::instance.meter.name;
+    }
+    static const cstring directTypeName() {
+        return P4V1::V1Model::instance.directMeter.name;
+    }
+};
+
+}  // namespace Helpers
+
+namespace Standard {
+
+/// Extends @ref P4RuntimeSymbolType for the standard (v1model & PSA) extern
+/// types.
+class SymbolType : public P4RuntimeSymbolType {
+ public:
+    SymbolType() = delete;
+
+    static P4RuntimeSymbolType ACTION_PROFILE() {
+        return P4RuntimeSymbolType::make(p4configv1::P4Ids::ACTION_PROFILE);
+    }
+    static P4RuntimeSymbolType COUNTER() {
+        return P4RuntimeSymbolType::make(p4configv1::P4Ids::COUNTER);
+    }
+    static P4RuntimeSymbolType DIGEST() {
+        return P4RuntimeSymbolType::make(p4configv1::P4Ids::DIGEST);
+    }
+    static P4RuntimeSymbolType DIRECT_COUNTER() {
+        return P4RuntimeSymbolType::make(p4configv1::P4Ids::DIRECT_COUNTER);
+    }
+    static P4RuntimeSymbolType DIRECT_METER() {
+        return P4RuntimeSymbolType::make(p4configv1::P4Ids::DIRECT_METER);
+    }
+    static P4RuntimeSymbolType METER() {
+        return P4RuntimeSymbolType::make(p4configv1::P4Ids::METER);
+    }
+    static P4RuntimeSymbolType REGISTER() {
+        return P4RuntimeSymbolType::make(p4configv1::P4Ids::REGISTER);
+    }
+};
+
+/// The information about a digest call which is needed to serialize it.
+struct Digest {
+    const cstring name;       // The fully qualified external name of the digest
+                              // *data* - in P4-14, the field list name, or in
+                              // P4-16, the type of the 'data' parameter.
+    const p4configv1::P4DataTypeSpec* typeSpec;  // The format of the packed data.
+};
+
+struct Register {
+    const cstring name;  // The fully qualified external name of this register.
+    const IR::IAnnotated* annotations;  // If non-null, any annotations applied
+                                        // to this field.
+    const int64_t size;
+    const p4configv1::P4DataTypeSpec* typeSpec;  // The format of the stored data.
+
+    /// @return the information required to serialize an @instance of register
+    /// or boost::none in case of error.
+    static boost::optional<Register>
+    from(const IR::ExternBlock* instance,
+         const ReferenceMap* refMap,
+         const TypeMap* typeMap,
+         p4configv1::P4TypeInfo* p4RtTypeInfo) {
+        CHECK_NULL(instance);
+        auto declaration = instance->node->to<IR::Declaration_Instance>();
+
+        auto size = instance->getParameterValue("size")->to<IR::Constant>();
+        if (!size->is<IR::Constant>()) {
+            ::error("Register '%1%' has a non-constant size: %2%", declaration, size);
+            return boost::none;
+        }
+        if (!size->to<IR::Constant>()->fitsInt()) {
+            ::error("Register '%1%' has a size that doesn't fit in an integer: %2%",
+                    declaration, size);
+            return boost::none;
+        }
+
+        // retrieve type parameter for the register instance and convert it to P4DataTypeSpec
+        BUG_CHECK(declaration->type->is<IR::Type_Specialized>(),
+                  "%1%: expected Type_Specialized", declaration->type);
+        auto type = declaration->type->to<IR::Type_Specialized>();
+        BUG_CHECK(type->arguments->size() == 1,
+                  "%1%: expected one type argument", instance);
+        auto typeArg = type->arguments->at(0);
+        auto typeSpec = TypeSpecConverter::convert(typeMap, refMap, typeArg, p4RtTypeInfo);
+        CHECK_NULL(typeSpec);
+
+        return Register{declaration->controlPlaneName(),
+                        declaration->to<IR::IAnnotated>(),
+                        size->value.get_si(),
+                        typeSpec};
+    }
+};
+
+/// The types of action profiles available in v1model & PSA.
+enum class ActionProfileType {
+    INDIRECT,
+    INDIRECT_WITH_SELECTOR
+};
+
+/// The information about an action profile which is necessary to generate its
+/// serialized representation.
+struct ActionProfile {
+    const cstring name;  // The fully qualified external name of this action profile.
+    const ActionProfileType type;
+    const int64_t size;
+    const IR::IAnnotated* annotations;  // If non-null, any annotations applied to this action
+                                        // profile declaration.
+
+    bool operator<(const ActionProfile& other) const {
+        if (name != other.name) return name < other.name;
+        if (type != other.type) return type < other.type;
+        return size < other.size;
+    }
+};
+
+/// Implements @ref P4RuntimeArchHandlerIface for the v1model architecture. The
+/// overridden metods will be called by the @P4RuntimeSerializer to collect and
+/// serialize v1model-specific symbols which are exposed to the control-plane.
+class P4RuntimeArchHandlerV1Model final : public P4RuntimeArchHandlerIface {
+ public:
+    using Counter = p4configv1::Counter;
+    using Meter = p4configv1::Meter;
+    using CounterSpec = p4configv1::CounterSpec;
+    using MeterSpec = p4configv1::MeterSpec;
+
+    P4RuntimeArchHandlerV1Model(ReferenceMap* refMap,
+                                TypeMap* typeMap,
+                                const IR::ToplevelBlock* evaluatedProgram)
+        : refMap(refMap), typeMap(typeMap), evaluatedProgram(evaluatedProgram) { }
+
+    void collectTableProperties(P4RuntimeSymbolTableIface* symbols,
+                                const IR::TableBlock* tableBlock) override {
+        CHECK_NULL(tableBlock);
+        auto table = tableBlock->container;
+        bool isConstructedInPlace = false;
+
+        {
+            auto instance = getExternInstanceFromProperty(
+                table,
+                P4V1::V1Model::instance.tableAttributes.tableImplementation.name,
+                refMap,
+                typeMap,
+                &isConstructedInPlace);
+            if (instance != boost::none) {
+                if (instance->type->name != P4V1::V1Model::instance.action_profile.name &&
+                    instance->type->name != P4V1::V1Model::instance.action_selector.name) {
+                    ::error("Expected an action profile or action selector: %1%",
+                            instance->expression);
+                } else if (isConstructedInPlace) {
+                    symbols->add(SymbolType::ACTION_PROFILE(), *instance->name);
+                }
+            }
+        }
+        {
+            auto instance = getExternInstanceFromProperty(
+                table,
+                P4V1::V1Model::instance.tableAttributes.counters.name,
+                refMap,
+                typeMap,
+                &isConstructedInPlace);
+            if (instance != boost::none) {
+                if (instance->type->name != P4V1::V1Model::instance.directCounter.name) {
+                    ::error("Expected a direct counter: %1%", instance->expression);
+                } else if (isConstructedInPlace) {
+                    symbols->add(SymbolType::DIRECT_COUNTER(), *instance->name);
+                }
+            }
+        }
+        {
+            auto instance = getExternInstanceFromProperty(
+                table,
+                P4V1::V1Model::instance.tableAttributes.meters.name,
+                refMap,
+                typeMap,
+                &isConstructedInPlace);
+            if (instance != boost::none) {
+                if (instance->type->name != P4V1::V1Model::instance.directMeter.name) {
+                    ::error("Expected a direct meter: %1%", instance->expression);
+                } else if (isConstructedInPlace) {
+                    symbols->add(SymbolType::DIRECT_METER(), *instance->name);
+                }
+            }
+        }
+    }
+
+    void collectExternInstance(P4RuntimeSymbolTableIface* symbols,
+                               const IR::ExternBlock* externBlock) override {
+        CHECK_NULL(externBlock);
+
+        auto decl = externBlock->node->to<IR::IDeclaration>();
+        if (decl == nullptr) return;
+
+        if (externBlock->type->name == P4V1::V1Model::instance.counter.name) {
+            symbols->add(SymbolType::COUNTER(), decl);
+        } else if (externBlock->type->name == P4V1::V1Model::instance.directCounter.name) {
+            symbols->add(SymbolType::DIRECT_COUNTER(), decl);
+        } else if (externBlock->type->name == P4V1::V1Model::instance.meter.name) {
+            symbols->add(SymbolType::METER(), decl);
+        } else if (externBlock->type->name == P4V1::V1Model::instance.directMeter.name) {
+            symbols->add(SymbolType::DIRECT_METER(), decl);
+        } else if (externBlock->type->name == P4V1::V1Model::instance.action_profile.name ||
+                   externBlock->type->name == P4V1::V1Model::instance.action_selector.name) {
+            symbols->add(SymbolType::ACTION_PROFILE(), decl);
+        } else if (externBlock->type->name == P4V1::V1Model::instance.registers.name) {
+            symbols->add(SymbolType::REGISTER(), decl);
+        }
+    }
+
+    void collectExternFunction(P4RuntimeSymbolTableIface* symbols,
+                               const P4::ExternFunction* externFunction) override {
+        auto digest = getDigestCall(externFunction, refMap, typeMap, nullptr);
+        if (digest) symbols->add(SymbolType::DIGEST(), digest->name);
+    }
+
+    void postCollect(const P4RuntimeSymbolTableIface& symbols) override {
+        (void)symbols;
+        // analyze action profiles and build a mapping from action profile name
+        // to the set of tables referencing them
+        Helpers::forAllEvaluatedBlocks(evaluatedProgram, [&](const IR::Block* block) {
+            if (!block->is<IR::TableBlock>()) return;
+            auto table = block->to<IR::TableBlock>()->container;
+            auto implementation = getTableImplementationName(table, refMap);
+            if (implementation)
+                actionProfilesRefs[*implementation].insert(table->controlPlaneName());
+        });
+    }
+
+    void addTableProperties(const P4RuntimeSymbolTableIface& symbols,
+                            p4configv1::P4Info* p4info,
+                            p4configv1::Table* table,
+                            const IR::TableBlock* tableBlock) override {
+        CHECK_NULL(tableBlock);
+        auto tableDeclaration = tableBlock->container;
+
+        using Helpers::isExternPropertyConstructedInPlace;
+
+        auto implementation = getActionProfile(tableDeclaration, refMap, typeMap);
+        auto directCounter = Helpers::getDirectCounterlike<CounterExtern>(
+            tableDeclaration, refMap, typeMap);
+        auto directMeter = Helpers::getDirectCounterlike<MeterExtern>(
+            tableDeclaration, refMap, typeMap);
+        bool supportsTimeout = getSupportsTimeout(tableDeclaration);
+
+        if (implementation) {
+            auto id = symbols.getId(SymbolType::ACTION_PROFILE(),
+                                    implementation->name);
+            table->set_implementation_id(id);
+            auto propertyName = P4V1::V1Model::instance.tableAttributes.tableImplementation.name;
+            if (isExternPropertyConstructedInPlace(tableDeclaration, propertyName))
+                addActionProfile(symbols, p4info, *implementation);
+        }
+
+        if (directCounter) {
+            auto id = symbols.getId(SymbolType::DIRECT_COUNTER(),
+                                    directCounter->name);
+            table->add_direct_resource_ids(id);
+            // no risk to add twice because direct counters cannot be shared
+            // auto propertyName = P4V1::V1Model::instance.tableAttributes.counters.name;
+            // if (isExternPropertyConstructedInPlace(tableDeclaration, propertyName))
+            //     addCounter(symbols, p4info, *directCounter);
+            addCounter(symbols, p4info, *directCounter);
+        }
+
+        if (directMeter) {
+            auto id = symbols.getId(SymbolType::DIRECT_METER(),
+                                    directMeter->name);
+            table->add_direct_resource_ids(id);
+            // no risk to add twice because direct meters cannot be shared
+            // auto propertyName = P4V1::V1Model::instance.tableAttributes.meters.name;
+            // if (isExternPropertyConstructedInPlace(tableDeclaration, propertyName))
+            //     addMeter(symbols, p4info, *directMeter);
+            addMeter(symbols, p4info, *directMeter);
+        }
+
+        if (supportsTimeout) {
+            table->set_idle_timeout_behavior(p4configv1::Table::NOTIFY_CONTROL);
+        } else {
+            table->set_idle_timeout_behavior(p4configv1::Table::NO_TIMEOUT);
+        }
+    }
+
+    void addExternInstance(const P4RuntimeSymbolTableIface& symbols,
+                           p4configv1::P4Info* p4info,
+                           const IR::ExternBlock* externBlock) override {
+        auto decl = externBlock->node->to<IR::Declaration_Instance>();
+        if (decl == nullptr) return;
+
+        auto p4RtTypeInfo = p4info->mutable_type_info();
+        if (externBlock->type->name == Helpers::CounterlikeTraits<CounterExtern>::typeName()) {
+            auto counter = Helpers::Counterlike<CounterExtern>::from(externBlock);
+            if (counter) addCounter(symbols, p4info, *counter);
+        } else if (externBlock->type->name == Helpers::CounterlikeTraits<MeterExtern>::typeName()) {
+            auto meter = Helpers::Counterlike<MeterExtern>::from(externBlock);
+            if (meter) addMeter(symbols, p4info, *meter);
+        } else if (externBlock->type->name == P4V1::V1Model::instance.registers.name) {
+            auto register_ = Register::from(externBlock, refMap, typeMap, p4RtTypeInfo);
+            if (register_) addRegister(symbols, p4info, *register_);
+        } else if (externBlock->type->name == P4V1::V1Model::instance.action_profile.name ||
+                   externBlock->type->name == P4V1::V1Model::instance.action_selector.name) {
+            auto actionProfile = getActionProfile(decl, externBlock->type);
+            if (actionProfile) addActionProfile(symbols, p4info, *actionProfile);
+        }
+    }
+
+    void addExternFunction(const P4RuntimeSymbolTableIface& symbols,
+                           p4configv1::P4Info* p4info,
+                           const P4::ExternFunction* externFunction) override {
+        auto p4RtTypeInfo = p4info->mutable_type_info();
+        auto digest = getDigestCall(externFunction, refMap, typeMap, p4RtTypeInfo);
+        if (digest) addDigest(symbols, p4info, *digest);
+    }
+
+    /// @return serialization information for the digest() call represented by
+    /// @call, or boost::none if @call is not a digest() call or is invalid.
+    static boost::optional<Digest>
+    getDigestCall(const P4::ExternFunction* function,
+                  ReferenceMap* refMap,
+                  TypeMap* typeMap,
+                  p4configv1::P4TypeInfo* p4RtTypeInfo) {
+        if (function->method->name != P4V1::V1Model::instance.digest_receiver.name)
+            return boost::none;
+
+        auto call = function->expr;
+        BUG_CHECK(call->typeArguments->size() == 1,
+                  "%1%: Expected one type argument", call);
+        BUG_CHECK(call->arguments->size() == 2, "%1%: Expected 2 arguments", call);
+
+        // An invocation of digest() looks like this:
+        //   digest<T>(receiver, { fields });
+        // The name that shows up in the control plane API is the type name T. If T
+        // doesn't have a name (e.g. tuple), we auto-generate one; ideally we would
+        // be able to annotate the digest method call with a @name annotation in the
+        // P4 but annotations are not supported on expressions.
+        cstring controlPlaneName;
+        auto* typeArg = call->typeArguments->at(0);
+        if (typeArg->is<IR::Type_StructLike>()) {
+            auto structType = typeArg->to<IR::Type_StructLike>();
+            controlPlaneName = structType->controlPlaneName();
+        } else if (auto* typeName = typeArg->to<IR::Type_Name>()) {
+            auto* referencedType = refMap->getDeclaration(typeName->path, true);
+            CHECK_NULL(referencedType);
+            controlPlaneName = referencedType->controlPlaneName();
+        } else {
+            static std::unordered_map<const IR::MethodCallExpression*, cstring> autoNames;
+            auto it = autoNames.find(call);
+            if (it == autoNames.end()) {
+              controlPlaneName = "digest_" + cstring::to_cstring(autoNames.size());
+              ::warning("Cannot find a good name for %1% method call, using "
+                        "auto-generated name '%2%'", call, controlPlaneName);
+              autoNames.emplace(call, controlPlaneName);
+            } else {
+              controlPlaneName = it->second;
+            }
+        }
+
+        // Convert the generic type for the digest method call to a P4DataTypeSpec
+        auto* typeSpec = TypeSpecConverter::convert(typeMap, refMap, typeArg, p4RtTypeInfo);
+        BUG_CHECK(typeSpec != nullptr, "P4 type %1% could not be converted to P4Info P4DataTypeSpec");
+        return Digest{controlPlaneName, typeSpec};
+    }
+
+    void addDigest(const P4RuntimeSymbolTableIface& symbols,
+                   p4configv1::P4Info* p4Info,
+                   const Digest& digest) {
+        // Each call to digest() creates a new digest entry in the P4Info.
+        // Right now we only take the type of data included in the digest
+        // (encoded in its name) into account, but it may be that we should also
+        // consider the receiver.
+        auto id = symbols.getId(SymbolType::DIGEST(), digest.name);
+        if (serializedInstances.find(id) != serializedInstances.end()) return;
+        serializedInstances.insert(id);
+
+        auto* digestInstance = p4Info->add_digests();
+        digestInstance->mutable_preamble()->set_id(id);
+        digestInstance->mutable_preamble()->set_name(digest.name);
+        digestInstance->mutable_preamble()->set_alias(symbols.getAlias(digest.name));
+        digestInstance->mutable_type_spec()->CopyFrom(*digest.typeSpec);
+    }
+
+    static boost::optional<ActionProfile>
+    getActionProfile(cstring name,
+                     const IR::Type_Extern* type,
+                     const IR::Vector<IR::Argument>* arguments,
+                     const IR::IAnnotated* annotations) {
+        ActionProfileType actionProfileType;
+        const IR::Expression* sizeExpression;
+        if (type->name == P4V1::V1Model::instance.action_selector.name) {
+            actionProfileType = ActionProfileType::INDIRECT_WITH_SELECTOR;
+            sizeExpression = arguments->at(1)->expression;
+        } else if (type->name == P4V1::V1Model::instance.action_profile.name) {
+            actionProfileType = ActionProfileType::INDIRECT;
+            sizeExpression = arguments->at(0)->expression;
+        } else {
+            return boost::none;
+        }
+
+        if (!sizeExpression->is<IR::Constant>()) {
+            ::error("Action profile '%1%' has non-constant size '%1%'",
+                    name, sizeExpression);
+            return boost::none;
+        }
+
+        const int64_t size = sizeExpression->to<IR::Constant>()->asInt();
+        return ActionProfile{name, actionProfileType, size, annotations};
+    }
+
+    /// @return the action profile referenced in @table's implementation property,
+    /// if it has one, or boost::none otherwise.
+    static boost::optional<ActionProfile>
+    getActionProfile(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMap) {
+        auto propertyName = P4V1::V1Model::instance.tableAttributes.tableImplementation.name;
+        auto instance =
+            getExternInstanceFromProperty(table, propertyName, refMap, typeMap);
+        if (!instance) return boost::none;
+        return getActionProfile(*instance->name, instance->type, instance->arguments,
+                                getTableImplementationAnnotations(table, refMap));
+    }
+
+    /// @return the action profile declared with @decl
+    static boost::optional<ActionProfile>
+    getActionProfile(const IR::Declaration_Instance* decl, const IR::Type_Extern* type) {
+        return getActionProfile(decl->controlPlaneName(), type, decl->arguments,
+                                decl->to<IR::IAnnotated>());
+    }
+
+    /// @return true if @table's 'support_timeout' property exists and is true. This
+    /// indicates that @table supports entry ageing.
+    static bool getSupportsTimeout(const IR::P4Table* table) {
+        auto timeout = table->properties->getProperty(P4V1::V1Model::instance
+                                                      .tableAttributes
+                                                      .supportTimeout.name);
+        if (timeout == nullptr) return false;
+        if (!timeout->value->is<IR::ExpressionValue>()) {
+            ::error("Unexpected value %1% for supports_timeout on table %2%",
+                    timeout, table);
+            return false;
+        }
+
+        auto expr = timeout->value->to<IR::ExpressionValue>()->expression;
+        if (!expr->is<IR::BoolLiteral>()) {
+            ::error("Unexpected non-boolean value %1% for supports_timeout "
+                    "property on table %2%", timeout, table);
+            return false;
+        }
+
+        return expr->to<IR::BoolLiteral>()->value;
+    }
+
+    /// Set common fields between Counter and DirectCounter.
+    template <typename Kind>
+    void setCounterCommon(const P4RuntimeSymbolTableIface& symbols, Kind *counter,
+                          const Helpers::Counterlike<CounterExtern>& counterInstance) {
+        counter->mutable_preamble()->set_name(counterInstance.name);
+        counter->mutable_preamble()->set_alias(symbols.getAlias(counterInstance.name));
+        addAnnotations(counter->mutable_preamble(), counterInstance.annotations);
+        auto counter_spec = counter->mutable_spec();
+
+        if (counterInstance.unit == "packets") {
+            counter_spec->set_unit(CounterSpec::PACKETS);
+        } else if (counterInstance.unit == "bytes") {
+            counter_spec->set_unit(CounterSpec::BYTES);
+        } else if (counterInstance.unit == "packets_and_bytes") {
+            counter_spec->set_unit(CounterSpec::BOTH);
+        } else {
+            counter_spec->set_unit(CounterSpec::UNSPECIFIED);
+        }
+    }
+
+    void addCounter(const P4RuntimeSymbolTableIface& symbols,
+                    p4configv1::P4Info* p4Info,
+                    const Helpers::Counterlike<CounterExtern>& counterInstance) {
+        if (counterInstance.table) {
+            auto counter = p4Info->add_direct_counters();
+            auto id = symbols.getId(SymbolType::DIRECT_COUNTER(),
+                                    counterInstance.name);
+            counter->mutable_preamble()->set_id(id);
+            setCounterCommon(symbols, counter, counterInstance);
+            auto tableId = symbols.getId(P4RuntimeSymbolType::TABLE(), *counterInstance.table);
+            counter->set_direct_table_id(tableId);
+        } else {
+            auto counter = p4Info->add_counters();
+            auto id = symbols.getId(SymbolType::COUNTER(),
+                                    counterInstance.name);
+            counter->mutable_preamble()->set_id(id);
+            setCounterCommon(symbols, counter, counterInstance);
+            counter->set_size(counterInstance.size);
+        }
+    }
+
+    /// Set common fields between Meter and DirectMeter.
+    template <typename Kind>
+    void setMeterCommon(const P4RuntimeSymbolTableIface& symbols, Kind *meter,
+                        const Helpers::Counterlike<MeterExtern>& meterInstance) {
+        meter->mutable_preamble()->set_name(meterInstance.name);
+        meter->mutable_preamble()->set_alias(symbols.getAlias(meterInstance.name));
+        addAnnotations(meter->mutable_preamble(), meterInstance.annotations);
+        auto meter_spec = meter->mutable_spec();
+        meter_spec->set_type(MeterSpec::COLOR_UNAWARE);  // A default; this isn't exposed.
+
+        if (meterInstance.unit == "packets") {
+            meter_spec->set_unit(MeterSpec::PACKETS);
+        } else if (meterInstance.unit == "bytes") {
+            meter_spec->set_unit(MeterSpec::BYTES);
+        } else {
+            meter_spec->set_unit(MeterSpec::UNSPECIFIED);
+        }
+    }
+
+    void addMeter(const P4RuntimeSymbolTableIface& symbols,
+                  p4configv1::P4Info* p4Info,
+                  const Helpers::Counterlike<MeterExtern>& meterInstance) {
+        if (meterInstance.table) {
+            auto meter = p4Info->add_direct_meters();
+            auto id = symbols.getId(SymbolType::DIRECT_METER(),
+                                    meterInstance.name);
+            meter->mutable_preamble()->set_id(id);
+            setMeterCommon(symbols, meter, meterInstance);
+            auto tableId = symbols.getId(P4RuntimeSymbolType::TABLE(), *meterInstance.table);
+            meter->set_direct_table_id(tableId);
+        } else {
+            auto meter = p4Info->add_meters();
+            auto id = symbols.getId(SymbolType::METER(),
+                                    meterInstance.name);
+            meter->mutable_preamble()->set_id(id);
+            setMeterCommon(symbols, meter, meterInstance);
+            meter->set_size(meterInstance.size);
+        }
+    }
+
+    void addRegister(const P4RuntimeSymbolTableIface& symbols,
+                     p4configv1::P4Info* p4Info,
+                     const Register& registerInstance) {
+        auto register_ = p4Info->add_registers();
+        auto id = symbols.getId(SymbolType::REGISTER(),
+                                registerInstance.name);
+        register_->mutable_preamble()->set_id(id);
+        register_->mutable_preamble()->set_name(registerInstance.name);
+        register_->mutable_preamble()->set_alias(symbols.getAlias(registerInstance.name));
+        addAnnotations(register_->mutable_preamble(), registerInstance.annotations);
+        register_->set_size(registerInstance.size);
+        register_->mutable_type_spec()->CopyFrom(*registerInstance.typeSpec);
+    }
+
+    void addActionProfile(const P4RuntimeSymbolTableIface& symbols,
+                          p4configv1::P4Info* p4Info,
+                          const ActionProfile& actionProfile) {
+        auto profile = p4Info->add_action_profiles();
+        auto id = symbols.getId(SymbolType::ACTION_PROFILE(),
+                                actionProfile.name);
+        profile->mutable_preamble()->set_id(id);
+        profile->mutable_preamble()->set_name(actionProfile.name);
+        profile->mutable_preamble()->set_alias(symbols.getAlias(actionProfile.name));
+        profile->set_with_selector(
+            actionProfile.type == ActionProfileType::INDIRECT_WITH_SELECTOR);
+        profile->set_size(actionProfile.size);
+
+        auto tablesIt = actionProfilesRefs.find(actionProfile.name);
+        if (tablesIt != actionProfilesRefs.end()) {
+            for (const auto& table : tablesIt->second)
+                profile->add_table_ids(symbols.getId(P4RuntimeSymbolType::TABLE(), table));
+        }
+
+        addAnnotations(profile->mutable_preamble(), actionProfile.annotations);
+    }
+
+ private:
+    /// @return the table implementation property, or nullptr if the table has no
+    /// such property.
+    static const IR::Property* getTableImplementationProperty(const IR::P4Table* table) {
+        return table->properties->getProperty(
+            P4V1::V1Model::instance.tableAttributes.tableImplementation.name);
+    }
+
+    static const IR::IAnnotated* getTableImplementationAnnotations(
+        const IR::P4Table* table, ReferenceMap* refMap) {
+        auto impl = getTableImplementationProperty(table);
+        if (impl == nullptr) return nullptr;
+        if (!impl->value->is<IR::ExpressionValue>()) return nullptr;
+        auto expr = impl->value->to<IR::ExpressionValue>()->expression;
+        if (expr->is<IR::ConstructorCallExpression>()) return impl->to<IR::IAnnotated>();
+        if (expr->is<IR::PathExpression>()) {
+            auto decl = refMap->getDeclaration(expr->to<IR::PathExpression>()->path, true);
+            return decl->to<IR::IAnnotated>();
+        }
+        return nullptr;
+    }
+
+    static boost::optional<cstring> getTableImplementationName(
+        const IR::P4Table* table, ReferenceMap* refMap) {
+        auto impl = getTableImplementationProperty(table);
+        if (impl == nullptr) return boost::none;
+        if (!impl->value->is<IR::ExpressionValue>()) {
+            ::error("Expected implementation property value for table %1% to be an expression: %2%",
+                    table->controlPlaneName(), impl);
+            return boost::none;
+        }
+        auto expr = impl->value->to<IR::ExpressionValue>()->expression;
+        if (expr->is<IR::ConstructorCallExpression>()) return impl->controlPlaneName();
+        if (expr->is<IR::PathExpression>()) {
+            auto decl = refMap->getDeclaration(expr->to<IR::PathExpression>()->path, true);
+            return decl->controlPlaneName();
+        }
+        return boost::none;
+    }
+
+    ReferenceMap* refMap;
+    TypeMap* typeMap;
+    const IR::ToplevelBlock* evaluatedProgram;
+
+    std::unordered_map<cstring, std::set<cstring> > actionProfilesRefs;
+
+    /// The extern instances we've serialized so far. Used for deduplication.
+    std::set<p4rt_id_t> serializedInstances;
+};
+
+P4RuntimeArchHandlerIface*
+V1ModelArchHandlerBuilder::operator()(
+    ReferenceMap* refMap, TypeMap* typeMap, const IR::ToplevelBlock* evaluatedProgram) const {
+    return new P4RuntimeArchHandlerV1Model(refMap, typeMap, evaluatedProgram);
+}
+
+}  // namespace Standard
+
+}  // namespace ControlPlaneAPI
+
+/** @} */  /* end group control_plane */
+}  // namespace P4


### PR DESCRIPTION
More architectures are being developped and there is a desire to be able
to use P4Runtime with them. P4Runtime supports standard architectures
(v1model & PSA) natively and support architecture-specific extensions
(table properties & externs). In order to enable using P4Runtime with
vendor-specific architectures, we define a framework that can be used to
implement P4Info generation for these architectures more easily. v1model
& PSA also use this framework, but support for these standard
architectures is supported natively by p4c, while vendor-specific
architectures must be supported in the vendor's backend.

The goal of the framework is to reduce code redundancy. A
P4RuntimeArchHandlerIface implementation can be registered for each
architecture. The P4RuntimeSerializer singleton object takes care of all
the common logic, and calls the overridden P4RuntimeArchHandlerIface
when needed for architecture-specific processing.

There are still some minor v1model references in P4RuntimeSerializer
that will be solved in a future commit. These are minor and are
dependent on some fixes in p4info.proto.

P4Info generation for PSA is not supported yet (it will be in a future
commit) but most of the v1model code should be re-usable.