### PR TITLE
P4_14->16 conversion of field_list_calculation with same name as other object

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -245,6 +245,7 @@ class ProgramStructure {
     virtual const IR::Declaration_Instance* convert(const IR::Register* reg, cstring newName,
                                                     const IR::Type *regElementType = nullptr);
     virtual const IR::Type_Struct* createFieldListType(const IR::Expression* expression);
+    virtual const IR::FieldListCalculation* getFieldListCalculation(const IR::Expression *);
     virtual const IR::FieldList* getFieldLists(const IR::FieldListCalculation* flc);
     virtual const IR::Expression* paramReference(const IR::Parameter* param);
     const IR::Statement* sliceAssign(const IR::Primitive* prim, const IR::Expression* left,


### PR DESCRIPTION

- P4_14 allows multiple things with the same name in the global scope
  and requires the compiler to figure out which is which based on
  context.  In P4_14 typechecking we don't have detailed knowledge of
  what primitive arguments should be, so we assume they are externs or
  other objects (target dependent), which can turn out to be wrong in
  the case of field_list_calculations.