### PR TITLE
Fixed an issue on bitvec slices larger than 64 bits

### DIFF
--- a/lib/bitvec.cpp
+++ b/lib/bitvec.cpp
@@ -90,8 +90,8 @@ bitvec bitvec::getslice(size_t idx, size_t sz) const {
             rv.expand((sz-1)/bits_per_unit + 1);
             for (size_t i = 0; i < rv.size; i++) {
                 if (shift != 0 && i != 0)
-                    rv.ptr[i-1] |= ptr[idx + 1] << (bits_per_unit - shift);
-                rv.ptr[i] = ptr[idx] >> shift; }
+                    rv.ptr[i-1] |= ptr[idx + i] << (bits_per_unit - shift);
+                rv.ptr[i] = ptr[idx + i] >> shift; }
             if ((sz %= bits_per_unit))
                 rv.ptr[rv.size-1] &= ~(~(uintptr_t)1 << (sz-1));
         } else {

--- a/test/gtest/bitvec_test.cpp
+++ b/test/gtest/bitvec_test.cpp
@@ -76,4 +76,20 @@ TEST(Bitvec, ranges) {
     EXPECT_EQ(bv.ffs(100), -1);
 }
 
+TEST(Bitvec, getslice) {
+    bitvec bv;
+    for (int i = 0; i < 256; i += 32) {
+        if (((i / 64) % 2) == 0) {
+            bv.setrange(i, 16);
+        } else {
+            bv.setrange(i + 16, 16);
+        }
+    }
+    auto slice = bv.getslice(16, 112);
+    EXPECT_EQ(bv.ffz(0), 16);
+    EXPECT_EQ(bv.ffs(16), 32);
+    EXPECT_EQ(bv.ffz(32), 48);
+    EXPECT_EQ(bv.ffs(48), 80);
+}
+
 }  // namespace Test


### PR DESCRIPTION
The slice of the bitvec would always be based on the first slice.  Surprising nobody has caught this one.