### PR TITLE
Generate P4info in p4test backend tests

### DIFF
--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -50,11 +50,31 @@ set (P4TEST_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_errors/*.p4"
   )
+# Builds a list of tests for which P4Info generation is not supported. It makes
+# sense not to fail the test just because P4Info generation fails. It probably
+# would not make sense to run all the tests twice (one with and one without
+# P4Runtime).
+set (P4RUNTIME_EXCLUDE
+  # Two counter instances provided for psa_direct_counter, illegal according to
+  # PSA spec and fails in P4Info generation
+  testdata/p4_16_samples/psa-counter5.p4
+  # Need to convert PSA_MeterColor_t to a serializable enum
+  testdata/p4_16_samples/psa-meter1.p4
+  # Compiler Bug: Type_Name is not a canonical type, use getTypeType()?
+  testdata/p4_16_samples/pvs-nested-struct.p4
+  testdata/p4_16_samples/pvs-struct.p4
+  # error not supported in static entries, not strictly required for P4Info
+  # generation though
+  testdata/p4_16_samples/issue1062-bmv2.p4
+)
+# Do not generate P4Info for tests which are expected to fail P4 compilation.
+p4c_find_test_names ("${P4C_SOURCE_DIR}/testdata/p4_16_errors/*.p4" P4RUNTIME_EXCLUDE_ERRORS)
+list (APPEND P4RUNTIME_EXCLUDE ${P4RUNTIME_EXCLUDE_ERRORS})
 set (P4_XFAIL_TESTS
   # issue #13
   testdata/p4_16_samples/cast-call.p4
   )
-p4c_add_tests("p4" ${P4TEST_DRIVER} "${P4TEST_SUITES}" "${P4_XFAIL_TESTS}")
+p4c_add_tests_w_p4runtime("p4" ${P4TEST_DRIVER} "${P4TEST_SUITES}" "${P4_XFAIL_TESTS}" "${P4RUNTIME_EXCLUDE}")
 
 set (P4_14_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_14_samples/*.p4"


### PR DESCRIPTION
* Fix P4Info register serialization for PSA

The PSA register has 2 type parameters (while the v1model register has a
single one), so the BUG_CHECK didn't make sense.

* Generate P4Info as part of p4test backend tests

In order to improve test coverage of P4Info generation, we are now
generating it by default in p4test backend tests.
Tests can be explicitly added to P4RUNTIME_EXCLUDE if P4Info cannot be
generated even though they are valid v1model / PSA programs.
A new cmake macro was introduced to register tests which include P4Info
generation: p4c_add_tests_w_p4runtime. I didn't want to modify
p4c_add_tests to avoid breaking backends that may be using this macro to
register their own tests.