### PR TITLE
Fix for issue #1325, hopefully for #808 too

### DIFF
--- a/backends/bmv2/common/header.cpp
+++ b/backends/bmv2/common/header.cpp
@@ -213,6 +213,13 @@ void HeaderConverter::addHeaderType(const IR::Type_StructLike *st) {
             if (varbitFound)
                 ::error("%1%: headers with multiple varbit fields not supported", st);
             varbitFound = true;
+        } else if (ftype->is<IR::Type_Error>()) {
+            // treat as bit<32>
+            auto field = pushNewArray(fields);
+            field->append(f->name.name);
+            field->append(32);
+            field->append(false);
+            max_length += 32;
         } else if (ftype->to<IR::Type_Stack>()) {
             BUG("%1%: nested stack", st);
         } else {

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -850,6 +850,9 @@ SimpleSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
     userMetaType = decl->to<IR::Type_Struct>();
     LOG2("User metadata type is " << userMetaType);
 
+    // Map for error code numbering.  Errors are converted to 32-bit unsigned integers.
+    std::map<cstring, size_t> errorMap;
+
     auto evaluator = new P4::EvaluatorPass(refMap, typeMap);
     auto program = tlb->getProgram();
     // These passes are logically bmv2-specific
@@ -899,13 +902,6 @@ SimpleSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
     if (::errorCount() > 0)
         return;
 
-    /// generate error types
-    for (const auto &p : structure->errorCodesMap) {
-        auto name = p.first->toString();
-        auto type = p.second;
-        json->add_error(name, type);
-    }
-
     main = toplevel->getMain();
     if (!main) return;  // no main
     main->apply(*parseV1Arch);
@@ -914,6 +910,13 @@ SimpleSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
     };
     program = toplevel->getProgram();
     program->apply(updateStructure);
+
+    /// generate error types
+    for (const auto &p : structure->errorCodesMap) {
+        auto name = p.first->toString();
+        auto type = p.second;
+        json->add_error(name, type);
+    }
 
     cstring scalarsName = refMap->newName("scalars");
     // This visitor is used in multiple passes to convert expression to json

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -850,9 +850,6 @@ SimpleSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
     userMetaType = decl->to<IR::Type_Struct>();
     LOG2("User metadata type is " << userMetaType);
 
