### PR TITLE
support const default_action in p4-14

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -855,7 +855,7 @@ ProgramStructure::convertTable(const IR::V1Table* table, cstring newName,
         auto prop = new IR::Property(
             IR::ID(IR::TableProperties::defaultActionPropertyName),
             new IR::ExpressionValue(methodCall),
-            /* isConstant = */ false);
+            table->default_action_is_const);
         props->push_back(prop);
     }
 

--- a/frontends/parsers/v1/v1lexer.ll
+++ b/frontends/parsers/v1/v1lexer.ll
@@ -111,6 +111,8 @@ using Parser = V1::V1Parser;
                   return Parser::make_DEFAULT(cstring(yytext), driver.yylloc); }
 "default_action" {BEGIN(driver.saveState);
                   return Parser::make_DEFAULT_ACTION(cstring(yytext), driver.yylloc); }
+"const_default_action" {BEGIN(driver.saveState);
+                  return Parser::make_CONST_DEFAULT_ACTION(cstring(yytext), driver.yylloc); }
 "direct"        { BEGIN(driver.saveState);
                   return Parser::make_DIRECT(cstring(yytext), driver.yylloc); }
 "drop"          { BEGIN(driver.saveState);

--- a/frontends/parsers/v1/v1lexer.ll
+++ b/frontends/parsers/v1/v1lexer.ll
@@ -111,8 +111,8 @@ using Parser = V1::V1Parser;
                   return Parser::make_DEFAULT(cstring(yytext), driver.yylloc); }
 "default_action" {BEGIN(driver.saveState);
                   return Parser::make_DEFAULT_ACTION(cstring(yytext), driver.yylloc); }
