### PR TITLE
Minor extension: prevent defined types from disabling table properties

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -160,7 +160,7 @@ typedef const IR::Type ConstType;
 %token<cstring> IDENTIFIER TYPE_IDENTIFIER STRING_LITERAL
 %token<UnparsedConstant>  INTEGER
 
-%type<IR::ID*>              name nonTypeName
+%type<IR::ID*>              name nonTypeName nonTableKwName
 %type<IR::Direction>        direction
 %type<IR::Path*>            prefixedNonTypeName prefixedType
 %type<IR::IndexedVector<IR::Type_Var>*>  typeParameterList
@@ -293,6 +293,14 @@ nonTypeName
 name
     : nonTypeName { $$ = $1; }
     | TYPE_IDENTIFIER  { $$ = new IR::ID(@1, $1); }
+    ;
+
+nonTableKwName
+    : IDENTIFIER       { $$ = new IR::ID(@1, $1); }
+    | TYPE_IDENTIFIER  { $$ = new IR::ID(@1, $1); }
+    | APPLY            { $$ = new IR::ID(@1, "apply"); }
+    | STATE            { $$ = new IR::ID(@1, "state"); }
+    | TYPE             { $$ = new IR::ID(@1, "type"); }
     ;
 
 optCONST
@@ -913,10 +921,10 @@ tableProperty
         { auto l = new IR::EntriesList(@3, *$6);
           auto id = IR::ID(@3+@7, "entries");
           $$ = new IR::Property(@3, id, $1, l, $2.isConst); }
-    | optAnnotations optCONST IDENTIFIER "=" initializer ";"
+    | optAnnotations optCONST nonTableKwName "=" initializer ";"
         { auto v = new IR::ExpressionValue(@5, $5);
-          auto id = IR::ID(@3, $3);
-          $$ = new IR::Property(@3, id, $1, v, $2.isConst); }
+          auto id = *$3;
+          $$ = new IR::Property(id, $1, v, $2.isConst); }
     ;
 
 keyElementList

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -924,7 +924,7 @@ tableProperty
     | optAnnotations optCONST nonTableKwName "=" initializer ";"
         { auto v = new IR::ExpressionValue(@5, $5);
           auto id = *$3;
-          $$ = new IR::Property(id, $1, v, $2.isConst); }
+          $$ = new IR::Property($3->srcInfo, id, $1, v, $2.isConst); }
     ;
 
 keyElementList


### PR DESCRIPTION
In the spec, it is written that each architecture may have its own table properties, like, for example, an `implementation` table property.

But table property names, in the current grammar, cannot be type names.

So imagine that a programmer accidentally defines a type that has the same name as a table property for the architecture he is targeting (or includes another P4 program that does). He could no longer use the table property in tables, as it would be seen as a syntax error.

This pr allows table properties to be type names, preventing this problem.