### PR TITLE
fix bmv2 backend names

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -81,22 +81,22 @@ add_library(bmv2backend ${BMV2_BACKEND_COMMON_SRCS})
 add_dependencies(bmv2backend genIR)
 
 build_unified(BMV2_SIMPLE_SWiTCH_SRCS)
-add_executable(p4c-bm-ss ${BMV2_SIMPLE_SWITCH_SRCS})
-target_link_libraries (p4c-bm-ss bmv2backend ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
+add_executable(p4c-bm2-ss ${BMV2_SIMPLE_SWITCH_SRCS})
+target_link_libraries (p4c-bm2-ss bmv2backend ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
 
-install(TARGETS p4c-bm-ss RUNTIME DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})
+install(TARGETS p4c-bm2-ss RUNTIME DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})
 
 build_unified(BMV2_PSA_SWiTCH_SRCS)
-add_executable(p4c-bm-psa ${BMV2_PSA_SWITCH_SRCS})
-target_link_libraries (p4c-bm-psa bmv2backend ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
-install(TARGETS p4c-bm-psa RUNTIME DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})
+add_executable(p4c-bm2-psa ${BMV2_PSA_SWITCH_SRCS})
+target_link_libraries (p4c-bm2-psa bmv2backend ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
+install(TARGETS p4c-bm2-psa RUNTIME DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})
 
 # hack to get around the fact that the test scripts expect the backend
 # binary to be in the top level directory. This should go away when we
 # remove automake and fix the scripts.
 add_custom_target(linkbmv2
-  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/p4c-bm-ss ${P4C_BINARY_DIR}/p4c-bm-ss
-  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/p4c-bm-psa ${P4C_BINARY_DIR}/p4c-bm-psa
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/p4c-bm2-ss ${P4C_BINARY_DIR}/p4c-bm2-ss
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/p4c-bm2-psa ${P4C_BINARY_DIR}/p4c-bm2-psa
   COMMAND ${CMAKE_COMMAND} -E create_symlink ${P4C_BINARY_DIR}/p4include ${CMAKE_CURRENT_BINARY_DIR}/p4include
   COMMAND ${CMAKE_COMMAND} -E create_symlink ${P4C_BINARY_DIR}/p4_14include ${CMAKE_CURRENT_BINARY_DIR}/p4_14include
   )

--- a/backends/bmv2/run-bmv2-test.py
+++ b/backends/bmv2/run-bmv2-test.py
@@ -204,9 +204,9 @@ def process_file(options, argv):
         raise Exception("No such file " + options.p4filename)
 
     if options.usePsa:
-        binary = "./p4c-bm-psa"
+        binary = "./p4c-bm2-psa"
     else:
-        binary = "./p4c-bm-ss"
+        binary = "./p4c-bm2-ss"
 
     args = [binary, "-o", jsonfile] + options.compilerOptions
     if "p4_14" in options.p4filename or "v1_samples" in options.p4filename:


### PR DESCRIPTION
restore original p4c-bm2-ss name.