### PR TITLE
error reporting

### DIFF
--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -129,7 +129,7 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                 continue;
             }
         }
-        ::error("%1%: not yet supported on this target", s);
+        ::error(ErrorType::ERR_EXPRESSION, s, "not yet supported on this target");
     }
 }
 
@@ -144,7 +144,8 @@ ActionConverter::convertActionParams(const IR::ParameterList *parameters,
         param->emplace("name", p->name);
         auto type = ctxt->typeMap->getType(p, true);
         if (!type->is<IR::Type_Bits>())
-            ::error("%1%: Action parameters can only be bit<> or int<> on this target", p);
+            ::error(ErrorType::ERR_INVALID, p,
+                    "action parameters must be bit<> or int<> on this target");
         param->emplace("bitwidth", type->width_bits());
         params->append(param);
     }

--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -129,7 +129,7 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                 continue;
             }
         }
-        ::error(ErrorType::ERR_EXPRESSION, s, "not yet supported on this target");
+        ::error(ErrorType::ERR_UNSUPPORTED, "%1% not yet supported on this target", s);
     }
 }
 
@@ -138,14 +138,14 @@ ActionConverter::convertActionParams(const IR::ParameterList *parameters,
                                      Util::JsonArray* params) {
     for (auto p : *parameters->getEnumerator()) {
         if (!ctxt->refMap->isUsed(p))
-            ::warning("Unused action parameter %1%", p);
+            ::warning(ErrorType::WARN_UNUSED, "Unused action parameter %1%", p);
 
         auto param = new Util::JsonObject();
         param->emplace("name", p->name);
         auto type = ctxt->typeMap->getType(p, true);
         if (!type->is<IR::Type_Bits>())
-            ::error(ErrorType::ERR_INVALID, p,
-                    "action parameters must be bit<> or int<> on this target");
+            ::error(ErrorType::ERR_INVALID,
+                    "action parameters must be bit<> or int<> on this target", p);
         param->emplace("bitwidth", type->width_bits());
         params->append(param);
     }

--- a/backends/bmv2/common/controlFlowGraph.cpp
+++ b/backends/bmv2/common/controlFlowGraph.cpp
@@ -89,9 +89,9 @@ bool CFG::dfs(Node* node, std::set<Node*> &visited,
     if (node->is<TableNode>()) {
         table = node->to<TableNode>()->table;
         if (stack.find(table) != stack.end()) {
-            ::error(ErrorType::ERR_INVALID, table,
-                    "program for this target since it contains a path from table " + table->name +
-                    " back to itself");
+            ::error(ErrorType::ERR_INVALID,
+                    "Program can not be implemented on this taret since it contains a path from "
+                    "table %1% back to itself", table);
             return false;
         }
     }
@@ -149,8 +149,8 @@ bool CFG::checkMergeable(std::set<TableNode*> nodes) const {
         }
         bool same = first->successors.checkSame(tn->successors);
         if (!same) {
-            ::error(ErrorType::ERR_INVALID, tn->table, "program on this target, because table " +
-                    tn->table->name + "has multiple successors");
+            ::error(ErrorType::ERR_INVALID, "Program is not supported by this target, because "
+                    "table %1% has multiple successors", tn->table);
             return false;
         }
     }
@@ -209,7 +209,7 @@ class CFGBuilder : public Inspector {
             return false;
         auto am = instance->to<P4::ApplyMethod>();
         if (!am->object->is<IR::P4Table>()) {
-            ::error(ErrorType::ERR_INVALID, statement, "apply method must be on a table");
+            ::error(ErrorType::ERR_INVALID, "apply method must be on a table", statement);
             return false;
         }
         auto tc = am->object->to<IR::P4Table>();

--- a/backends/bmv2/common/controlFlowGraph.cpp
+++ b/backends/bmv2/common/controlFlowGraph.cpp
@@ -89,9 +89,9 @@ bool CFG::dfs(Node* node, std::set<Node*> &visited,
     if (node->is<TableNode>()) {
         table = node->to<TableNode>()->table;
         if (stack.find(table) != stack.end()) {
-            ::error("Program cannot be implemented on this target since there it contains"
-                    "a path from table %1% back to itself",
-                    table);
+            ::error(ErrorType::ERR_INVALID, table,
+                    "program for this target since it contains a path from table " + table->name +
+                    " back to itself");
             return false;
         }
     }
@@ -149,8 +149,8 @@ bool CFG::checkMergeable(std::set<TableNode*> nodes) const {
         }
         bool same = first->successors.checkSame(tn->successors);
         if (!same) {
-            ::error("Program is not supported by this target, because "
-                    "table %1% has multiple successors", tn->table);
+            ::error(ErrorType::ERR_INVALID, tn->table, "program on this target, because table " +
+                    tn->table->name + "has multiple successors");
             return false;
         }
     }
@@ -209,7 +209,7 @@ class CFGBuilder : public Inspector {
             return false;
         auto am = instance->to<P4::ApplyMethod>();
         if (!am->object->is<IR::P4Table>()) {
-            ::error("%1%: apply method must be on a table", statement);
+            ::error(ErrorType::ERR_INVALID, statement, "apply method must be on a table");
             return false;
         }
         auto tc = am->object->to<IR::P4Table>();

--- a/backends/bmv2/common/deparser.cpp
+++ b/backends/bmv2/common/deparser.cpp
@@ -59,15 +59,15 @@ void DeparserConverter::convertDeparserBody(const IR::Vector<IR::StatOrDecl>* bo
                             auto val = j->to<Util::JsonObject>()->get("value");
                             result->append(val);
                         } else {
-                            ::error("%1%: emit only supports header and stack arguments, not %2%",
-                                    arg, type);
+                            ::error(ErrorType::ERR_UNSUPPORTED, arg,
+                                    "header and stack arguments for emit, not "+ type->toString());
                         }
                     }
                     continue;
                 }
             }
         }
-        ::error("%1%: not supported with a deparser on this target", s);
+        ::error(ErrorType::ERR_UNSUPPORTED, s, "within a deparser on this target");
     }
     ctxt->conv->simpleExpressionsOnly = false;
 }

--- a/backends/bmv2/common/deparser.cpp
+++ b/backends/bmv2/common/deparser.cpp
@@ -59,15 +59,16 @@ void DeparserConverter::convertDeparserBody(const IR::Vector<IR::StatOrDecl>* bo
                             auto val = j->to<Util::JsonObject>()->get("value");
                             result->append(val);
                         } else {
-                            ::error(ErrorType::ERR_UNSUPPORTED, arg,
-                                    "header and stack arguments for emit, not "+ type->toString());
+                            ::error(ErrorType::ERR_UNSUPPORTED,
+                                    "%1%: emit only supports header and stack arguments, not %2%",
+                                    arg, type);
                         }
                     }
                     continue;
                 }
             }
         }
-        ::error(ErrorType::ERR_UNSUPPORTED, s, "within a deparser on this target");
+        ::error(ErrorType::ERR_UNSUPPORTED, "within a deparser on this target", s);
     }
     ctxt->conv->simpleExpressionsOnly = false;
 }

--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -206,8 +206,7 @@ void ExpressionConverter::postorder(const IR::ArrayIndex* expression)  {
     }
 
     if (!expression->right->is<IR::Constant>()) {
-        ::error("%1%: all array indexes must be constant on this architecture",
-                expression->right);
+        ::error(ErrorType::ERR_INVALID, expression->right, "all array indexes must be constant");
     } else {
         int index = expression->right->to<IR::Constant>()->asInt();
         elementAccess += "[" + Util::toString(index) + "]";
@@ -333,7 +332,7 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
         auto mem = expression->expr->to<IR::Member>();
         auto memtype = typeMap->getType(mem->expr, true);
         if (memtype->is<IR::Type_Stack>() && mem->member == IR::Type_Stack::next)
-            ::error("%1%: Reading next field, which is always uninitialized", mem);
+            ::error(ErrorType::ERR_UNINITIALIZED, mem, "next field read");
         // array.last.field => type: "stack_field", value: [ array, field ]
         if (memtype->is<IR::Type_Stack>() && mem->member == IR::Type_Stack::last) {
             auto l = get(mem->expr);
@@ -433,7 +432,7 @@ void ExpressionConverter::postorder(const IR::Mux* expression)  {
     auto result = new Util::JsonObject();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error("%1%: expression to complex for this target", expression);
+        ::error(ErrorType::ERR_EXPRESSION, expression, "too complex for this target");
         return;
     }
 
@@ -473,7 +472,7 @@ void ExpressionConverter::binary(const IR::Operation_Binary* expression) {
     auto result = new Util::JsonObject();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error("%1%: expression to complex for this target", expression);
+        ::error(ErrorType::ERR_EXPRESSION, expression, "too complex for this target");
         return;
     }
 
@@ -528,7 +527,7 @@ void ExpressionConverter::postorder(const IR::ListExpression* expression)  {
     auto result = new Util::JsonArray();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error("%1%: expression to complex for this target", expression);
+        ::error(ErrorType::ERR_EXPRESSION, expression, "too complex for this target");
         return;
     }
 
@@ -543,7 +542,7 @@ void ExpressionConverter::postorder(const IR::StructInitializerExpression* expre
     auto result = new Util::JsonArray();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error("%1%: expression to complex for this target", expression);
+        ::error(ErrorType::ERR_EXPRESSION, expression, "too complex for this target");
         return;
     }
 
@@ -557,7 +556,7 @@ void ExpressionConverter::postorder(const IR::Operation_Unary* expression)  {
     auto result = new Util::JsonObject();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error("%1%: expression to complex for this target", expression);
+        ::error(ErrorType::ERR_EXPRESSION, expression, "too complex for this target");
         return;
     }
 

--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -206,7 +206,7 @@ void ExpressionConverter::postorder(const IR::ArrayIndex* expression)  {
     }
 
     if (!expression->right->is<IR::Constant>()) {
-        ::error(ErrorType::ERR_INVALID, expression->right, "all array indexes must be constant");
+        ::error(ErrorType::ERR_INVALID, "all array indexes must be constant", expression->right);
     } else {
         int index = expression->right->to<IR::Constant>()->asInt();
         elementAccess += "[" + Util::toString(index) + "]";
@@ -332,7 +332,7 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
         auto mem = expression->expr->to<IR::Member>();
         auto memtype = typeMap->getType(mem->expr, true);
         if (memtype->is<IR::Type_Stack>() && mem->member == IR::Type_Stack::next)
-            ::error(ErrorType::ERR_UNINITIALIZED, mem, "next field read");
+            ::error(ErrorType::ERR_UNINITIALIZED, "next field read", mem);
         // array.last.field => type: "stack_field", value: [ array, field ]
         if (memtype->is<IR::Type_Stack>() && mem->member == IR::Type_Stack::last) {
             auto l = get(mem->expr);
@@ -432,7 +432,7 @@ void ExpressionConverter::postorder(const IR::Mux* expression)  {
     auto result = new Util::JsonObject();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error(ErrorType::ERR_EXPRESSION, expression, "too complex for this target");
+        ::error(ErrorType::ERR_EXPRESSION, "too complex for this target", expression);
         return;
     }
 
@@ -472,7 +472,7 @@ void ExpressionConverter::binary(const IR::Operation_Binary* expression) {
     auto result = new Util::JsonObject();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error(ErrorType::ERR_EXPRESSION, expression, "too complex for this target");
+        ::error(ErrorType::ERR_EXPRESSION, "too complex for this target", expression);
         return;
     }
 
@@ -527,7 +527,7 @@ void ExpressionConverter::postorder(const IR::ListExpression* expression)  {
     auto result = new Util::JsonArray();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error(ErrorType::ERR_EXPRESSION, expression, "too complex for this target");
+        ::error(ErrorType::ERR_EXPRESSION, "too complex for this target", expression);
         return;
     }
 
@@ -542,7 +542,7 @@ void ExpressionConverter::postorder(const IR::StructInitializerExpression* expre
     auto result = new Util::JsonArray();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error(ErrorType::ERR_EXPRESSION, expression, "too complex for this target");
+        ::error(ErrorType::ERR_EXPRESSION, "too complex for this target", expression);
         return;
     }
 
@@ -556,7 +556,7 @@ void ExpressionConverter::postorder(const IR::Operation_Unary* expression)  {
     auto result = new Util::JsonObject();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error(ErrorType::ERR_EXPRESSION, expression, "too complex for this target");
+        ::error(ErrorType::ERR_EXPRESSION, "too complex for this target", expression);
         return;
     }
 

--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -432,7 +432,7 @@ void ExpressionConverter::postorder(const IR::Mux* expression)  {
     auto result = new Util::JsonObject();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error(ErrorType::ERR_EXPRESSION, "too complex for this target", expression);
+        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET, "expression too complex", expression);
         return;
     }
 
@@ -472,7 +472,7 @@ void ExpressionConverter::binary(const IR::Operation_Binary* expression) {
     auto result = new Util::JsonObject();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error(ErrorType::ERR_EXPRESSION, "too complex for this target", expression);
+        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET, "expression too complex", expression);
         return;
     }
 
@@ -527,7 +527,7 @@ void ExpressionConverter::postorder(const IR::ListExpression* expression)  {
     auto result = new Util::JsonArray();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error(ErrorType::ERR_EXPRESSION, "too complex for this target", expression);
+        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET, "expression too complex", expression);
         return;
     }
 
@@ -542,7 +542,7 @@ void ExpressionConverter::postorder(const IR::StructInitializerExpression* expre
     auto result = new Util::JsonArray();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error(ErrorType::ERR_EXPRESSION, "too complex for this target", expression);
+        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET, "expression too complex", expression);
         return;
     }
 
@@ -556,7 +556,7 @@ void ExpressionConverter::postorder(const IR::Operation_Unary* expression)  {
     auto result = new Util::JsonObject();
     mapExpression(expression, result);
     if (simpleExpressionsOnly) {
-        ::error(ErrorType::ERR_EXPRESSION, "too complex for this target", expression);
+        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET, "expression too complex", expression);
         return;
     }
 

--- a/backends/bmv2/common/extern.cpp
+++ b/backends/bmv2/common/extern.cpp
@@ -82,8 +82,8 @@ ExternConverter::convertExternObject(ConversionContext* ctxt,
         }
         return primitive;
     } else {
-        ::error(ErrorType::ERR_UNKNOWN, em->method->name,
-                "extern method from type " + em->originalExternType->name);
+        ::error(ErrorType::ERR_UNKNOWN, "Unknown extern method %1% from type %2%",
+                em->method->name, em->originalExternType->name);
         return nullptr;
     }
 }
@@ -94,7 +94,7 @@ ExternConverter::convertExternInstance(ConversionContext* ,
                                        const IR::ExternBlock* eb,
                                        const bool& emitExterns) {
     if (!emitExterns)
-        ::error(ErrorType::ERR_UNKNOWN, eb->type->name, "extern instance");
+        ::error(ErrorType::ERR_UNKNOWN, "extern instance", eb->type->name);
 }
 
 Util::IJson*
@@ -104,7 +104,7 @@ ExternConverter::convertExternFunction(ConversionContext* ctxt,
                                        const IR::StatOrDecl* s,
                                        const bool emitExterns) {
     if (!emitExterns) {
-        ::error(ErrorType::ERR_UNKNOWN, ef->method->name, "extern function");
+        ::error(ErrorType::ERR_UNKNOWN, "extern function", ef->method->name);
         return nullptr;
     }
     auto primitive = mkPrimitive(ef->method->name);

--- a/backends/bmv2/common/extern.cpp
+++ b/backends/bmv2/common/extern.cpp
@@ -82,8 +82,8 @@ ExternConverter::convertExternObject(ConversionContext* ctxt,
         }
         return primitive;
     } else {
-        ::error("Unknown extern method %1% from type %2%",
-                em->method->name, em->originalExternType->name);
+        ::error(ErrorType::ERR_UNKNOWN, em->method->name,
+                "extern method from type " + em->originalExternType->name);
         return nullptr;
     }
 }
@@ -94,7 +94,7 @@ ExternConverter::convertExternInstance(ConversionContext* ,
                                        const IR::ExternBlock* eb,
                                        const bool& emitExterns) {
     if (!emitExterns)
-        ::error("Unknown extern instance %1%", eb->type->name);
+        ::error(ErrorType::ERR_UNKNOWN, eb->type->name, "extern instance");
 }
 
 Util::IJson*
