### PR TITLE
Make global static class objects instances rather than pointers.

### DIFF
--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -22,14 +22,14 @@ const char* IrClass::indent = "    ";
 IrNamespace IrNamespace::global(nullptr, nullptr);
 static const LookupScope utilScope(nullptr, "Util");
 static const NamedType srcInfoType(Util::SourceInfo(), &utilScope, "SourceInfo");
-IrField *IrField::srcInfoField = new IrField(Util::SourceInfo(), &srcInfoType, "srcInfo", nullptr,
-                                             IrField::Inline | IrField::Optional);
-IrClass *IrClass::ideclaration = new IrClass(NodeKind::Interface, "IDeclaration");
-IrClass *IrClass::nodeClass = new IrClass(NodeKind::Abstract, "Node", {IrField::srcInfoField});
-IrClass *IrClass::vectorClass = new IrClass(NodeKind::Template, "Vector");
-IrClass *IrClass::indexedVectorClass = new IrClass(NodeKind::Template, "IndexedVector");
-IrClass *IrClass::namemapClass = new IrClass(NodeKind::Template, "NameMap");
-IrClass *IrClass::nodemapClass = new IrClass(NodeKind::Template, "NodeMap");
+IrField IrField::srcInfoField(Util::SourceInfo(), &srcInfoType, "srcInfo", nullptr,
+                               IrField::Inline | IrField::Optional);
+IrClass IrClass::ideclaration(NodeKind::Interface, "IDeclaration");
+IrClass IrClass::nodeClass(NodeKind::Abstract, "Node", { &IrField::srcInfoField });
+IrClass IrClass::vectorClass(NodeKind::Template, "Vector");
+IrClass IrClass::indexedVectorClass(NodeKind::Template, "IndexedVector");
+IrClass IrClass::namemapClass(NodeKind::Template, "NameMap");
+IrClass IrClass::nodemapClass(NodeKind::Template, "NodeMap");
 bool LineDirective::inhibit = false;
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -152,7 +152,7 @@ void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &i
 }
 
 void IrClass::generateTreeMacro(std::ostream &out) const {
-    for (auto p = this; p != nodeClass; p = p->getParent())
+    for (auto p = this; p != &nodeClass; p = p->getParent())
         out << "  ";
     out << "M(";
     const char *sep = "";
@@ -319,7 +319,7 @@ void IrClass::computeConstructorArguments(IrClass::ctor_args_t &args) const {
     if (concreteParent == nullptr) {
         if (kind != NodeKind::Nested) {
             // direct descendant of Node, add srcInfo
-            args.emplace_back(IrField::srcInfoField, IrClass::nodeClass); }
+            args.emplace_back(&IrField::srcInfoField, &IrClass::nodeClass); }
     } else {
         concreteParent->computeConstructorArguments(args); }
 
@@ -445,18 +445,18 @@ void IrField::generate(std::ostream &out, bool asField) const {
         if (tmpl) {
             if (cls->kind != NodeKind::Template)
                 throw Util::CompilationError("Template args with non-template class %1%", cls);
-            unsigned tmpl_args = (cls == IrClass::nodemapClass ? 2 : 1);
+            unsigned tmpl_args = (cls == &IrClass::nodemapClass ? 2 : 1);
             if (tmpl->args.size() < tmpl_args)
                 throw Util::CompilationError("Wrong number of args for template %1%", cls);
             for (unsigned i = 0; i < tmpl_args; i++) {
                 if (auto acl = tmpl->args[i]->resolve(clss ? clss->containedIn : nullptr)) {
-                    if (cls == IrClass::vectorClass)
+                    if (cls == &IrClass::vectorClass)
                         acl->needVector = true;
-                    else if (cls == IrClass::indexedVectorClass)
+                    else if (cls == &IrClass::indexedVectorClass)
                         acl->needIndexedVector = true;
-                    else if (cls == IrClass::namemapClass && !isInline)
+                    else if (cls == &IrClass::namemapClass && !isInline)
                         acl->needNameMap = true;
-                    else if (cls == IrClass::nodemapClass && !isInline)
+                    else if (cls == &IrClass::nodemapClass && !isInline)
                         acl->needNodeMap = true;
                 } else {
                     throw Util::CompilationError("%1% template argment %2% is not "

--- a/tools/ir-generator/irclass.h
+++ b/tools/ir-generator/irclass.h
@@ -123,7 +123,7 @@ class IrField : public IrElement {
     const bool isStatic = false;
     const bool isConst = false;
 
-    static IrField *srcInfoField;
+    static IrField srcInfoField;
 
     IrField(Util::SourceInfo info, const Type *type, cstring name, cstring init, int flags = 0)
     : IrElement(info), type(type), name(name), initializer(init), nullOK(flags & NullOK),
@@ -217,8 +217,8 @@ class IrClass : public IrElement {
 
  public:
     const IrClass *getParent() const {
-        if (concreteParent == nullptr && this != nodeClass && kind != NodeKind::Nested)
-            return IrClass::nodeClass;
+        if (concreteParent == nullptr && this != &nodeClass && kind != NodeKind::Nested)
+            return &IrClass::nodeClass;
         return concreteParent; }
 
     std::vector<const CommentBlock *> comments;
@@ -254,8 +254,8 @@ class IrClass : public IrElement {
       local(containedIn, name), kind(kind), name(name) {
         IrNamespace::add_class(this); }
 
-    static IrClass *nodeClass, *vectorClass, *namemapClass, *nodemapClass,
-                   *ideclaration, *indexedVectorClass;
+    static IrClass nodeClass, vectorClass, namemapClass, nodemapClass,
+                   ideclaration, indexedVectorClass;
 
     void declare(std::ostream &out) const;
     void generate_hdr(std::ostream &out) const override;
@@ -275,12 +275,12 @@ class IrDefinitions {
  public:
     explicit IrDefinitions(std::vector<IrElement*> classes) : elements(classes) {}
     void resolve() {
-        IrClass::nodeClass->resolve();
-        IrClass::vectorClass->resolve();
-        IrClass::namemapClass->resolve();
-        IrClass::nodemapClass->resolve();
-        IrClass::ideclaration->resolve();
-        IrClass::indexedVectorClass->resolve();
+        IrClass::nodeClass.resolve();
+        IrClass::vectorClass.resolve();
+        IrClass::namemapClass.resolve();
+        IrClass::nodemapClass.resolve();
+        IrClass::ideclaration.resolve();
+        IrClass::indexedVectorClass.resolve();
         for (auto cls : *getClasses())
             cls->resolve(); }
     void generate(std::ostream &t, std::ostream &out, std::ostream &impl) const;

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -57,7 +57,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
         buf << cl->indent << "}";
         return buf.str(); } } },
 { "equiv", { &NamedType::Bool,
-             { new IrField(new ReferenceType(new NamedType(IrClass::nodeClass), true), "a_") },
+             { new IrField(new ReferenceType(new NamedType(&IrClass::nodeClass), true), "a_") },
              CONST + IN_IMPL + OVERRIDE,
     [](IrClass *cl, Util::SourceInfo, cstring) -> cstring {
         std::stringstream buf;
@@ -211,7 +211,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
 };
 
 void IrClass::generateMethods() {
-    if (this == nodeClass || this == vectorClass) return;
+    if (this == &nodeClass || this == &vectorClass) return;
     if (kind != NodeKind::Interface) {
         for (auto &def : IrMethod::Generate) {
             if (def.second.flags & NOT_DEFAULT)
@@ -284,7 +284,7 @@ void IrClass::generateMethods() {
                 // This is a factory method. These return an IR:Node*. The
                 // exception is nested classes, which typically aren't IR::Nodes
                 // and therefore just return a pointer to their concrete type.
-                m->rtype = new PointerType(new NamedType(IrClass::nodeClass));
+                m->rtype = new PointerType(new NamedType(&IrClass::nodeClass));
             } else {
                 // By default predefined methods return a pointer to their
                 // concrete type.


### PR DESCRIPTION
- fixes order-of-initialization issues with global ctors (these objects
  need to refer to each other by address, but need not be initialized in
  any particular order.)