### PR TITLE
 Reorganize passes to handle default values; fixes #1638 and #1639 

### DIFF
--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -145,12 +145,11 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new Deprecated(&refMap),
         new CheckNamedArgs(),
         new TypeInference(&refMap, &typeMap, false),  // insert casts
-        new BindTypeVariables(&typeMap),
-        new StructInitializers(&refMap, &typeMap),
-        // Another round of constant folding, using type information.
-        new ClearTypeMap(&typeMap),
         new DefaultArguments(&refMap, &typeMap),  // add default argument values to parameters
+        new BindTypeVariables(&refMap, &typeMap),
+        new StructInitializers(&refMap, &typeMap),
         new TableKeyNames(&refMap, &typeMap),
+        // Another round of constant folding, using type information.
         new ConstantFolding(&refMap, &typeMap),
         new StrengthReduction(),
         new UselessCasts(&refMap, &typeMap),

--- a/frontends/p4/localizeActions.cpp
+++ b/frontends/p4/localizeActions.cpp
@@ -25,8 +25,8 @@ class ParamCloner : public ClonePathExpressions {
  public:
     ParamCloner() { setName("ParamCloner"); }
     const IR::Node* postorder(IR::Parameter* param) override {
-        return new IR::Parameter(param->srcInfo, param->name,
-                                 param->annotations, param->direction, param->type);
+        return new IR::Parameter(param->srcInfo, param->name, param->annotations,
+                                 param->direction, param->type, param->defaultValue);
     }
     const IR::Node* postorder(IR::Declaration_Variable* decl) override {
         return new IR::Declaration_Variable(decl->srcInfo, decl->name,

--- a/frontends/p4/typeChecking/bindVariables.cpp
+++ b/frontends/p4/typeChecking/bindVariables.cpp
@@ -17,7 +17,7 @@ class FindUntypedInt : public Inspector {
 };
 
 /// Lookup a type variable
-const IR::Type* BindTypeVariables::getVarValue(
+const IR::Type* DoBindTypeVariables::getVarValue(
     const IR::Type_Var* var, const IR::Node* errorPosition) const {
     const IR::Type* rtype = nullptr;
     auto type = typeMap->getSubstitution(var);
@@ -45,7 +45,7 @@ const IR::Type* BindTypeVariables::getVarValue(
     return rtype;  // This may be nullptr
 }
 
-const IR::Node* BindTypeVariables::postorder(IR::Expression* expression) {
+const IR::Node* DoBindTypeVariables::postorder(IR::Expression* expression) {
     // This is needed to handle newly created expressions because
     // their children have changed.
     auto type = typeMap->getType(getOriginal(), true);
@@ -53,7 +53,7 @@ const IR::Node* BindTypeVariables::postorder(IR::Expression* expression) {
     return expression;
 }
 
-const IR::Node* BindTypeVariables::postorder(IR::Declaration_Instance* decl) {
+const IR::Node* DoBindTypeVariables::postorder(IR::Declaration_Instance* decl) {
     if (decl->type->is<IR::Type_Specialized>())
         return decl;
     auto type = typeMap->getType(getOriginal(), true);
@@ -74,7 +74,7 @@ const IR::Node* BindTypeVariables::postorder(IR::Declaration_Instance* decl) {
     return decl;
 }
 
-const IR::Node* BindTypeVariables::postorder(IR::MethodCallExpression* expression) {
+const IR::Node* DoBindTypeVariables::postorder(IR::MethodCallExpression* expression) {
     if (!expression->typeArguments->empty())
         return expression;
     auto type = typeMap->getType(expression->method, true);
@@ -94,7 +94,7 @@ const IR::Node* BindTypeVariables::postorder(IR::MethodCallExpression* expressio
     return expression;
 }
 
-const IR::Node* BindTypeVariables::postorder(IR::ConstructorCallExpression* expression) {
+const IR::Node* DoBindTypeVariables::postorder(IR::ConstructorCallExpression* expression) {
     if (expression->constructedType->is<IR::Type_Specialized>())
         return expression;
     auto type = typeMap->getType(getOriginal(), true);
@@ -116,7 +116,7 @@ const IR::Node* BindTypeVariables::postorder(IR::ConstructorCallExpression* expr
     return expression;
 }
 
-const IR::Node* BindTypeVariables::insertTypes(const IR::Node* node) {
+const IR::Node* DoBindTypeVariables::insertTypes(const IR::Node* node) {
     CHECK_NULL(node);
     CHECK_NULL(newTypes);
     if (newTypes->empty())

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1404,16 +1404,6 @@ const IR::Node* TypeInference::postorder(IR::Parameter* param) {
         return param;
     BUG_CHECK(!paramType->is<IR::Type_Type>(), "%1%: unexpected type", paramType);
 
-#if 0
-    if (param->defaultValue != nullptr) {
-        auto init = assignment(param, paramType, param->defaultValue);
-        if (init == nullptr)
-            return param;
-        if (param->defaultValue != init)
-            param->defaultValue = init;
-    }
-#endif
-
     if (paramType->is<IR::P4Control>() || paramType->is<IR::P4Parser>()) {
         typeError("%1%: parameter cannot have type %2%", param, paramType);
         return param;

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -234,7 +234,8 @@ const IR::ParameterList* TypeInference::canonicalizeParameters(const IR::Paramet
             return nullptr;
         BUG_CHECK(!paramType->is<IR::Type_Type>(), "%1%: Unexpected parameter type", paramType);
         if (paramType != p->type) {
-            p = new IR::Parameter(p->srcInfo, p->name, p->annotations, p->direction, paramType);
+            p = new IR::Parameter(p->srcInfo, p->name, p->annotations,
+                                  p->direction, paramType, p->defaultValue);
             changes = true;
         }
         setType(p, paramType);
@@ -1403,6 +1404,7 @@ const IR::Node* TypeInference::postorder(IR::Parameter* param) {
         return param;
     BUG_CHECK(!paramType->is<IR::Type_Type>(), "%1%: unexpected type", paramType);
 
+#if 0
     if (param->defaultValue != nullptr) {
         auto init = assignment(param, paramType, param->defaultValue);
         if (init == nullptr)
@@ -1410,6 +1412,7 @@ const IR::Node* TypeInference::postorder(IR::Parameter* param) {
         if (param->defaultValue != init)
             param->defaultValue = init;
     }
+#endif
 
     if (paramType->is<IR::P4Control>() || paramType->is<IR::P4Parser>()) {
         typeError("%1%: parameter cannot have type %2%", param, paramType);

--- a/testdata/p4_16_errors/issue1638-e.p4
+++ b/testdata/p4_16_errors/issue1638-e.p4
@@ -1,0 +1,22 @@
+struct intrinsic_metadata_t {
+   bit<8> f0;
+   bit<8> f1;
+}
+
+struct empty_t {}
+
+control C<H, M>(
+    inout H hdr,
+    inout M meta,
+    in intrinsic_metadata_t intr_md = {0, 0, 0});
+
+package P<H, M>(C<H, M> c);
+
+struct hdr_t { }
+struct meta_t { }
+
+control MyC(inout hdr_t hdr, inout meta_t meta) {
+   apply {}
+}
+
+P(MyC()) main;

--- a/testdata/p4_16_errors_outputs/issue1638-e.p4
+++ b/testdata/p4_16_errors_outputs/issue1638-e.p4
@@ -1,0 +1,23 @@
+struct intrinsic_metadata_t {
+    bit<8> f0;
+    bit<8> f1;
+}
+
+struct empty_t {
+}
+
+control C<H, M>(inout H hdr, inout M meta, in intrinsic_metadata_t intr_md={ 0, 0, 0 });
+package P<H, M>(C<H, M> c);
+struct hdr_t {
+}
+
+struct meta_t {
+}
+
+control MyC(inout hdr_t hdr, inout meta_t meta) {
+    apply {
+    }
+}
+
+P(MyC()) main;
+

--- a/testdata/p4_16_errors_outputs/issue1638-e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1638-e.p4-stderr
@@ -1,0 +1,3 @@
+issue1638-e.p4(22): error: main: Cannot unify functions with different number of arguments:  function(hdr, meta) to  function(hdr, meta, intr_md)
+P(MyC()) main;
+         ^^^^

--- a/testdata/p4_16_samples/default-package-argument.p4
+++ b/testdata/p4_16_samples/default-package-argument.p4
@@ -1,0 +1,22 @@
+ struct intrinsic_metadata_t {
+    bit<8> f0;
+    bit<8> f1;
+ }
+
+ struct empty_t {}
+
+ control nothing(inout empty_t hdr, inout empty_t meta, in intrinsic_metadata_t imeta) {
+    apply {}
+ }
+
+ control C<H, M>(
+     inout H hdr,
+     inout M meta,
+     in intrinsic_metadata_t intr_md);
+
+ package P<H, M>(C<H, M> c = nothing());
+
+ struct hdr_t { }
+ struct meta_t { }
+
+ P() main;

--- a/testdata/p4_16_samples/issue1638.p4
+++ b/testdata/p4_16_samples/issue1638.p4
@@ -1,0 +1,39 @@
+#include <core.p4>
+
+struct intrinsic_metadata_t {
+   bit<8> f0;
+   bit<8> f1;
+}
+
+struct empty_t {}
+
+control C<H, M>(
+    inout H hdr,
+    inout M meta,
+    in intrinsic_metadata_t intr_md);
+
+package P<H, M>(C<H, M> c);
+
+struct hdr_t { }
+struct meta_t { bit<8> f0; bit<8> f1; bit<8> f2; }
+
+control MyC2(in meta_t meta = {0, 0, 0}) {
+  table a {
+    key = {
+      meta.f0 : exact;
+    }
+    actions = { NoAction; }
+  }
+  apply {
+    a.apply();
+  }
+}
+
+control MyC(inout hdr_t hdr, inout meta_t meta, in intrinsic_metadata_t intr_md) {
+   MyC2() c2;
+   apply {
+     c2.apply();
+   }
+}
+
+P(MyC()) main;

--- a/testdata/p4_16_samples_outputs/default-package-argument-first.p4
+++ b/testdata/p4_16_samples_outputs/default-package-argument-first.p4
@@ -1,0 +1,23 @@
+struct intrinsic_metadata_t {
+    bit<8> f0;
+    bit<8> f1;
+}
+
+struct empty_t {
+}
+
+control nothing(inout empty_t hdr, inout empty_t meta, in intrinsic_metadata_t imeta) {
+    apply {
+    }
+}
+
+control C<H, M>(inout H hdr, inout M meta, in intrinsic_metadata_t intr_md);
+package P<H, M>(C<H, M> c=nothing());
+struct hdr_t {
+}
+
+struct meta_t {
+}
+
+P<empty_t, empty_t>(c = nothing()) main;
+

--- a/testdata/p4_16_samples_outputs/default-package-argument-frontend.p4
+++ b/testdata/p4_16_samples_outputs/default-package-argument-frontend.p4
@@ -1,0 +1,23 @@
+struct intrinsic_metadata_t {
+    bit<8> f0;
+    bit<8> f1;
+}
+
+struct empty_t {
+}
+
+control nothing(inout empty_t hdr, inout empty_t meta, in intrinsic_metadata_t imeta) {
+    apply {
+    }
+}
+
+control C<H, M>(inout H hdr, inout M meta, in intrinsic_metadata_t intr_md);
+package P<H, M>(C<H, M> c=nothing());
+struct hdr_t {
+}
+
+struct meta_t {
+}
+
+P<empty_t, empty_t>(c = nothing()) main;
+

--- a/testdata/p4_16_samples_outputs/default-package-argument-midend.p4
+++ b/testdata/p4_16_samples_outputs/default-package-argument-midend.p4
@@ -1,0 +1,23 @@
+struct intrinsic_metadata_t {
+    bit<8> f0;
+    bit<8> f1;
+}
+
+struct empty_t {
+}
+
+control nothing(inout empty_t hdr, inout empty_t meta, in intrinsic_metadata_t imeta) {
+    apply {
+    }
+}
+
+control C<H, M>(inout H hdr, inout M meta, in intrinsic_metadata_t intr_md);
+package P<H, M>(C<H, M> c=nothing());
+struct hdr_t {
+}
+
+struct meta_t {
+}
+
+P<empty_t, empty_t>(c = nothing()) main;
+

--- a/testdata/p4_16_samples_outputs/default-package-argument.p4
+++ b/testdata/p4_16_samples_outputs/default-package-argument.p4
@@ -1,0 +1,23 @@
+struct intrinsic_metadata_t {
+    bit<8> f0;
+    bit<8> f1;
+}
+
+struct empty_t {
+}
+
+control nothing(inout empty_t hdr, inout empty_t meta, in intrinsic_metadata_t imeta) {
+    apply {
+    }
+}
+
+control C<H, M>(inout H hdr, inout M meta, in intrinsic_metadata_t intr_md);
+package P<H, M>(C<H, M> c=nothing());
+struct hdr_t {
+}
+
+struct meta_t {
+}
+
+P() main;
+

--- a/testdata/p4_16_samples_outputs/issue1333-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1333-first.p4
@@ -1,12 +1,12 @@
 #include <core.p4>
 
-extern void f(bit<32> a=32w0, bit<32> b);
+extern void f(bit<32> a=0, bit<32> b);
 extern E {
-    E(bit<32> x=32w0);
-    void f(in bit<16> z=16w2);
+    E(bit<32> x=0);
+    void f(in bit<16> z=2);
 }
 
-control c()(bit<32> binit=32w4) {
+control c()(bit<32> binit=4) {
     E(x = 32w0) e;
     apply {
         f(a = 32w0, b = binit);

--- a/testdata/p4_16_samples_outputs/issue1333-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1333-frontend.p4
@@ -1,9 +1,9 @@
 #include <core.p4>
 
-extern void f(bit<32> a=32w0, bit<32> b);
+extern void f(bit<32> a=0, bit<32> b);
 extern E {
-    E(bit<32> x=32w0);
-    void f(in bit<16> z=16w2);
+    E(bit<32> x=0);
+    void f(in bit<16> z=2);
 }
 
 control ctrl();

--- a/testdata/p4_16_samples_outputs/issue1333-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1333-midend.p4
@@ -1,9 +1,9 @@
 #include <core.p4>
 
-extern void f(bit<32> a=32w0, bit<32> b);
+extern void f(bit<32> a=0, bit<32> b);
 extern E {
-    E(bit<32> x=32w0);
-    void f(in bit<16> z=16w2);
+    E(bit<32> x=0);
+    void f(in bit<16> z=2);
 }
 
 control ctrl();

--- a/testdata/p4_16_samples_outputs/issue1638-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1638-first.p4
@@ -1,0 +1,45 @@
+#include <core.p4>
+
+struct intrinsic_metadata_t {
+    bit<8> f0;
+    bit<8> f1;
+}
+
+struct empty_t {
+}
+
+control C<H, M>(inout H hdr, inout M meta, in intrinsic_metadata_t intr_md);
+package P<H, M>(C<H, M> c);
+struct hdr_t {
+}
+
+struct meta_t {
+    bit<8> f0;
+    bit<8> f1;
+    bit<8> f2;
+}
+
+control MyC2(in meta_t meta={ 0, 0, 0 }) {
+    table a {
+        key = {
+            meta.f0: exact @name("meta.f0") ;
+        }
+        actions = {
+            NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        a.apply();
+    }
+}
+
+control MyC(inout hdr_t hdr, inout meta_t meta, in intrinsic_metadata_t intr_md) {
+    MyC2() c2;
+    apply {
+        c2.apply(meta = {8w0,8w0,8w0});
+    }
+}
+
+P<hdr_t, meta_t>(MyC()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1638-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1638-frontend.p4
@@ -1,0 +1,40 @@
+#include <core.p4>
+
+struct intrinsic_metadata_t {
+    bit<8> f0;
+    bit<8> f1;
+}
+
+struct empty_t {
+}
+
+control C<H, M>(inout H hdr, inout M meta, in intrinsic_metadata_t intr_md);
+package P<H, M>(C<H, M> c);
+struct hdr_t {
+}
+
+struct meta_t {
+    bit<8> f0;
+    bit<8> f1;
+    bit<8> f2;
+}
+
+control MyC(inout hdr_t hdr, inout meta_t meta, in intrinsic_metadata_t intr_md) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("MyC.c2.a") table c2_a {
+        key = {
+            {8w0,8w0,8w0}.f0: exact @name("meta.f0") ;
+        }
+        actions = {
+            NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        c2_a.apply();
+    }
+}
+
+P<hdr_t, meta_t>(MyC()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1638-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1638-midend.p4
@@ -1,0 +1,51 @@
+#include <core.p4>
+
+struct intrinsic_metadata_t {
+    bit<8> f0;
+    bit<8> f1;
+}
+
+struct empty_t {
+}
+
+control C<H, M>(inout H hdr, inout M meta, in intrinsic_metadata_t intr_md);
+package P<H, M>(C<H, M> c);
+struct hdr_t {
+}
+
+struct meta_t {
+    bit<8> f0;
+    bit<8> f1;
+    bit<8> f2;
+}
+
+control MyC(inout hdr_t hdr, inout meta_t meta, in intrinsic_metadata_t intr_md) {
+    bit<8> key_0;
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("MyC.c2.a") table c2_a {
+        key = {
+            key_0: exact @name("meta.f0") ;
+        }
+        actions = {
+            NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    @hidden action act() {
+        key_0 = 8w0;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+        c2_a.apply();
+    }
+}
+
+P<hdr_t, meta_t>(MyC()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1638.p4
+++ b/testdata/p4_16_samples_outputs/issue1638.p4
@@ -1,0 +1,44 @@
+#include <core.p4>
+
+struct intrinsic_metadata_t {
+    bit<8> f0;
+    bit<8> f1;
+}
+
+struct empty_t {
+}
+
+control C<H, M>(inout H hdr, inout M meta, in intrinsic_metadata_t intr_md);
+package P<H, M>(C<H, M> c);
+struct hdr_t {
+}
+
+struct meta_t {
+    bit<8> f0;
+    bit<8> f1;
+    bit<8> f2;
+}
+
+control MyC2(in meta_t meta={ 0, 0, 0 }) {
+    table a {
+        key = {
+            meta.f0: exact;
+        }
+        actions = {
+            NoAction;
+        }
+    }
+    apply {
+        a.apply();
+    }
+}
+
+control MyC(inout hdr_t hdr, inout meta_t meta, in intrinsic_metadata_t intr_md) {
+    MyC2() c2;
+    apply {
+        c2.apply();
+    }
+}
+
+P(MyC()) main;
+


### PR DESCRIPTION
This also fixes a couple of bugs which were losing default parameter values, found by @hanw.