### PR TITLE
 Improve error message for a specific type inferencing failure that seems to come up frequently.

### DIFF
--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -35,10 +35,12 @@ constexpr char ANSI_CLR[]  = "\e[0m";
 class P4CExceptionBase : public std::exception {
  protected:
     cstring message;
+    void traceCreation() { }
 
  public:
     template <typename... T>
     P4CExceptionBase(const char* format, T... args) {
+        traceCreation();
         boost::format fmt(format);
         message = ::bug_helper(fmt, "", "", "", std::forward<T>(args)...);
     }


### PR DESCRIPTION
The specific case that comes up is passing a list of values to validateChecksum -- if one value is an untyped constant, then the error message was just giving the line info about the validateChecksum declaration (in the header file) and not providing any clarity as to the actual problem.  Several people have run into this problem and been unable to figure out what was going wrong from the error message.

I'm not a big fan of elaborating special cases in error messages like this, so it would be better to come up with a more general scheme; perhaps saving the expressions that are used to infer types in type inferencing.
