### PR TITLE
Fix irgenerator dependecy in cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,10 @@ set (IR_GENERATED_SRCS
   ${P4C_BINARY_DIR}/ir/ir-generated.h
   ${P4C_BINARY_DIR}/ir/ir-generated.cpp
   ${P4C_BINARY_DIR}/ir/gen-tree-macro.h)
-set (IR_GENERATOR ${P4C_BINARY_DIR}/tools/ir-generator/irgenerator)
+# IR_GENERATOR_DIRECTORY is used to set the RUNTIME_OUTPUT_DIRECTORY property
+# of the irgenerator target to the matching path
+set (IR_GENERATOR_DIRECTORY ${P4C_BINARY_DIR}/tools/ir-generator)
+set (IR_GENERATOR ${IR_GENERATOR_DIRECTORY}/irgenerator)
 
 # the order of adding subdirectories matters because of target dependencies
 add_subdirectory (tools/driver)
@@ -279,7 +282,7 @@ add_custom_command (OUTPUT ${IR_GENERATED_SRCS}
   COMMAND awk -v name=gen-tree-macro.h -f ${fixup_file} ir/gen-tree-macro.h.tmp > ir/gen-tree-macro.h.fixup
   COMMAND ${CMAKE_COMMAND} -E copy_if_different ir/gen-tree-macro.h.fixup ir/gen-tree-macro.h
   MAIN_DEPENDENCY ${IR_GENERATOR}
-  DEPENDS ${IR_DEF_FILES}
+  DEPENDS irgenerator ${IR_DEF_FILES}
   COMMENT "Generating IR class files")
 
 add_custom_target(genIR DEPENDS ${IR_GENERATED_SRCS})

--- a/tools/ir-generator/CMakeLists.txt
+++ b/tools/ir-generator/CMakeLists.txt
@@ -43,4 +43,9 @@ set_source_files_properties(${IRGENERATOR_GEN_SRCS} PROPERTIES GENERATED TRUE)
 set_source_files_properties(${IRGENERATOR_GEN_SRCS} PROPERTIES OBJECT_DEPENDS ${FLEX_IRgenLexer_OUTPUTS})
 build_unified(IRGENERATOR_SRCS ALL)
 add_executable (irgenerator ${IRGENERATOR_SRCS} ${IRGENERATOR_GEN_SRCS})
+# Unconditionally set the output directory for the irgenerator to the path
+# where the custom command that generates IR sources expects to find it.
+# The generator expression $<BOOL:1> prevents IDE generators like Xcode
+# from appending a per-configuration subdirectory to the specified path.
+set_property(TARGET irgenerator PROPERTY RUNTIME_OUTPUT_DIRECTORY $<$<BOOL:1>:${IR_GENERATOR_DIRECTORY}>)
 target_link_libraries (irgenerator p4ctoolkit ${P4C_LIB_DEPS})


### PR DESCRIPTION
This fix makes the build system work with the Xcode generator,
which otherwise fails to produce the correct dependencies for
the custom command that builds IR generated sources.