### PR TITLE
Allow ebpf tests to work in any build location

### DIFF
--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -78,9 +78,9 @@ add_dependencies(p4c_driver linkp4cebpf)
 
 # Tests
 
-set(EBPF_DRIVER_KERNEL "${CMAKE_CURRENT_SOURCE_DIR}/run-ebpf-test.py -t kernel")
-set(EBPF_DRIVER_BCC "${CMAKE_CURRENT_SOURCE_DIR}/run-ebpf-test.py -t bcc")
-set(EBPF_DRIVER_TEST "${CMAKE_CURRENT_SOURCE_DIR}/run-ebpf-test.py -t test")
+set(EBPF_DRIVER_KERNEL "${CMAKE_CURRENT_SOURCE_DIR}/run-ebpf-test.py -t kernel -c \"${P4C_BINARY_DIR}/p4c-ebpf\"")
+set(EBPF_DRIVER_BCC "${CMAKE_CURRENT_SOURCE_DIR}/run-ebpf-test.py -t bcc -c \"${P4C_BINARY_DIR}/p4c-ebpf\"")
+set(EBPF_DRIVER_TEST "${CMAKE_CURRENT_SOURCE_DIR}/run-ebpf-test.py -t test -c \"${P4C_BINARY_DIR}/p4c-ebpf\"")
 
 set (XFAIL_TESTS_KERNEL)
 set (XFAIL_TESTS_BCC)

--- a/backends/ebpf/run-ebpf-test.py
+++ b/backends/ebpf/run-ebpf-test.py
@@ -40,6 +40,9 @@ PARSER.add_argument("rootdir", help="the root directory of "
 PARSER.add_argument("p4filename", help="the p4 file to process")
 PARSER.add_argument("-b", "--nocleanup", action="store_false",
                     help="do not remove temporary results for failing tests")
+PARSER.add_argument("-c", "--compiler", dest="compiler", default="p4c-ebpf",
+                    help="Specify the path to the compiler binary, "
+                    "default is p4c-ebpf")
 PARSER.add_argument("-v", "--verbose", action="store_true",
                     help="verbose operation")
 PARSER.add_argument("-f", "--replace", action="store_true",
@@ -77,8 +80,8 @@ class Options(object):
     def __init__(self):
         self.binary = ""                # This program's name
         self.cleanupTmp = True          # Remove tmp folder?
+        self.compiler = ""              # Path to the P4 compiler binary
         self.p4Filename = ""            # File that is being compiled
-        self.compilerdir = ""              # Path to the P4 compiler
         self.verbose = False            # Enable verbose output
         self.replace = False            # Replace previous outputs
         self.target = "test"            # The name of the target compiler
@@ -174,7 +177,7 @@ if __name__ == '__main__':
     # Parse options and process argv
     args, argv = PARSER.parse_known_args()
     options = Options()
-    options.compilerdir = check_path(args.rootdir)
+    options.compiler = check_path(args.compiler)
     options.p4filename = check_path(args.p4filename)
     options.verbose = args.verbose
     options.replace = args.replace

--- a/backends/ebpf/targets/target.py
+++ b/backends/ebpf/targets/target.py
@@ -51,7 +51,7 @@ class EBPFTarget(object):
         # location of the runtime folder
         self.runtimedir = self.options.testdir + "/runtime"
         # location of the p4c compiler binary
-        self.compiler = self.options.compilerdir + "/build/p4c-ebpf"
+        self.compiler = self.options.compiler
 
     def get_make_args(self, runtimedir, target):
         args = "make "


### PR DESCRIPTION
Currently to run ebpf tests the compiler must be built in `build/` subdirectory of the repository clone.  It is hard-coded.  This patch fixes that and allows the compiler to be built anywhere, including outside the source directory.