### PR TITLE
Fix a bug with the backtracking framework

### DIFF
--- a/ir/pass_manager.cpp
+++ b/ir/pass_manager.cpp
@@ -62,7 +62,7 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
                 LOG1(log_indent << "pass " << b->name() << " can't handle it"); }
             if (backup.empty()) {
                 LOG1(log_indent << "rethrow trigger");
-                throw trig; }
+                throw; }
             continue; }
         runDebugHooks(v->name(), program);
         if (early_exit_flag)


### PR DESCRIPTION
When a backtrack trigger of type `t` is thrown from a nested pass manager and when it is meant to be
caught in the top-level pass manager, the trigger type currently does not recognize type `t`. This
PR ensures that the trigger type is not lost when a backtrack exception is rethrown by the nested
pass manager.