### PR TITLE
Sanitize CMake file paths. Second attempt.

### DIFF
--- a/backends/ebpf/targets/ebpfenv.py
+++ b/backends/ebpf/targets/ebpfenv.py
@@ -39,7 +39,7 @@ class Bridge(object):
         """ Initialize the namespace. """
         cmd = "ip netns add %s" % self.ns_name
         errmsg = "Failed to create namespace %s :" % self.ns_name
-        result = run_timeout(True, cmd, TIMEOUT,
+        result = run_timeout(self.verbose, cmd, TIMEOUT,
                              self.outputs, errmsg)
         self.ns_exec("ip link set dev lo up")
         return result
@@ -48,7 +48,7 @@ class Bridge(object):
         """ Delete the namespace. """
         cmd = "ip netns del %s" % self.ns_name
         errmsg = "Failed to delete namespace %s :" % self.ns_name
-        return run_timeout(True, cmd, TIMEOUT,
+        return run_timeout(self.verbose, cmd, TIMEOUT,
                            self.outputs, errmsg)
 
     def get_ns_prefix(self):
@@ -61,7 +61,8 @@ class Bridge(object):
         prefix = self.get_ns_prefix()
         # bash -c allows us to run multiple commands at once
         cmd = "%s bash -c \"%s\"" % (prefix, cmd_string)
-        errmsg = "Failed to run command in namespace %s:" % self.ns_name
+        errmsg = "Failed to run command %s in namespace %s:" % (
+            cmd, self.ns_name)
         return run_timeout(self.verbose, cmd, TIMEOUT,
                            self.outputs, errmsg)
 

--- a/backends/ebpf/targets/kernel_target.py
+++ b/backends/ebpf/targets/kernel_target.py
@@ -160,11 +160,16 @@ class Target(EBPFTarget):
 
     def run(self):
         # Root is necessary to load ebpf into the kernel
-        if check_root():
+        if not check_root():
             errmsg = "This test requires root privileges; skipping execution."
             report_err(self.outputs["stderr"], errmsg)
             return SKIPPED
-
+        # Sadly the Travis environment does not work with ip netns yet
+        if check_travis():
+            errmsg = ("The travis build currently does not support virtual"
+                      " namespaces; skipping execution.")
+            report_err(self.outputs["stderr"], errmsg)
+            return SKIPPED
         result = self._create_runtime()
         if result != SUCCESS:
             return result

--- a/cmake/P4CUtils.cmake
+++ b/cmake/P4CUtils.cmake
@@ -141,11 +141,26 @@ endmacro(p4c_add_test_list)
 
 # generate a list of test name suffixes based on specified testsuites
 function(p4c_find_test_names testsuites tests)
-  foreach(ts "${testsuites}")
+  set(__tests "")
+  p4c_sanitize_path("${testsuites}" abs_paths)
+  foreach(ts ${abs_paths})
     file (GLOB __testfiles RELATIVE ${P4C_SOURCE_DIR} ${ts})
     list (APPEND __tests ${__testfiles})
   endforeach()
   set(${tests} "${__tests}" PARENT_SCOPE)
+endfunction()
+
+# convert the paths from a list of input files to their absolute value,
+# does not follow symlinks.
+#   - files is a list of (relative) file paths
+#   - abs_files is the return set of absolute file paths
+function(p4c_sanitize_path files abs_files)
+  foreach(file ${files})
+    get_filename_component(__file "${file}"
+                       ABSOLUTE BASE_DIR "${P4C_SOURCE_DIR}")
+    list (APPEND __abs_files ${__file})
+  endforeach()
+  set(${abs_files} "${__abs_files}" PARENT_SCOPE)
 endfunction()
 
 # generate all the tests specified in the testsuites: builds a list of tests
@@ -159,21 +174,26 @@ endfunction()
 #
 # The macro generates the test files in a directory prefixed by tag.
 #
-macro(p4c_add_tests tag driver testsuites xfail)
+macro(p4c_add_tests tag driver testsuites xfails)
   set(__tests "")
+  set(__xfails "")
   p4c_find_test_names("${testsuites}" __tests)
-  p4c_add_test_list (${tag} ${driver} "${__tests}" "${xfail}" "${ARGN}")
+  p4c_find_test_names("${xfails}" __xfails)
+  p4c_add_test_list (${tag} ${driver} "${__tests}" "${__xfails}" "${ARGN}")
 endmacro(p4c_add_tests)
 
 # same as p4c_add_tests but adds --p4runtime flag when invoking test driver
 # unless test is listed in p4rt_exclude
-macro(p4c_add_tests_w_p4runtime tag driver testsuites xfail p4rt_exclude)
+macro(p4c_add_tests_w_p4runtime tag driver testsuites xfails p4rt_exclude)
+  set(__tests "")
+  set(__xfails "")
   p4c_find_test_names("${testsuites}" __tests)
+  p4c_find_test_names("${xfails}" __xfails)
   set(__tests_no_p4runtime "${p4rt_exclude}")
   set(__tests_p4runtime "${__tests}")
   list (REMOVE_ITEM __tests_p4runtime ${__tests_no_p4runtime})
-  p4c_add_test_list (${tag} ${driver} "${__tests_no_p4runtime}" "${xfail}" "${ARGN}")
-  p4c_add_test_list (${tag} ${driver} "${__tests_p4runtime}" "${xfail}" "--p4runtime ${ARGN}")
+  p4c_add_test_list (${tag} ${driver} "${__tests_no_p4runtime}" "${__xfails}" "${ARGN}")
+  p4c_add_test_list (${tag} ${driver} "${__tests_p4runtime}" "${__xfails}" "--p4runtime ${ARGN}")
 endmacro(p4c_add_tests_w_p4runtime)
 
 # add rules to make check and recheck for a specific test suite

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -29,6 +29,7 @@ SUCCESS = 0
 FAILURE = 1
 SKIPPED = 2  # used occasionally to indicate that a test was not executed
 
+
 def is_err(p4filename):
     """ True if the filename represents a p4 program that should fail. """
     return "_errors" in p4filename
@@ -145,3 +146,9 @@ def check_root():
     """ This function returns False if the user does not have root privileges.
         Caution: Only works on Unix systems """
     return (os.getuid() == 0)
+
+
+def check_travis():
+    """ This function returns True if the tests are being run in a
+    travis environment."""
+    return (os.environ.get('TRAVIS') == 'true')


### PR DESCRIPTION
This is the second attempt to fix the path inputs for the CMake testing script. Both tests and their corresponding xfail counterparts now follow identical patterns to make matching of file on different paths work. 
However, instead of casting the paths to absolute values after the `file GLOB` matching, it is now done before the function call. The original output of the `file GLOB` operation is preserved. In addition, the absolute value function does not use the REALPATH parameter anymore. It now does not follow symlinks in order to prevent odd behavior. I hope this prevents the regression tests from breaking.
