### PR TITLE
Fixes & improvements to annotation parsing

### DIFF
--- a/backends/bmv2/common/annotations.h
+++ b/backends/bmv2/common/annotations.h
@@ -28,7 +28,7 @@ namespace BMV2 {
 class ParseAnnotations : public P4::ParseAnnotations {
  public:
     ParseAnnotations() : P4::ParseAnnotations("BMV2", {
-                PARSE_NO_BODY("metadata"),
+                PARSE_EMPTY("metadata"),
                 PARSE("alias", StringLiteral),
                 PARSE("priority", Constant)
             }) { }

--- a/backends/bmv2/common/annotations.h
+++ b/backends/bmv2/common/annotations.h
@@ -27,7 +27,7 @@ namespace BMV2 {
  */
 class ParseAnnotations : public P4::ParseAnnotations {
  public:
-    ParseAnnotations() : P4::ParseAnnotations("BMV2", {
+    ParseAnnotations() : P4::ParseAnnotations("BMV2", false, {
                 PARSE_EMPTY("metadata"),
                 PARSE("alias", StringLiteral),
                 PARSE("priority", Constant)

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -657,7 +657,7 @@ getMatchFields(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMap)
 /// Parses P4Runtime-specific annotations.
 class ParseAnnotations : public P4::ParseAnnotations {
  public:
-    ParseAnnotations() : P4::ParseAnnotations("P4Runtime", {
+    ParseAnnotations() : P4::ParseAnnotations("P4Runtime", false, {
                 PARSE("controller_header", StringLiteral),
                 PARSE_EMPTY("hidden"),
                 PARSE("id", Constant)

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -659,7 +659,7 @@ class ParseAnnotations : public P4::ParseAnnotations {
  public:
     ParseAnnotations() : P4::ParseAnnotations("P4Runtime", {
                 PARSE("controller_header", StringLiteral),
-                PARSE_NO_BODY("hidden"),
+                PARSE_EMPTY("hidden"),
                 PARSE("id", Constant)
             }) { }
 };

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -237,6 +237,7 @@ set (FRONTEND_SOURCES
 set_source_files_properties(${IR_GENERATED_SRCS} PROPERTIES GENERATED TRUE)
 set_source_files_properties(${v1PARSER_GEN_SRCS} PROPERTIES GENERATED TRUE)
 set_source_files_properties(${p4PARSER_GEN_SRCS} PROPERTIES GENERATED TRUE)
+set_source_files_properties(frontends/parsers/p4/p4parser.hpp PROPERTIES GENERATED TRUE)
 
 set (FRONTEND_CPPLINT_FILES
   ${P4_FRONTEND_SRCS} ${P4_FRONTEND_HDRS}

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -126,7 +126,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
 
     PassManager passes = {
         // Parse annotations
-        new ParseAnnotations(),
+        &parseAnnotations,
         new PrettyPrint(options),
         // Simple checks on parsed program
         new ValidateParsedProgram(),

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -18,15 +18,26 @@ limitations under the License.
 #define _P4_FRONTEND_H_
 
 #include "ir/ir.h"
+#include "parseAnnotations.h"
 #include "../common/options.h"
 
 namespace P4 {
 
 class FrontEnd {
+    /// A pass for parsing annotations.
+    ParseAnnotations parseAnnotations;
+
     std::vector<DebugHook> hooks;
+
  public:
     FrontEnd() = default;
+    explicit FrontEnd(ParseAnnotations parseAnnotations)
+        : parseAnnotations(parseAnnotations) { }
     explicit FrontEnd(DebugHook hook) { hooks.push_back(hook); }
+    explicit FrontEnd(ParseAnnotations parseAnnotations, DebugHook hook)
+            : FrontEnd(parseAnnotations) {
+        hooks.push_back(hook);
+    }
     void addDebugHook(DebugHook hook) { hooks.push_back(hook); }
     const IR::P4Program* run(const CompilerOptions& options, const IR::P4Program* program,
                              bool skipSideEffectOrdering = false);

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -46,7 +46,7 @@ bool ParseAnnotations::parseSkip(IR::Annotation*) {
 
 bool ParseAnnotations::parseEmpty(IR::Annotation* annotation) {
     if (!annotation->body.empty()) {
-        ::error("%1% should not have any argumentss", annotation);
+        ::error("%1% should not have any arguments", annotation);
         return false;
     }
 

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -85,16 +85,17 @@ void ParseAnnotations::postorder(IR::Annotation* annotation) {
         return;
     }
 
-    if (!handlers.count(annotation->name)) {
+    cstring name = annotation->name.name;
+    if (!handlers.count(name)) {
         // Unknown annotation. Leave as is, but warn if desired.
-        if (warnUnknown && warned.count(annotation->name) != 0) {
-            warned.insert(annotation->name);
+        if (warnUnknown && warned.count(name) == 0) {
+            warned.insert(name);
             ::warning("Unknown annotation: %1%", annotation->name);
         }
         return;
     }
 
-    annotation->needsParsing = !handlers[annotation->name](annotation);
+    annotation->needsParsing = !handlers[name](annotation);
 }
 
 }  // namespace P4

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -18,24 +18,26 @@ limitations under the License.
 
 namespace P4 {
 
-const ParseAnnotations::HandlerMap& ParseAnnotations::standardHandlers = {
-    // @tableonly, @defaultonly, @hidden, @atomic, and @optional have
-    // empty bodies.
-    PARSE_EMPTY(IR::Annotation::tableOnlyAnnotation),
-    PARSE_EMPTY(IR::Annotation::defaultOnlyAnnotation),
-    PARSE_EMPTY(IR::Annotation::hiddenAnnotation),
-    PARSE_EMPTY(IR::Annotation::atomicAnnotation),
-    PARSE_EMPTY(IR::Annotation::optionalAnnotation),
+ParseAnnotations::HandlerMap ParseAnnotations::standardHandlers() {
+    return {
+            // @tableonly, @defaultonly, @hidden, @atomic, and @optional have
+            // empty bodies.
+            PARSE_EMPTY(IR::Annotation::tableOnlyAnnotation),
+            PARSE_EMPTY(IR::Annotation::defaultOnlyAnnotation),
+            PARSE_EMPTY(IR::Annotation::hiddenAnnotation),
+            PARSE_EMPTY(IR::Annotation::atomicAnnotation),
+            PARSE_EMPTY(IR::Annotation::optionalAnnotation),
 
-    // @name and @deprecated have a string literal argument.
-    PARSE(IR::Annotation::nameAnnotation, StringLiteral),
-    PARSE(IR::Annotation::deprecatedAnnotation, StringLiteral),
+            // @name and @deprecated have a string literal argument.
+            PARSE(IR::Annotation::nameAnnotation, StringLiteral),
+            PARSE(IR::Annotation::deprecatedAnnotation, StringLiteral),
 
-    // @length has an expression argument.
-    PARSE(IR::Annotation::lengthAnnotation, Expression),
+            // @length has an expression argument.
+            PARSE(IR::Annotation::lengthAnnotation, Expression),
 
-    // @pkginfo has a key-value list argument.
-    PARSE_KV_LIST(IR::Annotation::pkginfoAnnotation)
+            // @pkginfo has a key-value list argument.
+            PARSE_KV_LIST(IR::Annotation::pkginfoAnnotation)
+        };
 };
 
 bool ParseAnnotations::parseSkip(IR::Annotation*) {

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -18,29 +18,27 @@ limitations under the License.
 
 namespace P4 {
 
-ParseAnnotations::HandlerMap ParseAnnotations::standardHandlers() {
-    return {
-            // @tableonly, @defaultonly, @hidden, @atomic, and @optional have
-            // empty bodies.
-            PARSE_EMPTY(IR::Annotation::tableOnlyAnnotation),
-            PARSE_EMPTY(IR::Annotation::defaultOnlyAnnotation),
-            PARSE_EMPTY(IR::Annotation::hiddenAnnotation),
-            PARSE_EMPTY(IR::Annotation::atomicAnnotation),
-            PARSE_EMPTY(IR::Annotation::optionalAnnotation),
+const ParseAnnotations::HandlerMap& ParseAnnotations::standardHandlers = {
+    // @tableonly, @defaultonly, @hidden, @atomic, and @optional have
+    // empty bodies.
+    PARSE_EMPTY(IR::Annotation::tableOnlyAnnotation),
+    PARSE_EMPTY(IR::Annotation::defaultOnlyAnnotation),
+    PARSE_EMPTY(IR::Annotation::hiddenAnnotation),
+    PARSE_EMPTY(IR::Annotation::atomicAnnotation),
+    PARSE_EMPTY(IR::Annotation::optionalAnnotation),
 
-            // @name and @deprecated have a string literal argument.
-            PARSE(IR::Annotation::nameAnnotation, StringLiteral),
-            PARSE(IR::Annotation::deprecatedAnnotation, StringLiteral),
+    // @name and @deprecated have a string literal argument.
+    PARSE(IR::Annotation::nameAnnotation, StringLiteral),
+    PARSE(IR::Annotation::deprecatedAnnotation, StringLiteral),
 
-            // @length has an expression argument.
-            PARSE(IR::Annotation::lengthAnnotation, Expression),
+    // @length has an expression argument.
+    PARSE(IR::Annotation::lengthAnnotation, Expression),
 
-            // @pkginfo has a key-value list argument.
-            PARSE_KV_LIST(IR::Annotation::pkginfoAnnotation)
-        };
-}
+    // @pkginfo has a key-value list argument.
+    PARSE_KV_LIST(IR::Annotation::pkginfoAnnotation)
+};
 
-bool ParseAnnotations::parseSkip(IR::Annotation* annotation) {
+bool ParseAnnotations::parseSkip(IR::Annotation*) {
     return false;
 }
 

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -38,7 +38,7 @@ ParseAnnotations::HandlerMap ParseAnnotations::standardHandlers() {
             // @pkginfo has a key-value list argument.
             PARSE_KV_LIST(IR::Annotation::pkginfoAnnotation)
         };
-};
+}
 
 bool ParseAnnotations::parseSkip(IR::Annotation*) {
     return false;

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -89,7 +89,10 @@ bool ParseAnnotations::needsParsing(IR::Annotation* annotation) {
 
 void ParseAnnotations::postorder(IR::Annotation* annotation) {
     if (!handlers.count(annotation->name)) {
-        // Unknown annotation. Leave as is.
+        // Unknown annotation. Leave as is, but warn if desired.
+        if (warnUnknown) {
+            ::warning("Unknown annotation: %1%", annotation->name);
+        }
         return;
     }
 

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -87,7 +87,8 @@ void ParseAnnotations::postorder(IR::Annotation* annotation) {
 
     if (!handlers.count(annotation->name)) {
         // Unknown annotation. Leave as is, but warn if desired.
-        if (warnUnknown) {
+        if (warnUnknown && warned.count(annotation->name) != 0) {
+            warned.insert(annotation->name);
             ::warning("Unknown annotation: %1%", annotation->name);
         }
         return;

--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -25,9 +25,11 @@ limitations under the License.
  */
 namespace P4 {
 
+// Parses an annotation with no body.
 #define PARSE_NO_BODY(aname) \
     { aname, &P4::ParseAnnotations::parseNoBody }
 
+// Parses an annotation with a single-element body.
 #define PARSE(aname, tname)                                             \
     { aname, [](IR::Annotation* annotation) {                           \
             if (!P4::ParseAnnotations::needsParsing(annotation)) {      \
@@ -41,6 +43,39 @@ namespace P4 {
                 annotation->expr.push_back(parsed);                     \
             }                                                           \
         }                                                               \
+    }
+
+// Parses an annotation whose body is a pair.
+#define PARSE_PAIR(aname, tname)                                   \
+    { aname, [](IR::Annotation* annotation) {                      \
+            if (!P4::ParseAnnotations::needsParsing(annotation)) { \
+                return;                                            \
+            }                                                      \
+                                                                   \
+            const IR::Vector<IR::Expression>* parsed =             \
+                P4::P4ParserDriver::parse ## tname ## Pair(        \
+                    annotation->srcInfo,                           \
+                    annotation->body);                             \
+            if (parsed != nullptr) {                               \
+                annotation->expr.append(*parsed);                  \
+            }                                                      \
+        }                                                          \
+    }
+
+// Parses an annotation whose body is a triple.
+#define PARSE_TRIPLE(aname, tname)                                 \
+    { aname, [](IR::Annotation* annotation) {                      \
+            if (!P4::ParseAnnotations::needsParsing(annotation)) { \
+                return;                                            \
+            }                                                      \
+                                                                   \
+            const IR::Vector<IR::Expression>* parsed =             \
+                P4::P4ParserDriver::parse ## tname ## Triple(      \
+                    annotation->srcInfo, annotation->body);        \
+            if (parsed != nullptr) {                               \
+                annotation->expr.append(*parsed);                  \
+            }                                                      \
+        }                                                          \
     }
 
 #define PARSE_EXPRESSION_LIST(aname) \

--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -91,8 +91,8 @@ class ParseAnnotations : public Modifier {
     typedef std::unordered_map<cstring, Handler> HandlerMap;
 
     /// Produces a pass that rewrites the spec-defined annotations.
-    explicit ParseAnnotations(bool warn = false) : warnUnknown(warn),
-                                                   handlers(standardHandlers) {
+    explicit ParseAnnotations(bool warn = false)
+            : warnUnknown(warn), handlers(standardHandlers()) {
         setName("ParseAnnotations");
     }
 
@@ -100,24 +100,22 @@ class ParseAnnotations : public Modifier {
     ParseAnnotations(const char* targetName, bool includeStandard,
                      HandlerMap handlers,
                      bool warn = false)
-            : warnUnknown(warn), handlers(handlers) {
+            : warnUnknown(warn) {
         std::string buf = targetName;
         buf += "__ParseAnnotations";
         setName(buf.c_str());
 
         if (includeStandard) {
-            // Merge in standard handlers without clobbering custom handlers.
-            for (const auto& entry : standardHandlers) {
-                if (this->handlers.count(entry.first) == 0) {
-                    this->handlers[entry.first] = entry.second;
-                }
-            }
+            this->handlers = standardHandlers();
+            this->handlers.insert(handlers.begin(), handlers.end());
+        } else {
+            this->handlers = handlers;
         }
     }
 
     void postorder(IR::Annotation* annotation) final;
 
-    static const HandlerMap& standardHandlers;
+    static HandlerMap standardHandlers();
 
     static bool parseSkip(IR::Annotation* annotation);
     static bool parseEmpty(IR::Annotation* annotation);

--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -59,13 +59,15 @@ class ParseAnnotations : public Modifier {
     typedef std::unordered_map<cstring, Handler> HandlerMap;
 
     /// Produces a pass that rewrites the spec-defined annotations.
-    ParseAnnotations() : handlers(standardHandlers()) {
+    ParseAnnotations(bool warn = false) : warnUnknown(warn),
+                                          handlers(standardHandlers()) {
         setName("ParseAnnotations");
     }
 
     /// Produces a pass that rewrites a custom set of annotations.
-    ParseAnnotations(const char* targetName, HandlerMap handlers)
-            : handlers(handlers) {
+    ParseAnnotations(const char* targetName, HandlerMap handlers,
+                     bool warn = false)
+            : warnUnknown(warn), handlers(handlers) {
         std::string buf = targetName;
         buf += "__ParseAnnotations";
         setName(buf.c_str());
@@ -85,6 +87,9 @@ class ParseAnnotations : public Modifier {
     static bool needsParsing(IR::Annotation* annotation);
 
  private:
+    /// Whether to warn about unknown annotations.
+    const bool warnUnknown;
+
     HandlerMap handlers;
 };
 

--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -82,8 +82,8 @@ class ParseAnnotations : public Modifier {
     typedef std::unordered_map<cstring, Handler> HandlerMap;
 
     /// Produces a pass that rewrites the spec-defined annotations.
-    ParseAnnotations(bool warn = false) : warnUnknown(warn),
-                                          handlers(standardHandlers()) {
+    explicit ParseAnnotations(bool warn = false) : warnUnknown(warn),
+                                                   handlers(standardHandlers()) {
         setName("ParseAnnotations");
     }
 

--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -32,10 +32,6 @@ namespace P4 {
 // Parses an annotation with a single-element body.
 #define PARSE(aname, tname)                                             \
     { aname, [](IR::Annotation* annotation) {                           \
-            if (!P4::ParseAnnotations::needsParsing(annotation)) {      \
-                return;                                                 \
-            }                                                           \
-                                                                        \
             const IR::tname* parsed =                                   \
                 P4::P4ParserDriver::parse ## tname(annotation->srcInfo, \
                                                    annotation->body);   \
@@ -48,10 +44,6 @@ namespace P4 {
 // Parses an annotation whose body is a pair.
 #define PARSE_PAIR(aname, tname)                                   \
     { aname, [](IR::Annotation* annotation) {                      \
-            if (!P4::ParseAnnotations::needsParsing(annotation)) { \
-                return;                                            \
-            }                                                      \
-                                                                   \
             const IR::Vector<IR::Expression>* parsed =             \
                 P4::P4ParserDriver::parse ## tname ## Pair(        \
                     annotation->srcInfo,                           \
@@ -65,10 +57,6 @@ namespace P4 {
 // Parses an annotation whose body is a triple.
 #define PARSE_TRIPLE(aname, tname)                                 \
     { aname, [](IR::Annotation* annotation) {                      \
-            if (!P4::ParseAnnotations::needsParsing(annotation)) { \
-                return;                                            \
-            }                                                      \
-                                                                   \
             const IR::Vector<IR::Expression>* parsed =             \
                 P4::P4ParserDriver::parse ## tname ## Triple(      \
                     annotation->srcInfo, annotation->body);        \
@@ -115,11 +103,6 @@ class ParseAnnotations : public Modifier {
     static void parseNoBody(IR::Annotation* annotation);
     static void parseExpressionList(IR::Annotation* annotation);
     static void parseKvList(IR::Annotation* annotation);
-
-    /// Checks if the annotation needs parsing. An annotation needs parsing if
-    /// it was derived from P4₁₆. A BUG is thrown if the annotation is derived
-    /// from P4₁₆ and is already parsed.
-    static bool needsParsing(IR::Annotation* annotation);
 
  private:
     /// Whether to warn about unknown annotations.

--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -118,6 +118,10 @@ class ParseAnnotations : public Modifier {
     /// Whether to warn about unknown annotations.
     const bool warnUnknown;
 
+    /// The set of unknown annotations for which warnings have already been
+    /// made.
+    std::set<cstring> warned;
+
     HandlerMap handlers;
 };
 

--- a/frontends/parsers/p4/p4AnnotationLexer.cpp
+++ b/frontends/parsers/p4/p4AnnotationLexer.cpp
@@ -18,11 +18,11 @@ P4AnnotationLexer::Token P4AnnotationLexer::yylex(P4::P4ParserDriver&) {
     if (needStart) {
         needStart = false;
         return P4Parser::symbol_type((P4Parser::token_type) type,
-                                     Util::SourceInfo(body.srcInfo));
+                                     Util::SourceInfo(srcInfo));
     }
 
     if (it == body.end()) {
-        return P4Parser::make_END(Util::SourceInfo(body.srcInfo));
+        return P4Parser::make_END_ANNOTATION(Util::SourceInfo(srcInfo));
     }
 
     auto cur = *(it++);

--- a/frontends/parsers/p4/p4AnnotationLexer.hpp
+++ b/frontends/parsers/p4/p4AnnotationLexer.hpp
@@ -20,10 +20,12 @@ class P4AnnotationLexer : public AbstractP4Lexer {
 
         // Pairs
         EXPRESSION_PAIR = P4Parser::token_type::TOK_START_EXPRESSION_PAIR,
+        INTEGER_PAIR = P4Parser::token_type::TOK_START_INTEGER_PAIR,
         STRING_LITERAL_PAIR = P4Parser::token_type::TOK_START_STRING_LITERAL_PAIR,
 
         // Triples
         EXPRESSION_TRIPLE = P4Parser::token_type::TOK_START_EXPRESSION_TRIPLE,
+        INTEGER_TRIPLE = P4Parser::token_type::TOK_START_INTEGER_TRIPLE,
         STRING_LITERAL_TRIPLE = P4Parser::token_type::TOK_START_STRING_LITERAL_TRIPLE,
     };
 

--- a/frontends/parsers/p4/p4AnnotationLexer.hpp
+++ b/frontends/parsers/p4/p4AnnotationLexer.hpp
@@ -9,11 +9,22 @@ namespace P4 {
 class P4AnnotationLexer : public AbstractP4Lexer {
  public:
     enum Type {
+        // Lists
         EXPRESSION_LIST = P4Parser::token_type::TOK_START_EXPRESSION_LIST,
         KV_LIST = P4Parser::token_type::TOK_START_KV_LIST,
+
+        // Singletons
         EXPRESSION = P4Parser::token_type::TOK_START_EXPRESSION,
         INTEGER = P4Parser::token_type::TOK_START_INTEGER,
         STRING_LITERAL = P4Parser::token_type::TOK_START_STRING_LITERAL,
+
+        // Pairs
+        EXPRESSION_PAIR = P4Parser::token_type::TOK_START_EXPRESSION_PAIR,
+        STRING_LITERAL_PAIR = P4Parser::token_type::TOK_START_STRING_LITERAL_PAIR,
+
+        // Triples
+        EXPRESSION_TRIPLE = P4Parser::token_type::TOK_START_EXPRESSION_TRIPLE,
+        STRING_LITERAL_TRIPLE = P4Parser::token_type::TOK_START_STRING_LITERAL_TRIPLE,
     };
 
  private:

--- a/frontends/parsers/p4/p4AnnotationLexer.hpp
+++ b/frontends/parsers/p4/p4AnnotationLexer.hpp
@@ -21,10 +21,13 @@ class P4AnnotationLexer : public AbstractP4Lexer {
     const IR::Vector<IR::AnnotationToken>& body;
     bool needStart;
     IR::Vector<IR::AnnotationToken>::const_iterator it;
+    const Util::SourceInfo& srcInfo;
 
  public:
-    P4AnnotationLexer(Type type, const IR::Vector<IR::AnnotationToken>& body)
-        : type(type), body(body), needStart(true), it(this->body.begin()) { }
+    P4AnnotationLexer(Type type, const Util::SourceInfo& srcInfo,
+                      const IR::Vector<IR::AnnotationToken>& body)
+        : srcInfo(srcInfo), type(type), body(body), needStart(true),
+          it(this->body.begin()) { }
 
     Token yylex(P4::P4ParserDriver& driver);
 };

--- a/frontends/parsers/p4/p4AnnotationLexer.hpp
+++ b/frontends/parsers/p4/p4AnnotationLexer.hpp
@@ -26,8 +26,8 @@ class P4AnnotationLexer : public AbstractP4Lexer {
  public:
     P4AnnotationLexer(Type type, const Util::SourceInfo& srcInfo,
                       const IR::Vector<IR::AnnotationToken>& body)
-        : srcInfo(srcInfo), type(type), body(body), needStart(true),
-          it(this->body.begin()) { }
+        : type(type), body(body), needStart(true), it(this->body.begin()),
+          srcInfo(srcInfo) { }
 
     Token yylex(P4::P4ParserDriver& driver);
 };

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -131,8 +131,11 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %printer { yyoutput << $$; } <*>;
 
 %define api.token.prefix {TOK_}
-%token             START_PROGRAM START_EXPRESSION_LIST START_KV_LIST
+%token             START_PROGRAM
+                   START_EXPRESSION_LIST START_KV_LIST
                    START_EXPRESSION START_INTEGER START_STRING_LITERAL
+                   START_EXPRESSION_PAIR START_STRING_LITERAL_PAIR
+                   START_EXPRESSION_TRIPLE START_STRING_LITERAL_TRIPLE
 %token             END END_ANNOTATION
 
 
@@ -306,11 +309,41 @@ start
     ;
 
 fragment
+      // Lists
     : START_EXPRESSION_LIST expressionList { $$ = $2; }
     | START_KV_LIST kvList                 { $$ = $2; }
+
+      // Singletons
     | START_EXPRESSION expression          { $$ = $2; }
     | START_INTEGER INTEGER                { $$ = parseConstant(@2, $2, 0); }
     | START_STRING_LITERAL STRING_LITERAL  { $$ = new IR::StringLiteral(@2, $2); }
+
+      // Pairs
+    | START_EXPRESSION_PAIR expression "," expression
+        { auto* result = new IR::Vector<IR::Expression>();
+          result->push_back($2);
+          result->push_back($4);
+          $$ = result; }
+    | START_STRING_LITERAL_PAIR STRING_LITERAL "," STRING_LITERAL
+        { auto* result = new IR::Vector<IR::Expression>();
+          result->push_back(new IR::StringLiteral(@2, $2));
+          result->push_back(new IR::StringLiteral(@4, $4));
+          $$ = result; }
+
+      // Triples
+    | START_EXPRESSION_TRIPLE expression "," expression "," expression
+        { auto* result = new IR::Vector<IR::Expression>();
+          result->push_back($2);
+          result->push_back($4);
+          result->push_back($6);
+          $$ = result; }
+    | START_STRING_LITERAL_TRIPLE STRING_LITERAL "," STRING_LITERAL ","
+      STRING_LITERAL
+        { auto* result = new IR::Vector<IR::Expression>();
+          result->push_back(new IR::StringLiteral(@2, $2));
+          result->push_back(new IR::StringLiteral(@4, $4));
+          result->push_back(new IR::StringLiteral(@6, $6));
+          $$ = result; }
     ;
 
 program : input END { YYACCEPT; };
@@ -396,7 +429,6 @@ annotationBody
 
 annotationToken
     : UNEXPECTED_TOKEN { $$ = $1; }
-    | END_PRAGMA       { $$ = $1; }
     | ABSTRACT         { $$ = $1; }
     | ACTION           { $$ = $1; }
     | ACTIONS          { $$ = $1; }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -134,8 +134,10 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %token             START_PROGRAM
                    START_EXPRESSION_LIST START_KV_LIST
                    START_EXPRESSION START_INTEGER START_STRING_LITERAL
-                   START_EXPRESSION_PAIR START_STRING_LITERAL_PAIR
-                   START_EXPRESSION_TRIPLE START_STRING_LITERAL_TRIPLE
+                   START_EXPRESSION_PAIR START_INTEGER_PAIR
+                   START_STRING_LITERAL_PAIR
+                   START_EXPRESSION_TRIPLE START_INTEGER_TRIPLE
+                   START_STRING_LITERAL_TRIPLE
 %token             END END_ANNOTATION
 
 
@@ -324,6 +326,11 @@ fragment
           result->push_back($2);
           result->push_back($4);
           $$ = result; }
+    | START_INTEGER_PAIR INTEGER "," INTEGER
+        { auto* result = new IR::Vector<IR::Expression>();
+          result->push_back(parseConstant(@2, $2, 0));
+          result->push_back(parseConstant(@4, $4, 0));
+          $$ = result; }
     | START_STRING_LITERAL_PAIR STRING_LITERAL "," STRING_LITERAL
         { auto* result = new IR::Vector<IR::Expression>();
           result->push_back(new IR::StringLiteral(@2, $2));
@@ -336,6 +343,12 @@ fragment
           result->push_back($2);
           result->push_back($4);
           result->push_back($6);
+          $$ = result; }
+    | START_INTEGER_TRIPLE INTEGER "," INTEGER "," INTEGER
+        { auto* result = new IR::Vector<IR::Expression>();
+          result->push_back(parseConstant(@2, $2, 0));
+          result->push_back(parseConstant(@4, $4, 0));
+          result->push_back(parseConstant(@6, $6, 0));
           $$ = result; }
     | START_STRING_LITERAL_TRIPLE STRING_LITERAL "," STRING_LITERAL ","
       STRING_LITERAL

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -133,7 +133,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %define api.token.prefix {TOK_}
 %token             START_PROGRAM START_EXPRESSION_LIST START_KV_LIST
                    START_EXPRESSION START_INTEGER START_STRING_LITERAL
-%token             END
+%token             END END_ANNOTATION
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -301,7 +301,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 // Simulate multiple start symbols to allow the parser to be reused for
 // annotation bodies.
 start
-    : fragment END { driver.nodes->push_back($1->getNode()); YYACCEPT; }
+    : fragment END_ANNOTATION { driver.nodes->push_back($1->getNode()); YYACCEPT; }
     | START_PROGRAM program
     ;
 

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -406,8 +406,13 @@ annotations
     ;
 
 annotation
-    : "@" name                        { $$ = new IR::Annotation(@1, *$2, {}); }
-    | "@" name "(" annotationBody ")" { $$ = new IR::Annotation(@1, *$2, *$4); }
+    : "@" name
+        { // Initialize with an empty sequence of annotation tokens so that the
+          // annotation node is marked as unparsed.
+          IR::Vector<IR::AnnotationToken> body;
+          $$ = new IR::Annotation(@1, *$2, body); }
+    | "@" name "(" annotationBody ")"
+        { $$ = new IR::Annotation(@1, *$2, *$4); }
     // Experimental: backwards compatibility with P4-14 pragmas (which
     // themselves are experimental!)
     | PRAGMA name annotationBody END_PRAGMA

--- a/frontends/parsers/parserDriver.cpp
+++ b/frontends/parsers/parserDriver.cpp
@@ -217,6 +217,38 @@ P4ParserDriver::parseStringLiteral(const Util::SourceInfo& srcInfo,
             P4AnnotationLexer::STRING_LITERAL, srcInfo, body);
 }
 
+/* static */ const IR::Vector<IR::Expression>*
+P4ParserDriver::parseExpressionPair(const Util::SourceInfo& srcInfo,
+                                    const IR::Vector<IR::AnnotationToken>& body) {
+    P4ParserDriver driver;
+    return driver.parse<IR::Vector<IR::Expression>>(
+            P4AnnotationLexer::EXPRESSION_PAIR, srcInfo, body);
+}
+
+/* static */ const IR::Vector<IR::Expression>*
+P4ParserDriver::parseStringLiteralPair(const Util::SourceInfo& srcInfo,
+                                       const IR::Vector<IR::AnnotationToken>& body) {
+    P4ParserDriver driver;
+    return driver.parse<IR::Vector<IR::Expression>>(
+            P4AnnotationLexer::STRING_LITERAL_PAIR, srcInfo, body);
+}
+
+/* static */ const IR::Vector<IR::Expression>*
+P4ParserDriver::parseExpressionTriple(const Util::SourceInfo& srcInfo,
+                                     const IR::Vector<IR::AnnotationToken>& body) {
+    P4ParserDriver driver;
+    return driver.parse<IR::Vector<IR::Expression>>(
+            P4AnnotationLexer::EXPRESSION_TRIPLE, srcInfo, body);
+}
+
+/* static */ const IR::Vector<IR::Expression>*
+P4ParserDriver::parseStringLiteralTriple(const Util::SourceInfo& srcInfo,
+                                         const IR::Vector<IR::AnnotationToken>& body) {
+    P4ParserDriver driver;
+    return driver.parse<IR::Vector<IR::Expression>>(
+            P4AnnotationLexer::STRING_LITERAL_TRIPLE, srcInfo, body);
+}
+
 /* static */ void P4ParserDriver::checkShift(const Util::SourceInfo& l,
                                              const Util::SourceInfo& r) {
     if (!l.isValid() || !r.isValid())

--- a/frontends/parsers/parserDriver.cpp
+++ b/frontends/parsers/parserDriver.cpp
@@ -226,6 +226,14 @@ P4ParserDriver::parseExpressionPair(const Util::SourceInfo& srcInfo,
 }
 
 /* static */ const IR::Vector<IR::Expression>*
+P4ParserDriver::parseConstantPair(const Util::SourceInfo& srcInfo,
+                                  const IR::Vector<IR::AnnotationToken>& body) {
+    P4ParserDriver driver;
+    return driver.parse<IR::Vector<IR::Expression>>(
+            P4AnnotationLexer::INTEGER_PAIR, srcInfo, body);
+}
+
+/* static */ const IR::Vector<IR::Expression>*
 P4ParserDriver::parseStringLiteralPair(const Util::SourceInfo& srcInfo,
                                        const IR::Vector<IR::AnnotationToken>& body) {
     P4ParserDriver driver;
@@ -239,6 +247,14 @@ P4ParserDriver::parseExpressionTriple(const Util::SourceInfo& srcInfo,
     P4ParserDriver driver;
     return driver.parse<IR::Vector<IR::Expression>>(
             P4AnnotationLexer::EXPRESSION_TRIPLE, srcInfo, body);
+}
+
+/* static */ const IR::Vector<IR::Expression>*
+P4ParserDriver::parseConstantTriple(const Util::SourceInfo& srcInfo,
+                                    const IR::Vector<IR::AnnotationToken>& body) {
+    P4ParserDriver driver;
+    return driver.parse<IR::Vector<IR::Expression>>(
+            P4AnnotationLexer::INTEGER_TRIPLE, srcInfo, body);
 }
 
 /* static */ const IR::Vector<IR::Expression>*

--- a/frontends/parsers/parserDriver.cpp
+++ b/frontends/parsers/parserDriver.cpp
@@ -169,7 +169,7 @@ P4ParserDriver::parse(P4AnnotationLexer::Type type,
                       const IR::Vector<IR::AnnotationToken>& body) {
     LOG3("Parsing P4-16 annotation " << srcInfo);
 
-    P4AnnotationLexer lexer(type, body);
+    P4AnnotationLexer lexer(type, srcInfo, body);
     if (!parse(lexer, srcInfo.getSourceFile())) {
         return nullptr;
     }

--- a/frontends/parsers/parserDriver.h
+++ b/frontends/parsers/parserDriver.h
@@ -149,12 +149,20 @@ class P4ParserDriver final : public AbstractParserDriver {
         const Util::SourceInfo& srcInfo,
         const IR::Vector<IR::AnnotationToken>& body);
 
+    static const IR::Vector<IR::Expression>* parseConstantPair(
+        const Util::SourceInfo& srcInfo,
+        const IR::Vector<IR::AnnotationToken>& body);
+
     static const IR::Vector<IR::Expression>* parseStringLiteralPair(
         const Util::SourceInfo& srcInfo,
         const IR::Vector<IR::AnnotationToken>& body);
 
     // Triples ///////////////////////////////////////////////////////////////
     static const IR::Vector<IR::Expression>* parseExpressionTriple(
+        const Util::SourceInfo& srcInfo,
+        const IR::Vector<IR::AnnotationToken>& body);
+
+    static const IR::Vector<IR::Expression>* parseConstantTriple(
         const Util::SourceInfo& srcInfo,
         const IR::Vector<IR::AnnotationToken>& body);
 

--- a/frontends/parsers/parserDriver.h
+++ b/frontends/parsers/parserDriver.h
@@ -122,6 +122,7 @@ class P4ParserDriver final : public AbstractParserDriver {
      * @param body  The unparsed annotation body.
      * @returns an AST node if parsing was successful, or null otherwise.
      */
+    // Lists /////////////////////////////////////////////////////////////////
     static const IR::Vector<IR::Expression>* parseExpressionList(
         const Util::SourceInfo& srcInfo,
         const IR::Vector<IR::AnnotationToken>& body);
@@ -130,6 +131,7 @@ class P4ParserDriver final : public AbstractParserDriver {
         const Util::SourceInfo& srcInfo,
         const IR::Vector<IR::AnnotationToken>& body);
 
+    // Singletons ////////////////////////////////////////////////////////////
     static const IR::Expression* parseExpression(
         const Util::SourceInfo& srcInfo,
         const IR::Vector<IR::AnnotationToken>& body);
@@ -139,6 +141,24 @@ class P4ParserDriver final : public AbstractParserDriver {
         const IR::Vector<IR::AnnotationToken>& body);
 
     static const IR::StringLiteral* parseStringLiteral(
+        const Util::SourceInfo& srcInfo,
+        const IR::Vector<IR::AnnotationToken>& body);
+
+    // Pairs /////////////////////////////////////////////////////////////////
+    static const IR::Vector<IR::Expression>* parseExpressionPair(
+        const Util::SourceInfo& srcInfo,
+        const IR::Vector<IR::AnnotationToken>& body);
+
+    static const IR::Vector<IR::Expression>* parseStringLiteralPair(
+        const Util::SourceInfo& srcInfo,
+        const IR::Vector<IR::AnnotationToken>& body);
+
+    // Triples ///////////////////////////////////////////////////////////////
+    static const IR::Vector<IR::Expression>* parseExpressionTriple(
+        const Util::SourceInfo& srcInfo,
+        const IR::Vector<IR::AnnotationToken>& body);
+
+    static const IR::Vector<IR::Expression>* parseStringLiteralTriple(
         const Util::SourceInfo& srcInfo,
         const IR::Vector<IR::AnnotationToken>& body);
 

--- a/ir/base.def
+++ b/ir/base.def
@@ -231,13 +231,13 @@ class Annotation {
 
     /// The remaining constructors are for compiler-generated annotations.
     Annotation(Util::SourceInfo si, ID n, const std::initializer_list<const Expression *> &a)
-    : Node(si), name(n), expr(a), needsParsing(false) {}
+    : Node(si), name(n), needsParsing(false), expr(a) {}
     Annotation(Util::SourceInfo si, ID n, const IR::Vector<Expression> &a)
-    : Node(si), name(n), expr(a), needsParsing(false) {}
+    : Node(si), name(n), needsParsing(false), expr(a) {}
     Annotation(Util::SourceInfo si, ID n, const IndexedVector<NamedExpression> &kv)
-    : Node(si), name(n), kv(kv), needsParsing(false) {}
-    Annotation(ID n, const std::initializer_list<const Expression *> &a) : name(n), expr(a), needsParsing(false) {}
-    Annotation(ID n, const IR::Vector<Expression> &a) : name(n), expr(a), needsParsing(false) {}
+    : Node(si), name(n), needsParsing(false), kv(kv) {}
+    Annotation(ID n, const std::initializer_list<const Expression *> &a) : name(n), needsParsing(false), expr(a) {}
+    Annotation(ID n, const IR::Vector<Expression> &a) : name(n), needsParsing(false), expr(a) {}
 
     Annotation(ID n, intmax_t v) : name(n) {
         expr.push_back(new Constant(v)); }

--- a/ir/base.def
+++ b/ir/base.def
@@ -206,26 +206,41 @@ class AnnotationToken {
 /// Most P4 entities can be optionally annotated
 class Annotation {
     ID name;
+
     /// An unparsed annotation body
     inline Vector<AnnotationToken> body;
+
+    /// Whether the annotation body needs to be parsed.
+    /// Invariant: if this is true, then expr and kv must both be empty. If the
+    /// annotation is compiler-generated (e.g., derived from a P4₁₄ pragma),
+    /// then needsParsing will be false and the body will be empty, but expr or
+    /// kv may be populated.
+    bool needsParsing;
+
     /// Annotations that are simple expressions
     inline Vector<Expression> expr;
+
     /// Annotations described as key-value pairs
     inline IndexedVector<NamedExpression> kv;
+
     Annotation { if (!srcInfo) srcInfo = name.srcInfo; }
+
+    /// For annotations parsed from P4₁₆ source.
     Annotation(Util::SourceInfo si, ID n, const Vector<AnnotationToken> &a)
-    : Node(si), name(n), body(a) {}
+    : Node(si), name(n), body(a), needsParsing(true) {}
+
+    /// The remaining constructors are for compiler-generated annotations.
     Annotation(Util::SourceInfo si, ID n, const std::initializer_list<const Expression *> &a)
-    : Node(si), name(n), expr(a) {}
+    : Node(si), name(n), expr(a), needsParsing(false) {}
     Annotation(Util::SourceInfo si, ID n, const IR::Vector<Expression> &a)
-    : Node(si), name(n), expr(a) {}
+    : Node(si), name(n), expr(a), needsParsing(false) {}
     Annotation(Util::SourceInfo si, ID n, const IndexedVector<NamedExpression> &kv)
-    : Node(si), name(n), kv(kv) {}
-    Annotation(ID n, const std::initializer_list<const Expression *> &a) : name(n), expr(a) {}
-    Annotation(ID n, const IR::Vector<Expression> &a) : name(n), expr(a) {}
+    : Node(si), name(n), kv(kv), needsParsing(false) {}
+    Annotation(ID n, const std::initializer_list<const Expression *> &a) : name(n), expr(a), needsParsing(false) {}
+    Annotation(ID n, const IR::Vector<Expression> &a) : name(n), expr(a), needsParsing(false) {}
+
     Annotation(ID n, intmax_t v) : name(n) {
         expr.push_back(new Constant(v)); }
-    /// Predefined annotations used by the compiler
     static const cstring nameAnnotation;  /// Indicates the control-plane name.
     static const cstring tableOnlyAnnotation;  /// Action cannot be a default_action.
     static const cstring defaultOnlyAnnotation;  /// action can only be a default_action.
@@ -236,7 +251,13 @@ class Annotation {
     static const cstring pkginfoAnnotation;  /// Package documentation annotation.
     static const cstring deprecatedAnnotation;  /// Deprecation annotation.
     toString{ return cstring("@") + name; }
-    validate{ BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name"); }
+    validate{
+        BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name");
+        BUG_CHECK(!(needsParsing && !expr.empty()),
+            "unparsed annotation body with non-empty expr");
+        BUG_CHECK(!(needsParsing && !kv.empty()),
+            "unparsed annotation body with non-empty kv");
+    }
 
     /// Useful helper: extracts name value from a name annotation
     static cstring getName(const Annotation* annotation);

--- a/ir/base.def
+++ b/ir/base.def
@@ -225,11 +225,11 @@ class Annotation {
 
     Annotation { if (!srcInfo) srcInfo = name.srcInfo; }
 
-    /// For annotations parsed from P4₁₆ source.
+    /// For annotations parsed from P4-16 source.
     Annotation(Util::SourceInfo si, ID n, const Vector<AnnotationToken> &a)
     : Node(si), name(n), body(a), needsParsing(true) {}
 
-    /// The remaining constructors are for compiler-generated annotations.
+    // The remaining constructors are for compiler-generated annotations.
     Annotation(Util::SourceInfo si, ID n, const std::initializer_list<const Expression *> &a)
     : Node(si), name(n), needsParsing(false), expr(a) {}
     Annotation(Util::SourceInfo si, ID n, const IR::Vector<Expression> &a)

--- a/test/gtest/helpers.cpp
+++ b/test/gtest/helpers.cpp
@@ -127,17 +127,12 @@ P4CTestEnvironment::P4CTestEnvironment() {
 
 namespace Test {
 
-class ParseAnnotations : public P4::ParseAnnotations {
- public:
-    ParseAnnotations() : P4::ParseAnnotations("FrontendTest", false, {
-                PARSE("my_anno", StringLiteral)
-            }) { }
-};
-
 /* static */ boost::optional<FrontendTestCase>
 FrontendTestCase::create(const std::string& source,
                          CompilerOptions::FrontendVersion langVersion
-                            /* = CompilerOptions::FrontendVersion::P4_16 */) {
+                            /* = CompilerOptions::FrontendVersion::P4_16 */,
+                         P4::ParseAnnotations parseAnnotations
+                            /* = P4::ParseAnnotations() */) {
     auto* program = P4::parseP4String(source, langVersion);
     if (program == nullptr) {
         std::cerr << "Couldn't parse test case source" << std::endl;
@@ -159,7 +154,7 @@ FrontendTestCase::create(const std::string& source,
 
     CompilerOptions options;
     options.langVersion = langVersion;
-    program = P4::FrontEnd().run(options, program, true);
+    program = P4::FrontEnd(parseAnnotations).run(options, program, true);
     if (program == nullptr) {
         std::cerr << "Frontend failed" << std::endl;
         return boost::none;
@@ -170,11 +165,6 @@ FrontendTestCase::create(const std::string& source,
         return boost::none;
     }
 
-    program = program->apply(ParseAnnotations());
-    if (program == nullptr) {
-        std::cerr << "Back-end annotation parsing failed" << std::endl;
-        return boost::none;
-    }
     if (::errorCount() > 0) {
         std::cerr << "Encountered " << ::errorCount()
                   << " errors while parsing back-end annotations" << std::endl;

--- a/test/gtest/helpers.cpp
+++ b/test/gtest/helpers.cpp
@@ -129,7 +129,7 @@ namespace Test {
 
 class ParseAnnotations : public P4::ParseAnnotations {
  public:
-    ParseAnnotations() : P4::ParseAnnotations("FrontendTest", {
+    ParseAnnotations() : P4::ParseAnnotations("FrontendTest", false, {
                 PARSE("my_anno", StringLiteral)
             }) { }
 };

--- a/test/gtest/helpers.h
+++ b/test/gtest/helpers.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <string>
 
 #include "frontends/common/options.h"
+#include "frontends/p4/parseAnnotations.h"
 #include "gtest/gtest.h"
 
 namespace IR {
@@ -105,11 +106,19 @@ class P4CTest : public ::testing::Test {
 };
 
 struct FrontendTestCase {
+    static const CompilerOptions::FrontendVersion defaultVersion =
+        CompilerOptions::FrontendVersion::P4_16;
+
     /// Create a test case that only requires the frontend to run.
     static boost::optional<FrontendTestCase>
     create(const std::string& source,
-           CompilerOptions::FrontendVersion langVersion
-              = CompilerOptions::FrontendVersion::P4_16);
+           CompilerOptions::FrontendVersion langVersion = defaultVersion,
+           P4::ParseAnnotations parseAnnotations = P4::ParseAnnotations());
+
+    static boost::optional<FrontendTestCase>
+    create(const std::string& source, P4::ParseAnnotations parseAnnotations) {
+        return create(source, defaultVersion, parseAnnotations);
+    }
 
     /// The output of the frontend.
     const IR::P4Program* program;

--- a/testdata/p4_16_errors/annotation.p4
+++ b/testdata/p4_16_errors/annotation.p4
@@ -1,0 +1,2 @@
+@pkginfo
+const bit<32> x = 0;

--- a/testdata/p4_16_errors_outputs/annotation.p4-stderr
+++ b/testdata/p4_16_errors_outputs/annotation.p4-stderr
@@ -1,0 +1,3 @@
+../testdata/p4_16_errors/annotation.p4(1):syntax error, unexpected END_ANNOTATION
+@pkginfo
+^

--- a/testdata/p4_16_errors_outputs/annotation.p4-stderr
+++ b/testdata/p4_16_errors_outputs/annotation.p4-stderr
@@ -1,3 +1,3 @@
-../testdata/p4_16_errors/annotation.p4(1):syntax error, unexpected END_ANNOTATION
+annotation.p4(1):syntax error, unexpected END_ANNOTATION
 @pkginfo
 ^


### PR DESCRIPTION
* Improved the reporting of annotation-parsing errors:
  * We now report source-line information when the annotation parser runs off the end of the annotation.
  * Introduced a new `END_ANNOTATION` symbol for a better error message when the parser runs off the end of the annotation.
  * Added a negative test case for annotation parsing.

* Fixed & improved handling of unparsed annotations, and added the ability to warn about unknown annotations.
  * We now explicitly track whether an annotation needs parsing.

* Added a few more productions for parsing annotations with pairs or triples of expressions, string literals, and integer constants.
* Added ability to skip parsing of annotations. This is useful for avoiding warnings about annotations that are explicitly ignored.
* Renamed `PARSE_NO_BODY` to `PARSE_EMPTY`.
* Fixed a bug in the `annotationToken` production.