### PR TITLE
Fix segfault when compiling with O3

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -1836,9 +1836,11 @@ ProgramStructure::convertDirectMeter(const IR::Meter* m, cstring newName) {
     auto kindarg = counterType(m);
     args->push_back(new IR::Argument(kindarg));
     auto annos = addGlobalNameAnnotation(m->name, m->annotations);
-    auto meterPreColor = ExpressionConverter(this).convert(m->pre_color);
-    if (meterPreColor != nullptr)
-        annos = annos->addAnnotation("pre_color", meterPreColor);
+    if (m->pre_color != nullptr) {
+        auto meterPreColor = ExpressionConverter(this).convert(m->pre_color);
+        if (meterPreColor != nullptr)
+            annos = annos->addAnnotation("pre_color", meterPreColor);
+    }
     auto decl = new IR::Declaration_Instance(newName, annos, specType, args, nullptr);
     return decl;
 }


### PR DESCRIPTION
The issue seems to occur when compiling a P4_14 program which has a
direct meter with a pre_color property. It seems to be fixed by only
invoking the ExpressionConverter on pre_color if the field is not null.