### PR TITLE
add hook to support custom expression converter visitor function

### DIFF
--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -70,7 +70,7 @@ const IR::Node* ExpressionConverter::postorder(IR::Constant* expression) {
 
 const IR::Node* ExpressionConverter::postorder(IR::FieldList* fl) {
     // Field lists may contain other field lists
-    if (auto func = get(typeid(fl))) {
+    if (auto func = get(std::type_index(typeid(*fl)).name())) {
         return func(fl); }
     return new IR::ListExpression(fl->srcInfo, fl->fields);
 }
@@ -242,15 +242,15 @@ const IR::Node* ExpressionConverter::postorder(IR::Neq *neq) {
         return new IR::BoolLiteral(neq->srcInfo, true);  // everything else is true
 }
 
-std::map<std::type_index, ExpressionConverter::funcType>* ExpressionConverter::cvtForType = nullptr;
+std::map<cstring, ExpressionConverter::funcType>* ExpressionConverter::cvtForType = nullptr;
 
-void ExpressionConverter::addConverter(const std::type_info& type, ExpressionConverter::funcType cvt) {
-    static std::map<std::type_index, ExpressionConverter::funcType> tbl;
+void ExpressionConverter::addConverter(cstring type, ExpressionConverter::funcType cvt) {
+    static std::map<cstring, ExpressionConverter::funcType> tbl;
     cvtForType = &tbl;
-    tbl.emplace(type, cvt);
+    tbl[type] = cvt;
 }
 
-ExpressionConverter::funcType ExpressionConverter::get(const std::type_info& type) {
+ExpressionConverter::funcType ExpressionConverter::get(cstring type) {
     if (cvtForType && cvtForType->count(type))
         return cvtForType->at(type);
     return nullptr;

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -70,6 +70,8 @@ const IR::Node* ExpressionConverter::postorder(IR::Constant* expression) {
 
 const IR::Node* ExpressionConverter::postorder(IR::FieldList* fl) {
     // Field lists may contain other field lists
+    if (auto func = get(typeid(fl))) {
+        return func(fl); }
     return new IR::ListExpression(fl->srcInfo, fl->fields);
 }
 
@@ -240,6 +242,20 @@ const IR::Node* ExpressionConverter::postorder(IR::Neq *neq) {
         return new IR::BoolLiteral(neq->srcInfo, true);  // everything else is true
 }
 
+std::map<std::type_index, ExpressionConverter::funcType>* ExpressionConverter::cvtForType = nullptr;
+
+void ExpressionConverter::addConverter(const std::type_info& type, ExpressionConverter::funcType cvt) {
+    static std::map<std::type_index, ExpressionConverter::funcType> tbl;
+    cvtForType = &tbl;
+    tbl.emplace(type, cvt);
+}
+
+ExpressionConverter::funcType ExpressionConverter::get(const std::type_info& type) {
+    if (cvtForType && cvtForType->count(type))
+        return cvtForType->at(type);
+    return nullptr;
+}
+
 const IR::Node* StatementConverter::preorder(IR::Apply* apply) {
     auto table = structure->tables.get(apply->name);
     auto newname = structure->tables.get(table);
@@ -313,7 +329,7 @@ const IR::Node* StatementConverter::preorder(IR::Apply* apply) {
 const IR::Node* StatementConverter::preorder(IR::Primitive* primitive) {
     auto control = structure->controls.get(primitive->name);
     if (control != nullptr) {
-        auto instanceName = get(renameMap, control->name);
+        auto instanceName = ::get(renameMap, control->name);
         auto ctrl = new IR::PathExpression(IR::ID(instanceName));
         auto method = new IR::Member(ctrl, IR::ID(IR::IApply::applyMethodName));
         auto args = new IR::Vector<IR::Argument>();

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -17,6 +17,9 @@ limitations under the License.
 #ifndef _FRONTENDS_P4_FROMV1_0_CONVERTERS_H_
 #define _FRONTENDS_P4_FROMV1_0_CONVERTERS_H_
 
+#include <typeindex>
+#include <typeinfo>
+
 #include "ir/ir.h"
 #include "lib/safe_vector.h"
 #include "frontends/p4/coreLibrary.h"
@@ -30,6 +33,8 @@ class ExpressionConverter : public Transform {
  protected:
     ProgramStructure* structure;
     P4::P4CoreLibrary &p4lib;
+    using funcType = std::function<const IR::Node*(const IR::Node*)>;
+    static std::map<std::type_index, funcType> *cvtForType;
 
  public:
     bool replaceNextWithLast;  // if true p[next] becomes p.last
@@ -53,6 +58,8 @@ class ExpressionConverter : public Transform {
         auto result = node->apply(*this);
         return result->to<IR::Expression>();
     }
+    static void addConverter(const std::type_info& type, funcType);
+    static funcType get(const std::type_info& type);
 };
 
 class StatementConverter : public ExpressionConverter {

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -34,7 +34,7 @@ class ExpressionConverter : public Transform {
     ProgramStructure* structure;
     P4::P4CoreLibrary &p4lib;
     using funcType = std::function<const IR::Node*(const IR::Node*)>;
-    static std::map<std::type_index, funcType> *cvtForType;
+    static std::map<cstring, funcType> *cvtForType;
 
  public:
     bool replaceNextWithLast;  // if true p[next] becomes p.last
@@ -58,8 +58,8 @@ class ExpressionConverter : public Transform {
         auto result = node->apply(*this);
         return result->to<IR::Expression>();
     }
-    static void addConverter(const std::type_info& type, funcType);
-    static funcType get(const std::type_info& type);
+    static void addConverter(cstring type, funcType);
+    static funcType get(cstring type);
 };
 
 class StatementConverter : public ExpressionConverter {


### PR DESCRIPTION
Added a hook in P4-14 to P4-16 translation to allow customizing ExpressionConverter visitor function. Currently, it is only used to overload IR::FieldList visitor function.