### PR TITLE
Add getOutputStream method to ErrorReporter

### DIFF
--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -443,8 +443,13 @@ class ErrorReporter final {
         return errorCount + warningCount;
     }
 
-    void setOutputStream(std::ostream* stream)
-    { outputstream = stream; }
+    void setOutputStream(std::ostream* stream) {
+        outputstream = stream;
+    }
+
+    std::ostream* getOutputStream() const {
+        return outputstream;
+    }
 
     /// Reports an error @message at @location. This allows us to use the
     /// position information provided by Bison.


### PR DESCRIPTION
I would like to write some GTests in which I change the output stream to
be a stringstream so that the unit test can verify that the error
message is the expected one. Adding the getOutputStream method enables
me to "save" the existing output stream then "restore" it when I am
done.