### PR TITLE
add specialized methods for other integer types

### DIFF
--- a/lib/bitvec.h
+++ b/lib/bitvec.h
@@ -366,10 +366,16 @@ class bitvec {
         rv |= ((*t | a) != *t);
         *t |= a;
         return rv; }
+    template<typename T, typename = typename
+             std::enable_if<std::is_integral<T>::value && (sizeof(T) > sizeof(uintptr_t))>::type>
+    bool operator|=(T a) { return (*this) |= bitvec(a); }
     bitvec operator|(const bitvec &a) const {
         bitvec rv(*this); rv |= a; return rv; }
     bitvec operator|(uintptr_t a) const {
         bitvec rv(*this); rv |= a; return rv; }
+    template<typename T, typename = typename
+             std::enable_if<std::is_integral<T>::value && (sizeof(T) > sizeof(uintptr_t))>::type>
+    bitvec operator|(T a) { bitvec rv(*this); rv |= bitvec(a); return rv; }
     bitvec &operator^=(const bitvec &a) {
         if (size < a.size) expand(a.size);
         if (size > 1) {


### PR DESCRIPTION
Bitvec operators that have arguments uintptr_t end up converting
other integer types to uintptr_t. On 32-bit systems, the conversion
from uint64_t to uintptr_t is wrong. For that we add new template
methods that do the proper conversion.

Interestingly enough, only the OR methods had the uintptr_t parameters.
Why?