### PR TITLE
add saturated arithmetic support to p4-14

### DIFF
--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <utility>
 #include "ir.h"
 
 namespace IR {
@@ -39,19 +40,18 @@ const cstring IR::Annotation::hiddenAnnotation = "hidden";
 const cstring IR::Annotation::lengthAnnotation = "length";
 const cstring IR::Annotation::optionalAnnotation = "optional";
 
-std::map<int, const IR::Type_Bits*> *Type_Bits::signedTypes = nullptr;
-std::map<int, const IR::Type_Bits*> *Type_Bits::unsignedTypes = nullptr;
-
 int Type_Declaration::nextId = 0;
 int Type_InfInt::nextId = 0;
 
 Annotations* Annotations::empty = new Annotations(Vector<Annotation>());
 
 const Type_Bits* Type_Bits::get(int width, bool isSigned) {
-    std::map<int, const IR::Type_Bits*> *&map = isSigned ? signedTypes : unsignedTypes;
-    if (map == nullptr)
-        map = new std::map<int, const IR::Type_Bits*>();
-    auto &result = (*map)[width];
+    // map (width, signed) to type
+    using bit_type_key = std::pair<int, bool>;
+    static std::map<bit_type_key, const IR::Type_Bits*> *type_map = nullptr;
+    if (type_map == nullptr)
+        type_map = new std::map<bit_type_key, const IR::Type_Bits*>();
+    auto &result = (*type_map)[std::make_pair(width, isSigned)];
     if (!result)
         result = new Type_Bits(width, isSigned);
     return result;

--- a/ir/type.def
+++ b/ir/type.def
@@ -86,9 +86,6 @@ class Type_Bits : Type_Base {
     cstring baseName() const { return isSigned ? "int" : "bit"; }
     int width_bits() const override { return size; }
 
-    /// canonical types: no source-level information
-    static std::map<int, IR::Type_Bits> *signedTypes;
-    static std::map<int, IR::Type_Bits> *unsignedTypes;
     toString{ return baseName() + "<" + Util::toString(size) + ">"; }
     dbprint { out << toString(); }
 }

--- a/testdata/p4_14_samples/saturated-bmv2.p4
+++ b/testdata/p4_14_samples/saturated-bmv2.p4
@@ -1,0 +1,82 @@
+/*
+Copyright 2018-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// Test saturating arithmetic
+/// The header specifies the operation:
+/// op = 1 - sat_plus, 2 - sat_minus, 3 - sat_add_to, 4 - sat_subtract_from
+/// oprX_8 - unsigned 8-bit operands, res_8 contains the result
+/// oprX_16 - signed 16-bit operands, res_16 contains the result
+header_type hdr {
+  fields {
+    op : 8;
+    opr1_8 : 8  (saturating);
+    opr2_8 : 8  (saturating);
+    res_8  : 8  (saturating);
+    opr1_16: 16 (signed,saturating);
+    opr2_16: 16 (signed,saturating);
+    res_16 : 16 (signed,saturating);
+  }
+}
+
+header hdr data;
+
+parser start {
+    extract(data);
+    return ingress;
+}
+
+action sat_plus() {
+    modify_field(standard_metadata.egress_spec, 0);
+    add(data.res_8, data.opr1_8, data.opr2_8);
+}
+action sat_minus() {
+    modify_field(standard_metadata.egress_spec, 0);
+    subtract(data.res_8, data.opr1_8, data.opr2_8);
+}
+action sat_add_to() {
+    modify_field(standard_metadata.egress_spec, 0);
+    modify_field(data.res_16, data.opr1_16);
+    add_to_field(data.res_16, data.opr2_16);
+}
+action sat_subtract_from() {
+    modify_field(standard_metadata.egress_spec, 0);
+    modify_field(data.res_16, data.opr1_16);
+    subtract_from_field(data.res_16, data.opr2_16);
+}
+
+action _drop() { drop(); }
+
+table t {
+
+  reads {
+    data.op : exact;
+  }
+
+  actions {
+    sat_plus;
+    sat_minus;
+    sat_add_to;
+    sat_subtract_from;
+    _drop;
+  }
+
+  default_action: _drop;
+
+}
+
+control ingress {
+    apply(t);
+}

--- a/testdata/p4_14_samples/saturated-bmv2.stf
+++ b/testdata/p4_14_samples/saturated-bmv2.stf
@@ -1,0 +1,46 @@
+# Test saturating arithmetic
+# Entries
+add t 0 data.op:0x01 sat_plus()
+add t 1 data.op:0x02 sat_minus()
+add t 2 data.op:0x03 sat_add_to()
+add t 3 data.op:0x04 sat_subtract_from()
+
+# unsigned: 1 + 1 = 2
+packet 0 01 01 01 00 0000 0000 0000
+expect 0 01 01 01 02 0000 0000 0000
+
+# unsigned: 2 - 1 = 1
+packet 0 02 02 01 00 0000 0000 0000
+expect 0 02 02 01 01 0000 0000 0000
+
+# unsigned: 254 + 2 = 255
+packet 0 01 fe 02 00 0000 0000 0000
+expect 0 01 fe 02 ff 0000 0000 0000
+
+# # unsigned: 8 - 10 = 0
+packet 0 02 08 0a aa 0000 0000 0000
+expect 0 02 08 0a 00 0000 0000 0000
+
+# signed: 10 + 10 = 20
+packet 0 03 00 00 00 000a 000a 0000
+expect 0 03 00 00 00 000a 000a 0014
+
+# signed: 32766 + 10 = 32767
+packet 0 03 00 00 00 7ffe 000a 0000
+expect 0 03 00 00 00 7ffe 000a 7fff
+
+# signed: 10 - 20 = -10
+packet 0 04 00 00 00 000a 0014 0000
+expect 0 04 00 00 00 000a 0014 fff6
+
+# signed: -32766 - 10 = -32768
+packet 0 04 00 00 00 8002 000a 0000
+expect 0 04 00 00 00 8002 000a 8000
+
+# signed: 1 + (-10) = -9
+packet 0 03 00 00 00 0001 fff6 0000
+expect 0 03 00 00 00 0001 fff6 fff7
+
+# signed: 1 - (-10) = 11
+packet 0 04 00 00 00 0001 fff6 0000
+expect 0 04 00 00 00 0001 fff6 000b

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -1879,10 +1879,10 @@ control process_mtu(inout headers hdr, inout metadata meta, inout standard_metad
         meta.l3_metadata.l3_mtu_check = 16w0xffff;
     }
     @name(".ipv4_mtu_check") action ipv4_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - hdr.ipv4.totalLen;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| hdr.ipv4.totalLen;
     }
     @name(".ipv6_mtu_check") action ipv6_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - hdr.ipv6.payloadLen;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| hdr.ipv6.payloadLen;
     }
     @name(".mtu") table mtu {
         actions = {
@@ -2573,7 +2573,7 @@ control process_tunnel_encap(inout headers hdr, inout metadata meta, inout stand
         meta.tunnel_metadata.tunnel_index = tunnel_index;
     }
     @name(".tunnel_mtu_check") action tunnel_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - meta.egress_metadata.payload_length;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| meta.egress_metadata.payload_length;
     }
     @name(".tunnel_mtu_miss") action tunnel_mtu_miss() {
         meta.l3_metadata.l3_mtu_check = 16w0xffff;
@@ -4274,7 +4274,7 @@ control process_ingress_sflow(inout headers hdr, inout metadata meta, inout stan
         clone3<tuple<tuple<bit<16>, bit<16>, bit<16>, bit<9>>, bit<16>, bit<16>>>(CloneType.I2E, sflow_i2e_mirror_id, { { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port }, meta.sflow_metadata.sflow_session_id, meta.i2e_metadata.mirror_session_id });
     }
     @name(".sflow_ing_session_enable") action sflow_ing_session_enable(bit<32> rate_thr, bit<16> session_id) {
-        meta.ingress_metadata.sflow_take_sample = rate_thr + meta.ingress_metadata.sflow_take_sample;
+        meta.ingress_metadata.sflow_take_sample = rate_thr |+| meta.ingress_metadata.sflow_take_sample;
         meta.sflow_metadata.sflow_session_id = session_id;
     }
     @name(".nop") action nop_1() {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -1877,10 +1877,10 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta.l3_metadata.l3_mtu_check = 16w0xffff;
     }
     @name(".ipv4_mtu_check") action _ipv4_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - hdr.ipv4.totalLen;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| hdr.ipv4.totalLen;
     }
     @name(".ipv6_mtu_check") action _ipv6_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - hdr.ipv6.payloadLen;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| hdr.ipv6.payloadLen;
     }
     @name(".mtu") table _mtu_0 {
         actions = {
@@ -2684,7 +2684,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta.tunnel_metadata.tunnel_index = tunnel_index;
     }
     @name(".tunnel_mtu_check") action _tunnel_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - meta.egress_metadata.payload_length;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| meta.egress_metadata.payload_length;
     }
     @name(".tunnel_mtu_miss") action _tunnel_mtu_miss() {
         meta.l3_metadata.l3_mtu_check = 16w0xffff;
@@ -4302,7 +4302,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_39() {
     }
     @name(".sflow_ing_session_enable") action _sflow_ing_session_enable(bit<32> rate_thr, bit<16> session_id) {
-        meta.ingress_metadata.sflow_take_sample = rate_thr + meta.ingress_metadata.sflow_take_sample;
+        meta.ingress_metadata.sflow_take_sample = rate_thr |+| meta.ingress_metadata.sflow_take_sample;
         meta.sflow_metadata.sflow_session_id = session_id;
     }
     @name(".nop") action _nop_40() {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -1882,10 +1882,10 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta.l3_metadata.l3_mtu_check = 16w0xffff;
     }
     @name(".ipv4_mtu_check") action _ipv4_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - hdr.ipv4.totalLen;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| hdr.ipv4.totalLen;
     }
     @name(".ipv6_mtu_check") action _ipv6_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - hdr.ipv6.payloadLen;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| hdr.ipv6.payloadLen;
     }
     @name(".mtu") table _mtu_0 {
         actions = {
@@ -2689,7 +2689,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta.tunnel_metadata.tunnel_index = tunnel_index;
     }
     @name(".tunnel_mtu_check") action _tunnel_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - meta.egress_metadata.payload_length;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| meta.egress_metadata.payload_length;
     }
     @name(".tunnel_mtu_miss") action _tunnel_mtu_miss() {
         meta.l3_metadata.l3_mtu_check = 16w0xffff;
@@ -4366,7 +4366,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_39() {
     }
     @name(".sflow_ing_session_enable") action _sflow_ing_session_enable(bit<32> rate_thr, bit<16> session_id) {
-        meta.ingress_metadata.sflow_take_sample = rate_thr + meta.ingress_metadata.sflow_take_sample;
+        meta.ingress_metadata.sflow_take_sample = rate_thr |+| meta.ingress_metadata.sflow_take_sample;
         meta.sflow_metadata.sflow_session_id = session_id;
     }
     @name(".nop") action _nop_40() {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -1862,10 +1862,10 @@ control process_mtu(inout headers hdr, inout metadata meta, inout standard_metad
         meta.l3_metadata.l3_mtu_check = 16w0xffff;
     }
     @name(".ipv4_mtu_check") action ipv4_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - hdr.ipv4.totalLen;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| hdr.ipv4.totalLen;
     }
     @name(".ipv6_mtu_check") action ipv6_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - hdr.ipv6.payloadLen;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| hdr.ipv6.payloadLen;
     }
     @name(".mtu") table mtu {
         actions = {
@@ -2550,7 +2550,7 @@ control process_tunnel_encap(inout headers hdr, inout metadata meta, inout stand
         meta.tunnel_metadata.tunnel_index = tunnel_index;
     }
     @name(".tunnel_mtu_check") action tunnel_mtu_check(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu - meta.egress_metadata.payload_length;
+        meta.l3_metadata.l3_mtu_check = l3_mtu |-| meta.egress_metadata.payload_length;
     }
     @name(".tunnel_mtu_miss") action tunnel_mtu_miss() {
         meta.l3_metadata.l3_mtu_check = 16w0xffff;
@@ -4189,7 +4189,7 @@ control process_ingress_sflow(inout headers hdr, inout metadata meta, inout stan
         clone3(CloneType.I2E, (bit<32>)sflow_i2e_mirror_id, { { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port }, meta.sflow_metadata.sflow_session_id, meta.i2e_metadata.mirror_session_id });
     }
     @name(".sflow_ing_session_enable") action sflow_ing_session_enable(bit<32> rate_thr, bit<16> session_id) {
-        meta.ingress_metadata.sflow_take_sample = rate_thr + meta.ingress_metadata.sflow_take_sample;
+        meta.ingress_metadata.sflow_take_sample = rate_thr |+| meta.ingress_metadata.sflow_take_sample;
         meta.sflow_metadata.sflow_session_id = session_id;
     }
     @name(".nop") action nop_1() {


### PR DESCRIPTION
Implements saturated arithmetic in P4-14. Since the fields are tagged
with the saturated annotation, we add isSaturated to the Type_Bits.

This also requires refactoring the map caching the bit
types. Previously, we were storing signed and unsigned in separate
maps. Adding more maps to accomodate the saturated types is
impractical, so we unified the maps and added a key consisting of
(width, sign, saturation).

Since P4-16 supports only operations as saturated, the conversion
routines for the supported primitives, add, subtract, add_to_field,
subtract_from_field, change the operation to saturated if any of its
arguments are saturated.