### PR TITLE
Include missing header file

### DIFF
--- a/frontends/p4/commonInlining.h
+++ b/frontends/p4/commonInlining.h
@@ -17,6 +17,7 @@ limitations under the License.
 #ifndef _FRONTENDS_P4_COMMONINLINING_H_
 #define _FRONTENDS_P4_COMMONINLINING_H_
 
+#include "frontends/p4/callGraph.h"
 #include "ir/ir.h"
 
 /**


### PR DESCRIPTION
The build with -DENABLE_UNIFIED_COMPILATION=OFF is currently broken. It fails with the error
```
In file included from p4c/frontends/p4/actionsInlining.cpp:17:
In file included from p4c/frontends/p4/actionsInlining.h:23:
p4c/frontends/p4/commonInlining.h:77:13: error: no member named 'CallGraph' in namespace 'P4'
        P4::CallGraph<const Callable*> cg("Call-graph");
        ~~~~^
```

This change adds `#include` with the missing dependency.