### PR TITLE
Move #include directives to fix broken dependencies

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -35,6 +35,14 @@ limitations under the License.
 
 // Declare dependencies.
 %code requires {
+#include <cassert>   // NOLINT(build/include_order)
+#include <iostream>  // NOLINT(build/include_order)
+
+#include "frontends/common/constantParsing.h"
+#include "ir/ir.h"
+#include "lib/cstring.h"
+#include "lib/source_file.h"
+
 namespace P4 {
 class AbstractP4Lexer;
 class P4ParserDriver;
@@ -72,10 +80,6 @@ typedef const IR::Type ConstType;
 
 #define YY_NULLPTR nullptr
 
-#include "frontends/common/constantParsing.h"
-#include "lib/cstring.h"
-#include "lib/source_file.h"
-
 namespace P4 {
 class Token {
  public:
@@ -110,13 +114,9 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %define api.location.type {Util::SourceInfo}
 
 %{ /* -*-C++-*- */
-#include <cassert>   // NOLINT(build/include_order)
-#include <iostream>  // NOLINT(build/include_order)
-
 #include "frontends/parsers/parserDriver.h"
 #include "frontends/parsers/p4/p4lexer.hpp"
 #include "frontends/parsers/p4/p4parser.hpp"
-#include "ir/ir.h"
 
 #define YYLLOC_DEFAULT(Cur, Rhs, N)                                             \
     ((Cur) = (N) ? YYRHSLOC(Rhs, 1) + YYRHSLOC(Rhs, N)                          \


### PR DESCRIPTION
This fixes the broken build when ENABLE_UNIFIED_COMPILATION=OFF
The error is the following
```
In file included from ../frontends/parsers/p4/p4AnnotationLexer.cpp:1:
In file included from ../frontends/parsers/p4/p4AnnotationLexer.hpp:4:
In file included from ../frontends/parsers/p4/abstractP4Lexer.hpp:4:
parsers/p4/p4parser.ypp:57:8: error: use of undeclared identifier 'std'
inline std::ostream& operator<<(std::ostream& out, const P4::OptionalConst& oc) {
```