### PR TITLE
Skip tests that require root rather than failing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Most dependencies can be installed using `apt-get install`:
 `sudo apt-get install g++ git automake libtool libgc-dev bison flex
 libfl-dev libgmp-dev libboost-dev libboost-iostreams-dev
 libboost-graph-dev pkg-config python python-scapy python-ipaddr python-ply
-tcpdump cmake`
+tcpdump cmake llvm`
 
 For documentation building:
 `sudo apt-get install -y doxygen graphviz texlive-full`

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ included with `p4c` are documented here:
 
 Most dependencies can be installed using `apt-get install`:
 
-`sudo apt-get install g++ git automake libtool libgc-dev bison flex
+`sudo apt-get install cmake g++ git automake libtool libgc-dev bison flex
 libfl-dev libgmp-dev libboost-dev libboost-iostreams-dev
-libboost-graph-dev pkg-config python python-scapy python-ipaddr python-ply
-tcpdump cmake llvm`
+libboost-graph-dev llvm pkg-config python python-scapy python-ipaddr python-ply
+tcpdump`
 
 For documentation building:
 `sudo apt-get install -y doxygen graphviz texlive-full`

--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -125,4 +125,4 @@ endif()
 # ToDo Add check which verifies that BCC is installed
 # Ideally, this is done via check for the python package
 p4c_add_tests("ebpf-bcc" ${EBPF_DRIVER_BCC} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_BCC}")
-p4c_add_tests("ebpf-test" ${EBPF_DRIVER_TEST} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_TEST}")
+p4c_add_tests("ebpf" ${EBPF_DRIVER_TEST} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_TEST}")

--- a/backends/ebpf/README.md
+++ b/backends/ebpf/README.md
@@ -245,7 +245,7 @@ state transition | `goto` statement
 `extract` | load/shift/mask data from packet buffer
 
 #### Translating match-action pipelines
-## 
+##
 P4 Construct | C Translation
 ----------|------------
 table     | 2 eBPF tables: second one used just for the default action
@@ -272,12 +272,19 @@ data-plane.  This C file can be manipulated using clang or BCC tools;
 please refer to the BCC project documentation and sample test files of
 the P4 to eBPF source code for an in-depth understanding.
 
-The general C-file alone will not compile. It depends on headers specific to the generated target. For the default target, this is the `kernel_ebpf.h` file which can be found in the P4 backend under `p4c/backends/ebpf/runtime`.
-The P4 backend also provides a makefile and sample header which allow for quick generation and automatic compilation of the generated file.
+The general C-file alone will not compile. It depends on headers
+specific to the generated target. For the default target, this is the
+`kernel_ebpf.h` file which can be found in the P4 backend under
+`p4c/backends/ebpf/runtime`.  The P4 backend also provides a makefile
+and sample header which allow for quick generation and automatic
+compilation of the generated file.
 
 `make -f p4c/backends/ebpf/runtime/kernel.mk BPFOBJ=out.o P4FILE=PROGRAM.p4`
 
-where -f path is the path to the makefile, BPFOBJ is the output ebpf byte code and P4FILE is the input P4 program. This command sequence will generate an eBPF program, which can be loaded into the kernel using TC.
+where -f path is the path to the makefile, BPFOBJ is the output ebpf
+byte code and P4FILE is the input P4 program. This command sequence
+will generate an eBPF program, which can be loaded into the kernel
+using TC.
 
 ##### Connecting the generated program with the TC
 
@@ -289,17 +296,35 @@ used to control the program behavior.
 
 `tc qdisc add dev IFACE clsact`
 
-Creates a classifier qdisc on the respective interface. Once created, eBPF programs can be attached to it using the following command:
+Creates a classifier qdisc on the respective interface. Once created,
+eBPF programs can be attached to it using the following command:
 
 `tc filter add dev IFACE egress bpf da obj YOUREBPFCODE section prog verbose`
 
-`da` implies that tc takes action input directly from the return codes provided by the eBPF program. We currently support `TC_ACT_SHOT` and `TC_ACT_OK`. For more information, see this link:
+`da` implies that tc takes action input directly from the return codes
+provided by the eBPF program. We currently support `TC_ACT_SHOT` and
+`TC_ACT_OK`. For more information, see this link:
 
 http://docs.cilium.io/en/latest/bpf/#tc-traffic-control
 
 # How to run the generated eBPF program
-Once the eBPF program is loaded, various methods exist to manipulate the tables. The easiest and simplest way is to use the [bpftool](http://docs.cilium.io/en/latest/bpf/#bpftool) provided by the kernel.
 
-An alternative is to use explicit syscalls (an example can be found in the [kernel tools folder](https://github.com/torvalds/linux/blob/master/tools/lib/bpf/bpf.c).
+Once the eBPF program is loaded, various methods exist to manipulate
+the tables. The easiest and simplest way is to use the
+[bpftool](http://docs.cilium.io/en/latest/bpf/#bpftool) provided by
+the kernel.
 
-The P4 compiler automatically provides a set of table initializers, which may also serve as example, in the header of the generated C-file.
+An alternative is to use explicit syscalls (an example can be found in
+the [kernel tools
+folder](https://github.com/torvalds/linux/blob/master/tools/lib/bpf/bpf.c).
+
+The P4 compiler automatically provides a set of table initializers,
+which may also serve as example, in the header of the generated
+C-file.
+
+The following tests run ebpf programs:
+
+- `make check-ebpf`: runs the basic ebpf user-space tests
+- `make check-ebpf-bcc`: runs the user-space tests using bcc to compile ebpf
+- `sudo make check-ebpf-kernel`: runs the kernel-level tests.
+   Requires root privileges to install the ebpf program in the Linux kernel.

--- a/backends/ebpf/run-ebpf-test.py
+++ b/backends/ebpf/run-ebpf-test.py
@@ -79,7 +79,6 @@ def isdir(path):
 
 
 def run_model(ebpf, stffile):
-
     result = ebpf.generate_model_inputs(stffile)
     if result != SUCCESS:
         return result
@@ -89,6 +88,8 @@ def run_model(ebpf, stffile):
         return result
 
     result = ebpf.run()
+    if result == SKIPPED:
+        return SUCCESS
     if result != SUCCESS:
         return result
 

--- a/backends/ebpf/targets/kernel_target.py
+++ b/backends/ebpf/targets/kernel_target.py
@@ -160,7 +160,11 @@ class Target(EBPFTarget):
 
     def run(self):
         # Root is necessary to load ebpf into the kernel
-        require_root(self.outputs)
+        if check_root():
+            errmsg = "This test requires root privileges; skipping execution."
+            report_err(self.outputs["stderr"], errmsg)
+            return SUCCESS
+
         result = self._create_runtime()
         if result != SUCCESS:
             return result

--- a/backends/ebpf/targets/kernel_target.py
+++ b/backends/ebpf/targets/kernel_target.py
@@ -163,7 +163,7 @@ class Target(EBPFTarget):
         if check_root():
             errmsg = "This test requires root privileges; skipping execution."
             report_err(self.outputs["stderr"], errmsg)
-            return SUCCESS
+            return SKIPPED
 
         result = self._create_runtime()
         if result != SUCCESS:

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -27,7 +27,7 @@ import os
 TIMEOUT = 10 * 60
 SUCCESS = 0
 FAILURE = 1
-
+SKIPPED = 2  # used occasionally to indicate that a test was not executed
 
 def is_err(p4filename):
     """ True if the filename represents a p4 program that should fail. """
@@ -144,4 +144,4 @@ def run_timeout(verbose, args, timeout, outputs, errmsg):
 def check_root():
     """ This function returns False if the user does not have root privileges.
         Caution: Only works on Unix systems """
-    return (os.getuid() == 0):
+    return (os.getuid() == 0)

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -141,10 +141,7 @@ def run_timeout(verbose, args, timeout, outputs, errmsg):
     return run_process(verbose, proc, timeout, outputs, errmsg)
 
 
-def require_root(outputs):
-    """ Some calls may require root, this is how we check for it.
+def check_root():
+    """ This function returns False if the user does not have root privileges.
         Caution: Only works on Unix systems """
-    if not (os.getuid() == 0):
-        errmsg = "This test requires root privileges! Failing..."
-        report_err(outputs["stderr"], errmsg)
-        sys.exit(FAILURE)
+    return (os.getuid() == 0):


### PR DESCRIPTION
This should fix issue #1459.
To run the tests that require root one should do `sudo make check-ebpf-kernel`.