### PR TITLE
std::set, std::map, ordered_set now allowed in IR

### DIFF
--- a/ir/json_generator.h
+++ b/ir/json_generator.h
@@ -25,6 +25,8 @@ limitations under the License.
 #include "lib/cstring.h"
 #include "lib/indent.h"
 #include "lib/match.h"
+#include "lib/ordered_map.h"
+#include "lib/ordered_set.h"
 #include "lib/safe_vector.h"
 
 #include "ir.h"
@@ -96,6 +98,52 @@ class JSONGenerator {
         out << "\"value\" : ";
         generate(*v);
         out << std::endl << --indent << "}";
+    }
+
+    template<typename T>
+    void generate(const std::set<T> &v) {
+        out << "[" << std::endl;
+        if (v.size() > 0) {
+            auto it = v.begin();
+            out << ++indent;
+            generate(*it);
+            for (it++; it != v.end(); ++it) {
+                out << "," << std::endl << indent;
+                generate(*it);
+            }
+            out << std::endl << --indent;
+        }
+        out << "]";
+    }
+
+    template<typename T>
+    void generate(const ordered_set<T> &v) {
+        out << "[" << std::endl;
+        if (v.size() > 0) {
+            auto it = v.begin();
+            out << ++indent;
+            generate(*it);
+            for (it++; it != v.end(); ++it) {
+                out << "," << std::endl << indent;
+                generate(*it);
+            }
+            out << std::endl << --indent;
+        }
+        out << "]";
+    }
+
+    template<typename K, typename V>
+    void generate(const std::map<K, V> &v) {
+        out << "[" << std::endl;
+        if (v.size() > 0) {
+            auto it = v.begin();
+            out << ++indent;
+            generate(*it);
+            for (it++; it != v.end(); ++it) {
+                out << "," << std::endl << indent;
+                generate(*it); }
+            out << std::endl << --indent; }
+        out << "]";
     }
 
     template<typename K, typename V>

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -27,6 +27,8 @@ limitations under the License.
 #include "lib/cstring.h"
 #include "lib/indent.h"
 #include "lib/match.h"
+#include "lib/ordered_map.h"
+#include "lib/ordered_set.h"
 #include "lib/safe_vector.h"
 #include "ir.h"
 #include "json_parser.h"
@@ -80,6 +82,24 @@ class JSONLoader {
         for (auto e : *json->to<JsonVector>()) {
             load(e, temp);
             v.push_back(temp);
+        }
+    }
+
+    template<typename T>
+    void unpack_json(std::set<T> &v) {
+        T temp;
+        for (auto e : *json->to<JsonVector>()) {
+            load(e, temp);
+            v.insert(temp);
+        }
+    }
+
+    template<typename T>
+    void unpack_json(ordered_set<T> &v) {
+        T temp;
+        for (auto e : *json->to<JsonVector>()) {
+            load(e, temp);
+            v.insert(temp);
         }
     }
 


### PR DESCRIPTION
A JSON loader/JSON generator template class was required for std::set, std::map, and ordered_set in order to include it as part of the IR.