### PR TITLE
make optional arguments to cmake explicit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ OPTION (ENABLE_P4C_GRAPHS "Build the p4c-graphs backend" ON)
 OPTION (ENABLE_PROTOBUF_STATIC "Link against Protobuf statically" ON)
 OPTION (ENABLE_GC "Use libgc" ON)
 
+if (NOT CMAKE_BUILD_TYPE)
+  set (CMAKE_BUILD_TYPE "RELEASE")
+endif()
+
 if (NOT $ENV{P4C_VERSION} STREQUAL "")
   # Allow the version to be set from outside
   set (P4C_VERSION $ENV{P4C_VERSION})

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ dot -Tpdf ParserImpl.dot > ParserImpl.pdf
     further customize the build:
      - `-DCMAKE_BUILD_TYPE=RELEASE|DEBUG` -- set CMAKE_BUILD_TYPE to
       RELEASE or DEBUG to build with optimizations or with debug
-      symbols to run in gdb.
+      symbols to run in gdb. Default is RELEASE.
      - `-DCMAKE_INSTALL_PREFIX=<path>` -- set the directory where
        `make install` installs the compiler. Defaults to /usr/local.
      - `-DENABLE_BMV2=ON|OFF`. Enable the bmv2 backend. Default ON.
@@ -120,7 +120,7 @@ dot -Tpdf ParserImpl.dot > ParserImpl.pdf
      - `-DENABLE_DOCS=ON|OFF`. Build documentation. Default is OFF.
      - `-DENABLE_GC=ON|OFF`. Enable the use of the garbage collection
        library. Default is ON.
-     - `-DENABLE_GTESTS=ON|OFF`. Enable the building and running GTest unit tests.
+     - `-DENABLE_GTESTS=ON|OFF`. Enable building and running GTest unit tests.
        Default is ON.
      - `-DENABLE_PROTOBUF_STATIC=ON|OFF`. Enable the use of static
        protobuf libraries. Default is ON.

--- a/README.md
+++ b/README.md
@@ -102,11 +102,31 @@ dot -Tpdf ParserImpl.dot > ParserImpl.pdf
     ```
     mkdir build
     cd build
-    cmake .. [-DCMAKE_BUILD_TYPE=RELEASE|DEBUG] [-DCMAKE_INSTALL_PREFIX=<path>] [-DENABLE_DOCS=ON (default off)] [-DENABLE_P4RUNTIME_TO_PD=OFF (default on)] [-DENABLE_PROTOBUF_STATIC=OFF (default on)] [-DENABLE_GC=OFF (default on)]
+    cmake .. <optional arguments>
     make -j4
     make -j4 check
     ```
-    If adding new targets to this build system, please see [instructions](#defining-new-cmake-targets).
+    The cmake command takes the following optional arguments to
+    further customize the build:
+     - `-DCMAKE_BUILD_TYPE=RELEASE|DEBUG` -- set CMAKE_BUILD_TYPE to
+      RELEASE or DEBUG to build with optimizations or with debug
+      symbols to run in gdb.
+     - `-DCMAKE_INSTALL_PREFIX=<path>` -- set the directory where
+       `make install` installs the compiler. Defaults to /usr/local.
+     - `-DENABLE_BMV2=ON|OFF`. Enable the bmv2 backend. Default ON.
+     - `-DENABLE_EBPF=ON|OFF`. Enable the ebpf backend. Default ON.
+     - `-DENABLE_P4C_GRAPHS=ON|OFF`. Enable the p4c-graphs backend. Default ON.
+     - `-DENABLE_P4TEST=ON|OFF`. Enable the p4test backend. Default ON.
+     - `-DENABLE_DOCS=ON|OFF`. Build documentation. Default is OFF.
+     - `-DENABLE_GC=ON|OFF`. Enable the use of the garbage collection
+       library. Default is ON.
+     - `-DENABLE_GTESTS=ON|OFF`. Enable the building and running GTest unit tests.
+       Default is ON.
+     - `-DENABLE_PROTOBUF_STATIC=ON|OFF`. Enable the use of static
+       protobuf libraries. Default is ON.
+
+    If adding new targets to this build system, please see
+    [instructions](#defining-new-cmake-targets).
 
 4.  (Optional) Install the compiler and the P4 shared headers globally.
     ```


### PR DESCRIPTION
I believe we've had more than 3 people cut and paste optional arguments to cmake, so here is for their benefit!