### PR TITLE
Handle complex headers (with nested structs) in P4Info generation

### DIFF
--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -66,9 +66,6 @@ set (P4RUNTIME_EXCLUDE
   # error not supported in static entries, not strictly required for P4Info
   # generation though
   testdata/p4_16_samples/issue1062-bmv2.p4
-  # issue #1670: no support for headers containing structs
-  testdata/p4_16_samples/issue1670-bmv2.p4
-  testdata/p4_16_samples/p4rt_digest_complex.p4
 )
 # Do not generate P4Info for tests which are expected to fail P4 compilation.
 p4c_find_test_names ("${P4C_SOURCE_DIR}/testdata/p4_16_errors/*.p4" P4RUNTIME_EXCLUDE_ERRORS)

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -71,6 +71,7 @@ add_custom_command(OUTPUT ${P4RUNTIME_GEN_SRCS} ${P4RUNTIME_GEN_HDRS}
 #PROTOBUF_GENERATE_PYTHON (P4RUNTIME_GEN_PYTHON P4RUNTIME_INFO_GEN_HDRS ${P4RUNTIME_INFO_PROTO})
 
 set (CONTROLPLANE_SRCS
+  flattenHeader.cpp
   p4RuntimeArchHandler.cpp
   p4RuntimeArchStandard.cpp
   p4RuntimeSerializer.cpp
@@ -82,6 +83,7 @@ set (CONTROLPLANE_SOURCES
   )
 
 set (CONTROLPLANE_HDRS
+  flattenHeader.h
   p4RuntimeArchHandler.h
   p4RuntimeArchStandard.h
   p4RuntimeSerializer.h

--- a/control-plane/flattenHeader.cpp
+++ b/control-plane/flattenHeader.cpp
@@ -1,0 +1,82 @@
+/*
+Copyright 2019-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "flattenHeader.h"
+#include "frontends/p4/typeMap.h"
+
+namespace P4 {
+
+namespace ControlPlaneAPI {
+
+FlattenHeader::FlattenHeader(const P4::TypeMap* typeMap, IR::Type_Header* flattenedHeader)
+    : typeMap(typeMap), flattenedHeader(flattenedHeader) { }
+
+void FlattenHeader::doFlatten(const IR::Type* type) {
+    if (type->is<IR::Type_Struct>()) needsFlattening = true;
+    if (auto st = type->to<IR::Type_StructLike>()) {
+        for (auto f : st->fields) {
+            nameSegments.push_back(f->name);
+            allAnnotations.push_back(f->annotations);
+            doFlatten(typeMap->getType(f, true));
+            allAnnotations.pop_back();
+            nameSegments.pop_back();
+        }
+    } else {  // primitive field types
+        auto& newFields = flattenedHeader->fields;
+        auto newName = makeName("_");
+        // preserve the original name using an annotation
+        auto originalName = makeName(".");
+        auto annotations = mergeAnnotations();
+        annotations = annotations->addOrReplace(
+            IR::Annotation::nameAnnotation, new IR::StringLiteral(originalName));
+        newFields.push_back(new IR::StructField(IR::ID(newName), annotations, type));
+    }
+}
+
+cstring FlattenHeader::makeName(cstring sep) const {
+    cstring name = "";
+    for (auto n : nameSegments) name += sep + n;
+    return name;
+}
+
+/// Merge all the annotation vectors in allAnnotations into a single
+/// one. Duplicates are resolved, with preference given to the ones towards the
+/// end of allAnnotations, which correspond to the most "nested" ones.
+const IR::Annotations* FlattenHeader::mergeAnnotations() const {
+    auto mergedAnnotations = new IR::Annotations();
+    for (auto annosIt = allAnnotations.rbegin(); annosIt != allAnnotations.rend(); annosIt++) {
+        for (auto anno : (*annosIt)->annotations) {
+            // if an annotation with the same name was added previously, skip
+            if (mergedAnnotations->getSingle(anno->name)) continue;
+            mergedAnnotations->add(anno);
+        }
+    }
+    return mergedAnnotations;
+}
+
+/* static */
+const IR::Type_Header* FlattenHeader::flatten(
+    const P4::TypeMap* typeMap, const IR::Type_Header* headerType) {
+    auto flattenedHeader = headerType->clone();
+    flattenedHeader->fields.clear();
+    FlattenHeader flattener(typeMap, flattenedHeader);
+    flattener.doFlatten(headerType);
+    return flattener.needsFlattening ? flattenedHeader : headerType;
+}
+
+}  // namespace ControlPlaneAPI
+
+}  // namespace P4

--- a/control-plane/flattenHeader.h
+++ b/control-plane/flattenHeader.h
@@ -1,0 +1,58 @@
+/*
+Copyright 2019-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef CONTROL_PLANE_FLATTENHEADER_H_
+#define CONTROL_PLANE_FLATTENHEADER_H_
+
+#include <vector>
+
+#include "ir/ir.h"
+
+namespace P4 {
+
+class TypeMap;
+
+namespace ControlPlaneAPI {
+
+/// Flattens a header type "locally", without modifying the IR.
+class FlattenHeader {
+ private:
+    const P4::TypeMap* typeMap;
+    IR::Type_Header* flattenedHeader;
+    std::vector<cstring> nameSegments{};
+    std::vector<const IR::Annotations*> allAnnotations{};
+    bool needsFlattening{false};
+
+    FlattenHeader(const P4::TypeMap* typeMap, IR::Type_Header* flattenedHeader);
+
+    void doFlatten(const IR::Type* type);
+
+    cstring makeName(cstring sep) const;
+    const IR::Annotations* mergeAnnotations() const;
+
+ public:
+    /// If the @headerType needs flattening, creates a clone of the IR node with
+    /// a new flattened field list. Otherwise returns @headerType. This does not
+    /// modify the IR.
+    static const IR::Type_Header* flatten(
+        const P4::TypeMap* typeMap, const IR::Type_Header* headerType);
+};
+
+}  // namespace ControlPlaneAPI
+
+}  // namespace P4
+
+#endif  // CONTROL_PLANE_FLATTENHEADER_H_

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -289,6 +289,7 @@ struct Register {
     static boost::optional<Register>
     from(const IR::ExternBlock* instance,
          const ReferenceMap* refMap,
+         const P4::TypeMap* typeMap,
          p4configv1::P4TypeInfo* p4RtTypeInfo) {
         CHECK_NULL(instance);
         auto declaration = instance->node->to<IR::Declaration_Instance>();
@@ -312,7 +313,7 @@ struct Register {
         BUG_CHECK(type->arguments->size() > typeParamIdx,
                   "%1%: expected at least %2% type arguments", instance, typeParamIdx + 1);
         auto typeArg = type->arguments->at(typeParamIdx);
-        auto typeSpec = TypeSpecConverter::convert(refMap, typeArg, p4RtTypeInfo);
+        auto typeSpec = TypeSpecConverter::convert(refMap, typeMap, typeArg, p4RtTypeInfo);
         CHECK_NULL(typeSpec);
 
         return Register{declaration->controlPlaneName(),
@@ -528,7 +529,7 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
             auto meter = Helpers::Counterlike<ArchMeterExtern>::from(externBlock);
             if (meter) addMeter(symbols, p4info, *meter);
         } else if (externBlock->type->name == RegisterTraits<arch>::typeName()) {
-            auto register_ = Register::from<arch>(externBlock, refMap, p4RtTypeInfo);
+            auto register_ = Register::from<arch>(externBlock, refMap, typeMap, p4RtTypeInfo);
             if (register_) addRegister(symbols, p4info, *register_);
         } else if (externBlock->type->name == ActionProfileTraits<arch>::typeName() ||
                    externBlock->type->name == ActionSelectorTraits<arch>::typeName()) {
@@ -779,7 +780,7 @@ class P4RuntimeArchHandlerV1Model final : public P4RuntimeArchHandlerCommon<Arch
 
     void collectExternFunction(P4RuntimeSymbolTableIface* symbols,
                                const P4::ExternFunction* externFunction) override {
-        auto digest = getDigestCall(externFunction, refMap, nullptr);
+        auto digest = getDigestCall(externFunction, refMap, typeMap, nullptr);
         if (digest) symbols->add(SymbolType::DIGEST(), digest->name);
     }
 
@@ -803,7 +804,7 @@ class P4RuntimeArchHandlerV1Model final : public P4RuntimeArchHandlerCommon<Arch
                            p4configv1::P4Info* p4info,
                            const P4::ExternFunction* externFunction) override {
         auto p4RtTypeInfo = p4info->mutable_type_info();
-        auto digest = getDigestCall(externFunction, refMap, p4RtTypeInfo);
+        auto digest = getDigestCall(externFunction, refMap, typeMap, p4RtTypeInfo);
         if (digest) addDigest(symbols, p4info, *digest);
     }
 
@@ -812,6 +813,7 @@ class P4RuntimeArchHandlerV1Model final : public P4RuntimeArchHandlerCommon<Arch
     static boost::optional<Digest>
     getDigestCall(const P4::ExternFunction* function,
                   ReferenceMap* refMap,
+                  const P4::TypeMap* typeMap,
                   p4configv1::P4TypeInfo* p4RtTypeInfo) {
         if (function->method->name != P4V1::V1Model::instance.digest_receiver.name)
             return boost::none;
@@ -850,7 +852,7 @@ class P4RuntimeArchHandlerV1Model final : public P4RuntimeArchHandlerCommon<Arch
         }
 
         // Convert the generic type for the digest method call to a P4DataTypeSpec
-        auto* typeSpec = TypeSpecConverter::convert(refMap, typeArg, p4RtTypeInfo);
+        auto* typeSpec = TypeSpecConverter::convert(refMap, typeMap, typeArg, p4RtTypeInfo);
         BUG_CHECK(typeSpec != nullptr, "P4 type %1% could not be converted to P4Info P4DataTypeSpec");
         return Digest{controlPlaneName, typeSpec, nullptr};
     }
@@ -939,7 +941,7 @@ class P4RuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
         auto type = decl->type->to<IR::Type_Specialized>();
         BUG_CHECK(type->arguments->size() == 1, "%1%: expected one type argument", decl);
         auto typeArg = type->arguments->at(0);
-        auto typeSpec = TypeSpecConverter::convert(refMap, typeArg, p4RtTypeInfo);
+        auto typeSpec = TypeSpecConverter::convert(refMap, typeMap, typeArg, p4RtTypeInfo);
         BUG_CHECK(typeSpec != nullptr,
                   "P4 type %1% could not be converted to P4Info P4DataTypeSpec");
 

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -770,6 +770,8 @@ class P4RuntimeAnalyzer {
     void addControllerHeader(const IR::Type_Header* type) {
         if (isHidden(type)) return;
 
+        auto flattenedHeaderType = FlattenHeader::flatten(typeMap, type);
+
         auto name = type->controlPlaneName();
         auto id = symbols.getId(P4RuntimeSymbolType::CONTROLLER_HEADER(), name);
         auto annotations = type->to<IR::IAnnotated>();
@@ -789,7 +791,7 @@ class P4RuntimeAnalyzer {
                     controllerName /* name */, controllerName /* alias */, annotations);
 
         size_t index = 1;
