### PR TITLE
Extend P4-14 frontend to support multiple entry points to parser

### DIFF
--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -1081,6 +1081,8 @@ class RemoveAnnotatedFields : public Transform {
     }
 };
 
+// If a parser state has a pragma @packet_entry, it is treated as a new entry
+// point to the parser.
 class CheckIfMultiEntryPoint: public Inspector {
     ProgramStructure* structure;
 
@@ -1097,6 +1099,11 @@ class CheckIfMultiEntryPoint: public Inspector {
     }
 };
 
+// Generate a new start state that selects on the meta variable,
+// standard_metadata.instance_type and branches into one of the entry points.
+// The backend is responsible for removing the use of the meta variable and
+// eliminate the new start state.  The new start state is not added if the user
+// does not use the @packet_entry pragma.
 class InsertCompilerGeneratedStartState: public Transform {
     ProgramStructure* structure;
     IR::IndexedVector<IR::Node>        allTypeDecls;
@@ -1159,10 +1166,9 @@ class InsertCompilerGeneratedStartState: public Transform {
     }
 };
 
-// handle @packet_entry pragma in P4-14.
-// A P4-14 program may be extended to support multiple entry points to
-// the parser. This feature does not compliant to P4-14 specification,
-// but it is useful in certain use cases.
+// Handle @packet_entry pragma in P4-14. A P4-14 program may be extended to
+// support multiple entry points to the parser. This feature does not comply
+// with P4-14 specification, but it is useful in certain use cases.
 class FixMultiEntryPoint : public PassManager {
  public:
     FixMultiEntryPoint(ProgramStructure* structure) {

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -1111,7 +1111,7 @@ class InsertCompilerGeneratedStartState: public Transform {
     IR::Vector<IR::SelectCase>         selCases;
  public:
     InsertCompilerGeneratedStartState(ProgramStructure* structure): structure(structure) {
-        setName("FixMultiEntryPoint"); }
+        setName("InsertCompilerGeneratedStartState"); }
 
     const IR::Node* postorder(IR::P4Program* program) override {
         allTypeDecls.append(program->declarations);

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -1121,6 +1121,8 @@ class InsertCompilerGeneratedStartState: public Transform {
 
     // rename original start state
     const IR::Node* postorder(IR::ParserState* state) override {
+        if (!structure->parserEntryPoints.size())
+            return state;
         if (state->name == IR::ParserState::start) {
             state->name = "$start";
         }

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -149,6 +149,8 @@ class ProgramStructure {
     /// pass to cope with varbit fields.
     std::map<const IR::MethodCallExpression*, const IR::Type_Header*> extractsSynthesized;
 
+    std::map<cstring, const IR::ParserState*> parserEntryPoints;
+
     struct ConversionContext {
         const IR::Expression* header;
         const IR::Expression* userMetadata;

--- a/frontends/p4/simplifyParsers.cpp
+++ b/frontends/p4/simplifyParsers.cpp
@@ -56,11 +56,6 @@ class RemoveUnreachableStates : public Transform {
             state->name == IR::ParserState::reject)
             return state;
 
-        // Do not eliminate states with annotations other than name.
-        for (const auto* anno : state->getAnnotations()->annotations) {
-            if (anno->name.name != "name") {
-                return state; } }
-
         auto orig = getOriginal<IR::ParserState>();
         if (reachable.find(orig) == reachable.end()) {
             if (state->name == IR::ParserState::accept) {

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -136,11 +136,6 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::ParserState* state) {
         state->name == IR::ParserState::start)
         return state;
 
-    // Do not eliminate states with annotations other than name.
-    for (const auto* anno : state->getAnnotations()->annotations) {
-        if (anno->name.name != "name") {
-            return state; } }
-
     if (refMap->isUsed(getOriginal<IR::ParserState>()))
         return state;
     LOG3("Removing " << state);

--- a/testdata/p4_14_samples/parser_pragma2.p4
+++ b/testdata/p4_14_samples/parser_pragma2.p4
@@ -1,0 +1,32 @@
+parser start {
+    return ingress;
+}
+
+parser Cowles {
+    return ingress;
+}
+
+@pragma packet_entry
+parser start_i2e_mirrored {
+    return ingress;
+}
+
+@pragma packet_entry
+parser start_e2e_mirrored {
+    return select(current(0, 32)) {
+        default : ingress;
+        0xAB00 : Cowles;
+    }
+}
+
+action nop() { }
+
+table exact {
+    reads { standard_metadata.egress_spec: exact; }
+    actions { nop; }
+}
+
+control ingress {
+    apply(exact);
+}
+

--- a/testdata/p4_14_samples_outputs/parser_pragma-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-first.p4
@@ -1,4 +1,4 @@
-enum bit<32> $InstanceType {
+enum bit<32> InstanceType_0 {
     START = 32w0,
     start_e2e_mirrored = 32w1,
     start_i2e_mirrored = 32w2
@@ -14,14 +14,14 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    state start {
-        transition select(($InstanceType)standard_metadata.instance_type) {
-            $InstanceType.START: $start;
-            $InstanceType.start_e2e_mirrored: start_e2e_mirrored;
-            $InstanceType.start_i2e_mirrored: start_i2e_mirrored;
+    @name("$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
         }
     }
-    @name(".start") state $start {
+    @name(".start") state start_0 {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {

--- a/testdata/p4_14_samples_outputs/parser_pragma-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-first.p4
@@ -1,3 +1,9 @@
+enum bit<32> $InstanceType {
+    START = 32w0,
+    start_e2e_mirrored = 32w1,
+    start_i2e_mirrored = 32w2
+}
+
 #include <core.p4>
 #include <v1model.p4>
 
@@ -8,7 +14,14 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".start") state start {
+    state start {
+        transition select(($InstanceType)standard_metadata.instance_type) {
+            $InstanceType.START: $start;
+            $InstanceType.start_e2e_mirrored: start_e2e_mirrored;
+            $InstanceType.start_i2e_mirrored: start_i2e_mirrored;
+        }
+    }
+    @name(".start") state $start {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {

--- a/testdata/p4_14_samples_outputs/parser_pragma-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-frontend.p4
@@ -1,4 +1,4 @@
-enum bit<32> $InstanceType {
+enum bit<32> InstanceType_0 {
     START = 32w0,
     start_e2e_mirrored = 32w1,
     start_i2e_mirrored = 32w2
@@ -14,14 +14,14 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    state start {
-        transition select(($InstanceType)standard_metadata.instance_type) {
-            $InstanceType.START: $start;
-            $InstanceType.start_e2e_mirrored: start_e2e_mirrored;
-            $InstanceType.start_i2e_mirrored: start_i2e_mirrored;
+    @name("ParserImpl.$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
         }
     }
-    @name(".start") state $start {
+    @name(".start") state start_0 {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {

--- a/testdata/p4_14_samples_outputs/parser_pragma-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-frontend.p4
@@ -1,3 +1,9 @@
+enum bit<32> $InstanceType {
+    START = 32w0,
+    start_e2e_mirrored = 32w1,
+    start_i2e_mirrored = 32w2
+}
+
 #include <core.p4>
 #include <v1model.p4>
 
@@ -8,7 +14,14 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".start") state start {
+    state start {
+        transition select(($InstanceType)standard_metadata.instance_type) {
+            $InstanceType.START: $start;
+            $InstanceType.start_e2e_mirrored: start_e2e_mirrored;
+            $InstanceType.start_i2e_mirrored: start_i2e_mirrored;
+        }
+    }
+    @name(".start") state $start {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {

--- a/testdata/p4_14_samples_outputs/parser_pragma-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-midend.p4
@@ -8,15 +8,15 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    state start {
+    @name("ParserImpl.$start") state start {
         transition select((bit<32>)standard_metadata.instance_type) {
-            32w0: $start;
+            32w0: start_0;
             32w1: start_e2e_mirrored;
             32w2: start_i2e_mirrored;
             default: noMatch;
         }
     }
-    @name(".start") state $start {
+    @name(".start") state start_0 {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {

--- a/testdata/p4_14_samples_outputs/parser_pragma-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-midend.p4
@@ -8,7 +8,15 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".start") state start {
+    state start {
+        transition select((bit<32>)standard_metadata.instance_type) {
+            32w0: $start;
+            32w1: start_e2e_mirrored;
+            32w2: start_i2e_mirrored;
+            default: noMatch;
+        }
+    }
+    @name(".start") state $start {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {
@@ -16,6 +24,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
         transition accept;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_pragma.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma.p4
@@ -1,4 +1,4 @@
-enum bit<32> $InstanceType {
+enum bit<32> InstanceType_0 {
     START = 0,
     start_e2e_mirrored = 1,
     start_i2e_mirrored = 2
@@ -14,14 +14,14 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    state start {
-        transition select(($InstanceType)standard_metadata.instance_type) {
-            $InstanceType.START: $start;
-            $InstanceType.start_e2e_mirrored: start_e2e_mirrored;
-            $InstanceType.start_i2e_mirrored: start_i2e_mirrored;
+    @name("$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
         }
     }
-    @name(".start") state $start {
+    @name(".start") state start_0 {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {

--- a/testdata/p4_14_samples_outputs/parser_pragma2-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2-first.p4
@@ -1,4 +1,4 @@
-enum bit<32> $InstanceType {
+enum bit<32> InstanceType_0 {
     START = 32w0,
     start_e2e_mirrored = 32w1,
     start_i2e_mirrored = 32w2
@@ -14,17 +14,17 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    state start {
-        transition select(($InstanceType)standard_metadata.instance_type) {
-            $InstanceType.START: $start;
-            $InstanceType.start_e2e_mirrored: start_e2e_mirrored;
-            $InstanceType.start_i2e_mirrored: start_i2e_mirrored;
+    @name("$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
         }
     }
     @name(".Cowles") state Cowles {
         transition accept;
     }
-    @name(".start") state $start {
+    @name(".start") state start_0 {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {

--- a/testdata/p4_14_samples_outputs/parser_pragma2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2-frontend.p4
@@ -1,4 +1,4 @@
-enum bit<32> $InstanceType {
+enum bit<32> InstanceType_0 {
     START = 32w0,
     start_e2e_mirrored = 32w1,
     start_i2e_mirrored = 32w2
@@ -15,17 +15,17 @@ struct headers {
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<32> tmp_0;
-    state start {
-        transition select(($InstanceType)standard_metadata.instance_type) {
-            $InstanceType.START: $start;
-            $InstanceType.start_e2e_mirrored: start_e2e_mirrored;
-            $InstanceType.start_i2e_mirrored: start_i2e_mirrored;
+    @name("ParserImpl.$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
         }
     }
     @name(".Cowles") state Cowles {
         transition accept;
     }
-    @name(".start") state $start {
+    @name(".start") state start_0 {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {

--- a/testdata/p4_14_samples_outputs/parser_pragma2-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2-midend.p4
@@ -9,15 +9,15 @@ struct headers {
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<32> tmp_0;
-    state start {
+    @name("ParserImpl.$start") state start {
         transition select((bit<32>)standard_metadata.instance_type) {
-            32w0: $start;
+            32w0: start_0;
             32w1: start_e2e_mirrored;
             32w2: start_i2e_mirrored;
             default: noMatch;
         }
     }
-    @name(".start") state $start {
+    @name(".start") state start_0 {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {

--- a/testdata/p4_14_samples_outputs/parser_pragma2.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2.p4
@@ -21,11 +21,17 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
             $InstanceType.start_i2e_mirrored: start_i2e_mirrored;
         }
     }
+    @name(".Cowles") state Cowles {
+        transition accept;
+    }
     @name(".start") state $start {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {
-        transition accept;
+        transition select((packet.lookahead<bit<32>>())[31:0]) {
+            default: accept;
+            32w0xab00: Cowles;
+        }
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
         transition accept;

--- a/testdata/p4_14_samples_outputs/parser_pragma2.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2.p4
@@ -1,4 +1,4 @@
-enum bit<32> $InstanceType {
+enum bit<32> InstanceType_0 {
     START = 0,
     start_e2e_mirrored = 1,
     start_i2e_mirrored = 2
@@ -14,17 +14,17 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    state start {
-        transition select(($InstanceType)standard_metadata.instance_type) {
-            $InstanceType.START: $start;
-            $InstanceType.start_e2e_mirrored: start_e2e_mirrored;
-            $InstanceType.start_i2e_mirrored: start_i2e_mirrored;
+    @name("$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
         }
     }
     @name(".Cowles") state Cowles {
         transition accept;
     }
-    @name(".start") state $start {
+    @name(".start") state start_0 {
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {

--- a/testdata/p4_14_samples_outputs/parser_pragma2.p4-stderr
+++ b/testdata/p4_14_samples_outputs/parser_pragma2.p4-stderr
@@ -1,0 +1,6 @@
+parser_pragma2.p4(18): warning: SelectCase: unreachable
+        0xAB00 : Cowles;
+        ^^^^^^
+parser_pragma2.p4(16): warning: ListExpression: transition does not depend on select argument
+    return select(current(0, 32)) {
+                  ^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR extends the P4-14 to P4-16 converter to support multiple entry points to parser. This feature does not comply with the P4-14 specification, as the P4-14 spec only allow one entry point to the parser, however, it is a useful feature for certain targets. 

Previously, the frontend had a hack in unusedDeclaration.cpp and simplifyParser.cpp to prevent any state with `packet_entry` pragma from being eliminated. However, this hack does not work on a state that is used and only used by the the additional entry point states. As a result, the frontend gives a 'Cannot find declaration' error when a state used by the additional entry point is eliminated. This PR fixes this bug.

The added `start` state needs to be removed by the backend. However, backend does not have to support this feature, as the feature is not in P4-14 spec.