### PR TITLE
Fix possible infinite recursion in cast operator

### DIFF
--- a/ir/json_parser.h
+++ b/ir/json_parser.h
@@ -43,7 +43,7 @@ class JsonString : public JsonData, public std::string {
     JsonString(JsonString&&) = default;
     JsonString &operator=(const JsonString&) & = default;
     JsonString &operator=(JsonString&&) & = default;
-    operator cstring() { return cstring(*this); }
+    operator cstring() { return cstring(this->c_str()); }
 };
 
 class JsonVector : public JsonData, public std::vector<JsonData*> {


### PR DESCRIPTION
Some compiler issue the following warning
```
p4c/ir/json_parser.h:46:24: warning: all paths through this function will call itself [-Winfinite-recursion]
    operator cstring() { return cstring(*this); }
```
This is because they interpret the expression in return statement
as cast and not as an invocation of cstring constructor.
To disambiguate, use the C string pointer embedded in the object
to invoke a different cstring constructor.