### PR TITLE
warnings

### DIFF
--- a/backends/graphs/parsers.cpp
+++ b/backends/graphs/parsers.cpp
@@ -17,7 +17,6 @@
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/toP4/toP4.h"
-#include "frontends/p4/typeMap.h"
 #include "lib/nullstream.h"
 #include "parsers.h"
 

--- a/backends/graphs/parsers.h
+++ b/backends/graphs/parsers.h
@@ -24,11 +24,15 @@
 #include "lib/path.h"
 #include "lib/safe_vector.h"
 
+namespace P4 {
+    // Forward declaration to avoid includes
+    class TypeMap;
+}  // end namespace P4
+
 namespace graphs {
 
 class ParserGraphs : public Inspector {
     const P4::ReferenceMap* refMap;
-    const P4::TypeMap* typeMap;
     const cstring graphsDir;
 
  protected:
@@ -47,9 +51,9 @@ class ParserGraphs : public Inspector {
     std::map<const IR::P4Parser*, safe_vector<const IR::ParserState*>> states;
 
  public:
-    ParserGraphs(P4::ReferenceMap *refMap, P4::TypeMap *typeMap, const cstring &graphsDir) :
-            refMap(refMap), typeMap(typeMap), graphsDir(graphsDir) {
-        CHECK_NULL(refMap); CHECK_NULL(typeMap); setName("ParserGraphs");
+    ParserGraphs(P4::ReferenceMap *refMap, P4::TypeMap *, const cstring &graphsDir) :
+            refMap(refMap), graphsDir(graphsDir) {
+        CHECK_NULL(refMap); setName("ParserGraphs");
     }
 
     void postorder(const IR::P4Parser* parser) override;

--- a/backends/graphs/parsers.h
+++ b/backends/graphs/parsers.h
@@ -25,8 +25,8 @@
 #include "lib/safe_vector.h"
 
 namespace P4 {
-    // Forward declaration to avoid includes
-    class TypeMap;
+// Forward declaration to avoid includes
+class TypeMap;
 }  // end namespace P4
 
 namespace graphs {

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -21,7 +21,10 @@ limitations under the License.
 
 #include <set>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "p4/config/v1/p4info.pb.h"
+#pragma GCC diagnostic pop
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/externInstance.h"

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -25,10 +25,13 @@ limitations under the License.
 #include <boost/optional.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <google/protobuf/text_format.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <google/protobuf/util/json_util.h>
 #include "p4/config/v1/p4info.pb.h"
 #include "p4/config/v1/p4types.pb.h"
 #include "p4/v1/p4runtime.pb.h"
+#pragma GCC diagnostic pop
 
 #include "frontends/common/options.h"
 #include "frontends/common/resolveReferences/referenceMap.h"

--- a/control-plane/typeSpecConverter.cpp
+++ b/control-plane/typeSpecConverter.cpp
@@ -39,9 +39,8 @@ namespace P4 {
 namespace ControlPlaneAPI {
 
 TypeSpecConverter::TypeSpecConverter(
-    const P4::TypeMap* typeMap, const P4::ReferenceMap* refMap, P4TypeInfo* p4RtTypeInfo)
-    : typeMap(typeMap), refMap(refMap), p4RtTypeInfo(p4RtTypeInfo) {
-    CHECK_NULL(typeMap);
+    const P4::ReferenceMap* refMap, P4TypeInfo* p4RtTypeInfo)
+    : refMap(refMap), p4RtTypeInfo(p4RtTypeInfo) {
     CHECK_NULL(refMap);
 }
 
@@ -250,9 +249,9 @@ bool TypeSpecConverter::preorder(const IR::Type_Error* type) {
 }
 
 const P4DataTypeSpec* TypeSpecConverter::convert(
-    const P4::TypeMap* typeMap, const P4::ReferenceMap* refMap,
+    const P4::ReferenceMap* refMap,
     const IR::Type* type, P4TypeInfo* typeInfo) {
-    TypeSpecConverter typeSpecConverter(typeMap, refMap, typeInfo);
+    TypeSpecConverter typeSpecConverter(refMap, typeInfo);
     type->apply(typeSpecConverter);
     return typeSpecConverter.map.at(type);
 }

--- a/control-plane/typeSpecConverter.h
+++ b/control-plane/typeSpecConverter.h
@@ -41,7 +41,6 @@ namespace ControlPlaneAPI {
 /// Generates the appropriate p4.P4DataTypeSpec for a given IR::Type node.
 class TypeSpecConverter : public Inspector {
  private:
-    const P4::TypeMap* typeMap;
     const P4::ReferenceMap* refMap;
     /// type_info field of the P4Info message: includes information about P4
     /// named types (struct, header, header union, enum, error).
@@ -50,7 +49,7 @@ class TypeSpecConverter : public Inspector {
     /// 'map'.
     std::map<const IR::Type*, ::p4::config::v1::P4DataTypeSpec*> map;
 
-    TypeSpecConverter(const P4::TypeMap* typeMap, const P4::ReferenceMap* refMap,
+    TypeSpecConverter(const P4::ReferenceMap* refMap,
                       ::p4::config::v1::P4TypeInfo* p4RtTypeInfo);
 
     // fallback for unsupported types, should be unreachable
@@ -78,7 +77,7 @@ class TypeSpecConverter : public Inspector {
     /// @typeInfo is nullptr, then the relevant information is not generated for
     /// named types.
     static const ::p4::config::v1::P4DataTypeSpec* convert(
-        const P4::TypeMap* typeMap, const P4::ReferenceMap* refMap,
+        const P4::ReferenceMap* refMap,
         const IR::Type* type, ::p4::config::v1::P4TypeInfo* typeInfo);
 };
 

--- a/ir/ir-tree-macros.h
+++ b/ir/ir-tree-macros.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,13 +32,14 @@ limitations under the License.
     M(Vector, D(Node), template<class T>, <T>, ##__VA_ARGS__)                                   \
     M(IndexedVector, D(Vector<T>) B(Node), template<class T>, <T>, ##__VA_ARGS__)               \
     M(NameMap, D(Node),                                                                         \
-      COPY(template<class T, template<class, class, class, class> class MAP TDA(= std::map),    \
-                    class COMP TDA(= std::less<cstring>),                                       \
-                    class ALLOC TDA(= std::allocator<std::pair<cstring, const T*>>) >),         \
-      COPY(<T, MAP, COMP, ALLOC>), ##__VA_ARGS__)                                               \
+      IR_TREE_COPY(template<class T, template<class, class, class, class>                       \
+                   class MAP TDA(= std::map),                                                   \
+                   class COMP TDA(= std::less<cstring>),                                        \
+                   class ALLOC TDA(= std::allocator<std::pair<cstring, const T*>>) >),          \
+      IR_TREE_COPY(<T, MAP, COMP, ALLOC>), ##__VA_ARGS__)                                       \
 
-#define COPY(...)       __VA_ARGS__
-#define IGNORE(...)
+#define IR_TREE_COPY(...)       __VA_ARGS__
+#define IR_TREE_IGNORE(...)
 
 /* all IR classes, including Node */
 #define IRNODE_ALL_CLASSES_AND_BASES(M, B, ...)                                                 \
@@ -47,31 +48,33 @@ limitations under the License.
 
 #define IRNODE_ALL_NON_TEMPLATE_CLASSES_AND_BASES(M, B, ...)                                    \
     M(Node, , ##__VA_ARGS__)                                                                    \
-        IRNODE_ALL_SUBCLASSES_AND_DIRECT_AND_INDIRECT_BASES(M, IGNORE, B, B, ##__VA_ARGS__)
+        IRNODE_ALL_SUBCLASSES_AND_DIRECT_AND_INDIRECT_BASES(M, IR_TREE_IGNORE, B, B, ##__VA_ARGS__)
 
 /* all the subclasses with just the immediate bases */
 #define IRNODE_ALL_SUBCLASSES(M, ...)   \
-    IRNODE_ALL_SUBCLASSES_AND_DIRECT_AND_INDIRECT_BASES(M, M, COPY, IGNORE, ##__VA_ARGS__)
+    IRNODE_ALL_SUBCLASSES_AND_DIRECT_AND_INDIRECT_BASES(M, M, IR_TREE_COPY, IR_TREE_IGNORE, \
+                                                        ##__VA_ARGS__)
 #define IRNODE_ALL_NON_TEMPLATE_SUBCLASSES(M, ...)      \
-    IRNODE_ALL_SUBCLASSES_AND_DIRECT_AND_INDIRECT_BASES(M, IGNORE, COPY, IGNORE, ##__VA_ARGS__)
+    IRNODE_ALL_SUBCLASSES_AND_DIRECT_AND_INDIRECT_BASES(M, IR_TREE_IGNORE, IR_TREE_COPY, \
+                                                        IR_TREE_IGNORE, ##__VA_ARGS__)
 #define IRNODE_ALL_TEMPLATES_AND_BASES(M, ...) \
-    IRNODE_ALL_TEMPLATES_AND_DIRECT_AND_INDIRECT_BASES(M, COPY, IGNORE, IGNORE, ##__VA_ARGS__)
+    IRNODE_ALL_TEMPLATES_AND_DIRECT_AND_INDIRECT_BASES(M, IR_TREE_COPY, IR_TREE_IGNORE, \
+                                                       IR_TREE_IGNORE, ##__VA_ARGS__)
 
 /* all classes with no bases */
-#define REMOVE_BASES_ARG(CLASS, BASES, M, ...) M(COPY(CLASS), ##__VA_ARGS__)
+#define REMOVE_BASES_ARG(CLASS, BASES, M, ...) M(IR_TREE_COPY(CLASS), ##__VA_ARGS__)
 #define IRNODE_ALL_CLASSES(M, ...)      \
-    IRNODE_ALL_CLASSES_AND_BASES(REMOVE_BASES_ARG, IGNORE, M, ##__VA_ARGS__)
+    IRNODE_ALL_CLASSES_AND_BASES(REMOVE_BASES_ARG, IR_TREE_IGNORE, M, ##__VA_ARGS__)
 #define IRNODE_ALL_NON_TEMPLATE_CLASSES(M, ...) \
-    IRNODE_ALL_NON_TEMPLATE_CLASSES_AND_BASES(REMOVE_BASES_ARG, IGNORE, M, ##__VA_ARGS__)
+    IRNODE_ALL_NON_TEMPLATE_CLASSES_AND_BASES(REMOVE_BASES_ARG, IR_TREE_IGNORE, M, ##__VA_ARGS__)
 
 #define REMOVE_TEMPLATE_BASES_ARG(CLASS, BASES, TEMPLATE, TARGS, M, ...)         \
-    M(COPY(CLASS), COPY(TEMPLATE), COPY(TARGS), ##__VA_ARGS__)
+    M(IR_TREE_COPY(CLASS), IR_TREE_COPY(TEMPLATE), IR_TREE_COPY(TARGS), ##__VA_ARGS__)
 #define IRNODE_ALL_TEMPLATES(M, ...) \
     IRNODE_ALL_TEMPLATES_AND_DIRECT_AND_INDIRECT_BASES(REMOVE_TEMPLATE_BASES_ARG,       \
-                                IGNORE, IGNORE, IGNORE, M, ##__VA_ARGS__)
+                                IR_TREE_IGNORE, IR_TREE_IGNORE, IR_TREE_IGNORE, M, ##__VA_ARGS__)
 #define IRNODE_ALL_TEMPLATES_WITH_DEFAULTS(M, ...) \
     IRNODE_ALL_TEMPLATES_AND_DIRECT_AND_INDIRECT_BASES(REMOVE_TEMPLATE_BASES_ARG,       \
-                                IGNORE, IGNORE, COPY, M, ##__VA_ARGS__)
-
+                                IR_TREE_IGNORE, IR_TREE_IGNORE, IR_TREE_COPY, M, ##__VA_ARGS__)
 
 #endif /* IR_IR_TREE_MACROS_H_ */

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -488,7 +488,7 @@ class SwitchStatement : Statement {
 class Function : Declaration, IFunctional {
     Type_Method    type;
     BlockStatement body;
-    ParameterList getParameters() const {
+    ParameterList getParameters() const override {
         return type->parameters;
     }
 }

--- a/ir/pass_manager.cpp
+++ b/ir/pass_manager.cpp
@@ -28,7 +28,7 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
     } nest_log_indent(log_indent);
 
     early_exit_flag = false;
-    int initial_error_count = ::errorCount();
+    unsigned initial_error_count = ::errorCount();
     BUG_CHECK(running, "not calling apply properly");
     for (auto it = passes.begin(); it != passes.end();) {
         Visitor* v = *it;
@@ -99,7 +99,7 @@ void PassManager::runDebugHooks(const char* visitorName, const IR::Node* program
 const IR::Node *PassRepeated::apply_visitor(const IR::Node *program, const char *name) {
     bool done = false;
     unsigned iterations = 0;
-    int initial_error_count = ::errorCount();
+    unsigned initial_error_count = ::errorCount();
     while (!done) {
         LOG5("PassRepeated state is:\n" << dumpToString(program));
         running = true;

--- a/lib/cstring.cpp
+++ b/lib/cstring.cpp
@@ -132,8 +132,7 @@ class table_entry {
 
 namespace std {
 template<>
-class hash<table_entry> {
- public:
+struct hash<table_entry> {
     std::size_t operator()(const table_entry &entry) const {
         return Util::Hash::murmur(entry.string(), entry.length());
     }

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <google/protobuf/util/message_differencer.h>
 
 #include <iterator>
@@ -24,6 +26,7 @@ limitations under the License.
 #include "control-plane/p4/config/v1/p4types.pb.h"
 #include "control-plane/p4/v1/p4runtime.pb.h"
 #include "gtest/gtest.h"
+#pragma GCC diagnostic pop
 
 #include "control-plane/p4RuntimeSerializer.h"
 #include "control-plane/typeSpecConverter.h"
@@ -1100,7 +1103,7 @@ TEST_F(P4RuntimeDataTypeSpec, Bits) {
     bool isSigned(true);
     auto type = new IR::Type_Bits(size, isSigned);
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_bitstring());
     const auto& bitstringTypeSpec = typeSpec->bitstring();
     ASSERT_TRUE(bitstringTypeSpec.has_int_());  // signed type
@@ -1111,7 +1114,7 @@ TEST_F(P4RuntimeDataTypeSpec, Varbits) {
     int size(64);
     auto type = new IR::Type_Varbits(size);
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_bitstring());
     const auto& bitstringTypeSpec = typeSpec->bitstring();
     ASSERT_TRUE(bitstringTypeSpec.has_varbit());
@@ -1121,7 +1124,7 @@ TEST_F(P4RuntimeDataTypeSpec, Varbits) {
 TEST_F(P4RuntimeDataTypeSpec, Boolean) {
     auto type = new IR::Type_Boolean();
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     EXPECT_TRUE(typeSpec->has_bool_());
 }
 
@@ -1131,18 +1134,18 @@ TEST_F(P4RuntimeDataTypeSpec, Tuple) {
     IR::Vector<IR::Type> components = {typeMember1, typeMember2};
     auto type = new IR::Type_Tuple(std::move(components));
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_tuple());
     const auto& tupleTypeSpec = typeSpec->tuple();
     ASSERT_EQ(2, tupleTypeSpec.members_size());
     {
         auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-            &typeMap, &refMap, typeMember1, nullptr);
+            &refMap, typeMember1, nullptr);
         EXPECT_TRUE(MessageDifferencer::Equals(*typeSpec, tupleTypeSpec.members(0)));
     }
     {
         auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-            &typeMap, &refMap, typeMember2, nullptr);
+            &refMap, typeMember2, nullptr);
         EXPECT_TRUE(MessageDifferencer::Equals(*typeSpec, tupleTypeSpec.members(1)));
     }
 }
@@ -1159,7 +1162,7 @@ TEST_F(P4RuntimeDataTypeSpec, Struct) {
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_struct_());
     EXPECT_EQ("my_struct", typeSpec->struct_().name());
 
@@ -1185,7 +1188,7 @@ TEST_F(P4RuntimeDataTypeSpec, Header) {
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_header());
     EXPECT_EQ("my_header", typeSpec->header().name());
 
@@ -1212,7 +1215,7 @@ TEST_F(P4RuntimeDataTypeSpec, HeaderUnion) {
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_header_union());
     EXPECT_EQ("my_header_union", typeSpec->header_union().name());
 
@@ -1242,7 +1245,7 @@ TEST_F(P4RuntimeDataTypeSpec, HeaderStack) {
     auto type = findExternTypeParameterName<IR::Type_Stack>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_header_stack());
     EXPECT_EQ("my_header", typeSpec->header_stack().header().name());
     EXPECT_EQ(3, typeSpec->header_stack().size());
@@ -1264,7 +1267,7 @@ TEST_F(P4RuntimeDataTypeSpec, HeaderUnionStack) {
     auto type = findExternTypeParameterName<IR::Type_Stack>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_header_union_stack());
     EXPECT_EQ("my_header_union", typeSpec->header_union_stack().header_union().name());
     EXPECT_EQ(3, typeSpec->header_union_stack().size());
@@ -1286,7 +1289,7 @@ TEST_F(P4RuntimeDataTypeSpec, Enum) {
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_enum_());
     EXPECT_EQ("my_enum", typeSpec->enum_().name());
 
@@ -1309,7 +1312,7 @@ TEST_F(P4RuntimeDataTypeSpec, Error) {
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_error());
 
     ASSERT_TRUE(typeInfo.has_error());
@@ -1331,7 +1334,7 @@ TEST_F(P4RuntimeDataTypeSpec, StructWithTypedef) {
     auto type = findExternTypeParameterName<IR::Type_Name>(pgm, "my_extern_t");
     ASSERT_TRUE(type != nullptr);
     auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(
-        &typeMap, &refMap, type, &typeInfo);
+        &refMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_struct_());
     EXPECT_EQ("my_struct", typeSpec->struct_().name());
 


### PR DESCRIPTION
Using generic names like COPY outside name spaces is bound to sooner or
later crash with an external library. Since COPY and IGNORE are macros
defined only for the ir-tree-macros benefit, I renamed them locally.

We seem to have a template of passing the typeMap to different passes
even though it is not used in the pass. I have removed a number of these
as well as a number of other inconsistencies.

Another big source of warnings seem to be unused parameters in the
google::protobuf objects. I disabled these warnings using pragma diagnostics
as we're not going to go into that code and fix them.

These were reported on Mac OS with Apple LLVM version 9.1.0 (clang-902.0.39.2).