### PR TITLE
Do not insert casts for fields in field lists; remove ugly macros. 

### DIFF
--- a/backends/bmv2/common/extern.cpp
+++ b/backends/bmv2/common/extern.cpp
@@ -150,7 +150,10 @@ ExternConverter::addToFieldList(ConversionContext* ctxt,
         return;
     }
 
+    bool simple = ctxt->conv->simpleExpressionsOnly;
+    ctxt->conv->simpleExpressionsOnly = true;  // we do not want casts d2b in field_lists
     auto j = ctxt->conv->convert(expr);
+    ctxt->conv->simpleExpressionsOnly = simple; // restore state
     if (auto jo = j->to<Util::JsonObject>()) {
         if (auto t = jo->get("type")) {
             if (auto type = t->to<Util::JsonValue>()) {

--- a/backends/bmv2/common/extern.h
+++ b/backends/bmv2/common/extern.h
@@ -72,94 +72,71 @@ class ExternConverter {
     static cstring convertHashAlgorithm(cstring algorithm);
 };
 
-#define EXTERN_CONVERTER_W_FUNCTION_AND_MODEL(extern_name, model_type, model_name, ...)  \
-    class ExternConverter_##extern_name##__VA_ARGS__ : public ExternConverter { \
+#define EXTERN_CONVERTER_W_FUNCTION_AND_MODEL(extern_name, model_type, model_name)  \
+    class ExternConverter_##extern_name : public ExternConverter {              \
         model_type&  model_name;                                                \
-        ExternConverter_##extern_name##__VA_ARGS__() :                          \
+        ExternConverter_##extern_name() :                                       \
             model_name(model_type::instance) {                                  \
             registerExternConverter(#extern_name, this); }                      \
-        static ExternConverter_##extern_name##__VA_ARGS__ singleton;            \
+        static ExternConverter_##extern_name singleton;                         \
         Util::IJson* convertExternFunction(ConversionContext* ctxt,             \
             const P4::ExternFunction* ef, const IR::MethodCallExpression* mc,   \
             const IR::StatOrDecl* s, const bool emitExterns) override;  };
 
-#define EXTERN_CONVERTER_W_FUNCTION(extern_name, ...)                           \
-    class ExternConverter_##extern_name##__VA_ARGS__ : public ExternConverter { \
-        ExternConverter_##extern_name##__VA_ARGS__() {                          \
+#define EXTERN_CONVERTER_W_FUNCTION(extern_name)                                \
+    class ExternConverter_##extern_name : public ExternConverter {              \
+        ExternConverter_##extern_name() {                                       \
             registerExternConverter(#extern_name, this); }                      \
-        static ExternConverter_##extern_name##__VA_ARGS__ singleton;            \
+        static ExternConverter_##extern_name singleton;                         \
         Util::IJson* convertExternFunction(ConversionContext* ctxt,             \
             const P4::ExternFunction* ef, const IR::MethodCallExpression* mc,   \
             const IR::StatOrDecl* s, const bool emitExterns) override;  };
 
-#define EXTERN_CONVERTER_W_INSTANCE_AND_MODEL(extern_name, model_type, model_name, ...) \
-    class ExternConverter_##extern_name##__VA_ARGS__ : public ExternConverter { \
+#define EXTERN_CONVERTER_W_INSTANCE_AND_MODEL(extern_name, model_type, model_name) \
+    class ExternConverter_##extern_name : public ExternConverter {              \
         model_type&      model_name;                                            \
-        ExternConverter_##extern_name##__VA_ARGS__() :                          \
+        ExternConverter_##extern_name() :                                       \
             model_name(model_type::instance) {                                  \
             registerExternConverter(#extern_name, this); }                      \
-        static ExternConverter_##extern_name##__VA_ARGS__ singleton;            \
-        void convertExternInstance(ConversionContext* ctxt,             \
-            const IR::Declaration* c, const IR::ExternBlock* eb,        \
+        static ExternConverter_##extern_name singleton;                         \
+        void convertExternInstance(ConversionContext* ctxt,                     \
+            const IR::Declaration* c, const IR::ExternBlock* eb,                \
             const bool& emitExterns) override; };
 
-#define EXTERN_CONVERTER_W_INSTANCE(extern_name, ...)                          \
-    class ExternConverter_##extern_name##__VA_ARGS__ : public ExternConverter { \
-        ExternConverter_##extern_name##__VA_ARGS__() {                          \
+#define EXTERN_CONVERTER_W_INSTANCE(extern_name)                                \
+    class ExternConverter_##extern_name : public ExternConverter {              \
+        ExternConverter_##extern_name() {                                       \
             registerExternConverter(#extern_name, this); }                      \
-        static ExternConverter_##extern_name##__VA_ARGS__ singleton;            \
-        void convertExternInstance(ConversionContext* ctxt,             \
-            const IR::Declaration* c, const IR::ExternBlock* eb,        \
+        static ExternConverter_##extern_name singleton;                         \
+        void convertExternInstance(ConversionContext* ctxt,                     \
+            const IR::Declaration* c, const IR::ExternBlock* eb,                \
             const bool& emitExterns) override; };
 
-#define EXTERN_CONVERTER_W_OBJECT_AND_INSTANCE_AND_MODEL(extern_name, type, name, ...)  \
-    class ExternConverter_##extern_name##__VA_ARGS__ : public ExternConverter { \
+#define EXTERN_CONVERTER_W_OBJECT_AND_INSTANCE_AND_MODEL(extern_name, type, name)  \
+    class ExternConverter_##extern_name : public ExternConverter {              \
         type&      name;                                                        \
-        ExternConverter_##extern_name##__VA_ARGS__() :                          \
+        ExternConverter_##extern_name() :                                       \
             name(type::instance) {                                              \
             registerExternConverter(#extern_name, this); }                      \
-        static ExternConverter_##extern_name##__VA_ARGS__ singleton;            \
-        void convertExternInstance(ConversionContext* ctxt,             \
-            const IR::Declaration* c, const IR::ExternBlock* eb,        \
-            const bool& emitExternes) override;      \
+        static ExternConverter_##extern_name singleton;                         \
+        void convertExternInstance(ConversionContext* ctxt,                     \
+            const IR::Declaration* c, const IR::ExternBlock* eb,                \
+            const bool& emitExternes) override;                                 \
         Util::IJson* convertExternObject(ConversionContext* ctxt,               \
             const P4::ExternMethod* em, const IR::MethodCallExpression* mc,     \
             const IR::StatOrDecl* s, const bool& emitExterns) override; };
 
-#define EXTERN_CONVERTER_W_OBJECT_AND_INSTANCE(extern_name, ...)               \
-    class ExternConverter_##extern_name##__VA_ARGS__ : public ExternConverter { \
-        ExternConverter_##extern_name##__VA_ARGS__() {                          \
+#define EXTERN_CONVERTER_W_OBJECT_AND_INSTANCE(extern_name)                     \
+    class ExternConverter_##extern_name : public ExternConverter {              \
+        ExternConverter_##extern_name() {                                       \
             registerExternConverter(#extern_name, this); }                      \
-        static ExternConverter_##extern_name##__VA_ARGS__ singleton;            \
-        void convertExternInstance(ConversionContext* ctxt,             \
-            const IR::Declaration* c, const IR::ExternBlock* eb,        \
-            const bool& emitExterns) override;      \
+        static ExternConverter_##extern_name singleton;                         \
+        void convertExternInstance(ConversionContext* ctxt,                     \
+            const IR::Declaration* c, const IR::ExternBlock* eb,                \
+            const bool& emitExterns) override;                                  \
         Util::IJson* convertExternObject(ConversionContext* ctxt,               \
             const P4::ExternMethod* em, const IR::MethodCallExpression* mc,     \
             const IR::StatOrDecl* s, const bool& emitExterns) override; };
-
-#define EXTERN_CONVERTER_SINGLETON(extern_name, ...)                           \
-    ExternConverter_##extern_name##__VA_ARGS__                                 \
-       ExternConverter_##extern_name##__VA_ARGS__::singleton;
-
-#define CONVERT_EXTERN_INSTANCE(extern_name, ...)                                     \
-    void ExternConverter_##extern_name##__VA_ARGS__::convertExternInstance(   \
-        UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,              \
-        UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns)
-
-
-#define CONVERT_EXTERN_OBJECT(extern_name, ...)                                       \
-    Util::IJson* ExternConverter_##extern_name##__VA_ARGS__::convertExternObject(     \
-        UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,            \
-        UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,    \
-        UNUSED const bool& emitExterns)
-
-
-#define CONVERT_EXTERN_FUNCTION(extern_name, ...)                                     \
-    Util::IJson* ExternConverter_##extern_name##__VA_ARGS__::convertExternFunction(   \
-        UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,          \
-        UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,    \
-        UNUSED const bool emitExterns)
 
 }  // namespace BMV2
 

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -443,35 +443,47 @@ void PsaSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
     json->add_meta_info();
 }
 
-EXTERN_CONVERTER_SINGLETON(Hash)
-EXTERN_CONVERTER_SINGLETON(Checksum)
-EXTERN_CONVERTER_SINGLETON(InternetChecksum)
-EXTERN_CONVERTER_SINGLETON(Counter)
-EXTERN_CONVERTER_SINGLETON(DirectCounter)
-EXTERN_CONVERTER_SINGLETON(Meter)
-EXTERN_CONVERTER_SINGLETON(DirectMeter)
-EXTERN_CONVERTER_SINGLETON(Register)
-EXTERN_CONVERTER_SINGLETON(Random)
-EXTERN_CONVERTER_SINGLETON(ActionProfile)
-EXTERN_CONVERTER_SINGLETON(ActionSelector)
-EXTERN_CONVERTER_SINGLETON(Digest)
+ExternConverter_Hash ExternConverter_Hash::singleton;
+ExternConverter_Checksum ExternConverter_Checksum::singleton;
+ExternConverter_InternetChecksum ExternConverter_InternetChecksum::singleton;
+ExternConverter_Counter ExternConverter_Counter::singleton;
+ExternConverter_DirectCounter ExternConverter_DirectCounter::singleton;
+ExternConverter_Meter ExternConverter_Meter::singleton;
+ExternConverter_DirectMeter ExternConverter_DirectMeter::singleton;
+ExternConverter_Register ExternConverter_Register::singleton;
+ExternConverter_Random ExternConverter_Random::singleton;
+ExternConverter_ActionProfile ExternConverter_ActionProfile::singleton;
+ExternConverter_ActionSelector ExternConverter_ActionSelector::singleton;
+ExternConverter_Digest ExternConverter_Digest::singleton;
 
-CONVERT_EXTERN_OBJECT(Hash) {
+Util::IJson* ExternConverter_Hash::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     auto primitive = mkPrimitive("Hash");
     return primitive;
 }
 
-CONVERT_EXTERN_OBJECT(Checksum) {
+Util::IJson* ExternConverter_Checksum::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     auto primitive = mkPrimitive("Checksum");
     return primitive;
 }
 
-CONVERT_EXTERN_OBJECT(InternetChecksum) {
+Util::IJson* ExternConverter_InternetChecksum::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     auto primitive = mkPrimitive("InternetChecksum");
     return primitive;
 }
 
-CONVERT_EXTERN_OBJECT(Counter) {
+Util::IJson* ExternConverter_Counter::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 1) {
         modelError("Expected 1 argument for %1%", mc);
         return nullptr;
@@ -487,7 +499,11 @@ CONVERT_EXTERN_OBJECT(Counter) {
     parameters->append(index);
     return primitive;
 }
-CONVERT_EXTERN_OBJECT(DirectCounter) {
+
+Util::IJson* ExternConverter_DirectCounter::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 0) {
         modelError("Expected 0 argument for %1%", mc);
         return nullptr;
@@ -495,7 +511,11 @@ CONVERT_EXTERN_OBJECT(DirectCounter) {
     // Do not generate any code for this operation
     return nullptr;
 }
-CONVERT_EXTERN_OBJECT(Meter) {
+
+Util::IJson* ExternConverter_Meter::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 2) {
         modelError("Expected 2 arguments for %1%", mc);
         return nullptr;
@@ -513,7 +533,11 @@ CONVERT_EXTERN_OBJECT(Meter) {
     parameters->append(result);
     return primitive;
 }
-CONVERT_EXTERN_OBJECT(DirectMeter) {
+
+Util::IJson* ExternConverter_DirectMeter::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 1) {
         modelError("Expected 1 argument for %1%", mc);
         return nullptr;
@@ -523,7 +547,11 @@ CONVERT_EXTERN_OBJECT(DirectMeter) {
     // Do not generate any code for this operation
     return nullptr;
 }
-CONVERT_EXTERN_OBJECT(Register) {
+
+Util::IJson* ExternConverter_Register::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 2) {
         modelError("Expected 2 arguments for %1%", mc);
         return nullptr;
@@ -556,7 +584,11 @@ CONVERT_EXTERN_OBJECT(Register) {
     }
     return nullptr;
 }
-CONVERT_EXTERN_OBJECT(Random) {
+
+Util::IJson* ExternConverter_Random::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 3) {
         modelError("Expected 3 arguments for %1%", mc);
         return nullptr;
@@ -575,7 +607,10 @@ CONVERT_EXTERN_OBJECT(Random) {
     return primitive;
 }
 
-CONVERT_EXTERN_OBJECT(Digest) {
+Util::IJson* ExternConverter_Digest::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 1) {
         modelError("Expected 1 arguments for %1%", mc);
         return nullptr;
@@ -608,10 +643,24 @@ CONVERT_EXTERN_OBJECT(Digest) {
     return primitive;
 }
 
-CONVERT_EXTERN_INSTANCE(Hash) { /* TODO */ }
-CONVERT_EXTERN_INSTANCE(Checksum) { /* TODO */ }
-CONVERT_EXTERN_INSTANCE(InternetChecksum) { /* TODO */ }
-CONVERT_EXTERN_INSTANCE(Counter) {
+void ExternConverter_Hash::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns)
+{ /* TODO */ }
+
+void ExternConverter_Checksum::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns)
+{ /* TODO */ }
+
+void ExternConverter_InternetChecksum::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns)
+{ /* TODO */ }
+
+void ExternConverter_Counter::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto jctr = new Util::JsonObject();
@@ -628,7 +677,10 @@ CONVERT_EXTERN_INSTANCE(Counter) {
     jctr->emplace("is_direct", false);
     ctxt->json->counters->append(jctr);
 }
-CONVERT_EXTERN_INSTANCE(DirectCounter) {
+
+void ExternConverter_DirectCounter::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto it = ctxt->structure->directCounterMap.find(name);
@@ -644,7 +696,10 @@ CONVERT_EXTERN_INSTANCE(DirectCounter) {
         ctxt->json->counters->append(jctr);
     }
 }
-CONVERT_EXTERN_INSTANCE(Meter) {
+
+void ExternConverter_Meter::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto jmtr = new Util::JsonObject();
@@ -678,7 +733,9 @@ CONVERT_EXTERN_INSTANCE(Meter) {
     ctxt->json->meter_arrays->append(jmtr);
 }
 
-CONVERT_EXTERN_INSTANCE(DirectMeter) {
+void ExternConverter_DirectMeter::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto info = ctxt->structure->directMeterMap.getInfo(c);
@@ -717,7 +774,9 @@ CONVERT_EXTERN_INSTANCE(DirectMeter) {
     ctxt->json->meter_arrays->append(jmtr);
 }
 
-CONVERT_EXTERN_INSTANCE(Register) {
+void ExternConverter_Register::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto jreg = new Util::JsonObject();
@@ -755,8 +814,15 @@ CONVERT_EXTERN_INSTANCE(Register) {
     jreg->emplace("bitwidth", width);
     ctxt->json->register_arrays->append(jreg);
 }
-CONVERT_EXTERN_INSTANCE(Random) { /* TODO */ }
-CONVERT_EXTERN_INSTANCE(ActionProfile) {
+
+void ExternConverter_Random::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns)
+{ /* TODO */ }
+
+void ExternConverter_ActionProfile::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     // Might call this multiple times if the selector/profile is used more than
@@ -776,7 +842,10 @@ CONVERT_EXTERN_INSTANCE(ActionProfile) {
 
     ctxt->action_profiles->append(action_profile);
 }
-CONVERT_EXTERN_INSTANCE(ActionSelector) {
+
+void ExternConverter_ActionSelector::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     // Might call this multiple times if the selector/profile is used more than
@@ -821,6 +890,10 @@ CONVERT_EXTERN_INSTANCE(ActionSelector) {
 
     ctxt->action_profiles->append(action_profile);
 }
-CONVERT_EXTERN_INSTANCE(Digest) { /* TODO */ }
+
+void ExternConverter_Digest::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns)
+{ /* TODO */ }
 
 }  // namespace BMV2

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -91,24 +91,27 @@ bool ParseV1Architecture::preorder(const IR::PackageBlock* main) {
     return false;
 }
 
-EXTERN_CONVERTER_SINGLETON(clone)
-EXTERN_CONVERTER_SINGLETON(clone3)
-EXTERN_CONVERTER_SINGLETON(hash)
-EXTERN_CONVERTER_SINGLETON(digest)
-EXTERN_CONVERTER_SINGLETON(resubmit)
-EXTERN_CONVERTER_SINGLETON(recirculate)
-EXTERN_CONVERTER_SINGLETON(mark_to_drop)
-EXTERN_CONVERTER_SINGLETON(random)
-EXTERN_CONVERTER_SINGLETON(truncate)
-EXTERN_CONVERTER_SINGLETON(register)
-EXTERN_CONVERTER_SINGLETON(counter)
-EXTERN_CONVERTER_SINGLETON(meter)
-EXTERN_CONVERTER_SINGLETON(direct_counter)
-EXTERN_CONVERTER_SINGLETON(direct_meter)
-EXTERN_CONVERTER_SINGLETON(action_profile)
-EXTERN_CONVERTER_SINGLETON(action_selector)
+ExternConverter_clone ExternConverter_clone::singleton;
+ExternConverter_clone3 ExternConverter_clone3::singleton;
+ExternConverter_hash ExternConverter_hash::singleton;
+ExternConverter_digest ExternConverter_digest::singleton;
+ExternConverter_resubmit ExternConverter_resubmit::singleton;
+ExternConverter_recirculate ExternConverter_recirculate::singleton;
+ExternConverter_mark_to_drop ExternConverter_mark_to_drop::singleton;
+ExternConverter_random ExternConverter_random::singleton;
+ExternConverter_truncate ExternConverter_truncate::singleton;
+ExternConverter_register ExternConverter_register::singleton;
+ExternConverter_counter ExternConverter_counter::singleton;
+ExternConverter_meter ExternConverter_meter::singleton;
+ExternConverter_direct_counter ExternConverter_direct_counter::singleton;
+ExternConverter_direct_meter ExternConverter_direct_meter::singleton;
+ExternConverter_action_profile ExternConverter_action_profile::singleton;
+ExternConverter_action_selector ExternConverter_action_selector::singleton;
 
-CONVERT_EXTERN_FUNCTION(clone) {
+Util::IJson* ExternConverter_clone::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
     int id = -1;
     if (mc->arguments->size() != 2) {
         modelError("Expected 2 arguments for %1%", mc);
@@ -141,7 +144,10 @@ CONVERT_EXTERN_FUNCTION(clone) {
     return primitive;
 }
 
-CONVERT_EXTERN_FUNCTION(clone3) {
+Util::IJson* ExternConverter_clone3::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
     (void) v1model.clone.clone3.name;
     int id = -1;
     if (mc->arguments->size() != 3) {
@@ -174,7 +180,10 @@ CONVERT_EXTERN_FUNCTION(clone3) {
     return primitive;
 }
 
-CONVERT_EXTERN_FUNCTION(hash) {
+Util::IJson* ExternConverter_hash::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
     static std::set<cstring> supportedHashAlgorithms = {
         v1model.algorithm.crc32.name, v1model.algorithm.crc32_custom.name,
         v1model.algorithm.crc16.name, v1model.algorithm.crc16_custom.name,
@@ -211,7 +220,10 @@ CONVERT_EXTERN_FUNCTION(hash) {
     return primitive;
 }
 
-CONVERT_EXTERN_FUNCTION(digest) {
+Util::IJson* ExternConverter_digest::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
     if (mc->arguments->size() != 2) {
         modelError("Expected 2 arguments for %1%", mc);
         return nullptr;
@@ -246,7 +258,10 @@ CONVERT_EXTERN_FUNCTION(digest) {
     return primitive;
 }
 
-CONVERT_EXTERN_FUNCTION(resubmit) {
+Util::IJson* ExternConverter_resubmit::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
     if (mc->arguments->size() != 1) {
         modelError("Expected 1 argument for %1%", mc);
         return nullptr;
@@ -278,7 +293,11 @@ CONVERT_EXTERN_FUNCTION(resubmit) {
     parameters->append(jcst);
     return primitive;
 }
-CONVERT_EXTERN_FUNCTION(recirculate) {
+
+Util::IJson* ExternConverter_recirculate::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
     if (mc->arguments->size() != 1) {
         modelError("Expected 1 argument for %1%", mc);
         return nullptr;
@@ -311,7 +330,10 @@ CONVERT_EXTERN_FUNCTION(recirculate) {
     return primitive;
 }
 
-CONVERT_EXTERN_FUNCTION(mark_to_drop) {
+Util::IJson* ExternConverter_mark_to_drop::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
     if (mc->arguments->size() != 0) {
         modelError("Expected 0 arguments for %1%", mc);
         return nullptr;
@@ -322,7 +344,10 @@ CONVERT_EXTERN_FUNCTION(mark_to_drop) {
     return primitive;
 }
 
-CONVERT_EXTERN_FUNCTION(random) {
+Util::IJson* ExternConverter_random::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
     if (mc->arguments->size() != 3) {
         modelError("Expected 3 arguments for %1%", mc);
         return nullptr;
@@ -340,7 +365,10 @@ CONVERT_EXTERN_FUNCTION(random) {
     return primitive;
 }
 
-CONVERT_EXTERN_FUNCTION(truncate) {
+Util::IJson* ExternConverter_truncate::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
     if (mc->arguments->size() != 1) {
         modelError("Expected 1 arguments for %1%", mc);
         return nullptr;
@@ -353,7 +381,10 @@ CONVERT_EXTERN_FUNCTION(truncate) {
     return primitive;
 }
 
-CONVERT_EXTERN_OBJECT(counter) {
+Util::IJson* ExternConverter_counter::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 1) {
         modelError("Expected 1 argument for %1%", mc);
         return nullptr;
@@ -370,7 +401,9 @@ CONVERT_EXTERN_OBJECT(counter) {
     return primitive;
 }
 
-CONVERT_EXTERN_INSTANCE(counter) {
+void ExternConverter_counter::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto jctr = new Util::JsonObject();
@@ -388,7 +421,10 @@ CONVERT_EXTERN_INSTANCE(counter) {
     ctxt->json->counters->append(jctr);
 }
 
-CONVERT_EXTERN_OBJECT(meter) {
+Util::IJson* ExternConverter_meter::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 2) {
         modelError("Expected 2 arguments for %1%", mc);
         return nullptr;
@@ -407,7 +443,9 @@ CONVERT_EXTERN_OBJECT(meter) {
     return primitive;
 }
 
-CONVERT_EXTERN_INSTANCE(meter) {
+void ExternConverter_meter::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto jmtr = new Util::JsonObject();
@@ -441,7 +479,10 @@ CONVERT_EXTERN_INSTANCE(meter) {
     ctxt->json->meter_arrays->append(jmtr);
 }
 
-CONVERT_EXTERN_OBJECT(register) {
+Util::IJson* ExternConverter_register::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 2) {
         modelError("Expected 2 arguments for %1%", mc);
         return nullptr;
@@ -474,7 +515,9 @@ CONVERT_EXTERN_OBJECT(register) {
     return nullptr;
 }
 
-CONVERT_EXTERN_INSTANCE(register) {
+void ExternConverter_register::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto jreg = new Util::JsonObject();
@@ -513,7 +556,10 @@ CONVERT_EXTERN_INSTANCE(register) {
     ctxt->json->register_arrays->append(jreg);
 }
 
-CONVERT_EXTERN_OBJECT(direct_counter) {
+Util::IJson* ExternConverter_direct_counter::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 0) {
         modelError("Expected 0 argument for %1%", mc);
         return nullptr;
@@ -522,7 +568,9 @@ CONVERT_EXTERN_OBJECT(direct_counter) {
     return nullptr;
 }
 
-CONVERT_EXTERN_INSTANCE(direct_counter) {
+void ExternConverter_direct_counter::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto it = ctxt->structure->directCounterMap.find(name);
@@ -539,7 +587,10 @@ CONVERT_EXTERN_INSTANCE(direct_counter) {
     }
 }
 
-CONVERT_EXTERN_OBJECT(direct_meter) {
+Util::IJson* ExternConverter_direct_meter::convertExternObject(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
+    UNUSED const bool& emitExterns) {
     if (mc->arguments->size() != 1) {
         modelError("Expected 1 argument for %1%", mc);
         return nullptr;
@@ -550,7 +601,9 @@ CONVERT_EXTERN_OBJECT(direct_meter) {
     return nullptr;
 }
 
-CONVERT_EXTERN_INSTANCE(direct_meter) {
+void ExternConverter_direct_meter::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto info = ctxt->structure->directMeterMap.getInfo(c);
@@ -589,7 +642,9 @@ CONVERT_EXTERN_INSTANCE(direct_meter) {
     ctxt->json->meter_arrays->append(jmtr);
 }
 
-CONVERT_EXTERN_INSTANCE(action_profile) {
+void ExternConverter_action_profile::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     // Might call this multiple times if the selector/profile is used more than
@@ -644,7 +699,9 @@ CONVERT_EXTERN_INSTANCE(action_profile) {
 }
 
 // action selector conversion is the same as action profile
-CONVERT_EXTERN_INSTANCE(action_selector) {
+void ExternConverter_action_selector::convertExternInstance(
+    UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     // Might call this multiple times if the selector/profile is used more than

--- a/testdata/p4_16_samples/issue1660-bmv2.p4
+++ b/testdata/p4_16_samples/issue1660-bmv2.p4
@@ -1,0 +1,46 @@
+#include <v1model.p4>
+
+struct HasBool {
+    bool x;
+}
+
+struct parsed_packet_t {}
+struct local_metadata_t {}
+
+parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_metadata,
+             inout standard_metadata_t standard_metadata) {
+    state start {
+	transition accept;
+    }
+}
+
+control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata,
+                inout standard_metadata_t standard_metadata) {
+    apply {
+        HasBool b;
+        b.x = true;
+        clone3(CloneType.I2E, 0, b);
+    }
+}
+
+control egress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata,
+               inout standard_metadata_t standard_metadata) {
+    apply { }
+}
+
+control deparser(packet_out b, in parsed_packet_t h) {
+    apply { }
+}
+
+control verify_checksum(inout parsed_packet_t hdr,
+inout local_metadata_t local_metadata) {
+    apply { }
+}
+
+control compute_checksum(inout parsed_packet_t hdr,
+                         inout local_metadata_t local_metadata) {
+    apply { }
+}
+
+V1Switch(parse(), verify_checksum(), ingress(), egress(),
+compute_checksum(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2-first.p4
@@ -1,0 +1,49 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct HasBool {
+    bool x;
+}
+
+struct parsed_packet_t {
+}
+
+struct local_metadata_t {
+}
+
+parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+        HasBool b;
+        b.x = true;
+        clone3<HasBool>(CloneType.I2E, 32w0, b);
+    }
+}
+
+control egress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in parsed_packet_t h) {
+    apply {
+    }
+}
+
+control verify_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+V1Switch<parsed_packet_t, local_metadata_t>(parse(), verify_checksum(), ingress(), egress(), compute_checksum(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2-frontend.p4
@@ -1,0 +1,49 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct HasBool {
+    bool x;
+}
+
+struct parsed_packet_t {
+}
+
+struct local_metadata_t {
+}
+
+parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    HasBool b_0;
+    apply {
+        b_0.x = true;
+        clone3<HasBool>(CloneType.I2E, 32w0, b_0);
+    }
+}
+
+control egress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in parsed_packet_t h) {
+    apply {
+    }
+}
+
+control verify_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+V1Switch<parsed_packet_t, local_metadata_t>(parse(), verify_checksum(), ingress(), egress(), compute_checksum(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2-midend.p4
@@ -1,0 +1,58 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct HasBool {
+    bool x;
+}
+
+struct parsed_packet_t {
+}
+
+struct local_metadata_t {
+}
+
+parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    HasBool b_0;
+    @hidden action act() {
+        b_0.x = true;
+        clone3<HasBool>(CloneType.I2E, 32w0, b_0);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control egress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in parsed_packet_t h) {
+    apply {
+    }
+}
+
+control verify_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+V1Switch<parsed_packet_t, local_metadata_t>(parse(), verify_checksum(), ingress(), egress(), compute_checksum(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2.p4
@@ -1,0 +1,49 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct HasBool {
+    bool x;
+}
+
+struct parsed_packet_t {
+}
+
+struct local_metadata_t {
+}
+
+parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+        HasBool b;
+        b.x = true;
+        clone3(CloneType.I2E, 0, b);
+    }
+}
+
+control egress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in parsed_packet_t h) {
+    apply {
+    }
+}
+
+control verify_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local_metadata) {
+    apply {
+    }
+}
+
+V1Switch(parse(), verify_checksum(), ingress(), egress(), compute_checksum(), deparser()) main;
+


### PR DESCRIPTION
Fixes #1471 and #1660.
The fix for #1660 is in file bmv2/common/extern.cpp.
All other files have fixes for #1471.