### PR TITLE
get rid of an unnecessary warning

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -675,9 +675,7 @@ void ProgramStructure::createDeparser() {
     }
 
     std::vector<const IR::Expression*> sortedHeaders;
-    bool loop = headerOrder.sccSort(startHeader, sortedHeaders);
-    if (loop)
-        ::warning("The order of headers in deparser is not uniquely determined by parser!");
+    headerOrder.sccSort(startHeader, sortedHeaders);
 
     auto params = new IR::ParameterList;
     auto poutpath = new IR::Path(p4lib.packetOut.Id());


### PR DESCRIPTION
This warning is redundant because all v1model programs that have parser branches will not have an unique header order in the deparser?