### PR TITLE
Fix handling of p4runtime options in p4c driver

### DIFF
--- a/tools/driver/p4c_src/p4c.bmv2.cfg
+++ b/tools/driver/p4c_src/p4c.bmv2.cfg
@@ -47,10 +47,6 @@ class BMV2Backend(BackendDriver):
         self.add_command_option('compiler', "{}.p4i".format(basepath))
         self.add_command_option('compiler', "--arch")
         self.add_command_option('compiler', self._arch)
-    
-        # generate api as part of the compilation
-        self.add_command_option('compiler', "--p4runtime-file");
-        self.add_command_option('compiler', "{}.p4rt".format(basepath))
 
 
 # target


### PR DESCRIPTION
The --p4runtime-file option provided by the user was ignored by the
driver (for bmv2), which was adding its own --p4runtime-file option when
invoking the compiler. For some reason, the bnv2 backend was the only
one to work this way. With this commit, the driver no longer generates
its own option by default and instead honors the one provided by the
user.

Fixes #1221