-        for (auto headerField : type->fields) {
+        for (auto headerField : flattenedHeaderType->fields) {
             if (isHidden(headerField)) continue;
             auto metadata = header->add_metadata();
             auto fieldName = headerField->controlPlaneName();

--- a/control-plane/typeSpecConverter.h
+++ b/control-plane/typeSpecConverter.h
@@ -42,6 +42,7 @@ namespace ControlPlaneAPI {
 class TypeSpecConverter : public Inspector {
  private:
     const P4::ReferenceMap* refMap;
+    const P4::TypeMap* typeMap;
     /// type_info field of the P4Info message: includes information about P4
     /// named types (struct, header, header union, enum, error).
     ::p4::config::v1::P4TypeInfo* p4RtTypeInfo;
@@ -50,6 +51,7 @@ class TypeSpecConverter : public Inspector {
     std::map<const IR::Type*, ::p4::config::v1::P4DataTypeSpec*> map;
 
     TypeSpecConverter(const P4::ReferenceMap* refMap,
+                      const P4::TypeMap* typeMap,
                       ::p4::config::v1::P4TypeInfo* p4RtTypeInfo);
 
     // fallback for unsupported types, should be unreachable
@@ -77,7 +79,7 @@ class TypeSpecConverter : public Inspector {
     /// @typeInfo is nullptr, then the relevant information is not generated for
     /// named types.
     static const ::p4::config::v1::P4DataTypeSpec* convert(
-        const P4::ReferenceMap* refMap,
+        const P4::ReferenceMap* refMap, const P4::TypeMap* typeMap,
         const IR::Type* type, ::p4::config::v1::P4TypeInfo* typeInfo);
 };
 

--- a/testdata/p4_16_samples_outputs/issue1670-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1670-bmv2.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "v1model"
+}

--- a/testdata/p4_16_samples_outputs/p4rt_digest_complex.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/p4rt_digest_complex.p4.p4info.txt
@@ -41,7 +41,7 @@ type_info {
     key: "h_t"
     value {
       members {
-        name: "_s_f80"
+        name: "s.f8"
         type_spec {
           bit {
             bitwidth: 8
@@ -49,7 +49,7 @@ type_info {
         }
       }
       members {
-        name: "_s_f161"
+        name: "s.f16"
         type_spec {
           bit {
             bitwidth: 16
@@ -57,7 +57,7 @@ type_info {
         }
       }
       members {
-        name: "_f322"
+        name: "f32"
         type_spec {
           bit {
             bitwidth: 32


### PR DESCRIPTION
The P4Info generation code now handles complex headers by flattening
them. This is independent from the FlattenHeaders pass, which is a
midend pass. This code is much simpler and has no dependency on non
frontend pass. It simply performs a "local" flattening of a given
Type_Header, without updating any program references. It also preserves
the fully-qualified name using a @name annotation (unlike the
FlattenHeaders pass), along with annotations of the nested
fields. Because of the local nature of this flattening, it seemed silly
to write an actual pass (I tried and it was clumsy, with a call to
visitAgain).

The flattening is performed wherever the p4RuntimeSerializer has to deal
with header types, so only 2 places: for controller headers and in the
typeSpecConverter.