### PR TITLE
Remove deprecated drop field from p4c tests for v1model arch

### DIFF
--- a/testdata/p4_16_bmv_errors/issue679-bmv2.p4
+++ b/testdata/p4_16_bmv_errors/issue679-bmv2.p4
@@ -29,7 +29,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { smeta.drop = 1; }
+    action drop() { mark_to_drop(); }
 
     action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
 

--- a/testdata/p4_16_samples/action_profile-bmv2.p4
+++ b/testdata/p4_16_samples/action_profile-bmv2.p4
@@ -30,7 +30,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { smeta.drop = 1; }
+    action drop() { mark_to_drop(); }
 
     table indirect {
         key = { }

--- a/testdata/p4_16_samples/action_selector_shared-bmv2.p4
+++ b/testdata/p4_16_samples/action_selector_shared-bmv2.p4
@@ -30,7 +30,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { smeta.drop = 1; }
+    action drop() { mark_to_drop(); }
 
     action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
 

--- a/testdata/p4_16_samples/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples/action_selector_unused-bmv2.p4
@@ -15,7 +15,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { smeta.drop = 1; }
+    action drop() { mark_to_drop(); }
 
     action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
     apply { }

--- a/testdata/p4_16_samples/drop-bmv2.p4
+++ b/testdata/p4_16_samples/drop-bmv2.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
     state start { transition accept; }
 }
 
-action drop(out standard_metadata_t smeta) { smeta.drop = 1; } // this global action seems to cause the problem
+action drop(out standard_metadata_t smeta) { mark_to_drop(); } // this global action seems to cause the problem
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 

--- a/testdata/p4_16_samples/issue242.p4
+++ b/testdata/p4_16_samples/issue242.p4
@@ -70,7 +70,7 @@ control Ing(inout Headers headers,
             inout Metadata meta,
             inout standard_metadata_t standard_meta) {
     apply {
-        standard_meta.drop = 0;
+        standard_meta.egress_spec = 0;
     }
 }
 

--- a/testdata/p4_16_samples/issue297-bmv2.p4
+++ b/testdata/p4_16_samples/issue297-bmv2.p4
@@ -31,7 +31,7 @@ action empty() { }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action_profile(32w128) ap;
 
