### PR TITLE
Utilities minor fixes

### DIFF
--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -199,7 +199,7 @@ inline cstring cstring::operator+=(const char *a) { *this = *this + a; return *t
 inline cstring cstring::operator+=(std::string a) { *this = *this + a; return *this; }
 inline cstring cstring::operator+=(char a) { *this = *this + a; return *this; }
 
-inline std::string operator+=(std::string a, cstring b) {
+inline std::string& operator+=(std::string& a, cstring b) {
     a.append(b.c_str());
     return a; }
 

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -172,7 +172,7 @@ class GenericEnumerator : public Enumerator<typename Iter::value_type> {
                 return true;
         }
 
-        throw new std::runtime_error("Unexpected enumerator state");
+        throw std::runtime_error("Unexpected enumerator state");
     }
 
     typename Iter::value_type getCurrent() const {
@@ -184,7 +184,7 @@ class GenericEnumerator : public Enumerator<typename Iter::value_type> {
             case EnumeratorState::Valid:
                 return *this->current;
         }
-        throw new std::runtime_error("Unexpected enumerator state");
+        throw std::runtime_error("Unexpected enumerator state");
     }
 };
 
@@ -233,7 +233,7 @@ class FilterEnumerator final : public Enumerator<T> {
             case EnumeratorState::PastEnd:
                 return false;
         }
-        throw new std::runtime_error("Unexpected enumerator state");
+        throw std::runtime_error("Unexpected enumerator state");
     }
 
     T getCurrent() const {
@@ -245,7 +245,7 @@ class FilterEnumerator final : public Enumerator<T> {
             case EnumeratorState::Valid:
                 return this->current;
         }
-        throw new std::runtime_error("Unexpected enumerator state");
+        throw std::runtime_error("Unexpected enumerator state");
     }
 };
 
@@ -326,7 +326,7 @@ class MapEnumerator final : public Enumerator<S> {
             case EnumeratorState::PastEnd:
                 return false;
         }
-        throw new std::runtime_error("Unexpected enumerator state");
+        throw std::runtime_error("Unexpected enumerator state");
     }
 
     S getCurrent() const {
@@ -338,7 +338,7 @@ class MapEnumerator final : public Enumerator<S> {
             case EnumeratorState::Valid:
                 return this->current;
         }
-        throw new std::runtime_error("Unexpected enumerator state");
+        throw std::runtime_error("Unexpected enumerator state");
     }
 };
 
@@ -404,7 +404,7 @@ class ConcatEnumerator final : public Enumerator<T> {
             case EnumeratorState::PastEnd:
                 return false;
         }
-        throw new std::runtime_error("Unexpected enumerator state");
+        throw std::runtime_error("Unexpected enumerator state");
     }
 
     T getCurrent() const {
@@ -416,7 +416,7 @@ class ConcatEnumerator final : public Enumerator<T> {
             case EnumeratorState::Valid:
                 return this->currentResult;
         }
-        throw new std::runtime_error("Unexpected enumerator state");
+        throw std::runtime_error("Unexpected enumerator state");
     }
 };
 

--- a/lib/json.h
+++ b/lib/json.h
@@ -54,19 +54,19 @@ class JsonValue final : public IJson {
         Null
     };
     JsonValue() : tag(Kind::Null) {}
