### PR TITLE
Extend arch-handler interface in P4Runtime serializer code

### DIFF
--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -146,7 +146,7 @@ class P4RuntimeArchHandlerIface {
                                        const P4::ExternFunction* externFunction) = 0;
     /// This method is called between the two passes (collect and add) in case
     /// the architecture requires some logic to be performed then.
-    virtual void postCollect(const P4RuntimeSymbolTableIface& symbols) = 0;
+    virtual void postCollect(P4RuntimeSymbolTableIface* symbols) = 0;
     /// Adds architecture-specific properties for @tableBlock to the @table
     /// Protobuf message.
     virtual void addTableProperties(const P4RuntimeSymbolTableIface& symbols,
@@ -163,6 +163,10 @@ class P4RuntimeArchHandlerIface {
     virtual void addExternFunction(const P4RuntimeSymbolTableIface& symbols,
                                    ::p4::config::v1::P4Info* p4info,
                                    const P4::ExternFunction* externFunction) = 0;
+    /// This method is called after the add pass in case the architecture
+    /// requires some logic to be performed then.
+    virtual void postAdd(const P4RuntimeSymbolTableIface& symbols,
+                         ::p4::config::v1::P4Info* p4info) = 0;
 };
 
 /// A functor interface that needs to be implemented for each

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -455,7 +455,7 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
         (void)externFunction;
     }
 
-    void postCollect(const P4RuntimeSymbolTableIface& symbols) override {
+    void postCollect(P4RuntimeSymbolTableIface* symbols) override {
         (void)symbols;
         // analyze action profiles and build a mapping from action profile name
         // to the set of tables referencing them
@@ -539,6 +539,13 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
         (void)symbols;
         (void)p4info;
         (void)externFunction;
+    }
+
+    void postAdd(const P4RuntimeSymbolTableIface& symbols,
+                 ::p4::config::v1::P4Info* p4info) override {
+        // nothing to do
+        (void)symbols;
+        (void)p4info;
     }
 
     static boost::optional<ActionProfile>


### PR DESCRIPTION
* modify postCollect method to accept a pointer to symbol table instead
  of a const reference, in case the architecture-specific code needs to
  add some new symbols to the table
* add postAdd method so that some architecture-specific post-processing
  can be performed on the P4Info message after all objects have been
  added