### PR TITLE
support for static linking

### DIFF
--- a/cmake/FindLibGmp.cmake
+++ b/cmake/FindLibGmp.cmake
@@ -26,6 +26,7 @@
 #   LIBGMP_LIBRARIES - The libraries needed to use LibGmp
 #   LIBGMP_DEFINITIONS - Compiler switches required for using LibGmp
 find_package(PkgConfig QUIET)
+find_package(Threads)
 PKG_CHECK_MODULES(PC_LIBGMP QUIET gmp)
 set(LIBGMP_DEFINITIONS ${PC_LIBGMP_CFLAGS_OTHER})
 
@@ -55,6 +56,5 @@ find_package_handle_standard_args(LibGmp
 mark_as_advanced(LIBGMP_INCLUDE_DIR LIBGMP_LIBRARY LIBGMPXX_LIBRARY)
 
 if(LIBGMP_FOUND)
-    set(LIBGMP_LIBRARIES ${LIBGMP_LIBRARY} ${LIBGMPXX_LIBRARY})
+    set(LIBGMP_LIBRARIES ${LIBGMPXX_LIBRARY} ${LIBGMP_LIBRARY})
 endif()
-

--- a/tools/ir-generator/CMakeLists.txt
+++ b/tools/ir-generator/CMakeLists.txt
@@ -48,4 +48,4 @@ add_executable (irgenerator ${IRGENERATOR_SRCS} ${IRGENERATOR_GEN_SRCS})
 # The generator expression $<BOOL:1> prevents IDE generators like Xcode
 # from appending a per-configuration subdirectory to the specified path.
 set_property(TARGET irgenerator PROPERTY RUNTIME_OUTPUT_DIRECTORY $<$<BOOL:1>:${IR_GENERATOR_DIRECTORY}>)
-target_link_libraries (irgenerator p4ctoolkit ${P4C_LIB_DEPS})
+target_link_libraries (irgenerator p4ctoolkit ${P4C_LIB_DEPS} ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
While statically linking the order of libraries matters. Note that we
don't do that by default, we just allow the tools to be built when
requested to link against static libraries for gmp and boost.