### PR TITLE
Avoid 'Null e' CompilerBug

### DIFF
--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -142,6 +142,7 @@ const Type* Type_Tuple::getP4Type() const {
     auto args = new IR::Vector<Type>();
     for (auto a : components) {
         auto at = a->getP4Type();
+        if (!at) return nullptr;
         args->push_back(at);
     }
     return new IR::Type_Tuple(srcInfo, *args);


### PR DESCRIPTION
- return a nullptr when trying to infer a tuple type from a list if an
  element can't be inferred properly.  Allows the calling code to give a
  reasonable error message.