-    // Map for error code numbering.  Errors are converted to 32-bit unsigned integers.
-    std::map<cstring, size_t> errorMap;
-
     auto evaluator = new P4::EvaluatorPass(refMap, typeMap);
     auto program = tlb->getProgram();
     // These passes are logically bmv2-specific

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -63,7 +63,7 @@ struct standard_metadata_t {
     bit<1>  checksum_error;
     @alias("intrinsic_metadata.recirculate_flag") bit<32> recirculate_flag;
     /// Error produced by parsing
-    bit<32> parser_error;
+    error parser_error;
 }
 
 enum CounterType {

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -59,8 +59,11 @@ struct standard_metadata_t {
     @alias("intrinsic_metadata.resubmit_flag") bit<32> resubmit_flag;
     @alias("intrinsic_metadata.egress_rid")    bit<16> egress_rid;
     /// Indicates that a verify_checksum() method has failed.
+    // TODO: this should be deprecated in favor of parser_error
     bit<1>  checksum_error;
     @alias("intrinsic_metadata.recirculate_flag") bit<32> recirculate_flag;
+    /// Error produced by parsing
+    bit<32> parser_error;
 }
 
 enum CounterType {

--- a/testdata/p4_14_samples_outputs/issue-1426-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-midend.p4
@@ -119,6 +119,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata_1.recirculate_port = standard_metadata.recirculate_port;
         standard_metadata_1.packet_length = standard_metadata.packet_length;
         standard_metadata_1.checksum_error = standard_metadata.checksum_error;
+        standard_metadata_1.parser_error = standard_metadata.parser_error;
     }
     @hidden action act_0() {
         standard_metadata.egress_port = standard_metadata_1.egress_port;
@@ -133,6 +134,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata_1.recirculate_port = standard_metadata.recirculate_port;
         standard_metadata_1.packet_length = standard_metadata.packet_length;
         standard_metadata_1.checksum_error = standard_metadata.checksum_error;
+        standard_metadata_1.parser_error = standard_metadata.parser_error;
     }
     @hidden action act_2() {
         standard_metadata.egress_port = standard_metadata_1.egress_port;

--- a/testdata/p4_16_errors_outputs/issue584.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue584.p4-stderr
@@ -1,6 +1,6 @@
 issue584.p4(28): error: hash: cannot infer bitwidth for integer-valued type parameter M
         hash(var, HashAlgorithm.crc16, 16w0, hdr, 0xFFFF);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-v1model.p4(126)
+v1model.p4(129)
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
                           ^

--- a/testdata/p4_16_samples/issue1325-bmv2.p4
+++ b/testdata/p4_16_samples/issue1325-bmv2.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+#include <v1model.p4>
+
+error {
+    Unused
+};
+
+struct parsed_packet_t {};
+
+struct test_struct {
+  error test_error;
+}
+
+struct local_metadata_t {
+  test_struct test;
+};
+
+parser parse(packet_in pk, out parsed_packet_t hdr,
+             inout local_metadata_t local_metadata,
+             inout standard_metadata_t standard_metadata) {
+  state start {
+    transition accept;
+  }
+}
+
+control ingress(inout parsed_packet_t hdr,
+                inout local_metadata_t local_metadata,
+	        inout standard_metadata_t standard_metadata) {
+    apply {
+        if (local_metadata.test.test_error == error.Unused)
+            mark_to_drop();
+    }
+}
+
+control egress(inout parsed_packet_t hdr,
+               inout local_metadata_t local_metadata,
+	       inout standard_metadata_t standard_metadata) {
+  apply { }
+}
+
+control deparser(packet_out b, in parsed_packet_t hdr) {
+  apply { }
+}
+
+control verify_checks(inout parsed_packet_t hdr,
+                      inout local_metadata_t local_metadata) {
+  apply { }
+}
+
+control compute_checksum(inout parsed_packet_t hdr,
+                         inout local_metadata_t local_metadata) {
+  apply { }
+}
+
+V1Switch(parse(), verify_checks(), ingress(), egress(),
+         compute_checksum(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
@@ -37,6 +37,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         smeta.egress_rid = smeta_1.egress_rid;
         smeta.checksum_error = smeta_1.checksum_error;
         smeta.recirculate_flag = smeta_1.recirculate_flag;
+        smeta.parser_error = smeta_1.parser_error;
     }
     @name("IngressI.forward") table forward {
         key = {

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-first.p4
@@ -1,0 +1,52 @@
+error {
+    Unused
+}
+#include <core.p4>
+#include <v1model.p4>
+
+struct parsed_packet_t {
+}
+
+struct test_struct {
+    error test_error;
+}
+
+struct local_metadata_t {
+    test_struct test;
+}
+
+parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+        if (local_metadata.test.test_error == error.Unused) 
+            mark_to_drop();
+    }
+}
+
+control egress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in parsed_packet_t hdr) {
+    apply {
+    }
+}
+
+control verify_checks(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+V1Switch<parsed_packet_t, local_metadata_t>(parse(), verify_checks(), ingress(), egress(), compute_checksum(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-frontend.p4
@@ -1,0 +1,52 @@
+error {
+    Unused
+}
+#include <core.p4>
+#include <v1model.p4>
+
+struct parsed_packet_t {
+}
+
+struct test_struct {
+    error test_error;
+}
+
+struct local_metadata_t {
+    test_struct test;
+}
+
+parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+        if (local_metadata.test.test_error == error.Unused) 
+            mark_to_drop();
+    }
+}
+
+control egress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in parsed_packet_t hdr) {
+    apply {
+    }
+}
+
+control verify_checks(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+V1Switch<parsed_packet_t, local_metadata_t>(parse(), verify_checks(), ingress(), egress(), compute_checksum(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-midend.p4
@@ -1,0 +1,61 @@
+error {
+    Unused
+}
+#include <core.p4>
+#include <v1model.p4>
+
+struct parsed_packet_t {
+}
+
+struct test_struct {
+    error test_error;
+}
+
+struct local_metadata_t {
+    test_struct test;
+}
+
+parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    @hidden action act() {
+        mark_to_drop();
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        if (local_metadata.test.test_error == error.Unused) 
+            tbl_act.apply();
+    }
+}
+
+control egress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in parsed_packet_t hdr) {
+    apply {
+    }
+}
+
+control verify_checks(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+V1Switch<parsed_packet_t, local_metadata_t>(parse(), verify_checks(), ingress(), egress(), compute_checksum(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2.p4
@@ -1,0 +1,52 @@
+error {
+    Unused
+}
+#include <core.p4>
+#include <v1model.p4>
+
+struct parsed_packet_t {
+}
+
+struct test_struct {
+    error test_error;
+}
+
+struct local_metadata_t {
+    test_struct test;
+}
+
+parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+        if (local_metadata.test.test_error == error.Unused) 
+            mark_to_drop();
+    }
+}
+
+control egress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in parsed_packet_t hdr) {
+    apply {
+    }
+}
+
+control verify_checks(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+V1Switch(parse(), verify_checks(), ingress(), egress(), compute_checksum(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2-first.p4
@@ -1,0 +1,58 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header test_header_t {
+    bit<8> value;
+}
+
+struct headers_t {
+    test_header_t[2] test;
+}
+
+struct metadata_t {
+}
+
+parser TestParser(packet_in b, out headers_t headers, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        b.extract<test_header_t>(headers.test.next);
+        bit<32> test_f = headers.test.lastIndex << 1;
+        transition select(test_f) {
+            32w0: f;
+            default: a;
+        }
+    }
+    state a {
+        transition accept;
+    }
+    state f {
+        transition reject;
+    }
+}
+
+control TestVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control TestIngress(inout headers_t headers, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control TestEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control TestComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control TestDeparser(packet_out b, in headers_t hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(TestParser(), TestVerifyChecksum(), TestIngress(), TestEgress(), TestComputeChecksum(), TestDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2-frontend.p4
@@ -1,0 +1,59 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header test_header_t {
+    bit<8> value;
+}
+
+struct headers_t {
+    test_header_t[2] test;
+}
+
+struct metadata_t {
+}
+
+parser TestParser(packet_in b, out headers_t headers, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    bit<32> test_f;
+    state start {
+        b.extract<test_header_t>(headers.test.next);
+        test_f = headers.test.lastIndex << 1;
+        transition select(test_f) {
+            32w0: f;
+            default: a;
+        }
+    }
+    state a {
+        transition accept;
+    }
+    state f {
+        transition reject;
+    }
+}
+
+control TestVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control TestIngress(inout headers_t headers, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control TestEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control TestComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control TestDeparser(packet_out b, in headers_t hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(TestParser(), TestVerifyChecksum(), TestIngress(), TestEgress(), TestComputeChecksum(), TestDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2-midend.p4
@@ -1,0 +1,59 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header test_header_t {
+    bit<8> value;
+}
+
+struct headers_t {
+    test_header_t[2] test;
+}
+
+struct metadata_t {
+}
+
+parser TestParser(packet_in b, out headers_t headers, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    bit<32> test_f;
+    state start {
+        b.extract<test_header_t>(headers.test.next);
+        test_f = headers.test.lastIndex << 1;
+        transition select(test_f) {
+            32w0: f;
+            default: a;
+        }
+    }
+    state a {
+        transition accept;
+    }
+    state f {
+        transition reject;
+    }
+}
+
+control TestVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control TestIngress(inout headers_t headers, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control TestEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control TestComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control TestDeparser(packet_out b, in headers_t hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(TestParser(), TestVerifyChecksum(), TestIngress(), TestEgress(), TestComputeChecksum(), TestDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header test_header_t {
+    bit<8> value;
+}
+
+struct headers_t {
+    test_header_t[2] test;
+}
+
+struct metadata_t {
+}
+
+parser TestParser(packet_in b, out headers_t headers, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        b.extract(headers.test.next);
+        bit<32> test_f = 2 * headers.test.lastIndex;
+        transition select(test_f) {
+            0: f;
+            default: a;
+        }
+    }
+    state a {
+        transition accept;
+    }
+    state f {
+    }
+}
+
+control TestVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control TestIngress(inout headers_t headers, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control TestEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control TestComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control TestDeparser(packet_out b, in headers_t hdr) {
+    apply {
+    }
+}
+
+V1Switch(TestParser(), TestVerifyChecksum(), TestIngress(), TestEgress(), TestComputeChecksum(), TestDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2.p4-stderr
@@ -1,0 +1,3 @@
+issue1409-bmv2.p4(32): warning: f: implicit transition to `reject'
+  state f {
+        ^

--- a/testdata/p4_16_samples_outputs/issue841.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue841.p4-stderr
@@ -1,6 +1,6 @@
 issue841.p4(39): warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
     Checksum16() checksum;
     ^^^^^^^^^^
-v1model.p4(138)
+v1model.p4(141)
 extern Checksum16 {
        ^^^^^^^^^^


### PR DESCRIPTION
@antoninbas : I don't know if this is sufficient to fix #808, but it can't harm.
@hanw: the error code generation was done too early, so the errors[] array was always empty.
We should write some real tests for handling parser errors, but this fix should address #1325.