-"const_default_action" {BEGIN(driver.saveState);
-                  return Parser::make_CONST_DEFAULT_ACTION(cstring(yytext), driver.yylloc); }
+"const"         {BEGIN(driver.saveState);
+                  return Parser::make_CONST(cstring(yytext), driver.yylloc); }
 "direct"        { BEGIN(driver.saveState);
                   return Parser::make_DIRECT(cstring(yytext), driver.yylloc); }
 "drop"          { BEGIN(driver.saveState);

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -160,7 +160,7 @@ typedef const IR::Type ConstType;
 %token      NEWLINE
 %token<cstring> ACTION ACTIONS ACTION_PROFILE ACTION_SELECTOR ALGORITHM APPLY
                 ATTRIBUTE ATTRIBUTES BIT BLACKBOX BLACKBOX_TYPE BLOCK BOOL
-                CALCULATED_FIELD CONTROL COUNTER CURRENT DEFAULT DEFAULT_ACTION CONST_DEFAULT_ACTION
+                CALCULATED_FIELD CONTROL COUNTER CONST CURRENT DEFAULT DEFAULT_ACTION
                 DIRECT DROP DYNAMIC_ACTION_SELECTION ELSE EXTRACT EXPRESSION
                 EXPRESSION_LOCAL_VARIABLES FALSE FIELD_LIST FIELD_LIST_CALCULATION
                 FIELDS HEADER HEADER_TYPE IF IMPLEMENTATION IN INPUT INSTANCE_COUNT
@@ -739,12 +739,12 @@ table_body: /* epsilon */
     | table_body DEFAULT_ACTION ":" name "(" opt_expression_list ")" ";"
         { ($$=$1)->default_action = IR::ID(@4, $4);
           $$->default_action_args = $6; }
-    | table_body CONST_DEFAULT_ACTION ":" name ";"
-      { ($$=$1)->default_action = IR::ID(@4, $4);
+    | table_body CONST DEFAULT_ACTION ":" name ";"
+      { ($$=$1)->default_action = IR::ID(@5, $5);
           $$->default_action_is_const = true; }
-    | table_body CONST_DEFAULT_ACTION ":" name "(" opt_expression_list ")" ";"
-        { ($$=$1)->default_action = IR::ID(@4, $4);
-          $$->default_action_args = $6;
+    | table_body CONST DEFAULT_ACTION ":" name "(" opt_expression_list ")" ";"
+        { ($$=$1)->default_action = IR::ID(@5, $5);
+          $$->default_action_args = $7;
 	  $$->default_action_is_const = true; }
     | table_body IDENTIFIER ":" expression ";"
       { auto exp = new IR::ExpressionValue(@4, $4);
@@ -1028,7 +1028,7 @@ name: IDENTIFIER { $$ = IR::ID(@1, $1); }
     | CONTROL { $$ = IR::ID(@1, $1); }
     | COUNTER { $$ = IR::ID(@1, $1); }
     | DEFAULT_ACTION { $$ = IR::ID(@1, $1); }
-    | CONST_DEFAULT_ACTION { $$ = IR::ID(@1, $1); }
+    | CONST { $$ = IR::ID(@1, $1); }
     | DIRECT { $$ = IR::ID(@1, $1); }
     | DROP { $$ = IR::ID(@1, $1); }
     | DYNAMIC_ACTION_SELECTION { $$ = IR::ID(@1, $1); }

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -160,7 +160,7 @@ typedef const IR::Type ConstType;
 %token      NEWLINE
 %token<cstring> ACTION ACTIONS ACTION_PROFILE ACTION_SELECTOR ALGORITHM APPLY
                 ATTRIBUTE ATTRIBUTES BIT BLACKBOX BLACKBOX_TYPE BLOCK BOOL
-                CALCULATED_FIELD CONTROL COUNTER CURRENT DEFAULT DEFAULT_ACTION
+                CALCULATED_FIELD CONTROL COUNTER CURRENT DEFAULT DEFAULT_ACTION CONST_DEFAULT_ACTION
                 DIRECT DROP DYNAMIC_ACTION_SELECTION ELSE EXTRACT EXPRESSION
                 EXPRESSION_LOCAL_VARIABLES FALSE FIELD_LIST FIELD_LIST_CALCULATION
                 FIELDS HEADER HEADER_TYPE IF IMPLEMENTATION IN INPUT INSTANCE_COUNT
@@ -739,6 +739,13 @@ table_body: /* epsilon */
     | table_body DEFAULT_ACTION ":" name "(" opt_expression_list ")" ";"
         { ($$=$1)->default_action = IR::ID(@4, $4);
           $$->default_action_args = $6; }
+    | table_body CONST_DEFAULT_ACTION ":" name ";"
+      { ($$=$1)->default_action = IR::ID(@4, $4);
+          $$->default_action_is_const = true; }
+    | table_body CONST_DEFAULT_ACTION ":" name "(" opt_expression_list ")" ";"
+        { ($$=$1)->default_action = IR::ID(@4, $4);
+          $$->default_action_args = $6;
+	  $$->default_action_is_const = true; }
     | table_body IDENTIFIER ":" expression ";"
       { auto exp = new IR::ExpressionValue(@4, $4);
         auto prop = new IR::Property(@2, IR::ID(@2, $2), exp, false);
@@ -1021,6 +1028,7 @@ name: IDENTIFIER { $$ = IR::ID(@1, $1); }
     | CONTROL { $$ = IR::ID(@1, $1); }
     | COUNTER { $$ = IR::ID(@1, $1); }
     | DEFAULT_ACTION { $$ = IR::ID(@1, $1); }
+    | CONST_DEFAULT_ACTION { $$ = IR::ID(@1, $1); }
     | DIRECT { $$ = IR::ID(@1, $1); }
     | DROP { $$ = IR::ID(@1, $1); }
     | DYNAMIC_ACTION_SELECTION { $$ = IR::ID(@1, $1); }

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -405,6 +405,7 @@ class V1Table : IInstance {
     ID                          action_profile = {};
     safe_vector<ID>             actions = {};
     ID                          default_action = {};
+    bool                        default_action_is_const = false;
     NullOK Vector<Expression>   default_action_args = 0;
     inline TableProperties      properties = {};  // non-standard properties
     optional Annotations        annotations = Annotations::empty;

--- a/testdata/p4_14_samples/const_default_action.p4
+++ b/testdata/p4_14_samples/const_default_action.p4
@@ -69,7 +69,7 @@ table port_vlan_to_bd_mapping {
         vlan_tag_[0].vid : ternary;
     }
     action_profile: bd_action_profile;
-    const_default_action: no_op();
+    const default_action: no_op();
     size : 1024;
 }
 
@@ -78,7 +78,7 @@ table vlan_to_bd_mapping {
         vlan_tag_[0].vid : exact;
     }
     action_profile: bd_action_profile;
-    const_default_action: no_op();
+    const default_action: no_op();
     size : 1024;
 }
 

--- a/testdata/p4_14_samples/const_default_action.p4
+++ b/testdata/p4_14_samples/const_default_action.p4
@@ -1,0 +1,96 @@
+header_type ethernet_t {
+    fields {
+        dstAddr : 48;
+        srcAddr : 48;
+        etherType : 16;
+    }
+}
+
+header_type vlan_tag_t {
+    fields {
+        pcp : 3;
+        cfi : 1;
+        vid : 12;
+        etherType : 16;
+    }
+}
+
+/* METADATA */
+header_type ingress_metadata_t {
+    fields {
+        ingress_port : 9;                         /* input physical port */
+        bd : 14;
+        rid : 14;
+        drop_flag : 1;
+    }
+}
+
+#define VLAN_DEPTH 2
+header vlan_tag_t vlan_tag_[VLAN_DEPTH];
+header ethernet_t ethernet;
+header ingress_metadata_t ingress_metadata;
+
+parser start {
+    extract(ethernet);
+    return select(latest.etherType) {
+	default: parse_vlan;
+    }
+}
+
+parser parse_vlan {
+    extract(vlan_tag_[0]);
+    return select(latest.etherType) {
+        0x800 : ingress;
+    }
+}
+
+action set_bd_properties(bd, ingress_rid) {
+    modify_field(ingress_metadata.bd, bd);
+    modify_field(ingress_metadata.rid, ingress_rid);
+}
+
+action port_vlan_mapping_miss() {
+    modify_field(ingress_metadata.drop_flag, 1);
+}
+
+action_profile bd_action_profile {
+    actions {
+        set_bd_properties;
+        port_vlan_mapping_miss;
+    }
+    size : 1024;
+}
+
+action no_op(){}
+
+table port_vlan_to_bd_mapping {
+    reads {
+        vlan_tag_[0] : valid;
+        vlan_tag_[0].vid : ternary;
+    }
+    action_profile: bd_action_profile;
+    const_default_action: no_op();
+    size : 1024;
+}
+
+table vlan_to_bd_mapping {
+    reads {
+        vlan_tag_[0].vid : exact;
+    }
+    action_profile: bd_action_profile;
+    const_default_action: no_op();
+    size : 1024;
+}
+
+control process_port_vlan_mapping {
+    apply(port_vlan_to_bd_mapping) {
+	    miss { apply(vlan_to_bd_mapping); }
+    }
+}
+
+control ingress {
+    /* derive bd and its properties  */
+    process_port_vlan_mapping();
+}
+
+control egress {}

--- a/testdata/p4_14_samples_outputs/const_default_action-first.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action-first.p4
@@ -1,0 +1,128 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ingress_metadata_t {
+    bit<9>  ingress_port;
+    bit<14> bd;
+    bit<14> rid;
+    bit<1>  drop_flag;
+}
+
+header vlan_tag_t {
+    bit<3>  pcp;
+    bit<1>  cfi;
+    bit<12> vid;
+    bit<16> etherType;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t         ethernet;
+    @name(".ingress_metadata") 
+    ingress_metadata_t ingress_metadata;
+    @name(".vlan_tag_") 
+    vlan_tag_t[2]      vlan_tag_;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_vlan") state parse_vlan {
+        packet.extract<vlan_tag_t>(hdr.vlan_tag_[0]);
+        transition select(hdr.vlan_tag_[0].etherType) {
+            16w0x800: accept;
+        }
+    }
+    @name(".start") state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            default: parse_vlan;
+        }
+    }
+}
+
+@name(".bd_action_profile") action_profile(32w1024) bd_action_profile;
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control process_port_vlan_mapping(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".no_op") action no_op() {
+    }
+    @name(".set_bd_properties") action set_bd_properties(bit<14> bd, bit<14> ingress_rid) {
+        hdr.ingress_metadata.bd = bd;
+        hdr.ingress_metadata.rid = ingress_rid;
+    }
+    @name(".port_vlan_mapping_miss") action port_vlan_mapping_miss() {
+        hdr.ingress_metadata.drop_flag = 1w1;
+    }
+    @name(".port_vlan_to_bd_mapping") table port_vlan_to_bd_mapping {
+        actions = {
+            set_bd_properties();
+            port_vlan_mapping_miss();
+            @defaultonly no_op();
+        }
+        key = {
+            hdr.vlan_tag_[0].isValid(): exact @name("vlan_tag_[0].$valid$") ;
+            hdr.vlan_tag_[0].vid      : ternary @name("vlan_tag_[0].vid") ;
+        }
+        size = 1024;
+        const default_action = no_op();
+        implementation = bd_action_profile;
+    }
+    @name(".vlan_to_bd_mapping") table vlan_to_bd_mapping {
+        actions = {
+            set_bd_properties();
+            port_vlan_mapping_miss();
+            @defaultonly no_op();
+        }
+        key = {
+            hdr.vlan_tag_[0].vid: exact @name("vlan_tag_[0].vid") ;
+        }
+        size = 1024;
+        const default_action = no_op();
+        implementation = bd_action_profile;
+    }
+    apply {
+        if (port_vlan_to_bd_mapping.apply().hit) 
+            ;
+        else 
+            vlan_to_bd_mapping.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".process_port_vlan_mapping") process_port_vlan_mapping() process_port_vlan_mapping_0;
+    apply {
+        process_port_vlan_mapping_0.apply(hdr, meta, standard_metadata);
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<vlan_tag_t>(hdr.vlan_tag_[0]);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/const_default_action-frontend.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action-frontend.p4
@@ -1,0 +1,132 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ingress_metadata_t {
+    bit<9>  ingress_port;
+    bit<14> bd;
+    bit<14> rid;
+    bit<1>  drop_flag;
+}
+
+header vlan_tag_t {
+    bit<3>  pcp;
+    bit<1>  cfi;
+    bit<12> vid;
+    bit<16> etherType;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t         ethernet;
+    @name(".ingress_metadata") 
+    ingress_metadata_t ingress_metadata;
+    @name(".vlan_tag_") 
+    vlan_tag_t[2]      vlan_tag_;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_vlan") state parse_vlan {
+        packet.extract<vlan_tag_t>(hdr.vlan_tag_[0]);
+        transition select(hdr.vlan_tag_[0].etherType) {
+            16w0x800: accept;
+        }
+    }
+    @name(".start") state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            default: parse_vlan;
+        }
+    }
+}
+
+@name(".bd_action_profile") action_profile(32w1024) bd_action_profile;
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bool _process_port_vlan_mapping_tmp_0;
+    @name(".no_op") action _no_op() {
+    }
+    @name(".no_op") action _no_op_2() {
+    }
+    @name(".set_bd_properties") action _set_bd_properties(bit<14> bd, bit<14> ingress_rid) {
+        hdr.ingress_metadata.bd = bd;
+        hdr.ingress_metadata.rid = ingress_rid;
+    }
+    @name(".set_bd_properties") action _set_bd_properties_2(bit<14> bd, bit<14> ingress_rid) {
+        hdr.ingress_metadata.bd = bd;
+        hdr.ingress_metadata.rid = ingress_rid;
+    }
+    @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss() {
+        hdr.ingress_metadata.drop_flag = 1w1;
+    }
+    @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss_2() {
+        hdr.ingress_metadata.drop_flag = 1w1;
+    }
+    @name(".port_vlan_to_bd_mapping") table _port_vlan_to_bd_mapping_0 {
+        actions = {
+            _set_bd_properties();
+            _port_vlan_mapping_miss();
+            @defaultonly _no_op();
+        }
+        key = {
+            hdr.vlan_tag_[0].isValid(): exact @name("vlan_tag_[0].$valid$") ;
+            hdr.vlan_tag_[0].vid      : ternary @name("vlan_tag_[0].vid") ;
+        }
+        size = 1024;
+        const default_action = _no_op();
+        implementation = bd_action_profile;
+    }
+    @name(".vlan_to_bd_mapping") table _vlan_to_bd_mapping_0 {
+        actions = {
+            _set_bd_properties_2();
+            _port_vlan_mapping_miss_2();
+            @defaultonly _no_op_2();
+        }
+        key = {
+            hdr.vlan_tag_[0].vid: exact @name("vlan_tag_[0].vid") ;
+        }
+        size = 1024;
+        const default_action = _no_op_2();
+        implementation = bd_action_profile;
+    }
+    apply {
+        _process_port_vlan_mapping_tmp_0 = _port_vlan_to_bd_mapping_0.apply().hit;
+        if (_process_port_vlan_mapping_tmp_0) 
+            ;
+        else 
+            _vlan_to_bd_mapping_0.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<vlan_tag_t>(hdr.vlan_tag_[0]);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/const_default_action-midend.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action-midend.p4
@@ -1,0 +1,158 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ingress_metadata_t {
+    bit<9>  ingress_port;
+    bit<14> bd;
+    bit<14> rid;
+    bit<1>  drop_flag;
+}
+
+header vlan_tag_t {
+    bit<3>  pcp;
+    bit<1>  cfi;
+    bit<12> vid;
+    bit<16> etherType;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t         ethernet;
+    @name(".ingress_metadata") 
+    ingress_metadata_t ingress_metadata;
+    @name(".vlan_tag_") 
+    vlan_tag_t[2]      vlan_tag_;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_vlan") state parse_vlan {
+        packet.extract<vlan_tag_t>(hdr.vlan_tag_[0]);
+        transition select(hdr.vlan_tag_[0].etherType) {
+            16w0x800: accept;
+            default: noMatch;
+        }
+    }
+    @name(".start") state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            default: parse_vlan;
+        }
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
+    }
+}
+
+@name(".bd_action_profile") action_profile(32w1024) bd_action_profile;
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bool _process_port_vlan_mapping_tmp_0;
+    @name(".no_op") action _no_op() {
+    }
+    @name(".no_op") action _no_op_2() {
+    }
+    @name(".set_bd_properties") action _set_bd_properties(bit<14> bd, bit<14> ingress_rid) {
+        hdr.ingress_metadata.bd = bd;
+        hdr.ingress_metadata.rid = ingress_rid;
+    }
+    @name(".set_bd_properties") action _set_bd_properties_2(bit<14> bd, bit<14> ingress_rid) {
+        hdr.ingress_metadata.bd = bd;
+        hdr.ingress_metadata.rid = ingress_rid;
+    }
+    @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss() {
+        hdr.ingress_metadata.drop_flag = 1w1;
+    }
+    @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss_2() {
+        hdr.ingress_metadata.drop_flag = 1w1;
+    }
+    @name(".port_vlan_to_bd_mapping") table _port_vlan_to_bd_mapping_0 {
+        actions = {
+            _set_bd_properties();
+            _port_vlan_mapping_miss();
+            @defaultonly _no_op();
+        }
+        key = {
+            hdr.vlan_tag_[0].isValid(): exact @name("vlan_tag_[0].$valid$") ;
+            hdr.vlan_tag_[0].vid      : ternary @name("vlan_tag_[0].vid") ;
+        }
+        size = 1024;
+        const default_action = _no_op();
+        implementation = bd_action_profile;
+    }
+    @name(".vlan_to_bd_mapping") table _vlan_to_bd_mapping_0 {
+        actions = {
+            _set_bd_properties_2();
+            _port_vlan_mapping_miss_2();
+            @defaultonly _no_op_2();
+        }
+        key = {
+            hdr.vlan_tag_[0].vid: exact @name("vlan_tag_[0].vid") ;
+        }
+        size = 1024;
+        const default_action = _no_op_2();
+        implementation = bd_action_profile;
+    }
+    @hidden action act() {
+        _process_port_vlan_mapping_tmp_0 = true;
+    }
+    @hidden action act_0() {
+        _process_port_vlan_mapping_tmp_0 = false;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    apply {
+        if (_port_vlan_to_bd_mapping_0.apply().hit) 
+            tbl_act.apply();
+        else 
+            tbl_act_0.apply();
+        if (_process_port_vlan_mapping_tmp_0) 
+            ;
+        else 
+            _vlan_to_bd_mapping_0.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<vlan_tag_t>(hdr.vlan_tag_[0]);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/const_default_action.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action.p4
@@ -1,0 +1,129 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ingress_metadata_t {
+    bit<9>  ingress_port;
+    bit<14> bd;
+    bit<14> rid;
+    bit<1>  drop_flag;
+}
+
+header vlan_tag_t {
+    bit<3>  pcp;
+    bit<1>  cfi;
+    bit<12> vid;
+    bit<16> etherType;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t         ethernet;
+    @name(".ingress_metadata") 
+    ingress_metadata_t ingress_metadata;
+    @name(".vlan_tag_") 
+    vlan_tag_t[2]      vlan_tag_;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_vlan") state parse_vlan {
+        packet.extract(hdr.vlan_tag_[0]);
+        transition select(hdr.vlan_tag_[0].etherType) {
+            16w0x800: accept;
+        }
+    }
+    @name(".start") state start {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            default: parse_vlan;
+        }
+    }
+}
+
+@name(".bd_action_profile") action_profile(32w1024) bd_action_profile;
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control process_port_vlan_mapping(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".no_op") action no_op() {
+    }
+    @name(".set_bd_properties") action set_bd_properties(bit<14> bd, bit<14> ingress_rid) {
+        hdr.ingress_metadata.bd = bd;
+        hdr.ingress_metadata.rid = ingress_rid;
+    }
+    @name(".port_vlan_mapping_miss") action port_vlan_mapping_miss() {
+        hdr.ingress_metadata.drop_flag = 1w1;
+    }
+    @name(".port_vlan_to_bd_mapping") table port_vlan_to_bd_mapping {
+        actions = {
+            set_bd_properties;
+            port_vlan_mapping_miss;
+            @defaultonly no_op;
+        }
+        key = {
+            hdr.vlan_tag_[0].isValid(): exact;
+            hdr.vlan_tag_[0].vid      : ternary;
+        }
+        size = 1024;
+        const default_action = no_op();
+        implementation = bd_action_profile;
+    }
+    @name(".vlan_to_bd_mapping") table vlan_to_bd_mapping {
+        actions = {
+            set_bd_properties;
+            port_vlan_mapping_miss;
+            @defaultonly no_op;
+        }
+        key = {
+            hdr.vlan_tag_[0].vid: exact;
+        }
+        size = 1024;
+        const default_action = no_op();
+        implementation = bd_action_profile;
+    }
+    apply {
+        if (port_vlan_to_bd_mapping.apply().hit) 
+            ;
+        else {
+            vlan_to_bd_mapping.apply();
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".process_port_vlan_mapping") process_port_vlan_mapping() process_port_vlan_mapping_0;
+    apply {
+        process_port_vlan_mapping_0.apply(hdr, meta, standard_metadata);
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.vlan_tag_[0]);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+


### PR DESCRIPTION
This PR implements an experimental feature in P4-14 to support const default_action by introducing a new table property keyword 'const_default_action'. 