### PR TITLE
Fix for issue #1508

### DIFF
--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -400,6 +400,11 @@ void PsaSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
     auto parsePsaArch = new ParsePsaArchitecture(&structure);
     auto main = tlb->getMain();
     if (!main) return;
+
+    if (main->type->name != "PSA_Switch")
+        ::warning("%1%: the main package should be called PSA_Switch"
+                  "; are you using the wrong architecture?", main->type->name);
+
     main->apply(*parsePsaArch);
 
     auto evaluator = new P4::EvaluatorPass(refMap, typeMap);

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -818,6 +818,11 @@ SimpleSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
     auto parseV1Arch = new ParseV1Architecture(structure);
     auto main = tlb->getMain();
     if (!main) return;  // no main
+
+    if (main->type->name != "V1Switch")
+        ::warning("%1%: the main package should be called V1Switch"
+                  "; are you using the wrong architecture?", main->type->name);
+
     main->apply(*parseV1Arch);
     if (::errorCount() > 0)
         return;

--- a/backends/ebpf/ebpfProgram.cpp
+++ b/backends/ebpf/ebpfProgram.cpp
@@ -29,6 +29,10 @@ namespace EBPF {
 
 bool EBPFProgram::build() {
     auto pack = toplevel->getMain();
+    if (pack->type->name != "ebpfFilter")
+        ::warning("%1%: the main ebpf package should be called ebpfFilter"
+                  "; are you using the wrong architecture?", pack->type->name);
+
     if (pack->getConstructorParameters()->size() != 2) {
         ::error("Expected toplevel package %1% to have 2 parameters", pack->type);
         return false;


### PR DESCRIPTION
This should improve the error message when someone uses the wrong architecture file.
Unfortunately it's not easy to add tests due to the way our testing infrastructure is setup. These would have to be negative tests, and the negative tests would only fail with some compilers, not with p4test.