### PR TITLE
move clone() method from ControlFlowVisitor to Visitor

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -39,7 +39,7 @@ class ConstantTypeSubstitution : public Transform {
     ConstantTypeSubstitution(TypeVariableSubstitution* subst,
                              ReferenceMap* refMap,
                              TypeMap* typeMap,
-                             TypeInference* tc) : 
+                             TypeInference* tc) :
         subst(subst), refMap(refMap), typeMap(typeMap), tc(tc) {
         CHECK_NULL(subst); CHECK_NULL(refMap); CHECK_NULL(typeMap);
         CHECK_NULL(tc);

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -282,6 +282,8 @@ class TypeInference : public Transform {
 
     Visitor::profile_t init_apply(const IR::Node* node) override;
     void end_apply(const IR::Node* Node) override;
+
+    TypeInference* clone() const override;
 };
 
 // Copy types from the typeMap to expressions.  Updates the typeMap with newly created nodes

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -439,11 +439,6 @@ bool Transform::check_clone(const Visitor *v) {
     return true;
 }
 
-ControlFlowVisitor* ControlFlowVisitor::clone() const {
-    BUG("must implement %s::clone method", name());
-    return nullptr;
-}
-
 ControlFlowVisitor &ControlFlowVisitor::flow_clone() {
     auto *rv = clone();
     assert(rv->check_clone(this));

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -439,6 +439,11 @@ bool Transform::check_clone(const Visitor *v) {
     return true;
 }
 
+ControlFlowVisitor* ControlFlowVisitor::clone() const {
+    BUG("must implement %s::clone method", name());
+    return nullptr;
+}
+
 ControlFlowVisitor &ControlFlowVisitor::flow_clone() {
     auto *rv = clone();
     assert(rv->check_clone(this));

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -314,7 +314,7 @@ class Transform : public virtual Visitor {
 class ControlFlowVisitor : public virtual Visitor {
     std::map<const IR::Node *, std::pair<ControlFlowVisitor *, int>> *flow_join_points = 0;
  protected:
-    ControlFlowVisitor* clone() const override;
+    ControlFlowVisitor* clone() const override = 0;
     void init_join_flows(const IR::Node *root) override;
     bool join_flows(const IR::Node *n) override;
 

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -125,6 +125,8 @@ class Visitor {
             ctxt->child_index = cidx; }
         v.parallel_visit_children(*this); }
 
+    virtual Visitor *clone() const { BUG("need %s::clone method",  name()); return nullptr; }
+
     // Functions for IR visit_children to call for ControlFlowVisitors.
     virtual Visitor &flow_clone() { return *this; }
 
@@ -312,7 +314,7 @@ class Transform : public virtual Visitor {
 class ControlFlowVisitor : public virtual Visitor {
     std::map<const IR::Node *, std::pair<ControlFlowVisitor *, int>> *flow_join_points = 0;
  protected:
-    virtual ControlFlowVisitor *clone() const = 0;
+    ControlFlowVisitor* clone() const override;
     void init_join_flows(const IR::Node *root) override;
     bool join_flows(const IR::Node *n) override;
 


### PR DESCRIPTION
A class that introducing new IR class needs to subclass TypeInference and overriding the clone() method. 