### PR TITLE
Fix OS X dependency script

### DIFF
--- a/tools/install_os_deps.sh
+++ b/tools/install_os_deps.sh
@@ -6,10 +6,11 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     if [[ ! -x $BREW ]]; then
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     fi
+    # Update PATH to prefer Homebrew's bison over the macOS-provided version
+    export PATH="/usr/local/opt/bison/bin:$PATH"
 
     $BREW update
     $BREW install autoconf automake bdw-gc bison boost ccache cmake git libtool openssl pkg-config protobuf
-    $BREW link --force bison
     $BREW install gmp --c++11
 
     # install pip and required pip packages

--- a/tools/install_os_deps.sh
+++ b/tools/install_os_deps.sh
@@ -6,12 +6,14 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     if [[ ! -x $BREW ]]; then
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     fi
-    # Update PATH to prefer Homebrew's bison over the macOS-provided version
-    export PATH="/usr/local/opt/bison/bin:$PATH"
 
     $BREW update
     $BREW install autoconf automake bdw-gc bison boost ccache cmake git libtool openssl pkg-config protobuf
     $BREW install gmp --c++11
+
+    # Prefer Homebrew's bison over the macOS-provided version
+    $BREW link --force bison
+    echo 'export PATH="/usr/local/opt/bison/bin:$PATH"' > ~/.bash_profile
 
     # install pip and required pip packages
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py


### PR DESCRIPTION
The command
```
brew link --force bison
```
returns an error on recent versions of Homebrew/OS X:
```
Warning: Refusing to link macOS-provided software: bison
...
```
This PR implements the suggestion from Homebrew. Note: it assumes that Homebrew binaries are installed in the standard location (`/usr/local/opt`).