@@ -104,7 +104,7 @@ ExternConverter::convertExternFunction(ConversionContext* ctxt,
                                        const IR::StatOrDecl* s,
                                        const bool emitExterns) {
     if (!emitExterns) {
-        ::error("Unknown extern function %1%", ef->method->name);
+        ::error(ErrorType::ERR_UNKNOWN, ef->method->name, "extern function");
         return nullptr;
     }
     auto primitive = mkPrimitive(ef->method->name);
@@ -248,7 +248,7 @@ ExternConverter::convertHashAlgorithm(cstring algorithm) {
     else if (algorithm == P4V1::V1Model::instance.algorithm.xor16.name)
         result = "xor16";
     else
-        ::error("%1%: unexpected algorithm", algorithm);
+        ::error("Unsupported algorithm %1%", algorithm);
     return result;
 }
 

--- a/backends/bmv2/common/header.cpp
+++ b/backends/bmv2/common/header.cpp
@@ -45,8 +45,8 @@ void HeaderConverter::addTypesAndInstances(const IR::Type_StructLike* type, bool
         if (ft->is<IR::Type_StructLike>()) {
             // The headers struct can not contain nested structures.
             if (!meta && ft->is<IR::Type_Struct>()) {
-                ::error("Type %1% should only contain headers, header stacks, or header unions",
-                        type);
+                ::error(ErrorType::ERR_INVALID, type,
+                        "type should only contain headers, header stacks, or header unions");
                 return;
             }
             auto st = ft->to<IR::Type_StructLike>();
@@ -211,7 +211,7 @@ void HeaderConverter::addHeaderType(const IR::Type_StructLike *st) {
             max_length += type->size;
             field->append("*");
             if (varbitFound)
-                ::error("%1%: headers with multiple varbit fields not supported", st);
+                ::error(ErrorType::ERR_UNSUPPORTED, st, "headers with multiple varbit fields");
             varbitFound = true;
         } else if (ftype->is<IR::Type_Error>()) {
             // treat as bit<32>
@@ -231,10 +231,9 @@ void HeaderConverter::addHeaderType(const IR::Type_StructLike *st) {
     unsigned padding = max_length % 8;
     if (padding != 0) {
         if (st->is<IR::Type_Header>()) {
-            ::error("%1%: Found header with fields totaling %2% bits."
-                    "  BMv2 target only supports headers with fields"
-                    " totaling a multiple of 8 bits.",
-                    st, max_length);
+            ::error(ErrorType::ERR_OVERLIMIT, st,
+                    "only headers with fields totaling a multiple of 8 bits. This header size is ",
+                    max_length, "bits");
         } else if (st->is<IR::Type_Struct>()) {
             cstring name = ctxt->refMap->newName("_padding");
             auto field = pushNewArray(fields);

--- a/backends/bmv2/common/header.cpp
+++ b/backends/bmv2/common/header.cpp
@@ -45,8 +45,8 @@ void HeaderConverter::addTypesAndInstances(const IR::Type_StructLike* type, bool
         if (ft->is<IR::Type_StructLike>()) {
             // The headers struct can not contain nested structures.
             if (!meta && ft->is<IR::Type_Struct>()) {
-                ::error(ErrorType::ERR_INVALID, type,
-                        "type should only contain headers, header stacks, or header unions");
+                ::error(ErrorType::ERR_INVALID,
+                        "type should only contain headers, header stacks, or header unions", type);
                 return;
             }
             auto st = ft->to<IR::Type_StructLike>();
@@ -211,7 +211,7 @@ void HeaderConverter::addHeaderType(const IR::Type_StructLike *st) {
             max_length += type->size;
             field->append("*");
             if (varbitFound)
-                ::error(ErrorType::ERR_UNSUPPORTED, st, "headers with multiple varbit fields");
+                ::error(ErrorType::ERR_UNSUPPORTED, "headers with multiple varbit fields", st);
             varbitFound = true;
         } else if (ftype->is<IR::Type_Error>()) {
             // treat as bit<32>
@@ -231,9 +231,10 @@ void HeaderConverter::addHeaderType(const IR::Type_StructLike *st) {
     unsigned padding = max_length % 8;
     if (padding != 0) {
         if (st->is<IR::Type_Header>()) {
-            ::error(ErrorType::ERR_OVERLIMIT, st,
-                    "only headers with fields totaling a multiple of 8 bits. This header size is ",
-                    max_length, "bits");
+            ::error(ErrorType::ERR_OVERLIMIT, "%1%: Found header with fields totaling %2% bits."
+                    "  BMv2 target only supports headers with fields"
+                    " totaling a multiple of 8 bits.",
+                    st, max_length);
         } else if (st->is<IR::Type_Struct>()) {
             cstring name = ctxt->refMap->newName("_padding");
             auto field = pushNewArray(fields);

--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -32,13 +32,13 @@ const IR::Expression* LowerExpressions::shift(const IR::Operation_Binary* expres
         auto cst = rhs->to<IR::Constant>();
         mpz_class maxShift = Util::shift_left(1, LowerExpressions::maxShiftWidth);
         if (cst->value > maxShift)
-            ::error("%1%: shift amount limited to %2% on this target", expression, maxShift);
+            ::error(ErrorType::ERR_OVERLIMIT, expression, "shift amounts up to", maxShift, "bits");
     } else {
         BUG_CHECK(rhstype->is<IR::Type_Bits>(), "%1%: expected a bit<> type", rhstype);
         auto bs = rhstype->to<IR::Type_Bits>();
         if (bs->size > LowerExpressions::maxShiftWidth)
-            ::error("%1%: shift amount limited to %2% bits on this target",
-                    expression, LowerExpressions::maxShiftWidth);
+            ::error(ErrorType::ERR_OVERLIMIT, expression, "shift amounts up to",
+                    LowerExpressions::maxShiftWidth, "bits");
     }
     auto ltype = typeMap->getType(getOriginal(), true);
     typeMap->setType(expression, ltype);
@@ -289,7 +289,7 @@ RemoveComplexExpressions::postorder(IR::MethodCallExpression* expression) {
             // one knew of this feature, since it was not very clearly
             // documented.
             if (expression->arguments->size() != 2) {
-                ::error("%1% expected 2 arguments", expression);
+                ::error(ErrorType::ERR_EXPECTED, expression, "2 arguments");
                 return expression;
             }
             auto vec = new IR::Vector<IR::Argument>();

--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -32,13 +32,15 @@ const IR::Expression* LowerExpressions::shift(const IR::Operation_Binary* expres
         auto cst = rhs->to<IR::Constant>();
         mpz_class maxShift = Util::shift_left(1, LowerExpressions::maxShiftWidth);
         if (cst->value > maxShift)
-            ::error(ErrorType::ERR_OVERLIMIT, expression, "shift amounts up to", maxShift, "bits");
+            ::error(ErrorType::ERR_OVERLIMIT, "%1%: shift amount limited to %2% on this target",
+                    expression, maxShift);
     } else {
         BUG_CHECK(rhstype->is<IR::Type_Bits>(), "%1%: expected a bit<> type", rhstype);
         auto bs = rhstype->to<IR::Type_Bits>();
         if (bs->size > LowerExpressions::maxShiftWidth)
-            ::error(ErrorType::ERR_OVERLIMIT, expression, "shift amounts up to",
-                    LowerExpressions::maxShiftWidth, "bits");
+            ::error(ErrorType::ERR_OVERLIMIT,
+                    "%1%: shift amount limited to %2% bits on this target",
+                    expression, LowerExpressions::maxShiftWidth);
     }
     auto ltype = typeMap->getType(getOriginal(), true);
     typeMap->setType(expression, ltype);
@@ -289,7 +291,7 @@ RemoveComplexExpressions::postorder(IR::MethodCallExpression* expression) {
             // one knew of this feature, since it was not very clearly
             // documented.
             if (expression->arguments->size() != 2) {
-                ::error(ErrorType::ERR_EXPECTED, expression, "2 arguments");
+                ::error(ErrorType::ERR_EXPECTED, "2 arguments", expression);
                 return expression;
             }
             auto vec = new IR::Vector<IR::Argument>();

--- a/backends/bmv2/common/metermap.cpp
+++ b/backends/bmv2/common/metermap.cpp
@@ -40,9 +40,9 @@ void DirectMeterMap::setTable(const IR::IDeclaration* meter, const IR::P4Table* 
     auto info = getInfo(meter);
     CHECK_NULL(info);
     if (info->table != nullptr)
-        ::error(ErrorType::ERR_INVALID, meter,
-                " -- direct meterss cannot be attached to multiple tables: " +
-                table->toString() + " and " + info->table->toString());
+        ::error(ErrorType::ERR_INVALID,
+                "%1%: Direct meters cannot be attached to multiple tables %2% and %3%",
+                meter, table, info->table);
     info->table = table;
 }
 
@@ -76,10 +76,9 @@ void DirectMeterMap::setDestination(const IR::IDeclaration* meter,
     } else {
         bool same = checkSame(destination, info->destinationField);
         if (!same)
-            ::error(ErrorType::ERR_INVALID, meter->getNode(),
-                    "all meter operations must write to the same destination, however " +
-                    destination->toString() + " and " + info->destinationField->toString() +
-                    " are different.");
+            ::error(ErrorType::ERR_INVALID,
+                    "all meter operations must write to the same destination,"
+                    " however %1% and %2% are different", destination, info->destinationField);
     }
 }
 

--- a/backends/bmv2/common/metermap.cpp
+++ b/backends/bmv2/common/metermap.cpp
@@ -40,8 +40,9 @@ void DirectMeterMap::setTable(const IR::IDeclaration* meter, const IR::P4Table* 
     auto info = getInfo(meter);
     CHECK_NULL(info);
     if (info->table != nullptr)
-        ::error("%1%: Direct meters cannot be attached to multiple tables %2% and %3%",
-                meter, table, info->table);
+        ::error(ErrorType::ERR_INVALID, meter,
+                " -- direct meterss cannot be attached to multiple tables: " +
+                table->toString() + " and " + info->table->toString());
     info->table = table;
 }
 
@@ -75,8 +76,10 @@ void DirectMeterMap::setDestination(const IR::IDeclaration* meter,
     } else {
         bool same = checkSame(destination, info->destinationField);
         if (!same)
-            ::error("On this target all meter operations must write to the same destination "
-                    "but %1% and %2% are different", destination, info->destinationField);
+            ::error(ErrorType::ERR_INVALID, meter->getNode(),
+                    "all meter operations must write to the same destination, however " +
+                    destination->toString() + " and " + info->destinationField->toString() +
+                    " are different.");
     }
 }
 
@@ -90,4 +93,3 @@ void DirectMeterMap::setSize(const IR::IDeclaration* meter, unsigned size) {
 }
 
 }  // namespace BMV2
-

--- a/backends/bmv2/common/parser.cpp
+++ b/backends/bmv2/common/parser.cpp
@@ -79,8 +79,9 @@ Util::IJson* ParserConverter::convertParserStatement(const IR::StatOrDecl* stat)
                     auto arg = mce->arguments->at(0);
                     auto argtype = ctxt->typeMap->getType(arg->expression, true);
                     if (!argtype->is<IR::Type_Header>()) {
-                        ::error("%1%: extract only accepts arguments with header types, not %2%",
-                                arg, argtype);
+                        ::error(ErrorType::ERR_INVALID, arg,
+                                "argument to extract. Must be a header type, not " +
+                                argtype->toString());
                         return result;
                     }
                     auto param = new Util::JsonObject();
@@ -189,7 +190,7 @@ Util::IJson* ParserConverter::convertParserStatement(const IR::StatOrDecl* stat)
             return result;
         }
     }
-    ::error("%1%: not supported in parser on this target", stat);
+    ::error(ErrorType::ERR_UNSUPPORTED, stat, "in parser on this target", stat);
     return result;
 }
 
@@ -199,11 +200,11 @@ void ParserConverter::convertSimpleKey(const IR::Expression* keySet,
     if (keySet->is<IR::Mask>()) {
         auto mk = keySet->to<IR::Mask>();
         if (!mk->left->is<IR::Constant>()) {
-            ::error("%1% must evaluate to a compile-time constant", mk->left);
+            ::error(ErrorType::ERR_INVALID, mk->left, "must evaluate to a compile-time constant");
             return;
         }
         if (!mk->right->is<IR::Constant>()) {
-            ::error("%1% must evaluate to a compile-time constant", mk->right);
+            ::error(ErrorType::ERR_INVALID, mk->right, "must evaluate to a compile-time constant");
             return;
         }
         value = mk->left->to<IR::Constant>()->value;
@@ -218,7 +219,7 @@ void ParserConverter::convertSimpleKey(const IR::Expression* keySet,
         value = 0;
         mask = 0;
     } else {
-        ::error("%1% must evaluate to a compile-time constant", keySet);
+        ::error(ErrorType::ERR_INVALID, keySet, "must evaluate to a compile-time constant");
         value = 0;
         mask = 0;
     }

--- a/backends/bmv2/common/parser.cpp
+++ b/backends/bmv2/common/parser.cpp
@@ -79,9 +79,9 @@ Util::IJson* ParserConverter::convertParserStatement(const IR::StatOrDecl* stat)
                     auto arg = mce->arguments->at(0);
                     auto argtype = ctxt->typeMap->getType(arg->expression, true);
                     if (!argtype->is<IR::Type_Header>()) {
-                        ::error(ErrorType::ERR_INVALID, arg,
-                                "argument to extract. Must be a header type, not " +
-                                argtype->toString());
+                        ::error(ErrorType::ERR_INVALID,
+                                "%1%: extract only accepts arguments with header types, not %2%",
+                                arg, argtype);
                         return result;
                     }
                     auto param = new Util::JsonObject();
@@ -190,7 +190,7 @@ Util::IJson* ParserConverter::convertParserStatement(const IR::StatOrDecl* stat)
             return result;
         }
     }
-    ::error(ErrorType::ERR_UNSUPPORTED, stat, "in parser on this target", stat);
+    ::error(ErrorType::ERR_UNSUPPORTED, "in parser on this target", stat);
     return result;
 }
 
@@ -200,11 +200,11 @@ void ParserConverter::convertSimpleKey(const IR::Expression* keySet,
     if (keySet->is<IR::Mask>()) {
         auto mk = keySet->to<IR::Mask>();
         if (!mk->left->is<IR::Constant>()) {
-            ::error(ErrorType::ERR_INVALID, mk->left, "must evaluate to a compile-time constant");
+            ::error(ErrorType::ERR_INVALID, "must evaluate to a compile-time constant", mk->left);
             return;
         }
         if (!mk->right->is<IR::Constant>()) {
-            ::error(ErrorType::ERR_INVALID, mk->right, "must evaluate to a compile-time constant");
+            ::error(ErrorType::ERR_INVALID, "must evaluate to a compile-time constant", mk->right);
             return;
         }
         value = mk->left->to<IR::Constant>()->value;
@@ -219,7 +219,7 @@ void ParserConverter::convertSimpleKey(const IR::Expression* keySet,
         value = 0;
         mask = 0;
     } else {
-        ::error(ErrorType::ERR_INVALID, keySet, "must evaluate to a compile-time constant");
+        ::error(ErrorType::ERR_INVALID, "must evaluate to a compile-time constant", keySet);
         value = 0;
         mask = 0;
     }
@@ -303,7 +303,9 @@ Util::IJson* ParserConverter::stateName(IR::ID state) {
     if (state.name == IR::ParserState::accept) {
         return Util::JsonValue::null;
     } else if (state.name == IR::ParserState::reject) {
-        ::warning("Explicit transition to %1% not supported on this target", state);
+        ::warning(ErrorType::WARN_UNSUPPORTED,
+                  "Explicit transition to %1% not supported on this target",
+                  state);
         return Util::JsonValue::null;
     } else {
         return new Util::JsonValue(state.name);

--- a/backends/bmv2/common/sharedActionSelectorCheck.cpp
+++ b/backends/bmv2/common/sharedActionSelectorCheck.cpp
@@ -33,7 +33,7 @@ SharedActionSelectorCheck::preorder(const IR::P4Table* table) {
     auto implementation = table->properties->getProperty("implementation");
     if (implementation == nullptr) return false;
     if (!implementation->value->is<IR::ExpressionValue>()) {
-        ::error(ErrorType::ERR_EXPECTED, implementation, "expression for property");
+        ::error(ErrorType::ERR_EXPECTED, "expression for property", implementation);
         return false;
     }
     auto propv = implementation->value->to<IR::ExpressionValue>();
@@ -41,12 +41,12 @@ SharedActionSelectorCheck::preorder(const IR::P4Table* table) {
     auto pathe = propv->expression->to<IR::PathExpression>();
     auto decl = refMap->getDeclaration(pathe->path, true);
     if (!decl->is<IR::Declaration_Instance>()) {
-        ::error(ErrorType::ERR_EXPECTED, pathe, "a reference to an instance");
+        ::error(ErrorType::ERR_EXPECTED, "a reference to an instance", pathe);
         return false;
     }
     auto dcltype = typeMap->getType(pathe, true);
     if (!dcltype->is<IR::Type_Extern>()) {
-        ::error(ErrorType::ERR_UNEXPECTED, dcltype, "type for implementation");
+        ::error(ErrorType::ERR_UNEXPECTED, "type for implementation", dcltype);
         return false;
     }
     auto type_extern_name = dcltype->to<IR::Type_Extern>()->name;
@@ -73,8 +73,9 @@ SharedActionSelectorCheck::preorder(const IR::P4Table* table) {
     };
 
     if (!cmp_inputs(it->second, input)) {
-        ::error(ErrorType::ERR_INVALID, decl,
-                "Action selector is used by multiple tables with different selector inputs");
+        ::error(ErrorType::ERR_INVALID,
+                "Action selector %1% is used by multiple tables with different selector inputs",
+                decl);
     }
 
     return false;

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -56,7 +56,7 @@ void PsaProgramStructure::createStructLike(ConversionContext* ctxt, const IR::Ty
             max_length += type->size;
             field->append("*");
             if (varbitFound)
-                ::error("%1%: headers with multiple varbit fields not supported", st);
+                ::error(ErrorType::ERR_UNSUPPORTED, st, "headers with multiple varbit fields");
             varbitFound = true;
         } else if (ftype->is<IR::Type_Error>()) {
             field->append(f->name.name);
@@ -289,8 +289,8 @@ void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bo
         if (ft->is<IR::Type_StructLike>()) {
             // The headers struct can not contain nested structures.
             if (isHeader && ft->is<IR::Type_Struct>()) {
-                ::error("Type %1% should only contain headers, header stacks, or header unions",
-                        type);
+                ::error(ErrorType::ERR_INVALID, type,
+                        "type should only contain headers, header stacks, or header unions");
                 return;
             }
             if (auto hft = ft->to<IR::Type_Header>()) {
@@ -303,7 +303,8 @@ void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bo
                         addHeaderType(h_type);
                         addHeaderInstance(h_type, uf->controlPlaneName());
                     } else {
-                        ::error("Type %1% cannot contain type %2%", ft, uft);
+                        ::error(ErrorType::ERR_INVALID, ft, "type cannot contain type " +
+                                uft->toString());
                         return;
                     }
                 }
@@ -728,7 +729,7 @@ void ExternConverter_Meter::convertExternInstance(
     else if (mkind_name == "BYTES")
         type = "bytes";
     else
-        ::error("Unexpected meter type %1%", mkind->getNode());
+        ::error(ErrorType::ERR_UNEXPECTED, mkind->getNode(), "meter type");
     jmtr->emplace("type", type);
     ctxt->json->meter_arrays->append(jmtr);
 }
@@ -790,7 +791,7 @@ void ExternConverter_Register::convertExternInstance(
         return;
     }
     if (sz->to<IR::Constant>()->value == 0)
-        error("%1%: direct registers are not supported in bmv2", inst);
+        error(ErrorType::ERR_UNSUPPORTED, inst, "direct registers");
     jreg->emplace("size", sz->to<IR::Constant>()->value);
     if (!eb->instanceType->is<IR::Type_SpecializedCanonical>()) {
         modelError("%1%: Expected a generic specialized type", eb->instanceType);
@@ -803,12 +804,12 @@ void ExternConverter_Register::convertExternInstance(
     }
     auto regType = st->arguments->at(0);
     if (!regType->is<IR::Type_Bits>()) {
-        ::error("%1%: Only registers with bit or int types are currently supported", eb);
+        ::error(ErrorType::ERR_UNSUPPORTED, eb, "registers with types other than bit or int");
         return;
     }
     unsigned width = regType->width_bits();
     if (width == 0) {
-        ::error("%1%: unknown width", st->arguments->at(0));
+        ::error(ErrorType::ERR_UNKNOWN, st->arguments->at(0), "width");
         return;
     }
     jreg->emplace("bitwidth", width);
@@ -836,7 +837,7 @@ void ExternConverter_ActionProfile::convertExternInstance(
 
     auto sz = eb->findParameterValue("size");
     if (!sz->is<IR::Constant>()) {
-        ::error("%1%: expected a constant", sz);
+        ::error(ErrorType::ERR_EXPECTED, sz, "a constant");
     }
     action_profile->emplace("max_size", sz->to<IR::Constant>()->value);
 
@@ -859,7 +860,7 @@ void ExternConverter_ActionSelector::convertExternInstance(
 
     auto sz = eb->findParameterValue("size");
     if (!sz->is<IR::Constant>()) {
-        ::error("%1%: expected a constant", sz);
+        ::error(ErrorType::ERR_EXPECTED, sz, "a constant");
     }
     action_profile->emplace("max_size", sz->to<IR::Constant>()->value);
 

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -575,7 +575,7 @@ void ExternConverter_direct_counter::convertExternInstance(
     cstring name = inst->controlPlaneName();
     auto it = ctxt->structure->directCounterMap.find(name);
     if (it == ctxt->structure->directCounterMap.end()) {
-        ::warning("%1%: Direct counter not used; ignoring", inst);
+        ::warning(ErrorType::WARN_UNUSED, "%1%: Direct counter not used; ignoring", inst);
     } else {
         auto jctr = new Util::JsonObject();
         jctr->emplace("name", name);
@@ -678,12 +678,12 @@ void ExternConverter_action_profile::convertExternInstance(
         }
         auto algo = ExternConverter::convertHashAlgorithm(hash->to<IR::Declaration_ID>()->name);
         selector->emplace("algo", algo);
-        auto input = ctxt->selector_check->get_selector_input(
-            c->to<IR::Declaration_Instance>());
+        auto input = ctxt->selector_check->get_selector_input(inst);
         if (input == nullptr) {
             // the selector is never used by any table, we cannot figure out its
             // input and therefore cannot include it in the JSON
-            ::warning("Action selector '%1%' is never referenced by a table "
+            ::warning(// ErrorType::WARN_UNUSED, -- none of the P4 objects seem to have source info
+                      "Action selector '%1%' is never referenced by a table "
                       "and cannot be included in bmv2 JSON", c);
             return;
         }
@@ -735,12 +735,12 @@ void ExternConverter_action_selector::convertExternInstance(
         }
         auto algo = ExternConverter::convertHashAlgorithm(hash->to<IR::Declaration_ID>()->name);
         selector->emplace("algo", algo);
-        auto input = ctxt->selector_check->get_selector_input(
-            c->to<IR::Declaration_Instance>());
+        auto input = ctxt->selector_check->get_selector_input(inst);
         if (input == nullptr) {
             // the selector is never used by any table, we cannot figure out its
             // input and therefore cannot include it in the JSON
-            ::warning("Action selector '%1%' is never referenced by a table "
+            ::warning(// ErrorType::WARN_UNUSED, -- none of the P4 objects seem to have source info
+                      "Action selector '%1%' is never referenced by a table "
                       "and cannot be included in bmv2 JSON", c);
             return;
         }
@@ -873,7 +873,7 @@ SimpleSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
     if (!main) return;  // no main
 
     if (main->type->name != "V1Switch")
-        ::warning("%1%: the main package should be called V1Switch"
+        ::warning(ErrorType::WARN_INVALID, "%1%: the main package should be called V1Switch"
                   "; are you using the wrong architecture?", main->type->name);
 
     main->apply(*parseV1Arch);

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -682,8 +682,7 @@ void ExternConverter_action_profile::convertExternInstance(
         if (input == nullptr) {
             // the selector is never used by any table, we cannot figure out its
             // input and therefore cannot include it in the JSON
-            ::warning(// ErrorType::WARN_UNUSED, -- none of the P4 objects seem to have source info
-                      "Action selector '%1%' is never referenced by a table "
+            ::warning("Action selector '%1%' is never referenced by a table "
                       "and cannot be included in bmv2 JSON", c);
             return;
         }
@@ -739,8 +738,7 @@ void ExternConverter_action_selector::convertExternInstance(
         if (input == nullptr) {
             // the selector is never used by any table, we cannot figure out its
             // input and therefore cannot include it in the JSON
-            ::warning(// ErrorType::WARN_UNUSED, -- none of the P4 objects seem to have source info
-                      "Action selector '%1%' is never referenced by a table "
+            ::warning("Action selector '%1%' is never referenced by a table "
                       "and cannot be included in bmv2 JSON", c);
             return;
         }

--- a/backends/ebpf/ebpfBackend.cpp
+++ b/backends/ebpf/ebpfBackend.cpp
@@ -32,7 +32,9 @@ void run_ebpf_backend(const EbpfOptions& options, const IR::ToplevelBlock* tople
 
     auto main = toplevel->getMain();
     if (main == nullptr) {
-        ::warning("Could not locate top-level block; is there a %1% module?", IR::P4Program::main);
+        ::warning(ErrorType::WARN_MISSING,
+                  "Could not locate top-level block; is there a %1% module?",
+                  IR::P4Program::main);
         return;
     }
 

--- a/backends/ebpf/ebpfProgram.cpp
+++ b/backends/ebpf/ebpfProgram.cpp
@@ -30,7 +30,7 @@ namespace EBPF {
 bool EBPFProgram::build() {
     auto pack = toplevel->getMain();
     if (pack->type->name != "ebpfFilter")
-        ::warning("%1%: the main ebpf package should be called ebpfFilter"
+        ::warning(ErrorType::WARN_INVALID, "%1%: the main ebpf package should be called ebpfFilter"
                   "; are you using the wrong architecture?", pack->type->name);
 
     if (pack->getConstructorParameters()->size() != 2) {

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -86,7 +86,7 @@ class EBPFStackType : public EBPFType, public IHasWidth {
     void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
     void emitInitializer(CodeBuilder* builder) override;
     unsigned widthInBits() override;
-    unsigned implementationWidthInBits();
+    unsigned implementationWidthInBits() override;
 };
 
 class EBPFScalarType : public EBPFType, public IHasWidth {

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -162,7 +162,8 @@ int main(int argc, char *const argv[]) {
                     t1 << ss1.str() << std::flush;
                     t2 << ss2.str() << std::flush;
                     auto rv = system("json_diff t1.json t2.json");
-                    if (rv != 0) ::warning("json_diff failed with code %1%", rv);
+                    if (rv != 0) ::warning(ErrorType::WARN_FAILED,
+                                           "json_diff failed with code %1%", rv);
                 }
             }
         }

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -841,7 +841,8 @@ class P4RuntimeArchHandlerV1Model final : public P4RuntimeArchHandlerCommon<Arch
             auto it = autoNames.find(call);
             if (it == autoNames.end()) {
               controlPlaneName = "digest_" + cstring::to_cstring(autoNames.size());
-              ::warning("Cannot find a good name for %1% method call, using "
+              ::warning(ErrorType::WARN_MISMATCH,
+                        "Cannot find a good name for %1% method call, using "
                         "auto-generated name '%2%'", call, controlPlaneName);
               autoNames.emplace(call, controlPlaneName);
             } else {

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -636,7 +636,8 @@ getMatchFields(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMap)
             // Nothing to do here, we cannot even perform some sanity-checking.
             continue;
         } else {
-            ::warning("Table '%1%': cannot represent match type '%2%' in P4Runtime, ignoring",
+            ::warning(ErrorType::WARN_MISMATCH,
+                      "Table '%1%': cannot represent match type '%2%' in P4Runtime, ignoring",
                       table->controlPlaneName(), matchTypeName);
             continue;
         }
@@ -963,7 +964,7 @@ class P4RuntimeAnalyzer {
             if (annotation->name != IR::Annotation::pkginfoAnnotation) continue;
             for (auto* kv : annotation->kv) {
                 auto name = kv->name.name;
-                auto setStringField = [kv, name, pkginfo, &keysVisited](cstring fName) {
+                auto setStringField = [kv, pkginfo, &keysVisited](cstring fName) {
                     auto* v = kv->expression->to<IR::StringLiteral>();
                     if (v == nullptr) {
                         ::error("Value for '%1%' key in @pkginfo annotation is not a string", kv);
@@ -985,13 +986,15 @@ class P4RuntimeAnalyzer {
                     name == "contact" || name == "url") {
                     setStringField(name);
                 } else if (name == "arch") {
-                    ::warning("The '%1%' field in PkgInfo should be set by the compiler, "
+                    ::warning(ErrorType::WARN_INVALID,
+                              "The '%1%' field in PkgInfo should be set by the compiler, "
                               "not by the user", kv);
                     // override the value set previously with the user-provided
                     // value.
                     setStringField(name);
                 } else {
-                    ::warning("Unknown key name '%1%' in @pkginfo annotation", name);
+                    ::warning(ErrorType::WARN_UNKNOWN,
+                              "Unknown key name '%1%' in @pkginfo annotation", name);
                 }
             }
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,10 @@ git push -f
 
 * After committing changes, create a pull request (using the github web UI)
 
+* Follow these
+  [guidelines](CodingStandardPhilosophy.md#Git-commits-and-pull-requests)
+  to write commit messages and open pull requests.
+
 ## Debugging
 
 * To debug the build process you can run `make V=1`
@@ -224,23 +228,9 @@ The testing infrastructure is based on small python and shell scripts.
   * use `BUG_CHECK()` instead of `assert`, and always supply an
     informative error message
 
-  * use `::error()` and `::warning()` for error reporting.  They use the
-    `boost::format` for the format argument, which has some compatibility
-    for `printf` arguments.   These functions handle IR and SourceInfo
-    objects smartly.  Here is an example:
-
-```C++
-IR::NamedRef *ref;
-error("%1%: No header or metadata named '%2%'", ref->srcInfo, ref->name);
-```
-
-output:
-
-```
-../testdata/v1_errors/missing_decls1.p4(6): Error: No header or metadata named 'data'
-    if (data.b2 == 0) {
-        ^^^^
-```
+  * use `::error()` and `::warning()` for error reporting. See the
+    [guidelines](CodingStandardPhilosophy.md#Handling-errors) for more
+    details.
 
   * use `LOGn()` for log messages -- the `n` is an integer constant for
     verbosity level.  These can be controlled on a per-source-file basis

--- a/frontends/common/applyOptionsPragmas.cpp
+++ b/frontends/common/applyOptionsPragmas.cpp
@@ -75,14 +75,15 @@ P4COptionPragmaParser::parseDiagnostic(const IR::Annotation* annotation) {
     }
 
     if (pragmaArgs->size() != 2) {
-        ::warning("@diagnostic takes two arguments: %1%", annotation);
+        ::warning(ErrorType::WARN_MISSING, "@diagnostic takes two arguments: %1%", annotation);
         return boost::none;
     }
 
     auto* diagnosticName = pragmaArgs->at(0)->to<IR::StringLiteral>();
     auto* diagnosticAction = pragmaArgs->at(1)->to<IR::StringLiteral>();
     if (!diagnosticName || !diagnosticAction) {
-        ::warning("@diagnostic arguments must be strings: %1%", annotation);
+        ::warning(ErrorType::WARN_MISSING, "@diagnostic arguments must be strings: %1%",
+                  annotation);
         return boost::none;
     }
 
@@ -94,7 +95,7 @@ P4COptionPragmaParser::parseDiagnostic(const IR::Annotation* annotation) {
     } else if (diagnosticAction->value == "error") {
         diagnosticOption = "--Werror=";
     } else {
-        ::warning("@diagnostic's second argument must be 'disable', "
+        ::warning(ErrorType::WARN_MISMATCH, "@diagnostic's second argument must be 'disable', "
                   "'warn', or 'error': %1%", annotation);
         return boost::none;
     }

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -104,15 +104,15 @@ const IR::Node* DoConstantFolding::postorder(IR::Type_Bits* type) {
             type->size = cst->asInt();
             type->expression = nullptr;
             if (type->size <= 0) {
-                ::error("%1%: Illegal type size", type);
+                ::error(ErrorType::ERR_INVALID, type, "type size");
                 // Convert it to something legal so we don't get
                 // weird errors elsewhere.
                 type->size = 64;
             }
             if (type->size == 1 && type->isSigned)
-                ::error("%1%: Signed types cannot be 1-bit wide", type);
+                ::error(ErrorType::ERR_INVALID, type, "signed type which is 1-bit wide");
         } else {
-            ::error("Could not evaluate %1% to a constant", type->expression);
+            ::error(ErrorType::ERR_EXPECTED, type->expression, "to evaluate to a constant");
         }
     }
     return type;
@@ -124,9 +124,9 @@ const IR::Node* DoConstantFolding::postorder(IR::Type_Varbits* type) {
             type->size = cst->asInt();
             type->expression = nullptr;
             if (type->size <= 0)
-                ::error("%1%: Illegal type size", type);
+                ::error(ErrorType::ERR_INVALID, type, "type size");
         } else {
-            ::error("Could not evaluate %1% to a constant", type->expression);
+            ::error(ErrorType::ERR_EXPECTED, type->expression, "to evaluate to a constant");
         }
     }
     return type;
@@ -171,7 +171,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Cmpl* e) {
 
     auto cst = op->to<IR::Constant>();
     if (cst == nullptr) {
-        ::error("%1%: Expected an integer value", op);
+        ::error(ErrorType::ERR_EXPECTED, op, "an integer value");
         return e;
     }
     const IR::Type* t = op->type;
@@ -198,7 +198,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Neg* e) {
 
     auto cst = op->to<IR::Constant>();
     if (cst == nullptr) {
-        ::error("%1%: Expected an integer value", op);
+        ::error(ErrorType::ERR_EXPECTED, op, "an integer value");
         return e;
     }
     const IR::Type* t = op->type;
@@ -511,17 +511,17 @@ const IR::Node* DoConstantFolding::postorder(IR::Slice* e) {
 
     auto cmsb = msb->to<IR::Constant>();
     if (cmsb == nullptr) {
-        ::error("%1%: Expected an integer value", msb);
+        ::error(ErrorType::ERR_EXPECTED, msb, "an integer value");
         return e;
     }
     auto clsb = lsb->to<IR::Constant>();
     if (clsb == nullptr) {
-        ::error("%1%: Expected an integer value", lsb);
+        ::error(ErrorType::ERR_EXPECTED, lsb, "an integer value");
         return e;
     }
     auto cbase = e0->to<IR::Constant>();
     if (cbase == nullptr) {
-        ::error("%1%: Expected an integer value", e->e0);
+        ::error(ErrorType::ERR_EXPECTED, e->e0, "an integer value");
         return e;
     }
 
@@ -655,7 +655,7 @@ const IR::Node* DoConstantFolding::shift(const IR::Operation_Binary* e) {
 
     auto cr = right->to<IR::Constant>();
     if (cr == nullptr) {
-        ::error("%1%: Expected an integer value", right);
+        ::error(ErrorType::ERR_EXPECTED, right, "an integer value");
         return e;
     }
     if (sgn(cr->value) < 0) {
@@ -674,7 +674,7 @@ const IR::Node* DoConstantFolding::shift(const IR::Operation_Binary* e) {
 
     auto cl = left->to<IR::Constant>();
     if (cl == nullptr) {
-        ::error("%1%: Expected an integer value", left);
+        ::error(ErrorType::ERR_EXPECTED, left, "an integer value");
         return e;
     }
 

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -104,15 +104,15 @@ const IR::Node* DoConstantFolding::postorder(IR::Type_Bits* type) {
             type->size = cst->asInt();
             type->expression = nullptr;
             if (type->size <= 0) {
-                ::error(ErrorType::ERR_INVALID, type, "type size");
+                ::error(ErrorType::ERR_INVALID, "type size", type);
                 // Convert it to something legal so we don't get
                 // weird errors elsewhere.
                 type->size = 64;
             }
             if (type->size == 1 && type->isSigned)
-                ::error(ErrorType::ERR_INVALID, type, "signed type which is 1-bit wide");
+                ::error(ErrorType::ERR_INVALID, "signed type which is 1-bit wide", type);
         } else {
-            ::error(ErrorType::ERR_EXPECTED, type->expression, "to evaluate to a constant");
+            ::error(ErrorType::ERR_EXPECTED, "to evaluate to a constant", type->expression);
         }
     }
     return type;
@@ -124,9 +124,9 @@ const IR::Node* DoConstantFolding::postorder(IR::Type_Varbits* type) {
             type->size = cst->asInt();
             type->expression = nullptr;
             if (type->size <= 0)
-                ::error(ErrorType::ERR_INVALID, type, "type size");
+                ::error(ErrorType::ERR_INVALID, "type size", type);
         } else {
-            ::error(ErrorType::ERR_EXPECTED, type->expression, "to evaluate to a constant");
+            ::error(ErrorType::ERR_EXPECTED, "to evaluate to a constant", type->expression);
         }
     }
     return type;
@@ -171,7 +171,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Cmpl* e) {
 
     auto cst = op->to<IR::Constant>();
     if (cst == nullptr) {
-        ::error(ErrorType::ERR_EXPECTED, op, "an integer value");
+        ::error(ErrorType::ERR_EXPECTED, "an integer value", op);
         return e;
     }
     const IR::Type* t = op->type;
@@ -198,7 +198,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Neg* e) {
 
     auto cst = op->to<IR::Constant>();
     if (cst == nullptr) {
-        ::error(ErrorType::ERR_EXPECTED, op, "an integer value");
+        ::error(ErrorType::ERR_EXPECTED, "an integer value", op);
         return e;
     }
     const IR::Type* t = op->type;
@@ -511,17 +511,17 @@ const IR::Node* DoConstantFolding::postorder(IR::Slice* e) {
 
     auto cmsb = msb->to<IR::Constant>();
     if (cmsb == nullptr) {
-        ::error(ErrorType::ERR_EXPECTED, msb, "an integer value");
+        ::error(ErrorType::ERR_EXPECTED, "an integer value", msb);
         return e;
     }
     auto clsb = lsb->to<IR::Constant>();
     if (clsb == nullptr) {
-        ::error(ErrorType::ERR_EXPECTED, lsb, "an integer value");
+        ::error(ErrorType::ERR_EXPECTED, "an integer value", lsb);
         return e;
     }
     auto cbase = e0->to<IR::Constant>();
     if (cbase == nullptr) {
-        ::error(ErrorType::ERR_EXPECTED, e->e0, "an integer value");
+        ::error(ErrorType::ERR_EXPECTED, "an integer value", e->e0);
         return e;
     }
 
@@ -655,7 +655,7 @@ const IR::Node* DoConstantFolding::shift(const IR::Operation_Binary* e) {
 
     auto cr = right->to<IR::Constant>();
     if (cr == nullptr) {
-        ::error(ErrorType::ERR_EXPECTED, right, "an integer value");
+        ::error(ErrorType::ERR_EXPECTED, "an integer value", right);
         return e;
     }
     if (sgn(cr->value) < 0) {
@@ -674,7 +674,7 @@ const IR::Node* DoConstantFolding::shift(const IR::Operation_Binary* e) {
 
     auto cl = left->to<IR::Constant>();
     if (cl == nullptr) {
-        ::error(ErrorType::ERR_EXPECTED, left, "an integer value");
+        ::error(ErrorType::ERR_EXPECTED, "an integer value", left);
         return e;
     }
 
@@ -684,7 +684,8 @@ const IR::Node* DoConstantFolding::shift(const IR::Operation_Binary* e) {
     auto tb = left->type->to<IR::Type_Bits>();
     if (tb != nullptr) {
         if (((unsigned)tb->size < shift) && warnings)
-            ::warning("%1%: Shifting %2%-bit value with %3%", e, tb->size, shift);
+            ::warning(ErrorType::WARN_OVERFLOW,
+                      "%1%: Shifting %2%-bit value with %3%", e, tb->size, shift);
     }
 
     if (e->is<IR::Shl>())
@@ -844,7 +845,7 @@ const IR::Node* DoConstantFolding::postorder(IR::SelectExpression* expression) {
     for (auto c : expression->selectCases) {
         if (finished) {
             if (warnings)
-                ::warning("%1%: unreachable case", c);
+                ::warning(ErrorType::WARN_PARSER_TRANSITION, "%1%: unreachable case", c);
             continue;
         }
         auto inside = setContains(c->keyset, sel);
@@ -869,7 +870,7 @@ const IR::Node* DoConstantFolding::postorder(IR::SelectExpression* expression) {
 
     if (changes) {
         if (cases.size() == 0 && result == expression && warnings)
-            ::warning("%1%: no case matches", expression);
+            ::warning(ErrorType::WARN_PARSER_TRANSITION, "%1%: no case matches", expression);
         expression->selectCases = std::move(cases);
     }
     return result;

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -67,7 +67,7 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                        } else if (!strcmp(arg, "1.2") || !strcmp(arg, "16")) {
                            langVersion = CompilerOptions::FrontendVersion::P4_16;
                        } else {
-                           ::error(ErrorType::ERR_INVALID, arg, "language version");
+                           ::error("Illegal language version %1%", arg);
                            return false;
                        }
                        return true; },
@@ -80,7 +80,7 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                        } else if (!strcmp(arg, "16") || !strcmp(arg, "p4-16")) {
                            langVersion = CompilerOptions::FrontendVersion::P4_16;
                        } else {
-                           ::error(ErrorType::ERR_INVALID, arg, "language version");
+                           ::error("Illegal language version %1%", arg);
                            return false;
                        }
                        return true; },
@@ -113,7 +113,7 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                        } else if (!strcmp(arg, "text")) {
                            p4RuntimeFormat = P4::P4RuntimeFormat::TEXT;
                        } else {
-                           ::error(ErrorType::ERR_INVALID, arg, "P4Runtime format");
+                           ::error("Illegal P4Runtime format %1%", arg);
                            return false;
                        }
                        return true; },
@@ -297,7 +297,7 @@ FILE* CompilerOptions::preprocess() {
             + " -I" + (isv1() ? p4_14includePath : p4includePath) + " " + file;
 
         if (Log::verbose())
-            std::clog << "Invoking preprocessor " << std::endl << cmd << std::endl;
+            std::cerr << "Invoking preprocessor " << std::endl << cmd << std::endl;
         in = popen(cmd.c_str(), "r");
         if (in == nullptr) {
             ::error("Error invoking preprocessor");

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -67,7 +67,7 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                        } else if (!strcmp(arg, "1.2") || !strcmp(arg, "16")) {
                            langVersion = CompilerOptions::FrontendVersion::P4_16;
                        } else {
-                           ::error("Illegal language version %1%", arg);
+                           ::error(ErrorType::ERR_INVALID, arg, "language version");
                            return false;
                        }
                        return true; },
@@ -80,7 +80,7 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                        } else if (!strcmp(arg, "16") || !strcmp(arg, "p4-16")) {
                            langVersion = CompilerOptions::FrontendVersion::P4_16;
                        } else {
-                           ::error("Illegal language version %1%", arg);
+                           ::error(ErrorType::ERR_INVALID, arg, "language version");
                            return false;
                        }
                        return true; },
@@ -113,7 +113,7 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                        } else if (!strcmp(arg, "text")) {
                            p4RuntimeFormat = P4::P4RuntimeFormat::TEXT;
                        } else {
-                           ::error("Illegal P4Runtime format %1%", arg);
+                           ::error(ErrorType::ERR_INVALID, arg, "P4Runtime format");
                            return false;
                        }
                        return true; },
@@ -297,7 +297,7 @@ FILE* CompilerOptions::preprocess() {
             + " -I" + (isv1() ? p4_14includePath : p4includePath) + " " + file;
 
         if (Log::verbose())
-            std::cerr << "Invoking preprocessor " << std::endl << cmd << std::endl;
+            std::clog << "Invoking preprocessor " << std::endl << cmd << std::endl;
         in = popen(cmd.c_str(), "r");
         if (in == nullptr) {
             ::error("Error invoking preprocessor");

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -270,7 +270,8 @@ std::vector<const char*>* CompilerOptions::process(int argc, char* const argv[])
 
 void CompilerOptions::validateOptions() const {
     if (p4RuntimeFile.isNullOrEmpty() && !p4RuntimeEntriesFile.isNullOrEmpty()) {
-        ::warning("When '--p4runtime-entries-file' is used without '--p4runtime-file', "
+        ::warning(ErrorType::WARN_IGNORE,
+                  "When '--p4runtime-entries-file' is used without '--p4runtime-file', "
                   "it is ignored");
     }
 }

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -138,13 +138,13 @@ ResolutionContext::resolveUnique(IR::ID name,
     }
 
     if (decls->empty()) {
-        ::error(ErrorType::ERR_NOT_FOUND, name, "declaration");
+        ::error(ErrorType::ERR_NOT_FOUND, "declaration", name);
         return nullptr;
     }
     if (decls->size() == 1)
         return decls->at(0);
 
-    ::error(ErrorType::ERR_INVALID, name, "multiple matching declarations", name);
+    ::error(ErrorType::ERR_INVALID, "multiple matching declarations", name);
     for (auto a : *decls)
         ::error("Candidate: %1%", a);
     return nullptr;
@@ -251,7 +251,7 @@ void ResolveReferences::checkShadowing(const IR::INamespace* ns) const {
                 // attribute locals often match attributes
                 continue;
 
-            ::warning("%1% shadows %2%", node, pnode);
+            ::warning(ErrorType::WARN_SHADOWING, "%1% shadows %2%", node, pnode);
         }
     }
 }
@@ -293,8 +293,8 @@ void ResolveReferences::postorder(const IR::P4Program*) {
 bool ResolveReferences::preorder(const IR::This* pointer) {
     auto decl = findContext<IR::Declaration_Instance>();
     if (findContext<IR::Function>() == nullptr || decl == nullptr)
-        ::error(ErrorType::ERR_INVALID, pointer,
-                "can only be used in the definition of an abstract method");
+        ::error(ErrorType::ERR_INVALID,
+                "%1% can only be used in the definition of an abstract method", pointer);
     refMap->setDeclaration(pointer, decl);
     return true;
 }

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -138,13 +138,13 @@ ResolutionContext::resolveUnique(IR::ID name,
     }
 
     if (decls->empty()) {
-        ::error("Could not find declaration for %1%", name);
+        ::error(ErrorType::ERR_NOT_FOUND, name, "declaration");
         return nullptr;
     }
     if (decls->size() == 1)
         return decls->at(0);
 
-    ::error("Multiple matching declarations for %1%", name);
+    ::error(ErrorType::ERR_INVALID, name, "multiple matching declarations", name);
     for (auto a : *decls)
         ::error("Candidate: %1%", a);
     return nullptr;
@@ -293,7 +293,8 @@ void ResolveReferences::postorder(const IR::P4Program*) {
 bool ResolveReferences::preorder(const IR::This* pointer) {
     auto decl = findContext<IR::Declaration_Instance>();
     if (findContext<IR::Function>() == nullptr || decl == nullptr)
-        ::error("%1%: can only be used in the definition of an abstract method", pointer);
+        ::error(ErrorType::ERR_INVALID, pointer,
+                "can only be used in the definition of an abstract method");
     refMap->setDeclaration(pointer, decl);
     return true;
 }

--- a/frontends/p4/actionsInlining.cpp
+++ b/frontends/p4/actionsInlining.cpp
@@ -32,7 +32,7 @@ void DiscoverActionsInlining::postorder(const IR::MethodCallStatement* mcs) {
     auto caller = findContext<IR::P4Action>();
     if (caller == nullptr) {
         if (findContext<IR::P4Parser>() != nullptr) {
-            ::error(ErrorType::ERR_UNSUPPORTED, mcs, "action invocation in parser");
+            ::error(ErrorType::ERR_UNSUPPORTED, "action invocation in parser", mcs);
         } else if (findContext<IR::P4Control>() == nullptr) {
             BUG("%1%: unexpected action invocation", mcs);
         }

--- a/frontends/p4/actionsInlining.cpp
+++ b/frontends/p4/actionsInlining.cpp
@@ -32,7 +32,7 @@ void DiscoverActionsInlining::postorder(const IR::MethodCallStatement* mcs) {
     auto caller = findContext<IR::P4Action>();
     if (caller == nullptr) {
         if (findContext<IR::P4Parser>() != nullptr) {
-            ::error("%1%: action invocation in parser not supported", mcs);
+            ::error(ErrorType::ERR_UNSUPPORTED, mcs, "action invocation in parser");
         } else if (findContext<IR::P4Control>() == nullptr) {
             BUG("%1%: unexpected action invocation", mcs);
         }

--- a/frontends/p4/checkConstants.cpp
+++ b/frontends/p4/checkConstants.cpp
@@ -28,7 +28,7 @@ void DoCheckConstants::postorder(const IR::MethodCallExpression* expression) {
                       "Expected 1 argument for %1%", expression);
             auto arg0 = expression->arguments->at(0)->expression;
             if (!arg0->is<IR::Constant>())
-                ::error("%1%: argument must be a constant", arg0);
+                ::error(ErrorType::ERR_INVALID, arg0, "argument must be a constant");
         }
     }
 }

--- a/frontends/p4/checkConstants.cpp
+++ b/frontends/p4/checkConstants.cpp
@@ -28,14 +28,14 @@ void DoCheckConstants::postorder(const IR::MethodCallExpression* expression) {
                       "Expected 1 argument for %1%", expression);
             auto arg0 = expression->arguments->at(0)->expression;
             if (!arg0->is<IR::Constant>())
-                ::error(ErrorType::ERR_INVALID, arg0, "argument must be a constant");
+                ::error(ErrorType::ERR_INVALID, "argument must be a constant", arg0);
         }
     }
 }
 
 void DoCheckConstants::postorder(const IR::KeyElement* key) {
     if (key->expression->is<IR::Literal>())
-        ::warning("%1%: Constant key field", key->expression);
+        ::warning(ErrorType::WARN_MISMATCH, "%1%: Constant key field", key->expression);
 }
 
 void DoCheckConstants::postorder(const IR::P4Table* table) {

--- a/frontends/p4/checkNamedArgs.cpp
+++ b/frontends/p4/checkNamedArgs.cpp
@@ -31,8 +31,8 @@ bool CheckNamedArgs::checkArguments(const IR::Vector<IR::Argument>* arguments) {
             first = false;
         } else {
             if (argHasName != hasName)
-                ::error(ErrorType::ERR_INVALID, arg,
-                        "either all or none of the arguments of a call must be named");
+                ::error(ErrorType::ERR_INVALID,
+                        "either all or none of the arguments of a call must be named", arg);
             if (argHasName) {
                 auto it = found.find(argName);
                 if (it != found.end())

--- a/frontends/p4/checkNamedArgs.cpp
+++ b/frontends/p4/checkNamedArgs.cpp
@@ -31,7 +31,8 @@ bool CheckNamedArgs::checkArguments(const IR::Vector<IR::Argument>* arguments) {
             first = false;
         } else {
             if (argHasName != hasName)
-                ::error("%1%: all or none of the arguments of a call must be named", arg);
+                ::error(ErrorType::ERR_INVALID, arg,
+                        "either all or none of the arguments of a call must be named");
             if (argHasName) {
                 auto it = found.find(argName);
                 if (it != found.end())

--- a/frontends/p4/createBuiltins.cpp
+++ b/frontends/p4/createBuiltins.cpp
@@ -49,7 +49,7 @@ void CreateBuiltins::postorder(IR::ExpressionValue* expression) {
 
 void CreateBuiltins::postorder(IR::ParserState* state) {
     if (state->selectExpression == nullptr) {
-        warning("%1%: implicit transition to `reject'", state);
+        warning(ErrorType::WARN_PARSER_TRANSITION, "%1%: implicit transition to `reject'", state);
         state->selectExpression = new IR::PathExpression(IR::ParserState::reject);
     }
 }

--- a/frontends/p4/deprecated.cpp
+++ b/frontends/p4/deprecated.cpp
@@ -33,7 +33,7 @@ void CheckDeprecated::warnIfDeprecated(
         if (auto str = a->to<IR::StringLiteral>())
             message += str->value;
     }
-    ::warning("%1%: Using deprecated feature %2%. %3%",
+    ::warning(ErrorType::WARN_DEPRECATED, "%1%: Using deprecated feature %2%. %3%",
               errorNode, annotated->getNode(), message);
 }
 

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -464,7 +464,8 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                         return nullptr;
                     }
                 } else {
-                    ::warning("%1%: parser_value_set has no @parser_value_set_size annotation."
+                    ::warning(ErrorType::WARN_MISSING,
+                              "%1%: parser_value_set has no @parser_value_set_size annotation."
                               "Using default size 4.", c);
                     sizeConstant = new IR::Constant(4);
                 }
@@ -696,7 +697,9 @@ void ProgramStructure::createDeparser() {
     std::vector<const IR::Expression*> sortedHeaders;
     bool loop = headerOrder.sccSort(startHeader, sortedHeaders);
     if (loop)
-        ::warning("The order of headers in deparser is not uniquely determined by parser!");
+        ::warning(ErrorType::WARN_ORDERING,
+                  "The order of headers in deparser is not uniquely determined by parser!",
+                  startHeader);
 
     auto params = new IR::ParameterList;
     auto poutpath = new IR::Path(p4lib.packetOut.Id());
@@ -958,7 +961,7 @@ const IR::Expression* ProgramStructure::convertHashAlgorithm(
     } else if (algorithm == "xor16") {
         result = v1model.algorithm.xor16.Id();
     } else {
-        ::warning("%1%: unexpected algorithm", algorithm);
+        ::warning(ErrorType::WARN_UNSUPPORTED, "%1%: unexpected algorithm", algorithm);
         result = algorithm;
     }
     auto pe = new IR::TypeNameExpression(v1model.algorithm.Id());
@@ -970,7 +973,8 @@ const IR::Expression* ProgramStructure::convertHashAlgorithms(const IR::NameList
     if (!algorithm || algorithm->names.empty()) return nullptr;
     if (algorithm->names.size() > 1) {
 #if 1
-        ::warning("%s: Multiple algorithms in a field list not supported in P4_16 -- using "
+        ::warning(ErrorType::WARN_UNSUPPORTED,
+                  "%s: Multiple algorithms in a field list not supported in P4_16 -- using "
                   "only the first", algorithm->names[0].srcInfo);
 #else
         auto rv = new IR::ListExpression({});
@@ -1547,7 +1551,8 @@ CONVERT_PRIMITIVE(execute_meter) {
         ::error("Expected a meter reference %1%", ref);
         return nullptr; }
     if (!meter->implementation.name.isNullOrEmpty())
-        ::warning("Ignoring `implementation' field of meter %1%", meter);
+        ::warning(ErrorType::WARN_IGNORE_PROPERTY, "Ignoring `implementation' field of meter %1%",
+                  meter);
     auto newname = structure->meters.get(meter);
     auto meterref = new IR::PathExpression(newname);
     auto methodName = structure->v1model.meter.executeMeter.Id();
@@ -1750,7 +1755,8 @@ ProgramStructure::convertAction(const IR::ActionFunction* action, cstring newNam
             direction = p->write ? IR::Direction::InOut : IR::Direction::None;
         auto type = p->type;
         if (type == IR::Type_Unknown::get()) {
-            ::warning("Could not infer type for %1%, using bit<8>", p);
+            ::warning(ErrorType::WARN_TYPE_INFERENCE,
+                      "Could not infer type for %1%, using bit<8>", p);
             type = IR::Type_Bits::get(8);
         } else if (type->is<IR::Type_StructLike>()) {
             auto path = new IR::Path(type->to<IR::Type_StructLike>()->name);
@@ -1868,7 +1874,8 @@ ProgramStructure::convert(const IR::Register* reg, cstring newName,
             newName = reg->layout;
         regElementType = new IR::Type_Name(new IR::Path(newName));
     } else {
-        ::warning("%1%: Register width unspecified; using %2%", reg, defaultRegisterWidth);
+        ::warning(ErrorType::WARN_MISSING,
+                  "%1%: Register width unspecified; using %2%", reg, defaultRegisterWidth);
         regElementType = IR::Type_Bits::get(defaultRegisterWidth);
     }
 

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -464,8 +464,8 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                         return nullptr;
                     }
                 } else {
-                    ::warning("parser_value_set has no @parser_value_set_size annotation");
-                    ::warning("using default size 4");
+                    ::warning("%1%: parser_value_set has no @parser_value_set_size annotation."
+                              "Using default size 4.", c);
                     sizeConstant = new IR::Constant(4);
                 }
                 auto annos = addGlobalNameAnnotation(value_set->name, value_set->annotations);

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -698,7 +698,7 @@ void ProgramStructure::createDeparser() {
     bool loop = headerOrder.sccSort(startHeader, sortedHeaders);
     if (loop)
         ::warning(ErrorType::WARN_ORDERING,
-                  "The order of headers in deparser is not uniquely determined by parser!",
+                  "%1%: the order of headers in deparser is not uniquely determined by parser!",
                   startHeader);
 
     auto params = new IR::ParameterList;

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -93,7 +93,7 @@ void ParseAnnotations::postorder(IR::Annotation* annotation) {
         // Unknown annotation. Leave as is, but warn if desired.
         if (warnUnknown && warned.count(name) == 0) {
             warned.insert(name);
-            ::warning("Unknown annotation: %1%", annotation->name);
+            ::warning(ErrorType::WARN_UNKNOWN, "Unknown annotation: %1%", annotation->name);
         }
         return;
     }

--- a/frontends/p4/parserControlFlow.cpp
+++ b/frontends/p4/parserControlFlow.cpp
@@ -38,7 +38,7 @@ const IR::Node* DoRemoveParserControlFlow::postorder(IR::ParserState* state) {
 
             states->push_back(currentState);
             auto ifstat = c->to<IR::IfStatement>();
-            cstring joinName = refMap->newName(state->name.name + "_join");
+            joinName = refMap->newName(state->name.name + "_join");
 
             // s_true
             cstring trueName = refMap->newName(state->name.name + "_true");

--- a/frontends/p4/simplify.cpp
+++ b/frontends/p4/simplify.cpp
@@ -100,7 +100,7 @@ const IR::Node* DoSimplifyControlFlow::postorder(IR::SwitchStatement* statement)
             if ((*it)->statement != nullptr)
                 break;
             else
-                ::warning("%1%: fallthrough with no statement", last); }
+                ::warning(ErrorType::WARN_MISSING, "%1%: fallthrough with no statement", last); }
         statement->cases.erase(it.base(), statement->cases.end()); }
     return statement;
 }

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -448,7 +448,8 @@ class FindUninitialized : public Inspector {
                 reads(expression, storage);
                 registerUses(expression, false);
                 if (!lhs && expression->member.name == IR::Type_Stack::next)
-                    ::warning("%1%: reading uninitialized value", expression);
+                    ::warning(ErrorType::WARN_UNINITIALIZED,
+                              "%1%: reading uninitialized value", expression);
                 return false;
             } else if (expression->member.name == IR::Type_Stack::lastIndex) {
                 auto index = storage->getArrayLastIndex();

--- a/frontends/p4/simplifyParsers.cpp
+++ b/frontends/p4/simplifyParsers.cpp
@@ -59,7 +59,8 @@ class RemoveUnreachableStates : public Transform {
         auto orig = getOriginal<IR::ParserState>();
         if (reachable.find(orig) == reachable.end()) {
             if (state->name == IR::ParserState::accept) {
-                ::warning("%1% state in %2% is unreachable", state, findContext<IR::P4Parser>());
+                ::warning(ErrorType::WARN_UNREACHABLE,
+                          "%1% state in %2% is unreachable", state, findContext<IR::P4Parser>());
                 return state;
             } else  {
                 LOG1("Removing unreachable state " << dbp(state));

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -427,7 +427,8 @@ bool ToP4::preorder(const IR::Type_Extern* t) {
     builder.blockStart();
 
     if (t->attributes.size() != 0)
-        ::warning("%1%: extern has attributes, which are not supported "
+        ::warning(ErrorType::WARN_UNSUPPORTED,
+                  "%1%: extern has attributes, which are not supported "
                   "in P4-16, and thus are not emitted as P4-16", t);
 
     setVecSep(";\n", ";\n");

--- a/frontends/p4/typeChecking/bindVariables.h
+++ b/frontends/p4/typeChecking/bindVariables.h
@@ -30,11 +30,8 @@ class DoBindTypeVariables : public Transform {
 };
 
 class BindTypeVariables : public PassManager {
-    ReferenceMap* refMap;
-    TypeMap      *typeMap;
  public:
-    BindTypeVariables(ReferenceMap* refMap, TypeMap* typeMap):
-            refMap(refMap), typeMap(typeMap) {
+    BindTypeVariables(ReferenceMap* refMap, TypeMap* typeMap) {
         CHECK_NULL(refMap); CHECK_NULL(typeMap);
         passes.push_back(new ClearTypeMap(typeMap));
         passes.push_back(new ResolveReferences(refMap));

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1972,7 +1972,7 @@ const IR::Node* TypeInference::shift(const IR::Operation_Binary* expression) {
             return expression;
         }
         if (shift >= lt->size)
-            ::warning("%1%: shifting value with %2% bits by %3%",
+            ::warning(ErrorType::WARN_OVERFLOW, "%1%: shifting value with %2% bits by %3%",
                       expression, lt->size, shift);
     }
 

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -2467,8 +2467,8 @@ const IR::Node* TypeInference::postorder(IR::Member* expression) {
         auto stb = type->to<IR::Type_StructLike>();
         auto field = stb->getField(member);
         if (field == nullptr) {
-            typeError("Structure %1% does not have a field %2%",
-                      stb, expression->member);
+            typeError("Field %1% is not a member of structure %2%",
+                      expression->member, stb);
             return expression;
         }
 

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -92,7 +92,7 @@ class TypeInference : public Transform {
 
     template<typename... T>
     void typeError(const char* format, T... args) const {
-        ::error(format, args...);
+        ::error(ErrorType::ERR_TYPE_ERROR, format, args...);
     }
 
     // This is needed because sometimes we invoke visitors recursively on subtrees explicitly.

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -129,11 +129,13 @@ bool TypeMap::equivalent(const IR::Type* left, const IR::Type* right) {
         auto ls = left->to<IR::Type_Stack>();
         auto rs = right->to<IR::Type_Stack>();
         if (!ls->sizeKnown()) {
-            ::error("%1%: Size of header stack type should be a constant", left);
+            ::error(ErrorType::ERR_TYPE_ERROR,
+                    "%1%: Size of header stack type should be a constant", left);
             return false;
         }
         if (!rs->sizeKnown()) {
-            ::error("%1%: Size of header stack type should be a constant", right);
+            ::error(ErrorType::ERR_TYPE_ERROR,
+                    "%1%: Size of header stack type should be a constant", right);
             return false;
         }
         return equivalent(ls->elementType, rs->elementType) &&

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -79,7 +79,7 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Parser* cont) {
 const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Table* table) {
     if (!refMap->isUsed(getOriginal<IR::IDeclaration>())) {
         if (giveWarning(getOriginal()))
-            ::warning("Table %1% is not used; removing", table);
+            ::warning(ErrorType::WARN_UNUSED, "Table %1% is not used; removing", table);
         LOG3("Removing " << table);
         table = nullptr;
     }
@@ -113,7 +113,7 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::Declaration_Instance* dec
         return decl;
     if (!refMap->isUsed(getOriginal<IR::Declaration_Instance>())) {
         if (giveWarning(getOriginal()))
-            ::warning("%1%: unused instance", decl);
+            ::warning(ErrorType::WARN_UNUSED, "%1%: unused instance", decl);
         // We won't delete extern instances; these may be useful even if not references.
         auto type = decl->type;
         if (type->is<IR::Type_Specialized>())

--- a/frontends/p4/validateParsedProgram.cpp
+++ b/frontends/p4/validateParsedProgram.cpp
@@ -184,7 +184,7 @@ void ValidateParsedProgram::postorder(const IR::SwitchStatement* statement) {
     bool defaultFound = false;
     for (auto c : statement->cases) {
         if (defaultFound) {
-            ::warning("%1%: label following default label", c);
+            ::warning(ErrorType::WARN_ORDERING, "%1%: label following default label", c);
             break;
         }
         if (c->label->is<IR::DefaultExpression>())

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -535,7 +535,8 @@ case_value:
 parser_exception_declaration:
       PARSER_EXCEPTION name "{" parser_statement_list "}" {
           driver.clearPragmas();
-          ::warning("%1%: parser exception is not translated to P4-16", $1);
+          ::warning(ErrorType::WARN_UNSUPPORTED,
+                    "%1%: parser exception is not translated to P4-16", $1);
       }
     | PARSER_EXCEPTION name "{" parser_statement_list error END
 ;

--- a/ir/expression.cpp
+++ b/ir/expression.cpp
@@ -93,10 +93,12 @@ IR::Constant::handleOverflow(bool noWarning) {
     } else {
         if (sgn(value) < 0) {
             if (!noWarning)
-                ::warning(ErrorType::WARN_MISMATCH, "negative value with unsigned type", this);
+                ::warning(ErrorType::WARN_MISMATCH,
+                          "%1%: negative value with unsigned type", this);
         } else if ((value & mask) != value) {
             if (!noWarning)
-                ::warning(ErrorType::WARN_MISMATCH, "value does not fit in %2% bits", this, width);
+                ::warning(ErrorType::WARN_MISMATCH,
+                          "%1%: value does not fit in %2% bits", this, width);
         }
 
         value = value & mask;

--- a/ir/expression.cpp
+++ b/ir/expression.cpp
@@ -81,7 +81,8 @@ IR::Constant::handleOverflow(bool noWarning) {
         mpz_class min = -(one << (width - 1));
         if (value < min || value > max) {
             if (!noWarning)
-                ::warning("%1%: signed value does not fit in %2% bits", this, width);
+                ::warning(ErrorType::WARN_OVERFLOW,
+                          "%1%: signed value does not fit in %2% bits", this, width);
             LOG2("value=" << value << ", min=" << min <<
                  ", max=" << max << ", masked=" << (value & mask) <<
                  ", adj=" << ((value & mask) - (one << width)));
@@ -92,10 +93,10 @@ IR::Constant::handleOverflow(bool noWarning) {
     } else {
         if (sgn(value) < 0) {
             if (!noWarning)
-                ::warning(ErrorType::WARN_MISMATCH, this, "negative value with unsigned type");
+                ::warning(ErrorType::WARN_MISMATCH, "negative value with unsigned type", this);
         } else if ((value & mask) != value) {
             if (!noWarning)
-                ::warning(ErrorType::WARN_MISMATCH, this, "value does not fit in %2% bits", width);
+                ::warning(ErrorType::WARN_MISMATCH, "value does not fit in %2% bits", this, width);
         }
 
         value = value & mask;

--- a/ir/expression.cpp
+++ b/ir/expression.cpp
@@ -92,10 +92,10 @@ IR::Constant::handleOverflow(bool noWarning) {
     } else {
         if (sgn(value) < 0) {
             if (!noWarning)
-                ::warning("%1%: negative value with unsigned type", this);
+                ::warning(ErrorType::WARN_MISMATCH, this, "negative value with unsigned type");
         } else if ((value & mask) != value) {
             if (!noWarning)
-                ::warning("%1%: value does not fit in %2% bits", this, width);
+                ::warning(ErrorType::WARN_MISMATCH, this, "value does not fit in %2% bits", width);
         }
 
         value = value & mask;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,6 +17,7 @@ set (LIBP4CTOOLKIT_SRCS
 	compile_context.cpp
 	crash.cpp
 	cstring.cpp
+        error_catalog.cpp
 	gc.cpp
 	gmputil.cpp
 	hash.cpp
@@ -43,6 +44,7 @@ set (LIBP4CTOOLKIT_HDRS
 	cstring.h
 	enumerator.h
 	error.h
+        error_catalog.h
 	error_reporter.h
 	exceptions.h
 	gc.h

--- a/lib/error.h
+++ b/lib/error.h
@@ -47,6 +47,51 @@ inline void error(const char* format, T... args) {
     context.errorReporter().diagnoseUnnamed(action, format, args...);
 }
 
+/// Report errors of type kind. Requires that the node argument have source info.
+/// The message format is declared in the error catalog.
+template<class T,
+         typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+         class... Args>
+void error(int kind, const T *node, Args... args) {
+    auto& context = BaseCompileContext::get();
+    auto action = context.getDefaultErrorDiagnosticAction();
+    context.errorReporter().diagnose(action, kind, node, args...);
+}
+
+/// The const ref variant of the above
+template<class T,
+         typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+         class... Args>
+void error(int kind, const T &node, Args... args) {
+    auto& context = BaseCompileContext::get();
+    auto action = context.getDefaultErrorDiagnosticAction();
+    context.errorReporter().diagnose(action, kind, node, args...);
+}
+
+/// Convert errors that have a first argument as a node with source info to errors with kind
+/// This allows incremental migration toward minimizing the number of errors and warnings
+/// reported when passes are repeated, as typed errors are filtered.
+template<class T,
+         typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+         class... Args>
+void error(const char *format, const T *node, Args... args) {
+    auto& context = BaseCompileContext::get();
+    auto action = context.getDefaultErrorDiagnosticAction();
+    context.errorReporter().diagnose(action, ErrorType::LEGACY_ERROR, format, node, args...);
+}
+
+/// The const ref variant of the above
+template<class T,
+         typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+         class... Args>
+void error(const char *format, const T &node, Args... args) {
+    auto& context = BaseCompileContext::get();
+    auto action = context.getDefaultErrorDiagnosticAction();
+    context.errorReporter().diagnose(action, ErrorType::LEGACY_ERROR, format, node, args...);
+}
+
+
+/// Report an error if condition e is false.
 #define ERROR_CHECK(e, ...) do { if (!(e)) ::error(__VA_ARGS__); } while (0)
 
 /// Report a warning with the given message.
@@ -57,6 +102,50 @@ inline void warning(const char* format, T... args) {
     context.errorReporter().diagnoseUnnamed(action, format, args...);
 }
 
+/// Report warnings of type kind. Requires that the node argument have source info.
+/// The message format is declared in the error catalog.
+template<class T,
+         typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+         class... Args>
+void warning(int kind, const T *node, Args... args) {
+    auto& context = BaseCompileContext::get();
+    auto action = context.getDefaultWarningDiagnosticAction();
+    context.errorReporter().diagnose(action, kind, node, args...);
+}
+
+/// The const ref variant of the above
+template<class T,
+         typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+         class... Args>
+void warning(int kind, const T &node, Args... args) {
+    auto& context = BaseCompileContext::get();
+    auto action = context.getDefaultWarningDiagnosticAction();
+    context.errorReporter().diagnose(action, kind, node, args...);
+}
+
+/// Convert warnings that have a first argument as a node with source info to warnings with kind
+/// This allows incremental migration toward minimizing the number of warnings
+/// reported when passes are repeated, as typed warnings are filtered.
+template<class T,
+         typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+         class... Args>
+void warning(const char *format, const T *node, Args... args) {
+    auto& context = BaseCompileContext::get();
+    auto action = context.getDefaultWarningDiagnosticAction();
+    context.errorReporter().diagnose(action, ErrorType::LEGACY_WARNING, format, node, args...);
+}
+
+/// The const ref variant of the above
+template<class T,
+         typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+         class... Args>
+void warning(const char *format, const T &node, Args... args) {
+    auto& context = BaseCompileContext::get();
+    auto action = context.getDefaultWarningDiagnosticAction();
+    context.errorReporter().diagnose(action, ErrorType::LEGACY_WARNING, format, node, args...);
+}
+
+/// Report a warning if condition e is false.
 #define WARN_CHECK(e, ...) do { if (!(e)) ::warning(__VA_ARGS__); } while (0)
 
 /**

--- a/lib/error.h
+++ b/lib/error.h
@@ -40,6 +40,7 @@ inline unsigned diagnosticCount() {
 // Some compatibility for printf-style arguments is also supported.
 
 /// Report an error with the given message.
+// LEGACY: once we transition to error types, this should be deprecated
 template <typename... T>
 inline void error(const char* format, T... args) {
     auto& context = BaseCompileContext::get();
@@ -52,49 +53,54 @@ inline void error(const char* format, T... args) {
 template<class T,
          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
          class... Args>
-void error(int kind, const T *node, Args... args) {
+void error(const int kind, const char *format, const T *node, Args... args) {
     auto& context = BaseCompileContext::get();
     auto action = context.getDefaultErrorDiagnosticAction();
-    context.errorReporter().diagnose(action, kind, node, args...);
+    context.errorReporter().diagnose(action, kind, format, node, args...);
 }
 
 /// The const ref variant of the above
 template<class T,
          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
          class... Args>
-void error(int kind, const T &node, Args... args) {
-    auto& context = BaseCompileContext::get();
-    auto action = context.getDefaultErrorDiagnosticAction();
-    context.errorReporter().diagnose(action, kind, node, args...);
+void error(const int kind, const char *format, const T &node, Args... args) {
+    error(kind, format, &node, std::forward<Args>(args)...);
 }
 
 /// Convert errors that have a first argument as a node with source info to errors with kind
 /// This allows incremental migration toward minimizing the number of errors and warnings
 /// reported when passes are repeated, as typed errors are filtered.
+// LEGACY: once we transition to error types, this should be deprecated
 template<class T,
          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
          class... Args>
 void error(const char *format, const T *node, Args... args) {
-    auto& context = BaseCompileContext::get();
-    auto action = context.getDefaultErrorDiagnosticAction();
-    context.errorReporter().diagnose(action, ErrorType::LEGACY_ERROR, format, node, args...);
+    error(ErrorType::LEGACY_ERROR, format, node, std::forward<Args>(args)...);
 }
 
 /// The const ref variant of the above
+// LEGACY: once we transition to error types, this should be deprecated
 template<class T,
          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
          class... Args>
 void error(const char *format, const T &node, Args... args) {
-    auto& context = BaseCompileContext::get();
-    auto action = context.getDefaultErrorDiagnosticAction();
-    context.errorReporter().diagnose(action, ErrorType::LEGACY_ERROR, format, node, args...);
+    error(ErrorType::LEGACY_ERROR, format, node, std::forward<Args>(args)...);
 }
 
+/// Report errors of type kind for messages that do not have a node.
+/// These will not be filtered
+template<typename... Args>
+void error(const int kind, const char *format, Args... args) {
+    auto& context = BaseCompileContext::get();
+    auto action = context.getDefaultErrorDiagnosticAction();
+    context.errorReporter().diagnose(action, kind, format, std::forward<Args>(args)...);
+}
 
 /// Report an error if condition e is false.
 #define ERROR_CHECK(e, ...) do { if (!(e)) ::error(__VA_ARGS__); } while (0)
 
 /// Report a warning with the given message.
+// LEGACY: once we transition to error types, this should be deprecated
 template <typename... T>
 inline void warning(const char* format, T... args) {
     auto& context = BaseCompileContext::get();
@@ -103,46 +109,30 @@ inline void warning(const char* format, T... args) {
 }
 
 /// Report warnings of type kind. Requires that the node argument have source info.
-/// The message format is declared in the error catalog.
 template<class T,
          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
          class... Args>
-void warning(int kind, const T *node, Args... args) {
+void warning(const int kind, const char *format, const T *node, Args... args) {
     auto& context = BaseCompileContext::get();
     auto action = context.getDefaultWarningDiagnosticAction();
-    context.errorReporter().diagnose(action, kind, node, args...);
+    context.errorReporter().diagnose(action, kind, format, node, args...);
 }
 
 /// The const ref variant of the above
 template<class T,
          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
          class... Args>
-void warning(int kind, const T &node, Args... args) {
-    auto& context = BaseCompileContext::get();
-    auto action = context.getDefaultWarningDiagnosticAction();
-    context.errorReporter().diagnose(action, kind, node, args...);
+void warning(const int kind, const char *format, const T &node, Args... args) {
+    ::warning(kind, format, &node, std::forward<Args>(args)...);
 }
 
-/// Convert warnings that have a first argument as a node with source info to warnings with kind
-/// This allows incremental migration toward minimizing the number of warnings
-/// reported when passes are repeated, as typed warnings are filtered.
-template<class T,
-         typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
-         class... Args>
-void warning(const char *format, const T *node, Args... args) {
+/// Report warnings of type kind, for messages that do not have a node.
+/// These will not be filtered
+template<typename... Args>
+void warning(const int kind, const char *format, Args... args) {
     auto& context = BaseCompileContext::get();
     auto action = context.getDefaultWarningDiagnosticAction();
-    context.errorReporter().diagnose(action, ErrorType::LEGACY_WARNING, format, node, args...);
-}
-
-/// The const ref variant of the above
-template<class T,
-         typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
-         class... Args>
-void warning(const char *format, const T &node, Args... args) {
-    auto& context = BaseCompileContext::get();
-    auto action = context.getDefaultWarningDiagnosticAction();
-    context.errorReporter().diagnose(action, ErrorType::LEGACY_WARNING, format, node, args...);
+    context.errorReporter().diagnose(action, kind, format, std::forward<Args>(args)...);
 }
 
 /// Report a warning if condition e is false.

--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -1,0 +1,37 @@
+/*
+Copyright 2018-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <map>
+#include <string>
+#include "error_catalog.h"
+#include "error_reporter.h"
+
+std::map<int, const std::string> ErrorReporter::errorCatalog = {
+    { ErrorType::ERR_UNKNOWN,     "%1%: Unknown %2%"},      // args: %1% - IR node, %2% - what
+    { ErrorType::ERR_UNSUPPORTED, "%1%: Unsupported %2%"},  // args: %1% - IR node, %2% - what
+    { ErrorType::ERR_UNEXPECTED,  "%1%: Unexpected %2%"},   // args: %1% - IR node, %2% - what
+    { ErrorType::ERR_EXPECTED,    "%1%: Expected %2%"},     // args: %1% - IR node, %2% - what
+    { ErrorType::ERR_NOT_FOUND,   "%1%: %2% not found"},    // args: %1% - IR node, %2% - what
+    { ErrorType::ERR_INVALID,     "%1%: Invalid %2%"},      // args: %1% - IR node, %2% - what
+    { ErrorType::ERR_EXPRESSION,  "%1%: Expression %2%"},   // args: %1% - the expr, %2% - what
+    { ErrorType::ERR_OVERLIMIT,   "%1%: Target supports %2% %3% %4%"}, // args: %1% - IR node, %2% - what, %3% - limit, %4% - unit
+    { ErrorType::ERR_INSUFFICIENT,  "%1%: Target requires %2% %3% %4%"}, // args: %1% - IR node, %2% - limit, %3% - what, %4% - units
+    { ErrorType::ERR_UNINITIALIZED, "%1%: Uninitialized %2%"}, // args: %1% - IR node, %2% - what
+    // Warnings
+    { ErrorType::WARN_UNKNOWN,     "%1%: Unknown %2%"},      // args: %1% - IR node, %2% - what
+    { ErrorType::WARN_UNSUPPORTED, "%1%: Unsupported %2%"},  // args: %1% - IR node, %2% - what
+    { ErrorType::WARN_MISMATCH,    "%1%: %2%"},              // args: %1% - IR node, $2% -what
+};

--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -30,6 +30,8 @@ const int ErrorType::ERR_INVALID       =   7;
 const int ErrorType::ERR_EXPRESSION    =   8;
 const int ErrorType::ERR_OVERLIMIT     =   9;
 const int ErrorType::ERR_INSUFFICIENT  =  10;
+const int ErrorType::ERR_TYPE_ERROR    =  11;
+const int ErrorType::ERR_UNSUPPORTED_ON_TARGET = 12;
 // If we specialize for 1000 error types we're good!
 const int ErrorType::ERR_MAX_ERRORS    = 999;
 
@@ -70,25 +72,27 @@ std::map<int, ErrorSig> ErrorCatalog::errorCatalog = {
     { ErrorType::ERR_OVERLIMIT,          ErrorSig("overlimit", "%1%: Target supports")},
     { ErrorType::ERR_INSUFFICIENT,       ErrorSig("insufficient", "%1%: Target requires")},
     { ErrorType::ERR_UNINITIALIZED,      ErrorSig("uninitialized", "%1%: Uninitialized")},
+    { ErrorType::ERR_TYPE_ERROR,         ErrorSig("type-error", "")},
+    { ErrorType::ERR_UNSUPPORTED_ON_TARGET, ErrorSig("target-error",
+                                                     "%1%: Unsupported on target")},
 
     // Warnings
     { ErrorType::LEGACY_WARNING,         ErrorSig("legacy", "")},
-    { ErrorType::WARN_FAILED,            ErrorSig("failed", "%1%:")},
-    { ErrorType::WARN_UNKNOWN,           ErrorSig("unknown", "%1%:")},
-    { ErrorType::WARN_INVALID,           ErrorSig("invalid", "%1%:")},
-    { ErrorType::WARN_UNSUPPORTED,       ErrorSig("unsupported", "%1%:")},
-    { ErrorType::WARN_DEPRECATED,        ErrorSig("deprecated", "%1%:")},
-    { ErrorType::WARN_UNINITIALIZED,     ErrorSig("uninitialized", "%1%:")},
-    { ErrorType::WARN_UNUSED,            ErrorSig("unused", "%1%:")},
-    { ErrorType::WARN_MISSING,           ErrorSig("missing", "%1%:")},
-    { ErrorType::WARN_ORDERING,          ErrorSig("ordering", "%1%:")},
-    { ErrorType::WARN_MISMATCH,          ErrorSig("mismatch", "%1%:")},
-    { ErrorType::WARN_OVERFLOW,          ErrorSig("overflow", "%1%:")},
-    { ErrorType::WARN_IGNORE_PROPERTY,   ErrorSig("ignore-prop", "%1%:")},
-    { ErrorType::WARN_TYPE_INFERENCE,    ErrorSig("type-inference", "%1%:")},
-    { ErrorType::WARN_PARSER_TRANSITION, ErrorSig("parser-transition", "%1%:")},
-    { ErrorType::WARN_UNREACHABLE,       ErrorSig("parser-transition", "%1%:")},
-    { ErrorType::WARN_SHADOWING,         ErrorSig("shadow", "%1%:")},
-    { ErrorType::WARN_IGNORE,            ErrorSig("ignore", "%1%:")},
-
+    { ErrorType::WARN_FAILED,            ErrorSig("failed", "")},
+    { ErrorType::WARN_UNKNOWN,           ErrorSig("unknown", "")},
+    { ErrorType::WARN_INVALID,           ErrorSig("invalid", "")},
+    { ErrorType::WARN_UNSUPPORTED,       ErrorSig("unsupported", "")},
+    { ErrorType::WARN_DEPRECATED,        ErrorSig("deprecated", "")},
+    { ErrorType::WARN_UNINITIALIZED,     ErrorSig("uninitialized", "")},
+    { ErrorType::WARN_UNUSED,            ErrorSig("unused", "")},
+    { ErrorType::WARN_MISSING,           ErrorSig("missing", "")},
+    { ErrorType::WARN_ORDERING,          ErrorSig("ordering", "")},
+    { ErrorType::WARN_MISMATCH,          ErrorSig("mismatch", "")},
+    { ErrorType::WARN_OVERFLOW,          ErrorSig("overflow", "")},
+    { ErrorType::WARN_IGNORE_PROPERTY,   ErrorSig("ignore-prop", "")},
+    { ErrorType::WARN_TYPE_INFERENCE,    ErrorSig("type-inference", "")},
+    { ErrorType::WARN_PARSER_TRANSITION, ErrorSig("parser-transition", "")},
+    { ErrorType::WARN_UNREACHABLE,       ErrorSig("parser-transition", "")},
+    { ErrorType::WARN_SHADOWING,         ErrorSig("shadow", "")},
+    { ErrorType::WARN_IGNORE,            ErrorSig("ignore", "")},
 };

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -1,0 +1,53 @@
+/*
+Copyright 2018-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef P4C_LIB_ERROR_CATALOG_H_
+#define P4C_LIB_ERROR_CATALOG_H_
+
+/// enumerate supported errors
+/// Backends should extend this class with additional errors in the range 500-999 and
+/// warnings in the range 1500-2141.
+/// It is a class and not an enum class because in C++11 you can't extend an enum class
+class ErrorType {
+ public:
+    // -------- Errors -------------
+    // errors as initially defined with a format string
+    static const int LEGACY_ERROR      = 0;
+    static const int ERR_UNKNOWN       = 1;  // unknown construct (in context)
+    static const int ERR_UNSUPPORTED   = 2;  // unsupported construct
+    static const int ERR_UNEXPECTED    = 3;  // unexpected construct
+    static const int ERR_UNINITIALIZED = 4;  // uninitialized reads/writes
+    static const int ERR_EXPECTED      = 5;  // language, compiler expects a different construct
+    static const int ERR_NOT_FOUND     = 6;  // A different way to say ERR_EXPECTED
+    static const int ERR_INVALID       = 7;  // invalid construct
+    static const int ERR_EXPRESSION    = 8;  // expression too complex, or other expression related errors
+    static const int ERR_OVERLIMIT     = 9;  // program node exceeds target limits
+    static const int ERR_INSUFFICIENT  = 10;  // program node does not have enough of ...
+
+    // If we specialize for 1000 error types we're good!
+    static const int ERR_MAX_ERRORS = 999;
+
+    // -------- Warnings -----------
+    // warnings as initially defined with a format string
+    static const int LEGACY_WARNING = ERR_MAX_ERRORS + 1;
+    static const int WARN_UNKNOWN     = 1001;  // unknown construct (in context)
+    static const int WARN_UNSUPPORTED = 1002;  // unsupported construct
+    static const int WARN_MISMATCH    = 1003;  // mismatched constructs
+
+    static const int WARN_MAX_WARNINGS = 2142;
+};
+
+#endif  // P4C_LIB_ERROR_CATALOG_H_

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -36,10 +36,11 @@ class ErrorType {
     static const int ERR_EXPECTED;            // language, compiler expects a different construct
     static const int ERR_NOT_FOUND;           // A different way to say ERR_EXPECTED
     static const int ERR_INVALID;             // invalid construct
-    static const int ERR_EXPRESSION;          // expression too complex, or other expression
-                                              // related errors
+    static const int ERR_EXPRESSION;          // expression related errors
     static const int ERR_OVERLIMIT;           // program node exceeds target limits
     static const int ERR_INSUFFICIENT;        // program node does not have enough of ...
+    static const int ERR_TYPE_ERROR;          // P4 type checking errors
+    static const int ERR_UNSUPPORTED_ON_TARGET;  // target can not handle construct
 
     // If we specialize for 1000 error types we're good!
     static const int ERR_MAX_ERRORS;
@@ -112,7 +113,7 @@ class ErrorCatalog {
     }
 
  private:
-    explicit ErrorCatalog() {}
+    ErrorCatalog() {}
 
     /// map from errorCode to pairs of (name, format)
     static std::map<int, std::pair<const char *, const std::string>> errorCatalog;

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -17,6 +17,8 @@ limitations under the License.
 #ifndef P4C_LIB_ERROR_REPORTER_H_
 #define P4C_LIB_ERROR_REPORTER_H_
 
+#include <map>
+#include <set>
 #include <stdarg.h>
 #include <boost/format.hpp>
 #include <type_traits>
@@ -354,6 +356,8 @@ enum class DiagnosticAction {
     Error    /// Print an error and signal that compilation should be aborted.
 };
 
+#include "error_catalog.h"
+
 // Keeps track of compilation errors.
 // Errors are specified using the error() and warning() methods,
 // that use boost::format format strings, i.e.,
@@ -363,9 +367,25 @@ class ErrorReporter final {
  private:
     std::ostream* outputstream;
 
+    /// Message catalog for errors: error type to message format.
+    static std::map<int, const std::string> errorCatalog;
+
+    /// Track errors or warnings that have already been issued for a particular source location
+    std::set<std::pair<int, const Util::SourceInfo>> errorTracker;
+
+    /// Output the message and flush the stream
     void emit_message(cstring message) {
         *outputstream << message;
         outputstream->flush();
+    }
+
+    /// Check whether an error has already been reported, by keeping track of error type
+    /// and source info.
+    /// If the error has been reported, return true. Otherwise, insert add the error to the
+    /// list of seen errors, and return false.
+    bool error_reported(int err, const Util::SourceInfo source) {
+        auto p = errorTracker.emplace(err, source);
+        return !p.second;  // if insertion took place, then we have not seen the error.
     }
 
  public:
@@ -388,6 +408,41 @@ class ErrorReporter final {
         std::string message = ::error_helper(fmt, "", "", "", args...);
         return message;
     }
+
+    template <typename Kind, class T,
+              typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+              typename... Args>
+    void diagnose(DiagnosticAction action, Kind k, const T *node, Args... args) {
+        if (!error_reported(k, node->getSourceInfo()))
+            diagnoseUnnamed(action, errorCatalog.at(k).c_str(), node, std::forward<Args>(args)...);
+    }
+
+    template <typename Kind, class T,
+              typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+              typename... Args>
+    void diagnose(DiagnosticAction action, Kind k, const T &node, Args... args) {
+        if (!error_reported(k, node.getSourceInfo()))
+            diagnoseUnnamed(action, errorCatalog.at(k).c_str(), node, std::forward<Args>(args)...);
+    }
+
+    template <class T,
+              typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+              typename... Args>
+    void diagnose(DiagnosticAction action, int kind, const char *format, const T *node,
+                  Args... args) {
+        if (!error_reported(kind, node->getSourceInfo()))
+            diagnoseUnnamed(action, format, node, std::forward<Args>(args)...);
+    }
+
+    template <class T,
+              typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+              typename... Args>
+    void diagnose(DiagnosticAction action, int kind, const char *format, const T &node,
+                  Args... args) {
+        if (!error_reported(kind, node.getSourceInfo()))
+            diagnoseUnnamed(action, format, node, std::forward<Args>(args)...);
+    }
+
 
     template <typename... T>
     void diagnose(DiagnosticAction action, const char* diagnosticName,

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -17,10 +17,10 @@ limitations under the License.
 #ifndef P4C_LIB_ERROR_REPORTER_H_
 #define P4C_LIB_ERROR_REPORTER_H_
 
+#include <boost/format.hpp>
+#include <stdarg.h>
 #include <map>
 #include <set>
-#include <stdarg.h>
-#include <boost/format.hpp>
 #include <type_traits>
 
 #include "lib/cstring.h"
@@ -422,7 +422,9 @@ class ErrorReporter final {
     void diagnose(DiagnosticAction action, const int errorCode, const char *format, const T *node,
                   Args... args) {
         if (!error_reported(errorCode, node->getSourceInfo())) {
-            std::string fmt = std::string(get_format(errorCode)) + " " + format;
+            std::string fmt = std::string(get_format(errorCode));
+            if (!fmt.empty()) fmt += std::string(" ") + format;
+            else              fmt += format;
             const char *name = get_error_name(errorCode);
             if (name)
                 diagnose(action, name, fmt.c_str(), node, args...);
@@ -442,7 +444,9 @@ class ErrorReporter final {
 
     template <typename... Args>
     void diagnose(DiagnosticAction action, const int errorCode, const char *format, Args... args) {
-        std::string fmt = std::string(get_format(errorCode)) + " " + format;
+        std::string fmt = std::string(get_format(errorCode));
+        if (!fmt.empty()) fmt += std::string(" ") + format;
+        else              fmt += format;
         const char *name = get_error_name(errorCode);
         if (name)
             diagnose(action, name, fmt.c_str(), args...);

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -95,4 +95,8 @@ class CompilationError : public P4CExceptionBase {
     } while (0)
 
 }  // namespace Util
+
+/// Report an error and exit
+#define FATAL_ERROR(...) do { throw Util::CompilationError(__VA_ARGS__); } while (0)
+
 #endif /* P4C_LIB_EXCEPTIONS_H_ */

--- a/midend/checkSize.h
+++ b/midend/checkSize.h
@@ -34,13 +34,15 @@ class CheckTableSize : public Modifier {
         auto key = table->getKey();
         if (key == nullptr) {
             if (size->value != 1) {
-                ::warning("%1%: Size specified for table without keys", size);
+                ::warning(ErrorType::WARN_MISMATCH,
+                          "Size %2% specified for table without keys", table, size);
                 deleteSize = true;
             }
         }
         auto entries = table->properties->getProperty(IR::TableProperties::entriesPropertyName);
         if (entries != nullptr && entries->isConstant) {
-            ::warning("%1%: Size specified for table with constant entries", size);
+            ::warning(ErrorType::WARN_MISMATCH,
+                      "Size %2% specified for table with constant entries", table, size);
             deleteSize = true;
         }
         if (deleteSize) {

--- a/midend/checkSize.h
+++ b/midend/checkSize.h
@@ -35,14 +35,14 @@ class CheckTableSize : public Modifier {
         if (key == nullptr) {
             if (size->value != 1) {
                 ::warning(ErrorType::WARN_MISMATCH,
-                          "Size %2% specified for table without keys", table, size);
+                          "%1%: size %2% specified for table without keys", table, size);
                 deleteSize = true;
             }
         }
         auto entries = table->properties->getProperty(IR::TableProperties::entriesPropertyName);
         if (entries != nullptr && entries->isConstant) {
             ::warning(ErrorType::WARN_MISMATCH,
-                      "Size %2% specified for table with constant entries", table, size);
+                      "%1%: size %2% specified for table with constant entries", table, size);
             deleteSize = true;
         }
         if (deleteSize) {

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -271,7 +271,8 @@ class ParserSymbolicInterpreter {
                     }
 
                     if (conservative)
-                        ::warning("Potential parser cycle without extracting any bytes:\n%1%",
+                        ::warning(ErrorType::WARN_PARSER_TRANSITION,
+                                  "Potential parser cycle without extracting any bytes:\n%1%",
                                   stateChain(state));
                     else
                         ::error("Parser cycle without extracting any bytes:\n%1%",

--- a/midend/simplifySelectCases.cpp
+++ b/midend/simplifySelectCases.cpp
@@ -60,7 +60,7 @@ const IR::Node* DoSimplifySelectCases::preorder(IR::SelectExpression* expression
     bool changes = false;
     for (auto c : expression->selectCases) {
         if (seenDefault) {
-            ::warning("%1%: unreachable", c);
+            ::warning(ErrorType::WARN_PARSER_TRANSITION, "%1%: unreachable", c);
             changes = true;
             continue;
         }
@@ -73,7 +73,8 @@ const IR::Node* DoSimplifySelectCases::preorder(IR::SelectExpression* expression
     if (changes) {
         if (cases.size() == 1) {
             // just one default label
-            ::warning("%1%: transition does not depend on select argument", expression->select);
+            ::warning(ErrorType::WARN_PARSER_TRANSITION,
+                      "%1%: transition does not depend on select argument", expression->select);
             return cases.at(0)->state;
         }
         expression->selectCases = std::move(cases);

--- a/midend/validateProperties.cpp
+++ b/midend/validateProperties.cpp
@@ -5,7 +5,7 @@ namespace P4 {
 void ValidateTableProperties::postorder(const IR::Property* property) {
     if (legalProperties.find(property->name.name) != legalProperties.end())
         return;
-    ::warning("Unknown table property: %1%", property);
+    ::warning(ErrorType::WARN_IGNORE_PROPERTY, "Unknown table property: %1%", property);
 }
 
 }  // namespace P4

--- a/testdata/p4_14_errors_outputs/array_index.p4-stderr
+++ b/testdata/p4_14_errors_outputs/array_index.p4-stderr
@@ -1,4 +1,4 @@
-array_index.p4(30): warning: Could not infer type for port, using bit<8>
+array_index.p4(30): [--Wwarn=type-inference] warning: Could not infer type for port, using bit<8>
 action a(port, val) {
          ^^^^
 array_index.p4(31): error: Illegal array index hdr.data[port]: must be a constant, 'last', or 'next'.

--- a/testdata/p4_14_errors_outputs/issue1238.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue1238.p4-stderr
@@ -1,4 +1,4 @@
-issue1238.p4(11): error: subtract: operation only defined for bit/int types
+issue1238.p4(11): [--Werror=legacy] error: subtract: operation only defined for bit/int types
   subtract(palatalising, palatalising, 1);
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_14_errors_outputs/issue1499.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue1499.p4-stderr
@@ -1,7 +1,7 @@
 issue1499.p4(18): error: latest: latest not yet defined
   set_metadata(hesitation.contracts, latest.cornstarchs);
                                      ^^^^^^
-issue1499.p4(21): error: ingress: unknown state
+issue1499.p4(21): [--Werror=legacy] error: ingress: unknown state
     1024 : ingress;
            ^^^^^^^
 error: 2 errors encountered, aborting compilation

--- a/testdata/p4_14_errors_outputs/issue747.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue747.p4-stderr
@@ -1,7 +1,7 @@
-issue747.p4(31): warning: Could not infer type for local_port, using bit<8>
+issue747.p4(31): [--Wwarn=type-inference] warning: Could not infer type for local_port, using bit<8>
 action local_recirc(local_port) {
                     ^^^^^^^^^^
-issue747.p4(31): error: local_port: expected a field list
+issue747.p4(31): [--Werror=legacy] error: local_port: expected a field list
 action local_recirc(local_port) {
                     ^^^^^^^^^^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_14_errors_outputs/issue763-1.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue763-1.p4-stderr
@@ -1,4 +1,4 @@
-issue763-1.p4(7): error: Header cannot have this name; it can only be used for metadata
+issue763-1.p4(7): [--Werror=legacy] error: Header cannot have this name; it can only be used for metadata
 header X standard_metadata;
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_14_errors_outputs/issue763-2.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue763-2.p4-stderr
@@ -1,4 +1,4 @@
-issue763-2.p4(1): error: v1HeaderType: name standard_metadata_t is reserved
+issue763-2.p4(1): [--Werror=legacy] error: v1HeaderType: name standard_metadata_t is reserved
 header_type standard_metadata_t {
 ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_14_errors_outputs/issue763.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue763.p4-stderr
@@ -1,4 +1,4 @@
-issue763.p4(1): error: v1HeaderType: same name as v1HeaderType
+issue763.p4(1): [--Werror=legacy] error: v1HeaderType: same name as v1HeaderType
 header_type X {
 ^
 issue763.p4(7)

--- a/testdata/p4_14_errors_outputs/issue780-10.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue780-10.p4-stderr
@@ -1,4 +1,4 @@
-issue780-10.p4(1): error: V1Control standard_metadata_t cannot have this name; it can only be used for type
+issue780-10.p4(1): [--Werror=legacy] error: V1Control standard_metadata_t cannot have this name; it can only be used for type
 control standard_metadata_t { }
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_14_errors_outputs/issue780-4.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue780-4.p4-stderr
@@ -1,7 +1,4 @@
-issue780-4.p4(1): error: header egress cannot have this name; it can only be used for control
+issue780-4.p4(1): [--Werror=legacy] error: header egress cannot have this name; it can only be used for control
 header_type egress {
 ^
-issue780-4.p4(1): error: struct egress cannot have this name; it can only be used for control
-header_type egress {
-^
-error: 2 errors encountered, aborting compilation
+error: 1 errors encountered, aborting compilation

--- a/testdata/p4_14_errors_outputs/issue780-6.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue780-6.p4-stderr
@@ -1,7 +1,4 @@
-issue780-6.p4(1): error: header standard_metadata cannot have this name; it can only be used for metadata
+issue780-6.p4(1): [--Werror=legacy] error: header standard_metadata cannot have this name; it can only be used for metadata
 header_type standard_metadata {
 ^
-issue780-6.p4(1): error: struct standard_metadata cannot have this name; it can only be used for metadata
-header_type standard_metadata {
-^
-error: 2 errors encountered, aborting compilation
+error: 1 errors encountered, aborting compilation

--- a/testdata/p4_14_errors_outputs/issue905.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue905.p4-stderr
@@ -1,4 +1,4 @@
-issue905.p4(34): error: *: not defined on operands of type varbit<0>
+issue905.p4(34): [--Werror=legacy] error: *: not defined on operands of type varbit<0>
  modify_field(can_data.value, can_data.value * 2); // error
                                              ^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_14_errors_outputs/unknown-state.p4-stderr
+++ b/testdata/p4_14_errors_outputs/unknown-state.p4-stderr
@@ -1,4 +1,4 @@
-unknown-state.p4(2): error: ingress: unknown state
+unknown-state.p4(2): [--Werror=legacy] error: ingress: unknown state
     return ingress;
            ^^^^^^^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_14_samples_outputs/11-MultiTags.p4-stderr
+++ b/testdata/p4_14_samples_outputs/11-MultiTags.p4-stderr
@@ -1,1 +1,1 @@
-warning: The order of headers in deparser is not uniquely determined by parser!
+[--Wwarn=ordering] warning: hdr.ethernet: the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop.p4-stderr
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop.p4-stderr
@@ -1,1 +1,1 @@
-warning: The order of headers in deparser is not uniquely determined by parser!
+[--Wwarn=ordering] warning: hdr.ethernet: the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect.p4-stderr
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect.p4-stderr
@@ -1,1 +1,1 @@
-warning: The order of headers in deparser is not uniquely determined by parser!
+[--Wwarn=ordering] warning: hdr.ethernet: the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/TLV_parsing.p4-stderr
+++ b/testdata/p4_14_samples_outputs/TLV_parsing.p4-stderr
@@ -1,4 +1,4 @@
-TLV_parsing.p4(118): warning: 20: value does not fit in 4 bits
+TLV_parsing.p4(118): [--Wwarn=mismatch] warning: 20: value does not fit in 4 bits
     set_metadata(my_metadata.parse_ipv4_counter, ipv4_base.ihl * 4 - 20);
                                                                      ^^
-warning: The order of headers in deparser is not uniquely determined by parser!
+[--Wwarn=ordering] warning: "start": the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/acl1.p4-stderr
+++ b/testdata/p4_14_samples_outputs/acl1.p4-stderr
@@ -1,3 +1,3 @@
-acl1.p4(223): warning: Could not infer type for session_id, using bit<8>
+acl1.p4(223): [--Wwarn=type-inference] warning: Could not infer type for session_id, using bit<8>
 action negative_mirror(session_id) {
                        ^^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/axon.p4-stderr
+++ b/testdata/p4_14_samples_outputs/axon.p4-stderr
@@ -1,1 +1,1 @@
-warning: The order of headers in deparser is not uniquely determined by parser!
+[--Wwarn=ordering] warning: "start": the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/basic_routing.p4-stderr
+++ b/testdata/p4_14_samples_outputs/basic_routing.p4-stderr
@@ -1,4 +1,4 @@
-basic_routing.p4(117): warning: bd shadows .bd
+basic_routing.p4(117): [--Wwarn=shadow] warning: bd shadows .bd
 action set_bd(bd) {
               ^^
 basic_routing.p4(135)

--- a/testdata/p4_14_samples_outputs/flowlet_switching.p4-stderr
+++ b/testdata/p4_14_samples_outputs/flowlet_switching.p4-stderr
@@ -1,6 +1,6 @@
-flowlet_switching.p4(128): warning: Could not infer type for ecmp_base, using bit<8>
+flowlet_switching.p4(128): [--Wwarn=type-inference] warning: Could not infer type for ecmp_base, using bit<8>
 action set_ecmp_select(ecmp_base, ecmp_count) {
                        ^^^^^^^^^
-flowlet_switching.p4(128): warning: Could not infer type for ecmp_count, using bit<8>
+flowlet_switching.p4(128): [--Wwarn=type-inference] warning: Could not infer type for ecmp_count, using bit<8>
 action set_ecmp_select(ecmp_base, ecmp_count) {
                                   ^^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/issue1237.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue1237.p4-stderr
@@ -1,6 +1,6 @@
-issue1237.p4(37): warning: 0: zero mask
+issue1237.p4(37): [--Wwarn=invalid] warning: 0: zero mask
     kilometer.flaccidly mask 0 : lpm;
                              ^
-issue1237.p4(37): warning: 0: Constant key field
+issue1237.p4(37): [--Wwarn=mismatch] warning: 0: Constant key field
     kilometer.flaccidly mask 0 : lpm;
                              ^

--- a/testdata/p4_14_samples_outputs/issue583.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue583.p4-stderr
@@ -1,3 +1,3 @@
-issue583.p4(189): warning: 4294967295: value does not fit in 9 bits
+issue583.p4(189): [--Wwarn=mismatch] warning: 4294967295: value does not fit in 9 bits
     modify_field(standard_metadata.egress_spec, egress_spec, 0xFFFFFFFF);
                                                              ^^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/issue604.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue604.p4-stderr
@@ -1,18 +1,6 @@
-issue604.p4(2): warning: extern_test: P4_14 extern type not fully supported
+issue604.p4(2): [--Wwarn=unsupported] warning: extern_test: P4_14 extern type not fully supported
 extern_type extern_test {
 ^
-issue604.p4(8): warning: my_extern_inst: P4_14 extern not fully supported
+issue604.p4(8): [--Wwarn=unsupported] warning: my_extern_inst: P4_14 extern not fully supported
 extern extern_test my_extern_inst {
                    ^^^^^^^^^^^^^^
-issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
-extern_type extern_test {
-^
-issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
-extern_type extern_test {
-^
-issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
-extern_type extern_test {
-^
-issue604.p4(2): warning: extern_test: extern has attributes, which are not supported in P4-16, and thus are not emitted as P4-16
-extern_type extern_test {
-^

--- a/testdata/p4_14_samples_outputs/issue846.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue846.p4-stderr
@@ -1,9 +1,9 @@
-issue846.p4(47): warning: Could not infer type for p, using bit<8>
+issue846.p4(47): [--Wwarn=type-inference] warning: Could not infer type for p, using bit<8>
 action action_0(p){
                 ^
-issue846.p4(51): warning: Could not infer type for p, using bit<8>
+issue846.p4(51): [--Wwarn=type-inference] warning: Could not infer type for p, using bit<8>
 action action_1(p){
                 ^
-issue846.p4(54): warning: Could not infer type for p, using bit<8>
+issue846.p4(54): [--Wwarn=type-inference] warning: Could not infer type for p, using bit<8>
 action action_2(p){
                 ^

--- a/testdata/p4_14_samples_outputs/issue946.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue946.p4-stderr
@@ -1,2 +1,3 @@
-warning: parser_value_set has no @parser_value_set_size annotation
-warning: using default size 4
+issue946.p4(19): [--Wwarn=missing] warning: CaseEntry: parser_value_set has no @parser_value_set_size annotation.Using default size 4.
+        pvs : ingress;
+        ^^^

--- a/testdata/p4_14_samples_outputs/overflow.p4-stderr
+++ b/testdata/p4_14_samples_outputs/overflow.p4-stderr
@@ -1,3 +1,3 @@
-overflow.p4(36): warning: 11: value does not fit in 1 bits
+overflow.p4(36): [--Wwarn=mismatch] warning: 11: value does not fit in 1 bits
 action action_1_1(value) { modify_field(md.field_1_1_1, value); modify_field(md.field_2_1_1, 11); }
                                                                                              ^^

--- a/testdata/p4_14_samples_outputs/parser-exception.p4-stderr
+++ b/testdata/p4_14_samples_outputs/parser-exception.p4-stderr
@@ -1,1 +1,1 @@
-warning: parser_exception: parser exception is not translated to P4-16
+[--Wwarn=unsupported] warning: parser_exception: parser exception is not translated to P4-16

--- a/testdata/p4_14_samples_outputs/parser1.p4-stderr
+++ b/testdata/p4_14_samples_outputs/parser1.p4-stderr
@@ -1,1 +1,1 @@
-warning: The order of headers in deparser is not uniquely determined by parser!
+[--Wwarn=ordering] warning: "start": the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/parser2.p4-stderr
+++ b/testdata/p4_14_samples_outputs/parser2.p4-stderr
@@ -1,1 +1,1 @@
-warning: The order of headers in deparser is not uniquely determined by parser!
+[--Wwarn=ordering] warning: "start": the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/parser4.p4-stderr
+++ b/testdata/p4_14_samples_outputs/parser4.p4-stderr
@@ -1,1 +1,1 @@
-warning: The order of headers in deparser is not uniquely determined by parser!
+[--Wwarn=ordering] warning: "start": the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/parser_dc_full.p4-stderr
+++ b/testdata/p4_14_samples_outputs/parser_dc_full.p4-stderr
@@ -1,1 +1,1 @@
-warning: The order of headers in deparser is not uniquely determined by parser!
+[--Wwarn=ordering] warning: "start": the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/parser_pragma2.p4-stderr
+++ b/testdata/p4_14_samples_outputs/parser_pragma2.p4-stderr
@@ -1,6 +1,6 @@
-parser_pragma2.p4(18): warning: SelectCase: unreachable
+parser_pragma2.p4(18): [--Wwarn=parser-transition] warning: SelectCase: unreachable
         0xAB00 : Cowles;
         ^^^^^^
-parser_pragma2.p4(16): warning: ListExpression: transition does not depend on select argument
+parser_pragma2.p4(16): [--Wwarn=parser-transition] warning: ListExpression: transition does not depend on select argument
     return select(current(0, 32)) {
                   ^^^^^^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/parser_value_set0.p4-stderr
+++ b/testdata/p4_14_samples_outputs/parser_value_set0.p4-stderr
@@ -1,4 +1,6 @@
-warning: parser_value_set has no @parser_value_set_size annotation
-warning: using default size 4
-warning: parser_value_set has no @parser_value_set_size annotation
-warning: using default size 4
+parser_value_set0.p4(25): [--Wwarn=missing] warning: CaseEntry: parser_value_set has no @parser_value_set_size annotation.Using default size 4.
+        pvs0 : ingress;
+        ^^^^
+parser_value_set0.p4(26): [--Wwarn=missing] warning: CaseEntry: parser_value_set has no @parser_value_set_size annotation.Using default size 4.
+        pvs1 : parse_inner_ethernet;
+        ^^^^

--- a/testdata/p4_14_samples_outputs/parser_value_set1.p4-stderr
+++ b/testdata/p4_14_samples_outputs/parser_value_set1.p4-stderr
@@ -1,4 +1,6 @@
-warning: parser_value_set has no @parser_value_set_size annotation
-warning: using default size 4
-warning: parser_value_set has no @parser_value_set_size annotation
-warning: using default size 4
+parser_value_set1.p4(43): [--Wwarn=missing] warning: CaseEntry: parser_value_set has no @parser_value_set_size annotation.Using default size 4.
+        pvs0 : ingress;
+        ^^^^
+parser_value_set1.p4(45): [--Wwarn=missing] warning: CaseEntry: parser_value_set has no @parser_value_set_size annotation.Using default size 4.
+        pvs1 : parse_inner_ethernet;
+        ^^^^

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping.p4-stderr
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping.p4-stderr
@@ -1,1 +1,1 @@
-warning: The order of headers in deparser is not uniquely determined by parser!
+[--Wwarn=ordering] warning: "start": the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/register.p4-stderr
+++ b/testdata/p4_14_samples_outputs/register.p4-stderr
@@ -1,3 +1,3 @@
-register.p4(67): warning: Could not infer type for register_idx, using bit<8>
+register.p4(67): [--Wwarn=type-inference] warning: Could not infer type for register_idx, using bit<8>
 action m_action(register_idx) {
                 ^^^^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
+++ b/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
@@ -1,113 +1,86 @@
-sai_p4.p4(432): warning: Could not infer type for type_, using bit<8>
+sai_p4.p4(432): [--Wwarn=type-inference] warning: Could not infer type for type_, using bit<8>
 action set_next_hop(type_, ip, router_interface_id) {
                     ^^^^^
-sai_p4.p4(432): warning: Could not infer type for ip, using bit<8>
+sai_p4.p4(432): [--Wwarn=type-inference] warning: Could not infer type for ip, using bit<8>
 action set_next_hop(type_, ip, router_interface_id) {
                            ^^
-sai_p4.p4(282): warning: Could not infer type for admin_state, using bit<8>
+sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for admin_state, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                     ^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for default_vlan_priority, using bit<8>
+sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for default_vlan_priority, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                ^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for sflow, using bit<8>
+sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for sflow, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                     ^^^^^
-sai_p4.p4(282): warning: Could not infer type for flood_storm_control, using bit<8>
+sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for flood_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for broadcast_storm_control, using bit<8>
+sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for broadcast_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for multicast_storm_control, using bit<8>
+sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for multicast_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                                          ^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
+sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for max_virtual_routers, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for max_virtual_routers, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                          ^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for fdb_table_size, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for fdb_table_size, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                               ^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for on_link_route_supported, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for on_link_route_supported, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                               ^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for max_temp, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for max_temp, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                     ^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for switching_mode, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for switching_mode, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                               ^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for cpu_flood_enable, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for cpu_flood_enable, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                               ^^^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for ttl1_action, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for ttl1_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                 ^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for fdb_aging_time, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for fdb_aging_time, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                             ^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for fdb_unicast_miss_action, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for fdb_unicast_miss_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for fdb_broadcast_miss_action, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for fdb_broadcast_miss_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for fdb_multicast_miss_action, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for fdb_multicast_miss_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for ecmp_hash_seed, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_seed, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for ecmp_hash_type, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_type, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for ecmp_hash_fields, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_fields, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^
-sai_p4.p4(265): warning: Could not infer type for ecmp_max_paths, using bit<8>
+sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for ecmp_max_paths, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                                                                              ^^^^^^^^^^^^^^
-sai_p4.p4(583): warning: Could not infer type for violation_ttl1_action, using bit<8>
+sai_p4.p4(583): [--Wwarn=type-inference] warning: Could not infer type for violation_ttl1_action, using bit<8>
 action set_router(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
                                                                    ^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(583): warning: Could not infer type for violation_ip_options, using bit<8>
+sai_p4.p4(583): [--Wwarn=type-inference] warning: Could not infer type for violation_ip_options, using bit<8>
 action set_router(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
                                                                                           ^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for admin_state, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                    ^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for default_vlan_priority, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                               ^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for sflow, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                    ^^^^^
-sai_p4.p4(282): warning: Could not infer type for flood_storm_control, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                           ^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for broadcast_storm_control, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                                                ^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for multicast_storm_control, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                                                                         ^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): warning: port shadows .port
+sai_p4.p4(282): [--Wwarn=shadow] warning: port shadows .port
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                    ^^^^
 sai_p4.p4(305)
 table port {
 ^
-sai_p4.p4(282): warning: port shadows .port
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                   ^^^^
-sai_p4.p4(305)
-table port {
-^
-warning: .next_hop_group: unused instance
-warning: .vlan: unused instance
+[--Wwarn=unused] warning: .next_hop_group: unused instance
+[--Wwarn=unused] warning: .vlan: unused instance

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4-stderr
@@ -1,6 +1,6 @@
-tunnel.p4(880): warning: -14: negative value with unsigned type
+tunnel.p4(880): [--Wwarn=mismatch] warning: -14: negative value with unsigned type
     add(egress_metadata.payload_length, standard_metadata.packet_length, -14);
                                                                           ^^
-fabric.p4(230): warning: Could not infer type for fabric_mgid, using bit<8>
+fabric.p4(230): [--Wwarn=type-inference] warning: Could not infer type for fabric_mgid, using bit<8>
 action set_fabric_multicast(fabric_mgid) {
                             ^^^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
@@ -1,9 +1,9 @@
-tunnel.p4(1002): warning: -14: negative value with unsigned type
+tunnel.p4(1002): [--Wwarn=mismatch] warning: -14: negative value with unsigned type
     add(egress_metadata.payload_length, standard_metadata.packet_length, -14);
                                                                           ^^
-fabric.p4(210): warning: Could not infer type for fabric_mgid, using bit<8>
+fabric.p4(210): [--Wwarn=type-inference] warning: Could not infer type for fabric_mgid, using bit<8>
 action set_fabric_multicast(fabric_mgid) {
                             ^^^^^^^^^^^
-parser.p4(487): warning: SelectCase: unreachable
+parser.p4(487): [--Wwarn=parser-transition] warning: SelectCase: unreachable
         default: parse_all_int_meta_value_heders;
         ^^^^^^^

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified.p4-stderr
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified.p4-stderr
@@ -1,3 +1,3 @@
-test_config_23_same_container_modified.p4(88): warning: Could not infer type for my_param2, using bit<8>
+test_config_23_same_container_modified.p4(88): [--Wwarn=type-inference] warning: Could not infer type for my_param2, using bit<8>
 action action_1(my_param2) {
                 ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/accept_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/accept_e.p4-stderr
@@ -1,3 +1,3 @@
-accept_e.p4(18): error: accept: parser state should not be implemented, it is built-in
+accept_e.p4(18): [--Werror=legacy] error:  accept: parser state should not be implemented, it is built-in
     state accept { // reserved name
           ^^^^^^

--- a/testdata/p4_16_errors_outputs/accept_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/accept_e.p4-stderr
@@ -1,3 +1,3 @@
-accept_e.p4(18): [--Werror=legacy] error:  accept: parser state should not be implemented, it is built-in
+accept_e.p4(18): [--Werror=legacy] error: accept: parser state should not be implemented, it is built-in
     state accept { // reserved name
           ^^^^^^

--- a/testdata/p4_16_errors_outputs/action-bind.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind.p4-stderr
@@ -1,4 +1,4 @@
-action-bind.p4(23): [--Werror=legacy] error:  y: argument does not match declaration in actions list: x
+action-bind.p4(23): [--Werror=type-error] error: y: argument does not match declaration in actions list: x
         default_action = a(y, 0); // error: different bound argument
                            ^
 action-bind.p4(22)

--- a/testdata/p4_16_errors_outputs/action-bind.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind.p4-stderr
@@ -1,4 +1,4 @@
-action-bind.p4(23): error: y: argument does not match declaration in actions list: x
+action-bind.p4(23): [--Werror=legacy] error:  y: argument does not match declaration in actions list: x
         default_action = a(y, 0); // error: different bound argument
                            ^
 action-bind.p4(22)

--- a/testdata/p4_16_errors_outputs/action-bind1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind1.p4-stderr
@@ -1,4 +1,4 @@
-action-bind1.p4(22): error: a: Parameter b must be bound
+action-bind1.p4(22): [--Werror=legacy] error:  a: Parameter b must be bound
         default_action = a(); // error: too few arguments
                          ^^^
 action-bind1.p4(17)

--- a/testdata/p4_16_errors_outputs/action-bind1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind1.p4-stderr
@@ -1,4 +1,4 @@
-action-bind1.p4(22): [--Werror=legacy] error:  a: Parameter b must be bound
+action-bind1.p4(22): [--Werror=type-error] error: a: Parameter b must be bound
         default_action = a(); // error: too few arguments
                          ^^^
 action-bind1.p4(17)

--- a/testdata/p4_16_errors_outputs/action-bind2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind2.p4-stderr
@@ -1,9 +1,9 @@
-action-bind2.p4(21): [--Werror=legacy] error:  a: Parameter b must be bound
+action-bind2.p4(21): [--Werror=type-error] error: a: Parameter b must be bound
         actions = { a; } // error: not enough arguments
                     ^
 action-bind2.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                            ^
-action-bind2.p4(22): [--Werror=legacy] error:  0: must be a left-value
+action-bind2.p4(22): [--Werror=type-error] error: 0: must be a left-value
         default_action = a(0);
                            ^

--- a/testdata/p4_16_errors_outputs/action-bind2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind2.p4-stderr
@@ -1,15 +1,9 @@
-action-bind2.p4(21): error: a: Parameter b must be bound
+action-bind2.p4(21): [--Werror=legacy] error:  a: Parameter b must be bound
         actions = { a; } // error: not enough arguments
                     ^
 action-bind2.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                            ^
-action-bind2.p4(22): error: 0: must be a left-value
+action-bind2.p4(22): [--Werror=legacy] error:  0: must be a left-value
         default_action = a(0);
-                           ^
-action-bind2.p4(21): error: a: Parameter b must be bound
-        actions = { a; } // error: not enough arguments
-                    ^
-action-bind2.p4(17)
-    action a(inout bit<32> b, bit<32> d) {
                            ^

--- a/testdata/p4_16_errors_outputs/action-bind3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind3.p4-stderr
@@ -1,9 +1,9 @@
-action-bind3.p4(21): [--Werror=legacy] error:  0: parameter d cannot be bound: it is set by the control plane
+action-bind3.p4(21): [--Werror=type-error] error: 0: parameter d cannot be bound: it is set by the control plane
         actions = { a(x, 0); } // error: too many arguments
                          ^
 action-bind3.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                                       ^
-action-bind3.p4(22): [--Werror=legacy] error:  0: must be a left-value
+action-bind3.p4(22): [--Werror=type-error] error: 0: must be a left-value
         default_action = a(0);
                            ^

--- a/testdata/p4_16_errors_outputs/action-bind3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/action-bind3.p4-stderr
@@ -1,9 +1,9 @@
-action-bind3.p4(21): error: 0: parameter d cannot be bound: it is set by the control plane
+action-bind3.p4(21): [--Werror=legacy] error:  0: parameter d cannot be bound: it is set by the control plane
         actions = { a(x, 0); } // error: too many arguments
                          ^
 action-bind3.p4(17)
     action a(inout bit<32> b, bit<32> d) {
                                       ^
-action-bind3.p4(22): error: 0: must be a left-value
+action-bind3.p4(22): [--Werror=legacy] error:  0: must be a left-value
         default_action = a(0);
                            ^

--- a/testdata/p4_16_errors_outputs/assign.p4-stderr
+++ b/testdata/p4_16_errors_outputs/assign.p4-stderr
@@ -1,3 +1,3 @@
-assign.p4(23): [--Werror=legacy] error:  Expression e1 cannot be the target of an assignment
+assign.p4(23): [--Werror=type-error] error: Expression e1 cannot be the target of an assignment
         e1 = e2;
         ^^

--- a/testdata/p4_16_errors_outputs/assign.p4-stderr
+++ b/testdata/p4_16_errors_outputs/assign.p4-stderr
@@ -1,3 +1,3 @@
-assign.p4(23): error: Expression e1 cannot be the target of an assignment
+assign.p4(23): [--Werror=legacy] error:  Expression e1 cannot be the target of an assignment
         e1 = e2;
         ^^

--- a/testdata/p4_16_errors_outputs/binary_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/binary_e.p4-stderr
@@ -1,15 +1,15 @@
-binary_e.p4(32): error: Array indexing [] applied to non-array type int<2>
+binary_e.p4(32): [--Werror=type-error] error: Array indexing [] applied to non-array type int<2>
         c = a[2]; // not an array
             ^^^^
-binary_e.p4(33): [--Werror=legacy] error:  Array index d must be an integer, but it has type bool
+binary_e.p4(33): [--Werror=type-error] error: Array index d must be an integer, but it has type bool
         c = stack[d]; // indexing with bool
                   ^
-binary_e.p4(35): [--Werror=legacy] error:  &: Cannot operate on values with different types bit<2> and bit<4>
+binary_e.p4(35): [--Werror=type-error] error: &: Cannot operate on values with different types bit<2> and bit<4>
         f = e & f; // different width
             ^^^^^
-binary_e.p4(38): error: <: not defined on bool and bool
+binary_e.p4(38): [--Werror=type-error] error: <: not defined on bool and bool
         d = d < d; // not defined on bool
             ^^^^^
-binary_e.p4(39): error: >: not defined on int<2> and int<4>
+binary_e.p4(39): [--Werror=type-error] error: >: not defined on int<2> and int<4>
         d = a > c; // different width
             ^^^^^

--- a/testdata/p4_16_errors_outputs/binary_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/binary_e.p4-stderr
@@ -1,10 +1,10 @@
 binary_e.p4(32): error: Array indexing [] applied to non-array type int<2>
         c = a[2]; // not an array
             ^^^^
-binary_e.p4(33): error: Array index d must be an integer, but it has type bool
+binary_e.p4(33): [--Werror=legacy] error:  Array index d must be an integer, but it has type bool
         c = stack[d]; // indexing with bool
                   ^
-binary_e.p4(35): error: &: Cannot operate on values with different types bit<2> and bit<4>
+binary_e.p4(35): [--Werror=legacy] error:  &: Cannot operate on values with different types bit<2> and bit<4>
         f = e & f; // different width
             ^^^^^
 binary_e.p4(38): error: <: not defined on bool and bool

--- a/testdata/p4_16_errors_outputs/bitExtract_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/bitExtract_e.p4-stderr
@@ -1,9 +1,9 @@
-bitExtract_e.p4(25): error: s[3:0]: bit extraction only defined for bit<> types
+bitExtract_e.p4(25): [--Werror=type-error] error: s[3:0]: bit extraction only defined for bit<> types
         bit<4> x = s[3:0]; // wrong type for s
                    ^^^^^^
-bitExtract_e.p4(26): [--Werror=legacy] error:  Bit index 7 greater than width 4
+bitExtract_e.p4(26): [--Werror=type-error] error: Bit index 7 greater than width 4
         bit<8> y = dt[7:0]; // too many bits
                       ^
-bitExtract_e.p4(27): [--Werror=legacy] error:  Bit index 7 greater than width 4
+bitExtract_e.p4(27): [--Werror=type-error] error: Bit index 7 greater than width 4
         bit<4> z = dt[7:4]; // too many bits
                       ^

--- a/testdata/p4_16_errors_outputs/bitExtract_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/bitExtract_e.p4-stderr
@@ -1,9 +1,9 @@
 bitExtract_e.p4(25): error: s[3:0]: bit extraction only defined for bit<> types
         bit<4> x = s[3:0]; // wrong type for s
                    ^^^^^^
-bitExtract_e.p4(26): error: Bit index 7 greater than width 4
+bitExtract_e.p4(26): [--Werror=legacy] error:  Bit index 7 greater than width 4
         bit<8> y = dt[7:0]; // too many bits
                       ^
-bitExtract_e.p4(27): error: Bit index 7 greater than width 4
+bitExtract_e.p4(27): [--Werror=legacy] error:  Bit index 7 greater than width 4
         bit<4> z = dt[7:4]; // too many bits
                       ^

--- a/testdata/p4_16_errors_outputs/call-table.p4-stderr
+++ b/testdata/p4_16_errors_outputs/call-table.p4-stderr
@@ -1,3 +1,3 @@
-call-table.p4(24): error: t.apply: tables cannot be invoked from actions
+call-table.p4(24): [--Werror=type-error] error: t.apply: tables cannot be invoked from actions
         t.apply(); // cannot invoke table from action
         ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/call1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/call1_e.p4-stderr
@@ -1,4 +1,4 @@
-call1_e.p4(20): error: s: cannot allocate objects of type struct S
+call1_e.p4(20): [--Werror=type-error] error: s: cannot allocate objects of type struct S
     S() s; // structs have no constructors
         ^
 call1_e.p4(16)

--- a/testdata/p4_16_errors_outputs/conditional_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/conditional_e.p4-stderr
@@ -1,3 +1,3 @@
-conditional_e.p4(21): error: Condition of IfStatement does not evaluate to a bool but bit<1>
+conditional_e.p4(21): [--Werror=type-error] error: Condition of IfStatement does not evaluate to a bool but bit<1>
         if (b) ; else ; // non-bool condition
         ^^

--- a/testdata/p4_16_errors_outputs/const1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/const1_e.p4-stderr
@@ -1,4 +1,4 @@
-const1_e.p4(19): error: +: operands have different types: bit<32> and bit<16>
+const1_e.p4(19): [--Werror=legacy] error:  +: operands have different types: bit<32> and bit<16>
     x = 32w5 + 16w3;
         ^^^^^^^^^^^
 const1_e.p4(21): error: /: Division by zero

--- a/testdata/p4_16_errors_outputs/const1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/const1_e.p4-stderr
@@ -1,4 +1,4 @@
-const1_e.p4(19): [--Werror=legacy] error:  +: operands have different types: bit<32> and bit<16>
+const1_e.p4(19): [--Werror=legacy] error: +: operands have different types: bit<32> and bit<16>
     x = 32w5 + 16w3;
         ^^^^^^^^^^^
 const1_e.p4(21): error: /: Division by zero

--- a/testdata/p4_16_errors_outputs/const_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/const_e.p4-stderr
@@ -1,3 +1,3 @@
-const_e.p4(18): [--Werror=legacy] error:  x: Cannot declare constants of extern types
+const_e.p4(18): [--Werror=type-error] error: x: Cannot declare constants of extern types
 const I x = I(); // illegal constants of extern types
         ^

--- a/testdata/p4_16_errors_outputs/const_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/const_e.p4-stderr
@@ -1,3 +1,3 @@
-const_e.p4(18): error: x: Cannot declare constants of extern types
+const_e.p4(18): [--Werror=legacy] error:  x: Cannot declare constants of extern types
 const I x = I(); // illegal constants of extern types
         ^

--- a/testdata/p4_16_errors_outputs/constructor3_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor3_e.p4-stderr
@@ -1,3 +1,3 @@
-constructor3_e.p4(22): [--Werror=legacy] error:  e: Cannot unify bool to bit<1>
+constructor3_e.p4(22): [--Werror=legacy] error: e: Cannot unify bool to bit<1>
     E(true) e;
             ^

--- a/testdata/p4_16_errors_outputs/constructor3_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor3_e.p4-stderr
@@ -1,3 +1,3 @@
-constructor3_e.p4(22): error: e: Cannot unify bool to bit<1>
+constructor3_e.p4(22): [--Werror=legacy] error:  e: Cannot unify bool to bit<1>
     E(true) e;
             ^

--- a/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
@@ -1,3 +1,3 @@
-constructor_e.p4(18): error: X: Constructor cannot have a return type
+constructor_e.p4(18): [--Werror=legacy] error:  X: Constructor cannot have a return type
     void X(); // no return type allowed
          ^

--- a/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
@@ -1,3 +1,3 @@
-constructor_e.p4(18): [--Werror=legacy] error:  X: Constructor cannot have a return type
+constructor_e.p4(18): [--Werror=legacy] error: X: Constructor cannot have a return type
     void X(); // no return type allowed
          ^

--- a/testdata/p4_16_errors_outputs/control-inline.p4-stderr
+++ b/testdata/p4_16_errors_outputs/control-inline.p4-stderr
@@ -1,3 +1,3 @@
-control-inline.p4(35): error: vc: instances cannot be in a control 'apply' block
+control-inline.p4(35): [--Werror=legacy] error:  vc: instances cannot be in a control 'apply' block
         VC() vc;
              ^^

--- a/testdata/p4_16_errors_outputs/control-inline.p4-stderr
+++ b/testdata/p4_16_errors_outputs/control-inline.p4-stderr
@@ -1,3 +1,3 @@
-control-inline.p4(35): [--Werror=legacy] error:  vc: instances cannot be in a control 'apply' block
+control-inline.p4(35): [--Werror=legacy] error: vc: instances cannot be in a control 'apply' block
         VC() vc;
              ^^

--- a/testdata/p4_16_errors_outputs/control-verify.p4-stderr
+++ b/testdata/p4_16_errors_outputs/control-verify.p4-stderr
@@ -1,3 +1,3 @@
-control-verify.p4(7): [--Werror=legacy] error:  verify: may only be invoked in parsers
+control-verify.p4(7): [--Werror=type-error] error: verify: may only be invoked in parsers
     verify(8w0 == 8w1, error.Oops);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/control-verify.p4-stderr
+++ b/testdata/p4_16_errors_outputs/control-verify.p4-stderr
@@ -1,3 +1,3 @@
-control-verify.p4(7): error: verify: may only be invoked in parsers
+control-verify.p4(7): [--Werror=legacy] error:  verify: may only be invoked in parsers
     verify(8w0 == 8w1, error.Oops);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/default-param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default-param.p4-stderr
@@ -1,6 +1,6 @@
-default-param.p4(1): [--Werror=legacy] error:  x: out parameters cannot have default values
+default-param.p4(1): [--Werror=legacy] error: x: out parameters cannot have default values
 extern void f(out bit<32> x = 0, // illegal: out parameter with default value
                           ^
-default-param.p4(2): [--Werror=legacy] error:  y: optional parameters cannot have default values
+default-param.p4(2): [--Werror=legacy] error: y: optional parameters cannot have default values
              @optional bit<32> y = 0); // illegal: optional parameter with default value
                                ^

--- a/testdata/p4_16_errors_outputs/default-param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default-param.p4-stderr
@@ -1,6 +1,6 @@
-default-param.p4(1): error: x: out parameters cannot have default values
+default-param.p4(1): [--Werror=legacy] error:  x: out parameters cannot have default values
 extern void f(out bit<32> x = 0, // illegal: out parameter with default value
                           ^
-default-param.p4(2): error: y: optional parameters cannot have default values
+default-param.p4(2): [--Werror=legacy] error:  y: optional parameters cannot have default values
              @optional bit<32> y = 0); // illegal: optional parameter with default value
                                ^

--- a/testdata/p4_16_errors_outputs/default_action.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default_action.p4-stderr
@@ -1,3 +1,3 @@
-default_action.p4(21): [--Werror=legacy] error:  b not present in action list
+default_action.p4(21): [--Werror=type-error] error: b not present in action list
         default_action = b; // not in the list of actions
                          ^

--- a/testdata/p4_16_errors_outputs/default_action.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default_action.p4-stderr
@@ -1,3 +1,3 @@
-default_action.p4(21): error: b not present in action list
+default_action.p4(21): [--Werror=legacy] error:  b not present in action list
         default_action = b; // not in the list of actions
                          ^

--- a/testdata/p4_16_errors_outputs/default_action1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default_action1.p4-stderr
@@ -1,10 +1,10 @@
-default_action1.p4(20): [--Wwarn=shadow] warning: b: b shadows b
+default_action1.p4(20): [--Wwarn=shadow] warning: b shadows b
     action b() {}
            ^
 default_action1.p4(16)
 action b() {}
        ^
-default_action1.p4(23): [--Werror=legacy] error:  .b and b refer to different actions
+default_action1.p4(23): [--Werror=type-error] error: .b and b refer to different actions
         default_action = .b(); // not the same b
                          ^^^^
 default_action1.p4(22)

--- a/testdata/p4_16_errors_outputs/default_action1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default_action1.p4-stderr
@@ -1,10 +1,10 @@
-default_action1.p4(20): warning: b shadows b
+default_action1.p4(20): [--Wwarn=shadow] warning: b: b shadows b
     action b() {}
            ^
 default_action1.p4(16)
 action b() {}
        ^
-default_action1.p4(23): error: .b and b refer to different actions
+default_action1.p4(23): [--Werror=legacy] error:  .b and b refer to different actions
         default_action = .b(); // not the same b
                          ^^^^
 default_action1.p4(22)

--- a/testdata/p4_16_errors_outputs/directionless.p4-stderr
+++ b/testdata/p4_16_errors_outputs/directionless.p4-stderr
@@ -1,6 +1,6 @@
-directionless.p4(18): error: y0: direction-less action parameters have to be at the end
+directionless.p4(18): [--Werror=legacy] error:  y0: direction-less action parameters have to be at the end
     action a(bit x0, out bit y0)
                              ^^
-directionless.p4(24): error: y: direction-less action parameters have to be at the end
+directionless.p4(24): [--Werror=legacy] error:  y: direction-less action parameters have to be at the end
     action b(bit x, out bit y)
                             ^

--- a/testdata/p4_16_errors_outputs/directionless.p4-stderr
+++ b/testdata/p4_16_errors_outputs/directionless.p4-stderr
@@ -1,6 +1,6 @@
-directionless.p4(18): [--Werror=legacy] error:  y0: direction-less action parameters have to be at the end
+directionless.p4(18): [--Werror=type-error] error: y0: direction-less action parameters have to be at the end
     action a(bit x0, out bit y0)
                              ^^
-directionless.p4(24): [--Werror=legacy] error:  y: direction-less action parameters have to be at the end
+directionless.p4(24): [--Werror=type-error] error: y: direction-less action parameters have to be at the end
     action b(bit x, out bit y)
                             ^

--- a/testdata/p4_16_errors_outputs/div1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/div1.p4-stderr
@@ -1,12 +1,12 @@
-div1.p4(18): error: /: not defined on negative numbers
+div1.p4(18): [--Werror=legacy] error:  /: not defined on negative numbers
     a = a / -1; // not defined for negative numbers
         ^^^^^^
-div1.p4(19): error: /: not defined on negative numbers
+div1.p4(19): [--Werror=legacy] error:  /: not defined on negative numbers
     a = -5 / a;
         ^^^^^^
-div1.p4(20): error: %: not defined on negative numbers
+div1.p4(20): [--Werror=legacy] error:  %: not defined on negative numbers
     a = a % -1;
         ^^^^^^
-div1.p4(21): error: %: not defined on negative numbers
+div1.p4(21): [--Werror=legacy] error:  %: not defined on negative numbers
     a = -5 % a;
         ^^^^^^

--- a/testdata/p4_16_errors_outputs/div1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/div1.p4-stderr
@@ -1,12 +1,12 @@
-div1.p4(18): [--Werror=legacy] error:  /: not defined on negative numbers
+div1.p4(18): [--Werror=type-error] error: /: not defined on negative numbers
     a = a / -1; // not defined for negative numbers
         ^^^^^^
-div1.p4(19): [--Werror=legacy] error:  /: not defined on negative numbers
+div1.p4(19): [--Werror=type-error] error: /: not defined on negative numbers
     a = -5 / a;
         ^^^^^^
-div1.p4(20): [--Werror=legacy] error:  %: not defined on negative numbers
+div1.p4(20): [--Werror=type-error] error: %: not defined on negative numbers
     a = a % -1;
         ^^^^^^
-div1.p4(21): [--Werror=legacy] error:  %: not defined on negative numbers
+div1.p4(21): [--Werror=type-error] error: %: not defined on negative numbers
     a = -5 % a;
         ^^^^^^

--- a/testdata/p4_16_errors_outputs/div3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/div3.p4-stderr
@@ -1,3 +1,3 @@
-div3.p4(19): error: /: could not evaluate at compilation time
+div3.p4(19): [--Werror=legacy] error:  /: could not evaluate at compilation time
         a = a / b; // not a compile-time constant
             ^^^^^

--- a/testdata/p4_16_errors_outputs/div3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/div3.p4-stderr
@@ -1,3 +1,3 @@
-div3.p4(19): [--Werror=legacy] error:  /: could not evaluate at compilation time
+div3.p4(19): [--Werror=legacy] error: /: could not evaluate at compilation time
         a = a / b; // not a compile-time constant
             ^^^^^

--- a/testdata/p4_16_errors_outputs/dup-param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param.p4-stderr
@@ -1,4 +1,4 @@
-dup-param.p4(17): error: Duplicated parameter name: p and p
+dup-param.p4(17): [--Werror=legacy] error:  Duplicated parameter name: p and p
 control c(bit<32> p)(bool p) {
                   ^
 dup-param.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param.p4-stderr
@@ -1,4 +1,4 @@
-dup-param.p4(17): [--Werror=legacy] error:  Duplicated parameter name: p and p
+dup-param.p4(17): [--Werror=legacy] error: Duplicated parameter name: p and p
 control c(bit<32> p)(bool p) {
                   ^
 dup-param.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
@@ -1,4 +1,4 @@
-dup-param1.p4(17): [--Werror=legacy] error:  Duplicated parameter name: p and p
+dup-param1.p4(17): [--Werror=legacy] error: Duplicated parameter name: p and p
 control MyIngress<p>(inout bit<32> p) {
                   ^
 dup-param1.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
@@ -1,4 +1,4 @@
-dup-param1.p4(17): error: Duplicated parameter name: p and p
+dup-param1.p4(17): [--Werror=legacy] error:  Duplicated parameter name: p and p
 control MyIngress<p>(inout bit<32> p) {
                   ^
 dup-param1.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
@@ -1,4 +1,4 @@
-dup-param2.p4(17): [--Werror=legacy] error:  Duplicated parameter name: p and p
+dup-param2.p4(17): [--Werror=legacy] error: Duplicated parameter name: p and p
 control MyIngress<p>(inout bit<32> x)(bit<32> p) {
                   ^
 dup-param2.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
@@ -1,4 +1,4 @@
-dup-param2.p4(17): error: Duplicated parameter name: p and p
+dup-param2.p4(17): [--Werror=legacy] error:  Duplicated parameter name: p and p
 control MyIngress<p>(inout bit<32> x)(bit<32> p) {
                   ^
 dup-param2.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
@@ -1,12 +1,6 @@
-dup-param3.p4(17): error: Duplicated parameter name: p and p
+dup-param3.p4(17): [--Werror=legacy] error:  Duplicated parameter name: p and p
 control MyIngress<p>(inout bit<32> p)(bit<32> p) {
                   ^
 dup-param3.p4(17)
 control MyIngress<p>(inout bit<32> p)(bit<32> p) {
                                    ^
-dup-param3.p4(17): error: Duplicated parameter name: p and p
-control MyIngress<p>(inout bit<32> p)(bit<32> p) {
-                  ^
-dup-param3.p4(17)
-control MyIngress<p>(inout bit<32> p)(bit<32> p) {
-                                              ^

--- a/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
@@ -1,4 +1,4 @@
-dup-param3.p4(17): [--Werror=legacy] error:  Duplicated parameter name: p and p
+dup-param3.p4(17): [--Werror=legacy] error: Duplicated parameter name: p and p
 control MyIngress<p>(inout bit<32> p)(bit<32> p) {
                   ^
 dup-param3.p4(17)

--- a/testdata/p4_16_errors_outputs/dupConst.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dupConst.p4-stderr
@@ -1,4 +1,4 @@
-dupConst.p4(17): [--Werror=legacy] error:  Duplicate declaration of a: a
+dupConst.p4(17): [--Werror=legacy] error: Duplicate declaration of a: a
 const bit<4> a = 2;
              ^
 dupConst.p4(16)

--- a/testdata/p4_16_errors_outputs/dupConst.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dupConst.p4-stderr
@@ -1,4 +1,4 @@
-dupConst.p4(17): error: Duplicate declaration of a: a
+dupConst.p4(17): [--Werror=legacy] error:  Duplicate declaration of a: a
 const bit<4> a = 2;
              ^
 dupConst.p4(16)

--- a/testdata/p4_16_errors_outputs/duplicate-label.p4-stderr
+++ b/testdata/p4_16_errors_outputs/duplicate-label.p4-stderr
@@ -1,3 +1,3 @@
-duplicate-label.p4(26): [--Werror=legacy] error:  a: duplicate switch label
+duplicate-label.p4(26): [--Werror=type-error] error: a: duplicate switch label
             a: { arun = 1; } // duplicate label
             ^

--- a/testdata/p4_16_errors_outputs/duplicate-label.p4-stderr
+++ b/testdata/p4_16_errors_outputs/duplicate-label.p4-stderr
@@ -1,3 +1,3 @@
-duplicate-label.p4(26): error: a: duplicate switch label
+duplicate-label.p4(26): [--Werror=legacy] error:  a: duplicate switch label
             a: { arun = 1; } // duplicate label
             ^

--- a/testdata/p4_16_errors_outputs/equality-fail.p4-stderr
+++ b/testdata/p4_16_errors_outputs/equality-fail.p4-stderr
@@ -1,18 +1,18 @@
-equality-fail.p4(23): error: ==: not defined on varbit<32> and header H
+equality-fail.p4(23): [--Werror=type-error] error: ==: not defined on varbit<32> and header H
         if (a == h1) {
             ^^^^^^^
-equality-fail.p4(25): error: ==: not defined on header H and struct S
+equality-fail.p4(25): [--Werror=type-error] error: ==: not defined on header H and struct S
         } else if (h1 == s2) {
                    ^^^^^^^^
-equality-fail.p4(27): error: ==: not defined on struct S and header H[]
+equality-fail.p4(27): [--Werror=type-error] error: ==: not defined on struct S and header H[]
         } else if (s1 == a2) {
                    ^^^^^^^^
-equality-fail.p4(29): error: ==: not defined on header H[] and bit<32>
+equality-fail.p4(29): [--Werror=type-error] error: ==: not defined on header H[] and bit<32>
         } else if (a1 == h1.a) {
                    ^^^^^^^^^^
-equality-fail.p4(31): error: ==: not defined on varbit<32> and bit<32>
+equality-fail.p4(31): [--Werror=type-error] error: ==: not defined on varbit<32> and bit<32>
         } else if (a == h1.a) {
                    ^^^^^^^^^
-equality-fail.p4(33): error: ==: not defined on header H[] and header H[]
+equality-fail.p4(33): [--Werror=type-error] error: ==: not defined on header H[] and header H[]
         } else if (a1 == a3) {
                    ^^^^^^^^

--- a/testdata/p4_16_errors_outputs/extern.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extern.p4-stderr
@@ -1,6 +1,6 @@
-extern.p4(19): error: x: a parameter with an extern type cannot have a direction
+extern.p4(19): [--Werror=legacy] error:  x: a parameter with an extern type cannot have a direction
 control c(in X x) { // Cannot have externs with direction
                ^
-extern.p4(24): error: x: a parameter with an extern type cannot have a direction
+extern.p4(24): [--Werror=legacy] error:  x: a parameter with an extern type cannot have a direction
 control proto(in X x);
                    ^

--- a/testdata/p4_16_errors_outputs/extern.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extern.p4-stderr
@@ -1,6 +1,6 @@
-extern.p4(19): [--Werror=legacy] error:  x: a parameter with an extern type cannot have a direction
+extern.p4(19): [--Werror=type-error] error: x: a parameter with an extern type cannot have a direction
 control c(in X x) { // Cannot have externs with direction
                ^
-extern.p4(24): [--Werror=legacy] error:  x: a parameter with an extern type cannot have a direction
+extern.p4(24): [--Werror=type-error] error: x: a parameter with an extern type cannot have a direction
 control proto(in X x);
                    ^

--- a/testdata/p4_16_errors_outputs/extract.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extract.p4-stderr
@@ -1,3 +1,3 @@
-extract.p4(20): [--Werror=legacy] error:  h: argument must be a header
+extract.p4(20): [--Werror=type-error] error: h: argument must be a header
         p.extract(h); // error: not a header
                   ^

--- a/testdata/p4_16_errors_outputs/extract.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extract.p4-stderr
@@ -1,3 +1,3 @@
-extract.p4(20): error: h: argument must be a header
+extract.p4(20): [--Werror=legacy] error:  h: argument must be a header
         p.extract(h); // error: not a header
                   ^

--- a/testdata/p4_16_errors_outputs/extract1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extract1.p4-stderr
@@ -1,3 +1,3 @@
-extract1.p4(24): [--Werror=legacy] error:  h: argument should contain a varbit field
+extract1.p4(24): [--Werror=type-error] error: h: argument should contain a varbit field
         p.extract(h, 32); // error: not a variable-sized header
                   ^

--- a/testdata/p4_16_errors_outputs/extract1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/extract1.p4-stderr
@@ -1,3 +1,3 @@
-extract1.p4(24): error: h: argument should contain a varbit field
+extract1.p4(24): [--Werror=legacy] error:  h: argument should contain a varbit field
         p.extract(h, 32); // error: not a variable-sized header
                   ^

--- a/testdata/p4_16_errors_outputs/factory-err2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/factory-err2.p4-stderr
@@ -4,6 +4,6 @@ factory-err2.p4(31): error: : not a compile-time constant when binding to a
 factory-err2.p4(20)
 extern widget<T> createWidget<T, U>(U a, T b);
                                       ^
-factory-err2.p4(31): error: createWidget: cannot evaluate to a compile-time constant
+factory-err2.p4(31): [--Werror=legacy] error:  createWidget: cannot evaluate to a compile-time constant
     c1<bit<16>>(createWidget(hdr.f1, hdr.f2)) c; // factory args must be constants
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/factory-err2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/factory-err2.p4-stderr
@@ -4,6 +4,6 @@ factory-err2.p4(31): error: : not a compile-time constant when binding to a
 factory-err2.p4(20)
 extern widget<T> createWidget<T, U>(U a, T b);
                                       ^
-factory-err2.p4(31): [--Werror=legacy] error:  createWidget: cannot evaluate to a compile-time constant
+factory-err2.p4(31): [--Werror=type-error] error: createWidget: cannot evaluate to a compile-time constant
     c1<bit<16>>(createWidget(hdr.f1, hdr.f2)) c; // factory args must be constants
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/function_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function_e.p4-stderr
@@ -1,15 +1,15 @@
-function_e.p4(22): [--Werror=legacy] error:  f: No argument for parameter x
+function_e.p4(22): [--Werror=legacy] error: f: No argument for parameter x
         f(); // not enough arguments
         ^^^
 function_e.p4(16)
 extern void f(in bit x);
                      ^
-function_e.p4(23): [--Werror=legacy] error:  f: Passing 2 arguments when 1 expected
+function_e.p4(23): [--Werror=legacy] error: f: Passing 2 arguments when 1 expected
         f(1w1, 1w0); // too many arguments
         ^^^^^^^^^^^
-function_e.p4(24): [--Werror=legacy] error:  f has 0 type parameters, but is invoked with 1 type arguments
+function_e.p4(24): [--Werror=legacy] error: f has 0 type parameters, but is invoked with 1 type arguments
         f<bit>(1w0); // too many type arguments
         ^^^^^^^^^^^
-function_e.p4(25): [--Werror=legacy] error:  g has 1 type parameters, but is invoked with 2 type arguments
+function_e.p4(25): [--Werror=legacy] error: g has 1 type parameters, but is invoked with 2 type arguments
         g<bit, bit>(); // too many type arguments
         ^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/function_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function_e.p4-stderr
@@ -1,15 +1,15 @@
-function_e.p4(22): error: f: No argument for parameter x
+function_e.p4(22): [--Werror=legacy] error:  f: No argument for parameter x
         f(); // not enough arguments
         ^^^
 function_e.p4(16)
 extern void f(in bit x);
                      ^
-function_e.p4(23): error: f: Passing 2 arguments when 1 expected
+function_e.p4(23): [--Werror=legacy] error:  f: Passing 2 arguments when 1 expected
         f(1w1, 1w0); // too many arguments
         ^^^^^^^^^^^
-function_e.p4(24): error: f has 0 type parameters, but is invoked with 1 type arguments
+function_e.p4(24): [--Werror=legacy] error:  f has 0 type parameters, but is invoked with 1 type arguments
         f<bit>(1w0); // too many type arguments
         ^^^^^^^^^^^
-function_e.p4(25): error: g has 1 type parameters, but is invoked with 2 type arguments
+function_e.p4(25): [--Werror=legacy] error:  g has 1 type parameters, but is invoked with 2 type arguments
         g<bit, bit>(); // too many type arguments
         ^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/function_e1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function_e1.p4-stderr
@@ -1,3 +1,3 @@
-function_e1.p4(1): [--Werror=legacy] error:  Function max does not return a value on all paths
+function_e1.p4(1): [--Werror=legacy] error: Function max does not return a value on all paths
 bit<16> max(in bit<16> left, in bit<16> right) {
         ^^^

--- a/testdata/p4_16_errors_outputs/function_e1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function_e1.p4-stderr
@@ -1,3 +1,3 @@
-function_e1.p4(1): error: Function max does not return a value on all paths
+function_e1.p4(1): [--Werror=legacy] error:  Function max does not return a value on all paths
 bit<16> max(in bit<16> left, in bit<16> right) {
         ^^^

--- a/testdata/p4_16_errors_outputs/function_e2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function_e2.p4-stderr
@@ -1,3 +1,3 @@
-function_e2.p4(4): error: a: Functions cannot call actions
+function_e2.p4(4): [--Werror=type-error] error: a: Functions cannot call actions
     a();
     ^^^

--- a/testdata/p4_16_errors_outputs/functors2_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/functors2_e.p4-stderr
@@ -1,3 +1,3 @@
-functors2_e.p4(20): error: p: Cannot refer to control inside itself
+functors2_e.p4(20): [--Werror=type-error] error: p: Cannot refer to control inside itself
         p.apply();
         ^

--- a/testdata/p4_16_errors_outputs/functors3_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/functors3_e.p4-stderr
@@ -1,4 +1,4 @@
-functors3_e.p4(18): error: s1: cannot allocate objects of type struct s
+functors3_e.p4(18): [--Werror=type-error] error: s1: cannot allocate objects of type struct s
 s() s1;
     ^^
 functors3_e.p4(16)

--- a/testdata/p4_16_errors_outputs/generic1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/generic1_e.p4-stderr
@@ -1,13 +1,13 @@
-generic1_e.p4(21): [--Werror=legacy] error:  Type parameters needed for x
+generic1_e.p4(21): [--Werror=type-error] error: Type parameters needed for x
 control p1(If x) // missing type parameter
               ^
-generic1_e.p4(26): [--Werror=legacy] error:  If<...>: Type If has 1 type parameter(s), but it is specialized with 2
+generic1_e.p4(26): [--Werror=type-error] error: If<...>: Type If has 1 type parameter(s), but it is specialized with 2
 control p2(If<int<32>, int<32>> x) // too many type parameters
            ^^^^^^^^^^^^^^^^^^^^
 generic1_e.p4(16)
 extern If<T>
        ^^
-generic1_e.p4(36): [--Werror=legacy] error:  h<...>: Type header h is not generic and thus it cannot be specialized using type arguments
+generic1_e.p4(36): [--Werror=type-error] error: h<...>: Type header h is not generic and thus it cannot be specialized using type arguments
         h<bit> x; // no type parameter
         ^^^^^^
 generic1_e.p4(31)

--- a/testdata/p4_16_errors_outputs/generic1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/generic1_e.p4-stderr
@@ -1,13 +1,13 @@
-generic1_e.p4(21): error: Type parameters needed for x
+generic1_e.p4(21): [--Werror=legacy] error:  Type parameters needed for x
 control p1(If x) // missing type parameter
               ^
-generic1_e.p4(26): error: If<...>: Type If has 1 type parameter(s), but it is specialized with 2
+generic1_e.p4(26): [--Werror=legacy] error:  If<...>: Type If has 1 type parameter(s), but it is specialized with 2
 control p2(If<int<32>, int<32>> x) // too many type parameters
            ^^^^^^^^^^^^^^^^^^^^
 generic1_e.p4(16)
 extern If<T>
        ^^
-generic1_e.p4(36): error: h<...>: Type header h is not generic and thus it cannot be specialized using type arguments
+generic1_e.p4(36): [--Werror=legacy] error:  h<...>: Type header h is not generic and thus it cannot be specialized using type arguments
         h<bit> x; // no type parameter
         ^^^^^^
 generic1_e.p4(31)

--- a/testdata/p4_16_errors_outputs/header2_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header2_e.p4-stderr
@@ -1,15 +1,15 @@
-header2_e.p4(27): [--Werror=legacy] error:  Field field of struct s1 cannot have type parser p
+header2_e.p4(27): [--Werror=type-error] error: Field field of struct s1 cannot have type parser p
     p field; // no functor-typed fields allowed
       ^^^^^
 header2_e.p4(23)
 parser p();
        ^
-header2_e.p4(32): [--Werror=legacy] error:  Field field of header_union u cannot have type struct s
+header2_e.p4(32): [--Werror=type-error] error: Field field of header_union u cannot have type struct s
    s field; // no struct field allowed in header_union
      ^^^^^
 header2_e.p4(16)
 struct s {}
        ^
-header2_e.p4(33): [--Werror=legacy] error:  Field field1 of header_union u cannot have type bit<1>
+header2_e.p4(33): [--Werror=type-error] error: Field field1 of header_union u cannot have type bit<1>
    bit field1; // no non-header field allowed in header_union
        ^^^^^^

--- a/testdata/p4_16_errors_outputs/header2_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header2_e.p4-stderr
@@ -1,15 +1,15 @@
-header2_e.p4(27): error: Field field of struct s1 cannot have type parser p
+header2_e.p4(27): [--Werror=legacy] error:  Field field of struct s1 cannot have type parser p
     p field; // no functor-typed fields allowed
       ^^^^^
 header2_e.p4(23)
 parser p();
        ^
-header2_e.p4(32): error: Field field of header_union u cannot have type struct s
+header2_e.p4(32): [--Werror=legacy] error:  Field field of header_union u cannot have type struct s
    s field; // no struct field allowed in header_union
      ^^^^^
 header2_e.p4(16)
 struct s {}
        ^
-header2_e.p4(33): error: Field field1 of header_union u cannot have type bit<1>
+header2_e.p4(33): [--Werror=legacy] error:  Field field1 of header_union u cannot have type bit<1>
    bit field1; // no non-header field allowed in header_union
        ^^^^^^

--- a/testdata/p4_16_errors_outputs/header3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header3.p4-stderr
@@ -1,4 +1,4 @@
-header3.p4(18): error: Field field1 of header H cannot have type Tuple(2)
+header3.p4(18): [--Werror=legacy] error:  Field field1 of header H cannot have type Tuple(2)
     tuple<bit, bit> field1; // tuples not allowed in header
                     ^^^^^^
 header3.p4(18)

--- a/testdata/p4_16_errors_outputs/header3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header3.p4-stderr
@@ -1,4 +1,4 @@
-header3.p4(18): [--Werror=legacy] error:  Field field1 of header H cannot have type Tuple(2)
+header3.p4(18): [--Werror=type-error] error: Field field1 of header H cannot have type Tuple(2)
     tuple<bit, bit> field1; // tuples not allowed in header
                     ^^^^^^
 header3.p4(18)

--- a/testdata/p4_16_errors_outputs/implicit.p4-stderr
+++ b/testdata/p4_16_errors_outputs/implicit.p4-stderr
@@ -1,3 +1,3 @@
-implicit.p4(19): error: b: Cannot unify int<32> to bit<32>
+implicit.p4(19): [--Werror=legacy] error:  b: Cannot unify int<32> to bit<32>
     bit<32> b = 32s1;
     ^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/implicit.p4-stderr
+++ b/testdata/p4_16_errors_outputs/implicit.p4-stderr
@@ -1,3 +1,3 @@
-implicit.p4(19): [--Werror=legacy] error:  b: Cannot unify int<32> to bit<32>
+implicit.p4(19): [--Werror=legacy] error: b: Cannot unify int<32> to bit<32>
     bit<32> b = 32s1;
     ^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/inro.p4-stderr
+++ b/testdata/p4_16_errors_outputs/inro.p4-stderr
@@ -1,3 +1,3 @@
-inro.p4(19): [--Werror=legacy] error:  Expression x cannot be the target of an assignment
+inro.p4(19): [--Werror=type-error] error: Expression x cannot be the target of an assignment
         x = 3; // x is not a left-value
         ^

--- a/testdata/p4_16_errors_outputs/inro.p4-stderr
+++ b/testdata/p4_16_errors_outputs/inro.p4-stderr
@@ -1,3 +1,3 @@
-inro.p4(19): error: Expression x cannot be the target of an assignment
+inro.p4(19): [--Werror=legacy] error:  Expression x cannot be the target of an assignment
         x = 3; // x is not a left-value
         ^

--- a/testdata/p4_16_errors_outputs/interface1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/interface1_e.p4-stderr
@@ -1,4 +1,4 @@
-interface1_e.p4(25): error: x.f: extern X does not have method matching this call
+interface1_e.p4(25): [--Werror=type-error] error: x.f: extern X does not have method matching this call
         x.f();
         ^^^
 interface1_e.p4(16)

--- a/testdata/p4_16_errors_outputs/interface_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/interface_e.p4-stderr
@@ -1,3 +1,3 @@
-interface_e.p4(21): [--Werror=legacy] error:  x: Type parameters must be supplied for constructor
+interface_e.p4(21): [--Werror=type-error] error: x: Type parameters must be supplied for constructor
     X() x;
         ^

--- a/testdata/p4_16_errors_outputs/interface_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/interface_e.p4-stderr
@@ -1,3 +1,3 @@
-interface_e.p4(21): error: x: Type parameters must be supplied for constructor
+interface_e.p4(21): [--Werror=legacy] error:  x: Type parameters must be supplied for constructor
     X() x;
         ^

--- a/testdata/p4_16_errors_outputs/issue1006-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1006-1.p4-stderr
@@ -1,3 +1,3 @@
-issue1006-1.p4(14): [--Werror=legacy] error:  reg2: Cannot unify bit<16> to bit<8>
+issue1006-1.p4(14): [--Werror=legacy] error: reg2: Cannot unify bit<16> to bit<8>
     R<bit<8>>(16w1) reg2;
                     ^^^^

--- a/testdata/p4_16_errors_outputs/issue1006-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1006-1.p4-stderr
@@ -1,3 +1,3 @@
-issue1006-1.p4(14): error: reg2: Cannot unify bit<16> to bit<8>
+issue1006-1.p4(14): [--Werror=legacy] error:  reg2: Cannot unify bit<16> to bit<8>
     R<bit<8>>(16w1) reg2;
                     ^^^^

--- a/testdata/p4_16_errors_outputs/issue1059.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1059.p4-stderr
@@ -1,4 +1,4 @@
-issue1059.p4(1): error: Structure struct X does not have a field x
+issue1059.p4(1): [--Werror=legacy] error:  Structure struct X does not have a field x
 struct X {}
        ^
 issue1059.p4(9)

--- a/testdata/p4_16_errors_outputs/issue1059.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1059.p4-stderr
@@ -1,6 +1,6 @@
-issue1059.p4(1): [--Werror=type-error] error: Structure struct X does not have a field x
-struct X {}
-       ^
-issue1059.p4(9)
+issue1059.p4(9): [--Werror=type-error] error: Field x is not a member of structure struct X
         a(x.x);
             ^
+issue1059.p4(1)
+struct X {}
+       ^

--- a/testdata/p4_16_errors_outputs/issue1059.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1059.p4-stderr
@@ -1,4 +1,4 @@
-issue1059.p4(1): [--Werror=legacy] error:  Structure struct X does not have a field x
+issue1059.p4(1): [--Werror=type-error] error: Structure struct X does not have a field x
 struct X {}
        ^
 issue1059.p4(9)

--- a/testdata/p4_16_errors_outputs/issue1230.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1230.p4-stderr
@@ -1,3 +1,3 @@
-issue1230.p4(6): error: size must be a constant numeric expression
+issue1230.p4(6): [--Werror=legacy] error:  size must be a constant numeric expression
         size = true;
         ^^^^

--- a/testdata/p4_16_errors_outputs/issue1230.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1230.p4-stderr
@@ -1,3 +1,3 @@
-issue1230.p4(6): [--Werror=legacy] error:  size must be a constant numeric expression
+issue1230.p4(6): [--Werror=legacy] error: size must be a constant numeric expression
         size = true;
         ^^^^

--- a/testdata/p4_16_errors_outputs/issue1296.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1296.p4-stderr
@@ -1,6 +1,6 @@
-issue1296.p4(7): [--Werror=legacy] error:  test_extern: recursive type specialization
+issue1296.p4(7): [--Werror=type-error] error: test_extern: recursive type specialization
 test_extern<test_extern<bit<32>>>() test;
             ^^^^^^^^^^^
-issue1296.p4(13): [--Werror=legacy] error:  test_extern1: recursive type specialization
+issue1296.p4(13): [--Werror=type-error] error: test_extern1: recursive type specialization
 test_extern1<test_extern<test_extern1<bit<32>>>>() test1;
                          ^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue1296.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1296.p4-stderr
@@ -1,6 +1,6 @@
-issue1296.p4(7): error: test_extern: recursive type specialization
+issue1296.p4(7): [--Werror=legacy] error:  test_extern: recursive type specialization
 test_extern<test_extern<bit<32>>>() test;
             ^^^^^^^^^^^
-issue1296.p4(13): error: test_extern1: recursive type specialization
+issue1296.p4(13): [--Werror=legacy] error:  test_extern1: recursive type specialization
 test_extern1<test_extern<test_extern1<bit<32>>>>() test1;
                          ^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue1331.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1331.p4-stderr
@@ -1,3 +1,3 @@
-issue1331.p4(17): [--Werror=legacy] error:  p: instantiation of parser in control
+issue1331.p4(17): [--Werror=legacy] error: p: instantiation of parser in control
 control MyC(packet_in pkt, inout ethernet ether)(P p) {
                                                    ^

--- a/testdata/p4_16_errors_outputs/issue1331.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1331.p4-stderr
@@ -1,3 +1,3 @@
-issue1331.p4(17): error: p: instantiation of parser in control
+issue1331.p4(17): [--Werror=legacy] error:  p: instantiation of parser in control
 control MyC(packet_in pkt, inout ethernet ether)(P p) {
                                                    ^

--- a/testdata/p4_16_errors_outputs/issue1541.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1541.p4-stderr
@@ -1,4 +1,4 @@
-issue1541.p4(25): warning: hash shadows hash
+issue1541.p4(25): [--Wwarn=shadow] warning: hash: hash shadows hash
     action hash() {
            ^^^^
 v1model.p4(138)

--- a/testdata/p4_16_errors_outputs/issue1541.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1541.p4-stderr
@@ -1,9 +1,9 @@
-issue1541.p4(25): [--Wwarn=shadow] warning: hash: hash shadows hash
+issue1541.p4(25): [--Wwarn=shadow] warning: hash shadows hash
     action hash() {
            ^^^^
 v1model.p4(138)
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
             ^^^^
-issue1541.p4(26): error: hash: Recursive action call
+issue1541.p4(26): [--Werror=type-error] error: hash: Recursive action call
  hash(meta.x, HashAlgorithm.crc16, 3w0, { }, 3w7);
  ^^^^

--- a/testdata/p4_16_errors_outputs/issue1542.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1542.p4-stderr
@@ -1,4 +1,4 @@
-issue1542.p4(27): [--Werror=legacy] error:  2: argument does not match declaration in actions list: 1
+issue1542.p4(27): [--Werror=type-error] error: 2: argument does not match declaration in actions list: 1
             ( true, 1, true ) : multicast(2);
                                           ^
 issue1542.p4(22)

--- a/testdata/p4_16_errors_outputs/issue1542.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1542.p4-stderr
@@ -1,4 +1,4 @@
-issue1542.p4(27): error: 2: argument does not match declaration in actions list: 1
+issue1542.p4(27): [--Werror=legacy] error:  2: argument does not match declaration in actions list: 1
             ( true, 1, true ) : multicast(2);
                                           ^
 issue1542.p4(22)

--- a/testdata/p4_16_errors_outputs/issue1557-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1557-bmv2.p4-stderr
@@ -1,4 +1,4 @@
-issue1557-bmv2.p4(19): error: idx: parameter should be assigned in call rewrite
+issue1557-bmv2.p4(19): [--Werror=legacy] error:  idx: parameter should be assigned in call rewrite
     action rewrite(bit<16> idx) { meta.idx = idx; }
                            ^^^
 issue1557-bmv2.p4(24)

--- a/testdata/p4_16_errors_outputs/issue1557-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1557-bmv2.p4-stderr
@@ -1,4 +1,4 @@
-issue1557-bmv2.p4(19): [--Werror=legacy] error:  idx: parameter should be assigned in call rewrite
+issue1557-bmv2.p4(19): [--Werror=type-error] error: idx: parameter should be assigned in call rewrite
     action rewrite(bit<16> idx) { meta.idx = idx; }
                            ^^^
 issue1557-bmv2.p4(24)

--- a/testdata/p4_16_errors_outputs/issue1580.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1580.p4-stderr
@@ -1,6 +1,6 @@
-issue1580.p4(65): error: Entry: Action marked with defaultonly used in table
+issue1580.p4(65): [--Werror=type-error] error: Entry: Action marked with defaultonly used in table
             3 : a3();
             ^^^^^^^^
-issue1580.p4(69): error: default_action: Action marked with tableonly used as default action
+issue1580.p4(69): [--Werror=type-error] error: default_action: Action marked with tableonly used as default action
         default_action = a1;
         ^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue306.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue306.p4-stderr
@@ -1,6 +1,36 @@
-issue306.p4(30): [--Werror=type-error] error: Structure struct my_packet does not have a field stack
-struct my_packet {
-       ^^^^^^^^^
-issue306.p4(45)
+issue306.p4(45): [--Werror=type-error] error: Field stack is not a member of structure struct my_packet
     b.extract(p.stack.next);
                 ^^^^^
+issue306.p4(30)
+struct my_packet {
+       ^^^^^^^^^
+issue306.p4(46): [--Werror=type-error] error: Field stack is not a member of structure struct my_packet
+    transition select(p.stack.last.op_code) {
+                        ^^^^^
+issue306.p4(30)
+struct my_packet {
+       ^^^^^^^^^
+issue306.p4(53): [--Werror=type-error] error: Field stack is not a member of structure struct my_packet
+    b.extract(p.stack.next);
+                ^^^^^
+issue306.p4(30)
+struct my_packet {
+       ^^^^^^^^^
+issue306.p4(54): [--Werror=type-error] error: Field stack is not a member of structure struct my_packet
+    transition select(p.stack.last.op_code) {
+                        ^^^^^
+issue306.p4(30)
+struct my_packet {
+       ^^^^^^^^^
+issue306.p4(73): [--Werror=type-error] error: Field stack is not a member of structure struct my_packet
+    key = { p.stack[0].op_code : exact; }
+              ^^^^^
+issue306.p4(30)
+struct my_packet {
+       ^^^^^^^^^
+issue306.p4(91): [--Werror=type-error] error: Field stack is not a member of structure struct my_packet
+    b.emit(p.stack);
+             ^^^^^
+issue306.p4(30)
+struct my_packet {
+       ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue306.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue306.p4-stderr
@@ -1,36 +1,6 @@
-issue306.p4(30): error: Structure struct my_packet does not have a field stack
+issue306.p4(30): [--Werror=legacy] error:  Structure struct my_packet does not have a field stack
 struct my_packet {
        ^^^^^^^^^
 issue306.p4(45)
     b.extract(p.stack.next);
                 ^^^^^
-issue306.p4(30): error: Structure struct my_packet does not have a field stack
-struct my_packet {
-       ^^^^^^^^^
-issue306.p4(46)
-    transition select(p.stack.last.op_code) {
-                        ^^^^^
-issue306.p4(30): error: Structure struct my_packet does not have a field stack
-struct my_packet {
-       ^^^^^^^^^
-issue306.p4(53)
-    b.extract(p.stack.next);
-                ^^^^^
-issue306.p4(30): error: Structure struct my_packet does not have a field stack
-struct my_packet {
-       ^^^^^^^^^
-issue306.p4(54)
-    transition select(p.stack.last.op_code) {
-                        ^^^^^
-issue306.p4(30): error: Structure struct my_packet does not have a field stack
-struct my_packet {
-       ^^^^^^^^^
-issue306.p4(73)
-    key = { p.stack[0].op_code : exact; }
-              ^^^^^
-issue306.p4(30): error: Structure struct my_packet does not have a field stack
-struct my_packet {
-       ^^^^^^^^^
-issue306.p4(91)
-    b.emit(p.stack);
-             ^^^^^

--- a/testdata/p4_16_errors_outputs/issue306.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue306.p4-stderr
@@ -1,4 +1,4 @@
-issue306.p4(30): [--Werror=legacy] error:  Structure struct my_packet does not have a field stack
+issue306.p4(30): [--Werror=type-error] error: Structure struct my_packet does not have a field stack
 struct my_packet {
        ^^^^^^^^^
 issue306.p4(45)

--- a/testdata/p4_16_errors_outputs/issue345.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue345.p4-stderr
@@ -1,4 +1,4 @@
-issue345.p4(19): error: h: Cannot unify type int with H
+issue345.p4(19): [--Werror=legacy] error:  h: Cannot unify type int with H
         H h = 0;
         ^^^^^^^^
 issue345.p4(17)

--- a/testdata/p4_16_errors_outputs/issue345.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue345.p4-stderr
@@ -1,4 +1,4 @@
-issue345.p4(19): [--Werror=legacy] error:  h: Cannot unify type int with H
+issue345.p4(19): [--Werror=legacy] error: h: Cannot unify type int with H
         H h = 0;
         ^^^^^^^^
 issue345.p4(17)

--- a/testdata/p4_16_errors_outputs/issue394.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue394.p4-stderr
@@ -1,4 +1,4 @@
-issue394.p4(19): error: c: cannot declare variables of type C (consider using an instantiation)
+issue394.p4(19): [--Werror=type-error] error: c: cannot declare variables of type C (consider using an instantiation)
     C c;
     ^^^^
 issue394.p4(16)

--- a/testdata/p4_16_errors_outputs/issue401.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue401.p4-stderr
@@ -1,6 +1,6 @@
-issue401.p4(42): [--Werror=legacy] error:  cast: Cannot unify Tuple(1) to bit<1>
+issue401.p4(42): [--Werror=legacy] error: cast: Cannot unify Tuple(1) to bit<1>
     bit<1> b = (bit<1>) { 0 };
                ^^^^^^^^^^^^^^
-issue401.p4(42): error: cast: Illegal cast from Tuple(1) to bit<1>
+issue401.p4(42): [--Werror=type-error] error: cast: Illegal cast from Tuple(1) to bit<1>
     bit<1> b = (bit<1>) { 0 };
                ^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue401.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue401.p4-stderr
@@ -1,4 +1,4 @@
-issue401.p4(42): error: cast: Cannot unify Tuple(1) to bit<1>
+issue401.p4(42): [--Werror=legacy] error:  cast: Cannot unify Tuple(1) to bit<1>
     bit<1> b = (bit<1>) { 0 };
                ^^^^^^^^^^^^^^
 issue401.p4(42): error: cast: Illegal cast from Tuple(1) to bit<1>

--- a/testdata/p4_16_errors_outputs/issue407-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue407-1.p4-stderr
@@ -1,28 +1,28 @@
-issue407-1.p4(47): error: Field x7 of header H cannot have type error
+issue407-1.p4(47): [--Werror=legacy] error:  Field x7 of header H cannot have type error
     error x7;
           ^^
 core.p4(23)
 error {
 ^
-issue407-1.p4(49): error: Field x9 of header H cannot have type myenum1
+issue407-1.p4(49): [--Werror=legacy] error:  Field x9 of header H cannot have type myenum1
     myenum1 x9;
             ^^
 issue407-1.p4(32)
 enum myenum1 {
      ^^^^^^^
-issue407-1.p4(50): error: Field x10 of header H cannot have type header Ethernet_h
+issue407-1.p4(50): [--Werror=legacy] error:  Field x10 of header H cannot have type header Ethernet_h
     Ethernet_h x10;
                ^^^
 issue407-1.p4(38)
 header Ethernet_h {
        ^^^^^^^^^^
-issue407-1.p4(51): error: Field x11 of header H cannot have type header Ethernet_h[]
+issue407-1.p4(51): [--Werror=legacy] error:  Field x11 of header H cannot have type header Ethernet_h[]
     Ethernet_h[4] x11;
                   ^^^
 issue407-1.p4(51)
     Ethernet_h[4] x11;
     ^^^^^^^^^^^^^
-issue407-1.p4(54): error: Field x14 of header H cannot have type Tuple(2)
+issue407-1.p4(54): [--Werror=legacy] error:  Field x14 of header H cannot have type Tuple(2)
     myTuple0 x14;
              ^^^
 issue407-1.p4(44)

--- a/testdata/p4_16_errors_outputs/issue407-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue407-1.p4-stderr
@@ -1,28 +1,28 @@
-issue407-1.p4(47): [--Werror=legacy] error:  Field x7 of header H cannot have type error
+issue407-1.p4(47): [--Werror=type-error] error: Field x7 of header H cannot have type error
     error x7;
           ^^
 core.p4(23)
 error {
 ^
-issue407-1.p4(49): [--Werror=legacy] error:  Field x9 of header H cannot have type myenum1
+issue407-1.p4(49): [--Werror=type-error] error: Field x9 of header H cannot have type myenum1
     myenum1 x9;
             ^^
 issue407-1.p4(32)
 enum myenum1 {
      ^^^^^^^
-issue407-1.p4(50): [--Werror=legacy] error:  Field x10 of header H cannot have type header Ethernet_h
+issue407-1.p4(50): [--Werror=type-error] error: Field x10 of header H cannot have type header Ethernet_h
     Ethernet_h x10;
                ^^^
 issue407-1.p4(38)
 header Ethernet_h {
        ^^^^^^^^^^
-issue407-1.p4(51): [--Werror=legacy] error:  Field x11 of header H cannot have type header Ethernet_h[]
+issue407-1.p4(51): [--Werror=type-error] error: Field x11 of header H cannot have type header Ethernet_h[]
     Ethernet_h[4] x11;
                   ^^^
 issue407-1.p4(51)
     Ethernet_h[4] x11;
     ^^^^^^^^^^^^^
-issue407-1.p4(54): [--Werror=legacy] error:  Field x14 of header H cannot have type Tuple(2)
+issue407-1.p4(54): [--Werror=type-error] error: Field x14 of header H cannot have type Tuple(2)
     myTuple0 x14;
              ^^^
 issue407-1.p4(44)

--- a/testdata/p4_16_errors_outputs/issue413.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue413.p4-stderr
@@ -1,6 +1,6 @@
 issue413.p4(34): [--Wwarn=mismatch] warning: 3405691582: value does not fit in 16 bits
     const bit<32> c1d = 32w0xcafebabe;
                         ^^^^^^^^^^^^^
-issue413.p4(41): [--Werror=legacy] error:  foo2: Action calls are not allowed within parsers
+issue413.p4(41): [--Werror=type-error] error: foo2: Action calls are not allowed within parsers
         foo2((bit<16>) c1d, b1a);
         ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue413.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue413.p4-stderr
@@ -1,6 +1,6 @@
-issue413.p4(34): warning: 3405691582: value does not fit in 16 bits
+issue413.p4(34): [--Wwarn=mismatch] warning: 3405691582: value does not fit in 16 bits
     const bit<32> c1d = 32w0xcafebabe;
                         ^^^^^^^^^^^^^
-issue413.p4(41): error: foo2: Action calls are not allowed within parsers
+issue413.p4(41): [--Werror=legacy] error:  foo2: Action calls are not allowed within parsers
         foo2((bit<16>) c1d, b1a);
         ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue435.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue435.p4-stderr
@@ -1,3 +1,3 @@
-issue435.p4(7): error: mystruct1: Method has no return type
+issue435.p4(7): [--Werror=legacy] error:  mystruct1: Method has no return type
     mystruct1(in bit<8> a, out bit<16> b);
     ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue435.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue435.p4-stderr
@@ -1,3 +1,3 @@
-issue435.p4(7): [--Werror=legacy] error:  mystruct1: Method has no return type
+issue435.p4(7): [--Werror=legacy] error: mystruct1: Method has no return type
     mystruct1(in bit<8> a, out bit<16> b);
     ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue473.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue473.p4-stderr
@@ -1,3 +1,3 @@
-issue473.p4(70): error: cast: action argument must be a compile-time constant
+issue473.p4(70): [--Werror=legacy] error:  cast: action argument must be a compile-time constant
         default_action = b(meta.c, (bit<8>) meta.d);
                                    ^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue473.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue473.p4-stderr
@@ -1,3 +1,3 @@
-issue473.p4(70): [--Werror=legacy] error:  cast: action argument must be a compile-time constant
+issue473.p4(70): [--Werror=type-error] error: cast: action argument must be a compile-time constant
         default_action = b(meta.c, (bit<8>) meta.d);
                                    ^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue477.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue477.p4-stderr
@@ -1,3 +1,3 @@
-issue477.p4(28): error: p.h: argument must be a header
+issue477.p4(28): [--Werror=legacy] error:  p.h: argument must be a header
         b.extract(p.h);
                   ^^^

--- a/testdata/p4_16_errors_outputs/issue477.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue477.p4-stderr
@@ -1,3 +1,3 @@
-issue477.p4(28): [--Werror=legacy] error:  p.h: argument must be a header
+issue477.p4(28): [--Werror=type-error] error: p.h: argument must be a header
         b.extract(p.h);
                   ^^^

--- a/testdata/p4_16_errors_outputs/issue478.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue478.p4-stderr
@@ -1,3 +1,3 @@
-issue478.p4(29): [--Werror=legacy] error:  p.h: argument cannot contain varbit fields
+issue478.p4(29): [--Werror=type-error] error: p.h: argument cannot contain varbit fields
         b.extract(p.h);
                   ^^^

--- a/testdata/p4_16_errors_outputs/issue478.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue478.p4-stderr
@@ -1,3 +1,3 @@
-issue478.p4(29): error: p.h: argument cannot contain varbit fields
+issue478.p4(29): [--Werror=legacy] error:  p.h: argument cannot contain varbit fields
         b.extract(p.h);
                   ^^^

--- a/testdata/p4_16_errors_outputs/issue513.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue513.p4-stderr
@@ -1,3 +1,3 @@
-issue513.p4(60): [--Werror=legacy] error:  MethodCallStatement: Conditional execution in actions is not supported on this target
+issue513.p4(60): [--Werror=legacy] error: MethodCallStatement: Conditional execution in actions is not supported on this target
             mark_to_drop();
             ^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue513.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue513.p4-stderr
@@ -1,3 +1,3 @@
-issue513.p4(60): error: MethodCallStatement: Conditional execution in actions is not supported on this target
+issue513.p4(60): [--Werror=legacy] error:  MethodCallStatement: Conditional execution in actions is not supported on this target
             mark_to_drop();
             ^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue529-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue529-1.p4-stderr
@@ -1,6 +1,6 @@
-issue529-1.p4(28): [--Werror=legacy] error:  h_t: cast not supported
+issue529-1.p4(28): [--Werror=legacy] error: h_t: cast not supported
         h_t h2 = (h_t) h; // illegal cast
                   ^^^
-issue529-1.p4(29): [--Werror=legacy] error:  h_t: cast not supported
+issue529-1.p4(29): [--Werror=legacy] error: h_t: cast not supported
         h_t h4 = (h_t) { h.f }; // illegal cast
                   ^^^

--- a/testdata/p4_16_errors_outputs/issue529-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue529-1.p4-stderr
@@ -1,6 +1,6 @@
-issue529-1.p4(28): error: h_t: cast not supported
+issue529-1.p4(28): [--Werror=legacy] error:  h_t: cast not supported
         h_t h2 = (h_t) h; // illegal cast
                   ^^^
-issue529-1.p4(29): error: h_t: cast not supported
+issue529-1.p4(29): [--Werror=legacy] error:  h_t: cast not supported
         h_t h4 = (h_t) { h.f }; // illegal cast
                   ^^^

--- a/testdata/p4_16_errors_outputs/issue532.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue532.p4-stderr
@@ -1,3 +1,3 @@
-issue532.p4(35): error: choose_entry: functions or methods returning structures are not supported on this target
+issue532.p4(35): [--Werror=legacy] error:  choose_entry: functions or methods returning structures are not supported on this target
     my_meta.entry = choose_entry(choices);
                     ^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue532.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue532.p4-stderr
@@ -1,3 +1,3 @@
-issue532.p4(35): [--Werror=legacy] error:  choose_entry: functions or methods returning structures are not supported on this target
+issue532.p4(35): [--Werror=legacy] error: choose_entry: functions or methods returning structures are not supported on this target
     my_meta.entry = choose_entry(choices);
                     ^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
@@ -1,4 +1,4 @@
-issue561-1.p4(29): [--Werror=legacy] error:  u: Cannot unify Tuple(2) to header_union U
+issue561-1.p4(29): [--Werror=legacy] error: u: Cannot unify Tuple(2) to header_union U
         U u = { { 10 }, { 20 } }; // illegal to initialize unions
         ^^^^^^^^^^^^^^^^^^^^^^^^^
 issue561-1.p4(29)
@@ -7,7 +7,7 @@ issue561-1.p4(29)
 issue561-1.p4(19)
 header_union U {
              ^
-issue561-1.p4(19): [--Werror=legacy] error:  Structure header_union U does not have a field setValid
+issue561-1.p4(19): [--Werror=type-error] error: Structure header_union U does not have a field setValid
 header_union U {
              ^
 issue561-1.p4(30)

--- a/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
@@ -1,4 +1,4 @@
-issue561-1.p4(29): error: u: Cannot unify Tuple(2) to header_union U
+issue561-1.p4(29): [--Werror=legacy] error:  u: Cannot unify Tuple(2) to header_union U
         U u = { { 10 }, { 20 } }; // illegal to initialize unions
         ^^^^^^^^^^^^^^^^^^^^^^^^^
 issue561-1.p4(29)
@@ -7,7 +7,7 @@ issue561-1.p4(29)
 issue561-1.p4(19)
 header_union U {
              ^
-issue561-1.p4(19): error: Structure header_union U does not have a field setValid
+issue561-1.p4(19): [--Werror=legacy] error:  Structure header_union U does not have a field setValid
 header_union U {
              ^
 issue561-1.p4(30)

--- a/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
@@ -7,9 +7,9 @@ issue561-1.p4(29)
 issue561-1.p4(19)
 header_union U {
              ^
-issue561-1.p4(19): [--Werror=type-error] error: Structure header_union U does not have a field setValid
-header_union U {
-             ^
-issue561-1.p4(30)
+issue561-1.p4(30): [--Werror=type-error] error: Field setValid is not a member of structure header_union U
         u.setValid(); // no such method
           ^^^^^^^^
+issue561-1.p4(19)
+header_union U {
+             ^

--- a/testdata/p4_16_errors_outputs/issue584.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue584.p4-stderr
@@ -1,4 +1,4 @@
-issue584.p4(28): error: hash: cannot infer bitwidth for integer-valued type parameter M
+issue584.p4(28): [--Werror=legacy] error:  hash: cannot infer bitwidth for integer-valued type parameter M
         hash(var, HashAlgorithm.crc16, 16w0, hdr, 0xFFFF);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 v1model.p4(138)

--- a/testdata/p4_16_errors_outputs/issue584.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue584.p4-stderr
@@ -1,4 +1,4 @@
-issue584.p4(28): [--Werror=legacy] error:  hash: cannot infer bitwidth for integer-valued type parameter M
+issue584.p4(28): [--Werror=legacy] error: hash: cannot infer bitwidth for integer-valued type parameter M
         hash(var, HashAlgorithm.crc16, 16w0, hdr, 0xFFFF);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 v1model.p4(138)

--- a/testdata/p4_16_errors_outputs/issue600.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue600.p4-stderr
@@ -1,3 +1,3 @@
-issue600.p4(25): error: H: type argument must be a fixed-width type
+issue600.p4(25): [--Werror=legacy] error:  H: type argument must be a fixed-width type
         h = pkt.lookahead<H>();
                           ^

--- a/testdata/p4_16_errors_outputs/issue600.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue600.p4-stderr
@@ -1,3 +1,3 @@
-issue600.p4(25): [--Werror=legacy] error:  H: type argument must be a fixed-width type
+issue600.p4(25): [--Werror=type-error] error: H: type argument must be a fixed-width type
         h = pkt.lookahead<H>();
                           ^

--- a/testdata/p4_16_errors_outputs/issue67.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue67.p4-stderr
@@ -1,3 +1,3 @@
-issue67.p4(1): error: x: Cannot unify type int with bool
+issue67.p4(1): [--Werror=legacy] error:  x: Cannot unify type int with bool
 const bool x = 20; // error
                ^^

--- a/testdata/p4_16_errors_outputs/issue67.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue67.p4-stderr
@@ -1,3 +1,3 @@
-issue67.p4(1): [--Werror=legacy] error:  x: Cannot unify type int with bool
+issue67.p4(1): [--Werror=legacy] error: x: Cannot unify type int with bool
 const bool x = 20; // error
                ^^

--- a/testdata/p4_16_errors_outputs/issue764.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue764.p4-stderr
@@ -1,4 +1,4 @@
-issue764.p4(8): error: func: cannot infer bitwidth for integer-valued type parameter T
+issue764.p4(8): [--Werror=legacy] error:  func: cannot infer bitwidth for integer-valued type parameter T
         func(5);
         ^^^^^^^
 issue764.p4(1)

--- a/testdata/p4_16_errors_outputs/issue764.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue764.p4-stderr
@@ -1,4 +1,4 @@
-issue764.p4(8): [--Werror=legacy] error:  func: cannot infer bitwidth for integer-valued type parameter T
+issue764.p4(8): [--Werror=legacy] error: func: cannot infer bitwidth for integer-valued type parameter T
         func(5);
         ^^^^^^^
 issue764.p4(1)

--- a/testdata/p4_16_errors_outputs/issue774-2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue774-2.p4-stderr
@@ -1,3 +1,3 @@
-issue774-2.p4(11): error: Could not infer type for DefaultExpression
+issue774-2.p4(11): [--Werror=legacy] error:  Could not infer type for DefaultExpression
         b.extract(_);
                   ^

--- a/testdata/p4_16_errors_outputs/issue774-2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue774-2.p4-stderr
@@ -1,3 +1,3 @@
-issue774-2.p4(11): [--Werror=legacy] error:  Could not infer type for DefaultExpression
+issue774-2.p4(11): [--Werror=legacy] error: Could not infer type for DefaultExpression
         b.extract(_);
                   ^

--- a/testdata/p4_16_errors_outputs/issue803-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue803-1.p4-stderr
@@ -1,3 +1,3 @@
-issue803-1.p4(14): [--Werror=legacy] error:  ig1: Passing 1 arguments when 0 expected
+issue803-1.p4(14): [--Werror=legacy] error: ig1: Passing 1 arguments when 0 expected
 Ingress<H>(ing_parse()) ig1;
                         ^^^

--- a/testdata/p4_16_errors_outputs/issue803-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue803-1.p4-stderr
@@ -1,3 +1,3 @@
-issue803-1.p4(14): error: ig1: Passing 1 arguments when 0 expected
+issue803-1.p4(14): [--Werror=legacy] error:  ig1: Passing 1 arguments when 0 expected
 Ingress<H>(ing_parse()) ig1;
                         ^^^

--- a/testdata/p4_16_errors_outputs/issue807.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue807.p4-stderr
@@ -1,10 +1,10 @@
-issue807.p4(20): error: e.get2: illegal return type control C2
+issue807.p4(20): [--Werror=type-error] error: e.get2: illegal return type control C2
     C2 c2 = e.get2();
             ^^^^^^^^
 issue807.p4(5)
 control C2();
         ^^
-issue807.p4(26): error: e.get1: illegal return type control C1
+issue807.p4(26): [--Werror=type-error] error: e.get1: illegal return type control C1
     C1 c1 = e.get1();
             ^^^^^^^^
 issue807.p4(4)

--- a/testdata/p4_16_errors_outputs/issue816-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue816-1.p4-stderr
@@ -1,6 +1,6 @@
-issue816-1.p4(14): [--Werror=legacy] error:  p: parameter cannot be a package
+issue816-1.p4(14): [--Werror=type-error] error: p: parameter cannot be a package
 control MyC1()(P p) {
                  ^
-issue816-1.p4(18): [--Werror=legacy] error:  p: parameter cannot be a package
+issue816-1.p4(18): [--Werror=type-error] error: p: parameter cannot be a package
 control MyC2()(P p) {
                  ^

--- a/testdata/p4_16_errors_outputs/issue816-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue816-1.p4-stderr
@@ -1,6 +1,6 @@
-issue816-1.p4(14): error: p: parameter cannot be a package
+issue816-1.p4(14): [--Werror=legacy] error:  p: parameter cannot be a package
 control MyC1()(P p) {
                  ^
-issue816-1.p4(18): error: p: parameter cannot be a package
+issue816-1.p4(18): [--Werror=legacy] error:  p: parameter cannot be a package
 control MyC2()(P p) {
                  ^

--- a/testdata/p4_16_errors_outputs/issue816.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue816.p4-stderr
@@ -1,4 +1,4 @@
-issue816.p4(15): [--Werror=legacy] error:  c1: parameter cannot have type control C
+issue816.p4(15): [--Werror=type-error] error: c1: parameter cannot have type control C
 action a(in C c1, in C c2) {
               ^^
 issue816.p4(4)

--- a/testdata/p4_16_errors_outputs/issue816.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue816.p4-stderr
@@ -1,4 +1,4 @@
-issue816.p4(15): error: c1: parameter cannot have type control C
+issue816.p4(15): [--Werror=legacy] error:  c1: parameter cannot have type control C
 action a(in C c1, in C c2) {
               ^^
 issue816.p4(4)

--- a/testdata/p4_16_errors_outputs/issue818.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue818.p4-stderr
@@ -1,10 +1,4 @@
-issue818.p4(13): error: c: parameter cannot have type control C
-  WrapControl(C c);
-                ^
-issue818.p4(5)
-control C();
-        ^
-issue818.p4(13): error: c: parameter cannot have type control C
+issue818.p4(13): [--Werror=legacy] error:  c: parameter cannot have type control C
   WrapControl(C c);
                 ^
 issue818.p4(5)

--- a/testdata/p4_16_errors_outputs/issue818.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue818.p4-stderr
@@ -1,4 +1,4 @@
-issue818.p4(13): [--Werror=legacy] error:  c: parameter cannot have type control C
+issue818.p4(13): [--Werror=type-error] error: c: parameter cannot have type control C
   WrapControl(C c);
                 ^
 issue818.p4(5)

--- a/testdata/p4_16_errors_outputs/issue819-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue819-1.p4-stderr
@@ -1,6 +1,6 @@
-issue819-1.p4(14): error: Type parameters needed for wc
+issue819-1.p4(14): [--Werror=legacy] error:  Type parameters needed for wc
 control MyC1(WrapControls wc) {
                           ^^
-issue819-1.p4(19): error: Type parameters needed for wc
+issue819-1.p4(19): [--Werror=legacy] error:  Type parameters needed for wc
 control MyC2(WrapControls wc) {
                           ^^

--- a/testdata/p4_16_errors_outputs/issue819-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue819-1.p4-stderr
@@ -1,6 +1,6 @@
-issue819-1.p4(14): [--Werror=legacy] error:  Type parameters needed for wc
+issue819-1.p4(14): [--Werror=type-error] error: Type parameters needed for wc
 control MyC1(WrapControls wc) {
                           ^^
-issue819-1.p4(19): [--Werror=legacy] error:  Type parameters needed for wc
+issue819-1.p4(19): [--Werror=type-error] error: Type parameters needed for wc
 control MyC2(WrapControls wc) {
                           ^^

--- a/testdata/p4_16_errors_outputs/issue819.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue819.p4-stderr
@@ -1,4 +1,4 @@
-issue819.p4(27): error: WrapControls<...>: Cannot use control MyC1 as a type parameter
+issue819.p4(27): [--Werror=legacy] error:  WrapControls<...>: Cannot use control MyC1 as a type parameter
   WrapControls<MyC1,MyC2>(c1,c2) wc;
   ^^^^^^^^^^^^^^^^^^^^^^^
 issue819.p4(14)

--- a/testdata/p4_16_errors_outputs/issue819.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue819.p4-stderr
@@ -1,4 +1,4 @@
-issue819.p4(27): [--Werror=legacy] error:  WrapControls<...>: Cannot use control MyC1 as a type parameter
+issue819.p4(27): [--Werror=type-error] error: WrapControls<...>: Cannot use control MyC1 as a type parameter
   WrapControls<MyC1,MyC2>(c1,c2) wc;
   ^^^^^^^^^^^^^^^^^^^^^^^
 issue819.p4(14)

--- a/testdata/p4_16_errors_outputs/key-name.p4-stderr
+++ b/testdata/p4_16_errors_outputs/key-name.p4-stderr
@@ -1,3 +1,3 @@
-key-name.p4(28): error: +: Complex key expression requires a @name annotation
+key-name.p4(28): [--Werror=legacy] error:  +: Complex key expression requires a @name annotation
         key = { h.a + h.a : exact; }
                 ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/key-name.p4-stderr
+++ b/testdata/p4_16_errors_outputs/key-name.p4-stderr
@@ -1,3 +1,3 @@
-key-name.p4(28): [--Werror=legacy] error:  +: Complex key expression requires a @name annotation
+key-name.p4(28): [--Werror=legacy] error: +: Complex key expression requires a @name annotation
         key = { h.a + h.a : exact; }
                 ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/local_instance.p4-stderr
+++ b/testdata/p4_16_errors_outputs/local_instance.p4-stderr
@@ -1,3 +1,3 @@
-local_instance.p4(33): error: vc: instances cannot be in a control 'apply' block
+local_instance.p4(33): [--Werror=legacy] error:  vc: instances cannot be in a control 'apply' block
         VC() vc; // illegal instance within an apply block
              ^^

--- a/testdata/p4_16_errors_outputs/local_instance.p4-stderr
+++ b/testdata/p4_16_errors_outputs/local_instance.p4-stderr
@@ -1,3 +1,3 @@
-local_instance.p4(33): [--Werror=legacy] error:  vc: instances cannot be in a control 'apply' block
+local_instance.p4(33): [--Werror=legacy] error: vc: instances cannot be in a control 'apply' block
         VC() vc; // illegal instance within an apply block
              ^^

--- a/testdata/p4_16_errors_outputs/missing_actions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/missing_actions.p4-stderr
@@ -1,3 +1,3 @@
-missing_actions.p4(19): error: Table t does not have an `actions' property
+missing_actions.p4(19): [--Werror=legacy] error:  Table t does not have an `actions' property
     table t {
           ^

--- a/testdata/p4_16_errors_outputs/missing_actions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/missing_actions.p4-stderr
@@ -1,3 +1,3 @@
-missing_actions.p4(19): [--Werror=legacy] error:  Table t does not have an `actions' property
+missing_actions.p4(19): [--Werror=legacy] error: Table t does not have an `actions' property
     table t {
           ^

--- a/testdata/p4_16_errors_outputs/missing_match.p4-stderr
+++ b/testdata/p4_16_errors_outputs/missing_match.p4-stderr
@@ -1,3 +1,3 @@
-missing_match.p4(20): error: Could not find declaration for noSuchMatch
+missing_match.p4(20): [--Werror=not-found] error: noSuchMatch: Not found declaration
         key = { b : noSuchMatch; }
                     ^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/module_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/module_e.p4-stderr
@@ -1,4 +1,4 @@
-module_e.p4(25): error: main: Cannot unify parameter x with filter because they have different directions
+module_e.p4(25): [--Werror=legacy] error:  main: Cannot unify parameter x with filter because they have different directions
 top(g()) main;
          ^^^^
 module_e.p4(20)

--- a/testdata/p4_16_errors_outputs/module_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/module_e.p4-stderr
@@ -1,4 +1,4 @@
-module_e.p4(25): [--Werror=legacy] error:  main: Cannot unify parameter x with filter because they have different directions
+module_e.p4(25): [--Werror=legacy] error: main: Cannot unify parameter x with filter because they have different directions
 top(g()) main;
          ^^^^
 module_e.p4(20)

--- a/testdata/p4_16_errors_outputs/mux_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/mux_e.p4-stderr
@@ -1,4 +1,4 @@
-error: Selector of ?: must be bool, not bit<1>
-mux_e.p4(25): [--Werror=legacy] error:  ?:: Cannot unify bool to bit<1>
+[--Werror=type-error] error: Selector of ?: must be bool, not bit<1>
+mux_e.p4(25): [--Werror=legacy] error: ?:: Cannot unify bool to bit<1>
         d = d ? a : d; // wrong types a <-> d
             ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/mux_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/mux_e.p4-stderr
@@ -1,4 +1,4 @@
 error: Selector of ?: must be bool, not bit<1>
-mux_e.p4(25): error: ?:: Cannot unify bool to bit<1>
+mux_e.p4(25): [--Werror=legacy] error:  ?:: Cannot unify bool to bit<1>
         d = d ? a : d; // wrong types a <-> d
             ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/named-fail.p4-stderr
+++ b/testdata/p4_16_errors_outputs/named-fail.p4-stderr
@@ -1,7 +1,7 @@
 named-fail.p4(8): [--Werror=invalid] error: xv: Invalid either all or none of the arguments of a call must be named
         f(y = b, xv); // not all arguments named
                  ^^
-named-fail.p4(9): [--Werror=legacy] error:  y = b and y = b: same argument name
+named-fail.p4(9): [--Werror=legacy] error: y = b and y = b: same argument name
         f(y = b, y = b); // same argument twice
           ^
 named-fail.p4(9)

--- a/testdata/p4_16_errors_outputs/named-fail.p4-stderr
+++ b/testdata/p4_16_errors_outputs/named-fail.p4-stderr
@@ -1,7 +1,7 @@
-named-fail.p4(8): error: xv: all or none of the arguments of a call must be named
+named-fail.p4(8): [--Werror=invalid] error: xv: Invalid either all or none of the arguments of a call must be named
         f(y = b, xv); // not all arguments named
                  ^^
-named-fail.p4(9): error: y = b and y = b: same argument name
+named-fail.p4(9): [--Werror=legacy] error:  y = b and y = b: same argument name
         f(y = b, y = b); // same argument twice
           ^
 named-fail.p4(9)

--- a/testdata/p4_16_errors_outputs/named-fail1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/named-fail1.p4-stderr
@@ -1,4 +1,4 @@
-named-fail1.p4(8): error: f: No parameter named z
+named-fail1.p4(8): [--Werror=legacy] error:  f: No parameter named z
         f(z = b, y = b); // No such parameter
         ^^^^^^^^^^^^^^^
 named-fail1.p4(8)

--- a/testdata/p4_16_errors_outputs/named-fail1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/named-fail1.p4-stderr
@@ -1,4 +1,4 @@
-named-fail1.p4(8): [--Werror=legacy] error:  f: No parameter named z
+named-fail1.p4(8): [--Werror=legacy] error: f: No parameter named z
         f(z = b, y = b); // No such parameter
         ^^^^^^^^^^^^^^^
 named-fail1.p4(8)

--- a/testdata/p4_16_errors_outputs/neg.p4-stderr
+++ b/testdata/p4_16_errors_outputs/neg.p4-stderr
@@ -1,6 +1,6 @@
-neg.p4(21): error: /: Cannot operate on signed values
+neg.p4(21): [--Werror=legacy] error:  /: Cannot operate on signed values
     c = a / b; // not defined for signed values
         ^^^^^
-neg.p4(22): error: %: Cannot operate on signed values
+neg.p4(22): [--Werror=legacy] error:  %: Cannot operate on signed values
     c = a % b;
         ^^^^^

--- a/testdata/p4_16_errors_outputs/neg.p4-stderr
+++ b/testdata/p4_16_errors_outputs/neg.p4-stderr
@@ -1,6 +1,6 @@
-neg.p4(21): [--Werror=legacy] error:  /: Cannot operate on signed values
+neg.p4(21): [--Werror=type-error] error: /: Cannot operate on signed values
     c = a / b; // not defined for signed values
         ^^^^^
-neg.p4(22): [--Werror=legacy] error:  %: Cannot operate on signed values
+neg.p4(22): [--Werror=type-error] error: %: Cannot operate on signed values
     c = a % b;
         ^^^^^

--- a/testdata/p4_16_errors_outputs/newtype-err.p4-stderr
+++ b/testdata/p4_16_errors_outputs/newtype-err.p4-stderr
@@ -1,4 +1,4 @@
-newtype-err.p4(10): error: AssignmentStatement: Cannot unify bit<32> to N32
+newtype-err.p4(10): [--Werror=legacy] error:  AssignmentStatement: Cannot unify bit<32> to N32
         n = b + b;
           ^
 newtype-err.p4(2)
@@ -7,6 +7,6 @@ type bit<32> N32;
 newtype-err.p4(11): error: +: cannot be applied to n of type N32
         n1 = n + 0;
              ^
-newtype-err.p4(12): error: AssignmentStatement: Cannot unify N32 to bit<32>
+newtype-err.p4(12): [--Werror=legacy] error:  AssignmentStatement: Cannot unify N32 to bit<32>
         x = n;
           ^

--- a/testdata/p4_16_errors_outputs/newtype-err.p4-stderr
+++ b/testdata/p4_16_errors_outputs/newtype-err.p4-stderr
@@ -1,12 +1,12 @@
-newtype-err.p4(10): [--Werror=legacy] error:  AssignmentStatement: Cannot unify bit<32> to N32
+newtype-err.p4(10): [--Werror=legacy] error: AssignmentStatement: Cannot unify bit<32> to N32
         n = b + b;
           ^
 newtype-err.p4(2)
 type bit<32> N32;
              ^^^
-newtype-err.p4(11): error: +: cannot be applied to n of type N32
+newtype-err.p4(11): [--Werror=type-error] error: +: cannot be applied to n of type N32
         n1 = n + 0;
              ^
-newtype-err.p4(12): [--Werror=legacy] error:  AssignmentStatement: Cannot unify N32 to bit<32>
+newtype-err.p4(12): [--Werror=legacy] error: AssignmentStatement: Cannot unify N32 to bit<32>
         x = n;
           ^

--- a/testdata/p4_16_errors_outputs/next.p4-stderr
+++ b/testdata/p4_16_errors_outputs/next.p4-stderr
@@ -1,6 +1,6 @@
 next.p4(24): error: stack.last: 'last' and 'next' for stacks cannot be used in a control
         stack.last = { 10 };
         ^^^^^^^^^^
-next.p4(24): error: Expression stack.last cannot be the target of an assignment
+next.p4(24): [--Werror=legacy] error:  Expression stack.last cannot be the target of an assignment
         stack.last = { 10 };
         ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/next.p4-stderr
+++ b/testdata/p4_16_errors_outputs/next.p4-stderr
@@ -1,6 +1,6 @@
-next.p4(24): error: stack.last: 'last' and 'next' for stacks cannot be used in a control
+next.p4(24): [--Werror=type-error] error: stack.last: 'last' and 'next' for stacks cannot be used in a control
         stack.last = { 10 };
         ^^^^^^^^^^
-next.p4(24): [--Werror=legacy] error:  Expression stack.last cannot be the target of an assignment
+next.p4(24): [--Werror=type-error] error: Expression stack.last cannot be the target of an assignment
         stack.last = { 10 };
         ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/nostart.p4-stderr
+++ b/testdata/p4_16_errors_outputs/nostart.p4-stderr
@@ -1,9 +1,9 @@
-nostart.p4(18): warning: next: implicit transition to `reject'
+nostart.p4(18): [--Wwarn=parser-transition] warning: next: next: implicit transition to `reject'
     state next {}
           ^^^^
 nostart.p4(17): error: parser p: parser does not have a `start' state
 parser p() {
        ^
-nostart.p4(17): warning: accept state in parser p is unreachable
+nostart.p4(17): [--Wwarn=parser-transition] warning: accept: accept state in parser p is unreachable
 parser p() {
        ^

--- a/testdata/p4_16_errors_outputs/nostart.p4-stderr
+++ b/testdata/p4_16_errors_outputs/nostart.p4-stderr
@@ -1,9 +1,9 @@
-nostart.p4(18): [--Wwarn=parser-transition] warning: next: next: implicit transition to `reject'
+nostart.p4(18): [--Wwarn=parser-transition] warning: next: implicit transition to `reject'
     state next {}
           ^^^^
 nostart.p4(17): error: parser p: parser does not have a `start' state
 parser p() {
        ^
-nostart.p4(17): [--Wwarn=parser-transition] warning: accept: accept state in parser p is unreachable
+nostart.p4(17): [--Wwarn=parser-transition] warning: accept state in parser p is unreachable
 parser p() {
        ^

--- a/testdata/p4_16_errors_outputs/not_bound.p4-stderr
+++ b/testdata/p4_16_errors_outputs/not_bound.p4-stderr
@@ -1,4 +1,4 @@
-not_bound.p4(36): error: action set_nhop: parameter port must be bound
+not_bound.p4(36): [--Werror=legacy] error:  action set_nhop: parameter port must be bound
         set_nhop(); // parameter not bound
         ^^^^^^^^^^
 not_bound.p4(32)

--- a/testdata/p4_16_errors_outputs/not_bound.p4-stderr
+++ b/testdata/p4_16_errors_outputs/not_bound.p4-stderr
@@ -1,4 +1,4 @@
-not_bound.p4(36): [--Werror=legacy] error:  action set_nhop: parameter port must be bound
+not_bound.p4(36): [--Werror=legacy] error: action set_nhop: parameter port must be bound
         set_nhop(); // parameter not bound
         ^^^^^^^^^^
 not_bound.p4(32)

--- a/testdata/p4_16_errors_outputs/package.p4-stderr
+++ b/testdata/p4_16_errors_outputs/package.p4-stderr
@@ -1,3 +1,3 @@
-package.p4(18): error: _c: constructor parameters cannot have a direction
+package.p4(18): [--Werror=legacy] error:  _c: constructor parameters cannot have a direction
 package top(in proto _c); // Package should not have in parameters
                      ^^

--- a/testdata/p4_16_errors_outputs/package.p4-stderr
+++ b/testdata/p4_16_errors_outputs/package.p4-stderr
@@ -1,3 +1,3 @@
-package.p4(18): [--Werror=legacy] error:  _c: constructor parameters cannot have a direction
+package.p4(18): [--Werror=legacy] error: _c: constructor parameters cannot have a direction
 package top(in proto _c); // Package should not have in parameters
                      ^^

--- a/testdata/p4_16_errors_outputs/param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/param.p4-stderr
@@ -1,3 +1,3 @@
-param.p4(22): [--Werror=legacy] error:  E: Action parameters cannot have extern types
+param.p4(22): [--Werror=type-error] error: E: Action parameters cannot have extern types
     action a(E e) { e.call(); }
              ^

--- a/testdata/p4_16_errors_outputs/param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/param.p4-stderr
@@ -1,3 +1,3 @@
-param.p4(22): error: E: Action parameters cannot have extern types
+param.p4(22): [--Werror=legacy] error:  E: Action parameters cannot have extern types
     action a(E e) { e.call(); }
              ^

--- a/testdata/p4_16_errors_outputs/parser-arg.p4-stderr
+++ b/testdata/p4_16_errors_outputs/parser-arg.p4-stderr
@@ -1,16 +1,16 @@
-parser-arg.p4(18): [--Werror=legacy] error:  p: parameter cannot have type parser Parser
+parser-arg.p4(18): [--Werror=type-error] error: p: parameter cannot have type parser Parser
 parser MyParser(Parser p);
                        ^
 parser-arg.p4(17)
 parser Parser();
        ^^^^^^
-parser-arg.p4(21): [--Werror=legacy] error:  p: parameter cannot have type parser Parser
+parser-arg.p4(21): [--Werror=type-error] error: p: parameter cannot have type parser Parser
 parser Parser1(Parser p) {
                       ^
 parser-arg.p4(17)
 parser Parser();
        ^^^^^^
-parser-arg.p4(28): [--Werror=legacy] error:  p: parameter cannot have type parser Parser
+parser-arg.p4(28): [--Werror=type-error] error: p: parameter cannot have type parser Parser
 parser Parser2(Parser p) {
                       ^
 parser-arg.p4(17)

--- a/testdata/p4_16_errors_outputs/parser-arg.p4-stderr
+++ b/testdata/p4_16_errors_outputs/parser-arg.p4-stderr
@@ -1,16 +1,16 @@
-parser-arg.p4(18): error: p: parameter cannot have type parser Parser
+parser-arg.p4(18): [--Werror=legacy] error:  p: parameter cannot have type parser Parser
 parser MyParser(Parser p);
                        ^
 parser-arg.p4(17)
 parser Parser();
        ^^^^^^
-parser-arg.p4(21): error: p: parameter cannot have type parser Parser
+parser-arg.p4(21): [--Werror=legacy] error:  p: parameter cannot have type parser Parser
 parser Parser1(Parser p) {
                       ^
 parser-arg.p4(17)
 parser Parser();
        ^^^^^^
-parser-arg.p4(28): error: p: parameter cannot have type parser Parser
+parser-arg.p4(28): [--Werror=legacy] error:  p: parameter cannot have type parser Parser
 parser Parser2(Parser p) {
                       ^
 parser-arg.p4(17)

--- a/testdata/p4_16_errors_outputs/persistent_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/persistent_e.p4-stderr
@@ -1,3 +1,3 @@
-persistent_e.p4(23): error: z: cannot evaluate to a compile-time constant
+persistent_e.p4(23): [--Werror=legacy] error:  z: cannot evaluate to a compile-time constant
     p(z) p1; // argument is not constant
       ^

--- a/testdata/p4_16_errors_outputs/persistent_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/persistent_e.p4-stderr
@@ -1,3 +1,3 @@
-persistent_e.p4(23): [--Werror=legacy] error:  z: cannot evaluate to a compile-time constant
+persistent_e.p4(23): [--Werror=type-error] error: z: cannot evaluate to a compile-time constant
     p(z) p1; // argument is not constant
       ^

--- a/testdata/p4_16_errors_outputs/psa-meter2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/psa-meter2.p4-stderr
@@ -1,4 +1,4 @@
-psa-meter2.p4(53): error: cast: Cannot unify PSA_MeterColor_t to bit<16>
+psa-meter2.p4(53): [--Werror=legacy] error:  cast: Cannot unify PSA_MeterColor_t to bit<16>
         b.data = (bit<16>)meter0.execute(index, PSA_MeterColor_t.GREEN);
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 psa-meter2.p4(53): error: cast: Illegal cast from PSA_MeterColor_t to bit<16>

--- a/testdata/p4_16_errors_outputs/psa-meter2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/psa-meter2.p4-stderr
@@ -1,6 +1,6 @@
-psa-meter2.p4(53): [--Werror=legacy] error:  cast: Cannot unify PSA_MeterColor_t to bit<16>
+psa-meter2.p4(53): [--Werror=legacy] error: cast: Cannot unify PSA_MeterColor_t to bit<16>
         b.data = (bit<16>)meter0.execute(index, PSA_MeterColor_t.GREEN);
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-psa-meter2.p4(53): error: cast: Illegal cast from PSA_MeterColor_t to bit<16>
+psa-meter2.p4(53): [--Werror=type-error] error: cast: Illegal cast from PSA_MeterColor_t to bit<16>
         b.data = (bit<16>)meter0.execute(index, PSA_MeterColor_t.GREEN);
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/push_nonconstant.p4-stderr
+++ b/testdata/p4_16_errors_outputs/push_nonconstant.p4-stderr
@@ -1,3 +1,3 @@
-push_nonconstant.p4(10): error: x: argument must be a constant
+push_nonconstant.p4(10): [--Werror=invalid] error: x: Invalid argument must be a constant
         h.push_front(x);
                      ^

--- a/testdata/p4_16_errors_outputs/range_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/range_e.p4-stderr
@@ -1,3 +1,3 @@
-range_e.p4(20): error: ..: Cannot operate on values with different types bit<2> and bit<3>
+range_e.p4(20): [--Werror=legacy] error:  ..: Cannot operate on values with different types bit<2> and bit<3>
             2w2 .. 3w3 : reject; // different widths
             ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/range_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/range_e.p4-stderr
@@ -1,3 +1,3 @@
-range_e.p4(20): [--Werror=legacy] error:  ..: Cannot operate on values with different types bit<2> and bit<3>
+range_e.p4(20): [--Werror=type-error] error: ..: Cannot operate on values with different types bit<2> and bit<3>
             2w2 .. 3w3 : reject; // different widths
             ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/scope.p4-stderr
+++ b/testdata/p4_16_errors_outputs/scope.p4-stderr
@@ -1,4 +1,4 @@
-scope.p4(25): [--Werror=legacy] error:  Cannot extract field x from q which has type Type(control q)
+scope.p4(25): [--Werror=type-error] error: Cannot extract field x from q which has type Type(control q)
         bit<8> y = .q.x.get(); // should be unreachable
                       ^
 scope.p4(25)

--- a/testdata/p4_16_errors_outputs/scope.p4-stderr
+++ b/testdata/p4_16_errors_outputs/scope.p4-stderr
@@ -1,4 +1,4 @@
-scope.p4(25): error: Cannot extract field x from q which has type Type(control q)
+scope.p4(25): [--Werror=legacy] error:  Cannot extract field x from q which has type Type(control q)
         bit<8> y = .q.x.get(); // should be unreachable
                       ^
 scope.p4(25)

--- a/testdata/p4_16_errors_outputs/self-call.p4-stderr
+++ b/testdata/p4_16_errors_outputs/self-call.p4-stderr
@@ -1,3 +1,3 @@
-self-call.p4(17): error: c: Cannot refer to control inside itself
+self-call.p4(17): [--Werror=type-error] error: c: Cannot refer to control inside itself
     c() c_inst;
     ^

--- a/testdata/p4_16_errors_outputs/signs.p4-stderr
+++ b/testdata/p4_16_errors_outputs/signs.p4-stderr
@@ -1,12 +1,12 @@
-signs.p4(17): warning: a shadows a
+signs.p4(17): [--Wwarn=shadow] warning: a: a shadows a
     bit<8> a = 8w0;
     ^^^^^^^^^^^^^^^
 signs.p4(16)
 action a() {
        ^
-signs.p4(18): error: b: Cannot unify bit<8> to int<8>
+signs.p4(18): [--Werror=legacy] error:  b: Cannot unify bit<8> to int<8>
     int<8> b = 8w0;
     ^^^^^^^^^^^^^^^
-signs.p4(19): error: -: Cannot operate on values with different signs
+signs.p4(19): [--Werror=legacy] error:  -: Cannot operate on values with different signs
     a = a - b;
         ^^^^^

--- a/testdata/p4_16_errors_outputs/signs.p4-stderr
+++ b/testdata/p4_16_errors_outputs/signs.p4-stderr
@@ -1,12 +1,12 @@
-signs.p4(17): [--Wwarn=shadow] warning: a: a shadows a
+signs.p4(17): [--Wwarn=shadow] warning: a shadows a
     bit<8> a = 8w0;
     ^^^^^^^^^^^^^^^
 signs.p4(16)
 action a() {
        ^
-signs.p4(18): [--Werror=legacy] error:  b: Cannot unify bit<8> to int<8>
+signs.p4(18): [--Werror=legacy] error: b: Cannot unify bit<8> to int<8>
     int<8> b = 8w0;
     ^^^^^^^^^^^^^^^
-signs.p4(19): [--Werror=legacy] error:  -: Cannot operate on values with different signs
+signs.p4(19): [--Werror=type-error] error: -: Cannot operate on values with different signs
     a = a - b;
         ^^^^^

--- a/testdata/p4_16_errors_outputs/spec-ex32_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/spec-ex32_e.p4-stderr
@@ -1,3 +1,3 @@
-spec-ex32_e.p4(22): error: Could not find declaration for size2
+spec-ex32_e.p4(22): [--Werror=not-found] error: size2: Not found declaration
     @length(size2) // illegal: cannot use size2, defined after data2
             ^^^^^

--- a/testdata/p4_16_errors_outputs/spec-issue563.p4-stderr
+++ b/testdata/p4_16_errors_outputs/spec-issue563.p4-stderr
@@ -1,4 +1,4 @@
-spec-issue563.p4(12): error: a: parameter cannot have type control A
+spec-issue563.p4(12): [--Werror=type-error] error: a: parameter cannot have type control A
 control C()(A a) {
               ^
 spec-issue563.p4(5)

--- a/testdata/p4_16_errors_outputs/stack1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack1_e.p4-stderr
@@ -1,6 +1,6 @@
-stack1_e.p4(21): warning: 5: signed value does not fit in 3 bits
+stack1_e.p4(21): [--Wwarn=overflow] warning: 5: 5: signed value does not fit in 3 bits
         int<3> w = 5;
                    ^
-stack1_e.p4(22): error: header h[]: Size of header stack type should be a constant
+stack1_e.p4(22): [--Werror=legacy] error:  header h[]: Size of header stack type should be a constant
         h[w] stack;
         ^^^^

--- a/testdata/p4_16_errors_outputs/stack1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack1_e.p4-stderr
@@ -1,6 +1,6 @@
-stack1_e.p4(21): [--Wwarn=overflow] warning: 5: 5: signed value does not fit in 3 bits
+stack1_e.p4(21): [--Wwarn=overflow] warning: 5: signed value does not fit in 3 bits
         int<3> w = 5;
                    ^
-stack1_e.p4(22): [--Werror=legacy] error:  header h[]: Size of header stack type should be a constant
+stack1_e.p4(22): [--Werror=type-error] error: header h[]: Size of header stack type should be a constant
         h[w] stack;
         ^^^^

--- a/testdata/p4_16_errors_outputs/stack2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack2.p4-stderr
@@ -1,4 +1,4 @@
-stack2.p4(24): [--Werror=legacy] error:  AssignmentStatement: cannot unify stacks with different sized header h[] and header h[]
+stack2.p4(24): [--Werror=legacy] error: AssignmentStatement: cannot unify stacks with different sized header h[] and header h[]
         stack1 = stack2; // assignment between different stacks
                ^
 stack2.p4(21)
@@ -7,9 +7,9 @@ stack2.p4(21)
 stack2.p4(22)
         h[3] stack2;
         ^^^^
-stack2.p4(25): [--Werror=legacy] error:  Expression stack1.lastIndex cannot be the target of an assignment
+stack2.p4(25): [--Werror=type-error] error: Expression stack1.lastIndex cannot be the target of an assignment
         stack1.lastIndex = 3; // not an l-value
         ^^^^^^^^^^^^^^^^
-stack2.p4(26): [--Werror=legacy] error:  Expression stack2.size cannot be the target of an assignment
+stack2.p4(26): [--Werror=type-error] error: Expression stack2.size cannot be the target of an assignment
         stack2.size = 4; // not an l-value
         ^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/stack2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack2.p4-stderr
@@ -1,4 +1,4 @@
-stack2.p4(24): error: AssignmentStatement: cannot unify stacks with different sized header h[] and header h[]
+stack2.p4(24): [--Werror=legacy] error:  AssignmentStatement: cannot unify stacks with different sized header h[] and header h[]
         stack1 = stack2; // assignment between different stacks
                ^
 stack2.p4(21)
@@ -7,9 +7,9 @@ stack2.p4(21)
 stack2.p4(22)
         h[3] stack2;
         ^^^^
-stack2.p4(25): error: Expression stack1.lastIndex cannot be the target of an assignment
+stack2.p4(25): [--Werror=legacy] error:  Expression stack1.lastIndex cannot be the target of an assignment
         stack1.lastIndex = 3; // not an l-value
         ^^^^^^^^^^^^^^^^
-stack2.p4(26): error: Expression stack2.size cannot be the target of an assignment
+stack2.p4(26): [--Werror=legacy] error:  Expression stack2.size cannot be the target of an assignment
         stack2.size = 4; // not an l-value
         ^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/stack3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack3.p4-stderr
@@ -1,6 +1,6 @@
-stack3.p4(34): [--Werror=legacy] error:  header h[]: Size of header stack type should be a constant
+stack3.p4(34): [--Werror=type-error] error: header h[]: Size of header stack type should be a constant
         h[s1.size + 1] s2;
         ^^^^^^^^^^^^^^
-stack3.p4(35): [--Werror=legacy] error:  header h[]: Size of header stack type should be a constant
+stack3.p4(35): [--Werror=type-error] error: header h[]: Size of header stack type should be a constant
         h[x] s3;
         ^^^^

--- a/testdata/p4_16_errors_outputs/stack3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack3.p4-stderr
@@ -1,30 +1,6 @@
-stack3.p4(34): error: header h[]: Size of header stack type should be a constant
+stack3.p4(34): [--Werror=legacy] error:  header h[]: Size of header stack type should be a constant
         h[s1.size + 1] s2;
         ^^^^^^^^^^^^^^
-stack3.p4(34): error: header h[]: Size of header stack type should be a constant
-        h[s1.size + 1] s2;
-        ^^^^^^^^^^^^^^
-stack3.p4(34): error: header h[]: Size of header stack type should be a constant
-        h[s1.size + 1] s2;
-        ^^^^^^^^^^^^^^
-stack3.p4(35): error: header h[]: Size of header stack type should be a constant
-        h[x] s3;
-        ^^^^
-stack3.p4(35): error: header h[]: Size of header stack type should be a constant
-        h[x] s3;
-        ^^^^
-stack3.p4(35): error: header h[]: Size of header stack type should be a constant
-        h[x] s3;
-        ^^^^
-stack3.p4(35): error: header h[]: Size of header stack type should be a constant
-        h[x] s3;
-        ^^^^
-stack3.p4(35): error: header h[]: Size of header stack type should be a constant
-        h[x] s3;
-        ^^^^
-stack3.p4(35): error: header h[]: Size of header stack type should be a constant
-        h[x] s3;
-        ^^^^
-stack3.p4(35): error: header h[]: Size of header stack type should be a constant
+stack3.p4(35): [--Werror=legacy] error:  header h[]: Size of header stack type should be a constant
         h[x] s3;
         ^^^^

--- a/testdata/p4_16_errors_outputs/stack_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack_e.p4-stderr
@@ -1,13 +1,13 @@
-stack_e.p4(23): error: Header stack struct s[] used with non-header type struct s
+stack_e.p4(23): [--Werror=type-error] error: Header stack struct s[] used with non-header type struct s
         s[5] stack1; // non-header illegal in header stack
         ^^^^
-stack_e.p4(26): [--Werror=legacy] error:  Index too large: 1231092310293
+stack_e.p4(26): [--Werror=type-error] error: Index too large: 1231092310293
         h b = stack[1231092310293];
                     ^^^^^^^^^^^^^
-stack_e.p4(27): [--Werror=legacy] error:  Negative array index -2
+stack_e.p4(27): [--Werror=type-error] error: Negative array index -2
         h c = stack[-2];
                      ^
-stack_e.p4(28): [--Werror=legacy] error:  Array index 6 larger or equal to array size 5
+stack_e.p4(28): [--Werror=type-error] error: Array index 6 larger or equal to array size 5
         h d = stack[6];
                     ^
 stack_e.p4(22)

--- a/testdata/p4_16_errors_outputs/stack_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack_e.p4-stderr
@@ -1,13 +1,13 @@
 stack_e.p4(23): error: Header stack struct s[] used with non-header type struct s
         s[5] stack1; // non-header illegal in header stack
         ^^^^
-stack_e.p4(26): error: Index too large: 1231092310293
+stack_e.p4(26): [--Werror=legacy] error:  Index too large: 1231092310293
         h b = stack[1231092310293];
                     ^^^^^^^^^^^^^
-stack_e.p4(27): error: Negative array index -2
+stack_e.p4(27): [--Werror=legacy] error:  Negative array index -2
         h c = stack[-2];
                      ^
-stack_e.p4(28): error: Array index 6 larger or equal to array size 5
+stack_e.p4(28): [--Werror=legacy] error:  Array index 6 larger or equal to array size 5
         h d = stack[6];
                     ^
 stack_e.p4(22)

--- a/testdata/p4_16_errors_outputs/struct_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/struct_e.p4-stderr
@@ -1,10 +1,10 @@
-struct_e.p4(16): error: Structure struct s does not have a field data
+struct_e.p4(16): [--Werror=legacy] error:  Structure struct s does not have a field data
 struct s {}
        ^
 struct_e.p4(24)
         v.data = 1w0; // no such field
           ^^^^
-struct_e.p4(25): error: Cannot extract field data from b which has type bit<1>
+struct_e.p4(25): [--Werror=legacy] error:  Cannot extract field data from b which has type bit<1>
         b.data = 5; // no such field
           ^^^^
 struct_e.p4(25)

--- a/testdata/p4_16_errors_outputs/struct_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/struct_e.p4-stderr
@@ -1,9 +1,9 @@
-struct_e.p4(16): [--Werror=type-error] error: Structure struct s does not have a field data
-struct s {}
-       ^
-struct_e.p4(24)
+struct_e.p4(24): [--Werror=type-error] error: Field data is not a member of structure struct s
         v.data = 1w0; // no such field
           ^^^^
+struct_e.p4(16)
+struct s {}
+       ^
 struct_e.p4(25): [--Werror=type-error] error: Cannot extract field data from b which has type bit<1>
         b.data = 5; // no such field
           ^^^^

--- a/testdata/p4_16_errors_outputs/struct_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/struct_e.p4-stderr
@@ -1,10 +1,10 @@
-struct_e.p4(16): [--Werror=legacy] error:  Structure struct s does not have a field data
+struct_e.p4(16): [--Werror=type-error] error: Structure struct s does not have a field data
 struct s {}
        ^
 struct_e.p4(24)
         v.data = 1w0; // no such field
           ^^^^
-struct_e.p4(25): [--Werror=legacy] error:  Cannot extract field data from b which has type bit<1>
+struct_e.p4(25): [--Werror=type-error] error: Cannot extract field data from b which has type bit<1>
         b.data = 5; // no such field
           ^^^^
 struct_e.p4(25)

--- a/testdata/p4_16_errors_outputs/table-entries-decl-order.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-decl-order.p4-stderr
@@ -1,4 +1,4 @@
-table-entries-decl-order.p4(56): error: EntriesList: Entries list must be after table key Key
+table-entries-decl-order.p4(56): [--Werror=type-error] error: EntriesList: Entries list must be after table key Key
         const entries = {
               ^^^^^^^
 table-entries-decl-order.p4(63)

--- a/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-exact.p4(72): error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-exact.p4(72): [--Werror=legacy] error:  Entry: Cannot match tuples with different sizes 1 vs 2
             (0x1111 &&& 0xF, 0x1 ) : a(); // invalid exact key
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-exact.p4(72): [--Werror=legacy] error:  Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-exact.p4(72): [--Werror=legacy] error: Entry: Cannot match tuples with different sizes 1 vs 2
             (0x1111 &&& 0xF, 0x1 ) : a(); // invalid exact key
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-lpm.p4(72): [--Werror=legacy] error:  Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-lpm.p4(72): [--Werror=legacy] error: Entry: Cannot match tuples with different sizes 1 vs 2
             (0x1, 0x11 &&& 0xF0): a(); // invalid keyset
             ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-lpm.p4(72): error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-lpm.p4(72): [--Werror=legacy] error:  Entry: Cannot match tuples with different sizes 1 vs 2
             (0x1, 0x11 &&& 0xF0): a(); // invalid keyset
             ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-non-const.p4(68): error: EntriesList: table initializers must be constant
+table-entries-non-const.p4(68): [--Werror=legacy] error:  EntriesList: table initializers must be constant
         entries = {
         ^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-non-const.p4(68): [--Werror=legacy] error:  EntriesList: table initializers must be constant
+table-entries-non-const.p4(68): [--Werror=legacy] error: EntriesList: table initializers must be constant
         entries = {
         ^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-range.p4(71): error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-range.p4(71): [--Werror=legacy] error:  Entry: Cannot match tuples with different sizes 1 vs 2
             (0x18, 0xF) : a_with_control_params(24); // not a range
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-range.p4(71): [--Werror=legacy] error:  Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-range.p4(71): [--Werror=legacy] error: Entry: Cannot match tuples with different sizes 1 vs 2
             (0x18, 0xF) : a_with_control_params(24); // not a range
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-ternary.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-ternary.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-ternary.p4(76): error: Could not find declaration for missing_a
+table-entries-ternary.p4(76): [--Werror=not-found] error: missing_a: Not found declaration
             0x1111 : missing_a(); // action not in action list
                      ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/template_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/template_e.p4-stderr
@@ -1,4 +1,4 @@
-template_e.p4(16): [--Werror=legacy] error:  T: Duplicates declaration T
+template_e.p4(16): [--Werror=legacy] error: T: Duplicates declaration T
 package S<T, T
              ^
 template_e.p4(16)

--- a/testdata/p4_16_errors_outputs/template_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/template_e.p4-stderr
@@ -1,4 +1,4 @@
-template_e.p4(16): error: T: Duplicates declaration T
+template_e.p4(16): [--Werror=legacy] error:  T: Duplicates declaration T
 package S<T, T
              ^
 template_e.p4(16)

--- a/testdata/p4_16_errors_outputs/tuple-to-header.p4-stderr
+++ b/testdata/p4_16_errors_outputs/tuple-to-header.p4-stderr
@@ -1,4 +1,4 @@
-tuple-to-header.p4(23): error: AssignmentStatement: Cannot assign a Tuple(1) to a header H
+tuple-to-header.p4(23): [--Werror=legacy] error:  AssignmentStatement: Cannot assign a Tuple(1) to a header H
         h = t; // illegal assignment between tuple and header
           ^
 tuple-to-header.p4(20)

--- a/testdata/p4_16_errors_outputs/tuple-to-header.p4-stderr
+++ b/testdata/p4_16_errors_outputs/tuple-to-header.p4-stderr
@@ -1,4 +1,4 @@
-tuple-to-header.p4(23): [--Werror=legacy] error:  AssignmentStatement: Cannot assign a Tuple(1) to a header H
+tuple-to-header.p4(23): [--Werror=type-error] error: AssignmentStatement: Cannot assign a Tuple(1) to a header H
         h = t; // illegal assignment between tuple and header
           ^
 tuple-to-header.p4(20)

--- a/testdata/p4_16_errors_outputs/twovarbit.p4-stderr
+++ b/testdata/p4_16_errors_outputs/twovarbit.p4-stderr
@@ -1,10 +1,4 @@
-twovarbit.p4(2): error: x and u: multiple varbit fields in a header
-    varbit<120> x;
-                ^
-twovarbit.p4(3)
-    varbit<120> u;
-                ^
-twovarbit.p4(2): error: x and u: multiple varbit fields in a header
+twovarbit.p4(2): [--Werror=legacy] error:  x and u: multiple varbit fields in a header
     varbit<120> x;
                 ^
 twovarbit.p4(3)

--- a/testdata/p4_16_errors_outputs/twovarbit.p4-stderr
+++ b/testdata/p4_16_errors_outputs/twovarbit.p4-stderr
@@ -1,4 +1,4 @@
-twovarbit.p4(2): [--Werror=legacy] error:  x and u: multiple varbit fields in a header
+twovarbit.p4(2): [--Werror=type-error] error: x and u: multiple varbit fields in a header
     varbit<120> x;
                 ^
 twovarbit.p4(3)

--- a/testdata/p4_16_errors_outputs/type-field.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-field.p4-stderr
@@ -1,4 +1,4 @@
-type-field.p4(59): [--Werror=legacy] error:  Cannot extract field d from h which has type Type(struct h)
+type-field.p4(59): [--Werror=type-error] error: Cannot extract field d from h which has type Type(struct h)
     b.emit(h.d);
              ^
 type-field.p4(59)

--- a/testdata/p4_16_errors_outputs/type-field.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-field.p4-stderr
@@ -1,4 +1,4 @@
-type-field.p4(59): error: Cannot extract field d from h which has type Type(struct h)
+type-field.p4(59): [--Werror=legacy] error:  Cannot extract field d from h which has type Type(struct h)
     b.emit(h.d);
              ^
 type-field.p4(59)

--- a/testdata/p4_16_errors_outputs/type-params_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-params_e.p4-stderr
@@ -1,3 +1,3 @@
-type-params_e.p4(18): error: Could not find declaration for D
+type-params_e.p4(18): [--Werror=not-found] error: D: Not found declaration
 package m(p<D> m);
             ^

--- a/testdata/p4_16_errors_outputs/typecheck1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typecheck1_e.p4-stderr
@@ -1,15 +1,15 @@
-typecheck1_e.p4(27): error: Cannot apply ~ to value d of type bool
+typecheck1_e.p4(27): [--Werror=type-error] error: Cannot apply ~ to value d of type bool
         d = ~d;
              ^
-typecheck1_e.p4(32): error: +: cannot be applied to d of type bool
+typecheck1_e.p4(32): [--Werror=type-error] error: +: cannot be applied to d of type bool
         d = d + d;
             ^
-typecheck1_e.p4(33): error: -: cannot be applied to d of type bool
+typecheck1_e.p4(33): [--Werror=type-error] error: -: cannot be applied to d of type bool
         d = d - d;
             ^
-typecheck1_e.p4(35): error: Cannot apply ! to value a of type bit<32>
+typecheck1_e.p4(35): [--Werror=type-error] error: Cannot apply ! to value a of type bit<32>
         a = !a;
              ^
-typecheck1_e.p4(36): error: Cannot apply ! to value b of type int<32>
+typecheck1_e.p4(36): [--Werror=type-error] error: Cannot apply ! to value b of type int<32>
         b = !b;
              ^

--- a/testdata/p4_16_errors_outputs/typecheck_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typecheck_e.p4-stderr
@@ -1,3 +1,3 @@
-typecheck_e.p4(21): [--Werror=legacy] error:  f: Cannot unify T to int<32>
+typecheck_e.p4(21): [--Werror=legacy] error: f: Cannot unify T to int<32>
         f(x);
         ^^^^

--- a/testdata/p4_16_errors_outputs/typecheck_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typecheck_e.p4-stderr
@@ -1,3 +1,3 @@
-typecheck_e.p4(21): error: f: Cannot unify T to int<32>
+typecheck_e.p4(21): [--Werror=legacy] error:  f: Cannot unify T to int<32>
         f(x);
         ^^^^

--- a/testdata/p4_16_errors_outputs/virtual1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual1.p4-stderr
@@ -1,6 +1,6 @@
-virtual1.p4(23): [--Werror=legacy] error:  return +: Cannot unify bit<16> to bool
+virtual1.p4(23): [--Werror=legacy] error: return +: Cannot unify bit<16> to bool
             return (ix + 1);
             ^^^^^^
-virtual1.p4(21): [--Werror=legacy] error:  cntr: Cannot unify bool to bit<16>
+virtual1.p4(21): [--Werror=legacy] error: cntr: Cannot unify bool to bit<16>
     Virtual() cntr = {
               ^^^^

--- a/testdata/p4_16_errors_outputs/virtual1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual1.p4-stderr
@@ -1,6 +1,6 @@
-virtual1.p4(23): error: return +: Cannot unify bit<16> to bool
+virtual1.p4(23): [--Werror=legacy] error:  return +: Cannot unify bit<16> to bool
             return (ix + 1);
             ^^^^^^
-virtual1.p4(21): error: cntr: Cannot unify bool to bit<16>
+virtual1.p4(21): [--Werror=legacy] error:  cntr: Cannot unify bool to bit<16>
     Virtual() cntr = {
               ^^^^

--- a/testdata/p4_16_errors_outputs/virtual2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual2.p4-stderr
@@ -1,6 +1,6 @@
 virtual2.p4(23): error: return +: return expression in function with void return
             return (ix + 1);
             ^^^^^^
-virtual2.p4(21): error: cntr: Cannot unify void to bit<16>
+virtual2.p4(21): [--Werror=legacy] error:  cntr: Cannot unify void to bit<16>
     Virtual() cntr = {
               ^^^^

--- a/testdata/p4_16_errors_outputs/virtual2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual2.p4-stderr
@@ -1,6 +1,6 @@
-virtual2.p4(23): error: return +: return expression in function with void return
+virtual2.p4(23): [--Werror=type-error] error: return +: return expression in function with void return
             return (ix + 1);
             ^^^^^^
-virtual2.p4(21): [--Werror=legacy] error:  cntr: Cannot unify void to bit<16>
+virtual2.p4(21): [--Werror=legacy] error: cntr: Cannot unify void to bit<16>
     Virtual() cntr = {
               ^^^^

--- a/testdata/p4_16_errors_outputs/virtual3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual3.p4-stderr
@@ -1,3 +1,3 @@
-virtual3.p4(24): error: return : return with no expression in a function returning bit<16>
+virtual3.p4(24): [--Werror=type-error] error: return : return with no expression in a function returning bit<16>
             return;
             ^^^^^^

--- a/testdata/p4_16_errors_outputs/virtual4.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual4.p4-stderr
@@ -1,4 +1,4 @@
-virtual4.p4(22): [--Werror=legacy] error:  g: no matching abstract method in Virtual
+virtual4.p4(22): [--Werror=type-error] error: g: no matching abstract method in Virtual
         bit<16> g(in bit<16> ix) {
                 ^
 virtual4.p4(16)

--- a/testdata/p4_16_errors_outputs/virtual4.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual4.p4-stderr
@@ -1,4 +1,4 @@
-virtual4.p4(22): error: g: no matching abstract method in Virtual
+virtual4.p4(22): [--Werror=legacy] error:  g: no matching abstract method in Virtual
         bit<16> g(in bit<16> ix) {
                 ^
 virtual4.p4(16)

--- a/testdata/p4_16_errors_outputs/virtual5.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual5.p4-stderr
@@ -1,4 +1,4 @@
-virtual5.p4(25): error: g: no matching abstract method in Virtual
+virtual5.p4(25): [--Werror=legacy] error:  g: no matching abstract method in Virtual
         bit<16> g() { return 0; }
                 ^
 virtual5.p4(16)

--- a/testdata/p4_16_errors_outputs/virtual5.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual5.p4-stderr
@@ -1,4 +1,4 @@
-virtual5.p4(25): [--Werror=legacy] error:  g: no matching abstract method in Virtual
+virtual5.p4(25): [--Werror=type-error] error: g: no matching abstract method in Virtual
         bit<16> g() { return 0; }
                 ^
 virtual5.p4(16)

--- a/testdata/p4_16_errors_outputs/virtual6.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual6.p4-stderr
@@ -1,4 +1,4 @@
-virtual6.p4(22): [--Werror=legacy] error:  cntr: g abstract method not implemented
+virtual6.p4(22): [--Werror=type-error] error: cntr: g abstract method not implemented
     Virtual() cntr = {
               ^^^^
 virtual6.p4(18)

--- a/testdata/p4_16_errors_outputs/virtual6.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual6.p4-stderr
@@ -1,4 +1,4 @@
-virtual6.p4(22): error: cntr: g abstract method not implemented
+virtual6.p4(22): [--Werror=legacy] error:  cntr: g abstract method not implemented
     Virtual() cntr = {
               ^^^^
 virtual6.p4(18)

--- a/testdata/p4_16_errors_outputs/width1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/width1_e.p4-stderr
@@ -1,9 +1,9 @@
-width1_e.p4(16): warning: 4294967295: signed value does not fit in 32 bits
+width1_e.p4(16): [--Wwarn=overflow] warning: 4294967295: 4294967295: signed value does not fit in 32 bits
 const int<32> c1 = 0xFFFFFFFF;
                    ^^^^^^^^^^
-width1_e.p4(17): error: int<-2>: Illegal type size
+width1_e.p4(17): [--Werror=invalid] error: int<-2>: Invalid type size
 const int<(c1 + c1)> c2 = 0;
       ^^^^^^^^^^^^^^
-width1_e.p4(18): error: int<-3>: Illegal type size
+width1_e.p4(18): [--Werror=invalid] error: int<-3>: Invalid type size
 const int<(-3)> c3 = 0;
       ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/width1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/width1_e.p4-stderr
@@ -1,4 +1,4 @@
-width1_e.p4(16): [--Wwarn=overflow] warning: 4294967295: 4294967295: signed value does not fit in 32 bits
+width1_e.p4(16): [--Wwarn=overflow] warning: 4294967295: signed value does not fit in 32 bits
 const int<32> c1 = 0xFFFFFFFF;
                    ^^^^^^^^^^
 width1_e.p4(17): [--Werror=invalid] error: int<-2>: Invalid type size

--- a/testdata/p4_16_errors_outputs/width_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/width_e.p4-stderr
@@ -1,4 +1,4 @@
-width_e.p4(16): error: 12301923123132: Value too large for int
+width_e.p4(16): [--Werror=legacy] error:  12301923123132: Value too large for int
 const bit<12301923123132>
           ^^^^^^^^^^^^^^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/width_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/width_e.p4-stderr
@@ -1,4 +1,4 @@
-width_e.p4(16): [--Werror=legacy] error:  12301923123132: Value too large for int
+width_e.p4(16): [--Werror=legacy] error: 12301923123132: Value too large for int
 const bit<12301923123132>
           ^^^^^^^^^^^^^^
 error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-action_selector_unused-bmv2.p4(20): [--Wwarn=unused] warning: as: as: unused instance
+action_selector_unused-bmv2.p4(20): [--Wwarn=unused] warning: as: unused instance
     action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
                                                              ^^

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-action_selector_unused-bmv2.p4(20): warning: as: unused instance
+action_selector_unused-bmv2.p4(20): [--Wwarn=unused] warning: as: as: unused instance
     action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
                                                              ^^

--- a/testdata/p4_16_samples_outputs/bfd_offload.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bfd_offload.p4-stderr
@@ -1,4 +1,4 @@
-bfd_offload.p4(29): warning: bfd_session_liveness_tracker: unused instance
+bfd_offload.p4(29): [--Wwarn=unused] warning: bfd_session_liveness_tracker: bfd_session_liveness_tracker: unused instance
 BFD_Offload(32768) bfd_session_liveness_tracker = {
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/bfd_offload.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bfd_offload.p4-stderr
@@ -1,4 +1,4 @@
-bfd_offload.p4(29): [--Wwarn=unused] warning: bfd_session_liveness_tracker: bfd_session_liveness_tracker: unused instance
+bfd_offload.p4(29): [--Wwarn=unused] warning: bfd_session_liveness_tracker: unused instance
 BFD_Offload(32768) bfd_session_liveness_tracker = {
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/cases.p4-stderr
+++ b/testdata/p4_16_samples_outputs/cases.p4-stderr
@@ -1,4 +1,4 @@
-cases.p4(31): warning: SwitchCase: fallthrough with no statement
+cases.p4(31): [--Wwarn=missing] warning: SwitchCase: SwitchCase: fallthrough with no statement
             c:
             ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/cases.p4-stderr
+++ b/testdata/p4_16_samples_outputs/cases.p4-stderr
@@ -1,4 +1,4 @@
-cases.p4(31): [--Wwarn=missing] warning: SwitchCase: SwitchCase: fallthrough with no statement
+cases.p4(31): [--Wwarn=missing] warning: SwitchCase: fallthrough with no statement
             c:
             ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/const.p4-stderr
+++ b/testdata/p4_16_samples_outputs/const.p4-stderr
@@ -1,4 +1,4 @@
-const.p4(19): warning: 48057234611961600: value does not fit in 48 bits
+const.p4(19): [--Wwarn=mismatch] warning: 48057234611961600: value does not fit in 48 bits
 const bit<48> tooLarge = 48w0xAA_BB_CC_DD_EE_FF_00
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/constant_folding.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constant_folding.p4-stderr
@@ -1,4 +1,4 @@
-constant_folding.p4(95): [--Wwarn=overflow] warning: <<: <<: Shifting 8-bit value with 9
+constant_folding.p4(95): [--Wwarn=overflow] warning: <<: Shifting 8-bit value with 9
         z = 8w1 << 9;
             ^^^^^^^^
 constant_folding.p4(95): [--Wwarn=mismatch] warning: 512: value does not fit in 8 bits

--- a/testdata/p4_16_samples_outputs/constant_folding.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constant_folding.p4-stderr
@@ -1,15 +1,15 @@
-constant_folding.p4(95): warning: <<: Shifting 8-bit value with 9
+constant_folding.p4(95): [--Wwarn=overflow] warning: <<: <<: Shifting 8-bit value with 9
         z = 8w1 << 9;
             ^^^^^^^^
-constant_folding.p4(95): warning: 512: value does not fit in 8 bits
+constant_folding.p4(95): [--Wwarn=mismatch] warning: 512: value does not fit in 8 bits
         z = 8w1 << 9;
             ^^^^^^^^
-constant_folding.p4(88): warning: 256: value does not fit in 8 bits
+constant_folding.p4(88): [--Wwarn=mismatch] warning: 256: value does not fit in 8 bits
         z = 128 + 128;
             ^^^^^^^^^
-constant_folding.p4(91): warning: -128: negative value with unsigned type
+constant_folding.p4(91): [--Wwarn=mismatch] warning: -128: negative value with unsigned type
         z = 0 - 128;
             ^^^^^^^
-constant_folding.p4(94): warning: 512: value does not fit in 8 bits
+constant_folding.p4(94): [--Wwarn=mismatch] warning: 512: value does not fit in 8 bits
         z = 1 << 9;
             ^^^^^^

--- a/testdata/p4_16_samples_outputs/constsigned.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constsigned.p4-stderr
@@ -1,46 +1,46 @@
-constsigned.p4(37): [--Wwarn=overflow] warning: 128: 128: signed value does not fit in 8 bits
+constsigned.p4(37): [--Wwarn=overflow] warning: 128: signed value does not fit in 8 bits
 const int<8> e0 = -8s128
                    ^^^^^
-constsigned.p4(38): [--Wwarn=overflow] warning: 129: 129: signed value does not fit in 8 bits
+constsigned.p4(38): [--Wwarn=overflow] warning: 129: signed value does not fit in 8 bits
 const int<8> f0 = -8s129
                    ^^^^^
-constsigned.p4(39): [--Wwarn=overflow] warning: 255: 255: signed value does not fit in 8 bits
+constsigned.p4(39): [--Wwarn=overflow] warning: 255: signed value does not fit in 8 bits
 const int<8> g0 = -8s255
                    ^^^^^
-constsigned.p4(40): [--Wwarn=overflow] warning: 256: 256: signed value does not fit in 8 bits
+constsigned.p4(40): [--Wwarn=overflow] warning: 256: signed value does not fit in 8 bits
 const int<8> h0 = -8s256
                    ^^^^^
-constsigned.p4(44): [--Wwarn=overflow] warning: 128: 128: signed value does not fit in 8 bits
+constsigned.p4(44): [--Wwarn=overflow] warning: 128: signed value does not fit in 8 bits
 const int<8> l0 = 8s128
                   ^^^^^
-constsigned.p4(45): [--Wwarn=overflow] warning: 129: 129: signed value does not fit in 8 bits
+constsigned.p4(45): [--Wwarn=overflow] warning: 129: signed value does not fit in 8 bits
 const int<8> m0 = 8s129
                   ^^^^^
-constsigned.p4(46): [--Wwarn=overflow] warning: 255: 255: signed value does not fit in 8 bits
+constsigned.p4(46): [--Wwarn=overflow] warning: 255: signed value does not fit in 8 bits
 const int<8> n0 = 8s255
                   ^^^^^
-constsigned.p4(47): [--Wwarn=overflow] warning: 256: 256: signed value does not fit in 8 bits
+constsigned.p4(47): [--Wwarn=overflow] warning: 256: signed value does not fit in 8 bits
 const int<8> o0 = 8s256
                   ^^^^^
-constsigned.p4(22): [--Wwarn=overflow] warning: -129: -129: signed value does not fit in 8 bits
+constsigned.p4(22): [--Wwarn=overflow] warning: -129: signed value does not fit in 8 bits
 const int<8> f = -129;
                   ^^^
-constsigned.p4(23): [--Wwarn=overflow] warning: -255: -255: signed value does not fit in 8 bits
+constsigned.p4(23): [--Wwarn=overflow] warning: -255: signed value does not fit in 8 bits
 const int<8> g = -255;
                   ^^^
-constsigned.p4(24): [--Wwarn=overflow] warning: -256: -256: signed value does not fit in 8 bits
+constsigned.p4(24): [--Wwarn=overflow] warning: -256: signed value does not fit in 8 bits
 const int<8> h = -256;
                   ^^^
-constsigned.p4(28): [--Wwarn=overflow] warning: 128: 128: signed value does not fit in 8 bits
+constsigned.p4(28): [--Wwarn=overflow] warning: 128: signed value does not fit in 8 bits
 const int<8> l = 128;
                  ^^^
-constsigned.p4(29): [--Wwarn=overflow] warning: 129: 129: signed value does not fit in 8 bits
+constsigned.p4(29): [--Wwarn=overflow] warning: 129: signed value does not fit in 8 bits
 const int<8> m = 129;
                  ^^^
-constsigned.p4(30): [--Wwarn=overflow] warning: 255: 255: signed value does not fit in 8 bits
+constsigned.p4(30): [--Wwarn=overflow] warning: 255: signed value does not fit in 8 bits
 const int<8> n = 255;
                  ^^^
-constsigned.p4(31): [--Wwarn=overflow] warning: 256: 256: signed value does not fit in 8 bits
+constsigned.p4(31): [--Wwarn=overflow] warning: 256: signed value does not fit in 8 bits
 const int<8> o = 256;
                  ^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/constsigned.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constsigned.p4-stderr
@@ -1,46 +1,46 @@
-constsigned.p4(37): warning: 128: signed value does not fit in 8 bits
+constsigned.p4(37): [--Wwarn=overflow] warning: 128: 128: signed value does not fit in 8 bits
 const int<8> e0 = -8s128
                    ^^^^^
-constsigned.p4(38): warning: 129: signed value does not fit in 8 bits
+constsigned.p4(38): [--Wwarn=overflow] warning: 129: 129: signed value does not fit in 8 bits
 const int<8> f0 = -8s129
                    ^^^^^
-constsigned.p4(39): warning: 255: signed value does not fit in 8 bits
+constsigned.p4(39): [--Wwarn=overflow] warning: 255: 255: signed value does not fit in 8 bits
 const int<8> g0 = -8s255
                    ^^^^^
-constsigned.p4(40): warning: 256: signed value does not fit in 8 bits
+constsigned.p4(40): [--Wwarn=overflow] warning: 256: 256: signed value does not fit in 8 bits
 const int<8> h0 = -8s256
                    ^^^^^
-constsigned.p4(44): warning: 128: signed value does not fit in 8 bits
+constsigned.p4(44): [--Wwarn=overflow] warning: 128: 128: signed value does not fit in 8 bits
 const int<8> l0 = 8s128
                   ^^^^^
-constsigned.p4(45): warning: 129: signed value does not fit in 8 bits
+constsigned.p4(45): [--Wwarn=overflow] warning: 129: 129: signed value does not fit in 8 bits
 const int<8> m0 = 8s129
                   ^^^^^
-constsigned.p4(46): warning: 255: signed value does not fit in 8 bits
+constsigned.p4(46): [--Wwarn=overflow] warning: 255: 255: signed value does not fit in 8 bits
 const int<8> n0 = 8s255
                   ^^^^^
-constsigned.p4(47): warning: 256: signed value does not fit in 8 bits
+constsigned.p4(47): [--Wwarn=overflow] warning: 256: 256: signed value does not fit in 8 bits
 const int<8> o0 = 8s256
                   ^^^^^
-constsigned.p4(22): warning: -129: signed value does not fit in 8 bits
+constsigned.p4(22): [--Wwarn=overflow] warning: -129: -129: signed value does not fit in 8 bits
 const int<8> f = -129;
                   ^^^
-constsigned.p4(23): warning: -255: signed value does not fit in 8 bits
+constsigned.p4(23): [--Wwarn=overflow] warning: -255: -255: signed value does not fit in 8 bits
 const int<8> g = -255;
                   ^^^
-constsigned.p4(24): warning: -256: signed value does not fit in 8 bits
+constsigned.p4(24): [--Wwarn=overflow] warning: -256: -256: signed value does not fit in 8 bits
 const int<8> h = -256;
                   ^^^
-constsigned.p4(28): warning: 128: signed value does not fit in 8 bits
+constsigned.p4(28): [--Wwarn=overflow] warning: 128: 128: signed value does not fit in 8 bits
 const int<8> l = 128;
                  ^^^
-constsigned.p4(29): warning: 129: signed value does not fit in 8 bits
+constsigned.p4(29): [--Wwarn=overflow] warning: 129: 129: signed value does not fit in 8 bits
 const int<8> m = 129;
                  ^^^
-constsigned.p4(30): warning: 255: signed value does not fit in 8 bits
+constsigned.p4(30): [--Wwarn=overflow] warning: 255: 255: signed value does not fit in 8 bits
 const int<8> n = 255;
                  ^^^
-constsigned.p4(31): warning: 256: signed value does not fit in 8 bits
+constsigned.p4(31): [--Wwarn=overflow] warning: 256: 256: signed value does not fit in 8 bits
 const int<8> o = 256;
                  ^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/decl.p4-stderr
+++ b/testdata/p4_16_samples_outputs/decl.p4-stderr
@@ -1,10 +1,10 @@
-decl.p4(33): [--Wwarn=shadow] warning: y: y shadows y
+decl.p4(33): [--Wwarn=shadow] warning: y shadows y
                 bit y;
                 ^^^^^^
 decl.p4(30)
             bit y;
             ^^^^^^
-decl.p4(37): [--Wwarn=shadow] warning: y: y shadows y
+decl.p4(37): [--Wwarn=shadow] warning: y shadows y
                     bit y;
                     ^^^^^^
 decl.p4(33)

--- a/testdata/p4_16_samples_outputs/decl.p4-stderr
+++ b/testdata/p4_16_samples_outputs/decl.p4-stderr
@@ -1,10 +1,10 @@
-decl.p4(33): warning: y shadows y
+decl.p4(33): [--Wwarn=shadow] warning: y: y shadows y
                 bit y;
                 ^^^^^^
 decl.p4(30)
             bit y;
             ^^^^^^
-decl.p4(37): warning: y shadows y
+decl.p4(37): [--Wwarn=shadow] warning: y: y shadows y
                     bit y;
                     ^^^^^^
 decl.p4(33)

--- a/testdata/p4_16_samples_outputs/default-switch.p4-stderr
+++ b/testdata/p4_16_samples_outputs/default-switch.p4-stderr
@@ -1,4 +1,4 @@
-default-switch.p4(13): warning: SwitchCase: label following default label
+default-switch.p4(13): [--Wwarn=ordering] warning: SwitchCase: SwitchCase: label following default label
             b: { return; }
             ^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/default-switch.p4-stderr
+++ b/testdata/p4_16_samples_outputs/default-switch.p4-stderr
@@ -1,4 +1,4 @@
-default-switch.p4(13): [--Wwarn=ordering] warning: SwitchCase: SwitchCase: label following default label
+default-switch.p4(13): [--Wwarn=ordering] warning: SwitchCase: label following default label
             b: { return; }
             ^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/default2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/default2.p4-stderr
@@ -1,6 +1,6 @@
-default2.p4(28): warning: SelectCase: unreachable
+default2.p4(28): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable
             default: reject;
             ^^^^^^^^^^^^^^^
-default2.p4(26): warning: ListExpression: transition does not depend on select argument
+default2.p4(26): [--Wwarn=parser-transition] warning: ListExpression: ListExpression: transition does not depend on select argument
         transition select(h.data) {
                           ^^^^^^

--- a/testdata/p4_16_samples_outputs/default2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/default2.p4-stderr
@@ -1,6 +1,6 @@
-default2.p4(28): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable
+default2.p4(28): [--Wwarn=parser-transition] warning: SelectCase: unreachable
             default: reject;
             ^^^^^^^^^^^^^^^
-default2.p4(26): [--Wwarn=parser-transition] warning: ListExpression: ListExpression: transition does not depend on select argument
+default2.p4(26): [--Wwarn=parser-transition] warning: ListExpression: transition does not depend on select argument
         transition select(h.data) {
                           ^^^^^^

--- a/testdata/p4_16_samples_outputs/fold_match.p4-stderr
+++ b/testdata/p4_16_samples_outputs/fold_match.p4-stderr
@@ -1,49 +1,49 @@
-fold_match.p4(25): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(25): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(35): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(35): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-fold_match.p4(44): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(44): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-fold_match.p4(45): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(45): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(54): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(54): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-fold_match.p4(55): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(55): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(64): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(64): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-fold_match.p4(65): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(65): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(75): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(75): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-fold_match.p4(84): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(84): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-fold_match.p4(85): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(85): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(94): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(94): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-fold_match.p4(95): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(95): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(104): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(104): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-fold_match.p4(105): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+fold_match.p4(105): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(111): [--Wwarn=parser-transition] warning: SelectExpression: SelectExpression: no case matches
+fold_match.p4(111): [--Wwarn=parser-transition] warning: SelectExpression: no case matches
         transition select(32w0)
                    ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/fold_match.p4-stderr
+++ b/testdata/p4_16_samples_outputs/fold_match.p4-stderr
@@ -1,49 +1,49 @@
-fold_match.p4(25): warning: SelectCase: unreachable case
+fold_match.p4(25): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(35): warning: SelectCase: unreachable case
+fold_match.p4(35): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-fold_match.p4(44): warning: SelectCase: unreachable case
+fold_match.p4(44): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-fold_match.p4(45): warning: SelectCase: unreachable case
+fold_match.p4(45): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(54): warning: SelectCase: unreachable case
+fold_match.p4(54): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-fold_match.p4(55): warning: SelectCase: unreachable case
+fold_match.p4(55): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(64): warning: SelectCase: unreachable case
+fold_match.p4(64): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             32w0 : reject;
             ^^^^^^^^^^^^^
-fold_match.p4(65): warning: SelectCase: unreachable case
+fold_match.p4(65): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(75): warning: SelectCase: unreachable case
+fold_match.p4(75): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-fold_match.p4(84): warning: SelectCase: unreachable case
+fold_match.p4(84): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-fold_match.p4(85): warning: SelectCase: unreachable case
+fold_match.p4(85): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(94): warning: SelectCase: unreachable case
+fold_match.p4(94): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-fold_match.p4(95): warning: SelectCase: unreachable case
+fold_match.p4(95): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(104): warning: SelectCase: unreachable case
+fold_match.p4(104): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             (true, 32w0) : reject;
             ^^^^^^^^^^^^^^^^^^^^^
-fold_match.p4(105): warning: SelectCase: unreachable case
+fold_match.p4(105): [--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
             default : reject;
             ^^^^^^^^^^^^^^^^
-fold_match.p4(111): warning: SelectExpression: no case matches
+fold_match.p4(111): [--Wwarn=parser-transition] warning: SelectExpression: SelectExpression: no case matches
         transition select(32w0)
                    ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/inline.p4-stderr
+++ b/testdata/p4_16_samples_outputs/inline.p4-stderr
@@ -1,4 +1,4 @@
-inline.p4(25): warning: y shadows y
+inline.p4(25): [--Wwarn=shadow] warning: y: y shadows y
     action b(in bit x, out bit y)
                                ^
 inline.p4(17)

--- a/testdata/p4_16_samples_outputs/inline.p4-stderr
+++ b/testdata/p4_16_samples_outputs/inline.p4-stderr
@@ -1,4 +1,4 @@
-inline.p4(25): [--Wwarn=shadow] warning: y: y shadows y
+inline.p4(25): [--Wwarn=shadow] warning: y shadows y
     action b(in bit x, out bit y)
                                ^
 inline.p4(17)

--- a/testdata/p4_16_samples_outputs/interface.p4-stderr
+++ b/testdata/p4_16_samples_outputs/interface.p4-stderr
@@ -1,9 +1,9 @@
-interface.p4(31): [--Wwarn=unused] warning: crc0: crc0: unused instance
+interface.p4(31): [--Wwarn=unused] warning: crc0: unused instance
     Crc16<bit<32>>() crc0;
                      ^^^^
-interface.p4(32): [--Wwarn=unused] warning: crc1: crc1: unused instance
+interface.p4(32): [--Wwarn=unused] warning: crc1: unused instance
     Crc16<int<32>>(32s0) crc1;
                          ^^^^
-interface.p4(33): [--Wwarn=unused] warning: crc2: crc2: unused instance
+interface.p4(33): [--Wwarn=unused] warning: crc2: unused instance
     Crc16<int<32>>() crc2;
                      ^^^^

--- a/testdata/p4_16_samples_outputs/interface.p4-stderr
+++ b/testdata/p4_16_samples_outputs/interface.p4-stderr
@@ -1,9 +1,9 @@
-interface.p4(31): warning: crc0: unused instance
+interface.p4(31): [--Wwarn=unused] warning: crc0: crc0: unused instance
     Crc16<bit<32>>() crc0;
                      ^^^^
-interface.p4(32): warning: crc1: unused instance
+interface.p4(32): [--Wwarn=unused] warning: crc1: crc1: unused instance
     Crc16<int<32>>(32s0) crc1;
                          ^^^^
-interface.p4(33): warning: crc2: unused instance
+interface.p4(33): [--Wwarn=unused] warning: crc2: crc2: unused instance
     Crc16<int<32>>() crc2;
                      ^^^^

--- a/testdata/p4_16_samples_outputs/interface1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/interface1.p4-stderr
@@ -1,6 +1,6 @@
-interface1.p4(24): warning: x: unused instance
+interface1.p4(24): [--Wwarn=unused] warning: x: x: unused instance
     X<int<32>>() x;
                  ^
-interface1.p4(25): warning: y: unused instance
+interface1.p4(25): [--Wwarn=unused] warning: y: y: unused instance
     Y() y;
         ^

--- a/testdata/p4_16_samples_outputs/interface1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/interface1.p4-stderr
@@ -1,6 +1,6 @@
-interface1.p4(24): [--Wwarn=unused] warning: x: x: unused instance
+interface1.p4(24): [--Wwarn=unused] warning: x: unused instance
     X<int<32>>() x;
                  ^
-interface1.p4(25): [--Wwarn=unused] warning: y: y: unused instance
+interface1.p4(25): [--Wwarn=unused] warning: y: unused instance
     Y() y;
         ^

--- a/testdata/p4_16_samples_outputs/issue1006.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1006.p4-stderr
@@ -1,6 +1,6 @@
-issue1006.p4(14): [--Wwarn=unused] warning: reg0: reg0: unused instance
+issue1006.p4(14): [--Wwarn=unused] warning: reg0: unused instance
     R<tuple<bit<8>>>({ 1 }) reg0;
                             ^^^^
-issue1006.p4(15): [--Wwarn=unused] warning: reg1: reg1: unused instance
+issue1006.p4(15): [--Wwarn=unused] warning: reg1: unused instance
     R<foo>({ 1 }) reg1;
                   ^^^^

--- a/testdata/p4_16_samples_outputs/issue1006.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1006.p4-stderr
@@ -1,6 +1,6 @@
-issue1006.p4(14): warning: reg0: unused instance
+issue1006.p4(14): [--Wwarn=unused] warning: reg0: reg0: unused instance
     R<tuple<bit<8>>>({ 1 }) reg0;
                             ^^^^
-issue1006.p4(15): warning: reg1: unused instance
+issue1006.p4(15): [--Wwarn=unused] warning: reg1: reg1: unused instance
     R<foo>({ 1 }) reg1;
                   ^^^^

--- a/testdata/p4_16_samples_outputs/issue1342.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1342.p4-stderr
@@ -1,4 +1,4 @@
-issue1342.p4(3): warning: X shadows X
+issue1342.p4(3): [--Wwarn=shadow] warning: X: X shadows X
 bit f<X>() {
       ^
 issue1342.p4(1)

--- a/testdata/p4_16_samples_outputs/issue1342.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1342.p4-stderr
@@ -1,4 +1,4 @@
-issue1342.p4(3): [--Wwarn=shadow] warning: X: X shadows X
+issue1342.p4(3): [--Wwarn=shadow] warning: X shadows X
 bit f<X>() {
       ^
 issue1342.p4(1)

--- a/testdata/p4_16_samples_outputs/issue1406.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1406.p4-stderr
@@ -1,9 +1,9 @@
-issue1406.p4(17): [--Wwarn=parser-transition] warning: start: start: implicit transition to `reject'
+issue1406.p4(17): [--Wwarn=parser-transition] warning: start: implicit transition to `reject'
   state start {
         ^^^^^
-issue1406.p4(14): [--Wwarn=parser-transition] warning: accept: accept state in parser TestParser is unreachable
+issue1406.p4(14): [--Wwarn=parser-transition] warning: accept state in parser TestParser is unreachable
 parser TestParser(packet_in b, out headers_t headers, inout metadata_t meta,
        ^^^^^^^^^^
-issue1406.p4(14): [--Wwarn=parser-transition] warning: accept: accept state in parser TestParser is unreachable
+issue1406.p4(14): [--Wwarn=parser-transition] warning: accept state in parser TestParser is unreachable
 parser TestParser(packet_in b, out headers_t headers, inout metadata_t meta,
        ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue1406.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1406.p4-stderr
@@ -1,9 +1,9 @@
-issue1406.p4(17): warning: start: implicit transition to `reject'
+issue1406.p4(17): [--Wwarn=parser-transition] warning: start: start: implicit transition to `reject'
   state start {
         ^^^^^
-issue1406.p4(14): warning: accept state in parser TestParser is unreachable
+issue1406.p4(14): [--Wwarn=parser-transition] warning: accept: accept state in parser TestParser is unreachable
 parser TestParser(packet_in b, out headers_t headers, inout metadata_t meta,
        ^^^^^^^^^^
-issue1406.p4(14): warning: accept state in parser TestParser is unreachable
+issue1406.p4(14): [--Wwarn=parser-transition] warning: accept: accept state in parser TestParser is unreachable
 parser TestParser(packet_in b, out headers_t headers, inout metadata_t meta,
        ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-issue1409-bmv2.p4(32): warning: f: implicit transition to `reject'
+issue1409-bmv2.p4(32): [--Wwarn=parser-transition] warning: f: f: implicit transition to `reject'
   state f {
         ^

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-issue1409-bmv2.p4(32): [--Wwarn=parser-transition] warning: f: f: implicit transition to `reject'
+issue1409-bmv2.p4(32): [--Wwarn=parser-transition] warning: f: implicit transition to `reject'
   state f {
         ^

--- a/testdata/p4_16_samples_outputs/issue344.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue344.p4-stderr
@@ -1,4 +1,4 @@
-issue344.p4(24): [--Wwarn=unused] warning: c: c: unused instance
+issue344.p4(24): [--Wwarn=unused] warning: c: unused instance
 top(C()) c;
          ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue344.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue344.p4-stderr
@@ -1,4 +1,4 @@
-issue344.p4(24): warning: c: unused instance
+issue344.p4(24): [--Wwarn=unused] warning: c: c: unused instance
 top(C()) c;
          ^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue361-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2.p4-stderr
@@ -1,1 +1,1 @@
-[--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+[--Wwarn=parser-transition] warning: SelectCase: unreachable case

--- a/testdata/p4_16_samples_outputs/issue361-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2.p4-stderr
@@ -1,1 +1,1 @@
-warning: SelectCase: unreachable case
+[--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case

--- a/testdata/p4_16_samples_outputs/issue414-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-issue414-bmv2.p4(64): [--Wwarn=unused] warning: cbar_inst2: cbar_inst2: unused instance
+issue414-bmv2.p4(64): [--Wwarn=unused] warning: cbar_inst2: unused instance
     cBar() cbar_inst2;
            ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue414-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-issue414-bmv2.p4(64): warning: cbar_inst2: unused instance
+issue414-bmv2.p4(64): [--Wwarn=unused] warning: cbar_inst2: cbar_inst2: unused instance
     cBar() cbar_inst2;
            ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-issue430-1-bmv2.p4(44): [--Wwarn=mismatch] warning: digest: Cannot find a good name for digest method call, using auto-generated name 'digest_0'
+issue430-1-bmv2.p4(44): [--Wwarn=mismatch] warning: Cannot find a good name for digest method call, using auto-generated name 'digest_0'
         digest(5, { hdr.ethernet.srcAddr });
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-issue430-1-bmv2.p4(44): warning: Cannot find a good name for digest method call, using auto-generated name 'digest_0'
+issue430-1-bmv2.p4(44): [--Wwarn=mismatch] warning: digest: Cannot find a good name for digest method call, using auto-generated name 'digest_0'
         digest(5, { hdr.ethernet.srcAddr });
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue692-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue692-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-issue692-bmv2.p4(19): warning: parsedHdr.hstack.next: reading uninitialized value
+issue692-bmv2.p4(19): [--Wwarn=uninitialized] warning: parsedHdr.hstack.next: parsedHdr.hstack.next: reading uninitialized value
       transition select(parsedHdr.hstack.next.y) {
                         ^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue692-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue692-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-issue692-bmv2.p4(19): [--Wwarn=uninitialized] warning: parsedHdr.hstack.next: parsedHdr.hstack.next: reading uninitialized value
+issue692-bmv2.p4(19): [--Wwarn=uninitialized] warning: parsedHdr.hstack.next: reading uninitialized value
       transition select(parsedHdr.hstack.next.y) {
                         ^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue754.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue754.p4-stderr
@@ -1,3 +1,3 @@
-issue754.p4(6): warning: 12345: value does not fit in 3 bits
+issue754.p4(6): [--Wwarn=mismatch] warning: 12345: value does not fit in 3 bits
 top(c(12345)) main;
       ^^^^^

--- a/testdata/p4_16_samples_outputs/issue803-2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue803-2.p4-stderr
@@ -1,7 +1,7 @@
-issue803-2.p4(140): warning: ig2: unused instance
+issue803-2.p4(140): [--Wwarn=unused] warning: ig2: ig2: unused instance
     (ing_parse(), ingress(), ing_deparse()) ig2;
                                             ^^^
-issue803-2.p4(144): warning: eg2: unused instance
+issue803-2.p4(144): [--Wwarn=unused] warning: eg2: eg2: unused instance
     (egr_parse(), egress(), egr_deparse()) eg2;
                                            ^^^
 issue803-2.p4(80): [--Wwarn=uninitialized_out_param] warning: out parameter parsed_hdr may be uninitialized when ing_parse terminates

--- a/testdata/p4_16_samples_outputs/issue803-2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue803-2.p4-stderr
@@ -1,7 +1,7 @@
-issue803-2.p4(140): [--Wwarn=unused] warning: ig2: ig2: unused instance
+issue803-2.p4(140): [--Wwarn=unused] warning: ig2: unused instance
     (ing_parse(), ingress(), ing_deparse()) ig2;
                                             ^^^
-issue803-2.p4(144): [--Wwarn=unused] warning: eg2: eg2: unused instance
+issue803-2.p4(144): [--Wwarn=unused] warning: eg2: unused instance
     (egr_parse(), egress(), egr_deparse()) eg2;
                                            ^^^
 issue803-2.p4(80): [--Wwarn=uninitialized_out_param] warning: out parameter parsed_hdr may be uninitialized when ing_parse terminates

--- a/testdata/p4_16_samples_outputs/issue822.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue822.p4-stderr
@@ -1,3 +1,3 @@
-issue822.p4(19): [--Wwarn=unused] warning: action_selector: action_selector: unused instance
+issue822.p4(19): [--Wwarn=unused] warning: action_selector: unused instance
   ActionSelector(r) action_selector;
                     ^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue822.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue822.p4-stderr
@@ -1,3 +1,3 @@
-issue822.p4(19): warning: action_selector: unused instance
+issue822.p4(19): [--Wwarn=unused] warning: action_selector: action_selector: unused instance
   ActionSelector(r) action_selector;
                     ^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue823.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue823.p4-stderr
@@ -1,6 +1,6 @@
-issue823.p4(17): [--Wwarn=parser-transition] warning: accept: accept state in parser MyP2 is unreachable
+issue823.p4(17): [--Wwarn=parser-transition] warning: accept state in parser MyP2 is unreachable
 parser MyP2(packet_in pkt, out headers_t hdr) {
        ^^^^
-issue823.p4(23): [--Wwarn=parser-transition] warning: accept: accept state in parser MyP1 is unreachable
+issue823.p4(23): [--Wwarn=parser-transition] warning: accept state in parser MyP1 is unreachable
 parser MyP1(packet_in pkt, out headers_t hdr) {
        ^^^^

--- a/testdata/p4_16_samples_outputs/issue823.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue823.p4-stderr
@@ -1,6 +1,6 @@
-issue823.p4(17): warning: accept state in parser MyP2 is unreachable
+issue823.p4(17): [--Wwarn=parser-transition] warning: accept: accept state in parser MyP2 is unreachable
 parser MyP2(packet_in pkt, out headers_t hdr) {
        ^^^^
-issue823.p4(23): warning: accept state in parser MyP1 is unreachable
+issue823.p4(23): [--Wwarn=parser-transition] warning: accept: accept state in parser MyP1 is unreachable
 parser MyP1(packet_in pkt, out headers_t hdr) {
        ^^^^

--- a/testdata/p4_16_samples_outputs/issue841.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue841.p4-stderr
@@ -1,4 +1,4 @@
-issue841.p4(39): warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
+issue841.p4(39): [--Wwarn=deprecated] warning: Checksum16: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
     Checksum16() checksum;
     ^^^^^^^^^^
 v1model.p4(150)

--- a/testdata/p4_16_samples_outputs/issue841.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue841.p4-stderr
@@ -1,4 +1,4 @@
-issue841.p4(39): [--Wwarn=deprecated] warning: Checksum16: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
+issue841.p4(39): [--Wwarn=deprecated] warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
     Checksum16() checksum;
     ^^^^^^^^^^
 v1model.p4(150)

--- a/testdata/p4_16_samples_outputs/issue940.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue940.p4-stderr
@@ -1,16 +1,16 @@
-issue940.p4(9): [--Wwarn=deprecated] warning: Checksum16: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
+issue940.p4(9): [--Wwarn=deprecated] warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
 Checksum16() instance;
 ^^^^^^^^^^
 issue940.p4(2)
 extern Checksum16 {
        ^^^^^^^^^^
-issue940.p4(13): [--Wwarn=deprecated] warning: wrong: wrong: Using deprecated feature wrong. Please don't use this function.
+issue940.p4(13): [--Wwarn=deprecated] warning: wrong: Using deprecated feature wrong. Please don't use this function.
         bit<6> x = wrong();
                    ^^^^^
 issue940.p4(7)
 extern bit<6> wrong();
               ^^^^^
-issue940.p4(9): [--Wwarn=unused] warning: instance: instance: unused instance
+issue940.p4(9): [--Wwarn=unused] warning: instance: unused instance
 Checksum16() instance;
              ^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue940.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue940.p4-stderr
@@ -1,16 +1,16 @@
-issue940.p4(9): warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
+issue940.p4(9): [--Wwarn=deprecated] warning: Checksum16: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
 Checksum16() instance;
 ^^^^^^^^^^
 issue940.p4(2)
 extern Checksum16 {
        ^^^^^^^^^^
-issue940.p4(13): warning: wrong: Using deprecated feature wrong. Please don't use this function.
+issue940.p4(13): [--Wwarn=deprecated] warning: wrong: wrong: Using deprecated feature wrong. Please don't use this function.
         bit<6> x = wrong();
                    ^^^^^
 issue940.p4(7)
 extern bit<6> wrong();
               ^^^^^
-issue940.p4(9): warning: instance: unused instance
+issue940.p4(9): [--Wwarn=unused] warning: instance: instance: unused instance
 Checksum16() instance;
              ^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/large.p4-stderr
+++ b/testdata/p4_16_samples_outputs/large.p4-stderr
@@ -1,4 +1,4 @@
-large.p4(17): warning: 103929005307130220006098923584552504982110632080: value does not fit in 128 bits
+large.p4(17): [--Wwarn=mismatch] warning: 103929005307130220006098923584552504982110632080: value does not fit in 128 bits
 const bit<128> large = 0x1234567890123456789012345678901234567890;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/module.p4-stderr
+++ b/testdata/p4_16_samples_outputs/module.p4-stderr
@@ -1,22 +1,22 @@
-module.p4(38): [--Wwarn=unused] warning: main1: main1: unused instance
+module.p4(38): [--Wwarn=unused] warning: main1: unused instance
 switch0(f()) main1;
              ^^^^^
-module.p4(39): [--Wwarn=unused] warning: main3: main3: unused instance
+module.p4(39): [--Wwarn=unused] warning: main3: unused instance
 switch1<bool>(f()) main3;
                    ^^^^^
-module.p4(40): [--Wwarn=unused] warning: main4: main4: unused instance
+module.p4(40): [--Wwarn=unused] warning: main4: unused instance
 switch2(f()) main4;
              ^^^^^
-module.p4(41): [--Wwarn=unused] warning: main5: main5: unused instance
+module.p4(41): [--Wwarn=unused] warning: main5: unused instance
 switch3(f2()) main5;
               ^^^^^
-module.p4(42): [--Wwarn=unused] warning: main6: main6: unused instance
+module.p4(42): [--Wwarn=unused] warning: main6: unused instance
 switch4<bool>(f2()) main6;
                     ^^^^^
-module.p4(43): [--Wwarn=unused] warning: main2: main2: unused instance
+module.p4(43): [--Wwarn=unused] warning: main2: unused instance
 switch1(f()) main2;
              ^^^^^
-module.p4(44): [--Wwarn=unused] warning: main7: main7: unused instance
+module.p4(44): [--Wwarn=unused] warning: main7: unused instance
 switch4(f2()) main7;
               ^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/module.p4-stderr
+++ b/testdata/p4_16_samples_outputs/module.p4-stderr
@@ -1,22 +1,22 @@
-module.p4(38): warning: main1: unused instance
+module.p4(38): [--Wwarn=unused] warning: main1: main1: unused instance
 switch0(f()) main1;
              ^^^^^
-module.p4(39): warning: main3: unused instance
+module.p4(39): [--Wwarn=unused] warning: main3: main3: unused instance
 switch1<bool>(f()) main3;
                    ^^^^^
-module.p4(40): warning: main4: unused instance
+module.p4(40): [--Wwarn=unused] warning: main4: main4: unused instance
 switch2(f()) main4;
              ^^^^^
-module.p4(41): warning: main5: unused instance
+module.p4(41): [--Wwarn=unused] warning: main5: main5: unused instance
 switch3(f2()) main5;
               ^^^^^
-module.p4(42): warning: main6: unused instance
+module.p4(42): [--Wwarn=unused] warning: main6: main6: unused instance
 switch4<bool>(f2()) main6;
                     ^^^^^
-module.p4(43): warning: main2: unused instance
+module.p4(43): [--Wwarn=unused] warning: main2: main2: unused instance
 switch1(f()) main2;
              ^^^^^
-module.p4(44): warning: main7: unused instance
+module.p4(44): [--Wwarn=unused] warning: main7: main7: unused instance
 switch4(f2()) main7;
               ^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/nested-tuple.p4-stderr
+++ b/testdata/p4_16_samples_outputs/nested-tuple.p4-stderr
@@ -1,4 +1,4 @@
-nested-tuple.p4(30): warning: T shadows struct T
+nested-tuple.p4(30): [--Wwarn=shadow] warning: T: T shadows struct T
 extern void f<T>(in T data);
               ^
 nested-tuple.p4(17)

--- a/testdata/p4_16_samples_outputs/nested-tuple.p4-stderr
+++ b/testdata/p4_16_samples_outputs/nested-tuple.p4-stderr
@@ -1,4 +1,4 @@
-nested-tuple.p4(30): [--Wwarn=shadow] warning: T: T shadows struct T
+nested-tuple.p4(30): [--Wwarn=shadow] warning: T shadows struct T
 extern void f<T>(in T data);
               ^
 nested-tuple.p4(17)

--- a/testdata/p4_16_samples_outputs/noMatch.p4-stderr
+++ b/testdata/p4_16_samples_outputs/noMatch.p4-stderr
@@ -1,9 +1,9 @@
-noMatch.p4(20): warning: accept state in parser p is unreachable
+noMatch.p4(20): [--Wwarn=parser-transition] warning: accept: accept state in parser p is unreachable
 parser p() {
        ^
 noMatch.p4(23): [--Wwarn=uninitialized_use] warning: x may be uninitialized
         transition select(x) {
                           ^
-noMatch.p4(20): warning: accept state in parser p is unreachable
+noMatch.p4(20): [--Wwarn=parser-transition] warning: accept: accept state in parser p is unreachable
 parser p() {
        ^

--- a/testdata/p4_16_samples_outputs/noMatch.p4-stderr
+++ b/testdata/p4_16_samples_outputs/noMatch.p4-stderr
@@ -1,9 +1,9 @@
-noMatch.p4(20): [--Wwarn=parser-transition] warning: accept: accept state in parser p is unreachable
+noMatch.p4(20): [--Wwarn=parser-transition] warning: accept state in parser p is unreachable
 parser p() {
        ^
 noMatch.p4(23): [--Wwarn=uninitialized_use] warning: x may be uninitialized
         transition select(x) {
                           ^
-noMatch.p4(20): [--Wwarn=parser-transition] warning: accept: accept state in parser p is unreachable
+noMatch.p4(20): [--Wwarn=parser-transition] warning: accept state in parser p is unreachable
 parser p() {
        ^

--- a/testdata/p4_16_samples_outputs/parser-conditional.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-conditional.p4-stderr
@@ -1,1 +1,1 @@
-[--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case
+[--Wwarn=parser-transition] warning: SelectCase: unreachable case

--- a/testdata/p4_16_samples_outputs/parser-conditional.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-conditional.p4-stderr
@@ -1,1 +1,1 @@
-warning: SelectCase: unreachable case
+[--Wwarn=parser-transition] warning: SelectCase: SelectCase: unreachable case

--- a/testdata/p4_16_samples_outputs/pr1363.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pr1363.p4-stderr
@@ -1,4 +1,4 @@
-pr1363.p4(12): [--Wwarn=shadow] warning: implementation: implementation shadows implementation
+pr1363.p4(12): [--Wwarn=shadow] warning: implementation shadows implementation
     implementation = ActionProfile(32);
     ^^^^^^^^^^^^^^
 pr1363.p4(3)

--- a/testdata/p4_16_samples_outputs/pr1363.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pr1363.p4-stderr
@@ -1,4 +1,4 @@
-pr1363.p4(12): warning: implementation shadows implementation
+pr1363.p4(12): [--Wwarn=shadow] warning: implementation: implementation shadows implementation
     implementation = ActionProfile(32);
     ^^^^^^^^^^^^^^
 pr1363.p4(3)

--- a/testdata/p4_16_samples_outputs/pragma-deprecated.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pragma-deprecated.p4-stderr
@@ -1,16 +1,16 @@
-pragma-deprecated.p4(9): [--Wwarn=deprecated] warning: Checksum16: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
+pragma-deprecated.p4(9): [--Wwarn=deprecated] warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
 Checksum16() instance;
 ^^^^^^^^^^
 pragma-deprecated.p4(2)
 extern Checksum16 {
        ^^^^^^^^^^
-pragma-deprecated.p4(13): [--Wwarn=deprecated] warning: wrong: wrong: Using deprecated feature wrong. Please don't use this function.
+pragma-deprecated.p4(13): [--Wwarn=deprecated] warning: wrong: Using deprecated feature wrong. Please don't use this function.
         bit<6> x = wrong();
                    ^^^^^
 pragma-deprecated.p4(7)
 extern bit<6> wrong();
               ^^^^^
-pragma-deprecated.p4(9): [--Wwarn=unused] warning: instance: instance: unused instance
+pragma-deprecated.p4(9): [--Wwarn=unused] warning: instance: unused instance
 Checksum16() instance;
              ^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/pragma-deprecated.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pragma-deprecated.p4-stderr
@@ -1,16 +1,16 @@
-pragma-deprecated.p4(9): warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
+pragma-deprecated.p4(9): [--Wwarn=deprecated] warning: Checksum16: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
 Checksum16() instance;
 ^^^^^^^^^^
 pragma-deprecated.p4(2)
 extern Checksum16 {
        ^^^^^^^^^^
-pragma-deprecated.p4(13): warning: wrong: Using deprecated feature wrong. Please don't use this function.
+pragma-deprecated.p4(13): [--Wwarn=deprecated] warning: wrong: wrong: Using deprecated feature wrong. Please don't use this function.
         bit<6> x = wrong();
                    ^^^^^
 pragma-deprecated.p4(7)
 extern bit<6> wrong();
               ^^^^^
-pragma-deprecated.p4(9): warning: instance: unused instance
+pragma-deprecated.p4(9): [--Wwarn=unused] warning: instance: instance: unused instance
 Checksum16() instance;
              ^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4-stderr
@@ -1,3 +1,3 @@
-psa-counter3.p4(48): warning: counter1: unused instance
+psa-counter3.p4(48): [--Wwarn=unused] warning: counter1: counter1: unused instance
     Counter<bit<10>,bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
                                                               ^^^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4-stderr
@@ -1,3 +1,3 @@
-psa-counter3.p4(48): [--Wwarn=unused] warning: counter1: counter1: unused instance
+psa-counter3.p4(48): [--Wwarn=unused] warning: counter1: unused instance
     Counter<bit<10>,bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
                                                               ^^^^^^^^

--- a/testdata/p4_16_samples_outputs/reject.p4-stderr
+++ b/testdata/p4_16_samples_outputs/reject.p4-stderr
@@ -1,9 +1,9 @@
-reject.p4(20): warning: start: implicit transition to `reject'
+reject.p4(20): [--Wwarn=parser-transition] warning: start: start: implicit transition to `reject'
     state start {
           ^^^^^
-reject.p4(19): warning: accept state in parser f is unreachable
+reject.p4(19): [--Wwarn=parser-transition] warning: accept: accept state in parser f is unreachable
 parser f() {
        ^
-reject.p4(19): warning: accept state in parser f is unreachable
+reject.p4(19): [--Wwarn=parser-transition] warning: accept: accept state in parser f is unreachable
 parser f() {
        ^

--- a/testdata/p4_16_samples_outputs/reject.p4-stderr
+++ b/testdata/p4_16_samples_outputs/reject.p4-stderr
@@ -1,9 +1,9 @@
-reject.p4(20): [--Wwarn=parser-transition] warning: start: start: implicit transition to `reject'
+reject.p4(20): [--Wwarn=parser-transition] warning: start: implicit transition to `reject'
     state start {
           ^^^^^
-reject.p4(19): [--Wwarn=parser-transition] warning: accept: accept state in parser f is unreachable
+reject.p4(19): [--Wwarn=parser-transition] warning: accept state in parser f is unreachable
 parser f() {
        ^
-reject.p4(19): [--Wwarn=parser-transition] warning: accept: accept state in parser f is unreachable
+reject.p4(19): [--Wwarn=parser-transition] warning: accept state in parser f is unreachable
 parser f() {
        ^

--- a/testdata/p4_16_samples_outputs/shadow.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow.p4-stderr
@@ -1,4 +1,4 @@
-shadow.p4(22): warning: x shadows x
+shadow.p4(22): [--Wwarn=shadow] warning: x: x shadows x
             bit x;
             ^^^^^^
 shadow.p4(20)

--- a/testdata/p4_16_samples_outputs/shadow.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow.p4-stderr
@@ -1,4 +1,4 @@
-shadow.p4(22): [--Wwarn=shadow] warning: x: x shadows x
+shadow.p4(22): [--Wwarn=shadow] warning: x shadows x
             bit x;
             ^^^^^^
 shadow.p4(20)

--- a/testdata/p4_16_samples_outputs/shadow1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow1.p4-stderr
@@ -1,4 +1,4 @@
-shadow1.p4(20): warning: counter shadows counter
+shadow1.p4(20): [--Wwarn=shadow] warning: counter: counter shadows counter
   bit<16> counter;
   ^^^^^^^^^^^^^^^^
 shadow1.p4(17)

--- a/testdata/p4_16_samples_outputs/shadow1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow1.p4-stderr
@@ -1,4 +1,4 @@
-shadow1.p4(20): [--Wwarn=shadow] warning: counter: counter shadows counter
+shadow1.p4(20): [--Wwarn=shadow] warning: counter shadows counter
   bit<16> counter;
   ^^^^^^^^^^^^^^^^
 shadow1.p4(17)

--- a/testdata/p4_16_samples_outputs/shadow3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow3.p4-stderr
@@ -1,4 +1,4 @@
-shadow3.p4(20): [--Wwarn=shadow] warning: p: p shadows p
+shadow3.p4(20): [--Wwarn=shadow] warning: p shadows p
   bit<8> p = 0;
   ^^^^^^^^^^^^^
 shadow3.p4(19)

--- a/testdata/p4_16_samples_outputs/shadow3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow3.p4-stderr
@@ -1,4 +1,4 @@
-shadow3.p4(20): warning: p shadows p
+shadow3.p4(20): [--Wwarn=shadow] warning: p: p shadows p
   bit<8> p = 0;
   ^^^^^^^^^^^^^
 shadow3.p4(19)

--- a/testdata/p4_16_samples_outputs/spec-ex04.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex04.p4-stderr
@@ -1,4 +1,4 @@
-spec-ex04.p4(24): warning: 170: signed value does not fit in 8 bits
+spec-ex04.p4(24): [--Wwarn=overflow] warning: 170: 170: signed value does not fit in 8 bits
 const int<8> b8 = 8s0b1010_1010
                   ^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex04.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex04.p4-stderr
@@ -1,4 +1,4 @@
-spec-ex04.p4(24): [--Wwarn=overflow] warning: 170: 170: signed value does not fit in 8 bits
+spec-ex04.p4(24): [--Wwarn=overflow] warning: 170: signed value does not fit in 8 bits
 const int<8> b8 = 8s0b1010_1010
                   ^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex16.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex16.p4-stderr
@@ -1,4 +1,4 @@
-spec-ex16.p4(32): [--Wwarn=unused] warning: main1: main1: unused instance
+spec-ex16.p4(32): [--Wwarn=unused] warning: main1: unused instance
                 Map1()) main1;
                         ^^^^^
 spec-ex16.p4(24): [--Wwarn=uninitialized_out_param] warning: out parameter d may be uninitialized when P terminates

--- a/testdata/p4_16_samples_outputs/spec-ex16.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex16.p4-stderr
@@ -1,4 +1,4 @@
-spec-ex16.p4(32): warning: main1: unused instance
+spec-ex16.p4(32): [--Wwarn=unused] warning: main1: main1: unused instance
                 Map1()) main1;
                         ^^^^^
 spec-ex16.p4(24): [--Wwarn=uninitialized_out_param] warning: out parameter d may be uninitialized when P terminates

--- a/testdata/p4_16_samples_outputs/stack.p4-stderr
+++ b/testdata/p4_16_samples_outputs/stack.p4-stderr
@@ -1,3 +1,3 @@
-stack.p4(30): warning: stack.next: reading uninitialized value
+stack.p4(30): [--Wwarn=uninitialized] warning: stack.next: stack.next: reading uninitialized value
         b = stack.next;
             ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/stack.p4-stderr
+++ b/testdata/p4_16_samples_outputs/stack.p4-stderr
@@ -1,3 +1,3 @@
-stack.p4(30): [--Wwarn=uninitialized] warning: stack.next: stack.next: reading uninitialized value
+stack.p4(30): [--Wwarn=uninitialized] warning: stack.next: reading uninitialized value
         b = stack.next;
             ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/strength.p4-stderr
+++ b/testdata/p4_16_samples_outputs/strength.p4-stderr
@@ -1,7 +1,7 @@
-strength.p4(50): warning: 15: signed value does not fit in 4 bits
+strength.p4(50): [--Wwarn=overflow] warning: 15: 15: signed value does not fit in 4 bits
         w = w - 4s0xF
                 ^^^^^
-strength.p4(38): warning: 16: value does not fit in 4 bits
+strength.p4(38): [--Wwarn=mismatch] warning: 16: value does not fit in 4 bits
         y = y * 16;
                 ^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/strength.p4-stderr
+++ b/testdata/p4_16_samples_outputs/strength.p4-stderr
@@ -1,4 +1,4 @@
-strength.p4(50): [--Wwarn=overflow] warning: 15: 15: signed value does not fit in 4 bits
+strength.p4(50): [--Wwarn=overflow] warning: 15: signed value does not fit in 4 bits
         w = w - 4s0xF
                 ^^^^^
 strength.p4(38): [--Wwarn=mismatch] warning: 16: value does not fit in 4 bits

--- a/testdata/p4_16_samples_outputs/type-shadow.p4-stderr
+++ b/testdata/p4_16_samples_outputs/type-shadow.p4-stderr
@@ -1,4 +1,4 @@
-type-shadow.p4(18): [--Wwarn=shadow] warning: D: D shadows D
+type-shadow.p4(18): [--Wwarn=shadow] warning: D shadows D
    void f<D>(in D d); // D shadows D
           ^
 type-shadow.p4(16)

--- a/testdata/p4_16_samples_outputs/type-shadow.p4-stderr
+++ b/testdata/p4_16_samples_outputs/type-shadow.p4-stderr
@@ -1,4 +1,4 @@
-type-shadow.p4(18): warning: D shadows D
+type-shadow.p4(18): [--Wwarn=shadow] warning: D: D shadows D
    void f<D>(in D d); // D shadows D
           ^
 type-shadow.p4(16)

--- a/testdata/p4_16_samples_outputs/unreachable-accept.p4-stderr
+++ b/testdata/p4_16_samples_outputs/unreachable-accept.p4-stderr
@@ -1,9 +1,9 @@
-unreachable-accept.p4(31): warning: start: implicit transition to `reject'
+unreachable-accept.p4(31): [--Wwarn=parser-transition] warning: start: start: implicit transition to `reject'
     state start {
           ^^^^^
-unreachable-accept.p4(30): warning: accept state in parser Parser is unreachable
+unreachable-accept.p4(30): [--Wwarn=parser-transition] warning: accept: accept state in parser Parser is unreachable
 parser Parser(packet_in pkt_in, out headers_t hdr) {
        ^^^^^^
-unreachable-accept.p4(30): warning: accept state in parser Parser is unreachable
+unreachable-accept.p4(30): [--Wwarn=parser-transition] warning: accept: accept state in parser Parser is unreachable
 parser Parser(packet_in pkt_in, out headers_t hdr) {
        ^^^^^^

--- a/testdata/p4_16_samples_outputs/unreachable-accept.p4-stderr
+++ b/testdata/p4_16_samples_outputs/unreachable-accept.p4-stderr
@@ -1,9 +1,9 @@
-unreachable-accept.p4(31): [--Wwarn=parser-transition] warning: start: start: implicit transition to `reject'
+unreachable-accept.p4(31): [--Wwarn=parser-transition] warning: start: implicit transition to `reject'
     state start {
           ^^^^^
-unreachable-accept.p4(30): [--Wwarn=parser-transition] warning: accept: accept state in parser Parser is unreachable
+unreachable-accept.p4(30): [--Wwarn=parser-transition] warning: accept state in parser Parser is unreachable
 parser Parser(packet_in pkt_in, out headers_t hdr) {
        ^^^^^^
-unreachable-accept.p4(30): [--Wwarn=parser-transition] warning: accept: accept state in parser Parser is unreachable
+unreachable-accept.p4(30): [--Wwarn=parser-transition] warning: accept state in parser Parser is unreachable
 parser Parser(packet_in pkt_in, out headers_t hdr) {
        ^^^^^^

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-unused-counter-bmv2.p4(51): warning: c1: unused instance
+unused-counter-bmv2.p4(51): [--Wwarn=unused] warning: c1: c1: unused instance
     direct_counter(CounterType.packets) c1;
                                         ^^

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-unused-counter-bmv2.p4(51): [--Wwarn=unused] warning: c1: c1: unused instance
+unused-counter-bmv2.p4(51): [--Wwarn=unused] warning: c1: unused instance
     direct_counter(CounterType.packets) c1;
                                         ^^


### PR DESCRIPTION
This PR addresses the issue of repeated error and warning messages when
compiler passes are repeated, by introducing error/warning types, and
an error catalog. Error types classify the errors and impose a format
that allows the compiler to automatically filter repeated
messages. The filtering is based on the type of error and the source
code location of the object that reports the error. Thus, it allows
multiple error types per source code line, and ensures that only one
error is reported even if the message is raised multiple times. Error
codes and formats are defined in `lib/error_catalog.[h,cpp]`. Backends
can extend the codes and formats as needed (and they are encouraged to
do so).

To ease the transition to typed errors and warnings, free form
messages whose first argument (`%1%`) is an `IR::Node` (or more
precisely a class that implements `Util::IHasSourceInfo` interface),
will be converted automatically to typed errors that use the format
argument of the message rather than the error catalog predefined
formats.

We converted the errors in the bmv2 backend to typed errors, as well 
as a number of errors and warnings in the frontend. The conversion is
by no means finalized, however, the added support for transition does
handle a fair number of the duplicates. And I would like to get feedback
from others on what is their view before continuing to convert.

Also introduces the `FATAL_ERROR` macro to print a message and raise
an CompilationError exception.

And finally adds documentation on how to use to the coding standards.

**For reviewers**
I broke the PR in several commits to ease the review process:
- the first commit (https://github.com/p4lang/p4c/commit/fb2c8bcd01515f27ff0f11699fa63c20af0788b6) fixes a couple of warnings that point to potential issues with scoping
- the second commit (https://github.com/p4lang/p4c/commit/5f8b3c17b11e177f7e9fbbf5ed4c8578a943819d) adds the infrastructure support for typed errors. 
- and finally the https://github.com/p4lang/p4c/commit/7ac417bef01beca36e1e67304d2c7d6be64a2e29 converts bmv2 errors and https://github.com/p4lang/p4c/commit/9bcf80709b41cde3201821ecba9cc99f27d5e20e converts frontend errors and warnings.
It might help if you review these separately. 

**Still to do**
The sample outputs will need to be adjusted. Will do that after initial feedback.