-    JsonValue(bool b) : tag(b ? Kind::True : Kind::False) {}   // NOLINT
-    JsonValue(mpz_class v) : tag(Kind::Number), value(v) {}    // NOLINT
-    JsonValue(int v) : tag(Kind::Number), value(v) {}          // NOLINT
-    JsonValue(long v) : tag(Kind::Number), value(v) {}         // NOLINT
-    JsonValue(long long v);                                    // NOLINT
-    JsonValue(unsigned v) : tag(Kind::Number), value(v) {}     // NOLINT
-    JsonValue(unsigned long v) : tag(Kind::Number), value(v) {}// NOLINT
-    JsonValue(unsigned long long v);                           // NOLINT
-    JsonValue(double v) : tag(Kind::Number), value(v) {}       // NOLINT
-    JsonValue(float v) : tag(Kind::Number), value(v) {}        // NOLINT
-    JsonValue(cstring s) : tag(Kind::String), str(s) {}        // NOLINT
-    JsonValue(std::string s) : tag(Kind::String), str(s) {}    // NOLINT
-    JsonValue(const char* s) : tag(Kind::String), str(s) {}    // NOLINT
+    JsonValue(bool b) : tag(b ? Kind::True : Kind::False) {}          // NOLINT
+    JsonValue(mpz_class v) : tag(Kind::Number), value(v) {}           // NOLINT
+    JsonValue(int v) : tag(Kind::Number), value(v) {}                 // NOLINT
+    JsonValue(long v) : tag(Kind::Number), value(v) {}                // NOLINT
+    JsonValue(long long v);                                           // NOLINT
+    JsonValue(unsigned v) : tag(Kind::Number), value(v) {}            // NOLINT
+    JsonValue(unsigned long v) : tag(Kind::Number), value(v) {}       // NOLINT
+    JsonValue(unsigned long long v);                                  // NOLINT
+    JsonValue(double v) : tag(Kind::Number), value(v) {}              // NOLINT
+    JsonValue(float v) : tag(Kind::Number), value(v) {}               // NOLINT
+    JsonValue(cstring s) : tag(Kind::String), str(s) {}               // NOLINT
+    JsonValue(const std::string &s) : tag(Kind::String), str(s) {}    // NOLINT
+    JsonValue(const char* s) : tag(Kind::String), str(s) {}           // NOLINT
     void serialize(std::ostream& out) const;
 
     bool operator==(const mpz_class& v) const;
@@ -118,7 +118,7 @@ class JsonArray final : public IJson, public std::vector<IJson*> {
     JsonArray* append(double v) { append(new JsonValue(v)); return this; }
     JsonArray* append(float v) { append(new JsonValue(v)); return this; }
     JsonArray* append(cstring s) { append(new JsonValue(s)); return this; }
-    JsonArray* append(std::string s) { append(new JsonValue(s)); return this; }
+    JsonArray* append(const std::string &s) { append(new JsonValue(s)); return this; }
     JsonArray* append(const char* s) { append(new JsonValue(s)); return this; }
     JsonArray(std::initializer_list<IJson*> data) : std::vector<IJson*>(data) {} // NOLINT
     JsonArray() = default;

--- a/lib/path.h
+++ b/lib/path.h
@@ -42,9 +42,9 @@ class PathName final {
 #endif
     }
 
-    PathName(cstring str) : str(str)  {}        // NOLINT(runtime/explicit)
-    PathName(const char* str) : str(str) {}     // NOLINT(runtime/explicit)
-    PathName(std::string str) : str(str) {}     // NOLINT(runtime/explicit)
+    PathName(cstring str) : str(str)  {}             // NOLINT(runtime/explicit)
+    PathName(const char* str) : str(str) {}          // NOLINT(runtime/explicit)
+    PathName(const std::string &str) : str(str) {}   // NOLINT(runtime/explicit)
     // get the file name extension.  It starts at the last dot.
     // e.g, exe
     cstring getExtension() const;

--- a/lib/sourceCodeBuilder.h
+++ b/lib/sourceCodeBuilder.h
@@ -55,7 +55,7 @@ class SourceCodeBuilder {
 
     void append(cstring str) { append(str.c_str()); }
     void appendLine(cstring str) { append(str); newline(); }
-    void append(std::string str) {
+    void append(const std::string &str) {
         if (str.size() == 0)
             return;
         endsInSpace = ::isspace(str.at(str.size() - 1));

--- a/lib/stringify.cpp
+++ b/lib/stringify.cpp
@@ -80,7 +80,9 @@ cstring vprintf_format(const char* fmt_str, va_list ap) {
     if (static_cast<size_t>(size) >= sizeof(buf)) {
         char* formatted = new char[size + 1];
         vsnprintf(formatted, size + 1, fmt_str, ap_copy);
-        return cstring(formatted);
+        cstring result(formatted);
+        delete[] formatted;
+        return result;
     }
     va_end(ap_copy);
     return cstring(buf);


### PR DESCRIPTION
Fixed operator std::string += cstring in cstring library. Implementation do nothing now, modifies copy of string and returns copy of modified copy.

Fixed memory leak in stringify utility. cstring makes copy of string internally in strings table,
memory will never be released without GC


LUTSENKO DANIL
SOFTWARE DEVELOPER
![Jabil Logo](https://user-images.githubusercontent.com/42373060/44663565-9bd2fc00-aa19-11e8-9b32-38290b66f22e.jpg)
www.jabil.com