### PR TITLE
Sanitize file path input in cmake, add travis check to skip tests

### DIFF
--- a/backends/ebpf/targets/ebpfenv.py
+++ b/backends/ebpf/targets/ebpfenv.py
@@ -39,7 +39,7 @@ class Bridge(object):
         """ Initialize the namespace. """
         cmd = "ip netns add %s" % self.ns_name
         errmsg = "Failed to create namespace %s :" % self.ns_name
-        result = run_timeout(True, cmd, TIMEOUT,
+        result = run_timeout(self.verbose, cmd, TIMEOUT,
                              self.outputs, errmsg)
         self.ns_exec("ip link set dev lo up")
         return result
@@ -48,7 +48,7 @@ class Bridge(object):
         """ Delete the namespace. """
         cmd = "ip netns del %s" % self.ns_name
         errmsg = "Failed to delete namespace %s :" % self.ns_name
-        return run_timeout(True, cmd, TIMEOUT,
+        return run_timeout(self.verbose, cmd, TIMEOUT,
                            self.outputs, errmsg)
 
     def get_ns_prefix(self):
@@ -61,7 +61,8 @@ class Bridge(object):
         prefix = self.get_ns_prefix()
         # bash -c allows us to run multiple commands at once
         cmd = "%s bash -c \"%s\"" % (prefix, cmd_string)
-        errmsg = "Failed to run command in namespace %s:" % self.ns_name
+        errmsg = "Failed to run command %s in namespace %s:" % (
+            cmd, self.ns_name)
         return run_timeout(self.verbose, cmd, TIMEOUT,
                            self.outputs, errmsg)
 

--- a/backends/ebpf/targets/kernel_target.py
+++ b/backends/ebpf/targets/kernel_target.py
@@ -164,7 +164,12 @@ class Target(EBPFTarget):
             errmsg = "This test requires root privileges; skipping execution."
             report_err(self.outputs["stderr"], errmsg)
             return SKIPPED
-
+        # Sadly the Travis environment does not work with ip netns yet
+        if check_travis():
+            errmsg = ("The travis build currently does not support virtual"
+                      "namespaces; skipping execution.")
+            report_err(self.outputs["stderr"], errmsg)
+            return SKIPPED
         result = self._create_runtime()
         if result != SUCCESS:
             return result

--- a/backends/ebpf/targets/kernel_target.py
+++ b/backends/ebpf/targets/kernel_target.py
@@ -160,14 +160,14 @@ class Target(EBPFTarget):
 
     def run(self):
         # Root is necessary to load ebpf into the kernel
-        if check_root():
+        if not check_root():
             errmsg = "This test requires root privileges; skipping execution."
             report_err(self.outputs["stderr"], errmsg)
             return SKIPPED
         # Sadly the Travis environment does not work with ip netns yet
         if check_travis():
             errmsg = ("The travis build currently does not support virtual"
-                      "namespaces; skipping execution.")
+                      " namespaces; skipping execution.")
             report_err(self.outputs["stderr"], errmsg)
             return SKIPPED
         result = self._create_runtime()

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -29,6 +29,7 @@ SUCCESS = 0
 FAILURE = 1
 SKIPPED = 2  # used occasionally to indicate that a test was not executed
 
+
 def is_err(p4filename):
     """ True if the filename represents a p4 program that should fail. """
     return "_errors" in p4filename
@@ -145,3 +146,9 @@ def check_root():
     """ This function returns False if the user does not have root privileges.
         Caution: Only works on Unix systems """
     return (os.getuid() == 0)
+
+
+def check_travis():
+    """ This function returns True if the tests are being run in a
+    travis environment."""
+    return (os.environ.get('TRAVIS') == 'true')


### PR DESCRIPTION
This requests modifies `p4c_add_test_list` to add the absolute path to file inputs. This is necessary for xfail tests in extensions such as p4c-xdp, which did not properly matched and were ignored.

Another addition is a check for Travis builds in the ebpf-kernel tests. It seems that due to privilege issues Travis does not support netem or ip netns commands:
`mount --make-shared /var/run/netns failed: Operation not permitted`
The check is to ensure that run does not get executed. Ideally, we still want to check that loading is possible, but this requires creating a new type of virtual environment.