### PR TITLE
prevent opening a pipe in case there were errors

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -564,13 +564,14 @@ void ProgramStructure::include(cstring filename, cstring ppoptions) {
         options.preprocessor_options += ppoptions; }
     options.langVersion = CompilerOptions::FrontendVersion::P4_16;
     options.file = path.toString();
-    if (FILE* file = options.preprocess()) {
-        if (!::errorCount()) {
+    if (!::errorCount())
+        if (FILE* file = options.preprocess()) {
             auto code = P4::P4ParserDriver::parse(file, options.file);
             if (code && !::errorCount())
                 for (auto decl : code->declarations)
-                    declarations->push_back(decl); }
-        options.closeInput(file); }
+                    declarations->push_back(decl);
+            options.closeInput(file);
+        }
 }
 
 void ProgramStructure::loadModel() {


### PR DESCRIPTION
If there have been compiler errors and we open a pipe to
preprocess additional files, we end up killing the pipe early.
So it is better not to open the file at all.