### PR TITLE
Ignore unknown match types (with warning) rather than crashing out.

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -632,9 +632,9 @@ getMatchFields(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMap)
             // Nothing to do here, we cannot even perform some sanity-checking.
             continue;
         } else {
-            ::error("Table '%1%': cannot represent match type '%2%' in P4Runtime",
-                    table->controlPlaneName(), matchTypeName);
-            break;
+            ::warning("Table '%1%': cannot represent match type '%2%' in P4Runtime, ignoring",
+                      table->controlPlaneName(), matchTypeName);
+            continue;
         }
 
         auto matchFieldName = explicitNameAnnotation(keyElement);


### PR DESCRIPTION
Targets/backends can define additional match types, so there should be some way of telling this code what to do with them.  For now though, its better to just ignore them so at least the compiler can get to the backend...