### PR TITLE
Try to preserve IR::ID::originalName when renaming things

### DIFF
--- a/frontends/p4/inlining.cpp
+++ b/frontends/p4/inlining.cpp
@@ -295,7 +295,7 @@ class Substitutions : public SubstituteParameters {
             newName = renameMap->getName(decl);
         else
             newName = expression->path->name;
-        IR::ID newid = IR::ID(expression->path->srcInfo, newName);
+        IR::ID newid(expression->path->srcInfo, newName, expression->path->name.originalName);
         auto newpath = new IR::Path(newid, expression->path->absolute);
         auto result = new IR::PathExpression(newpath);
         refMap->setDeclaration(newpath, decl);
@@ -673,7 +673,7 @@ class RenameStates : public Transform {
     const IR::Node* preorder(IR::Path* path) override {
         // This is certainly a state name, by the way we organized the visitors
         cstring newName = ::get(stateRenameMap, path->name);
-        path->name = IR::ID(path->name.srcInfo, newName);
+        path->name = IR::ID(path->name.srcInfo, newName, path->name.originalName);
         return path;
     }
     const IR::Node* preorder(IR::SelectExpression* expression) override {
@@ -693,7 +693,7 @@ class RenameStates : public Transform {
             return state;
         }
         cstring newName = ::get(stateRenameMap, state->name.name);
-        state->name = IR::ID(state->name.srcInfo, newName);
+        state->name.name = newName;
         if (state->selectExpression != nullptr)
             visit(state->selectExpression);
         prune();

--- a/frontends/p4/localizeActions.cpp
+++ b/frontends/p4/localizeActions.cpp
@@ -78,8 +78,9 @@ bool FindGlobalActionUses::preorder(const IR::PathExpression* path) {
             annos = IR::Annotations::empty;
         annos->addAnnotationIfNew(IR::Annotation::nameAnnotation,
                                   new IR::StringLiteral(action->name));
-        auto replacement = new IR::P4Action(action->srcInfo, IR::ID(action->name.srcInfo, newName),
-                                            annos, params, replBody);
+        auto replacement = new IR::P4Action(action->srcInfo,
+                    IR::ID(action->name.srcInfo, newName, action->name.originalName),
+                    annos, params, replBody);
         repl->addReplacement(action, control, replacement);
     }
     return false;
@@ -112,7 +113,8 @@ const IR::Node* LocalizeActions::postorder(IR::PathExpression* expression) {
     auto replacement = repl->getReplacement(action, control);
     if (replacement != nullptr) {
         LOG1("Rewriting " << dbp(expression) << " to " << dbp(replacement));
-        expression = new IR::PathExpression(IR::ID(expression->srcInfo, replacement->name));
+        expression = new IR::PathExpression(IR::ID(expression->srcInfo, replacement->name,
+                                                   expression->path->name.originalName));
     }
     return expression;
 }
@@ -166,8 +168,9 @@ bool FindRepeatedActionUses::preorder(const IR::PathExpression* expression) {
             annos = IR::Annotations::empty;
         annos->addAnnotationIfNew(IR::Annotation::nameAnnotation,
                                   new IR::StringLiteral(action->name));
-        replacement = new IR::P4Action(action->srcInfo, IR::ID(action->name.srcInfo, newName),
-                                       annos, params, replBody);
+        replacement = new IR::P4Action(action->srcInfo,
+                IR::ID(action->name.srcInfo, newName, action->name.originalName),
+                annos, params, replBody);
         repl->createReplacement(action, actionUser, replacement);
     }
     repl->setRefReplacement(expression, replacement);
@@ -202,7 +205,8 @@ const IR::Node* DuplicateActions::postorder(IR::PathExpression* expression) {
     auto replacement = ::get(repl->repl, getOriginal<IR::PathExpression>());
     if (replacement != nullptr) {
         LOG1("Rewriting " << dbp(expression) << " to " << dbp(replacement));
-        expression = new IR::PathExpression(IR::ID(expression->srcInfo, replacement->name));
+        expression = new IR::PathExpression(IR::ID(expression->srcInfo, replacement->name,
+                                                   expression->path->name.originalName));
     }
     return expression;
 }

--- a/frontends/p4/symbol_table.cpp
+++ b/frontends/p4/symbol_table.cpp
@@ -228,7 +228,7 @@ void ProgramStructure::declareTypes(const IR::IndexedVector<IR::Type_Var>* typeV
     if (typeVars == nullptr)
         return;
     for (auto tv : *typeVars)
-        declareType(IR::ID(tv->srcInfo, tv->name));
+        declareType(tv->name);
 }
 
 void ProgramStructure::endParse() {


### PR DESCRIPTION
- error messages should use the original name from the source