### PR TITLE
add support for versioning p4c backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,21 @@ if (NOT $ENV{P4C_VERSION} STREQUAL "")
   # Allow the version to be set from outside
   set (P4C_VERSION $ENV{P4C_VERSION})
 else()
+  # Semantic version numbering: <major>.<minor>.<patch>[-rcX]
+  # Examples: 0.5.1, 1.0.0-rc1, 1.0.1-alpha
+  set (P4C_SEM_VERSION_STRING "1.1.0-rc1")
+  string (REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)([-0-9a-z\\.]*).*"
+    __p4c_version ${P4C_SEM_VERSION_STRING})
+  set (P4C_VERSION_MAJOR ${CMAKE_MATCH_1})
+  set (P4C_VERSION_MINOR ${CMAKE_MATCH_2})
+  set (P4C_VERSION_PATCH ${CMAKE_MATCH_3})
+  set (P4C_VERSION_RC ${CMAKE_MATCH_4})
   execute_process (COMMAND git rev-parse --short HEAD
     OUTPUT_VARIABLE P4C_GIT_SHA
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    RESULT_VARIABLE rc)
-  set (P4C_VERSION "0.5 (SHA: ${P4C_GIT_SHA})")
+    RESULT_VARIABLE rc
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  set (P4C_VERSION "${P4C_SEM_VERSION_STRING} (SHA: ${P4C_GIT_SHA})")
 endif()
 include(P4CUtils)
 include(UnifiedBuild)

