### PR TITLE
Avoid unneeded copies when inlining controls

### DIFF
--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -345,12 +345,7 @@ bool CompilerOptions::isv1() const {
 
 void CompilerOptions::dumpPass(const char* manager, unsigned seq, const char* pass,
                                const IR::Node* node) const {
-    // Some pass names are currently C++ class names mangled;
-    // this is a weak attempt at making them more readable.
-    std::string p = pass;
-    size_t last = p.find_last_of("0123456789", strlen(pass) - 3);
-    if (last != strlen(pass))
-        pass = pass + last + 1;
+    if (strncmp(pass, "P4::", 4) == 0) pass += 4;
     cstring name = cstring(manager) + "_" + Util::toString(seq) + "_" + pass;
     if (Log::verbose())
         std::cerr << name << std::endl;

--- a/frontends/p4/commonInlining.h
+++ b/frontends/p4/commonInlining.h
@@ -157,7 +157,7 @@ class AbstractInliner : public Transform {
 };
 
 template <class InlineList, class InlineWorkList>
-class InlineDriver : public Transform {
+class InlineDriver : public Visitor {
     InlineList*     toInline;
     AbstractInliner<InlineList, InlineWorkList>* inliner;
 
@@ -166,17 +166,14 @@ class InlineDriver : public Transform {
         InlineList* toInline, AbstractInliner<InlineList, InlineWorkList> *inliner) :
             toInline(toInline), inliner(inliner)
     { CHECK_NULL(toInline); CHECK_NULL(inliner); setName("InlineDriver"); }
-    // Not really a visitor, but we want to embed it into a PassManager,
-    // so we make it look like a visitor.
-    const IR::Node* preorder(IR::P4Program* program) override {
+    const IR::Node* apply_visitor(const IR::Node *program, const char * = 0) override {
         LOG2("InlineDriver");
-        const IR::P4Program* prog = program;
         toInline->analyze();
         LOG3("InlineList size " << toInline->size());
         while (auto todo = toInline->next()) {
             LOG2("Processing " << todo);
             inliner->prepare(toInline, todo);
-            prog = prog->apply(*inliner);
+            program = program->apply(*inliner);
             if (::errorCount() > 0)
                 break;
 
@@ -184,12 +181,10 @@ class InlineDriver : public Transform {
             // debugging code; we don't have an easy way to dump the program here,
             // since we are not between passes
             ToP4 top4(&std::cout, false, nullptr);
-            prog->apply(top4);
+            program->apply(top4);
 #endif
         }
-
-        prune();
-        return prog;
+        return program;
     }
 };
 

--- a/frontends/p4/inlining.cpp
+++ b/frontends/p4/inlining.cpp
@@ -500,9 +500,20 @@ const IR::Node* GeneralInliner::preorder(IR::P4Control* caller) {
             // Use temporaries for these parameters
             std::set<const IR::Parameter*> useTemporary;
 
-            auto call = workToDo->uniqueCaller(inst);
+            const IR::MethodCallStatement *call = nullptr;
+            for (auto m : workToDo->callToInstance) {
+                if (m.second != inst) continue;
+                if (call) {
+                    if (!call->equiv(*m.first)) {
+                        call = nullptr;
+                        break; }
+                } else {
+                    call = m.first; } }
             MethodInstance *mi = nullptr;
             if (call != nullptr) {
+                // All call sites are the same (call is one of them), so we use the
+                // same arguments in all cases.  So we can avoid copies if args do
+                // not alias
                 std::map<const IR::Parameter*, const LocationSet*> locationSets;
                 FindLocationSets fls(refMap, typeMap);
 

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -39,8 +39,7 @@ class ConstantTypeSubstitution : public Transform {
                              ReferenceMap* refMap,
                              TypeMap* typeMap) : subst(subst), refMap(refMap), typeMap(typeMap) {
         CHECK_NULL(subst); CHECK_NULL(refMap); CHECK_NULL(typeMap);
-        LOG3("ConstantTypeSubstitution " << subst);
-        setName("ConstantTypeSubstitution"); }
+        LOG3("ConstantTypeSubstitution " << subst); }
     const IR::Node* postorder(IR::Constant* cst) override {
         auto cstType = typeMap->getType(getOriginal(), true);
         if (!cstType->is<IR::ITypeVar>())
@@ -92,7 +91,6 @@ TypeChecking::TypeChecking(ReferenceMap* refMap, TypeMap* typeMap,
        new P4::TypeInference(refMap, typeMap, true),
        updateExpressions ? new ApplyTypesToExpressions(typeMap) : nullptr,
        updateExpressions ? new P4::ResolveReferences(refMap) : nullptr });
-    setName("TypeChecking");
     setStopOnError(true);
 }
 
@@ -125,7 +123,6 @@ TypeInference::TypeInference(ReferenceMap* refMap, TypeMap* typeMap, bool readOn
     CHECK_NULL(typeMap);
     CHECK_NULL(refMap);
     visitDagOnce = false;  // the done() method will take care of this
-    setName("TypeInference");
 }
 
 Visitor::profile_t TypeInference::init_apply(const IR::Node* node) {

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -35,7 +35,7 @@ class ClearTypeMap : public Inspector {
     TypeMap* typeMap;
  public:
     explicit ClearTypeMap(TypeMap* typeMap) :
-            typeMap(typeMap) { CHECK_NULL(typeMap); setName("ClearTypeMap"); }
+            typeMap(typeMap) { CHECK_NULL(typeMap); }
     bool preorder(const IR::P4Program* program) override {
         // Clear map only if program has not changed from last time
         // otherwise we can reuse it
@@ -308,8 +308,7 @@ class ApplyTypesToExpressions : public Transform {
         return e; }
 
  public:
-    explicit ApplyTypesToExpressions(TypeMap *typeMap) : typeMap(typeMap)
-    { setName("ApplyTypesToExpressions"); }
+    explicit ApplyTypesToExpressions(TypeMap *typeMap) : typeMap(typeMap) { }
 };
 
 }  // namespace P4

--- a/ir/pass_manager.h
+++ b/ir/pass_manager.h
@@ -68,9 +68,9 @@ class PassManager : virtual public Visitor, virtual public Backtrack {
 class PassRepeated : virtual public PassManager {
     unsigned            repeats;  // 0 = until convergence
  public:
-    PassRepeated() : PassRepeated({}) {}
+    PassRepeated() : repeats(0) {}
     PassRepeated(const std::initializer_list<Visitor *> &init) :
-            PassManager(init), repeats(0) { setName("PassRepeated"); }
+            PassManager(init), repeats(0) {}
     const IR::Node *apply_visitor(const IR::Node *, const char * = 0) override;
     PassRepeated *setRepeats(unsigned repeats) { this->repeats = repeats; return this; }
 };
@@ -78,6 +78,7 @@ class PassRepeated : virtual public PassManager {
 class PassRepeatUntil : virtual public PassManager {
     std::function<bool()>       done;
  public:
+    explicit PassRepeatUntil(std::function<bool()> done) : done(done) {}
     PassRepeatUntil(const std::initializer_list<Visitor *> &init,
                     std::function<bool()> done)
     : PassManager(init), done(done) {}

--- a/lib/log.cpp
+++ b/lib/log.cpp
@@ -169,13 +169,18 @@ static bool match(const char *pattern, const char *name) {
             if (pattern > pend) pend = pattern + strcspn(pattern, ",:");
             name++;
             continue; }
-        if (*pattern++ != '*') return false;
+        if (!pbackup && *pattern != '*') return false;
+        while (*pattern == '*') {
+            ++pattern;
+            pbackup = nullptr; }
         if (pattern == pend) return true;
+        // FIXME -- does not work for * followed by [ -- matches a literal [ instead.
         while (*name && *name != *pattern) {
             if (pbackup && *name == *pbackup) {
                 pattern = pbackup;
                 break; }
             name++; }
+        if (!*name) return false;
         pbackup = pattern;
     }
 }

--- a/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
@@ -72,14 +72,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1024;
         default_action = NoAction_5();
     }
-    headers hdr_0;
-    metadata meta_0;
-    standard_metadata_t standard_metadata_0;
     @name(".send") action _send_0(bit<9> port) {
-        standard_metadata_0.egress_port = port;
+        standard_metadata.egress_port = port;
     }
     @name(".send") action _send_2(bit<9> port) {
-        standard_metadata_0.egress_port = port;
+        standard_metadata.egress_port = port;
     }
     @name(".discard") action _discard_0() {
         mark_to_drop();
@@ -94,7 +91,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_6();
         }
         key = {
-            hdr_0.ethernet.dstAddr: exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.dstAddr: exact @name("ethernet.dstAddr") ;
         }
         size = 1024;
         default_action = NoAction_6();
@@ -106,7 +103,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_7();
         }
         key = {
-            hdr_0.ethernet.dstAddr: exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.dstAddr: exact @name("ethernet.dstAddr") ;
         }
         size = 1024;
         default_action = NoAction_7();
@@ -114,29 +111,23 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     apply {
         if (standard_metadata.ingress_port & 9w0x1 == 9w1) {
             a1_0.apply();
-            hdr_0 = hdr;
-            meta_0 = meta;
-            standard_metadata_0 = standard_metadata;
-            if (standard_metadata_0.ingress_port & 9w0x2 == 9w1) 
+            hdr = hdr;
+            meta = meta;
+            standard_metadata = standard_metadata;
+            if (standard_metadata.ingress_port & 9w0x2 == 9w1) 
                 _c1.apply();
-            if (standard_metadata_0.ingress_port & 9w0x4 == 9w1) 
+            if (standard_metadata.ingress_port & 9w0x4 == 9w1) 
                 _c2.apply();
-            hdr = hdr_0;
-            meta = meta_0;
-            standard_metadata = standard_metadata_0;
+            hdr = hdr;
+            meta = meta;
+            standard_metadata = standard_metadata;
         }
         else {
             b1_0.apply();
-            hdr_0 = hdr;
-            meta_0 = meta;
-            standard_metadata_0 = standard_metadata;
-            if (standard_metadata_0.ingress_port & 9w0x2 == 9w1) 
+            if (standard_metadata.ingress_port & 9w0x2 == 9w1) 
                 _c1.apply();
-            if (standard_metadata_0.ingress_port & 9w0x4 == 9w1) 
+            if (standard_metadata.ingress_port & 9w0x4 == 9w1) 
                 _c2.apply();
-            hdr = hdr_0;
-            meta = meta_0;
-            standard_metadata = standard_metadata_0;
         }
     }
 }

--- a/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
@@ -111,16 +111,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     apply {
         if (standard_metadata.ingress_port & 9w0x1 == 9w1) {
             a1_0.apply();
-            hdr = hdr;
-            meta = meta;
-            standard_metadata = standard_metadata;
             if (standard_metadata.ingress_port & 9w0x2 == 9w1) 
                 _c1.apply();
             if (standard_metadata.ingress_port & 9w0x4 == 9w1) 
                 _c2.apply();
-            hdr = hdr;
-            meta = meta;
-            standard_metadata = standard_metadata;
         }
         else {
             b1_0.apply();

--- a/testdata/p4_14_samples_outputs/issue-1426-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-midend.p4
@@ -28,7 +28,6 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    standard_metadata_t standard_metadata_0;
     @name(".NoAction") action NoAction_0() {
     }
     @name(".NoAction") action NoAction_5() {
@@ -74,10 +73,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_5();
     }
     @name(".send") action _send_0(bit<9> port) {
-        standard_metadata_0.egress_port = port;
+        standard_metadata.egress_port = port;
     }
     @name(".send") action _send_2(bit<9> port) {
-        standard_metadata_0.egress_port = port;
+        standard_metadata.egress_port = port;
     }
     @name(".discard") action _discard_0() {
         mark_to_drop();
@@ -109,78 +108,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1024;
         default_action = NoAction_7();
     }
-    @hidden action act() {
-        standard_metadata_0.ingress_port = standard_metadata.ingress_port;
-        standard_metadata_0.egress_spec = standard_metadata.egress_spec;
-        standard_metadata_0.egress_port = standard_metadata.egress_port;
-        standard_metadata_0.clone_spec = standard_metadata.clone_spec;
-        standard_metadata_0.instance_type = standard_metadata.instance_type;
-        standard_metadata_0.drop = standard_metadata.drop;
-        standard_metadata_0.recirculate_port = standard_metadata.recirculate_port;
-        standard_metadata_0.packet_length = standard_metadata.packet_length;
-        standard_metadata_0.checksum_error = standard_metadata.checksum_error;
-        standard_metadata_0.parser_error = standard_metadata.parser_error;
-    }
-    @hidden action act_0() {
-        standard_metadata.egress_port = standard_metadata_0.egress_port;
-    }
-    @hidden action act_1() {
-        standard_metadata_0.ingress_port = standard_metadata.ingress_port;
-        standard_metadata_0.egress_spec = standard_metadata.egress_spec;
-        standard_metadata_0.egress_port = standard_metadata.egress_port;
-        standard_metadata_0.clone_spec = standard_metadata.clone_spec;
-        standard_metadata_0.instance_type = standard_metadata.instance_type;
-        standard_metadata_0.drop = standard_metadata.drop;
-        standard_metadata_0.recirculate_port = standard_metadata.recirculate_port;
-        standard_metadata_0.packet_length = standard_metadata.packet_length;
-        standard_metadata_0.checksum_error = standard_metadata.checksum_error;
-        standard_metadata_0.parser_error = standard_metadata.parser_error;
-    }
-    @hidden action act_2() {
-        standard_metadata.egress_port = standard_metadata_0.egress_port;
-    }
-    @hidden table tbl_act {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
-    @hidden table tbl_act_0 {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
-    @hidden table tbl_act_1 {
-        actions = {
-            act_1();
-        }
-        const default_action = act_1();
-    }
-    @hidden table tbl_act_2 {
-        actions = {
-            act_2();
-        }
-        const default_action = act_2();
-    }
     apply {
         if (standard_metadata.ingress_port & 9w0x1 == 9w1) {
             a1_0.apply();
-            tbl_act.apply();
             if (standard_metadata.ingress_port & 9w0x2 == 9w1) 
                 _c1.apply();
             if (standard_metadata.ingress_port & 9w0x4 == 9w1) 
                 _c2.apply();
-            tbl_act_0.apply();
         }
         else {
             b1_0.apply();
-            tbl_act_1.apply();
             if (standard_metadata.ingress_port & 9w0x2 == 9w1) 
                 _c1.apply();
             if (standard_metadata.ingress_port & 9w0x4 == 9w1) 
                 _c2.apply();
-            tbl_act_2.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2-frontend.p4
@@ -31,8 +31,6 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
     apply {
-        hdr = hdr;
-        hdr = hdr;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2-frontend.p4
@@ -30,12 +30,9 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 }
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
-    H hdr_0;
     apply {
-        hdr_0 = hdr;
-        hdr = hdr_0;
-        hdr_0 = hdr;
-        hdr = hdr_0;
+        hdr = hdr;
+        hdr = hdr;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1466-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1466-frontend.p4
@@ -3,14 +3,11 @@ header hdr {
 }
 
 control A(inout hdr _hdr) {
-    hdr _hdr_0;
     apply {
-        _hdr_0 = _hdr;
-        _hdr_0.g = 1w1;
-        _hdr = _hdr_0;
-        _hdr_0 = _hdr;
-        _hdr_0.g = 1w1;
-        _hdr = _hdr_0;
+        _hdr = _hdr;
+        _hdr.g = 1w1;
+        _hdr = _hdr;
+        _hdr.g = 1w1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1466-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1466-frontend.p4
@@ -4,9 +4,7 @@ header hdr {
 
 control A(inout hdr _hdr) {
     apply {
-        _hdr = _hdr;
         _hdr.g = 1w1;
-        _hdr = _hdr;
         _hdr.g = 1w1;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1466-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1466-midend.p4
@@ -3,13 +3,9 @@ header hdr {
 }
 
 control A(inout hdr _hdr) {
-    hdr _hdr_0;
     @hidden action act() {
-        _hdr_0 = _hdr;
-        _hdr_0.g = 1w1;
-        _hdr = _hdr_0;
-        _hdr_0.g = 1w1;
-        _hdr = _hdr_0;
+        _hdr.g = 1w1;
+        _hdr.g = 1w1;
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2-frontend.p4
@@ -28,10 +28,8 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
     @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
     apply {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
-        hdr.ethernet.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
         E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
-        hdr.ethernet.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
         E_c1_stats.count((bit<32>)hdr.ethernet.etherType);

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2-frontend.p4
@@ -25,19 +25,16 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 }
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    bit<16> x_0;
     @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
     apply {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
-        x_0 = hdr.ethernet.etherType;
-        x_0 = x_0 + 16w1;
-        E_c1_stats.count((bit<32>)x_0);
-        hdr.ethernet.etherType = x_0;
+        hdr.ethernet.etherType = hdr.ethernet.etherType;
+        hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
+        hdr.ethernet.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
-        x_0 = hdr.ethernet.etherType;
-        x_0 = x_0 + 16w1;
-        E_c1_stats.count((bit<32>)x_0);
-        hdr.ethernet.etherType = x_0;
+        hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2-midend.p4
@@ -28,11 +28,11 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
     @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
     @hidden action act() {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
-        E_c1_stats.count((bit<32>)(hdr.ethernet.etherType + 16w1));
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
-        E_c1_stats.count((bit<32>)(hdr.ethernet.etherType + 16w1));
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1566-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-frontend.p4
@@ -28,10 +28,8 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
     @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
     apply {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
-        hdr.ethernet.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
         E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
-        hdr.ethernet.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
         E_c1_stats.count((bit<32>)hdr.ethernet.etherType);

--- a/testdata/p4_16_samples_outputs/issue1566-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-frontend.p4
@@ -25,19 +25,16 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 }
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    bit<16> x_0;
     @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
     apply {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
-        x_0 = hdr.ethernet.etherType;
-        x_0 = x_0 + 16w1;
-        E_c1_stats.count((bit<32>)x_0);
-        hdr.ethernet.etherType = x_0;
+        hdr.ethernet.etherType = hdr.ethernet.etherType;
+        hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
+        hdr.ethernet.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
-        x_0 = hdr.ethernet.etherType;
-        x_0 = x_0 + 16w1;
-        E_c1_stats.count((bit<32>)x_0);
-        hdr.ethernet.etherType = x_0;
+        hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-midend.p4
@@ -28,11 +28,11 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
     @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
     @hidden action act() {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
-        E_c1_stats.count((bit<32>)(hdr.ethernet.etherType + 16w1));
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
-        E_c1_stats.count((bit<32>)(hdr.ethernet.etherType + 16w1));
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/pipe-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pipe-frontend.p4
@@ -69,10 +69,7 @@ control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
         const default_action = NoAction_0();
     }
     apply {
-        qArg1 = qArg1;
-        qArg2 = qArg2;
         p1_thost_T.apply();
-        qArg1 = qArg1;
         p1_thost_T.apply();
         p1_Tinner.apply();
     }

--- a/testdata/p4_16_samples_outputs/pipe-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pipe-frontend.p4
@@ -37,21 +37,19 @@ struct Packet_data {
 control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
     @name(".NoAction") action NoAction_0() {
     }
-    TArg1 p1_tArg1;
-    TArg2 p1_aArg2;
     @name("Q_pipe.p1.thost.B_action") action p1_thost_B_action_0(out bit<9> barg, BParamType bData) {
         barg = bData;
     }
     @name("Q_pipe.p1.thost.C_action") action p1_thost_C_action_0(bit<9> cData) {
-        p1_tArg1.field1 = cData;
+        qArg1.field1 = cData;
     }
     @name("Q_pipe.p1.thost.T") table p1_thost_T {
         key = {
-            p1_tArg1.field1: ternary @name("tArg1.field1") ;
-            p1_aArg2.field2: exact @name("aArg2.field2") ;
+            qArg1.field1: ternary @name("tArg1.field1") ;
+            qArg2.field2: exact @name("aArg2.field2") ;
         }
         actions = {
-            p1_thost_B_action_0(p1_tArg1.field1);
+            p1_thost_B_action_0(qArg1.field1);
             p1_thost_C_action_0();
         }
         size = 32w5;
@@ -71,14 +69,11 @@ control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
         const default_action = NoAction_0();
     }
     apply {
-        p1_tArg1 = qArg1;
-        p1_aArg2 = qArg2;
+        qArg1 = qArg1;
+        qArg2 = qArg2;
         p1_thost_T.apply();
-        qArg1 = p1_tArg1;
-        p1_tArg1 = qArg1;
-        p1_aArg2 = qArg2;
+        qArg1 = qArg1;
         p1_thost_T.apply();
-        qArg1 = p1_tArg1;
         p1_Tinner.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/pipe-midend.p4
+++ b/testdata/p4_16_samples_outputs/pipe-midend.p4
@@ -35,20 +35,18 @@ struct Packet_data {
 }
 
 control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
-    TArg1 p1_tArg1;
-    TArg2 p1_aArg2;
     @name(".NoAction") action NoAction_0() {
     }
     @name("Q_pipe.p1.thost.B_action") action p1_thost_B_action_0(BParamType bData) {
-        p1_tArg1.field1 = bData;
+        qArg1.field1 = bData;
     }
     @name("Q_pipe.p1.thost.C_action") action p1_thost_C_action_0(bit<9> cData) {
-        p1_tArg1.field1 = cData;
+        qArg1.field1 = cData;
     }
     @name("Q_pipe.p1.thost.T") table p1_thost_T {
         key = {
-            p1_tArg1.field1: ternary @name("tArg1.field1") ;
-            p1_aArg2.field2: exact @name("aArg2.field2") ;
+            qArg1.field1: ternary @name("tArg1.field1") ;
+            qArg2.field2: exact @name("aArg2.field2") ;
         }
         actions = {
             p1_thost_B_action_0();
@@ -62,7 +60,7 @@ control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
     }
     @name("Q_pipe.p1.Tinner") table p1_Tinner {
         key = {
-            p1_tArg1.field1: ternary @name("pArg1.field1") ;
+            qArg1.field1: ternary @name("pArg1.field1") ;
         }
         actions = {
             p1_Drop_0();
@@ -70,43 +68,9 @@ control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
         }
         const default_action = NoAction_0();
     }
-    @hidden action act() {
-        p1_tArg1.field1 = qArg1.field1;
-        p1_tArg1.drop = qArg1.drop;
-        p1_aArg2.field2 = qArg2.field2;
-    }
-    @hidden action act_0() {
-        qArg1.field1 = p1_tArg1.field1;
-        p1_tArg1.drop = qArg1.drop;
-        p1_aArg2.field2 = qArg2.field2;
-    }
-    @hidden action act_1() {
-        qArg1.field1 = p1_tArg1.field1;
-    }
-    @hidden table tbl_act {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
-    @hidden table tbl_act_0 {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
-    @hidden table tbl_act_1 {
-        actions = {
-            act_1();
-        }
-        const default_action = act_1();
-    }
     apply {
-        tbl_act.apply();
         p1_thost_T.apply();
-        tbl_act_0.apply();
         p1_thost_T.apply();
-        tbl_act_1.apply();
         p1_Tinner.apply();
     }
 }


### PR DESCRIPTION
When inlining controls, we check for aliasing and avoid creating copies of arguments if there is no possibility of aliasing, but currently that is restricted to a single call site.  This change extends that to multiple call sites if all the call sites use the same arguments.  If the arguments are different, we would need copies in at least some cases (to get them into the same place), but if all call sites are the same, copies are not needed.

Currently this only avoids the copies if the call sites are completely the same -- if the call sites had the same arguments for some parameters and not others, copies would be needed only for the parameters that were different between calls sites, but that would be a bit more work.

There's also a bunch of cleanups that crept into this branch. 