### PR TITLE
Small refactor of ArchHandlerIface in P4Runtime serializer

### DIFF
--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -144,9 +144,12 @@ class P4RuntimeArchHandlerIface {
     /// needs to be exposed to the control-plane (e.g. digest call for v1model).
     virtual void collectExternFunction(P4RuntimeSymbolTableIface* symbols,
                                        const P4::ExternFunction* externFunction) = 0;
+    /// Collects any extra symbols you may want to include in the symbol table
+    /// and that are not covered by the above collection methods.
+    virtual void collectExtra(P4RuntimeSymbolTableIface* symbols) = 0;
     /// This method is called between the two passes (collect and add) in case
     /// the architecture requires some logic to be performed then.
-    virtual void postCollect(P4RuntimeSymbolTableIface* symbols) = 0;
+    virtual void postCollect(const P4RuntimeSymbolTableIface& symbols) = 0;
     /// Adds architecture-specific properties for @tableBlock to the @table
     /// Protobuf message.
     virtual void addTableProperties(const P4RuntimeSymbolTableIface& symbols,

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -455,7 +455,12 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
         (void)externFunction;
     }
 
-    void postCollect(P4RuntimeSymbolTableIface* symbols) override {
+    void collectExtra(P4RuntimeSymbolTableIface* symbols) override {
+        // nothing to do for standard architectures
+        (void)symbols;
+    }
+
+    void postCollect(const P4RuntimeSymbolTableIface& symbols) override {
         (void)symbols;
         // analyze action profiles and build a mapping from action profile name
         // to the set of tables referencing them

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1300,9 +1300,10 @@ P4RuntimeAnalyzer::analyze(const IR::P4Program* program,
                 symbols.add(P4RuntimeSymbolType::CONTROLLER_HEADER(), type);
             }
         });
+        archHandler->collectExtra(&symbols);
     });
 
-    archHandler->postCollect(&symbols);
+    archHandler->postCollect(symbols);
 
     // Construct a P4Runtime control plane API from the program.
     P4RuntimeAnalyzer analyzer(symbols, typeMap, refMap, archHandler);


### PR DESCRIPTION
New symbols cannot be added to the symbol table in the postCollect pass
because the table has already been created by then and cannot really be
mutated. A new virtual method (collectExtra) is added to let
architectures add symbols while the table can still be mutated.