### PR TITLE
Fix for issue #1560

### DIFF
--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -172,6 +172,13 @@ class TableKey(object):
         self.fields = OrderedDict()
     def append(self, name, type):
         self.fields[name] = type
+    def __str__(self):
+        result = ""
+        for f in self.fields.keys():
+            if result != "":
+                result += " "
+            result += f + ":" + self.fields[f]
+        return result
 
 class TableKeyInstance(object):
     def __init__(self, tableKey):
@@ -221,6 +228,7 @@ class TableKeyInstance(object):
             key = "$valid$"
             found = True
         if not found:
+            print(self.key.fields)
             raise Exception("Unexpected key field " + key)
         if self.key.fields[key] == "ternary":
             self.values[key] = self.makeMask(value)
@@ -315,7 +323,9 @@ class BMV2Table(object):
         self.key = TableKey()
         self.actions = {}
         for k in jsonTable["key"]:
-            name = k["target"]
+            name = k["name"]
+            if name is None:
+                name = k["target"]
             if isinstance(name, list):
                 name = ""
                 for t in k["target"]:

--- a/backends/bmv2/simple_switch/midend.cpp
+++ b/backends/bmv2/simple_switch/midend.cpp
@@ -89,6 +89,10 @@ SimpleSwitchMidEnd::SimpleSwitchMidEnd(CompilerOptions& options) : MidEnd(option
         new P4::ConstantFolding(&refMap, &typeMap),
         new P4::LocalCopyPropagation(&refMap, &typeMap),
         new P4::ConstantFolding(&refMap, &typeMap),
+        new P4::SimplifyKey(&refMap, &typeMap,
+                            new P4::OrPolicy(
+                                new P4::IsValid(&refMap, &typeMap),
+                                new P4::IsMask())),
         new P4::MoveDeclarations(),
         new P4::ValidateTableProperties({ "implementation",
                                           "size",

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -584,10 +584,10 @@ TEST_F(P4Runtime, P4_14_MatchFields) {
         { 12, "hStack[3].headerField", 16, MatchField::RANGE },
         { 13, "h.$valid$", 1, MatchField::EXACT },
         { 14, "hStack[3].$valid$", 1, MatchField::EXACT },
-        { 15, "h.headerField[3:2]", 2, MatchField::EXACT },
-        { 16, "h.headerField[3:2]", 2, MatchField::TERNARY },
-        { 17, "h.headerField & 13", 16, MatchField::EXACT },
-        { 18, "h.headerField & 13", 16, MatchField::TERNARY },
+        { 15, "h.headerField", 2, MatchField::EXACT },
+        { 16, "h.headerField", 2, MatchField::TERNARY },
+        { 17, "h.headerField", 16, MatchField::EXACT },
+        { 18, "h.headerField", 16, MatchField::TERNARY },
     };
 
     for (auto i = 0; i < igTable->match_fields_size(); i++) {

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-first.p4
@@ -38,7 +38,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction();
         }
         key = {
-            hdr.data.f1 & 32w0xff00ff: exact @name("data.f1 & 16711935") ;
+            hdr.data.f1 & 32w0xff00ff: exact @name("data.f1") ;
         }
         default_action = NoAction();
     }

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-frontend.p4
@@ -40,7 +40,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_0();
         }
         key = {
-            hdr.data.f1 & 32w0xff00ff: exact @name("data.f1 & 16711935") ;
+            hdr.data.f1 & 32w0xff00ff: exact @name("data.f1") ;
         }
         default_action = NoAction_0();
     }

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-midend.p4
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_0();
         }
         key = {
-            key_0: exact @name("data.f1 & 16711935") ;
+            key_0: exact @name("data.f1") ;
         }
         default_action = NoAction_0();
     }

--- a/testdata/p4_14_samples_outputs/exact_match_mask1.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1.p4
@@ -37,7 +37,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             noop;
         }
         key = {
-            hdr.data.f1 & 32w0xff00ff: exact;
+            hdr.data.f1 & 32w0xff00ff: exact @name("data.f1") ;
         }
     }
     apply {

--- a/testdata/p4_14_samples_outputs/issue1237-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1237-first.p4
@@ -45,7 +45,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             hdr.kilometer.isValid()      : exact @name("kilometer.$valid$") ;
-            48w0                         : lpm @name("0") ;
+            48w0                         : lpm @name("kilometer.flaccidly") ;
             hdr.expressivenesss.isValid(): exact @name("expressivenesss.$valid$") ;
         }
         default_action = NoAction();

--- a/testdata/p4_14_samples_outputs/issue1237-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1237-frontend.p4
@@ -47,7 +47,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             hdr.kilometer.isValid()      : exact @name("kilometer.$valid$") ;
-            48w0                         : lpm @name("0") ;
+            48w0                         : lpm @name("kilometer.flaccidly") ;
             hdr.expressivenesss.isValid(): exact @name("expressivenesss.$valid$") ;
         }
         default_action = NoAction_0();