-    action drop() { smeta.drop = 1; }
+    action drop() { mark_to_drop(); }
 
     table indirect {
         key = { }

--- a/testdata/p4_16_samples/issue677-bmv2.p4
+++ b/testdata/p4_16_samples/issue677-bmv2.p4
@@ -16,7 +16,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout SM smeta) {
 
 control IngressI(inout H hdr, inout M meta, inout SM smeta) {
     apply {
-        smeta.drop = 1;
+        smeta.egress_spec = 1;
     }
 }
 

--- a/testdata/p4_16_samples/issue696-bmv2.p4
+++ b/testdata/p4_16_samples/issue696-bmv2.p4
@@ -73,7 +73,7 @@ control Ing(inout Headers headers,
             inout Metadata meta,
             inout standard_metadata_t standard_meta) {
     apply {
-        standard_meta.drop = 0;
+        standard_meta.egress_spec = 1;
     }
 }
 

--- a/testdata/p4_16_samples/saturated-bmv2.p4
+++ b/testdata/p4_16_samples/saturated-bmv2.p4
@@ -71,7 +71,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
 
-    action drop() { standard_meta.drop = 1; }
+    action drop() { mark_to_drop(); }
 
     USat_t ru;
     Sat_t r;

--- a/testdata/p4_16_samples/v1model-newtype.pp
+++ b/testdata/p4_16_samples/v1model-newtype.pp
@@ -37,8 +37,11 @@ struct standard_metadata_t {
     PortId_t egress_port;
     bit<32> clone_spec;
     bit<32> instance_type;
-    bit<1>  drop;
-    bit<16> recirculate_port;
+    // deleted deprecated drop and recirculate_port fields from this
+    // slightly modified copy of v1model.p4, since this file is only
+    // #include'd in one test program that makes no mention of them.
+    //bit<1>  drop;
+    //bit<16> recirculate_port;
     bit<32> packet_length;
     //
     // @alias is used to generate the field_alias section of the BMV2 JSON.

--- a/testdata/p4_16_samples/v1model-special-ops-bmv2.p4
+++ b/testdata/p4_16_samples/v1model-special-ops-bmv2.p4
@@ -123,13 +123,17 @@ control debug_std_meta(in standard_metadata_t standard_metadata)
             // parser_error is commented out because the p4c back end
             // for bmv2 as of that date gives an error if you include
             // a field of type 'error' in a table key.
+
+            // drop and recirculate_port are commented out because
+            // they are not used by BMv2 simple_switch, and we may
+            // want to delete them from v1model.p4 in the future.
             standard_metadata.ingress_port : exact;
             standard_metadata.egress_spec : exact;
             standard_metadata.egress_port : exact;
             standard_metadata.clone_spec : exact;
             standard_metadata.instance_type : exact;
-            standard_metadata.drop : exact;
-            standard_metadata.recirculate_port : exact;
+            //standard_metadata.drop : exact;
+            //standard_metadata.recirculate_port : exact;
             standard_metadata.packet_length : exact;
             standard_metadata.enq_timestamp : exact;
             standard_metadata.enq_qdepth : exact;

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-frontend.p4
@@ -20,10 +20,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_0() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.drop") action drop_3() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.indirect") table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
@@ -20,10 +20,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_0() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.drop") action drop_3() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.indirect") table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        smeta.drop = 1;
+        mark_to_drop();
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     table indirect_ws {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-frontend.p4
@@ -20,10 +20,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_0() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.drop") action drop_3() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.as") action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     @name("IngressI.indirect_ws") table indirect_ws {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-midend.p4
@@ -20,10 +20,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_0() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.drop") action drop_3() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.as") action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     @name("IngressI.indirect_ws") table indirect_ws {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        smeta.drop = 1;
+        mark_to_drop();
     }
     action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     table indirect_ws {

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     apply {

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        smeta.drop = 1;
+        mark_to_drop();
     }
     action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     apply {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-first.p4
@@ -14,7 +14,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 action drop(out standard_metadata_t smeta) {
-    smeta.drop = 1w1;
+    mark_to_drop();
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     table forward {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
@@ -15,7 +15,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".drop") action drop_0(out standard_metadata_t smeta_1) {
-        smeta_1.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.forward") table forward {
         key = {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
@@ -16,13 +16,13 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     standard_metadata_t smeta_1;
     @name(".drop") action drop_0() {
-        smeta_1.drop = 1w1;
+        mark_to_drop();
         smeta.ingress_port = smeta_1.ingress_port;
         smeta.egress_spec = smeta_1.egress_spec;
         smeta.egress_port = smeta_1.egress_port;
         smeta.clone_spec = smeta_1.clone_spec;
         smeta.instance_type = smeta_1.instance_type;
-        smeta.drop = 1w1;
+        smeta.drop = smeta_1.drop;
         smeta.recirculate_port = smeta_1.recirculate_port;
         smeta.packet_length = smeta_1.packet_length;
         smeta.enq_timestamp = smeta_1.enq_timestamp;

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4
@@ -14,7 +14,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 action drop(out standard_metadata_t smeta) {
-    smeta.drop = 1;
+    mark_to_drop();
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     table forward {

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4-stderr
@@ -1,6 +1,6 @@
 drop-bmv2.p4(27): [--Wwarn=uninitialized_out_param] warning: out parameter smeta may be uninitialized when drop terminates
-action drop(out standard_metadata_t smeta) { smeta.drop = 1; } // this global action seems to cause the problem
+action drop(out standard_metadata_t smeta) { mark_to_drop(); } // this global action seems to cause the problem
                                     ^^^^^
 drop-bmv2.p4(27)
-action drop(out standard_metadata_t smeta) { smeta.drop = 1; } // this global action seems to cause the problem
+action drop(out standard_metadata_t smeta) { mark_to_drop(); } // this global action seems to cause the problem
        ^^^^

--- a/testdata/p4_16_samples_outputs/issue242-first.p4
+++ b/testdata/p4_16_samples_outputs/issue242-first.p4
@@ -51,7 +51,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     apply {
-        standard_meta.drop = 1w0;
+        standard_meta.egress_spec = 9w0;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue242-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-frontend.p4
@@ -51,7 +51,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     apply {
-        standard_meta.drop = 1w0;
+        standard_meta.egress_spec = 9w0;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue242-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-midend.p4
@@ -56,7 +56,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     @hidden action act() {
-        standard_meta.drop = 1w0;
+        standard_meta.egress_spec = 9w0;
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue242.p4
+++ b/testdata/p4_16_samples_outputs/issue242.p4
@@ -51,7 +51,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     apply {
-        standard_meta.drop = 0;
+        standard_meta.egress_spec = 0;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-first.p4
@@ -19,7 +19,7 @@ action empty() {
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action_profile(32w128) ap;
     action drop() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
@@ -21,10 +21,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     }
     @name("IngressI.ap") action_profile(32w128) ap;
     @name("IngressI.drop") action drop_0() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.drop") action drop_3() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.indirect") table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
@@ -21,10 +21,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     }
     @name("IngressI.ap") action_profile(32w128) ap;
     @name("IngressI.drop") action drop_0() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.drop") action drop_3() {
-        smeta.drop = 1w1;
+        mark_to_drop();
     }
     @name("IngressI.indirect") table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2.p4
@@ -19,7 +19,7 @@ action empty() {
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action_profile(32w128) ap;
     action drop() {
-        smeta.drop = 1;
+        mark_to_drop();
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/issue677-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue677-bmv2-first.p4
@@ -16,7 +16,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout SM smeta) {
 
 control IngressI(inout H hdr, inout M meta, inout SM smeta) {
     apply {
-        smeta.drop = 1w1;
+        smeta.egress_spec = 9w1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue677-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue677-bmv2-frontend.p4
@@ -16,7 +16,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout SM smeta) {
 
 control IngressI(inout H hdr, inout M meta, inout SM smeta) {
     apply {
-        smeta.drop = 1w1;
+        smeta.egress_spec = 9w1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue677-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue677-bmv2-midend.p4
@@ -16,7 +16,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout SM smeta) {
 
 control IngressI(inout H hdr, inout M meta, inout SM smeta) {
     @hidden action act() {
-        smeta.drop = 1w1;
+        smeta.egress_spec = 9w1;
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue677-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue677-bmv2.p4
@@ -16,7 +16,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout SM smeta) {
 
 control IngressI(inout H hdr, inout M meta, inout SM smeta) {
     apply {
-        smeta.drop = 1;
+        smeta.egress_spec = 1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-first.p4
@@ -55,7 +55,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     apply {
-        standard_meta.drop = 1w0;
+        standard_meta.egress_spec = 9w1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-frontend.p4
@@ -55,7 +55,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     apply {
-        standard_meta.drop = 1w0;
+        standard_meta.egress_spec = 9w1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-midend.p4
@@ -60,7 +60,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     @hidden action act() {
-        standard_meta.drop = 1w0;
+        standard_meta.egress_spec = 9w1;
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue696-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2.p4
@@ -55,7 +55,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     apply {
-        standard_meta.drop = 0;
+        standard_meta.egress_spec = 1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-portid-using-newtype2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-portid-using-newtype2-first.p4
@@ -14,8 +14,6 @@ match_kind {
     PortId_t egress_port;
     bit<32>  clone_spec;
     bit<32>  instance_type;
-    bit<1>   drop;
-    bit<16>  recirculate_port;
     bit<32>  packet_length;
     @alias("queueing_metadata.enq_timestamp") 
     bit<32>  enq_timestamp;

--- a/testdata/p4_16_samples_outputs/psa-portid-using-newtype2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-portid-using-newtype2-frontend.p4
@@ -14,8 +14,6 @@ match_kind {
     PortId_t egress_port;
     bit<32>  clone_spec;
     bit<32>  instance_type;
-    bit<1>   drop;
-    bit<16>  recirculate_port;
     bit<32>  packet_length;
     @alias("queueing_metadata.enq_timestamp") 
     bit<32>  enq_timestamp;
@@ -157,10 +155,10 @@ parser FabricParser(packet_in packet, out parsed_headers_t hdr, inout fabric_met
 }
 
 control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_metadata, inout standard_metadata_t standard_metadata) {
-    @name(".drop") action drop_0() {
+    @name(".drop") action drop() {
         mark_to_drop();
     }
-    @name(".drop") action drop_3() {
+    @name(".drop") action drop_0() {
         mark_to_drop();
     }
     @name(".nop") action nop() {
@@ -174,7 +172,7 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
             standard_metadata.ingress_port: exact @name("standard_metadata.ingress_port") ;
         }
         actions = {
-            drop_0();
+            drop();
             nop();
             @defaultonly NoAction_0();
         }
@@ -189,7 +187,7 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
             hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
         }
         actions = {
-            drop_3();
+            drop_0();
             forwarding_fwd();
             @defaultonly NoAction_3();
         }

--- a/testdata/p4_16_samples_outputs/psa-portid-using-newtype2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-portid-using-newtype2-midend.p4
@@ -14,8 +14,6 @@ match_kind {
     PortId_t egress_port;
     bit<32>  clone_spec;
     bit<32>  instance_type;
-    bit<1>   drop;
-    bit<16>  recirculate_port;
     bit<32>  packet_length;
     @alias("queueing_metadata.enq_timestamp") 
     bit<32>  enq_timestamp;
@@ -158,10 +156,10 @@ parser FabricParser(packet_in packet, out parsed_headers_t hdr, inout fabric_met
 
 control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_metadata, inout standard_metadata_t standard_metadata) {
     bool hasExited;
-    @name(".drop") action drop_0() {
+    @name(".drop") action drop() {
         mark_to_drop();
     }
-    @name(".drop") action drop_3() {
+    @name(".drop") action drop_0() {
         mark_to_drop();
     }
     @name(".nop") action nop() {
@@ -175,7 +173,7 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
             standard_metadata.ingress_port: exact @name("standard_metadata.ingress_port") ;
         }
         actions = {
-            drop_0();
+            drop();
             nop();
             @defaultonly NoAction_0();
         }
@@ -189,7 +187,7 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
             hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
         }
         actions = {
-            drop_3();
+            drop_0();
             forwarding_fwd();
             @defaultonly NoAction_3();
         }

--- a/testdata/p4_16_samples_outputs/psa-portid-using-newtype2.p4
+++ b/testdata/p4_16_samples_outputs/psa-portid-using-newtype2.p4
@@ -14,8 +14,6 @@ match_kind {
     PortId_t egress_port;
     bit<32>  clone_spec;
     bit<32>  instance_type;
-    bit<1>   drop;
-    bit<16>  recirculate_port;
     bit<32>  packet_length;
     @alias("queueing_metadata.enq_timestamp") 
     bit<32>  enq_timestamp;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
@@ -66,7 +66,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     action drop() {
-        standard_meta.drop = 1w1;
+        mark_to_drop();
     }
     USat_t ru;
     Sat_t r;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
@@ -66,7 +66,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     @name("ingress.drop") action drop_0() {
-        standard_meta.drop = 1w1;
+        mark_to_drop();
     }
     @name("ingress.t") table t {
         key = {

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
@@ -66,7 +66,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     @name("ingress.drop") action drop_0() {
-        standard_meta.drop = 1w1;
+        mark_to_drop();
     }
     @name("ingress.t") table t {
         key = {

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4
@@ -66,7 +66,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     action drop() {
-        standard_meta.drop = 1;
+        mark_to_drop();
     }
     USat_t ru;
     Sat_t r;


### PR DESCRIPTION
I know that the p4c test programs are often not complete functional
programs, but leaving a deprecated standard_metadata_t field like drop
in use in the test programs can be confusing to P4 developers looking
for examples.