### PR TITLE
Fix corner case bug in Transfor::apply_visitor

### DIFF
--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -321,7 +321,7 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
                 copy->visit_children(*this);
                 visitCurrentOnce = visited->refVisitOnce(n);
                 final_result = copy->apply_visitor_postorder(*this); }
-            if (final_result
+            if (final_result == copy
                 && final_result != preorder_result
                 && *final_result == *preorder_result)
                 final_result = preorder_result;


### PR DESCRIPTION
  When a Transform is trying memoize modified/generated nodes to avoid
  making duplicates in a postorder function, we don't want to undo that
  memoization with the fixup for a noop postorder.

A trivial fix for a very obscure, hard to track down corner case...