--- a/testdata/p4_14_samples_outputs/issue1237-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1237-midend.p4
@@ -48,7 +48,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             hdr.kilometer.isValid()      : exact @name("kilometer.$valid$") ;
-            key_0                        : lpm @name("0") ;
+            key_0                        : lpm @name("kilometer.flaccidly") ;
             hdr.expressivenesss.isValid(): exact @name("expressivenesss.$valid$") ;
         }
         default_action = NoAction_0();

--- a/testdata/p4_14_samples_outputs/issue1237.p4
+++ b/testdata/p4_14_samples_outputs/issue1237.p4
@@ -44,7 +44,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             hdr.kilometer.isValid()      : exact;
-            48w0                         : lpm;
+            48w0                         : lpm @name("kilometer.flaccidly") ;
             hdr.expressivenesss.isValid(): exact;
         }
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
@@ -2933,7 +2933,7 @@ control validate_outer_ipv4_header(inout headers hdr, inout metadata meta, inout
         key = {
             hdr.ipv4.version                     : ternary @name("ipv4.version") ;
             meta.l3_metadata.lkp_ip_ttl          : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]: ternary @name("ipv4_metadata.lkp_ipv4_sa[31:24]") ;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 512;
         default_action = NoAction();
@@ -2962,7 +2962,7 @@ control validate_outer_ipv6_header(inout headers hdr, inout metadata meta, inout
         key = {
             hdr.ipv6.version                       : ternary @name("ipv6.version") ;
             meta.l3_metadata.lkp_ip_ttl            : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa[127:112]") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction();
@@ -3665,13 +3665,13 @@ control process_validate_packet(inout headers hdr, inout metadata meta, inout st
             @defaultonly NoAction();
         }
         key = {
-            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa[40:40]") ;
+            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
             meta.l2_metadata.lkp_mac_da            : ternary @name("l2_metadata.lkp_mac_da") ;
             meta.l3_metadata.lkp_ip_type           : ternary @name("l3_metadata.lkp_ip_type") ;
             meta.l3_metadata.lkp_ip_ttl            : ternary @name("l3_metadata.lkp_ip_ttl") ;
             meta.l3_metadata.lkp_ip_version        : ternary @name("l3_metadata.lkp_ip_version") ;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa[31:24]") ;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa[127:112]") ;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction();

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -3213,7 +3213,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.ipv4.version                     : ternary @name("ipv4.version") ;
             meta.l3_metadata.lkp_ip_ttl          : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]: ternary @name("ipv4_metadata.lkp_ipv4_sa[31:24]") ;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 512;
         default_action = NoAction_117();
@@ -3236,7 +3236,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.ipv6.version                       : ternary @name("ipv6.version") ;
             meta.l3_metadata.lkp_ip_ttl            : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa[127:112]") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_118();
@@ -3689,13 +3689,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_132();
         }
         key = {
-            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa[40:40]") ;
+            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
             meta.l2_metadata.lkp_mac_da            : ternary @name("l2_metadata.lkp_mac_da") ;
             meta.l3_metadata.lkp_ip_type           : ternary @name("l3_metadata.lkp_ip_type") ;
             meta.l3_metadata.lkp_ip_ttl            : ternary @name("l3_metadata.lkp_ip_ttl") ;
             meta.l3_metadata.lkp_ip_version        : ternary @name("l3_metadata.lkp_ip_version") ;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa[31:24]") ;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa[127:112]") ;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_132();

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -3273,7 +3273,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.ipv4.version                     : ternary @name("ipv4.version") ;
             meta.l3_metadata.lkp_ip_ttl          : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]: ternary @name("ipv4_metadata.lkp_ipv4_sa[31:24]") ;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 512;
         default_action = NoAction_117();
@@ -3296,7 +3296,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.ipv6.version                       : ternary @name("ipv6.version") ;
             meta.l3_metadata.lkp_ip_ttl            : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa[127:112]") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_118();
@@ -3749,13 +3749,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_132();
         }
         key = {
-            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa[40:40]") ;
+            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
             meta.l2_metadata.lkp_mac_da            : ternary @name("l2_metadata.lkp_mac_da") ;
             meta.l3_metadata.lkp_ip_type           : ternary @name("l3_metadata.lkp_ip_type") ;
             meta.l3_metadata.lkp_ip_ttl            : ternary @name("l3_metadata.lkp_ip_ttl") ;
             meta.l3_metadata.lkp_ip_version        : ternary @name("l3_metadata.lkp_ip_version") ;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa[31:24]") ;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa[127:112]") ;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_132();

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
@@ -2892,7 +2892,7 @@ control validate_outer_ipv4_header(inout headers hdr, inout metadata meta, inout
         key = {
             hdr.ipv4.version                     : ternary;
             meta.l3_metadata.lkp_ip_ttl          : ternary;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]: ternary;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 512;
     }
