### PR TITLE
Fix equiv generation to be easier to override properly

### DIFF
--- a/ir/base.def
+++ b/ir/base.def
@@ -118,6 +118,7 @@ abstract Declaration : StatOrDecl, IDeclaration {
     ID          name;
     int declid = nextId++;
     ID getName() const override { return name; }
+    equiv { return name == a.name; /* ignore declid */ }
  private:
     static int nextId;
  public:
@@ -133,6 +134,7 @@ abstract Type_Declaration : Type, IDeclaration {
     ID name;
     int declid = nextId++;
     ID getName() const override { return name; }
+    equiv { return name == a.name; /* ignore declid */ }
  private:
     static int nextId;
  public:


### PR DESCRIPTION
- add Declarator::equiv and Type_Declarator::equiv that ignores declid,
  so repeated specializations with the same types will compare
  equivalent.