### PR TITLE
Supress error in P4RuntimeSerializer for default entry of unknown type

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1114,7 +1114,8 @@ class P4RuntimeEntriesConverter {
             } else if (matchType == P4V1::V1Model::instance.rangeMatchType.name) {
                 addRange(protoMatch, k, keyWidth);
             } else {
-                ::error("%1%: match type not supported by P4Runtime serializer", matchType);
+                if (!k->is<IR::DefaultExpression>())
+                    ::error("%1%: match type not supported by P4Runtime serializer", matchType);
                 continue;
             }
         }


### PR DESCRIPTION
- static entries for a table with a selector (or other) key component
  that is not relevant for the entry need a placeholder default for that
  key component, which should just be ignored.