@@ -2919,7 +2919,7 @@ control validate_outer_ipv6_header(inout headers hdr, inout metadata meta, inout
         key = {
             hdr.ipv6.version                       : ternary;
             meta.l3_metadata.lkp_ip_ttl            : ternary;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
     }
@@ -3605,13 +3605,13 @@ control process_validate_packet(inout headers hdr, inout metadata meta, inout st
             set_malformed_packet;
         }
         key = {
-            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary;
+            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
             meta.l2_metadata.lkp_mac_da            : ternary;
             meta.l3_metadata.lkp_ip_type           : ternary;
             meta.l3_metadata.lkp_ip_ttl            : ternary;
             meta.l3_metadata.lkp_ip_version        : ternary;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
     }

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -1774,8 +1774,8 @@ control process_rewrite(inout headers hdr, inout metadata meta, inout standard_m
         key = {
             hdr.ipv4.isValid()       : exact @name("ipv4.$valid$") ;
             hdr.ipv6.isValid()       : exact @name("ipv6.$valid$") ;
-            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr[31:28]") ;
-            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr[127:120]") ;
+            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr") ;
+            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr") ;
         }
         default_action = NoAction();
     }
@@ -1850,8 +1850,8 @@ control process_mac_rewrite(inout headers hdr, inout metadata meta, inout standa
             hdr.ipv4.isValid()       : exact @name("ipv4.$valid$") ;
             hdr.ipv6.isValid()       : exact @name("ipv6.$valid$") ;
             hdr.mpls[0].isValid()    : exact @name("mpls[0].$valid$") ;
-            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr[31:28]") ;
-            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr[127:120]") ;
+            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr") ;
+            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr") ;
         }
         default_action = NoAction();
     }
@@ -3150,7 +3150,7 @@ control validate_outer_ipv4_header(inout headers hdr, inout metadata meta, inout
         key = {
             hdr.ipv4.version       : ternary @name("ipv4.version") ;
             hdr.ipv4.ttl           : ternary @name("ipv4.ttl") ;
-            hdr.ipv4.srcAddr[31:24]: ternary @name("ipv4.srcAddr[31:24]") ;
+            hdr.ipv4.srcAddr[31:24]: ternary @name("ipv4.srcAddr") ;
         }
         size = 512;
         default_action = NoAction();
@@ -3179,7 +3179,7 @@ control validate_outer_ipv6_header(inout headers hdr, inout metadata meta, inout
         key = {
             hdr.ipv6.version         : ternary @name("ipv6.version") ;
             hdr.ipv6.hopLimit        : ternary @name("ipv6.hopLimit") ;
-            hdr.ipv6.srcAddr[127:112]: ternary @name("ipv6.srcAddr[127:112]") ;
+            hdr.ipv6.srcAddr[127:112]: ternary @name("ipv6.srcAddr") ;
         }
         size = 512;
         default_action = NoAction();
@@ -4386,13 +4386,13 @@ control process_validate_packet(inout headers hdr, inout metadata meta, inout st
             @defaultonly NoAction();
         }
         key = {
-            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa[40:40]") ;
+            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
             meta.l2_metadata.lkp_mac_da            : ternary @name("l2_metadata.lkp_mac_da") ;
             meta.l3_metadata.lkp_ip_type           : ternary @name("l3_metadata.lkp_ip_type") ;
             meta.l3_metadata.lkp_ip_ttl            : ternary @name("l3_metadata.lkp_ip_ttl") ;
             meta.l3_metadata.lkp_ip_version        : ternary @name("l3_metadata.lkp_ip_version") ;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa[31:24]") ;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa[127:112]") ;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction();

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -1796,8 +1796,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         key = {
             hdr.ipv4.isValid()       : exact @name("ipv4.$valid$") ;
             hdr.ipv6.isValid()       : exact @name("ipv6.$valid$") ;
-            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr[31:28]") ;
-            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr[127:120]") ;
+            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr") ;
+            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr") ;
         }
         default_action = NoAction_121();
     }
@@ -1857,8 +1857,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             hdr.ipv4.isValid()       : exact @name("ipv4.$valid$") ;
             hdr.ipv6.isValid()       : exact @name("ipv6.$valid$") ;
             hdr.mpls[0].isValid()    : exact @name("mpls[0].$valid$") ;
-            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr[31:28]") ;
-            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr[127:120]") ;
+            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr") ;
+            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr") ;
         }
         default_action = NoAction_123();
     }
@@ -3437,7 +3437,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.ipv4.version       : ternary @name("ipv4.version") ;
             hdr.ipv4.ttl           : ternary @name("ipv4.ttl") ;
