### PR TITLE
Fix 2 bugs in P4Info generation code

### DIFF
--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -519,7 +519,7 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
         if (externBlock->type->name == CounterTraits::typeName()) {
             auto counter = Helpers::Counterlike<ArchCounterExtern>::from(externBlock);
             if (counter) addCounter(symbols, p4info, *counter);
-        } else if (externBlock->type->name == CounterTraits::typeName()) {
+        } else if (externBlock->type->name == MeterTraits::typeName()) {
             auto meter = Helpers::Counterlike<ArchMeterExtern>::from(externBlock);
             if (meter) addMeter(symbols, p4info, *meter);
         } else if (externBlock->type->name == RegisterTraits<arch>::typeName()) {

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -879,6 +879,16 @@ class P4RuntimeAnalyzer {
                 }
             });
         });
+
+        // Generate P4Info for any extern function invoked directly from control.
+        forAllMatching<IR::MethodCallExpression>(control->body,
+                                                 [&](const IR::MethodCallExpression* call) {
+            auto instance = P4::MethodInstance::resolve(call, refMap, typeMap);
+            if (instance->is<P4::ExternFunction>()) {
+                archHandler->addExternFunction(
+                    symbols, p4Info, instance->to<P4::ExternFunction>());
+            }
+        });
     }
 
     void addValueSet(const IR::P4ValueSet* inst) {
@@ -953,6 +963,14 @@ static void collectControlSymbols(P4RuntimeSymbolTable& symbols,
             if (instance->is<P4::ExternFunction>())
                 archHandler->collectExternFunction(&symbols, instance->to<P4::ExternFunction>());
         });
+    });
+
+    // Collect any extern function invoked directly from the control.
+    forAllMatching<IR::MethodCallExpression>(control->body,
+                                             [&](const IR::MethodCallExpression* call) {
+        auto instance = P4::MethodInstance::resolve(call, refMap, typeMap);
+        if (instance->is<P4::ExternFunction>())
+                archHandler->collectExternFunction(&symbols, instance->to<P4::ExternFunction>());
     });
 }
 

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4-stderr
@@ -1,0 +1,3 @@
+issue430-1-bmv2.p4(44): warning: Cannot find a good name for digest method call, using auto-generated name 'digest_0'
+        digest(5, { hdr.ethernet.srcAddr });
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
 * Fix typo that was causing all indirect meters to be omitted from
   P4Info.
 * Collect extern functions (e.g. digest) invoked directly from a
   control. It may not have been necessary in the past when the
   serializer was run after the synthetization of actions by the
   compiler, but it is necessary now.