### PR TITLE
add support for uint64_t constants in IR::Constant (for 32-bit)

### DIFF
--- a/ir/expression.def
+++ b/ir/expression.def
@@ -148,10 +148,14 @@ class Constant : Literal {
         Literal(new Type_InfInt()), value(v), base(base) {}
     Constant(unsigned v, unsigned base = 10) :
         Literal(new Type_InfInt()), value(v), base(base) {}
+#emit
+#if __WORDSIZE < 64
     Constant(long v, unsigned base = 10) :
         Literal(new Type_InfInt()), value(v), base(base) {}
-    // Constant(unsigned long v, unsigned base = 10) : needs fixing the ir parser
-    //     Literal(new Type_InfInt()), value(v), base(base) {}
+    Constant(unsigned long v, unsigned base = 10) :
+        Literal(new Type_InfInt()), value(v), base(base) {}
+#endif
+#end
     Constant(intmax_t v, unsigned base = 10) :
         Literal(new Type_InfInt()), base(base) {
         mpz_import(value.get_mpz_t(), /* word count */1, /* msb first */0,

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -149,17 +149,20 @@ class Constant : Literal {
     Constant(unsigned v, unsigned base = 10) :
         Literal(new Type_InfInt()), value(v), base(base) {}
 #emit
-#if __WORDSIZE < 64
+#if __WORDSIZE == 64
+    Constant(intmax_t v, unsigned base = 10) :
+        Literal(new Type_InfInt()), value(v), base(base) {}
+#else
     Constant(long v, unsigned base = 10) :
         Literal(new Type_InfInt()), value(v), base(base) {}
     Constant(unsigned long v, unsigned base = 10) :
         Literal(new Type_InfInt()), value(v), base(base) {}
-#endif
-#end
     Constant(intmax_t v, unsigned base = 10) :
         Literal(new Type_InfInt()), base(base) {
         mpz_import(value.get_mpz_t(), /* word count */1, /* msb first */0,
                    /* word size */sizeof(v), /* native endian */0, /* nails */0, &v); }
+#endif
+#end
     Constant(uint64_t v, unsigned base = 10) :
         Literal(new Type_InfInt()), base(base) {
         mpz_import(value.get_mpz_t(), /* word count */1, /* msb first */0,

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -141,8 +141,25 @@ class Constant : Literal {
 #noconstructor
     /// if noWarning is true, no warning is emitted
     void handleOverflow(bool noWarning);
+    // We need to enumerate all the integer types because we need proper 64-bit handling on
+    // 32-bit systems (which ain't long!) and mpz_import is too big a hammer because and it loses
+    // the signess of the value.
+    Constant(int v, unsigned base = 10) :
+        Literal(new Type_InfInt()), value(v), base(base) {}
+    Constant(unsigned v, unsigned base = 10) :
+        Literal(new Type_InfInt()), value(v), base(base) {}
+    Constant(long v, unsigned base = 10) :
+        Literal(new Type_InfInt()), value(v), base(base) {}
+    // Constant(unsigned long v, unsigned base = 10) : needs fixing the ir parser
+    //     Literal(new Type_InfInt()), value(v), base(base) {}
     Constant(intmax_t v, unsigned base = 10) :
-            Literal(new Type_InfInt()), value((long)v), base(base) {}
+        Literal(new Type_InfInt()), base(base) {
+        mpz_import(value.get_mpz_t(), /* word count */1, /* msb first */0,
+                   /* word size */sizeof(v), /* native endian */0, /* nails */0, &v); }
+    Constant(uint64_t v, unsigned base = 10) :
+        Literal(new Type_InfInt()), base(base) {
+        mpz_import(value.get_mpz_t(), /* word count */1, /* msb first */0,
+                   /* word size */sizeof(v), /* native endian */0, /* nails */0, &v); }
     Constant(mpz_class v, unsigned base = 10) :
             Literal(new Type_InfInt()), value(v), base(base) {}
     Constant(Util::SourceInfo si, mpz_class v, unsigned base = 10) :
@@ -158,18 +175,29 @@ class Constant : Literal {
     bool fitsInt() const { return value.fits_sint_p(); }
     bool fitsLong() const { return value.fits_slong_p(); }
     bool fitsUint() const { return value.fits_uint_p(); }
+    bool fitsUint64() const { return mpz_sizeinbase(value.get_mpz_t(), 2) < 65; }
     long asLong() const {
         if (!fitsLong())
-            ::error("%1%: Value too large", this);
+            ::error("%1$x: Value too large for long", this);
         return value.get_si(); }
     int asInt() const {
         if (!fitsInt())
-            ::error("%1%: Value too large", this);
+            ::error("%1$x: Value too large for int", this);
         return value.get_si(); }
     unsigned asUnsigned() const {
         if (!fitsUint())
-            ::error("%1%: Value too large", this);
+            ::error("%1$x: Value too large for unsigned int", this);
         return value.get_ui();
+    }
+    uint64_t asUint64() const {
+        if (!fitsUint64())
+            ::error("%1$x: Value too large for uint64", this);
+        uint64_t res = UINT64_C(0);
+        size_t nWords = 0;
+        mpz_export(&res, &nWords, /* msb first */0, /* word size */8,
+                   /* native endian */0, /* nails */0,
+                   value.get_mpz_t());
+        return res;
     }
     // The following operators are only used in special circumstances.
     // They do not look at the type when operating.  There are separate

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/bitvec_test.cpp
   gtest/call_graph_test.cpp
   gtest/complex_bitwise.cpp
+  gtest/constant_expr_test.cpp
   gtest/cstring.cpp
   gtest/diagnostics.cpp
   gtest/dumpjson.cpp

--- a/test/gtest/constant_expr_test.cpp
+++ b/test/gtest/constant_expr_test.cpp
@@ -96,7 +96,6 @@ TEST_F(ConstantExpr, TestLong) {
     IR::Constant mr(val);
     res = mr.asLong();
     EXPECT_EQ(res, val);
-
 }
 
 TEST_F(ConstantExpr, TestUint64) {

--- a/test/gtest/constant_expr_test.cpp
+++ b/test/gtest/constant_expr_test.cpp
@@ -1,0 +1,120 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "gtest/gtest.h"
+#include "helpers.h"
+#include "ir/ir.h"
+
+namespace Test {
+
+class ConstantExpr : public P4CTest { };
+
+TEST_F(ConstantExpr, TestInt) {
+    int val = 0x1;
+    IR::Constant c(val);
+    auto res = c.asInt();
+    EXPECT_EQ(res, val);
+
+    val = INT32_MAX;
+    IR::Constant m(val);
+    res = m.asInt();
+    EXPECT_EQ(res, val);
+
+    val = 0;
+    IR::Constant z(val);
+    res = z.asInt();
+    EXPECT_EQ(res, val);
+
+    val = -1;
+    IR::Constant mo(val);
+    res = mo.asInt();
+    EXPECT_EQ(res, val);
+
+    val = -10000000;
+    IR::Constant mr(val);
+    res = mr.asInt();
+    EXPECT_EQ(res, val);
+}
+
+TEST_F(ConstantExpr, TestUInt) {
+    unsigned int val = 0x12345678U;
+    IR::Constant c(val);
+    auto res = c.asUnsigned();
+    EXPECT_EQ(res, val);
+
+    val = UINT32_MAX;
+    IR::Constant m(val);
+    res = m.asUnsigned();
+    EXPECT_EQ(res, val);
+
+    val = 0;
+    IR::Constant z(val);
+    res = z.asUnsigned();
+    EXPECT_EQ(res, val);
+}
+
+TEST_F(ConstantExpr, TestLong) {
+    long val = 0x12345678L;
+    IR::Constant c(val);
+    auto res = c.asLong();
+    EXPECT_EQ(res, val);
+
+    /* long is inconsistent! */
+#if __WORDSIZE == 64
+    val = INT64_MAX;
+#else
+    val = INT32_MAX;
+#endif
+    IR::Constant m(val);
+    res = m.asLong();
+    EXPECT_EQ(res, val);
+
+    val = 0L;
+    IR::Constant z(val);
+    res = z.asLong();
+    EXPECT_EQ(res, val);
+
+    val = -1L;
+    IR::Constant mo(val);
+    res = mo.asLong();
+    EXPECT_EQ(res, val);
+
+    val = -100L;
+    IR::Constant mr(val);
+    res = mr.asLong();
+    EXPECT_EQ(res, val);
+
+}
+
+TEST_F(ConstantExpr, TestUint64) {
+    uint64_t val = UINT64_C(0x100000000);
+    IR::Constant c(val);
+    auto res = c.asUint64();
+    EXPECT_EQ(res, val);
+
+    val = UINT64_MAX;
+    IR::Constant m(val);
+    res = m.asUint64();
+    EXPECT_EQ(res, val);
+
+    val = UINT64_C(0);
+    IR::Constant z(val);
+    res = z.asUint64();
+    EXPECT_EQ(res, val);
+}
+
+
+}  // namespace Test

--- a/testdata/p4_16_errors_outputs/width_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/width_e.p4-stderr
@@ -1,4 +1,4 @@
-width_e.p4(16): error: 12301923123132: Value too large
+width_e.p4(16): error: 12301923123132: Value too large for int
 const bit<12301923123132>
           ^^^^^^^^^^^^^^
 error: 1 errors encountered, aborting compilation


### PR DESCRIPTION
Casting to long on 32-bit machines does not achieve the expected
result that the value is 64-bit. This PR adds support for uint64_t in
IR::Constant, by expanding the set of constructors with the
almost all used integer data types (exception is unsigned long because the
ir parser generator does not handle types that have two qualifiers).

TODO: deprecate the use of asLong throughout the code base. Right now,
it is used only in v1parser.ypp, and as far as I can tell, only for
sizes that should be well within 32-bits (ids, bit-widths, etc.). I do
recommend a review of the code, and replacement with asUnsigned().

Added a gtest to check different values for all the types -- which is really
what forced me to the solution adding all constructors!