### PR TITLE
Fix bdw-gc package name in FindLibGc.make

### DIFF
--- a/cmake/FindLibGc.cmake
+++ b/cmake/FindLibGc.cmake
@@ -32,7 +32,7 @@
 # use pkg-config to get the directories and then use these values
 # in the find_path() and find_library() calls
 find_package(PkgConfig QUIET)
-PKG_CHECK_MODULES(PC_LIBGC QUIET bwd-gc)
+PKG_CHECK_MODULES(PC_LIBGC QUIET bdw-gc)
 set(LIBGC_DEFINITIONS ${PC_LIBGC_CFLAGS_OTHER})
 
 find_path(LIBGC_INCLUDE_DIR NAMES gc/gc.h


### PR DESCRIPTION
I noticed this while debugging a problem I was having finding libgc. The cause turned out to be unrelated i.e. FindLibGc worked as it is. Nevertheless the apparently mis-typed package name is confusing for a human.