--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -15,6 +15,11 @@
 # Makefile for a backend that generates code for the Behavioral Model version 2 (BMv2)
 # compiling for the simple_switch target.
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/simple_switch/version.h.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/simple_switch/version.h" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/psa_switch/version.h.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/psa_switch/version.h" @ONLY)
+
 # sources for backend executable
 set (BMV2_SIMPLE_SWITCH_SRCS
     simple_switch/main.cpp

--- a/backends/bmv2/psa_switch/main.cpp
+++ b/backends/bmv2/psa_switch/main.cpp
@@ -31,6 +31,7 @@ limitations under the License.
 #include "backends/bmv2/common/JsonObjects.h"
 #include "backends/bmv2/psa_switch/midend.h"
 #include "backends/bmv2/psa_switch/psaSwitch.h"
+#include "backends/bmv2/psa_switch/version.h"
 
 int main(int argc, char *const argv[]) {
     setup_gc_logging();
@@ -38,7 +39,7 @@ int main(int argc, char *const argv[]) {
     AutoCompileContext autoBMV2Context(new BMV2::BMV2Context);
     auto& options = BMV2::BMV2Context::get().options();
     options.langVersion = CompilerOptions::FrontendVersion::P4_16;
-    options.compilerVersion = "0.0.5";
+    options.compilerVersion = BMV2_PSA_VERSION_STRING;
 
     if (options.process(argc, argv) != nullptr)
         options.setInputFile();

--- a/backends/bmv2/psa_switch/version.h.cmake
+++ b/backends/bmv2/psa_switch/version.h.cmake
@@ -1,0 +1,38 @@
+/*
+Copyright 2018-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _BACKENDS_BMV2_PSASWITCH_VERSION_H
+#define _BACKENDS_BMV2_PSASWITCH_VERSION_H
+
+/**
+  Set the compiler version at build time.
+  The build system defines P4C_VERSION as a full string as well as the
+  following components: P4C_VERSION_MAJOR, P4C_VERSION_MINOR,
+  P4C_VERSION_PATCH, P4C_VERSION_RC, and P4C_GIT_SHA.
+
+  They can be used to construct a version string as follows:
+  #define VERSION_STRING "@P4C_VERSION@"
+  or
+  #define VERSION_STRING "@P4C_VERSION_MAJOR@.@P4C_VERSION_MINOR@.@P4C_VERSION_PATCH@@P4C_VERSION_RC@"
+
+  Or, since this is backend specific, feel free to define other numbering
+  scheme.
+
+  */
+
+#define BMV2_PSA_VERSION_STRING "0.0.1 (SHA: @P4C_GIT_SHA@)"
+
+#endif  // _BACKENDS_BMV2_PSASWITCH_VERSION_H

--- a/backends/bmv2/simple_switch/main.cpp
+++ b/backends/bmv2/simple_switch/main.cpp
@@ -31,6 +31,7 @@ limitations under the License.
 #include "backends/bmv2/common/JsonObjects.h"
 #include "backends/bmv2/simple_switch/midend.h"
 #include "backends/bmv2/simple_switch/simpleSwitch.h"
+#include "backends/bmv2/simple_switch/version.h"
 
 int main(int argc, char *const argv[]) {
     setup_gc_logging();
@@ -38,7 +39,7 @@ int main(int argc, char *const argv[]) {
     AutoCompileContext autoBMV2Context(new BMV2::BMV2Context);
     auto& options = BMV2::BMV2Context::get().options();
     options.langVersion = CompilerOptions::FrontendVersion::P4_16;
-    options.compilerVersion = "0.0.5";
+    options.compilerVersion = BMV2_SIMPLESWITCH_VERSION_STRING;
 
     if (options.process(argc, argv) != nullptr)
         options.setInputFile();

--- a/backends/bmv2/simple_switch/version.h.cmake
+++ b/backends/bmv2/simple_switch/version.h.cmake
@@ -1,0 +1,38 @@
+/*
+Copyright 2018-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _BACKENDS_BMV2_SIMPLESWITCH_VERSION_H
+#define _BACKENDS_BMV2_SIMPLESWITCH_VERSION_H
+
+/**
+  Set the compiler version at build time.
+  The build system defines P4C_VERSION as a full string as well as the
+  following components: P4C_VERSION_MAJOR, P4C_VERSION_MINOR,
+  P4C_VERSION_PATCH, P4C_VERSION_RC, and P4C_GIT_SHA.
+
+  They can be used to construct a version string as follows:
+  #define VERSION_STRING "@P4C_VERSION@"
+  or
+  #define VERSION_STRING "@P4C_VERSION_MAJOR@.@P4C_VERSION_MINOR@.@P4C_VERSION_PATCH@@P4C_VERSION_RC@"
+
+  Or, since this is backend specific, feel free to define other numbering
+  scheme.
+
+  */
+
+#define BMV2_SIMPLESWITCH_VERSION_STRING "@P4C_VERSION@"
+
+#endif  // _BACKENDS_BMV2_SIMPLESWITCH_VERSION_H

--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -15,6 +15,9 @@
 # Makefile for the EBPF P4-16 back-end.
 # To be included in the main P4C compiler makefile
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/version.h.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/version.h" @ONLY)
+
 set (P4C_EBPF_SRCS
   p4c-ebpf.cpp
   ebpfBackend.cpp

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <string>
 #include <iostream>
 
+#include "backends/ebpf/version.h"
 #include "ir/ir.h"
 #include "lib/log.h"
 #include "lib/crash.h"
@@ -69,7 +70,7 @@ int main(int argc, char *const argv[]) {
 
     AutoCompileContext autoEbpfContext(new EbpfContext);
     auto& options = EbpfContext::get().options();
-    options.compilerVersion = "0.0.1";
+    options.compilerVersion = P4C_EBPF_VERSION_STRING;
 
     if (options.process(argc, argv) != nullptr)
         options.setInputFile();

--- a/backends/ebpf/version.h.cmake
+++ b/backends/ebpf/version.h.cmake
@@ -1,0 +1,38 @@
+/*
+Copyright 2018-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _BACKENDS_EBPF_VERSION_H
+#define _BACKENDS_EBPF_VERSION_H
+
+/**
+  Set the compiler version at build time.
+  The build system defines P4C_VERSION as a full string as well as the
+  following components: P4C_VERSION_MAJOR, P4C_VERSION_MINOR,
+  P4C_VERSION_PATCH, P4C_VERSION_RC, and P4C_GIT_SHA.
+
+  They can be used to construct a version string as follows:
+  #define VERSION_STRING "@P4C_VERSION@"
+  or
+  #define VERSION_STRING "@P4C_VERSION_MAJOR@.@P4C_VERSION_MINOR@.@P4C_VERSION_PATCH@@P4C_VERSION_RC@"
+
+  Or, since this is backend specific, feel free to define other numbering
+  scheme.
+
+  */
+
+#define P4C_EBPF_VERSION_STRING "@P4C_VERSION@"
+
+#endif  // _BACKENDS_EBPF_VERSION_H

--- a/backends/graphs/CMakeLists.txt
+++ b/backends/graphs/CMakeLists.txt
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/version.h.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/version.h" @ONLY)
+
 set (GRAPHS_SRCS
   graphs.cpp
   controls.cpp

--- a/backends/graphs/p4c-graphs.cpp
+++ b/backends/graphs/p4c-graphs.cpp
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "backends/graphs/version.h"
 #include "ir/ir.h"
 #include "lib/log.h"
 #include "lib/error.h"
@@ -79,7 +80,7 @@ int main(int argc, char *const argv[]) {
     AutoCompileContext autoGraphsContext(new ::graphs::GraphsContext);
     auto& options = ::graphs::GraphsContext::get().options();
     options.langVersion = CompilerOptions::FrontendVersion::P4_16;
-    options.compilerVersion = "0.0.5";
+    options.compilerVersion = P4C_GRAPHS_VERSION_STRING;
 
     if (options.process(argc, argv) != nullptr)
         options.setInputFile();

--- a/backends/graphs/version.h.cmake
+++ b/backends/graphs/version.h.cmake
@@ -1,0 +1,38 @@
+/*
+Copyright 2018-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _BACKENDS_GRAPHS_VERSION_H
+#define _BACKENDS_GRAPHS_VERSION_H
+
+/**
+  Set the compiler version at build time.
+  The build system defines P4C_VERSION as a full string as well as the
+  following components: P4C_VERSION_MAJOR, P4C_VERSION_MINOR,
+  P4C_VERSION_PATCH, P4C_VERSION_RC, and P4C_GIT_SHA.
+
+  They can be used to construct a version string as follows:
+  #define VERSION_STRING "@P4C_VERSION@"
+  or
+  #define VERSION_STRING "@P4C_VERSION_MAJOR@.@P4C_VERSION_MINOR@.@P4C_VERSION_PATCH@@P4C_VERSION_RC@"
+
+  Or, since this is backend specific, feel free to define other numbering
+  scheme.
+
+  */
+
+#define P4C_GRAPHS_VERSION_STRING "@P4C_VERSION@"
+
+#endif  // _BACKENDS_GRAPHS_VERSION_H

--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -14,6 +14,9 @@
 
 # Makefile for a fake backend that is used for testing the P4-16 front-end.
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/version.h.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/version.h" @ONLY)
+
 set (P4TEST_SRCS
   p4test.cpp
   midend.cpp

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include <fstream>
 #include <iostream>
 
+#include "backends/p4test/version.h"
 #include "control-plane/p4RuntimeSerializer.h"
 #include "ir/ir.h"
 #include "ir/json_loader.h"
@@ -80,7 +81,7 @@ int main(int argc, char *const argv[]) {
     AutoCompileContext autoP4TestContext(new P4TestContext);
     auto& options = P4TestContext::get().options();
     options.langVersion = CompilerOptions::FrontendVersion::P4_16;
-    options.compilerVersion = "0.0.5";
+    options.compilerVersion = P4TEST_VERSION_STRING;
 
     if (options.process(argc, argv) != nullptr)
         options.setInputFile();

--- a/backends/p4test/version.h.cmake
+++ b/backends/p4test/version.h.cmake
@@ -1,0 +1,38 @@
+/*
+Copyright 2018-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _BACKENDS_P4TEST_VERSION_H
+#define _BACKENDS_P4TEST_VERSION_H
+
+/**
+  Set the compiler version at build time.
+  The build system defines P4C_VERSION as a full string as well as the
+  following components: P4C_VERSION_MAJOR, P4C_VERSION_MINOR,
+  P4C_VERSION_PATCH, P4C_VERSION_RC, and P4C_GIT_SHA.
+
+  They can be used to construct a version string as follows:
+  #define VERSION_STRING "@P4C_VERSION@"
+  or
+  #define VERSION_STRING "@P4C_VERSION_MAJOR@.@P4C_VERSION_MINOR@.@P4C_VERSION_PATCH@@P4C_VERSION_RC@"
+
+  Or, since this is backend specific, feel free to define other numbering
+  scheme.
+
+  */
+
+#define P4TEST_VERSION_STRING "@P4C_VERSION@"
+
+#endif  // _BACKENDS_P4TEST_VERSION_H


### PR DESCRIPTION
We add support for versioning different p4c backends independently of
each other. Currently we specify a global version in the root
CMakeLists.txt file, which will be reported by the p4c driver.
Individual backends get a configurable version string that is set at
configuration time based on macros derived from the global
version. However, each backend can customize the format of the
version, and see the example in the psa backend that hardcodes the
version to 0.0.1 and uses only the git SHA.

In honor of the language spec 1.1 release, I set the default version to 1.1.0-rc1.

Alternative solution to #1491.