### PR TITLE
Fix ebpf testing when make install has not been called.

### DIFF
--- a/backends/ebpf/ebpftargets.py
+++ b/backends/ebpf/ebpftargets.py
@@ -206,6 +206,8 @@ class EBPFTarget(object):
         args.append("BPFOBJ=" + self.template + ".c")
         # location of the P4 input file
         args.append("P4FILE=" + self.options.p4filename)
+        # location of the P4 compiler
+        args.append("P4C=" + self.options.compilerSrcDir + "/build/p4c-ebpf")
         p4_args = ' '.join(map(str, argv))
         if (p4_args):
             # Remaining arguments


### PR DESCRIPTION
This hotfix provides the makefile with the location of the compiler. It allows non-global generation of p4 programs.

In general the structure of the makefiles needs to be rethought, this is a future ToDo.