### PR TITLE
Remove standard_metadata from preserved metadata in test program

### DIFF
--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-first.p4
@@ -90,10 +90,10 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
     }
     action do_resubmit(bit<32> new_ipv4_dstAddr) {
         hdr.ipv4.dstAddr = new_ipv4_dstAddr;
-        resubmit<standard_metadata_t>(standard_metadata);
+        resubmit<tuple<>>({  });
     }
     action do_clone_i2e(bit<32> l2ptr) {
-        clone3<standard_metadata_t>(CloneType.I2E, 32w5, standard_metadata);
+        clone3<tuple<>>(CloneType.I2E, 32w5, {  });
         meta.fwd.l2ptr = l2ptr;
     }
     table ipv4_da_lpm {
@@ -162,11 +162,11 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
     }
     action do_recirculate(bit<32> new_ipv4_dstAddr) {
         hdr.ipv4.dstAddr = new_ipv4_dstAddr;
-        recirculate<standard_metadata_t>(standard_metadata);
+        recirculate<tuple<>>({  });
     }
     action do_clone_e2e(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
-        clone3<standard_metadata_t>(CloneType.E2E, 32w11, standard_metadata);
+        clone3<tuple<>>(CloneType.E2E, 32w11, {  });
     }
     table send_frame {
         key = {

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-frontend.p4
@@ -76,10 +76,10 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
     }
     @name("ingress.do_resubmit") action do_resubmit(bit<32> new_ipv4_dstAddr) {
         hdr.ipv4.dstAddr = new_ipv4_dstAddr;
-        resubmit<standard_metadata_t>(standard_metadata);
+        resubmit<tuple<>>({  });
     }
     @name("ingress.do_clone_i2e") action do_clone_i2e(bit<32> l2ptr) {
-        clone3<standard_metadata_t>(CloneType.I2E, 32w5, standard_metadata);
+        clone3<tuple<>>(CloneType.I2E, 32w5, {  });
         meta.fwd.l2ptr = l2ptr;
     }
     @name("ingress.ipv4_da_lpm") table ipv4_da_lpm_0 {
@@ -163,11 +163,11 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
     }
     @name("egress.do_recirculate") action do_recirculate(bit<32> new_ipv4_dstAddr) {
         hdr.ipv4.dstAddr = new_ipv4_dstAddr;
-        recirculate<standard_metadata_t>(standard_metadata);
+        recirculate<tuple<>>({  });
     }
     @name("egress.do_clone_e2e") action do_clone_e2e(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
-        clone3<standard_metadata_t>(CloneType.E2E, 32w11, standard_metadata);
+        clone3<tuple<>>(CloneType.E2E, 32w11, {  });
     }
     @name("egress.send_frame") table send_frame_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
@@ -56,6 +56,9 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
     }
 }
 
+struct tuple_0 {
+}
+
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop() {
         mark_to_drop();
@@ -71,10 +74,10 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
     }
     @name("ingress.do_resubmit") action do_resubmit(bit<32> new_ipv4_dstAddr) {
         hdr.ipv4.dstAddr = new_ipv4_dstAddr;
-        resubmit<standard_metadata_t>(standard_metadata);
+        resubmit<tuple_0>({  });
     }
     @name("ingress.do_clone_i2e") action do_clone_i2e(bit<32> l2ptr) {
-        clone3<standard_metadata_t>(CloneType.I2E, 32w5, standard_metadata);
+        clone3<tuple_0>(CloneType.I2E, 32w5, {  });
         meta.fwd.l2ptr = l2ptr;
     }
     @name("ingress.ipv4_da_lpm") table ipv4_da_lpm_0 {
@@ -166,11 +169,11 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
     }
     @name("egress.do_recirculate") action do_recirculate(bit<32> new_ipv4_dstAddr) {
         hdr.ipv4.dstAddr = new_ipv4_dstAddr;
-        recirculate<standard_metadata_t>(standard_metadata);
+        recirculate<tuple_0>({  });
     }
     @name("egress.do_clone_e2e") action do_clone_e2e(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
-        clone3<standard_metadata_t>(CloneType.E2E, 32w11, standard_metadata);
+        clone3<tuple_0>(CloneType.E2E, 32w11, {  });
     }
     @name("egress.send_frame") table send_frame_0 {
         key = {
@@ -230,7 +233,7 @@ control DeparserImpl(packet_out packet, in headers_t hdr) {
     }
 }
 
-struct tuple_0 {
+struct tuple_1 {
     bit<4>  field;
     bit<4>  field_0;
     bit<8>  field_1;
@@ -246,13 +249,13 @@ struct tuple_0 {
 
 control verifyChecksum(inout headers_t hdr, inout meta_t meta) {
     apply {
-        verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid() && hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        verify_checksum<tuple_1, bit<16>>(hdr.ipv4.isValid() && hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }
 }
 
 control computeChecksum(inout headers_t hdr, inout meta_t meta) {
     apply {
-        update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid() && hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+        update_checksum<tuple_1, bit<16>>(hdr.ipv4.isValid() && hdr.ipv4.ihl == 4w5, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4
@@ -90,10 +90,10 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
     }
     action do_resubmit(bit<32> new_ipv4_dstAddr) {
         hdr.ipv4.dstAddr = new_ipv4_dstAddr;
-        resubmit(standard_metadata);
+        resubmit({  });
     }
     action do_clone_i2e(bit<32> l2ptr) {
-        clone3(CloneType.I2E, I2E_CLONE_SESSION_ID, standard_metadata);
+        clone3(CloneType.I2E, I2E_CLONE_SESSION_ID, {  });
         meta.fwd.l2ptr = l2ptr;
     }
     table ipv4_da_lpm {
@@ -162,11 +162,11 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
     }
     action do_recirculate(bit<32> new_ipv4_dstAddr) {
         hdr.ipv4.dstAddr = new_ipv4_dstAddr;
-        recirculate(standard_metadata);
+        recirculate({  });
     }
     action do_clone_e2e(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
-        clone3(CloneType.E2E, E2E_CLONE_SESSION_ID, standard_metadata);
+        clone3(CloneType.E2E, E2E_CLONE_SESSION_ID, {  });
     }
     table send_frame {
         key = {


### PR DESCRIPTION
It seems unlikely that standard or intrinsic metadata should be
allowed to be explicitly preserved in this way, since the architecture
defines how these should be filled in at the beginning of an ingress
and/or egress pipeline.