### PR TITLE
Struct initializer

### DIFF
--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -535,6 +535,21 @@ void ExpressionConverter::postorder(const IR::ListExpression* expression)  {
     }
 }
 
+void ExpressionConverter::postorder(const IR::StructInitializerExpression* expression)  {
+    // Handle like a ListExpression
+    auto result = new Util::JsonArray();
+    mapExpression(expression, result);
+    if (simpleExpressionsOnly) {
+        ::error("%1%: expression to complex for this target", expression);
+        return;
+    }
+
+    for (auto e : expression->components) {
+        auto t = get(e->expression);
+        result->append(t);
+    }
+}
+
 void ExpressionConverter::postorder(const IR::Operation_Unary* expression)  {
     auto result = new Util::JsonObject();
     mapExpression(expression, result);

--- a/backends/bmv2/common/expression.h
+++ b/backends/bmv2/common/expression.h
@@ -115,6 +115,7 @@ class ExpressionConverter : public Inspector {
     void postorder(const IR::IntMod* expression) override;
     void postorder(const IR::Operation_Binary* expression) override;
     void postorder(const IR::ListExpression* expression) override;
+    void postorder(const IR::StructInitializerExpression* expression) override;
     void postorder(const IR::Operation_Unary* expression) override;
     void postorder(const IR::PathExpression* expression) override;
     void postorder(const IR::TypeNameExpression* expression) override;

--- a/backends/bmv2/common/extern.cpp
+++ b/backends/bmv2/common/extern.cpp
@@ -126,10 +126,14 @@ ExternConverter::modelError(const char* format, const IR::Node* node) const {
 void
 ExternConverter::addToFieldList(ConversionContext* ctxt,
                                 const IR::Expression* expr, Util::JsonArray* fl) {
-    if (expr->is<IR::ListExpression>()) {
-        auto le = expr->to<IR::ListExpression>();
+    if (auto le = expr->to<IR::ListExpression>()) {
         for (auto e : le->components) {
             addToFieldList(ctxt, e, fl);
+        }
+        return;
+    } else if (auto si = expr->to<IR::StructInitializerExpression>()) {
+        for (auto e : si->components) {
+            addToFieldList(ctxt, e->expression, fl);
         }
         return;
     }

--- a/backends/bmv2/common/lower.h
+++ b/backends/bmv2/common/lower.h
@@ -81,6 +81,8 @@ class RemoveComplexExpressions : public Transform {
         const IR::Vector<IR::Expression>* vec, bool force = false);
     const IR::Vector<IR::Argument>* simplifyExpressions(
         const IR::Vector<IR::Argument>* vec);
+    const IR::IndexedVector<IR::NamedExpression>* simplifyExpressions(
+        const IR::IndexedVector<IR::NamedExpression>* vec);
 
  public:
     RemoveComplexExpressions(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,

--- a/backends/bmv2/common/midend.h
+++ b/backends/bmv2/common/midend.h
@@ -45,6 +45,8 @@ class EnumOn32Bits : public P4::ChooseEnumRepresentation {
     { return 32; }
 
  public:
+    /// Convert all enums except all the ones appearing in the
+    /// specified file.
     explicit EnumOn32Bits(cstring filename) : filename(filename) { }
 };
 

--- a/control-plane/p4RuntimeArchHandler.cpp
+++ b/control-plane/p4RuntimeArchHandler.cpp
@@ -134,9 +134,9 @@ std::string serializeOneAnnotation(const IR::Annotation* annotation) {
     auto kvs = annotation->kv;
     if (expressions.size() > 0 && kvs.size() > 0) serializedAnnotation.append(", ");
     for (auto it = kvs.begin(); it != kvs.end();) {
-        serializedAnnotation.append(it->first);
+        serializedAnnotation.append((*it)->name.name);
         serializedAnnotation.append("=");
-        serializedAnnotation.append(serializeAnnotationExpression(it->second->expression));
+        serializedAnnotation.append(serializeAnnotationExpression((*it)->expression));
         if (++it != kvs.end()) serializedAnnotation.append(", ");
     }
     serializedAnnotation.append(")");

--- a/control-plane/p4RuntimeArchHandler.cpp
+++ b/control-plane/p4RuntimeArchHandler.cpp
@@ -136,7 +136,7 @@ std::string serializeOneAnnotation(const IR::Annotation* annotation) {
     for (auto it = kvs.begin(); it != kvs.end();) {
         serializedAnnotation.append(it->first);
         serializedAnnotation.append("=");
-        serializedAnnotation.append(serializeAnnotationExpression(it->second));
+        serializedAnnotation.append(serializeAnnotationExpression(it->second->expression));
         if (++it != kvs.end()) serializedAnnotation.append(", ");
     }
     serializedAnnotation.append(")");

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -51,6 +51,7 @@ set (P4_FRONTEND_SRCS
   p4/simplifyParsers.cpp
   p4/specialize.cpp
   p4/strengthReduction.cpp
+  p4/structInitializers.cpp
   p4/symbol_table.cpp
   p4/tableApply.cpp
   p4/tableKeyNames.cpp
@@ -111,6 +112,7 @@ set (P4_FRONTEND_HDRS
   p4/simplifyParsers.h
   p4/specialize.h
   p4/strengthReduction.h
+  p4/structInitializers.h
   p4/symbol_table.h
   p4/tableApply.h
   p4/tableKeyNames.h

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -57,8 +57,12 @@ const IR::Expression* DoConstantFolding::getConstant(const IR::Expression* expr)
             if (getConstant(e) == nullptr)
                 return nullptr;
         return expr;
-    }
-    if (auto cast = expr->to<IR::Cast>()) {
+    } else if (auto si = expr->to<IR::StructInitializerExpression>()) {
+        for (auto e : si->components)
+            if (getConstant(e.second->expression) == nullptr)
+                return nullptr;
+        return expr;
+    } else if (auto cast = expr->to<IR::Cast>()) {
         // Casts of a constant to a value with type Type_Newtype
         // are constants, but we cannot fold them.
         if (getConstant(cast->expr))
@@ -533,27 +537,30 @@ const IR::Node* DoConstantFolding::postorder(IR::Member* e) {
         auto expr = getConstant(e->expr);
         if (expr == nullptr)
             return e;
-        if (!type->is<IR::Type_StructLike>())
-            BUG("Expected a struct type, got %1%", type);
-        if (!expr->is<IR::ListExpression>())
-            BUG("Expected a list of constants, got %1%", expr);
-
-        auto list = expr->to<IR::ListExpression>();
         auto structType = type->to<IR::Type_StructLike>();
-
-        bool found = false;
-        int index = 0;
-        for (auto f : structType->fields) {
-            if (f->name.name == e->member.name) {
-                found = true;
-                break;
+        if (structType == nullptr)
+            BUG("Expected a struct type, got %1%", type);
+        if (auto list = expr->to<IR::ListExpression>()) {
+            bool found = false;
+            int index = 0;
+            for (auto f : structType->fields) {
+                if (f->name.name == e->member.name) {
+                    found = true;
+                    break;
+                }
+                index++;
             }
-            index++;
-        }
 
-        if (!found)
-            BUG("Could not find field %1% in type %2%", e->member, type);
-        result = CloneConstants::clone(list->components.at(index));
+            if (!found)
+                BUG("Could not find field %1% in type %2%", e->member, type);
+            result = CloneConstants::clone(list->components.at(index));
+        } else if (auto si = expr->to<IR::StructInitializerExpression>()) {
+            auto ne = si->components.getUnique(e->member.name);
+            BUG_CHECK(ne != nullptr, "Could not find field %1% in initializer %2%", e->member, si);
+            return CloneConstants::clone(ne->expression);
+        } else {
+            BUG("Unexpected initializer: %1%", expr);
+        }
     }
     return result;
 }

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -555,6 +555,8 @@ const IR::Node* DoConstantFolding::postorder(IR::Member* e) {
                 BUG("Could not find field %1% in type %2%", e->member, type);
             result = CloneConstants::clone(list->components.at(index));
         } else if (auto si = expr->to<IR::StructInitializerExpression>()) {
+            if (si->isHeader && e->member.name == IR::Type_Header::isValid)
+                return e;
             auto ne = si->components.getDeclaration<IR::NamedExpression>(e->member.name);
             BUG_CHECK(ne != nullptr, "Could not find field %1% in initializer %2%", e->member, si);
             return CloneConstants::clone(ne->expression);

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -59,7 +59,7 @@ const IR::Expression* DoConstantFolding::getConstant(const IR::Expression* expr)
         return expr;
     } else if (auto si = expr->to<IR::StructInitializerExpression>()) {
         for (auto e : si->components)
-            if (getConstant(e.second->expression) == nullptr)
+            if (getConstant(e->expression) == nullptr)
                 return nullptr;
         return expr;
     } else if (auto cast = expr->to<IR::Cast>()) {
@@ -555,7 +555,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Member* e) {
                 BUG("Could not find field %1% in type %2%", e->member, type);
             result = CloneConstants::clone(list->components.at(index));
         } else if (auto si = expr->to<IR::StructInitializerExpression>()) {
-            auto ne = si->components.getUnique(e->member.name);
+            auto ne = si->components.getDeclaration<IR::NamedExpression>(e->member.name);
             BUG_CHECK(ne != nullptr, "Could not find field %1% in initializer %2%", e->member, si);
             return CloneConstants::clone(ne->expression);
         } else {

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -53,6 +53,7 @@ limitations under the License.
 #include "simplifyParsers.h"
 #include "specialize.h"
 #include "strengthReduction.h"
+#include "structInitializers.h"
 #include "tableKeyNames.h"
 #include "toP4/toP4.h"
 #include "typeChecking/typeChecker.h"
@@ -142,6 +143,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new CheckNamedArgs(),
         new TypeInference(&refMap, &typeMap, false),  // insert casts
         new BindTypeVariables(&typeMap),
+        new StructInitializers(&refMap, &typeMap),
         // Another round of constant folding, using type information.
         new ClearTypeMap(&typeMap),
         new DefaultArguments(&refMap, &typeMap),  // add default argument values to parameters

--- a/frontends/p4/setHeaders.h
+++ b/frontends/p4/setHeaders.h
@@ -51,8 +51,8 @@ class DoSetHeaders final : public Transform {
 
     bool containsHeaderType(const IR::Type* type);
     void generateSetValid(
-        const IR::Type* destType, const IR::Type* srcType,
-        const IR::Expression* dest, IR::Vector<IR::StatOrDecl>* insert);
+        const IR::Expression* dest, const IR::Expression* src,
+        const IR::Type* destType, IR::Vector<IR::StatOrDecl>* insert);
 
  public:
     DoSetHeaders(ReferenceMap* refMap, TypeMap* typeMap) : refMap(refMap), typeMap(typeMap)

--- a/frontends/p4/structInitializers.cpp
+++ b/frontends/p4/structInitializers.cpp
@@ -1,0 +1,125 @@
+/*
+Copyright 2018 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "structInitializers.h"
+
+namespace P4 {
+
+/// Given an expression and a destination type, convert ListExpressions
+/// that occur within expression to StructInitializerExpression if the
+/// destination type matches.
+const IR::Expression*
+convert(const IR::Expression* expression, const IR::Type* type) {
+    bool modified = false;
+    if (auto st = type->to<IR::Type_StructLike>()) {
+        auto si = new IR::IndexedVector<IR::NamedExpression>();
+        if (auto le = expression->to<IR::ListExpression>()) {
+            size_t index = 0;
+            for (auto f : st->fields) {
+                auto expr = le->components.at(index);
+                auto conv = convert(expr, f->type);
+                auto ne = new IR::NamedExpression(conv->srcInfo, f->name, conv);
+                si->push_back(ne);
+                index++;
+            }
+            auto result = new IR::StructInitializerExpression(
+                expression->srcInfo, st->name, *si, st->is<IR::Type_Header>());
+            return result;
+        } else if (auto sli = expression->to<IR::StructInitializerExpression>()) {
+            for (auto f : st->fields) {
+                auto ne = sli->components.getDeclaration<IR::NamedExpression>(f->name.name);
+                BUG_CHECK(ne != nullptr, "%1%: no initializer for %2%", expression, f);
+                auto convNe = convert(ne->expression, f->type);
+                if (convNe != ne->expression)
+                    modified = true;
+                ne = new IR::NamedExpression(ne->srcInfo, f->name, convNe);
+                si->push_back(ne);
+            }
+            if (modified) {
+                auto result = new IR::StructInitializerExpression(
+                    expression->srcInfo, st->name, *si, st->is<IR::Type_Header>());
+                return result;
+            }
+        }
+    } else if (auto tup = type->to<IR::Type_Tuple>()) {
+        auto le = expression->to<IR::ListExpression>();
+        if (le == nullptr)
+            return expression;
+
+        auto vec = new IR::Vector<IR::Expression>();
+        for (size_t i = 0; i < le->size(); i++) {
+            auto expr = le->components.at(i);
+            auto type = tup->components.at(i);
+            auto conv = convert(expr, type);
+            vec->push_back(conv);
+            modified |= (conv != expr);
+        }
+        if (modified) {
+            auto result = new IR::ListExpression(expression->srcInfo, *vec);
+            return result;
+        }
+    }
+    return expression;
+}
+
+const IR::Node* CreateStructInitializers::postorder(IR::AssignmentStatement* statement) {
+    auto type = typeMap->getType(statement->left);
+    auto init = convert(statement->right, type);
+    if (init != statement->right)
+        statement->right = init;
+    return statement;
+}
+
+const IR::Node* CreateStructInitializers::postorder(IR::MethodCallExpression* expression) {
+    auto mi = MethodInstance::resolve(expression, refMap, typeMap);
+    auto result = expression;
+    auto convertedArgs = new IR::Vector<IR::Argument>();
+    bool modified = false;
+    for (auto p : *mi->substitution.getParametersInArgumentOrder()) {
+        auto arg = mi->substitution.lookup(p);
+        if (p->direction == IR::Direction::In ||
+            p->direction == IR::Direction::None) {
+            auto paramType = typeMap->getType(p, true);
+            auto init = convert(arg->expression, paramType);
+            CHECK_NULL(init);
+            if (init != arg->expression) {
+                modified = true;
+                convertedArgs->push_back(new IR::Argument(arg->srcInfo, arg->name, init));
+                continue;
+            }
+        }
+        convertedArgs->push_back(arg);
+    }
+    if (modified) {
+        LOG2("Converted some function arguments to struct initializers" << convertedArgs);
+        return new IR::MethodCallExpression(
+            result->srcInfo, result->method, result->typeArguments, convertedArgs);
+    }
+    return expression;
+}
+
+
+const IR::Node* CreateStructInitializers::postorder(IR::Operation_Relation* expression) {
+    auto ltype = typeMap->getType(expression->left);
+    auto rtype = typeMap->getType(expression->right);
+    if (ltype->is<IR::Type_StructLike>() && rtype->is<IR::Type_Tuple>())
+        expression->right = convert(expression->right, ltype);
+    if (rtype->is<IR::Type_StructLike>() && ltype->is<IR::Type_Tuple>())
+        expression->left = convert(expression->left, rtype);
+    return expression;
+}
+
+}  // namespace P4

--- a/frontends/p4/structInitializers.h
+++ b/frontends/p4/structInitializers.h
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _FRONTENDS_P4_STRUCTINITIALIZERS_H_
+#define _FRONTENDS_P4_STRUCTINITIALIZERS_H_
+
+#include "ir/ir.h"
+#include "frontends/p4/typeChecking/typeChecker.h"
+
+namespace P4 {
+
+/// Converts some list expressions into struct initializers.
+class CreateStructInitializers : public Transform {
+    ReferenceMap* refMap;
+    TypeMap* typeMap;
+ public:
+    CreateStructInitializers(ReferenceMap* refMap, TypeMap* typeMap):
+            refMap(refMap), typeMap(typeMap) {
+        setName("CreateStructInitializers");
+        CHECK_NULL(refMap); CHECK_NULL(typeMap);
+    }
+
+    const IR::Node* postorder(IR::AssignmentStatement* statement) override;
+    const IR::Node* postorder(IR::MethodCallExpression* expression) override;
+    const IR::Node* postorder(IR::Operation_Relation* expression) override;
+};
+
+class StructInitializers : public PassManager {
+ public:
+    StructInitializers(ReferenceMap* refMap, TypeMap* typeMap) {
+        setName("StructInitializers");
+        passes.push_back(new TypeChecking(refMap, typeMap));
+        passes.push_back(new CreateStructInitializers(refMap, typeMap));
+        passes.push_back(new ClearTypeMap(typeMap));
+    }
+};
+
+}  // namespace P4
+
+#endif /* _FRONTENDS_P4_STRUCTINITIALIZERS_H_ */

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -849,6 +849,8 @@ bool ToP4::preorder(const IR::NamedExpression* e) {
 bool ToP4::preorder(const IR::StructInitializerExpression* e) {
     // Currently the P4 language does not have a syntax
     // for struct initializers, so we use the same syntax as for list expressions.
+    // TODO: this is incorrect if the fields are not in the same order as
+    // in the type.
     builder.append("{");
     int prec = expressionPrecedence;
     expressionPrecedence = DBPrint::Prec_Low;
@@ -857,7 +859,7 @@ bool ToP4::preorder(const IR::StructInitializerExpression* e) {
         if (!first)
             builder.append(",");
         first = false;
-        visit(c.second->expression);
+        visit(c->expression);
     }
     expressionPrecedence = prec;
     builder.append("}");
@@ -1027,7 +1029,7 @@ bool ToP4::preorder(const IR::EmptyStatement*) {
 }
 
 bool ToP4::preorder(const IR::IfStatement* s) {
-    dump(1);
+    dump(2);
     builder.append("if (");
     visit(s->condition);
     builder.append(") ");
@@ -1101,9 +1103,9 @@ bool ToP4::preorder(const IR::Annotation * a) {
             if (!first)
                 builder.append(", ");
             first = false;
-            builder.append(kvp.first);
+            builder.append(kvp->name);
             builder.append("=");
-            visit(kvp.second->expression);
+            visit(kvp->expression);
         }
         builder.append(")");
     }

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -839,6 +839,31 @@ bool ToP4::preorder(const IR::ListExpression* e) {
     return false;
 }
 
+bool ToP4::preorder(const IR::NamedExpression* e) {
+    builder.append(e->name.name);
+    builder.append(" = ");
+    visit(e->expression);
+    return false;
+}
+
+bool ToP4::preorder(const IR::StructInitializerExpression* e) {
+    // Currently the P4 language does not have a syntax
+    // for struct initializers, so we use the same syntax as for list expressions.
+    builder.append("{");
+    int prec = expressionPrecedence;
+    expressionPrecedence = DBPrint::Prec_Low;
+    bool first = true;
+    for (auto c : e->components) {
+        if (!first)
+            builder.append(",");
+        first = false;
+        visit(c.second->expression);
+    }
+    expressionPrecedence = prec;
+    builder.append("}");
+    return false;
+}
+
 bool ToP4::preorder(const IR::MethodCallExpression* e) {
     int prec = expressionPrecedence;
     bool useParens = (prec > DBPrint::Prec_Postfix) ||

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -1078,7 +1078,7 @@ bool ToP4::preorder(const IR::Annotation * a) {
             first = false;
             builder.append(kvp.first);
             builder.append("=");
-            visit(kvp.second);
+            visit(kvp.second->expression);
         }
         builder.append(")");
     }

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -170,6 +170,7 @@ class ToP4 : public Inspector {
     bool preorder(const IR::SelectCase* e) override;
     bool preorder(const IR::SelectExpression* e) override;
     bool preorder(const IR::ListExpression* e) override;
+    bool preorder(const IR::StructInitializerExpression* e) override;
     bool preorder(const IR::MethodCallExpression* e) override;
     bool preorder(const IR::DefaultExpression* e) override;
     bool preorder(const IR::This* e) override;
@@ -204,6 +205,7 @@ class ToP4 : public Inspector {
     bool preorder(const IR::IfStatement* s) override;
 
     // misc
+    bool preorder(const IR::NamedExpression* ne) override;
     bool preorder(const IR::Argument* arg) override;
     bool preorder(const IR::Path* p) override;
     bool preorder(const IR::Parameter* p) override;

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -103,6 +103,8 @@ class TypeInference : public Transform {
         const IR::Node* errorPosition, const IR::Type* destType,
         const IR::Type* srcType, bool reportErrors);
 
+    const IR::Expression* convertStructInitializers(
+        const IR::Expression* expression, const IR::Type* type);
     /** Tries to assign sourceExpression to a destination with type destType.
         This may rewrite the sourceExpression, in particular converting InfInt values
         to values with concrete types.
@@ -256,6 +258,7 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::Member* expression) override;
     const IR::Node* postorder(IR::TypeNameExpression* expression) override;
     const IR::Node* postorder(IR::ListExpression* expression) override;
+    const IR::Node* postorder(IR::StructInitializerExpression* expression) override;
     const IR::Node* postorder(IR::MethodCallExpression* expression) override;
     const IR::Node* postorder(IR::ConstructorCallExpression* expression) override;
     const IR::Node* postorder(IR::SelectExpression* expression) override;

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -24,7 +24,6 @@ limitations under the License.
 #include "lib/cstring.h"
 #include "frontends/p4/typeChecking/typeSubstitution.h"
 #include "frontends/p4/typeChecking/typeSubstitutionVisitor.h"
-#include "typeConstraints.h"
 #include "typeUnification.h"
 #include "frontends/p4/methodInstance.h"
 
@@ -99,12 +98,12 @@ class TypeInference : public Transform {
     // This is needed because sometimes we invoke visitors recursively on subtrees explicitly.
     // (visitDagOnce cannot take care of this).
     bool done() const;
+    /// Unifies two types.  Returns nullptr if unification fails.
+    /// Populates the typeMap with values for the type variables.
     TypeVariableSubstitution* unify(
         const IR::Node* errorPosition, const IR::Type* destType,
-        const IR::Type* srcType, bool reportErrors);
+        const IR::Type* srcType);
 
-    const IR::Expression* convertStructInitializers(
-        const IR::Expression* expression, const IR::Type* type);
     /** Tries to assign sourceExpression to a destination with type destType.
         This may rewrite the sourceExpression, in particular converting InfInt values
         to values with concrete types.

--- a/frontends/p4/typeChecking/typeConstraints.h
+++ b/frontends/p4/typeChecking/typeConstraints.h
@@ -28,13 +28,16 @@ namespace P4 {
 
 // A list of equality constraints on types.
 class TypeConstraints final {
-    // Requires two types to be equal.
+    /// Requires two types to be equal.
     class EqualityConstraint : public IHasDbPrint {
      public:
         const IR::Type* left;
         const IR::Type* right;
-        EqualityConstraint(const IR::Type* left, const IR::Type* right)
-                : left(left), right(right) {
+        /// Constraint which produced this one.  May be nullptr.
+        const EqualityConstraint* derivedFrom;
+        EqualityConstraint(const IR::Type* left, const IR::Type* right,
+                           EqualityConstraint* derivedFrom)
+                : left(left), right(right), derivedFrom(derivedFrom) {
             CHECK_NULL(left); CHECK_NULL(right);
             if (left->is<IR::Type_Name>() || right->is<IR::Type_Name>())
                 BUG("Unifying type names %1% and %2%", left, right);
@@ -77,19 +80,19 @@ class TypeConstraints final {
     /// A variable is unifiable if it is marked so and it not already
     /// part of definedVariables.
     bool isUnifiableTypeVariable(const IR::Type* type);
-    void addEqualityConstraint(const IR::Type* left, const IR::Type* right);
+    void addEqualityConstraint(
+        const IR::Type* left, const IR::Type* right, EqualityConstraint* derivedFrom = nullptr);
 
     /*
      * Solve the specified constraint.
      * @param root       Element where error is signalled if necessary.
      * @param subst      Variable substitution which is updated with new constraints.
      * @param constraint Constraint to solve.
-     * @param reportErrors If true report errors.
      * @return           True on success.
      */
     bool solve(const IR::Node* root, EqualityConstraint *constraint,
-               TypeVariableSubstitution *subst, bool reportErrors);
-    TypeVariableSubstitution* solve(const IR::Node* root, bool reportErrors);
+               TypeVariableSubstitution *subst);
+    TypeVariableSubstitution* solve(const IR::Node* root);
     void dbprint(std::ostream& out) const;
 };
 }  // namespace P4

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -143,7 +143,7 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
                                      bool reportErrors,
                                      bool skipReturnValues) {
     CHECK_NULL(dest); CHECK_NULL(src);
-    LOG3("Unifying functions " << dest << " to " << src);
+    LOG3("Unifying functions " << dest << " with " << src);
 
     for (auto tv : dest->typeParameters->parameters)
         constraints->addUnifiableTypeVariable(tv);
@@ -195,7 +195,7 @@ bool TypeUnification::unifyBlocks(const IR::Node* errorPosition,
                                   bool reportErrors) {
     // These are canonical types.
     CHECK_NULL(dest); CHECK_NULL(src);
-    LOG3("Unifying blocks " << dest << " to " << src);
+    LOG3("Unifying blocks " << dest << " with " << src);
     if (typeid(*dest) != typeid(*src)) {
         if (reportErrors)
             ::error("%1%: Cannot unify %2% to %3%",
@@ -240,7 +240,7 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
                             bool reportErrors) {
     // These are canonical types.
     CHECK_NULL(dest); CHECK_NULL(src);
-    LOG3("Unifying " << dest << " to " << src);
+    LOG3("Unifying " << dest << " with " << src);
 
     if (src->is<IR::ITypeVar>())
         src = src->apply(constraints->replaceVariables)->to<IR::Type>();
@@ -309,8 +309,7 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
         return true;
     } else if (dest->is<IR::Type_Struct>() || dest->is<IR::Type_Header>()) {
         auto strct = dest->to<IR::Type_StructLike>();
-        if (src->is<IR::Type_Tuple>()) {
-            const IR::Type_Tuple* tpl = src->to<IR::Type_Tuple>();
+        if (auto tpl = src->to<IR::Type_Tuple>()) {
             if (strct->fields.size() != tpl->components.size()) {
                 if (reportErrors)
                     ::error("%1%: Number of fields %2% in initializer different "
@@ -329,6 +328,29 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
                 if (!success)
                     return false;
                 index++;
+            }
+            return true;
+        } else if (auto st = src->to<IR::Type_StructLike>()) {
+            // There is another case, in which each field of the source is unifiable with the
+            // corresponding field of the destination, e.g., a struct containing tuples.
+            if (strct->fields.size() != st->fields.size()) {
+                if (reportErrors)
+                    ::error("%1%: Number of fields %2% in initializer different "
+                            "than number of fields in structure %3%: %4% to %5%",
+                            errorPosition, st->fields.size(),
+                            strct->fields.size(), st, strct);
+                return false;
+            }
+
+            for (const IR::StructField* f : strct->fields) {
+                auto stField = st->getField(f->name);
+                if (stField == nullptr) {
+                    ::error("%1%: No initializer for field %2%", errorPosition, f);
+                    return false;
+                }
+                bool success = unify(errorPosition, f->type, stField->type, reportErrors);
+                if (!success)
+                    return false;
             }
             return true;
         }

--- a/frontends/p4/typeChecking/typeUnification.h
+++ b/frontends/p4/typeChecking/typeUnification.h
@@ -56,8 +56,8 @@ class TypeUnification final {
      * Return false if unification fails right away.
      * Generates a set of type constraints.
      * If it returns true unification could still fail later.
-     * @param dest Destination type.
-     * @param src  Source type.
+     * @param dest         Destination type.
+     * @param src          Source type.
      * @param reportErrors If true report errors caused by unification.
      * @return     False if unification fails immediately.
      */

--- a/frontends/p4/unusedDeclarations.h
+++ b/frontends/p4/unusedDeclarations.h
@@ -94,6 +94,7 @@ class RemoveUnusedDeclarations : public Transform {
     const IR::Node* preorder(IR::Type_Method* type) override
     { prune(); return type; }
     const IR::Node* preorder(IR::Parameter* param) override { return param; }  // never dead
+    const IR::Node* preorder(IR::NamedExpression* ne) override { return ne; }  // idem
 
     const IR::Node* preorder(IR::Declaration_Variable* decl)  override;
     const IR::Node* preorder(IR::Declaration* decl) override { return process(decl); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -59,11 +59,6 @@ inline std::ostream& operator<<(std::ostream& out, const P4::OptionalConst& oc) 
     return out;
 }
 
-struct KV {
-    cstring name;
-    const IR::Expression* expression;
-};
-
 // Bison uses the types you provide to %type to make constructors for the
 // variant type it uses under the hood, but its code generation is a little
 // naive and it always prepends 'const' to the type. This is problematic when
@@ -227,8 +222,8 @@ typedef const IR::Type ConstType;
 %type<IR::Entry*>           entry
 %type<IR::Vector<IR::Entry>*>  entriesList
 %type<IR::MethodCallExpression*>  actionBinding
-%type<IR::NameMap<IR::Expression>*> kvList
-%type<KV*> kvPair
+%type<IR::NameMap<IR::NamedExpression>*> kvList
+%type<IR::NamedExpression*> kvPair
 
 %left COMMA
 %nonassoc QUESTION
@@ -326,13 +321,12 @@ annotation
     ;
 
 kvList
-    : kvPair                          { $$ = new IR::NameMap<IR::Expression>;
-                                        $$->add($1->name, $1->expression); }
-    | kvList "," kvPair               { $$ = $1; $$->add($3->name, $3->expression); }
+    : kvPair                          { $$ = new IR::NameMap<IR::NamedExpression>; $$->addUnique($1->name, $1); }
+    | kvList "," kvPair               { $$ = $1; $$->addUnique($3->name, $3); }
     ;
 
 kvPair
-    : name "=" expression             { $$ = new KV; $$->name = $1->name; $$->expression = $3; }
+    : name "=" expression             { $$ = new IR::NamedExpression(@1, *$1, $3); }
     ;
 
 parameterList

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -222,7 +222,7 @@ typedef const IR::Type ConstType;
 %type<IR::Entry*>           entry
 %type<IR::Vector<IR::Entry>*>  entriesList
 %type<IR::MethodCallExpression*>  actionBinding
-%type<IR::NameMap<IR::NamedExpression>*> kvList
+%type<IR::IndexedVector<IR::NamedExpression>*> kvList
 %type<IR::NamedExpression*> kvPair
 
 %left COMMA
@@ -321,8 +321,8 @@ annotation
     ;
 
 kvList
-    : kvPair                          { $$ = new IR::NameMap<IR::NamedExpression>; $$->addUnique($1->name, $1); }
-    | kvList "," kvPair               { $$ = $1; $$->addUnique($3->name, $3); }
+    : kvPair                          { $$ = new IR::IndexedVector<IR::NamedExpression>; $$->push_back($1); }
+    | kvList "," kvPair               { $$ = $1; $$->push_back($3); }
     ;
 
 kvPair

--- a/ir/base.def
+++ b/ir/base.def
@@ -183,6 +183,11 @@ class Path {
     validate { BUG_CHECK(!name.name.isNullOrEmpty(), "Empty path"); }
 }
 
+/// Handy class used in several NamedMaps
+class NamedExpression : Declaration {
+    Expression expression;
+}
+
 /// Annotations are used to provide additional information to the compiler
 /// Most P4 entities can be optionally annotated
 class Annotation {
@@ -190,19 +195,18 @@ class Annotation {
     /// Annotations that are simple expressions
     inline Vector<Expression> expr;
     /// Annotations described as key-value pairs
-    // TODO: this should be a map from ID not from cstring
-    inline NameMap<Expression> kv;
+    inline NameMap<NamedExpression> kv;
     Annotation { if (!srcInfo) srcInfo = name.srcInfo; }
-    Annotation(Util::SourceInfo si, ID n, const std::initializer_list<const IR::Expression *> &a)
+    Annotation(Util::SourceInfo si, ID n, const std::initializer_list<const Expression *> &a)
     : Node(si), name(n), expr(a) {}
-    Annotation(Util::SourceInfo si, ID n, const IR::Vector<IR::Expression> &a)
+    Annotation(Util::SourceInfo si, ID n, const IR::Vector<Expression> &a)
     : Node(si), name(n), expr(a) {}
-    Annotation(Util::SourceInfo si, ID n, const NameMap<IR::Expression> &kv)
+    Annotation(Util::SourceInfo si, ID n, const NameMap<NamedExpression> &kv)
     : Node(si), name(n), kv(kv) {}
-    Annotation(ID n, const std::initializer_list<const IR::Expression *> &a) : name(n), expr(a) {}
-    Annotation(ID n, const IR::Vector<IR::Expression> &a) : name(n), expr(a) {}
+    Annotation(ID n, const std::initializer_list<const Expression *> &a) : name(n), expr(a) {}
+    Annotation(ID n, const IR::Vector<Expression> &a) : name(n), expr(a) {}
     Annotation(ID n, intmax_t v) : name(n) {
-        expr.push_back(new IR::Constant(v)); }
+        expr.push_back(new Constant(v)); }
     /// Predefined annotations used by the compiler
     static const cstring nameAnnotation;  /// Indicates the control-plane name.
     static const cstring tableOnlyAnnotation;  /// Action cannot be a default_action.
@@ -215,7 +219,7 @@ class Annotation {
     validate{ BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name"); }
 
     /// Useful helper: extracts name value from a name annotation
-    static cstring getName(const IR::Annotation* annotation);
+    static cstring getName(const Annotation* annotation);
 }
 
 /// There can be several annotations with the same "name", so this is a vector.

--- a/ir/base.def
+++ b/ir/base.def
@@ -195,13 +195,13 @@ class Annotation {
     /// Annotations that are simple expressions
     inline Vector<Expression> expr;
     /// Annotations described as key-value pairs
-    inline NameMap<NamedExpression> kv;
+    inline IndexedVector<NamedExpression> kv;
     Annotation { if (!srcInfo) srcInfo = name.srcInfo; }
     Annotation(Util::SourceInfo si, ID n, const std::initializer_list<const Expression *> &a)
     : Node(si), name(n), expr(a) {}
     Annotation(Util::SourceInfo si, ID n, const IR::Vector<Expression> &a)
     : Node(si), name(n), expr(a) {}
-    Annotation(Util::SourceInfo si, ID n, const NameMap<NamedExpression> &kv)
+    Annotation(Util::SourceInfo si, ID n, const IndexedVector<NamedExpression> &kv)
     : Node(si), name(n), kv(kv) {}
     Annotation(ID n, const std::initializer_list<const Expression *> &a) : name(n), expr(a) {}
     Annotation(ID n, const IR::Vector<Expression> &a) : name(n), expr(a) {}

--- a/ir/dbprint-expression.cpp
+++ b/ir/dbprint-expression.cpp
@@ -82,6 +82,17 @@ void IR::Constant::dbprint(std::ostream &out) const {
     // if (getprec(out) == 0) out << ';';
 }
 
+void IR::NamedExpression::dbprint(std::ostream &out) const {
+    out << name << ":" << expression;
+}
+
+void IR::StructInitializerExpression::dbprint(std::ostream& out) const {
+    out << "{" << indent;
+    for (auto &field : components)
+        out << endl << field.second << ';';
+    out << " }" << unindent;
+}
+
 void IR::Member::dbprint(std::ostream &out) const {
     int prec = getprec(out);
     out << setprec(Prec_Postfix) << expr << setprec(prec) << '.' << member;

--- a/ir/dbprint-expression.cpp
+++ b/ir/dbprint-expression.cpp
@@ -89,7 +89,7 @@ void IR::NamedExpression::dbprint(std::ostream &out) const {
 void IR::StructInitializerExpression::dbprint(std::ostream& out) const {
     out << "{" << indent;
     for (auto &field : components)
-        out << endl << field.second << ';';
+        out << endl << field << ';';
     out << " }" << unindent;
 }
 

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -408,9 +408,9 @@ class ListExpression : Expression {
 /// Currently it does not have a direct representation as P4 source.
 class StructInitializerExpression : Expression {
     inline NameMap<NamedExpression, ordered_map> components = {};
-    /// Type of the struct that is being intialized.
-    /// May only be known after type checking; so it can be nullptr.
-    optional Type_Name                     structType;
+    /// Name of the struct type that is being intialized.
+    /// May only be known after type checking; so it can be empty.
+    ID name;
     validate { components.check_null(); }
     size_t size() const { return components.size(); }
     void add(NamedExpression e) { components.addUnique(e->name, e); }

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -407,13 +407,12 @@ class ListExpression : Expression {
 /// IR representation of an initializer for a struct.
 /// Currently it does not have a direct representation as P4 source.
 class StructInitializerExpression : Expression {
-    inline NameMap<NamedExpression, ordered_map> components = {};
     /// Name of the struct type that is being intialized.
     /// May only be known after type checking; so it can be empty.
     ID name;
+    inline IndexedVector<NamedExpression> components;
     validate { components.check_null(); }
     size_t size() const { return components.size(); }
-    void add(NamedExpression e) { components.addUnique(e->name, e); }
 }
 
 /// A ListExpression where all the components are compile-time values.

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -404,6 +404,18 @@ class ListExpression : Expression {
     void push_back(Expression e) { components.push_back(e); }
 }
 
+/// IR representation of an initializer for a struct.
+/// Currently it does not have a direct representation as P4 source.
+class StructInitializerExpression : Expression {
+    inline NameMap<NamedExpression, ordered_map> components = {};
+    /// Type of the struct that is being intialized.
+    /// May only be known after type checking; so it can be nullptr.
+    optional Type_Name                     structType;
+    validate { components.check_null(); }
+    size_t size() const { return components.size(); }
+    void add(NamedExpression e) { components.addUnique(e->name, e); }
+}
+
 /// A ListExpression where all the components are compile-time values.
 /// This is used by the evaluator pass.
 class ListCompileTimeValue : CompileTimeValue {

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -411,6 +411,8 @@ class StructInitializerExpression : Expression {
     /// May only be known after type checking; so it can be empty.
     ID name;
     inline IndexedVector<NamedExpression> components;
+    /// If true this represents a header.
+    bool isHeader;
     validate { components.check_null(); }
     size_t size() const { return components.size(); }
 }

--- a/midend/eliminateTuples.h
+++ b/midend/eliminateTuples.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "ir/ir.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
+#include "frontends/common/resolveReferences/resolveReferences.h"
 
 namespace P4 {
 
@@ -99,6 +100,12 @@ class EliminateTuples final : public PassManager {
         passes.push_back(new TypeChecking(refMap, typeMap));
         passes.push_back(new DoReplaceTuples(repl));
         passes.push_back(new ClearTypeMap(typeMap));
+        // We do a round of type-checking which may mutate the program.
+        // This will convert some ListExpressions
+        // into StructInitializerExpression where tuples were converted
+        // to structs.
+        passes.push_back(new ResolveReferences(refMap)),
+        passes.push_back(new TypeInference(refMap, typeMap, false));
         setName("EliminateTuples");
     }
 };

--- a/midend/expandLookahead.cpp
+++ b/midend/expandLookahead.cpp
@@ -50,7 +50,8 @@ const IR::Expression* DoExpandLookahead::expand(
             auto e = expand(base, t, offset);
             vec->push_back(new IR::NamedExpression(f->srcInfo, f->name, e));
         }
-        return new IR::StructInitializerExpression(base->srcInfo, st->name, *vec);
+        return new IR::StructInitializerExpression(
+            base->srcInfo, st->name, *vec, type->is<IR::Type_Header>());
     } else if (type->is<IR::Type_Bits>() || type->is<IR::Type_Boolean>()) {
         unsigned size = type->width_bits();
         BUG_CHECK(size > 0, "%1%: unexpected size %2%", type, size);

--- a/midend/expandLookahead.cpp
+++ b/midend/expandLookahead.cpp
@@ -41,16 +41,16 @@ void DoExpandLookahead::expandSetValid(const IR::Expression* base, const IR::Typ
 const IR::Expression* DoExpandLookahead::expand(
     const IR::PathExpression* base, const IR::Type* type, unsigned* offset) {
     if (type->is<IR::Type_Struct>() || type->is<IR::Type_Header>()) {
-        auto vec = new IR::ListExpression({});
+        auto vec = new IR::IndexedVector<IR::NamedExpression>();
         auto st = type->to<IR::Type_StructLike>();
         for (auto f : st->fields) {
             auto t = typeMap->getTypeType(f->type, true);
             if (t == nullptr)
                 continue;
             auto e = expand(base, t, offset);
-            vec->push_back(e);
+            vec->push_back(new IR::NamedExpression(f->srcInfo, f->name, e));
         }
-        return vec;
+        return new IR::StructInitializerExpression(base->srcInfo, st->name, *vec);
     } else if (type->is<IR::Type_Bits>() || type->is<IR::Type_Boolean>()) {
         unsigned size = type->width_bits();
         BUG_CHECK(size > 0, "%1%: unexpected size %2%", type, size);

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-first.p4
@@ -1,0 +1,97 @@
+#include <core.p4>
+#include <v1model.p4>
+
+@name("hdr") header hdr_0 {
+    bit<8>  op;
+    @saturating 
+    bit<8>  opr1_8;
+    @saturating 
+    bit<8>  opr2_8;
+    @saturating 
+    bit<8>  res_8;
+    @saturating 
+    int<16> opr1_16;
+    @saturating 
+    int<16> opr2_16;
+    @saturating 
+    int<16> res_16;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".data") 
+    hdr_0 data;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start {
+        packet.extract<hdr_0>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".sat_plus") action sat_plus() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_8 = hdr.data.opr1_8 |+| hdr.data.opr2_8;
+    }
+    @name(".sat_minus") action sat_minus() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_8 = hdr.data.opr1_8 |-| hdr.data.opr2_8;
+    }
+    @name(".sat_add_to") action sat_add_to() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_16 = hdr.data.opr1_16;
+        hdr.data.res_16 = hdr.data.res_16 |+| hdr.data.opr2_16;
+    }
+    @name(".sat_subtract_from") action sat_subtract_from() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_16 = hdr.data.opr1_16;
+        hdr.data.res_16 = hdr.data.res_16 |-| hdr.data.opr2_16;
+    }
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
+    @name(".t") table t {
+        actions = {
+            sat_plus();
+            sat_minus();
+            sat_add_to();
+            sat_subtract_from();
+            _drop();
+        }
+        key = {
+            hdr.data.op: exact @name("data.op") ;
+        }
+        default_action = _drop();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<hdr_0>(hdr.data);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-frontend.p4
@@ -1,0 +1,97 @@
+#include <core.p4>
+#include <v1model.p4>
+
+@name("hdr") header hdr_0 {
+    bit<8>  op;
+    @saturating 
+    bit<8>  opr1_8;
+    @saturating 
+    bit<8>  opr2_8;
+    @saturating 
+    bit<8>  res_8;
+    @saturating 
+    int<16> opr1_16;
+    @saturating 
+    int<16> opr2_16;
+    @saturating 
+    int<16> res_16;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".data") 
+    hdr_0 data;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start {
+        packet.extract<hdr_0>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".sat_plus") action sat_plus() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_8 = hdr.data.opr1_8 |+| hdr.data.opr2_8;
+    }
+    @name(".sat_minus") action sat_minus() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_8 = hdr.data.opr1_8 |-| hdr.data.opr2_8;
+    }
+    @name(".sat_add_to") action sat_add_to() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_16 = hdr.data.opr1_16;
+        hdr.data.res_16 = hdr.data.res_16 |+| hdr.data.opr2_16;
+    }
+    @name(".sat_subtract_from") action sat_subtract_from() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_16 = hdr.data.opr1_16;
+        hdr.data.res_16 = hdr.data.res_16 |-| hdr.data.opr2_16;
+    }
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
+    @name(".t") table t_0 {
+        actions = {
+            sat_plus();
+            sat_minus();
+            sat_add_to();
+            sat_subtract_from();
+            _drop();
+        }
+        key = {
+            hdr.data.op: exact @name("data.op") ;
+        }
+        default_action = _drop();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<hdr_0>(hdr.data);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-midend.p4
@@ -1,0 +1,97 @@
+#include <core.p4>
+#include <v1model.p4>
+
+@name("hdr") header hdr_0 {
+    bit<8>  op;
+    @saturating 
+    bit<8>  opr1_8;
+    @saturating 
+    bit<8>  opr2_8;
+    @saturating 
+    bit<8>  res_8;
+    @saturating 
+    int<16> opr1_16;
+    @saturating 
+    int<16> opr2_16;
+    @saturating 
+    int<16> res_16;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".data") 
+    hdr_0 data;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start {
+        packet.extract<hdr_0>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".sat_plus") action sat_plus() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_8 = hdr.data.opr1_8 |+| hdr.data.opr2_8;
+    }
+    @name(".sat_minus") action sat_minus() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_8 = hdr.data.opr1_8 |-| hdr.data.opr2_8;
+    }
+    @name(".sat_add_to") action sat_add_to() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_16 = hdr.data.opr1_16;
+        hdr.data.res_16 = hdr.data.opr1_16 |+| hdr.data.opr2_16;
+    }
+    @name(".sat_subtract_from") action sat_subtract_from() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_16 = hdr.data.opr1_16;
+        hdr.data.res_16 = hdr.data.opr1_16 |-| hdr.data.opr2_16;
+    }
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
+    @name(".t") table t_0 {
+        actions = {
+            sat_plus();
+            sat_minus();
+            sat_add_to();
+            sat_subtract_from();
+            _drop();
+        }
+        key = {
+            hdr.data.op: exact @name("data.op") ;
+        }
+        default_action = _drop();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<hdr_0>(hdr.data);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2.p4
@@ -1,0 +1,97 @@
+#include <core.p4>
+#include <v1model.p4>
+
+@name("hdr") header hdr_0 {
+    bit<8>  op;
+    @saturating 
+    bit<8>  opr1_8;
+    @saturating 
+    bit<8>  opr2_8;
+    @saturating 
+    bit<8>  res_8;
+    @saturating 
+    int<16> opr1_16;
+    @saturating 
+    int<16> opr2_16;
+    @saturating 
+    int<16> res_16;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".data") 
+    hdr_0 data;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start {
+        packet.extract(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".sat_plus") action sat_plus() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_8 = hdr.data.opr1_8 |+| hdr.data.opr2_8;
+    }
+    @name(".sat_minus") action sat_minus() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_8 = hdr.data.opr1_8 |-| hdr.data.opr2_8;
+    }
+    @name(".sat_add_to") action sat_add_to() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_16 = hdr.data.opr1_16;
+        hdr.data.res_16 = hdr.data.res_16 |+| hdr.data.opr2_16;
+    }
+    @name(".sat_subtract_from") action sat_subtract_from() {
+        standard_metadata.egress_spec = 9w0;
+        hdr.data.res_16 = hdr.data.opr1_16;
+        hdr.data.res_16 = hdr.data.res_16 |-| hdr.data.opr2_16;
+    }
+    @name("._drop") action _drop() {
+        mark_to_drop();
+    }
+    @name(".t") table t {
+        actions = {
+            sat_plus;
+            sat_minus;
+            sat_add_to;
+            sat_subtract_from;
+            _drop;
+        }
+        key = {
+            hdr.data.op: exact;
+        }
+        default_action = _drop();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.data);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_16_samples/issue396.p4
+++ b/testdata/p4_16_samples/issue396.p4
@@ -48,7 +48,7 @@ control d(out bool b) {
 
         bool eout;
         einst.apply({ 0 }, eout);
-        b = h.isValid() && eout;
+        b = h.isValid() && eout && h3[1].isValid() && s1.h.isValid();
     }
 }
 top(d()) main;

--- a/testdata/p4_16_samples/list-compare.p4
+++ b/testdata/p4_16_samples/list-compare.p4
@@ -10,10 +10,6 @@ const pair y = { 30, 40 };
 const bool z = x == y;
 const bool w = x == x;
 const S s = { 10, 20 };
-const bool v = s == x;
-const bool o = s == y;
-const bool vnot = s != x;
-const bool onot = s != y;
 
 control c(out bool z);
 package top(c _c);

--- a/testdata/p4_16_samples/nested-tuple.p4
+++ b/testdata/p4_16_samples/nested-tuple.p4
@@ -22,12 +22,18 @@ struct S {
     bit z;
 }
 
+struct tuple_0 {
+    T field;
+    T field_0;
+}
+
 extern void f<T>(in T data);
 
 control c(inout bit r) {
     apply {
         S s = { { {0}, {1} }, {0}, 1 };
         f(s.f1);
+        f<tuple_0>({{0},{1}});
         r = s.f2.f & s.z;
     }
 }

--- a/testdata/p4_16_samples/struct_init.p4
+++ b/testdata/p4_16_samples/struct_init.p4
@@ -1,0 +1,20 @@
+struct PortId_t { bit<9> _v; }
+
+const PortId_t PSA_CPU_PORT = {9w192};
+
+struct metadata_t {
+    PortId_t foo;
+}
+
+control I(inout metadata_t meta) {
+    apply {
+        if (meta.foo == PSA_CPU_PORT) {
+            meta.foo._v = meta.foo._v + 1;
+        }
+    }
+}
+
+control C<M>(inout M m);
+package top<M>(C<M> c);
+
+top(I()) main;

--- a/testdata/p4_16_samples_outputs/annotation-bug-first.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-first.p4
@@ -21,7 +21,7 @@ extern bit<16> get<T>(in T data);
 control cc() {
     headers hdr;
     apply {
-        get<headers>({ hdr.ipv4_option_timestamp });
+        get<headers>({hdr.ipv4_option_timestamp});
     }
 }
 

--- a/testdata/p4_16_samples_outputs/annotation-bug-frontend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-frontend.p4
@@ -19,23 +19,11 @@ struct tuple_0 {
 
 extern bit<16> get<T>(in T data);
 control cc() {
-<<<<<<< 8af0e6b445341eac6e0f948de9f7331dab1b9c46
     headers hdr_0;
     headers tmp;
     apply {
-        tmp = { hdr_0.ipv4_option_timestamp };
+        tmp = {hdr_0.ipv4_option_timestamp};
         get<headers>(tmp);
-=======
-    headers hdr_1;
-    headers tmp_0;
-    apply {
-<<<<<<< d74514ef5e6617902dc0c751b56267b983591d4b
-        get<headers>({hdr_1.ipv4_option_timestamp});
->>>>>>> Moved structure initializer creation to a separate pass
-=======
-        tmp_0 = {hdr_1.ipv4_option_timestamp};
-        get<headers>(tmp_0);
->>>>>>> Handle StructInitializerExpression in the back-end
     }
 }
 

--- a/testdata/p4_16_samples_outputs/annotation-bug-frontend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-frontend.p4
@@ -27,9 +27,15 @@ control cc() {
         get<headers>(tmp);
 =======
     headers hdr_1;
+    headers tmp_0;
     apply {
+<<<<<<< d74514ef5e6617902dc0c751b56267b983591d4b
         get<headers>({hdr_1.ipv4_option_timestamp});
 >>>>>>> Moved structure initializer creation to a separate pass
+=======
+        tmp_0 = {hdr_1.ipv4_option_timestamp};
+        get<headers>(tmp_0);
+>>>>>>> Handle StructInitializerExpression in the back-end
     }
 }
 

--- a/testdata/p4_16_samples_outputs/annotation-bug-frontend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-frontend.p4
@@ -19,11 +19,17 @@ struct tuple_0 {
 
 extern bit<16> get<T>(in T data);
 control cc() {
+<<<<<<< 8af0e6b445341eac6e0f948de9f7331dab1b9c46
     headers hdr_0;
     headers tmp;
     apply {
         tmp = { hdr_0.ipv4_option_timestamp };
         get<headers>(tmp);
+=======
+    headers hdr_1;
+    apply {
+        get<headers>({hdr_1.ipv4_option_timestamp});
+>>>>>>> Moved structure initializer creation to a separate pass
     }
 }
 

--- a/testdata/p4_16_samples_outputs/annotation-bug-midend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-midend.p4
@@ -21,11 +21,15 @@ extern bit<16> get<T>(in T data);
 control cc() {
     ipv4_option_timestamp_t hdr_0_ipv4_option_timestamp;
     @hidden action act() {
+<<<<<<< d74514ef5e6617902dc0c751b56267b983591d4b
 <<<<<<< 8af0e6b445341eac6e0f948de9f7331dab1b9c46
         get<headers>({ hdr_0_ipv4_option_timestamp });
 =======
         get<headers>({hdr_1_ipv4_option_timestamp});
 >>>>>>> Moved structure initializer creation to a separate pass
+=======
+        get<headers>({ hdr_1_ipv4_option_timestamp });
+>>>>>>> Handle StructInitializerExpression in the back-end
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/annotation-bug-midend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-midend.p4
@@ -21,15 +21,7 @@ extern bit<16> get<T>(in T data);
 control cc() {
     ipv4_option_timestamp_t hdr_0_ipv4_option_timestamp;
     @hidden action act() {
-<<<<<<< d74514ef5e6617902dc0c751b56267b983591d4b
-<<<<<<< 8af0e6b445341eac6e0f948de9f7331dab1b9c46
         get<headers>({ hdr_0_ipv4_option_timestamp });
-=======
-        get<headers>({hdr_1_ipv4_option_timestamp});
->>>>>>> Moved structure initializer creation to a separate pass
-=======
-        get<headers>({ hdr_1_ipv4_option_timestamp });
->>>>>>> Handle StructInitializerExpression in the back-end
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/annotation-bug-midend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-midend.p4
@@ -21,7 +21,11 @@ extern bit<16> get<T>(in T data);
 control cc() {
     ipv4_option_timestamp_t hdr_0_ipv4_option_timestamp;
     @hidden action act() {
+<<<<<<< 8af0e6b445341eac6e0f948de9f7331dab1b9c46
         get<headers>({ hdr_0_ipv4_option_timestamp });
+=======
+        get<headers>({hdr_1_ipv4_option_timestamp});
+>>>>>>> Moved structure initializer creation to a separate pass
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue396-first.p4
+++ b/testdata/p4_16_samples_outputs/issue396-first.p4
@@ -20,13 +20,13 @@ control d(out bool b) {
         H h;
         H h1;
         H[2] h3;
-        h = { 32w0 };
+        h = {32w0};
         S s;
         S s1;
-        s = { { 32w0 } };
-        s1.h = { 32w0 };
-        h3[0] = { 32w0 };
-        h3[1] = { 32w1 };
+        s = {{32w0}};
+        s1.h = {32w0};
+        h3[0] = {32w0};
+        h3[1] = {32w1};
         bool eout;
         einst.apply({ 32w0 }, eout);
         b = h.isValid() && eout;

--- a/testdata/p4_16_samples_outputs/issue396-first.p4
+++ b/testdata/p4_16_samples_outputs/issue396-first.p4
@@ -28,8 +28,8 @@ control d(out bool b) {
         h3[0] = {32w0};
         h3[1] = {32w1};
         bool eout;
-        einst.apply({ 32w0 }, eout);
-        b = h.isValid() && eout;
+        einst.apply({32w0}, eout);
+        b = h.isValid() && eout && h3[1].isValid() && s1.h.isValid();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue396-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-frontend.p4
@@ -29,15 +29,29 @@ control d(out bool b) {
         b = h_0.isValid() && eout_0;
 =======
     H h_1;
+    H[2] h3;
+    S s;
+    S s1;
     bool eout;
     H tmp_0;
     apply {
+        h_1.setValid();
         h_1 = {32w0};
+        s.h.setValid();
+        s1.h.setValid();
+        s1.h = {32w0};
+        h3[0].setValid();
+        h3[1].setValid();
+        h3[1] = {32w1};
         tmp_0.setValid();
-        tmp_0 = { 32w0 };
+        tmp_0 = {32w0};
         eout = tmp_0.isValid();
+<<<<<<< 8af0e6b445341eac6e0f948de9f7331dab1b9c46
         b = h_1.isValid() && eout;
 >>>>>>> Implemented struct initializers - currently inferred by type inference
+=======
+        b = h_1.isValid() && eout && h3[1].isValid() && s1.h.isValid();
+>>>>>>> Moved structure initializer creation to a separate pass
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue396-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-frontend.p4
@@ -9,6 +9,7 @@ struct S {
 control c(out bool b);
 package top(c _c);
 control d(out bool b) {
+<<<<<<< c32cb7a0dac7bb9d5abd1dbee292690508bf513c
     H h_0;
     H[2] h3_0;
     S s_0;
@@ -26,6 +27,17 @@ control d(out bool b) {
         tmp = { 32w0 };
         eout_0 = tmp.isValid();
         b = h_0.isValid() && eout_0;
+=======
+    H h_1;
+    bool eout;
+    H tmp_0;
+    apply {
+        h_1 = {32w0};
+        tmp_0.setValid();
+        tmp_0 = { 32w0 };
+        eout = tmp_0.isValid();
+        b = h_1.isValid() && eout;
+>>>>>>> Implemented struct initializers - currently inferred by type inference
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue396-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-frontend.p4
@@ -9,7 +9,6 @@ struct S {
 control c(out bool b);
 package top(c _c);
 control d(out bool b) {
-<<<<<<< c32cb7a0dac7bb9d5abd1dbee292690508bf513c
     H h_0;
     H[2] h3_0;
     S s_0;
@@ -18,40 +17,17 @@ control d(out bool b) {
     H tmp;
     apply {
         h_0.setValid();
-        h_0 = { 32w0 };
+        h_0 = {32w0};
         s_0.h.setValid();
         s1_0.h.setValid();
+        s1_0.h = {32w0};
         h3_0[0].setValid();
         h3_0[1].setValid();
+        h3_0[1] = {32w1};
         tmp.setValid();
-        tmp = { 32w0 };
+        tmp = {32w0};
         eout_0 = tmp.isValid();
-        b = h_0.isValid() && eout_0;
-=======
-    H h_1;
-    H[2] h3;
-    S s;
-    S s1;
-    bool eout;
-    H tmp_0;
-    apply {
-        h_1.setValid();
-        h_1 = {32w0};
-        s.h.setValid();
-        s1.h.setValid();
-        s1.h = {32w0};
-        h3[0].setValid();
-        h3[1].setValid();
-        h3[1] = {32w1};
-        tmp_0.setValid();
-        tmp_0 = {32w0};
-        eout = tmp_0.isValid();
-<<<<<<< 8af0e6b445341eac6e0f948de9f7331dab1b9c46
-        b = h_1.isValid() && eout;
->>>>>>> Implemented struct initializers - currently inferred by type inference
-=======
-        b = h_1.isValid() && eout && h3[1].isValid() && s1.h.isValid();
->>>>>>> Moved structure initializer creation to a separate pass
+        b = h_0.isValid() && eout_0 && h3_0[1].isValid() && s1_0.h.isValid();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue396-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-midend.p4
@@ -9,7 +9,6 @@ struct S {
 control c(out bool b);
 package top(c _c);
 control d(out bool b) {
-<<<<<<< c32cb7a0dac7bb9d5abd1dbee292690508bf513c
     H h_0;
     H[2] h3_0;
     H s_0_h;
@@ -21,37 +20,14 @@ control d(out bool b) {
         h_0.x = 32w0;
         s_0_h.setValid();
         s1_0_h.setValid();
+        s1_0_h.x = 32w0;
         h3_0[0].setValid();
         h3_0[1].setValid();
+        h3_0[1].x = 32w1;
         tmp.setValid();
         tmp.x = 32w0;
         eout_0 = tmp.isValid();
-        b = h_0.isValid() && eout_0;
-=======
-    H h_1;
-    H[2] h3;
-    H s_h;
-    H s1_h;
-    bool eout;
-    H tmp_0;
-    @hidden action act() {
-        h_1.setValid();
-        h_1.x = 32w0;
-        s_h.setValid();
-        s1_h.setValid();
-        s1_h.x = 32w0;
-        h3[0].setValid();
-        h3[1].setValid();
-        h3[1].x = 32w1;
-        tmp_0.setValid();
-        tmp_0.x = 32w0;
-        eout = tmp_0.isValid();
-<<<<<<< 8af0e6b445341eac6e0f948de9f7331dab1b9c46
-        b = h_1.isValid() && eout;
->>>>>>> Implemented struct initializers - currently inferred by type inference
-=======
-        b = h_1.isValid() && eout && h3[1].isValid() && s1_h.isValid();
->>>>>>> Moved structure initializer creation to a separate pass
+        b = h_0.isValid() && eout_0 && h3_0[1].isValid() && s1_0_h.isValid();
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue396-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-midend.p4
@@ -29,15 +29,29 @@ control d(out bool b) {
         b = h_0.isValid() && eout_0;
 =======
     H h_1;
+    H[2] h3;
+    H s_h;
+    H s1_h;
     bool eout;
     H tmp_0;
     @hidden action act() {
+        h_1.setValid();
         h_1.x = 32w0;
+        s_h.setValid();
+        s1_h.setValid();
+        s1_h.x = 32w0;
+        h3[0].setValid();
+        h3[1].setValid();
+        h3[1].x = 32w1;
         tmp_0.setValid();
         tmp_0.x = 32w0;
         eout = tmp_0.isValid();
+<<<<<<< 8af0e6b445341eac6e0f948de9f7331dab1b9c46
         b = h_1.isValid() && eout;
 >>>>>>> Implemented struct initializers - currently inferred by type inference
+=======
+        b = h_1.isValid() && eout && h3[1].isValid() && s1_h.isValid();
+>>>>>>> Moved structure initializer creation to a separate pass
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue396-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-midend.p4
@@ -9,6 +9,7 @@ struct S {
 control c(out bool b);
 package top(c _c);
 control d(out bool b) {
+<<<<<<< c32cb7a0dac7bb9d5abd1dbee292690508bf513c
     H h_0;
     H[2] h3_0;
     H s_0_h;
@@ -26,6 +27,17 @@ control d(out bool b) {
         tmp.x = 32w0;
         eout_0 = tmp.isValid();
         b = h_0.isValid() && eout_0;
+=======
+    H h_1;
+    bool eout;
+    H tmp_0;
+    @hidden action act() {
+        h_1.x = 32w0;
+        tmp_0.setValid();
+        tmp_0.x = 32w0;
+        eout = tmp_0.isValid();
+        b = h_1.isValid() && eout;
+>>>>>>> Implemented struct initializers - currently inferred by type inference
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue396.p4
+++ b/testdata/p4_16_samples_outputs/issue396.p4
@@ -29,7 +29,7 @@ control d(out bool b) {
         h3[1] = { 1 };
         bool eout;
         einst.apply({ 0 }, eout);
-        b = h.isValid() && eout;
+        b = h.isValid() && eout && h3[1].isValid() && s1.h.isValid();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/list-compare-first.p4
+++ b/testdata/p4_16_samples_outputs/list-compare-first.p4
@@ -8,17 +8,13 @@ const pair x = { 32w10, 32w20 };
 const pair y = { 32w30, 32w40 };
 const bool z = false;
 const bool w = true;
-const S s = { 32w10, 32w20 };
-const bool v = true;
-const bool o = false;
-const bool vnot = false;
-const bool onot = true;
+const S s = {32w10,32w20};
 control c(out bool z);
 package top(c _c);
 control test(out bool zout) {
     apply {
         tuple<bit<32>, bit<32>> p = { 32w4, 32w5 };
-        S q = { 32w2, 32w3 };
+        S q = {32w2,32w3};
         zout = p == { 32w4, 32w5 };
         zout = zout && q == { 32w2, 32w3 };
     }

--- a/testdata/p4_16_samples_outputs/list-compare-first.p4
+++ b/testdata/p4_16_samples_outputs/list-compare-first.p4
@@ -8,15 +8,15 @@ const pair x = { 32w10, 32w20 };
 const pair y = { 32w30, 32w40 };
 const bool z = false;
 const bool w = true;
-const S s = {32w10,32w20};
+const S s = { 32w10, 32w20 };
 control c(out bool z);
 package top(c _c);
 control test(out bool zout) {
     apply {
         tuple<bit<32>, bit<32>> p = { 32w4, 32w5 };
-        S q = {32w2,32w3};
+        S q = { 32w2, 32w3 };
         zout = p == { 32w4, 32w5 };
-        zout = zout && q == { 32w2, 32w3 };
+        zout = zout && q == {32w2,32w3};
     }
 }
 

--- a/testdata/p4_16_samples_outputs/list-compare-frontend.p4
+++ b/testdata/p4_16_samples_outputs/list-compare-frontend.p4
@@ -9,17 +9,10 @@ control test(out bool zout) {
     tuple<bit<32>, bit<32>> p_0;
     S q_0;
     apply {
-<<<<<<< c32cb7a0dac7bb9d5abd1dbee292690508bf513c
         p_0 = { 32w4, 32w5 };
         q_0 = { 32w2, 32w3 };
         zout = p_0 == { 32w4, 32w5 };
-        zout = zout && q_0 == { 32w2, 32w3 };
-=======
-        p = { 32w4, 32w5 };
-        q = {32w2,32w3};
-        zout = p == { 32w4, 32w5 };
-        zout = zout && q == { 32w2, 32w3 };
->>>>>>> Implemented struct initializers - currently inferred by type inference
+        zout = zout && q_0 == {32w2,32w3};
     }
 }
 

--- a/testdata/p4_16_samples_outputs/list-compare-frontend.p4
+++ b/testdata/p4_16_samples_outputs/list-compare-frontend.p4
@@ -9,10 +9,17 @@ control test(out bool zout) {
     tuple<bit<32>, bit<32>> p_0;
     S q_0;
     apply {
+<<<<<<< c32cb7a0dac7bb9d5abd1dbee292690508bf513c
         p_0 = { 32w4, 32w5 };
         q_0 = { 32w2, 32w3 };
         zout = p_0 == { 32w4, 32w5 };
         zout = zout && q_0 == { 32w2, 32w3 };
+=======
+        p = { 32w4, 32w5 };
+        q = {32w2,32w3};
+        zout = p == { 32w4, 32w5 };
+        zout = zout && q == { 32w2, 32w3 };
+>>>>>>> Implemented struct initializers - currently inferred by type inference
     }
 }
 

--- a/testdata/p4_16_samples_outputs/list-compare.p4
+++ b/testdata/p4_16_samples_outputs/list-compare.p4
@@ -9,10 +9,6 @@ const pair y = { 30, 40 };
 const bool z = x == y;
 const bool w = x == x;
 const S s = { 10, 20 };
-const bool v = s == x;
-const bool o = s == y;
-const bool vnot = s != x;
-const bool onot = s != y;
 control c(out bool z);
 package top(c _c);
 control test(out bool zout) {

--- a/testdata/p4_16_samples_outputs/nested-tuple-first.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-first.p4
@@ -8,11 +8,17 @@ struct S {
     bit<1>      z;
 }
 
+struct tuple_0 {
+    T field;
+    T field_0;
+}
+
 extern void f<T>(in T data);
 control c(inout bit<1> r) {
     apply {
-        S s = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
+        S s = {{ {1w0}, {1w1} },{1w0},1w1};
         f<tuple<T, T>>(s.f1);
+        f<tuple_0>({ { 1w0 }, { 1w1 } });
         r = s.f2.f & s.z;
     }
 }

--- a/testdata/p4_16_samples_outputs/nested-tuple-first.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-first.p4
@@ -16,9 +16,9 @@ struct tuple_0 {
 extern void f<T>(in T data);
 control c(inout bit<1> r) {
     apply {
-        S s = {{ {1w0}, {1w1} },{1w0},1w1};
+        S s = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
         f<tuple<T, T>>(s.f1);
-        f<tuple_0>({ { 1w0 }, { 1w1 } });
+        f<tuple_0>({{1w0},{1w1}});
         r = s.f2.f & s.z;
     }
 }

--- a/testdata/p4_16_samples_outputs/nested-tuple-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-frontend.p4
@@ -17,16 +17,10 @@ extern void f<T>(in T data);
 control c(inout bit<1> r) {
     S s_0;
     apply {
-<<<<<<< c32cb7a0dac7bb9d5abd1dbee292690508bf513c
         s_0 = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
         f<tuple<T, T>>(s_0.f1);
+        f<tuple_0>({{1w0},{1w1}});
         r = s_0.f2.f & s_0.z;
-=======
-        s = {{ {1w0}, {1w1} },{1w0},1w1};
-        f<tuple<T, T>>(s.f1);
-        f<tuple_0>({ { 1w0 }, { 1w1 } });
-        r = s.f2.f & s.z;
->>>>>>> Implemented struct initializers - currently inferred by type inference
     }
 }
 

--- a/testdata/p4_16_samples_outputs/nested-tuple-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-frontend.p4
@@ -8,13 +8,25 @@ struct S {
     bit<1>      z;
 }
 
+struct tuple_0 {
+    T field;
+    T field_0;
+}
+
 extern void f<T>(in T data);
 control c(inout bit<1> r) {
     S s_0;
     apply {
+<<<<<<< c32cb7a0dac7bb9d5abd1dbee292690508bf513c
         s_0 = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
         f<tuple<T, T>>(s_0.f1);
         r = s_0.f2.f & s_0.z;
+=======
+        s = {{ {1w0}, {1w1} },{1w0},1w1};
+        f<tuple<T, T>>(s.f1);
+        f<tuple_0>({ { 1w0 }, { 1w1 } });
+        r = s.f2.f & s.z;
+>>>>>>> Implemented struct initializers - currently inferred by type inference
     }
 }
 

--- a/testdata/p4_16_samples_outputs/nested-tuple-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-midend.p4
@@ -2,15 +2,20 @@ struct T {
     bit<1> f;
 }
 
-struct tuple_0 {
-    T field;
-    T field_0;
+struct tuple_1 {
+    T field_1;
+    T field_2;
 }
 
 struct S {
-    tuple_0 f1;
+    tuple_1 f1;
     T       f2;
     bit<1>  z;
+}
+
+struct tuple_0 {
+    T field;
+    T field_0;
 }
 
 extern void f<T>(in T data);
@@ -19,11 +24,20 @@ control c(inout bit<1> r) {
     T s_0_f1_field_0;
     T s_0_f2;
     @hidden action act() {
+<<<<<<< c32cb7a0dac7bb9d5abd1dbee292690508bf513c
         s_0_f1_field.f = 1w0;
         s_0_f1_field_0.f = 1w1;
         s_0_f2.f = 1w0;
         f<tuple_0>({ s_0_f1_field, s_0_f1_field_0 });
         r = s_0_f2.f & 1w1;
+=======
+        s_f1_field.f = 1w0;
+        s_f1_field_0.f = 1w1;
+        s_f2.f = 1w0;
+        f<tuple_1>({ s_f1_field, s_f1_field_0 });
+        f<tuple_0>({ { 1w0 }, { 1w1 } });
+        r = s_f2.f & 1w1;
+>>>>>>> Implemented struct initializers - currently inferred by type inference
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/nested-tuple-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-midend.p4
@@ -24,20 +24,12 @@ control c(inout bit<1> r) {
     T s_0_f1_field_0;
     T s_0_f2;
     @hidden action act() {
-<<<<<<< c32cb7a0dac7bb9d5abd1dbee292690508bf513c
         s_0_f1_field.f = 1w0;
         s_0_f1_field_0.f = 1w1;
         s_0_f2.f = 1w0;
-        f<tuple_0>({ s_0_f1_field, s_0_f1_field_0 });
+        f<tuple_1>({ s_0_f1_field, s_0_f1_field_0 });
+        f<tuple_0>({{1w0},{1w1}});
         r = s_0_f2.f & 1w1;
-=======
-        s_f1_field.f = 1w0;
-        s_f1_field_0.f = 1w1;
-        s_f2.f = 1w0;
-        f<tuple_1>({ s_f1_field, s_f1_field_0 });
-        f<tuple_0>({ { 1w0 }, { 1w1 } });
-        r = s_f2.f & 1w1;
->>>>>>> Implemented struct initializers - currently inferred by type inference
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/nested-tuple.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple.p4
@@ -8,11 +8,17 @@ struct S {
     bit<1>      z;
 }
 
+struct tuple_0 {
+    T field;
+    T field_0;
+}
+
 extern void f<T>(in T data);
 control c(inout bit<1> r) {
     apply {
         S s = { { { 0 }, { 1 } }, { 0 }, 1 };
         f(s.f1);
+        f<tuple_0>({ { 0 }, { 1 } });
         r = s.f2.f & s.z;
     }
 }

--- a/testdata/p4_16_samples_outputs/nested-tuple.p4-stderr
+++ b/testdata/p4_16_samples_outputs/nested-tuple.p4-stderr
@@ -1,4 +1,4 @@
-nested-tuple.p4(25): warning: T shadows struct T
+nested-tuple.p4(30): warning: T shadows struct T
 extern void f<T>(in T data);
               ^
 nested-tuple.p4(17)

--- a/testdata/p4_16_samples_outputs/struct_init-first.p4
+++ b/testdata/p4_16_samples_outputs/struct_init-first.p4
@@ -1,0 +1,20 @@
+struct PortId_t {
+    bit<9> _v;
+}
+
+const PortId_t PSA_CPU_PORT = {9w192};
+struct metadata_t {
+    PortId_t foo;
+}
+
+control I(inout metadata_t meta) {
+    apply {
+        if (meta.foo == {9w192}) 
+            meta.foo._v = meta.foo._v + 9w1;
+    }
+}
+
+control C<M>(inout M m);
+package top<M>(C<M> c);
+top<metadata_t>(I()) main;
+

--- a/testdata/p4_16_samples_outputs/struct_init-frontend.p4
+++ b/testdata/p4_16_samples_outputs/struct_init-frontend.p4
@@ -1,0 +1,19 @@
+struct PortId_t {
+    bit<9> _v;
+}
+
+struct metadata_t {
+    PortId_t foo;
+}
+
+control I(inout metadata_t meta) {
+    apply {
+        if (meta.foo == {9w192}) 
+            meta.foo._v = meta.foo._v + 9w1;
+    }
+}
+
+control C<M>(inout M m);
+package top<M>(C<M> c);
+top<metadata_t>(I()) main;
+

--- a/testdata/p4_16_samples_outputs/struct_init-midend.p4
+++ b/testdata/p4_16_samples_outputs/struct_init-midend.p4
@@ -1,0 +1,28 @@
+struct PortId_t {
+    bit<9> _v;
+}
+
+struct metadata_t {
+    PortId_t foo;
+}
+
+control I(inout metadata_t meta) {
+    @hidden action act() {
+        meta.foo._v = meta.foo._v + 9w1;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        if (meta.foo._v == 9w192) 
+            tbl_act.apply();
+    }
+}
+
+control C<M>(inout M m);
+package top<M>(C<M> c);
+top<metadata_t>(I()) main;
+

--- a/testdata/p4_16_samples_outputs/struct_init.p4
+++ b/testdata/p4_16_samples_outputs/struct_init.p4
@@ -1,0 +1,21 @@
+struct PortId_t {
+    bit<9> _v;
+}
+
+const PortId_t PSA_CPU_PORT = { 9w192 };
+struct metadata_t {
+    PortId_t foo;
+}
+
+control I(inout metadata_t meta) {
+    apply {
+        if (meta.foo == PSA_CPU_PORT) {
+            meta.foo._v = meta.foo._v + 1;
+        }
+    }
+}
+
+control C<M>(inout M m);
+package top<M>(C<M> c);
+top(I()) main;
+


### PR DESCRIPTION
This PR was much harder to implement than I expected.
This introduces a new IR node, called StructInitializerExpression.
This will be very useful if we decide to add C99-like struct intializers to P4 - which we probably should.
This also makes it easier to write some analyses - because some ListExpressions were implicitly converted to structs, and now these conversions are explicit in the use of a struct initializer instead of a ListExpression.

(I also realized that the type-checker is too lenient: it allows some conversions between tuples and structs which should be illegal, but it's not easy to fix that with our current setup.)