### PR TITLE
Populate Documentation fields and PkgInfo in P4Info

### DIFF
--- a/control-plane/p4RuntimeArchHandler.cpp
+++ b/control-plane/p4RuntimeArchHandler.cpp
@@ -144,6 +144,16 @@ std::string serializeOneAnnotation(const IR::Annotation* annotation) {
     return serializedAnnotation;
 }
 
+void setPreamble(::p4::config::v1::Preamble* preamble,
+                 p4rt_id_t id, cstring name, cstring alias, const IR::IAnnotated* annotated) {
+    CHECK_NULL(preamble);
+    preamble->set_id(id);
+    preamble->set_name(name);
+    preamble->set_alias(alias);
+    addAnnotations(preamble, annotated);
+    addDocumentation(preamble, annotated);
+}
+
 }  // namespace Helpers
 
 }  // namespace ControlPlaneAPI

--- a/testdata/p4_16_samples_outputs/bitwise-and.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bitwise-and.p4-stderr
@@ -1,1 +1,3 @@
 warning: Program does not contain a `main' module
+warning: Program does not contain a main module, so P4Info's 'pkg_info' field will not be set
+warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue1524.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1524.p4-stderr
@@ -1,1 +1,3 @@
 warning: Program does not contain a `main' module
+warning: Program does not contain a main module, so P4Info's 'pkg_info' field will not be set
+warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue407-2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue407-2.p4-stderr
@@ -1,1 +1,3 @@
 warning: Program does not contain a `main' module
+warning: Program does not contain a main module, so P4Info's 'pkg_info' field will not be set
+warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue407-3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue407-3.p4-stderr
@@ -1,1 +1,3 @@
 warning: Program does not contain a `main' module
+warning: Program does not contain a main module, so P4Info's 'pkg_info' field will not be set
+warning: Program does not contain a `main' module


### PR DESCRIPTION
The documentation information comes from the '@brief' and '@description'
annotations. The PkgInfo message is populated based on the annotations
on the P4 package declaration.

To reduce code duplication, a new setPreamble helper function is added,
which can be used to set all the fields (including documentation and
generic annotations) in the preamble for all P4Info entities.

Fixes #1170