### PR TITLE
Optimizations on the testing backend

### DIFF
--- a/backends/ebpf/targets/bcc_target.py
+++ b/backends/ebpf/targets/bcc_target.py
@@ -26,7 +26,7 @@ class Target(EBPFTarget):
     def __init__(self, tmpdir, options, template, outputs):
         EBPFTarget.__init__(self, tmpdir, options, template, outputs)
 
-    def create_filter(self):
+    def compile_dataplane(self):
         # Not implemented yet, just pass the test
         return SUCCESS
 

--- a/backends/ebpf/targets/ebpfenv.py
+++ b/backends/ebpf/targets/ebpfenv.py
@@ -15,8 +15,7 @@
 
 """ Virtual environment which models a simple bridge with n attached
     interfaces. The bridge runs in a completely isolated namespace.
-    Allows the loading and testing of eBPF programs by initializing every
-    interface with a qdisc. """
+    Allows the loading and testing of eBPF programs. """
 
 import os
 import sys
@@ -98,16 +97,14 @@ class Bridge(object):
         return run_process(self.verbose, proc, TIMEOUT, self.outputs, errmsg)
 
     def _configure_bridge(self, br_name):
-        """ Set the bridge active and load the qdisc. We also disable IPv6 to
+        """ Set the bridge active. We also disable IPv6 to
             avoid ICMPv6 spam. """
         # We do not care about failures here
         self.ns_exec("ip link set dev %s up" % br_name)
         # Prevent the broadcasting of ipv6 link discovery messages
         self.ns_exec("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
         self.ns_exec("sysctl -w net.ipv6.conf.default.disable_ipv6=1")
-        # Add the qdisc. MUST be clsact layer.
-        cmd = "tc qdisc add dev %s clsact" % br_name
-        return self.ns_exec(cmd)
+        return SUCCESS
 
     def create_bridge(self):
         """ Create the central bridge of the environment and configure it. """
@@ -117,9 +114,8 @@ class Bridge(object):
         return self._configure_bridge(self.br_name)
 
     def _configure_bridge_port(self, port_name):
-        """ Set a bridge port active and load the qdisc. """
-        cmd = "ip link set dev %s up && " % port_name
-        cmd += "tc qdisc add dev %s clsact" % port_name
+        """ Set a bridge port active. """
+        cmd = "ip link set dev %s up" % port_name
         return self.ns_exec(cmd)
 
     def attach_interfaces(self, num_ifaces):

--- a/backends/ebpf/targets/ebpfenv.py
+++ b/backends/ebpf/targets/ebpfenv.py
@@ -100,12 +100,13 @@ class Bridge(object):
     def _configure_bridge(self, br_name):
         """ Set the bridge active and load the qdisc. We also disable IPv6 to
             avoid ICMPv6 spam. """
-        cmd = "ip link set dev %s up && " % br_name
+        # We do not care about failures here
+        self.ns_exec("ip link set dev %s up" % br_name)
         # Prevent the broadcasting of ipv6 link discovery messages
-        cmd += "sysctl -w net.ipv6.conf.all.disable_ipv6=1 && "
-        cmd += "sysctl -w net.ipv6.conf.default.disable_ipv6=1 && "
+        self.ns_exec("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
+        self.ns_exec("sysctl -w net.ipv6.conf.default.disable_ipv6=1")
         # Add the qdisc. MUST be clsact layer.
-        cmd += "tc qdisc add dev %s clsact" % br_name
+        cmd = "tc qdisc add dev %s clsact" % br_name
         return self.ns_exec(cmd)
 
     def create_bridge(self):

--- a/backends/ebpf/targets/kernel_target.py
+++ b/backends/ebpf/targets/kernel_target.py
@@ -32,7 +32,7 @@ class Target(EBPFTarget):
     def __init__(self, tmpdir, options, template, outputs):
         EBPFTarget.__init__(self, tmpdir, options, template, outputs)
 
-    def create_filter(self):
+    def compile_dataplane(self):
         # Use clang to compile the generated C code to a LLVM IR
         args = "make "
         # target makefile
@@ -102,11 +102,11 @@ class Target(EBPFTarget):
         # As a side-effect, this may create maps in /sys/fs/bpf/
 
         # Add the qdisc. MUST be clsact layer.
-        bridge.ns_proc_write(proc, "tc qdisc add dev %s clsacst" % port_name)
+        bridge.ns_exec("tc qdisc add dev %s clsact" % port_name)
         cmd = ("tc filter add dev %s egress"
                " bpf da obj %s section prog "
                "verbose" % (port_name, self.template + ".o"))
-        return bridge.ns_proc_append(proc, cmd)
+        return bridge.ns_proc_write(proc, cmd)
 
     def _attach_filters(self, bridge, proc):
         # Get the command to load eBPF code to all the attached ports

--- a/backends/ebpf/targets/target.py
+++ b/backends/ebpf/targets/target.py
@@ -150,7 +150,7 @@ class EBPFTarget(object):
                 return result
         return SUCCESS
 
-    def create_filter(self, argv=""):
+    def compile_dataplane(self, argv=""):
         # To override
         """ Compiles a filter from the previously generated template """
         raise NotImplementedError("Method create_filter not implemented!")

--- a/backends/ebpf/targets/test_target.py
+++ b/backends/ebpf/targets/test_target.py
@@ -28,7 +28,7 @@ class Target(EBPFTarget):
   def __init__(self, tmpdir, options, template, outputs):
     EBPFTarget.__init__(self, tmpdir, options, template, outputs)
 
-  def create_filter(self):
+  def compile_dataplane(self):
     args = self.get_make_args(self.runtimedir, self.options.target)
     # List of bpf programs to attach to the interface
     args += "BPFOBJ=" + self.template + " "


### PR DESCRIPTION
- Move IPv6 options out of the critical path
- Move qdisc operations into the kernel target, it is the only target that needs them.
- Improve the test parsing, it is now easier to modify or add options.
- Rename create_filter to compile_dataplane to clarify the purpose of the function