### PR TITLE
Include missing header

### DIFF
--- a/frontends/p4/defaultArguments.h
+++ b/frontends/p4/defaultArguments.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "ir/ir.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/p4/typeMap.h"
 
 namespace P4 {


### PR DESCRIPTION
This fixes the build when `ENABLE_UNIFIED_COMPILATION` cmake option is set to OFF.  Without this header `TypeChecking` class is undefined.