### PR TITLE
Get rid of Visitor::flow_dead

### DIFF
--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -127,7 +127,6 @@ class Visitor {
 
     // Functions for IR visit_children to call for ControlFlowVisitors.
     virtual Visitor &flow_clone() { return *this; }
-    virtual void flow_dead() { }
 
     /** Merge the given visitor into this visitor at a joint point in the
      * control flow graph.  Should update @this and leave the other unchanged.


### PR DESCRIPTION
- using this as a way of getting a 'bottom' flow lattice element is
  confusing and error prone, and not really necessary; not having it
  only makes a couple of visit_children routines slightly more complex.  That additional complexity also has the added bonus of being more efficient.
