### PR TITLE
Avoid crashing after errors

### DIFF
--- a/frontends/common/parseInput.cpp
+++ b/frontends/common/parseInput.cpp
@@ -49,12 +49,10 @@ parseV1Program(Input& stream, const char* sourceFile, unsigned sourceLine,
     if (Log::verbose())
         std::cerr << "Converting to P4-16" << std::endl;
     v1 = v1->apply(converter);
-    if (v1 != nullptr) {
-        BUG_CHECK(v1->is<IR::P4Program>(), "Conversion returned %1%", v1);
-        return v1->to<IR::P4Program>();
-    }
-
-    return nullptr;  // Conversion failed.
+    if (::errorCount() > 0 || v1 == nullptr)
+        return nullptr;
+    BUG_CHECK(v1->is<IR::P4Program>(), "Conversion returned %1%", v1);
+    return v1->to<IR::P4Program>();
 }
 
 const IR::P4Program* parseP4File(CompilerOptions& options) {

--- a/test/gtest/arch_test.cpp
+++ b/test/gtest/arch_test.cpp
@@ -62,7 +62,7 @@ TEST_F(P4CArchitecture, packet_out) {
     });
 
     pgm = pgm->apply(passes);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 }
 
 // Potential bug
@@ -96,7 +96,7 @@ TEST_F(P4CArchitecture, duplicatedDeclarationBug) {
     });
 
     pgm = pgm->apply(passes);
-    ASSERT_TRUE(pgm == nullptr);
+    ASSERT_GT(::errorCount(), 0U);
 }
 
 TEST_F(P4CArchitecture, instantiation) {
@@ -143,7 +143,7 @@ TEST_F(P4CArchitecture, instantiation) {
     });
 
     pgm = pgm->apply(passes);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 }
 
 TEST_F(P4CArchitecture, psa_package_with_body) {
@@ -173,7 +173,7 @@ TEST_F(P4CArchitecture, psa_package_with_body) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_TRUE(pgm == nullptr);
+    ASSERT_GT(::errorCount(), 0U);
 }
 
 TEST_F(P4CArchitecture, psa_control_in_control) {
@@ -209,7 +209,7 @@ TEST_F(P4CArchitecture, psa_control_in_control) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 }
 
 TEST_F(P4CArchitecture, psa_clone_as_param_to_package) {
@@ -234,7 +234,7 @@ TEST_F(P4CArchitecture, psa_clone_as_param_to_package) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 }
 
 TEST_F(P4CArchitecture, psa_clone_as_param_to_control) {
@@ -268,7 +268,7 @@ TEST_F(P4CArchitecture, psa_clone_as_param_to_control) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 }
 
 TEST_F(P4CArchitecture, psa_clone_as_param_to_extern) {
@@ -310,7 +310,7 @@ TEST_F(P4CArchitecture, psa_clone_as_param_to_extern) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 }
 
 TEST_F(P4CArchitecture, clone_as_extern_method) {
@@ -341,7 +341,7 @@ TEST_F(P4CArchitecture, clone_as_extern_method) {
         new TypeChecking(&refMap, &typeMap)
     });
     pgm = pgm->apply(passes);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 }
 
 }  // namespace Test

--- a/test/gtest/midend_test.cpp
+++ b/test/gtest/midend_test.cpp
@@ -52,7 +52,7 @@ TEST_F(P4CMidend, convertEnums_pass) {
         control m() { C(E.A) ctr; apply{} }
     )");
     auto pgm = P4::parseP4String(program, CompilerOptions::FrontendVersion::P4_16);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 
     // Example to enable logging in source
     // Log::addDebugSpec("convertEnums:0");
@@ -63,7 +63,7 @@ TEST_F(P4CMidend, convertEnums_pass) {
         convertEnums
     };
     pgm = pgm->apply(passes);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && errorCount() == 0);
 }
 
 TEST_F(P4CMidend, convertEnums_used_before_declare) {
@@ -72,7 +72,7 @@ TEST_F(P4CMidend, convertEnums_used_before_declare) {
         enum E { A, B, C, D };
     )");
     auto pgm = P4::parseP4String(program, CompilerOptions::FrontendVersion::P4_16);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm && ::errorCount() == 0);
 
     ReferenceMap  refMap;
     TypeMap       typeMap;
@@ -80,9 +80,9 @@ TEST_F(P4CMidend, convertEnums_used_before_declare) {
     PassManager passes = {
         convertEnums
     };
-    auto result = pgm->apply(passes);
+    pgm = pgm->apply(passes);
     // use enum before declaration should fail
-    ASSERT_TRUE(result == nullptr);
+    ASSERT_GT(::errorCount(), 0U);
 }
 
 // use enumMap in convertEnums directly
@@ -102,7 +102,7 @@ TEST_F(P4CMidend, getEnumMapping) {
         convertEnums
     };
     auto result = pgm->apply(passes_);
-    ASSERT_TRUE(result != nullptr);
+    ASSERT_TRUE(result != nullptr && ::errorCount() == 0);
 
     enumMap = convertEnums->getEnumMapping();
     ASSERT_EQ(enumMap.size(), (unsigned long)1);

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -1154,7 +1154,7 @@ TEST_F(P4RuntimeDataTypeSpec, Struct) {
         my_extern_t<my_struct>(32w1024) my_extern;
     )");
     auto pgm = getProgram(program);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
@@ -1180,7 +1180,7 @@ TEST_F(P4RuntimeDataTypeSpec, Header) {
         my_extern_t<my_header>(32w1024) my_extern;
     )");
     auto pgm = getProgram(program);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
@@ -1207,7 +1207,7 @@ TEST_F(P4RuntimeDataTypeSpec, HeaderUnion) {
         my_extern_t<my_header_union>(32w1024) my_extern;
     )");
     auto pgm = getProgram(program);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
@@ -1237,7 +1237,7 @@ TEST_F(P4RuntimeDataTypeSpec, HeaderStack) {
         my_extern_t<my_header[3]>(32w1024) my_extern;
     )");
     auto pgm = getProgram(program);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 
     auto type = findExternTypeParameterName<IR::Type_Stack>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
@@ -1259,7 +1259,7 @@ TEST_F(P4RuntimeDataTypeSpec, HeaderUnionStack) {
         my_extern_t<my_header_union[3]>(32w1024) my_extern;
     )");
     auto pgm = getProgram(program);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 
     auto type = findExternTypeParameterName<IR::Type_Stack>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
@@ -1281,7 +1281,7 @@ TEST_F(P4RuntimeDataTypeSpec, Enum) {
         my_extern_t<my_enum>(32w1024) my_extern;
     )");
     auto pgm = getProgram(program);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
@@ -1304,7 +1304,7 @@ TEST_F(P4RuntimeDataTypeSpec, Error) {
         my_extern_t<error>(32w1024) my_extern;
     )");
     auto pgm = getProgram(program);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
@@ -1326,7 +1326,7 @@ TEST_F(P4RuntimeDataTypeSpec, StructWithTypedef) {
         my_extern_t<my_struct>(32w1024) my_extern;
     )");
     auto pgm = getProgram(program);
-    ASSERT_TRUE(pgm != nullptr);
+    ASSERT_TRUE(pgm != nullptr && ::errorCount() == 0);
 
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);


### PR DESCRIPTION
- after an error, arbitrarily returning nullptr from a PassManager can
  result in a crash or error cascade -- we instead return the tree from
  before the error.
- stop_on_error should only abort after a NEW error, to allow some
  continued error checking after an error.