### PR TITLE
add support for OSX in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ branches:
   - master
   - stable
 
+os:
+  - linux
+  - osx
+
 services:
   - docker
 
@@ -15,10 +19,14 @@ cache:
 env:
   - CTEST_PARALLEL_LEVEL=4
 
+before_install:
+  - tools/install_os_deps.sh
+
 install:
-  - tools/start_ccache
-  - docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test .
+  - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then tools/start_ccache; fi
+  - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test . ; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE && cd build && make -j 4 ; fi
 
 script:
-  - docker run -w /p4c/build -e CTEST_PARALLEL_LEVEL p4c ctest --output-on-failure --schedule-random
-  - ls $HOME/.ccache
+  - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then docker run -w /p4c/build -e CTEST_PARALLEL_LEVEL p4c ctest --output-on-failure --schedule-random ; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then cd build && make check ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_install:
 install:
   - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then tools/start_ccache; fi
   - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test . ; fi
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE && cd build && make -j 4 ; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE && cd build && make -j 2 ; fi
 
 script:
   - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then docker run -w /p4c/build -e CTEST_PARALLEL_LEVEL p4c ctest --output-on-failure --schedule-random ; fi
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then make check ; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then ctest --output-on-failure -j 2 --schedule-random -LE "ebpf$" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
 
 script:
   - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then docker run -w /p4c/build -e CTEST_PARALLEL_LEVEL p4c ctest --output-on-failure --schedule-random ; fi
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then cd build && make check ; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then make check ; fi

--- a/backends/p4test/run-p4-sample.py
+++ b/backends/p4test/run-p4-sample.py
@@ -91,7 +91,7 @@ def run_timeout(options, args, timeout, stderr):
             # reason, even some character classes that the man page claims are
             # available don't seem to actually work.
             local.filter = Popen(['sed', '-E',
-                r's|^[-[:alnum:][:space:]_/]*/([-[:alnum:][:space:]_]+\.[ph]4?[:(][[:digit:]]+)|\1|'],
+                                  r's|^[-[:alnum:][:punct:][:space:]_/]*/([-[:alnum:][:punct:][:space:]_]+\.[ph]4?[:(][[:digit:]]+)|\1|'],
                 stdin=PIPE, stdout=outfile)
             procstderr = local.filter.stdin
         local.process = Popen(args, stderr=procstderr)

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -173,7 +173,8 @@ class IndexedVector : public Vector<T> {
     void check_valid() const {
         for (auto el : *this) {
             auto it = declarations.find(el->getName());
-            assert(it != declarations.end() && it->second == el); } }
+            BUG_CHECK(it != declarations.end() && it->second == el, "invalid element %1%", el); }
+    }
 };
 
 }  // namespace IR

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -553,7 +553,7 @@ class ParserBlock : InstantiatedBlock {
     ParameterList getConstructorParameters() const override {
         return container->constructorParams; }
     toString { return container->toString(); }
-    ID getName() const { return container->getName(); }
+    ID getName() const override { return container->getName(); }
 #nodbprint
 }
 
@@ -562,7 +562,7 @@ class ControlBlock : InstantiatedBlock {
     ParameterList getConstructorParameters() const override {
         return container->constructorParams; }
     toString { return container->toString(); }
-    ID getName() const { return container->getName(); }
+    ID getName() const override { return container->getName(); }
 #nodbprint
 }
 
@@ -570,7 +570,7 @@ class PackageBlock : InstantiatedBlock {
     Type_Package type;
     ParameterList getConstructorParameters() const override { return type->constructorParams; }
     toString { return type->toString(); }
-    ID getName() const { return type->getName(); }
+    ID getName() const override { return type->getName(); }
 #nodbprint
 }
 
@@ -580,7 +580,7 @@ class ExternBlock : InstantiatedBlock {
     ParameterList getConstructorParameters() const override {
         return constructor->type->parameters; }
     toString { return type->toString(); }
-    ID getName() const { return type->getName(); }
+    ID getName() const override { return type->getName(); }
 #nodbprint
 }
 
@@ -588,7 +588,7 @@ class ExternBlock : InstantiatedBlock {
 class ToplevelBlock : Block, IDeclaration {
     P4Program getProgram() const { return node->to<IR::P4Program>(); }
     PackageBlock getMain() const;
-    ID getName() const { return "main"; }
+    ID getName() const override { return "main"; }
 #nodbprint
     validate { BUG_CHECK(node->is<IR::P4Program>(), "%1%: expected a P4Program", node); }
 }

--- a/tools/install_os_deps.sh
+++ b/tools/install_os_deps.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    # Install some custom requirements on OS X using brew
+    BREW=/usr/local/bin/brew
+    if [[ ! -x $BREW ]]; then
+        /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    fi
+
+    $BREW update
+    $BREW install autoconf automake bdw-gc bison boost ccache cmake git libtool openssl pkg-config protobuf
+    $BREW link --force bison
+    $BREW install gmp --c++11
+fi

--- a/tools/install_os_deps.sh
+++ b/tools/install_os_deps.sh
@@ -11,4 +11,9 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     $BREW install autoconf automake bdw-gc bison boost ccache cmake git libtool openssl pkg-config protobuf
     $BREW link --force bison
     $BREW install gmp --c++11
+
+    # install pip and required pip packages
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    python get-pip.py --user
+    pip install --user scapy ply
 fi


### PR DESCRIPTION
Adds OSX in Travis. While we don't do as extensive testing as in docker since we do not install bmv2, we do compile and run the p4 tests, which will at least ensure that OSX builds are clean.