-            hdr.ipv4.srcAddr[31:24]: ternary @name("ipv4.srcAddr[31:24]") ;
+            hdr.ipv4.srcAddr[31:24]: ternary @name("ipv4.srcAddr") ;
         }
         size = 512;
         default_action = NoAction_152();
@@ -3460,7 +3460,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.ipv6.version         : ternary @name("ipv6.version") ;
             hdr.ipv6.hopLimit        : ternary @name("ipv6.hopLimit") ;
-            hdr.ipv6.srcAddr[127:112]: ternary @name("ipv6.srcAddr[127:112]") ;
+            hdr.ipv6.srcAddr[127:112]: ternary @name("ipv6.srcAddr") ;
         }
         size = 512;
         default_action = NoAction_153();
@@ -4400,13 +4400,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_182();
         }
         key = {
-            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa[40:40]") ;
+            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
             meta.l2_metadata.lkp_mac_da            : ternary @name("l2_metadata.lkp_mac_da") ;
             meta.l3_metadata.lkp_ip_type           : ternary @name("l3_metadata.lkp_ip_type") ;
             meta.l3_metadata.lkp_ip_ttl            : ternary @name("l3_metadata.lkp_ip_ttl") ;
             meta.l3_metadata.lkp_ip_version        : ternary @name("l3_metadata.lkp_ip_version") ;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa[31:24]") ;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa[127:112]") ;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_182();

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -1801,8 +1801,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         key = {
             hdr.ipv4.isValid()       : exact @name("ipv4.$valid$") ;
             hdr.ipv6.isValid()       : exact @name("ipv6.$valid$") ;
-            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr[31:28]") ;
-            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr[127:120]") ;
+            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr") ;
+            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr") ;
         }
         default_action = NoAction_121();
     }
@@ -1862,8 +1862,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             hdr.ipv4.isValid()       : exact @name("ipv4.$valid$") ;
             hdr.ipv6.isValid()       : exact @name("ipv6.$valid$") ;
             hdr.mpls[0].isValid()    : exact @name("mpls[0].$valid$") ;
-            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr[31:28]") ;
-            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr[127:120]") ;
+            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr") ;
+            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr") ;
         }
         default_action = NoAction_123();
     }
@@ -3501,7 +3501,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.ipv4.version       : ternary @name("ipv4.version") ;
             hdr.ipv4.ttl           : ternary @name("ipv4.ttl") ;
-            hdr.ipv4.srcAddr[31:24]: ternary @name("ipv4.srcAddr[31:24]") ;
+            hdr.ipv4.srcAddr[31:24]: ternary @name("ipv4.srcAddr") ;
         }
         size = 512;
         default_action = NoAction_152();
@@ -3524,7 +3524,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.ipv6.version         : ternary @name("ipv6.version") ;
             hdr.ipv6.hopLimit        : ternary @name("ipv6.hopLimit") ;
-            hdr.ipv6.srcAddr[127:112]: ternary @name("ipv6.srcAddr[127:112]") ;
+            hdr.ipv6.srcAddr[127:112]: ternary @name("ipv6.srcAddr") ;
         }
         size = 512;
         default_action = NoAction_153();
