### PR TITLE
Bitvec Barrel Shift

### DIFF
--- a/lib/bitvec.cpp
+++ b/lib/bitvec.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "bitvec.h"
 #include "hex.h"
+#include "lib/exceptions.h"
 
 std::ostream &operator<<(std::ostream &os, const bitvec &bv) {
     if (bv.size == 1) {
@@ -144,4 +145,21 @@ bool bitvec::is_contiguous() const {
     if (empty())
         return false;
     return max().index() - min().index() + 1 == popcount();
+}
+
+/**
+ * The purpose of this function is to barrel_shift a bitvec around a pivot.  This function
+ * will crash if the pivot is smaller than the size of the bitvector
+ */
+bitvec bitvec::barrel_shift_left(size_t shift, size_t pivot) const {
+    if (max().index() > pivot) {
+        BUG("Barrel shifting around pivot %d is smaller than the max of the bitvec %d", pivot,
+            max().index());
+        return *this;
+    }
+    int single_shift = shift % pivot;
+    bitvec rv;
+    rv |= *this << single_shift;
+    rv |= *this >> (pivot - single_shift);
+    return rv & bitvec(0, pivot);
 }

--- a/lib/bitvec.h
+++ b/lib/bitvec.h
@@ -435,6 +435,7 @@ class bitvec {
     bitvec &operator<<=(size_t count);
     bitvec operator>>(size_t count) const { bitvec rv(*this); rv >>= count; return rv; }
     bitvec operator<<(size_t count) const { bitvec rv(*this); rv <<= count; return rv; }
+    bitvec barrel_shift_left(size_t shift, size_t pivot) const;
     int popcount() const {
         int rv = 0;
         for (size_t i = 0; i < size; i++)

--- a/test/gtest/bitvec_test.cpp
+++ b/test/gtest/bitvec_test.cpp
@@ -93,4 +93,22 @@ TEST(Bitvec, getslice) {
     EXPECT_EQ(slice.ffs(80), 96);
 }
 
+TEST(Bitvec, barrel_shift) {
+    bitvec bv;
+    bv.setrange(0, 4);
+    bv.setrange(12, 4);
+    bitvec bv_test1 = bv.barrel_shift_left(8, 16);
+
+    bitvec bv_verify1(4, 8);
+    EXPECT_EQ(bv_test1, bv_verify1);
+
+    bitvec bv_test2 = bv.barrel_shift_left(32, 16);
+    EXPECT_EQ(bv_test2, bv);
+
+    bitvec bv_test3 = bv.barrel_shift_left(1, 16);
+    bitvec bv_verify3(0, 5);
+    bv_verify3.setrange(13, 3);
+    EXPECT_EQ(bv_test3, bv_verify3);
+}
+
 }  // namespace Test


### PR DESCRIPTION
Added a barrel shift for bitvec to rotationally shift around a pivot.  Not sure what to do with the corner case where pivot < max().index() of that bitvec.