### PR TITLE
Improved translation of P4-14 header stacks with varbits (fixes #576)

### DIFF
--- a/backends/bmv2/README.md
+++ b/backends/bmv2/README.md
@@ -24,25 +24,6 @@ Here are some unsupported features we are aware of. We will update this list as
 more features get supported in the bmv2 compiler backend and as we discover more
 issues.
 
-- nested structs in structs used as block constructor parameters
-```
-struct s0_t {
-  bit<8> f1;
-  bit<8> f2;
-};
-
-struct s1_t {
-  s0_t s01;
-  s0_t s02;
-};
-
-parser parse(packet_in pkt, out parsed_packet_t hdr,
-             inout s1_t my_metadata,
-             inout standard_metadata_t standard_metadata) {
-  // ...
-}
-```
-
 - explicit transition to reject in parse state
 
 - compound action parameters (can only be `bit<>` or `int<>`)
@@ -62,7 +43,5 @@ controlc c() {
 ```
 
 - user-defined extern types / methods which are not defined in `v1model.p4`
-
-- stacks of headers containing varbit fields
 
 - stacks of header unions

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -837,7 +837,7 @@ class FixExtracts final : public Transform {
     struct HeaderSplit {
         /// Fixed-size part of a header type (computed for each extract).
         const IR::Type_Header* fixedHeaderType;
-        /// Expression computing the length of the fixed-size header.
+        /// Expression computing the length of the variable-size header.
         const IR::Expression* headerLength;
     };
 
@@ -850,8 +850,9 @@ class FixExtracts final : public Transform {
     /// Maps each original header type name to the fixed part of it.
     std::map<cstring, HeaderSplit*> fixedPart;
 
-    /// If a header type contains a varbit field a, then create a new
+    /// If a header type contains a varbit field then create a new
     /// header type containing only the fields prior to the varbit.
+    /// Returns nullptr otherwise.
     HeaderSplit* splitHeaderType(const IR::Type_Header* type) {
         auto fixed = ::get(fixedPart, type->name.name);
         if (fixed != nullptr)
@@ -892,10 +893,11 @@ class FixExtracts final : public Transform {
     }
 
     /**
-       This pass rewrites expressions that apprear in a @length annotation:
-       PathExpressions that refer to enclosing struct fields are rewritten to
-       refer to the proper fields of a variable `var`.  In the example above, `len`
-       is translated to `h_0.len`.
+       This pass rewrites expressions that appear in a @length
+       annotation: PathExpressions that refer to enclosing struct
+       fields are rewritten to refer to the proper fields of a
+       variable `var`.  In the example above, the variable is `h_0`
+       and `len` is translated to `h_0.len`.
     */
     class RewriteLength final : public Transform {
         const IR::Type_Header* header;

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -878,7 +878,6 @@ class FixExtracts final : public Transform {
             if (fixedHeaderType == nullptr)
                 // We only keep the fields prior to the varbit field
                 fields.push_back(f);
-
         }
         if (fixedHeaderType != nullptr) {
             LOG3("Extracted fixed-size header type from " << type << " into " << fixedHeaderType);

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -799,6 +799,7 @@ class Rewriter : public Transform {
 /**
 This pass uses the @length annotation set by the v1 front-end on
 varbit fields and converts extracts for headers with varbit fields.
+This only supports headers with a single varbit field.
 (The @length annotation is inserted as a conversion from the length
 header property.)  For example:
 
@@ -819,93 +820,99 @@ header H {
 }
 ...
 H h;
+
+// Fixed-length size of H
 header H_0 {
    bit<8> len;
 }
-header H_1 {
-   varbit<64> data;
-}
 
 H_0 h_0;
-H_1 h_1;
-pkt.extract(h_0);
-pkt.extract(h_1, h_0.len);
-h.setValid();
-h.len = h_0.len;
-h.data = h_1.data;
+h_0 = pkt.lookahead<H_0>();
+pkt.extract(h, h_0.len);
 
 */
 class FixExtracts final : public Transform {
     ProgramStructure* structure;
 
-    /// Newly-introduced types for each extract.
-    std::vector<const IR::Type_Header*> typeDecls;
+    struct HeaderSplit {
+        /// Fixed-size part of a header type (computed for each extract).
+        const IR::Type_Header* fixedHeaderType;
+        /// Expression computing the length of the fixed-size header.
+        const IR::Expression* headerLength;
+    };
+
     /// All newly-introduced types.
-    // The following contains IR::Type_Header, but it is easier
+    // The following vector contains only IR::Type_Header, but it is easier
     // to append if the elements are Node.
     IR::Vector<IR::Node>               allTypeDecls;
     /// All newly-introduced variables, for each parser.
     IR::IndexedVector<IR::Declaration> varDecls;
-    /// Map each newly created header with a varbit field
-    /// to an expression that denotes its length.
-    std::map<const IR::Type_Header*, const IR::Expression*> lengths;
+    /// Maps each original header type name to the fixed part of it.
+    std::map<cstring, HeaderSplit*> fixedPart;
 
-    /// If a header type contains varbit fields split it into several
-    /// header types, each of which starts with a varbit field.  The
-    /// types are inserted in the typeDecls list.
-    void splitHeaderType(const IR::Type_Header* type) {
+    /// If a header type contains a varbit field a, then create a new
+    /// header type containing only the fields prior to the varbit.
+    HeaderSplit* splitHeaderType(const IR::Type_Header* type) {
+        auto fixed = ::get(fixedPart, type->name.name);
+        if (fixed != nullptr)
+            return fixed;
+
+        const IR::Expression* headerLength = nullptr;
+        const IR::Type_Header* fixedHeaderType = nullptr;
         IR::IndexedVector<IR::StructField> fields;
-        const IR::Expression* length = nullptr;
+
         for (auto f : type->fields) {
             if (f->type->is<IR::Type_Varbits>()) {
                 cstring hname = structure->makeUniqueName(type->name);
-                auto htype = new IR::Type_Header(IR::ID(hname), fields);
-                if (length != nullptr)
-                    lengths.emplace(htype, length);
-                typeDecls.push_back(htype);
-                fields.clear();
+                if (fixedHeaderType != nullptr)
+                    ::error("%1%: header types with multiple varbit fields are not supported",
+                            type);
+                fixedHeaderType = new IR::Type_Header(IR::ID(hname), fields);
                 auto anno = f->getAnnotation(IR::Annotation::lengthAnnotation);
                 BUG_CHECK(anno != nullptr, "No length annotation on varbit field", f);
                 BUG_CHECK(anno->expr.size() == 1, "Expected exactly 1 argument", anno->expr);
-                length = anno->expr.at(0);
+                headerLength = anno->expr.at(0);
                 f = new IR::StructField(f->srcInfo, f->name, f->type);  // lose the annotation
             }
-            fields.push_back(f);
+            if (fixedHeaderType == nullptr)
+                // We only keep the fields prior to the varbit field
+                fields.push_back(f);
+
         }
-        if (!typeDecls.empty() && !fields.empty()) {
-            cstring hname = structure->makeUniqueName(type->name);
-            auto htype = new IR::Type_Header(IR::ID(hname), fields);
-            typeDecls.push_back(htype);
-            lengths.emplace(htype, length);
-            LOG3("Split header type " << type << " into " << typeDecls.size() << " parts");
+        if (fixedHeaderType != nullptr) {
+            LOG3("Extracted fixed-size header type from " << type << " into " << fixedHeaderType);
+            fixed = new HeaderSplit;
+            fixed->fixedHeaderType = fixedHeaderType;
+            fixed->headerLength = headerLength;
+            fixedPart.emplace(type->name.name, fixed);
+            allTypeDecls.push_back(fixedHeaderType);
+            return fixed;
         }
+        return nullptr;
     }
 
     /**
-       This pass rewrites expressions from a @length annotation expression:
-       PathExpressions that refer to enclosing fields are rewritten to
-       refer to the proper fields in a different structure.  In the example above, `len`
+       This pass rewrites expressions that apprear in a @length annotation:
+       PathExpressions that refer to enclosing struct fields are rewritten to
+       refer to the proper fields of a variable `var`.  In the example above, `len`
        is translated to `h_0.len`.
-     */
+    */
     class RewriteLength final : public Transform {
-        const std::vector<const IR::Type_Header*> &typeDecls;
-        const IR::IndexedVector<IR::Declaration>  &vars;
+        const IR::Type_Header* header;
+        const IR::Declaration* var;
      public:
-        explicit RewriteLength(const std::vector<const IR::Type_Header*> &typeDecls,
-                               const IR::IndexedVector<IR::Declaration>  &vars) :
-                typeDecls(typeDecls), vars(vars) { setName("RewriteLength"); }
+        explicit RewriteLength(const IR::Type_Header* header,
+                               const IR::Declaration* var) :
+                header(header), var(var) { setName("RewriteLength"); }
+
         const IR::Node* postorder(IR::PathExpression* expression) override {
             if (expression->path->absolute)
                 return expression;
-            unsigned index = 0;
-            for (auto t : typeDecls) {
-                for (auto f : t->fields) {
-                    if (f->name == expression->path->name)
-                        return new IR::Member(
-                            expression->srcInfo,
-                            new IR::PathExpression(vars.at(index)->name), f->name);
-                }
-                index++;
+            for (auto f : header->fields) {
+                if (f->name == expression->path->name)
+                    return new IR::Member(
+                        expression->srcInfo,
+                        new IR::PathExpression(var->name), f->name);
             }
             return expression;
         }
@@ -932,7 +939,6 @@ class FixExtracts final : public Transform {
     }
 
     const IR::Node* postorder(IR::MethodCallStatement* statement) override {
-        typeDecls.clear();
         auto mce = getOriginal<IR::MethodCallStatement>()->methodCall;
         LOG3("Looking up in extracts " << dbp(mce));
         auto ht = ::get(structure->extractsSynthesized, mce);
@@ -944,49 +950,44 @@ class FixExtracts final : public Transform {
         BUG_CHECK(mce->arguments->size() == 1, "%1%: expected 1 argument", mce);
         auto arg = mce->arguments->at(0);
 
-        splitHeaderType(ht);
-        if (typeDecls.empty())
+        auto fixed = splitHeaderType(ht);
+        if (fixed == nullptr)
             return statement;
+        CHECK_NULL(fixed->headerLength);
+        CHECK_NULL(fixed->fixedHeaderType);
 
         auto result = new IR::IndexedVector<IR::StatOrDecl>();
-        RewriteLength rewrite(typeDecls, varDecls);
-        for (auto t : typeDecls) {
-            allTypeDecls.push_back(t);
-            cstring varName = structure->makeUniqueName("tmp_hdr");
-            auto var = new IR::Declaration_Variable(IR::ID(varName), t->to<IR::Type>());
-            auto length = ::get(lengths, t);
-            varDecls.push_back(var);
-            auto args = new IR::Vector<IR::Argument>();
-            args->push_back(new IR::Argument(new IR::PathExpression(IR::ID(varName))));
-            if (length != nullptr) {
-                length = length->apply(rewrite);
-                auto type = IR::Type_Bits::get(
-                    P4::P4CoreLibrary::instance.packetIn.extractSecondArgSize);
-                auto cast = new IR::Cast(Util::SourceInfo(), type, length);
-                args->push_back(new IR::Argument(cast));
-            }
-            auto expression = new IR::MethodCallExpression(
-                mce->srcInfo, mce->method->clone(), args);
-            result->push_back(new IR::MethodCallStatement(expression));
-        }
+        cstring varName = structure->makeUniqueName("tmp_hdr");
+        auto var = new IR::Declaration_Variable(
+            IR::ID(varName), fixed->fixedHeaderType->to<IR::Type>());
+        varDecls.push_back(var);
 
-        auto setValid = new IR::Member(
-            mce->srcInfo, arg->expression, IR::Type_Header::setValid);
-        result->push_back(new IR::MethodCallStatement(
-            new IR::MethodCallExpression(
-                mce->srcInfo, setValid, new IR::Vector<IR::Argument>())));
-        unsigned index = 0;
-        for (auto t : typeDecls) {
-            auto var = varDecls.at(index);
-            for (auto f : t->fields) {
-                auto left = new IR::Member(mce->srcInfo, arg->expression, f->name);
-                auto right = new IR::Member(mce->srcInfo,
-                                            new IR::PathExpression(var->name), f->name);
-                auto assign = new IR::AssignmentStatement(mce->srcInfo, left, right);
-                result->push_back(assign);
-            }
-            index++;
-        }
+        // Create lookahead
+        auto member = mce->method->to<IR::Member>();  // should be packet_in.extract
+        CHECK_NULL(member);
+        auto typeArgs = new IR::Vector<IR::Type>();
+        typeArgs->push_back(fixed->fixedHeaderType->getP4Type());
+        auto lookaheadMethod = new IR::Member(member->expr,
+                                              P4::P4CoreLibrary::instance.packetIn.lookahead.name);
+        auto lookahead = new IR::MethodCallExpression(
+            mce->srcInfo, lookaheadMethod, typeArgs, new IR::Vector<IR::Argument>());
+        auto assign = new IR::AssignmentStatement(
+            mce->srcInfo, new IR::PathExpression(varName), lookahead);
+        result->push_back(assign);
+        LOG3("Created lookahead " << assign);
+
+        // Create actual extract
+        RewriteLength rewrite(fixed->fixedHeaderType, var);
+        auto length = fixed->headerLength->apply(rewrite);
+        auto args = new IR::Vector<IR::Argument>();
+        args->push_back(arg->clone());
+        auto type = IR::Type_Bits::get(
+            P4::P4CoreLibrary::instance.packetIn.extractSecondArgSize);
+        auto cast = new IR::Cast(Util::SourceInfo(), type, length);
+        args->push_back(new IR::Argument(cast));
+        auto expression = new IR::MethodCallExpression(
+            mce->srcInfo, mce->method->clone(), args);
+        result->push_back(new IR::MethodCallStatement(expression));
         return result;
     }
 };

--- a/testdata/p4_14_samples/issue576.p4
+++ b/testdata/p4_14_samples/issue576.p4
@@ -1,0 +1,50 @@
+header_type simpleipv4_t {
+    fields {
+        version     : 4;
+        ihl         : 4;
+        diffserv    : 8;
+        totalLen    : 16;
+        id          : 16;
+        flags       : 3;
+        fragOffset  : 13;
+        ttl         : 8;
+        protocol    : 8;
+        hdrChecksum : 16;
+        srcAddr     : 32;
+        dstAddr     : 32;
+    }
+}
+
+header_type ipv4_t {
+    fields {
+        version     : 4;
+        ihl         : 4;
+        diffserv    : 8;
+        totalLen    : 16;
+        id          : 16;
+        flags       : 3;
+        fragOffset  : 13;
+        ttl         : 8;
+        protocol    : 8;
+        hdrChecksum : 16;
+        srcAddr     : 32;
+        dstAddr     : 32;
+        options_ipv4: *;
+    }
+    length          : (ihl << 2);
+    max_length      : 60;
+}
+
+header ipv4_t h[2];
+header simpleipv4_t sh[2];
+
+parser start {
+    extract(sh[next]);
+    extract(sh[next]);
+    extract(h[next]);
+    extract(h[next]);
+    return ingress;
+}
+
+control ingress {
+}

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-first.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-first.p4
@@ -15,10 +15,6 @@ header ipv4_t_1 {
     bit<32> dstAddr;
 }
 
-header ipv4_t_2 {
-    varbit<352> options;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -68,7 +64,6 @@ struct headers {
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     ipv4_t_1 tmp_hdr;
-    ipv4_t_2 tmp_hdr_0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.ethertype) {
@@ -78,24 +73,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_ipv4") state parse_ipv4 {
-        packet.extract<ipv4_t_1>(tmp_hdr);
-        packet.extract<ipv4_t_2>(tmp_hdr_0, ((bit<32>)tmp_hdr.ihl << 2 << 3) + 32w4294967136);
-        hdr.ipv4.setValid();
-        hdr.ipv4.version = tmp_hdr.version;
-        hdr.ipv4.ihl = tmp_hdr.ihl;
-        hdr.ipv4.diffserv = tmp_hdr.diffserv;
-        hdr.ipv4.totalLen = tmp_hdr.totalLen;
-        hdr.ipv4.identification = tmp_hdr.identification;
-        hdr.ipv4.reserved_0 = tmp_hdr.reserved_0;
-        hdr.ipv4.df = tmp_hdr.df;
-        hdr.ipv4.mf = tmp_hdr.mf;
-        hdr.ipv4.fragOffset = tmp_hdr.fragOffset;
-        hdr.ipv4.ttl = tmp_hdr.ttl;
-        hdr.ipv4.protocol = tmp_hdr.protocol;
-        hdr.ipv4.hdrChecksum = tmp_hdr.hdrChecksum;
-        hdr.ipv4.srcAddr = tmp_hdr.srcAddr;
-        hdr.ipv4.dstAddr = tmp_hdr.dstAddr;
-        hdr.ipv4.options = tmp_hdr_0.options;
+        tmp_hdr = packet.lookahead<ipv4_t_1>();
+        packet.extract<ipv4_t>(hdr.ipv4, ((bit<32>)tmp_hdr.ihl << 2 << 3) + 32w4294967136);
         transition accept;
     }
     @name(".parse_vlan_tag") state parse_vlan_tag {

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-frontend.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-frontend.p4
@@ -15,10 +15,6 @@ header ipv4_t_1 {
     bit<32> dstAddr;
 }
 
-header ipv4_t_2 {
-    varbit<352> options;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -67,8 +63,8 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    ipv4_t_1 tmp_hdr_1;
-    ipv4_t_2 tmp_hdr_2;
+    ipv4_t_1 tmp_hdr_0;
+    ipv4_t_1 tmp;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.ethertype) {
@@ -78,24 +74,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_ipv4") state parse_ipv4 {
-        packet.extract<ipv4_t_1>(tmp_hdr_1);
-        packet.extract<ipv4_t_2>(tmp_hdr_2, ((bit<32>)tmp_hdr_1.ihl << 2 << 3) + 32w4294967136);
-        hdr.ipv4.setValid();
-        hdr.ipv4.version = tmp_hdr_1.version;
-        hdr.ipv4.ihl = tmp_hdr_1.ihl;
-        hdr.ipv4.diffserv = tmp_hdr_1.diffserv;
-        hdr.ipv4.totalLen = tmp_hdr_1.totalLen;
-        hdr.ipv4.identification = tmp_hdr_1.identification;
-        hdr.ipv4.reserved_0 = tmp_hdr_1.reserved_0;
-        hdr.ipv4.df = tmp_hdr_1.df;
-        hdr.ipv4.mf = tmp_hdr_1.mf;
-        hdr.ipv4.fragOffset = tmp_hdr_1.fragOffset;
-        hdr.ipv4.ttl = tmp_hdr_1.ttl;
-        hdr.ipv4.protocol = tmp_hdr_1.protocol;
-        hdr.ipv4.hdrChecksum = tmp_hdr_1.hdrChecksum;
-        hdr.ipv4.srcAddr = tmp_hdr_1.srcAddr;
-        hdr.ipv4.dstAddr = tmp_hdr_1.dstAddr;
-        hdr.ipv4.options = tmp_hdr_2.options;
+        tmp = packet.lookahead<ipv4_t_1>();
+        tmp_hdr_0 = tmp;
+        packet.extract<ipv4_t>(hdr.ipv4, ((bit<32>)tmp_hdr_0.ihl << 2 << 3) + 32w4294967136);
         transition accept;
     }
     @name(".parse_vlan_tag") state parse_vlan_tag {

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
@@ -15,10 +15,6 @@ header ipv4_t_1 {
     bit<32> dstAddr;
 }
 
-header ipv4_t_2 {
-    varbit<352> options;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -67,8 +63,9 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    ipv4_t_1 tmp_hdr_1;
-    ipv4_t_2 tmp_hdr_2;
+    ipv4_t_1 tmp_hdr_0;
+    ipv4_t_1 tmp;
+    bit<160> tmp_0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.ethertype) {
@@ -78,24 +75,24 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_ipv4") state parse_ipv4 {
-        packet.extract<ipv4_t_1>(tmp_hdr_1);
-        packet.extract<ipv4_t_2>(tmp_hdr_2, ((bit<32>)tmp_hdr_1.ihl << 2 << 3) + 32w4294967136);
-        hdr.ipv4.setValid();
-        hdr.ipv4.version = tmp_hdr_1.version;
-        hdr.ipv4.ihl = tmp_hdr_1.ihl;
-        hdr.ipv4.diffserv = tmp_hdr_1.diffserv;
-        hdr.ipv4.totalLen = tmp_hdr_1.totalLen;
-        hdr.ipv4.identification = tmp_hdr_1.identification;
-        hdr.ipv4.reserved_0 = tmp_hdr_1.reserved_0;
-        hdr.ipv4.df = tmp_hdr_1.df;
-        hdr.ipv4.mf = tmp_hdr_1.mf;
-        hdr.ipv4.fragOffset = tmp_hdr_1.fragOffset;
-        hdr.ipv4.ttl = tmp_hdr_1.ttl;
-        hdr.ipv4.protocol = tmp_hdr_1.protocol;
-        hdr.ipv4.hdrChecksum = tmp_hdr_1.hdrChecksum;
-        hdr.ipv4.srcAddr = tmp_hdr_1.srcAddr;
-        hdr.ipv4.dstAddr = tmp_hdr_1.dstAddr;
-        hdr.ipv4.options = tmp_hdr_2.options;
+        tmp_0 = packet.lookahead<bit<160>>();
+        tmp.setValid();
+        tmp.version = tmp_0[159:156];
+        tmp.ihl = tmp_0[155:152];
+        tmp.diffserv = tmp_0[151:144];
+        tmp.totalLen = tmp_0[143:128];
+        tmp.identification = tmp_0[127:112];
+        tmp.reserved_0 = tmp_0[111:111];
+        tmp.df = tmp_0[110:110];
+        tmp.mf = tmp_0[109:109];
+        tmp.fragOffset = tmp_0[108:96];
+        tmp.ttl = tmp_0[95:88];
+        tmp.protocol = tmp_0[87:80];
+        tmp.hdrChecksum = tmp_0[79:64];
+        tmp.srcAddr = tmp_0[63:32];
+        tmp.dstAddr = tmp_0[31:0];
+        tmp_hdr_0 = tmp;
+        packet.extract<ipv4_t>(hdr.ipv4, ((bit<32>)tmp_hdr_0.ihl << 2 << 3) + 32w4294967136);
         transition accept;
     }
     @name(".parse_vlan_tag") state parse_vlan_tag {

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed.p4
@@ -15,10 +15,6 @@ header ipv4_t_1 {
     bit<32> dstAddr;
 }
 
-header ipv4_t_2 {
-    varbit<352> options;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -68,7 +64,6 @@ struct headers {
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     ipv4_t_1 tmp_hdr;
-    ipv4_t_2 tmp_hdr_0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.ethertype) {
@@ -78,24 +73,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_ipv4") state parse_ipv4 {
-        packet.extract(tmp_hdr);
-        packet.extract(tmp_hdr_0, (bit<32>)((bit<32>)tmp_hdr.ihl * 32w4 * 8 - 160));
-        hdr.ipv4.setValid();
-        hdr.ipv4.version = tmp_hdr.version;
-        hdr.ipv4.ihl = tmp_hdr.ihl;
-        hdr.ipv4.diffserv = tmp_hdr.diffserv;
-        hdr.ipv4.totalLen = tmp_hdr.totalLen;
-        hdr.ipv4.identification = tmp_hdr.identification;
-        hdr.ipv4.reserved_0 = tmp_hdr.reserved_0;
-        hdr.ipv4.df = tmp_hdr.df;
-        hdr.ipv4.mf = tmp_hdr.mf;
-        hdr.ipv4.fragOffset = tmp_hdr.fragOffset;
-        hdr.ipv4.ttl = tmp_hdr.ttl;
-        hdr.ipv4.protocol = tmp_hdr.protocol;
-        hdr.ipv4.hdrChecksum = tmp_hdr.hdrChecksum;
-        hdr.ipv4.srcAddr = tmp_hdr.srcAddr;
-        hdr.ipv4.dstAddr = tmp_hdr.dstAddr;
-        hdr.ipv4.options = tmp_hdr_0.options;
+        tmp_hdr = packet.lookahead<ipv4_t_1>();
+        packet.extract(hdr.ipv4, (bit<32>)((bit<32>)tmp_hdr.ihl * 32w4 * 8 - 160));
         transition accept;
     }
     @name(".parse_vlan_tag") state parse_vlan_tag {

--- a/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
@@ -3,10 +3,6 @@ header ipv4_option_timestamp_t_1 {
     bit<8> len;
 }
 
-header ipv4_option_timestamp_t_2 {
-    varbit<304> data;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -87,7 +83,6 @@ struct headers {
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     ipv4_option_timestamp_t_1 tmp_hdr;
-    ipv4_option_timestamp_t_2 tmp_hdr_0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {
@@ -119,12 +114,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition parse_ipv4_options;
     }
     @name(".parse_ipv4_option_timestamp") state parse_ipv4_option_timestamp {
-        packet.extract<ipv4_option_timestamp_t_1>(tmp_hdr);
-        packet.extract<ipv4_option_timestamp_t_2>(tmp_hdr_0, ((bit<32>)tmp_hdr.len << 3) + 32w4294967280);
-        hdr.ipv4_option_timestamp.setValid();
-        hdr.ipv4_option_timestamp.value = tmp_hdr.value;
-        hdr.ipv4_option_timestamp.len = tmp_hdr.len;
-        hdr.ipv4_option_timestamp.data = tmp_hdr_0.data;
+        tmp_hdr = packet.lookahead<ipv4_option_timestamp_t_1>();
+        packet.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)tmp_hdr.len << 3) + 32w4294967280);
         meta.my_metadata.parse_ipv4_counter = meta.my_metadata.parse_ipv4_counter - hdr.ipv4_option_timestamp.len;
         transition parse_ipv4_options;
     }

--- a/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
@@ -3,10 +3,6 @@ header ipv4_option_timestamp_t_1 {
     bit<8> len;
 }
 
-header ipv4_option_timestamp_t_2 {
-    varbit<304> data;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -86,9 +82,10 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    ipv4_option_timestamp_t_1 tmp_hdr_1;
-    ipv4_option_timestamp_t_2 tmp_hdr_2;
-    bit<8> tmp;
+    ipv4_option_timestamp_t_1 tmp_hdr_0;
+    ipv4_option_timestamp_t_1 tmp;
+    bit<8> tmp_0;
+    bit<16> tmp_1;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {
@@ -120,18 +117,18 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition parse_ipv4_options;
     }
     @name(".parse_ipv4_option_timestamp") state parse_ipv4_option_timestamp {
-        packet.extract<ipv4_option_timestamp_t_1>(tmp_hdr_1);
-        packet.extract<ipv4_option_timestamp_t_2>(tmp_hdr_2, ((bit<32>)tmp_hdr_1.len << 3) + 32w4294967280);
-        hdr.ipv4_option_timestamp.setValid();
-        hdr.ipv4_option_timestamp.value = tmp_hdr_1.value;
-        hdr.ipv4_option_timestamp.len = tmp_hdr_1.len;
-        hdr.ipv4_option_timestamp.data = tmp_hdr_2.data;
-        meta.my_metadata.parse_ipv4_counter = meta.my_metadata.parse_ipv4_counter - tmp_hdr_1.len;
+        tmp_1 = packet.lookahead<bit<16>>();
+        tmp.setValid();
+        tmp.value = tmp_1[15:8];
+        tmp.len = tmp_1[7:0];
+        tmp_hdr_0 = tmp;
+        packet.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)tmp_hdr_0.len << 3) + 32w4294967280);
+        meta.my_metadata.parse_ipv4_counter = meta.my_metadata.parse_ipv4_counter - hdr.ipv4_option_timestamp.len;
         transition parse_ipv4_options;
     }
     @name(".parse_ipv4_options") state parse_ipv4_options {
-        tmp = packet.lookahead<bit<8>>();
-        transition select(meta.my_metadata.parse_ipv4_counter, tmp[7:0]) {
+        tmp_0 = packet.lookahead<bit<8>>();
+        transition select(meta.my_metadata.parse_ipv4_counter, tmp_0[7:0]) {
             (8w0x0 &&& 8w0xff, 8w0x0 &&& 8w0x0): accept;
             (8w0x0 &&& 8w0x0, 8w0x0 &&& 8w0xff): parse_ipv4_option_EOL;
             (8w0x0 &&& 8w0x0, 8w0x1 &&& 8w0xff): parse_ipv4_option_NOP;

--- a/testdata/p4_14_samples_outputs/TLV_parsing.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing.p4
@@ -3,10 +3,6 @@ header ipv4_option_timestamp_t_1 {
     bit<8> len;
 }
 
-header ipv4_option_timestamp_t_2 {
-    varbit<304> data;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -87,7 +83,6 @@ struct headers {
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     ipv4_option_timestamp_t_1 tmp_hdr;
-    ipv4_option_timestamp_t_2 tmp_hdr_0;
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {
@@ -119,12 +114,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition parse_ipv4_options;
     }
     @name(".parse_ipv4_option_timestamp") state parse_ipv4_option_timestamp {
-        packet.extract(tmp_hdr);
-        packet.extract(tmp_hdr_0, (bit<32>)((bit<32>)tmp_hdr.len * 8 - 16));
-        hdr.ipv4_option_timestamp.setValid();
-        hdr.ipv4_option_timestamp.value = tmp_hdr.value;
-        hdr.ipv4_option_timestamp.len = tmp_hdr.len;
-        hdr.ipv4_option_timestamp.data = tmp_hdr_0.data;
+        tmp_hdr = packet.lookahead<ipv4_option_timestamp_t_1>();
+        packet.extract(hdr.ipv4_option_timestamp, (bit<32>)((bit<32>)tmp_hdr.len * 8 - 16));
         meta.my_metadata.parse_ipv4_counter = meta.my_metadata.parse_ipv4_counter - hdr.ipv4_option_timestamp.len;
         transition parse_ipv4_options;
     }

--- a/testdata/p4_14_samples_outputs/issue576-first.p4
+++ b/testdata/p4_14_samples_outputs/issue576-first.p4
@@ -1,0 +1,103 @@
+header ipv4_t_1 {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> id;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     id;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    bit<32>     srcAddr;
+    bit<32>     dstAddr;
+    @length(((bit<32>)ihl << 2 << 3) + 32w4294967136) 
+    varbit<320> options_ipv4;
+}
+
+header simpleipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> id;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".h") 
+    ipv4_t[2]       h;
+    @name(".sh") 
+    simpleipv4_t[2] sh;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    ipv4_t_1 tmp_hdr;
+    ipv4_t_1 tmp_hdr_0;
+    @name(".start") state start {
+        packet.extract<simpleipv4_t>(hdr.sh.next);
+        packet.extract<simpleipv4_t>(hdr.sh.next);
+        tmp_hdr = packet.lookahead<ipv4_t_1>();
+        packet.extract<ipv4_t>(hdr.h.next, ((bit<32>)tmp_hdr.ihl << 2 << 3) + 32w4294967136);
+        tmp_hdr_0 = packet.lookahead<ipv4_t_1>();
+        packet.extract<ipv4_t>(hdr.h.next, ((bit<32>)tmp_hdr_0.ihl << 2 << 3) + 32w4294967136);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<simpleipv4_t[2]>(hdr.sh);
+        packet.emit<ipv4_t[2]>(hdr.h);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/issue576-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue576-frontend.p4
@@ -1,0 +1,107 @@
+header ipv4_t_1 {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> id;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     id;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    bit<32>     srcAddr;
+    bit<32>     dstAddr;
+    @length(((bit<32>)ihl << 2 << 3) + 32w4294967136) 
+    varbit<320> options_ipv4;
+}
+
+header simpleipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> id;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".h") 
+    ipv4_t[2]       h;
+    @name(".sh") 
+    simpleipv4_t[2] sh;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    ipv4_t_1 tmp_hdr_1;
+    ipv4_t_1 tmp_hdr_2;
+    ipv4_t_1 tmp;
+    ipv4_t_1 tmp_0;
+    @name(".start") state start {
+        packet.extract<simpleipv4_t>(hdr.sh.next);
+        packet.extract<simpleipv4_t>(hdr.sh.next);
+        tmp = packet.lookahead<ipv4_t_1>();
+        tmp_hdr_1 = tmp;
+        packet.extract<ipv4_t>(hdr.h.next, ((bit<32>)tmp_hdr_1.ihl << 2 << 3) + 32w4294967136);
+        tmp_0 = packet.lookahead<ipv4_t_1>();
+        tmp_hdr_2 = tmp_0;
+        packet.extract<ipv4_t>(hdr.h.next, ((bit<32>)tmp_hdr_2.ihl << 2 << 3) + 32w4294967136);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<simpleipv4_t[2]>(hdr.sh);
+        packet.emit<ipv4_t[2]>(hdr.h);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/issue576-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue576-midend.p4
@@ -1,0 +1,137 @@
+header ipv4_t_1 {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> id;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     id;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    bit<32>     srcAddr;
+    bit<32>     dstAddr;
+    @length(((bit<32>)ihl << 2 << 3) + 32w4294967136) 
+    varbit<320> options_ipv4;
+}
+
+header simpleipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> id;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".h") 
+    ipv4_t[2]       h;
+    @name(".sh") 
+    simpleipv4_t[2] sh;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    ipv4_t_1 tmp_hdr_1;
+    ipv4_t_1 tmp_hdr_2;
+    ipv4_t_1 tmp;
+    ipv4_t_1 tmp_0;
+    bit<160> tmp_1;
+    bit<160> tmp_2;
+    @name(".start") state start {
+        packet.extract<simpleipv4_t>(hdr.sh.next);
+        packet.extract<simpleipv4_t>(hdr.sh.next);
+        tmp_1 = packet.lookahead<bit<160>>();
+        tmp.setValid();
+        tmp.version = tmp_1[159:156];
+        tmp.ihl = tmp_1[155:152];
+        tmp.diffserv = tmp_1[151:144];
+        tmp.totalLen = tmp_1[143:128];
+        tmp.id = tmp_1[127:112];
+        tmp.flags = tmp_1[111:109];
+        tmp.fragOffset = tmp_1[108:96];
+        tmp.ttl = tmp_1[95:88];
+        tmp.protocol = tmp_1[87:80];
+        tmp.hdrChecksum = tmp_1[79:64];
+        tmp.srcAddr = tmp_1[63:32];
+        tmp.dstAddr = tmp_1[31:0];
+        tmp_hdr_1 = tmp;
+        packet.extract<ipv4_t>(hdr.h.next, ((bit<32>)tmp_hdr_1.ihl << 2 << 3) + 32w4294967136);
+        tmp_2 = packet.lookahead<bit<160>>();
+        tmp_0.setValid();
+        tmp_0.version = tmp_2[159:156];
+        tmp_0.ihl = tmp_2[155:152];
+        tmp_0.diffserv = tmp_2[151:144];
+        tmp_0.totalLen = tmp_2[143:128];
+        tmp_0.id = tmp_2[127:112];
+        tmp_0.flags = tmp_2[111:109];
+        tmp_0.fragOffset = tmp_2[108:96];
+        tmp_0.ttl = tmp_2[95:88];
+        tmp_0.protocol = tmp_2[87:80];
+        tmp_0.hdrChecksum = tmp_2[79:64];
+        tmp_0.srcAddr = tmp_2[63:32];
+        tmp_0.dstAddr = tmp_2[31:0];
+        tmp_hdr_2 = tmp_0;
+        packet.extract<ipv4_t>(hdr.h.next, ((bit<32>)tmp_hdr_2.ihl << 2 << 3) + 32w4294967136);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<simpleipv4_t>(hdr.sh[0]);
+        packet.emit<simpleipv4_t>(hdr.sh[1]);
+        packet.emit<ipv4_t>(hdr.h[0]);
+        packet.emit<ipv4_t>(hdr.h[1]);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/issue576.p4
+++ b/testdata/p4_14_samples_outputs/issue576.p4
@@ -1,0 +1,103 @@
+header ipv4_t_1 {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> id;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     id;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    bit<32>     srcAddr;
+    bit<32>     dstAddr;
+    @length(((bit<32>)ihl << 2) * 8 - 160) 
+    varbit<320> options_ipv4;
+}
+
+header simpleipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> id;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    @name(".h") 
+    ipv4_t[2]       h;
+    @name(".sh") 
+    simpleipv4_t[2] sh;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    ipv4_t_1 tmp_hdr;
+    ipv4_t_1 tmp_hdr_0;
+    @name(".start") state start {
+        packet.extract(hdr.sh.next);
+        packet.extract(hdr.sh.next);
+        tmp_hdr = packet.lookahead<ipv4_t_1>();
+        packet.extract(hdr.h.next, (bit<32>)(((bit<32>)tmp_hdr.ihl << 2) * 8 - 160));
+        tmp_hdr_0 = packet.lookahead<ipv4_t_1>();
+        packet.extract(hdr.h.next, (bit<32>)(((bit<32>)tmp_hdr_0.ihl << 2) * 8 - 160));
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.sh);
+        packet.emit(hdr.h);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/issue576.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue576.p4-stderr
@@ -1,0 +1,1 @@
+warning: The order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/issue781-first.p4
+++ b/testdata/p4_14_samples_outputs/issue781-first.p4
@@ -13,10 +13,6 @@ header ipv4_t_1 {
     bit<32> dstAddr;
 }
 
-header ipv4_t_2 {
-    varbit<320> options_ipv4;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -47,24 +43,9 @@ struct headers {
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     ipv4_t_1 tmp_hdr;
-    ipv4_t_2 tmp_hdr_0;
     @name(".start") state start {
-        packet.extract<ipv4_t_1>(tmp_hdr);
-        packet.extract<ipv4_t_2>(tmp_hdr_0, ((bit<32>)tmp_hdr.ihl << 2 << 3) + 32w4294967136);
-        hdr.h.setValid();
-        hdr.h.version = tmp_hdr.version;
-        hdr.h.ihl = tmp_hdr.ihl;
-        hdr.h.diffserv = tmp_hdr.diffserv;
-        hdr.h.totalLen = tmp_hdr.totalLen;
-        hdr.h.id = tmp_hdr.id;
-        hdr.h.flags = tmp_hdr.flags;
-        hdr.h.fragOffset = tmp_hdr.fragOffset;
-        hdr.h.ttl = tmp_hdr.ttl;
-        hdr.h.protocol = tmp_hdr.protocol;
-        hdr.h.hdrChecksum = tmp_hdr.hdrChecksum;
-        hdr.h.srcAddr = tmp_hdr.srcAddr;
-        hdr.h.dstAddr = tmp_hdr.dstAddr;
-        hdr.h.options_ipv4 = tmp_hdr_0.options_ipv4;
+        tmp_hdr = packet.lookahead<ipv4_t_1>();
+        packet.extract<ipv4_t>(hdr.h, ((bit<32>)tmp_hdr.ihl << 2 << 3) + 32w4294967136);
         transition accept;
     }
 }

--- a/testdata/p4_14_samples_outputs/issue781-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue781-frontend.p4
@@ -13,10 +13,6 @@ header ipv4_t_1 {
     bit<32> dstAddr;
 }
 
-header ipv4_t_2 {
-    varbit<320> options_ipv4;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -46,25 +42,12 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    ipv4_t_1 tmp_hdr_1;
-    ipv4_t_2 tmp_hdr_2;
+    ipv4_t_1 tmp_hdr_0;
+    ipv4_t_1 tmp;
     @name(".start") state start {
-        packet.extract<ipv4_t_1>(tmp_hdr_1);
-        packet.extract<ipv4_t_2>(tmp_hdr_2, ((bit<32>)tmp_hdr_1.ihl << 2 << 3) + 32w4294967136);
-        hdr.h.setValid();
-        hdr.h.version = tmp_hdr_1.version;
-        hdr.h.ihl = tmp_hdr_1.ihl;
-        hdr.h.diffserv = tmp_hdr_1.diffserv;
-        hdr.h.totalLen = tmp_hdr_1.totalLen;
-        hdr.h.id = tmp_hdr_1.id;
-        hdr.h.flags = tmp_hdr_1.flags;
-        hdr.h.fragOffset = tmp_hdr_1.fragOffset;
-        hdr.h.ttl = tmp_hdr_1.ttl;
-        hdr.h.protocol = tmp_hdr_1.protocol;
-        hdr.h.hdrChecksum = tmp_hdr_1.hdrChecksum;
-        hdr.h.srcAddr = tmp_hdr_1.srcAddr;
-        hdr.h.dstAddr = tmp_hdr_1.dstAddr;
-        hdr.h.options_ipv4 = tmp_hdr_2.options_ipv4;
+        tmp = packet.lookahead<ipv4_t_1>();
+        tmp_hdr_0 = tmp;
+        packet.extract<ipv4_t>(hdr.h, ((bit<32>)tmp_hdr_0.ihl << 2 << 3) + 32w4294967136);
         transition accept;
     }
 }

--- a/testdata/p4_14_samples_outputs/issue781-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue781-midend.p4
@@ -13,10 +13,6 @@ header ipv4_t_1 {
     bit<32> dstAddr;
 }
 
-header ipv4_t_2 {
-    varbit<320> options_ipv4;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -46,25 +42,26 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    ipv4_t_1 tmp_hdr_1;
-    ipv4_t_2 tmp_hdr_2;
+    ipv4_t_1 tmp_hdr_0;
+    ipv4_t_1 tmp;
+    bit<160> tmp_0;
     @name(".start") state start {
-        packet.extract<ipv4_t_1>(tmp_hdr_1);
-        packet.extract<ipv4_t_2>(tmp_hdr_2, ((bit<32>)tmp_hdr_1.ihl << 2 << 3) + 32w4294967136);
-        hdr.h.setValid();
-        hdr.h.version = tmp_hdr_1.version;
-        hdr.h.ihl = tmp_hdr_1.ihl;
-        hdr.h.diffserv = tmp_hdr_1.diffserv;
-        hdr.h.totalLen = tmp_hdr_1.totalLen;
-        hdr.h.id = tmp_hdr_1.id;
-        hdr.h.flags = tmp_hdr_1.flags;
-        hdr.h.fragOffset = tmp_hdr_1.fragOffset;
-        hdr.h.ttl = tmp_hdr_1.ttl;
-        hdr.h.protocol = tmp_hdr_1.protocol;
-        hdr.h.hdrChecksum = tmp_hdr_1.hdrChecksum;
-        hdr.h.srcAddr = tmp_hdr_1.srcAddr;
-        hdr.h.dstAddr = tmp_hdr_1.dstAddr;
-        hdr.h.options_ipv4 = tmp_hdr_2.options_ipv4;
+        tmp_0 = packet.lookahead<bit<160>>();
+        tmp.setValid();
+        tmp.version = tmp_0[159:156];
+        tmp.ihl = tmp_0[155:152];
+        tmp.diffserv = tmp_0[151:144];
+        tmp.totalLen = tmp_0[143:128];
+        tmp.id = tmp_0[127:112];
+        tmp.flags = tmp_0[111:109];
+        tmp.fragOffset = tmp_0[108:96];
+        tmp.ttl = tmp_0[95:88];
+        tmp.protocol = tmp_0[87:80];
+        tmp.hdrChecksum = tmp_0[79:64];
+        tmp.srcAddr = tmp_0[63:32];
+        tmp.dstAddr = tmp_0[31:0];
+        tmp_hdr_0 = tmp;
+        packet.extract<ipv4_t>(hdr.h, ((bit<32>)tmp_hdr_0.ihl << 2 << 3) + 32w4294967136);
         transition accept;
     }
 }

--- a/testdata/p4_14_samples_outputs/issue781.p4
+++ b/testdata/p4_14_samples_outputs/issue781.p4
@@ -13,10 +13,6 @@ header ipv4_t_1 {
     bit<32> dstAddr;
 }
 
-header ipv4_t_2 {
-    varbit<320> options_ipv4;
-}
-
 #include <core.p4>
 #include <v1model.p4>
 
@@ -47,24 +43,9 @@ struct headers {
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     ipv4_t_1 tmp_hdr;
-    ipv4_t_2 tmp_hdr_0;
     @name(".start") state start {
-        packet.extract(tmp_hdr);
-        packet.extract(tmp_hdr_0, (bit<32>)(((bit<32>)tmp_hdr.ihl << 2) * 8 - 160));
-        hdr.h.setValid();
-        hdr.h.version = tmp_hdr.version;
-        hdr.h.ihl = tmp_hdr.ihl;
-        hdr.h.diffserv = tmp_hdr.diffserv;
-        hdr.h.totalLen = tmp_hdr.totalLen;
-        hdr.h.id = tmp_hdr.id;
-        hdr.h.flags = tmp_hdr.flags;
-        hdr.h.fragOffset = tmp_hdr.fragOffset;
-        hdr.h.ttl = tmp_hdr.ttl;
-        hdr.h.protocol = tmp_hdr.protocol;
-        hdr.h.hdrChecksum = tmp_hdr.hdrChecksum;
-        hdr.h.srcAddr = tmp_hdr.srcAddr;
-        hdr.h.dstAddr = tmp_hdr.dstAddr;
-        hdr.h.options_ipv4 = tmp_hdr_0.options_ipv4;
+        tmp_hdr = packet.lookahead<ipv4_t_1>();
+        packet.extract(hdr.h, (bit<32>)(((bit<32>)tmp_hdr.ihl << 2) * 8 - 160));
         transition accept;
     }
 }


### PR DESCRIPTION
This is about translating P4-14 header stacks into P4-16. The translation was incorrect for stacks with varbits. We now handle correctly headers that contain one varbit field. 
Instead of splitting a header into multiple headers, we read the fixed-sized part of a header using lookahead, and use it to compute the length, which is then used to read the whole header using an extract. The previous translation was not handling correctly the next/last stack fields.
Fixes #576.
(This also generates better code.)