@@ -4464,13 +4464,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_182();
         }
         key = {
-            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa[40:40]") ;
+            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
             meta.l2_metadata.lkp_mac_da            : ternary @name("l2_metadata.lkp_mac_da") ;
             meta.l3_metadata.lkp_ip_type           : ternary @name("l3_metadata.lkp_ip_type") ;
             meta.l3_metadata.lkp_ip_ttl            : ternary @name("l3_metadata.lkp_ip_ttl") ;
             meta.l3_metadata.lkp_ip_version        : ternary @name("l3_metadata.lkp_ip_version") ;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa[31:24]") ;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa[127:112]") ;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_182();

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -1762,8 +1762,8 @@ control process_rewrite(inout headers hdr, inout metadata meta, inout standard_m
         key = {
             hdr.ipv4.isValid()       : exact;
             hdr.ipv6.isValid()       : exact;
-            hdr.ipv4.dstAddr[31:28]  : ternary;
-            hdr.ipv6.dstAddr[127:120]: ternary;
+            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr") ;
+            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr") ;
         }
     }
     apply {
@@ -1836,8 +1836,8 @@ control process_mac_rewrite(inout headers hdr, inout metadata meta, inout standa
             hdr.ipv4.isValid()       : exact;
             hdr.ipv6.isValid()       : exact;
             hdr.mpls[0].isValid()    : exact;
-            hdr.ipv4.dstAddr[31:28]  : ternary;
-            hdr.ipv6.dstAddr[127:120]: ternary;
+            hdr.ipv4.dstAddr[31:28]  : ternary @name("ipv4.dstAddr") ;
+            hdr.ipv6.dstAddr[127:120]: ternary @name("ipv6.dstAddr") ;
         }
     }
     @name(".smac_rewrite") table smac_rewrite {
@@ -3099,7 +3099,7 @@ control validate_outer_ipv4_header(inout headers hdr, inout metadata meta, inout
         key = {
             hdr.ipv4.version       : ternary;
             hdr.ipv4.ttl           : ternary;
-            hdr.ipv4.srcAddr[31:24]: ternary;
+            hdr.ipv4.srcAddr[31:24]: ternary @name("ipv4.srcAddr") ;
         }
         size = 512;
     }
@@ -3126,7 +3126,7 @@ control validate_outer_ipv6_header(inout headers hdr, inout metadata meta, inout
         key = {
             hdr.ipv6.version         : ternary;
             hdr.ipv6.hopLimit        : ternary;
-            hdr.ipv6.srcAddr[127:112]: ternary;
+            hdr.ipv6.srcAddr[127:112]: ternary @name("ipv6.srcAddr") ;
         }
         size = 512;
     }
@@ -4295,13 +4295,13 @@ control process_validate_packet(inout headers hdr, inout metadata meta, inout st
             set_malformed_packet;
         }
         key = {
-            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary;
+            meta.l2_metadata.lkp_mac_sa[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
             meta.l2_metadata.lkp_mac_da            : ternary;
             meta.l3_metadata.lkp_ip_type           : ternary;
             meta.l3_metadata.lkp_ip_ttl            : ternary;
             meta.l3_metadata.lkp_ip_version        : ternary;
-            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary;
-            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary;
+            meta.ipv4_metadata.lkp_ipv4_sa[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta.ipv6_metadata.lkp_ipv6_sa[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
     }

--- a/testdata/p4_16_samples/issue1560-bmv2.p4
+++ b/testdata/p4_16_samples/issue1560-bmv2.p4
@@ -1,0 +1,214 @@
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48>  EthernetAddress;
+typedef bit<32>  IPv4Address;
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+// IPv4 header _with_ options
+header ipv4_t {
+    bit<4>       version;
+    bit<4>       ihl;
+    bit<8>       diffserv;
+    bit<16>      totalLen;
+    bit<16>      identification;
+    bit<3>       flags;
+    bit<13>      fragOffset;
+    bit<8>       ttl;
+    bit<8>       protocol;
+    bit<16>      hdrChecksum;
+    IPv4Address  srcAddr;
+    IPv4Address  dstAddr;
+    varbit<320>  options;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+header IPv4_up_to_ihl_only_h {
+    bit<4>       version;
+    bit<4>       ihl;
+}
+
+struct headers {
+    ethernet_t    ethernet;
+    ipv4_t        ipv4;
+    tcp_t         tcp;
+}
+
+struct mystruct1_t {
+    bit<4>  a;
+    bit<4>  b;
+}
+
+struct metadata {
+    mystruct1_t mystruct1;
+    bit<16> hash1;
+}
+
+// Declare user-defined errors that may be signaled during parsing
+error {
+    IPv4HeaderTooShort,
+    IPv4IncorrectVersion,
+    IPv4ChecksumError
+}
+
+parser parserI(packet_in pkt,
+               out headers hdr,
+               inout metadata meta,
+               inout standard_metadata_t stdmeta)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        // The 4-bit IHL field of the IPv4 base header is the number
+        // of 32-bit words in the entire IPv4 header.  It is an error
+        // for it to be less than 5.  There are only IPv4 options
+        // present if the value is at least 6.  The length of the IPv4
+        // options alone, without the 20-byte base header, is thus ((4
+        // * ihl) - 20) bytes, or 8 times that many bits.
+        pkt.extract(hdr.ipv4,
+                    (bit<32>)
+                    (8 *
+                     (4 * (bit<9>) (pkt.lookahead<IPv4_up_to_ihl_only_h >().ihl)
+                      - 20)));
+        verify(hdr.ipv4.version == 4w4, error.IPv4IncorrectVersion);
+        verify(hdr.ipv4.ihl >= 4w5, error.IPv4HeaderTooShort);
+        transition select (hdr.ipv4.protocol) {
+            6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t stdmeta)
+{
+    action foo1(IPv4Address dstAddr) {
+        hdr.ipv4.dstAddr = dstAddr;
+    }
+    action foo2(IPv4Address srcAddr) {
+        hdr.ipv4.srcAddr = srcAddr;
+    }
+    // Only defined here so that there is an action name that isn't an
+    // allowed action for table t1, so I can test whether
+    // simple_switch_CLI's act_prof_create_member command checks
+    // whether the action name is legal according to the P4 program.
+    action foo3(bit<8> ttl) {
+        hdr.ipv4.ttl = ttl;
+    }
+    table t0 {
+        key = {
+            hdr.tcp.dstPort : exact;
+        }
+        actions = {
+            foo1;
+            foo2;
+        }
+        size = 8;
+    }
+    table t1 {
+        key = {
+            hdr.tcp.dstPort : exact;
+        }
+        actions = {
+            foo1;
+            foo2;
+        }
+        size = 8;
+        //implementation = action_profile(4);
+    }
+    table t2 {
+        actions = {
+            foo1;
+            foo2;
+        }
+        key = {
+            hdr.tcp.srcPort : exact;
+            meta.hash1      : selector;
+        }
+        size = 16;
+        //@mode("fair") implementation = action_selector(HashAlgorithm.identity, 16, 4);
+    }
+    apply {
+        t0.apply();
+        t1.apply();
+
+        //hash(meta.hash1, HashAlgorithm.crc16, (bit<16>) 0,
+        //    { hdr.ipv4.srcAddr,
+        //        hdr.ipv4.dstAddr,
+        //        hdr.ipv4.protocol,
+        //        hdr.tcp.srcPort,
+        //        hdr.tcp.dstPort },
+        //    (bit<32>) 65536);
+
+        // The following assignment isn't really a good hash function
+        // for calculating meta.hash1.  I wrote it this way simply to
+        // make it easy to control and predict what its value will be
+        // when sending in test packets.
+        meta.hash1 = hdr.ipv4.dstAddr[15:0];
+        t2.apply();
+    }
+}
+
+control cEgress(inout headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t stdmeta)
+{
+    apply { }
+}
+
+control vc(inout headers hdr,
+           inout metadata meta)
+{
+    apply { }
+}
+
+control uc(inout headers hdr,
+           inout metadata meta)
+{
+    apply { }
+}
+
+control DeparserI(packet_out packet,
+                  in headers hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+V1Switch<headers, metadata>(parserI(),
+                            vc(),
+                            cIngress(),
+                            cEgress(),
+                            uc(),
+                            DeparserI()) main;

--- a/testdata/p4_16_samples/key-bmv2.stf
+++ b/testdata/p4_16_samples/key-bmv2.stf
@@ -1,10 +1,8 @@
 #       bit<32> A bit<32> B
 # In the output B = A if A + A matches in the table
 
-# TODO: today the back-end does not support @name annotations on keys
-# The key name should not be scalar.key_0, but e
-add c.t scalars.key_0:0 c.a()
-add c.t scalars.key_0:4 c.a()
+add c.t e:0 c.a()
+add c.t e:4 c.a()
 
 packet 0 00000000 00000000
 expect 0 00000000 00000000

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2-first.p4
@@ -1,0 +1,170 @@
+error {
+    IPv4HeaderTooShort,
+    IPv4IncorrectVersion,
+    IPv4ChecksumError
+}
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+    varbit<320> options;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+header IPv4_up_to_ihl_only_h {
+    bit<4> version;
+    bit<4> ihl;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+struct mystruct1_t {
+    bit<4> a;
+    bit<4> b;
+}
+
+struct metadata {
+    mystruct1_t mystruct1;
+    bit<16>     hash1;
+}
+
+parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4, (bit<32>)(((bit<9>)(pkt.lookahead<IPv4_up_to_ihl_only_h>()).ihl << 2) + 9w492 << 3));
+        verify(hdr.ipv4.version == 4w4, error.IPv4IncorrectVersion);
+        verify(hdr.ipv4.ihl >= 4w5, error.IPv4HeaderTooShort);
+        transition select(hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    action foo1(IPv4Address dstAddr) {
+        hdr.ipv4.dstAddr = dstAddr;
+    }
+    action foo2(IPv4Address srcAddr) {
+        hdr.ipv4.srcAddr = srcAddr;
+    }
+    action foo3(bit<8> ttl) {
+        hdr.ipv4.ttl = ttl;
+    }
+    table t0 {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+        }
+        actions = {
+            foo1();
+            foo2();
+            @defaultonly NoAction();
+        }
+        size = 8;
+        default_action = NoAction();
+    }
+    table t1 {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+        }
+        actions = {
+            foo1();
+            foo2();
+            @defaultonly NoAction();
+        }
+        size = 8;
+        default_action = NoAction();
+    }
+    table t2 {
+        actions = {
+            foo1();
+            foo2();
+            @defaultonly NoAction();
+        }
+        key = {
+            hdr.tcp.srcPort: exact @name("hdr.tcp.srcPort") ;
+            meta.hash1     : selector @name("meta.hash1") ;
+        }
+        size = 16;
+        default_action = NoAction();
+    }
+    apply {
+        t0.apply();
+        t1.apply();
+        meta.hash1 = hdr.ipv4.dstAddr[15:0];
+        t2.apply();
+    }
+}
+
+control cEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+V1Switch<headers, metadata>(parserI(), vc(), cIngress(), cEgress(), uc(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2-frontend.p4
@@ -1,0 +1,194 @@
+error {
+    IPv4HeaderTooShort,
+    IPv4IncorrectVersion,
+    IPv4ChecksumError
+}
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<32> IPv4Address;
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+    varbit<320> options;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+header IPv4_up_to_ihl_only_h {
+    bit<4> version;
+    bit<4> ihl;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+struct mystruct1_t {
+    bit<4> a;
+    bit<4> b;
+}
+
+struct metadata {
+    mystruct1_t mystruct1;
+    bit<16>     hash1;
+}
+
+parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    IPv4_up_to_ihl_only_h tmp;
+    bit<9> tmp_0;
+    bit<9> tmp_1;
+    bit<9> tmp_2;
+    bit<32> tmp_3;
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        tmp = pkt.lookahead<IPv4_up_to_ihl_only_h>();
+        tmp_0 = (bit<9>)tmp.ihl << 2;
+        tmp_1 = tmp_0 + 9w492;
+        tmp_2 = tmp_1 << 3;
+        tmp_3 = (bit<32>)tmp_2;
+        pkt.extract<ipv4_t>(hdr.ipv4, tmp_3);
+        verify(hdr.ipv4.version == 4w4, error.IPv4IncorrectVersion);
+        verify(hdr.ipv4.ihl >= 4w5, error.IPv4HeaderTooShort);
+        transition select(hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name(".NoAction") action NoAction_4() {
+    }
+    @name(".NoAction") action NoAction_5() {
+    }
+    @name("cIngress.foo1") action foo1(IPv4Address dstAddr) {
+        hdr.ipv4.dstAddr = dstAddr;
+    }
+    @name("cIngress.foo1") action foo1_3(IPv4Address dstAddr) {
+        hdr.ipv4.dstAddr = dstAddr;
+    }
+    @name("cIngress.foo1") action foo1_4(IPv4Address dstAddr) {
+        hdr.ipv4.dstAddr = dstAddr;
+    }
+    @name("cIngress.foo2") action foo2(IPv4Address srcAddr) {
+        hdr.ipv4.srcAddr = srcAddr;
+    }
+    @name("cIngress.foo2") action foo2_3(IPv4Address srcAddr) {
+        hdr.ipv4.srcAddr = srcAddr;
+    }
+    @name("cIngress.foo2") action foo2_4(IPv4Address srcAddr) {
+        hdr.ipv4.srcAddr = srcAddr;
+    }
+    @name("cIngress.t0") table t0_0 {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+        }
+        actions = {
+            foo1();
+            foo2();
+            @defaultonly NoAction_0();
+        }
+        size = 8;
+        default_action = NoAction_0();
+    }
+    @name("cIngress.t1") table t1_0 {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+        }
+        actions = {
+            foo1_3();
+            foo2_3();
+            @defaultonly NoAction_4();
+        }
+        size = 8;
+        default_action = NoAction_4();
+    }
+    @name("cIngress.t2") table t2_0 {
+        actions = {
+            foo1_4();
+            foo2_4();
+            @defaultonly NoAction_5();
+        }
+        key = {
+            hdr.tcp.srcPort: exact @name("hdr.tcp.srcPort") ;
+            meta.hash1     : selector @name("meta.hash1") ;
+        }
+        size = 16;
+        default_action = NoAction_5();
+    }
+    apply {
+        t0_0.apply();
+        t1_0.apply();
+        meta.hash1 = hdr.ipv4.dstAddr[15:0];
+        t2_0.apply();
+    }
+}
+
+control cEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+V1Switch<headers, metadata>(parserI(), vc(), cIngress(), cEgress(), uc(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2-midend.p4
@@ -1,0 +1,207 @@
+error {
+    IPv4HeaderTooShort,
+    IPv4IncorrectVersion,
+    IPv4ChecksumError
+}
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<32> IPv4Address;
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+    varbit<320> options;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+header IPv4_up_to_ihl_only_h {
+    bit<4> version;
+    bit<4> ihl;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+struct mystruct1_t {
+    bit<4> a;
+    bit<4> b;
+}
+
+struct metadata {
+    mystruct1_t mystruct1;
+    bit<16>     hash1;
+}
+
+parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    IPv4_up_to_ihl_only_h tmp;
+    bit<9> tmp_0;
+    bit<9> tmp_1;
+    bit<9> tmp_2;
+    bit<32> tmp_3;
+    bit<8> tmp_4;
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        tmp_4 = pkt.lookahead<bit<8>>();
+        tmp.setValid();
+        tmp.version = tmp_4[7:4];
+        tmp.ihl = tmp_4[3:0];
+        tmp_0 = (bit<9>)tmp.ihl << 2;
+        tmp_1 = tmp_0 + 9w492;
+        tmp_2 = tmp_1 << 3;
+        tmp_3 = (bit<32>)tmp_2;
+        pkt.extract<ipv4_t>(hdr.ipv4, tmp_3);
+        verify(hdr.ipv4.version == 4w4, error.IPv4IncorrectVersion);
+        verify(hdr.ipv4.ihl >= 4w5, error.IPv4HeaderTooShort);
+        transition select(hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name(".NoAction") action NoAction_4() {
+    }
+    @name(".NoAction") action NoAction_5() {
+    }
+    @name("cIngress.foo1") action foo1(IPv4Address dstAddr) {
+        hdr.ipv4.dstAddr = dstAddr;
+    }
+    @name("cIngress.foo1") action foo1_3(IPv4Address dstAddr) {
+        hdr.ipv4.dstAddr = dstAddr;
+    }
+    @name("cIngress.foo1") action foo1_4(IPv4Address dstAddr) {
+        hdr.ipv4.dstAddr = dstAddr;
+    }
+    @name("cIngress.foo2") action foo2(IPv4Address srcAddr) {
+        hdr.ipv4.srcAddr = srcAddr;
+    }
+    @name("cIngress.foo2") action foo2_3(IPv4Address srcAddr) {
+        hdr.ipv4.srcAddr = srcAddr;
+    }
+    @name("cIngress.foo2") action foo2_4(IPv4Address srcAddr) {
+        hdr.ipv4.srcAddr = srcAddr;
+    }
+    @name("cIngress.t0") table t0_0 {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+        }
+        actions = {
+            foo1();
+            foo2();
+            @defaultonly NoAction_0();
+        }
+        size = 8;
+        default_action = NoAction_0();
+    }
+    @name("cIngress.t1") table t1_0 {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+        }
+        actions = {
+            foo1_3();
+            foo2_3();
+            @defaultonly NoAction_4();
+        }
+        size = 8;
+        default_action = NoAction_4();
+    }
+    @name("cIngress.t2") table t2_0 {
+        actions = {
+            foo1_4();
+            foo2_4();
+            @defaultonly NoAction_5();
+        }
+        key = {
+            hdr.tcp.srcPort       : exact @name("hdr.tcp.srcPort") ;
+            hdr.ipv4.dstAddr[15:0]: selector @name("meta.hash1") ;
+        }
+        size = 16;
+        default_action = NoAction_5();
+    }
+    @hidden action act() {
+        meta.hash1 = hdr.ipv4.dstAddr[15:0];
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        t0_0.apply();
+        t1_0.apply();
+        tbl_act.apply();
+        t2_0.apply();
+    }
+}
+
+control cEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+V1Switch<headers, metadata>(parserI(), vc(), cIngress(), cEgress(), uc(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2.p4
@@ -1,0 +1,164 @@
+error {
+    IPv4HeaderTooShort,
+    IPv4IncorrectVersion,
+    IPv4ChecksumError
+}
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+    varbit<320> options;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+header IPv4_up_to_ihl_only_h {
+    bit<4> version;
+    bit<4> ihl;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+struct mystruct1_t {
+    bit<4> a;
+    bit<4> b;
+}
+
+struct metadata {
+    mystruct1_t mystruct1;
+    bit<16>     hash1;
+}
+
+parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4, (bit<32>)(8 * (4 * (bit<9>)(pkt.lookahead<IPv4_up_to_ihl_only_h>()).ihl - 20)));
+        verify(hdr.ipv4.version == 4w4, error.IPv4IncorrectVersion);
+        verify(hdr.ipv4.ihl >= 4w5, error.IPv4HeaderTooShort);
+        transition select(hdr.ipv4.protocol) {
+            6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    action foo1(IPv4Address dstAddr) {
+        hdr.ipv4.dstAddr = dstAddr;
+    }
+    action foo2(IPv4Address srcAddr) {
+        hdr.ipv4.srcAddr = srcAddr;
+    }
+    action foo3(bit<8> ttl) {
+        hdr.ipv4.ttl = ttl;
+    }
+    table t0 {
+        key = {
+            hdr.tcp.dstPort: exact;
+        }
+        actions = {
+            foo1;
+            foo2;
+        }
+        size = 8;
+    }
+    table t1 {
+        key = {
+            hdr.tcp.dstPort: exact;
+        }
+        actions = {
+            foo1;
+            foo2;
+        }
+        size = 8;
+    }
+    table t2 {
+        actions = {
+            foo1;
+            foo2;
+        }
+        key = {
+            hdr.tcp.srcPort: exact;
+            meta.hash1     : selector;
+        }
+        size = 16;
+    }
+    apply {
+        t0.apply();
+        t1.apply();
+        meta.hash1 = hdr.ipv4.dstAddr[15:0];
+        t2.apply();
+    }
+}
+
+control cEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+V1Switch<headers, metadata>(parserI(), vc(), cIngress(), cEgress(), uc(), DeparserI()) main;
+


### PR DESCRIPTION
Interestingly, this also fixes a long-standing bug in the stf testing infrastructure.
When converting P4-14 programs with table keys (reads) that have masks we have to generate the correct key names.