### PR TITLE
use parent stdout and stderr rather than pipe for subprocesses

### DIFF
--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -206,8 +206,7 @@ class BackendDriver:
 
         args = shlex.split(" ".join(cmd))
         try:
-            p = subprocess.Popen(args, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
+            p = subprocess.Popen(args)
         except:
             import traceback
             print >> sys.stderr, "error invoking {}".format(" ".join(cmd))
@@ -215,9 +214,7 @@ class BackendDriver:
             return 1
 
         if self._verbose: print 'running {}'.format(' '.join(cmd))
-        out, err = p.communicate() # now wait
-        if len(out) > 0: print out
-        if len(err) > 0: print >> sys.stderr, err
+        p.communicate() # now wait
         return p.returncode
 
 


### PR DESCRIPTION
Long running subprocesses with buffered output create the illusion
that nothing works. With this change, subprocesses of the driver will
inherit the stdout and stderr from the parent and display the output
of the child process unbuffered.