### PR TITLE
Add XFAIL P4_14 test program that fails because of issue #1669

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -144,6 +144,17 @@ set (XFAIL_TESTS
   testdata/p4_14_samples/issue60.p4
   # compiler claims (incorrectly?) that c2 has mulitple successors, so is not supported
   testdata/p4_14_samples/issue-1426.p4
+  # As of 2019-Feb-04 latest p4c code, this program fails due to the
+  # root cause of both issues #1694 and #1669.  I have tested it with
+  # the proposed fix for issue #1694 that is on PR #1704, and while
+  # that does make the produced BMv2 JSON file able to cause packets
+  # to be recirculated, resubmitted, etc. it still has the bug of not
+  # preserving the metadata specified in the program's field_lists, so
+  # the STF tests fail because of issue #1669.  As of this writing,
+  # this program is the _only_ p4c test program that relies for its
+  # successful execution on the preservation of metadata across
+  # resubmit, recirculate, and/or clone operations.
+  testdata/p4_14_samples/p414-special-ops-2-bmv2.p4
   # This test uses a feature currently unsupported in the BMv2 back-end.
   testdata/p4_16_samples/issue907-bmv2.p4
   # This test uses a table graph that is not implementable in BMv2

--- a/testdata/p4_14_samples/p414-special-ops-2-bmv2.p4
+++ b/testdata/p4_14_samples/p414-special-ops-2-bmv2.p4
@@ -1,0 +1,334 @@
+/*
+Copyright 2019 Cisco Systems, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#define MAC_DA_DO_RESUBMIT    0x000000000001
+#define MAC_DA_DO_RECIRCULATE 0x000000000002
+#define MAC_DA_DO_CLONE_E2E   0x000000000003
+
+#define MAX_RESUBMIT_COUNT    3
+#define MAX_RECIRCULATE_COUNT 5
+#define MAX_CLONE_E2E_COUNT   4
+
+#define ETHERTYPE_VANILLA               0xf00f
+#define ETHERTYPE_MAX_RESUBMIT          0xe50b
+#define ETHERTYPE_MAX_RECIRCULATE       0xec14
+#define ETHERTYPE_MAX_CLONE_E2E         0xce2e
+
+
+header_type ethernet_t {
+    fields {
+        dstAddr : 48;
+        srcAddr : 48;
+        etherType : 16;
+    }
+}
+
+header_type intrinsic_metadata_t {
+    fields {
+        ingress_global_timestamp : 48;
+        egress_global_timestamp : 48;
+        lf_field_list : 8;
+        mcast_grp : 16;
+        egress_rid : 16;
+        resubmit_flag : 8;
+        recirculate_flag : 8;
+    }
+}
+
+header_type mymeta_t {
+    fields {
+        resubmit_count : 8;
+        recirculate_count : 8;
+        clone_e2e_count : 8;
+        last_ing_instance_type : 8;
+        f1 : 8;
+    }
+}
+
+header_type temporaries_t {
+    fields {
+        temp1 : 48;
+    }
+}
+
+header ethernet_t ethernet;
+metadata intrinsic_metadata_t intrinsic_metadata;
+metadata mymeta_t mymeta;
+metadata temporaries_t temporaries;
+
+parser start {
+    return parse_ethernet;
+}
+
+parser parse_ethernet {
+    extract(ethernet);
+    return ingress;
+}
+
+action _drop() {
+    drop();
+}
+
+action _nop() {
+}
+
+#define ENABLE_DEBUG_TABLE
+#ifdef ENABLE_DEBUG_TABLE
+
+        //standard_metadata.egress_instance: exact;
+        //standard_metadata.parser_status: exact;
+        //standard_metadata.parser_error: exact;
+        //standard_metadata.clone_spec: exact;
+
+#define DEBUG_FIELD_LIST \
+        standard_metadata.ingress_port: exact; \
+        standard_metadata.packet_length: exact; \
+        standard_metadata.egress_spec: exact; \
+        standard_metadata.egress_port: exact; \
+        standard_metadata.instance_type: exact; \
+        intrinsic_metadata.ingress_global_timestamp: exact; \
+        intrinsic_metadata.egress_global_timestamp: exact; \
+        intrinsic_metadata.lf_field_list: exact; \
+        intrinsic_metadata.mcast_grp: exact; \
+        intrinsic_metadata.egress_rid: exact; \
+        intrinsic_metadata.resubmit_flag: exact; \
+        intrinsic_metadata.recirculate_flag: exact; \
+        mymeta.resubmit_count: exact; \
+        mymeta.recirculate_count: exact; \
+        mymeta.clone_e2e_count: exact; \
+        mymeta.f1: exact; \
+        mymeta.last_ing_instance_type : exact; \
+        ethernet.dstAddr: exact; \
+        ethernet.srcAddr: exact; \
+        ethernet.etherType: exact;
+
+table t_ing_debug_table1 {
+    reads { DEBUG_FIELD_LIST }
+    actions { _nop; }
+    default_action: _nop;
+}
+
+table t_ing_debug_table2 {
+    reads { DEBUG_FIELD_LIST }
+    actions { _nop; }
+    default_action: _nop;
+}
+
+table t_egr_debug_table1 {
+    reads { DEBUG_FIELD_LIST }
+    actions { _nop; }
+    default_action: _nop;
+}
+
+table t_egr_debug_table2 {
+    reads { DEBUG_FIELD_LIST }
+    actions { _nop; }
+    default_action: _nop;
+}
+#endif  // ENABLE_DEBUG_TABLE
+
+field_list resubmit_FL {
+    mymeta;
+}
+
+field_list recirculate_FL {
+    mymeta;
+}
+
+field_list clone_e2e_FL {
+    mymeta;
+}
+
+action do_resubmit() {
+    subtract_from_field(ethernet.srcAddr, 17);
+    add_to_field(mymeta.f1, 17);
+    add_to_field(mymeta.resubmit_count, 1);
+    resubmit(resubmit_FL);
+}
+
+table t_do_resubmit {
+    reads { }
+    actions { do_resubmit; }
+    default_action: do_resubmit;
+}
+
+action mark_max_resubmit_packet () {
+    modify_field(ethernet.etherType, ETHERTYPE_MAX_RESUBMIT);
+}
+
+table t_mark_max_resubmit_packet {
+    reads { }
+    actions { mark_max_resubmit_packet; }
+    default_action: mark_max_resubmit_packet;
+}
+
+action set_port_to_mac_da_lsbs() {
+    bit_and(standard_metadata.egress_spec, ethernet.dstAddr, 0xf);
+}
+
+table t_ing_mac_da {
+    reads { }
+    actions { set_port_to_mac_da_lsbs; }
+    default_action: set_port_to_mac_da_lsbs;
+}
+
+action save_ing_instance_type () {
+    modify_field(mymeta.last_ing_instance_type,
+        standard_metadata.instance_type);
+}
+
+table t_save_ing_instance_type {
+    reads { }
+    actions { save_ing_instance_type; }
+    default_action: save_ing_instance_type;
+}
+
+control ingress {
+#ifdef ENABLE_DEBUG_TABLE
+    apply(t_ing_debug_table1);
+#endif  // ENABLE_DEBUG_TABLE
+    if (ethernet.dstAddr == MAC_DA_DO_RESUBMIT) {
+        if (mymeta.resubmit_count < MAX_RESUBMIT_COUNT) {
+            apply(t_do_resubmit);
+        } else {
+            apply(t_mark_max_resubmit_packet);
+        }
+    } else {
+        apply(t_ing_mac_da);
+    }
+    apply(t_save_ing_instance_type);
+#ifdef ENABLE_DEBUG_TABLE
+    apply(t_ing_debug_table2);
+#endif  // ENABLE_DEBUG_TABLE
+}
+
+action put_debug_vals_in_eth_dstaddr () {
+    // By copying values of selected metadata fields into the output
+    // packet, we enable an automated STF test that checks the output
+    // packet contents, to also check that the values of these
+    // intermediate metadata field values are also correct.
+    modify_field(ethernet.dstAddr, 0);
+    shift_left(temporaries.temp1, mymeta.resubmit_count, 40);
+    bit_or(ethernet.dstAddr, ethernet.dstAddr, temporaries.temp1);
+    shift_left(temporaries.temp1, mymeta.recirculate_count, 32);
+    bit_or(ethernet.dstAddr, ethernet.dstAddr, temporaries.temp1);
+    shift_left(temporaries.temp1, mymeta.clone_e2e_count, 24);
+    bit_or(ethernet.dstAddr, ethernet.dstAddr, temporaries.temp1);
+    shift_left(temporaries.temp1, mymeta.f1, 16);
+    bit_or(ethernet.dstAddr, ethernet.dstAddr, temporaries.temp1);
+    shift_left(temporaries.temp1, mymeta.last_ing_instance_type, 8);
+    bit_or(ethernet.dstAddr, ethernet.dstAddr, temporaries.temp1);
+    // TBD: Commenting out the following lines, since the value that
+    // they copy into the output packet may change soon, depending
+    // upon the resolution of this issue:
+    // https://github.com/p4lang/behavioral-model/issues/706
+    //bit_and(temporaries.temp1, standard_metadata.instance_type, 0xff);
+    //bit_or(ethernet.dstAddr, ethernet.dstAddr, temporaries.temp1);
+}
+
+action mark_egr_resubmit_packet () {
+    put_debug_vals_in_eth_dstaddr();
+}
+
+table t_egr_mark_resubmit_packet {
+    reads { }
+    actions { mark_egr_resubmit_packet; }
+    default_action: mark_egr_resubmit_packet;
+}
+
+action do_recirculate () {
+    subtract_from_field(ethernet.srcAddr, 19);
+    add_to_field(mymeta.f1, 19);
+    add_to_field(mymeta.recirculate_count, 1);
+    recirculate(recirculate_FL);
+}
+
+table t_do_recirculate {
+    reads { }
+    actions { do_recirculate; }
+    default_action: do_recirculate;
+}
+
+action mark_max_recirculate_packet () {
+    put_debug_vals_in_eth_dstaddr();
+    modify_field(ethernet.etherType, ETHERTYPE_MAX_RECIRCULATE);
+}
+
+table t_mark_max_recirculate_packet {
+    reads { }
+    actions { mark_max_recirculate_packet; }
+    default_action: mark_max_recirculate_packet;
+}
+
+action do_clone_e2e () {
+    subtract_from_field(ethernet.srcAddr, 23);
+    add_to_field(mymeta.f1, 23);
+    add_to_field(mymeta.clone_e2e_count, 1);
+    clone_egress_pkt_to_egress(1, clone_e2e_FL);
+}
+
+table t_do_clone_e2e {
+    reads { }
+    actions { do_clone_e2e; }
+    default_action: do_clone_e2e;
+}
+
+action mark_max_clone_e2e_packet () {
+    put_debug_vals_in_eth_dstaddr();
+    modify_field(ethernet.etherType, ETHERTYPE_MAX_CLONE_E2E);
+}
+
+table t_mark_max_clone_e2e_packet {
+    reads { }
+    actions { mark_max_clone_e2e_packet; }
+    default_action: mark_max_clone_e2e_packet;
+}
+
+action mark_vanilla_packet () {
+    put_debug_vals_in_eth_dstaddr();
+    modify_field(ethernet.etherType, ETHERTYPE_VANILLA);
+}
+
+table t_mark_vanilla_packet {
+    reads { }
+    actions { mark_vanilla_packet; }
+    default_action: mark_vanilla_packet;
+}
+
+control egress {
+#ifdef ENABLE_DEBUG_TABLE
+    apply(t_egr_debug_table1);
+#endif  // ENABLE_DEBUG_TABLE
+    if (ethernet.dstAddr == MAC_DA_DO_RESUBMIT) {
+        // Do nothing to the packet in egress, not even marking it
+        // 'vanilla' as is done below.
+        apply(t_egr_mark_resubmit_packet);
+    } else if (ethernet.dstAddr == MAC_DA_DO_RECIRCULATE) {
+        if (mymeta.recirculate_count < MAX_RECIRCULATE_COUNT) {
+            apply(t_do_recirculate);
+        } else {
+            apply(t_mark_max_recirculate_packet);
+        }
+    } else if (ethernet.dstAddr == MAC_DA_DO_CLONE_E2E) {
+        if (mymeta.clone_e2e_count < MAX_CLONE_E2E_COUNT) {
+            apply(t_do_clone_e2e);
+        } else {
+            apply(t_mark_max_clone_e2e_packet);
+        }
+    } else {
+        apply(t_mark_vanilla_packet);
+    }
+#ifdef ENABLE_DEBUG_TABLE
+    apply(t_egr_debug_table2);
+#endif  // ENABLE_DEBUG_TABLE
+}

--- a/testdata/p4_14_samples/p414-special-ops-2-bmv2.stf
+++ b/testdata/p4_14_samples/p414-special-ops-2-bmv2.stf
@@ -1,0 +1,32 @@
+######################################################################
+
+# For details on the behavior of this program with these input
+# packets, and how they should produce these expected output packets,
+# see https://github.com/jafingerhut/p4-guide/tbd/README-p414.md
+
+# test resubmit operation
+
+packet 0 000000000001 000000000000 dead
+expect 0 030000330600 000000000000 e50b
+
+######################################################################
+
+# test recirculate operation
+
+packet 0 000000000002 000000000000 dead
+expect 2 0005005f0400 ffffffffffa1 ec14
+
+######################################################################
+
+# test clone operation from egress to egress
+
+# The mirroring_add command causes packets cloned to clone session id
+# 1, to be copied to egress_port 5.
+mirroring_add 1 5
+
+packet 0 000000000003 000000000000 dead
+expect 3 000000000003 ffffffffffe9 dead
+expect 5 000000000003 ffffffffffd2 dead
+expect 5 000000000003 ffffffffffbb dead
+expect 5 000000000003 ffffffffffa4 dead
+expect 5 0000045c0000 ffffffffffa4 ce2e

--- a/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-first.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-first.p4
@@ -1,0 +1,362 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct intrinsic_metadata_t {
+    bit<48> ingress_global_timestamp;
+    bit<48> egress_global_timestamp;
+    bit<8>  lf_field_list;
+    bit<16> mcast_grp;
+    bit<16> egress_rid;
+    bit<8>  resubmit_flag;
+    bit<8>  recirculate_flag;
+}
+
+struct mymeta_t {
+    bit<8> resubmit_count;
+    bit<8> recirculate_count;
+    bit<8> clone_e2e_count;
+    bit<8> last_ing_instance_type;
+    bit<8> f1;
+}
+
+struct temporaries_t {
+    bit<48> temp1;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+    @name(".intrinsic_metadata") 
+    intrinsic_metadata_t intrinsic_metadata;
+    @name(".mymeta") 
+    mymeta_t             mymeta;
+    @name(".temporaries") 
+    temporaries_t        temporaries;
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_ethernet") state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+    @name(".start") state start {
+        transition parse_ethernet;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_clone_e2e") action do_clone_e2e() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710633;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w23;
+        meta.mymeta.clone_e2e_count = meta.mymeta.clone_e2e_count + 8w1;
+        clone3<tuple<mymeta_t>>(CloneType.E2E, 32w1, { meta.mymeta });
+    }
+    @name(".do_recirculate") action do_recirculate() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710637;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w19;
+        meta.mymeta.recirculate_count = meta.mymeta.recirculate_count + 8w1;
+        recirculate<tuple<mymeta_t>>({ meta.mymeta });
+    }
+    @name("._nop") action _nop() {
+    }
+    @name(".put_debug_vals_in_eth_dstaddr") action put_debug_vals_in_eth_dstaddr() {
+        hdr.ethernet.dstAddr = 48w0;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.resubmit_count << 40;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.recirculate_count << 32;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.f1 << 16;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+    }
+    @name(".mark_egr_resubmit_packet") action mark_egr_resubmit_packet() {
+        put_debug_vals_in_eth_dstaddr();
+    }
+    @name(".mark_max_clone_e2e_packet") action mark_max_clone_e2e_packet() {
+        put_debug_vals_in_eth_dstaddr();
+        hdr.ethernet.etherType = 16w0xce2e;
+    }
+    @name(".mark_max_recirculate_packet") action mark_max_recirculate_packet() {
+        put_debug_vals_in_eth_dstaddr();
+        hdr.ethernet.etherType = 16w0xec14;
+    }
+    @name(".mark_vanilla_packet") action mark_vanilla_packet() {
+        put_debug_vals_in_eth_dstaddr();
+        hdr.ethernet.etherType = 16w0xf00f;
+    }
+    @name(".t_do_clone_e2e") table t_do_clone_e2e {
+        actions = {
+            do_clone_e2e();
+        }
+        key = {
+        }
+        default_action = do_clone_e2e();
+    }
+    @name(".t_do_recirculate") table t_do_recirculate {
+        actions = {
+            do_recirculate();
+        }
+        key = {
+        }
+        default_action = do_recirculate();
+    }
+    @name(".t_egr_debug_table1") table t_egr_debug_table1 {
+        actions = {
+            _nop();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop();
+    }
+    @name(".t_egr_debug_table2") table t_egr_debug_table2 {
+        actions = {
+            _nop();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop();
+    }
+    @name(".t_egr_mark_resubmit_packet") table t_egr_mark_resubmit_packet {
+        actions = {
+            mark_egr_resubmit_packet();
+        }
+        key = {
+        }
+        default_action = mark_egr_resubmit_packet();
+    }
+    @name(".t_mark_max_clone_e2e_packet") table t_mark_max_clone_e2e_packet {
+        actions = {
+            mark_max_clone_e2e_packet();
+        }
+        key = {
+        }
+        default_action = mark_max_clone_e2e_packet();
+    }
+    @name(".t_mark_max_recirculate_packet") table t_mark_max_recirculate_packet {
+        actions = {
+            mark_max_recirculate_packet();
+        }
+        key = {
+        }
+        default_action = mark_max_recirculate_packet();
+    }
+    @name(".t_mark_vanilla_packet") table t_mark_vanilla_packet {
+        actions = {
+            mark_vanilla_packet();
+        }
+        key = {
+        }
+        default_action = mark_vanilla_packet();
+    }
+    apply {
+        t_egr_debug_table1.apply();
+        if (hdr.ethernet.dstAddr == 48w0x1) 
+            t_egr_mark_resubmit_packet.apply();
+        else 
+            if (hdr.ethernet.dstAddr == 48w0x2) 
+                if (meta.mymeta.recirculate_count < 8w5) 
+                    t_do_recirculate.apply();
+                else 
+                    t_mark_max_recirculate_packet.apply();
+            else 
+                if (hdr.ethernet.dstAddr == 48w0x3) 
+                    if (meta.mymeta.clone_e2e_count < 8w4) 
+                        t_do_clone_e2e.apply();
+                    else 
+                        t_mark_max_clone_e2e_packet.apply();
+                else 
+                    t_mark_vanilla_packet.apply();
+        t_egr_debug_table2.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_resubmit") action do_resubmit() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710639;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w17;
+        meta.mymeta.resubmit_count = meta.mymeta.resubmit_count + 8w1;
+        resubmit<tuple<mymeta_t>>({ meta.mymeta });
+    }
+    @name("._nop") action _nop() {
+    }
+    @name(".set_port_to_mac_da_lsbs") action set_port_to_mac_da_lsbs() {
+        standard_metadata.egress_spec = (bit<9>)hdr.ethernet.dstAddr & 9w0xf;
+    }
+    @name(".mark_max_resubmit_packet") action mark_max_resubmit_packet() {
+        hdr.ethernet.etherType = 16w0xe50b;
+    }
+    @name(".save_ing_instance_type") action save_ing_instance_type() {
+        meta.mymeta.last_ing_instance_type = (bit<8>)standard_metadata.instance_type;
+    }
+    @name(".t_do_resubmit") table t_do_resubmit {
+        actions = {
+            do_resubmit();
+        }
+        key = {
+        }
+        default_action = do_resubmit();
+    }
+    @name(".t_ing_debug_table1") table t_ing_debug_table1 {
+        actions = {
+            _nop();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop();
+    }
+    @name(".t_ing_debug_table2") table t_ing_debug_table2 {
+        actions = {
+            _nop();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop();
+    }
+    @name(".t_ing_mac_da") table t_ing_mac_da {
+        actions = {
+            set_port_to_mac_da_lsbs();
+        }
+        key = {
+        }
+        default_action = set_port_to_mac_da_lsbs();
+    }
+    @name(".t_mark_max_resubmit_packet") table t_mark_max_resubmit_packet {
+        actions = {
+            mark_max_resubmit_packet();
+        }
+        key = {
+        }
+        default_action = mark_max_resubmit_packet();
+    }
+    @name(".t_save_ing_instance_type") table t_save_ing_instance_type {
+        actions = {
+            save_ing_instance_type();
+        }
+        key = {
+        }
+        default_action = save_ing_instance_type();
+    }
+    apply {
+        t_ing_debug_table1.apply();
+        if (hdr.ethernet.dstAddr == 48w0x1) 
+            if (meta.mymeta.resubmit_count < 8w3) 
+                t_do_resubmit.apply();
+            else 
+                t_mark_max_resubmit_packet.apply();
+        else 
+            t_ing_mac_da.apply();
+        t_save_ing_instance_type.apply();
+        t_ing_debug_table2.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-frontend.p4
@@ -1,0 +1,393 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct intrinsic_metadata_t {
+    bit<48> ingress_global_timestamp;
+    bit<48> egress_global_timestamp;
+    bit<8>  lf_field_list;
+    bit<16> mcast_grp;
+    bit<16> egress_rid;
+    bit<8>  resubmit_flag;
+    bit<8>  recirculate_flag;
+}
+
+struct mymeta_t {
+    bit<8> resubmit_count;
+    bit<8> recirculate_count;
+    bit<8> clone_e2e_count;
+    bit<8> last_ing_instance_type;
+    bit<8> f1;
+}
+
+struct temporaries_t {
+    bit<48> temp1;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+    @name(".intrinsic_metadata") 
+    intrinsic_metadata_t intrinsic_metadata;
+    @name(".mymeta") 
+    mymeta_t             mymeta;
+    @name(".temporaries") 
+    temporaries_t        temporaries;
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_ethernet") state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+    @name(".start") state start {
+        transition parse_ethernet;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_clone_e2e") action do_clone_e2e() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710633;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w23;
+        meta.mymeta.clone_e2e_count = meta.mymeta.clone_e2e_count + 8w1;
+        clone3<tuple<mymeta_t>>(CloneType.E2E, 32w1, { meta.mymeta });
+    }
+    @name(".do_recirculate") action do_recirculate() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710637;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w19;
+        meta.mymeta.recirculate_count = meta.mymeta.recirculate_count + 8w1;
+        recirculate<tuple<mymeta_t>>({ meta.mymeta });
+    }
+    @name("._nop") action _nop() {
+    }
+    @name("._nop") action _nop_2() {
+    }
+    @name(".mark_egr_resubmit_packet") action mark_egr_resubmit_packet() {
+        hdr.ethernet.dstAddr = 48w0;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.resubmit_count << 40;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.recirculate_count << 32;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.f1 << 16;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+    }
+    @name(".mark_max_clone_e2e_packet") action mark_max_clone_e2e_packet() {
+        hdr.ethernet.dstAddr = 48w0;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.resubmit_count << 40;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.recirculate_count << 32;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.f1 << 16;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        hdr.ethernet.etherType = 16w0xce2e;
+    }
+    @name(".mark_max_recirculate_packet") action mark_max_recirculate_packet() {
+        hdr.ethernet.dstAddr = 48w0;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.resubmit_count << 40;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.recirculate_count << 32;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.f1 << 16;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        hdr.ethernet.etherType = 16w0xec14;
+    }
+    @name(".mark_vanilla_packet") action mark_vanilla_packet() {
+        hdr.ethernet.dstAddr = 48w0;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.resubmit_count << 40;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.recirculate_count << 32;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.f1 << 16;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        hdr.ethernet.etherType = 16w0xf00f;
+    }
+    @name(".t_do_clone_e2e") table t_do_clone_e2e_0 {
+        actions = {
+            do_clone_e2e();
+        }
+        key = {
+        }
+        default_action = do_clone_e2e();
+    }
+    @name(".t_do_recirculate") table t_do_recirculate_0 {
+        actions = {
+            do_recirculate();
+        }
+        key = {
+        }
+        default_action = do_recirculate();
+    }
+    @name(".t_egr_debug_table1") table t_egr_debug_table1_0 {
+        actions = {
+            _nop();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop();
+    }
+    @name(".t_egr_debug_table2") table t_egr_debug_table2_0 {
+        actions = {
+            _nop_2();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop_2();
+    }
+    @name(".t_egr_mark_resubmit_packet") table t_egr_mark_resubmit_packet_0 {
+        actions = {
+            mark_egr_resubmit_packet();
+        }
+        key = {
+        }
+        default_action = mark_egr_resubmit_packet();
+    }
+    @name(".t_mark_max_clone_e2e_packet") table t_mark_max_clone_e2e_packet_0 {
+        actions = {
+            mark_max_clone_e2e_packet();
+        }
+        key = {
+        }
+        default_action = mark_max_clone_e2e_packet();
+    }
+    @name(".t_mark_max_recirculate_packet") table t_mark_max_recirculate_packet_0 {
+        actions = {
+            mark_max_recirculate_packet();
+        }
+        key = {
+        }
+        default_action = mark_max_recirculate_packet();
+    }
+    @name(".t_mark_vanilla_packet") table t_mark_vanilla_packet_0 {
+        actions = {
+            mark_vanilla_packet();
+        }
+        key = {
+        }
+        default_action = mark_vanilla_packet();
+    }
+    apply {
+        t_egr_debug_table1_0.apply();
+        if (hdr.ethernet.dstAddr == 48w0x1) 
+            t_egr_mark_resubmit_packet_0.apply();
+        else 
+            if (hdr.ethernet.dstAddr == 48w0x2) 
+                if (meta.mymeta.recirculate_count < 8w5) 
+                    t_do_recirculate_0.apply();
+                else 
+                    t_mark_max_recirculate_packet_0.apply();
+            else 
+                if (hdr.ethernet.dstAddr == 48w0x3) 
+                    if (meta.mymeta.clone_e2e_count < 8w4) 
+                        t_do_clone_e2e_0.apply();
+                    else 
+                        t_mark_max_clone_e2e_packet_0.apply();
+                else 
+                    t_mark_vanilla_packet_0.apply();
+        t_egr_debug_table2_0.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_resubmit") action do_resubmit() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710639;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w17;
+        meta.mymeta.resubmit_count = meta.mymeta.resubmit_count + 8w1;
+        resubmit<tuple<mymeta_t>>({ meta.mymeta });
+    }
+    @name("._nop") action _nop_5() {
+    }
+    @name("._nop") action _nop_6() {
+    }
+    @name(".set_port_to_mac_da_lsbs") action set_port_to_mac_da_lsbs() {
+        standard_metadata.egress_spec = (bit<9>)hdr.ethernet.dstAddr & 9w0xf;
+    }
+    @name(".mark_max_resubmit_packet") action mark_max_resubmit_packet() {
+        hdr.ethernet.etherType = 16w0xe50b;
+    }
+    @name(".save_ing_instance_type") action save_ing_instance_type() {
+        meta.mymeta.last_ing_instance_type = (bit<8>)standard_metadata.instance_type;
+    }
+    @name(".t_do_resubmit") table t_do_resubmit_0 {
+        actions = {
+            do_resubmit();
+        }
+        key = {
+        }
+        default_action = do_resubmit();
+    }
+    @name(".t_ing_debug_table1") table t_ing_debug_table1_0 {
+        actions = {
+            _nop_5();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop_5();
+    }
+    @name(".t_ing_debug_table2") table t_ing_debug_table2_0 {
+        actions = {
+            _nop_6();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop_6();
+    }
+    @name(".t_ing_mac_da") table t_ing_mac_da_0 {
+        actions = {
+            set_port_to_mac_da_lsbs();
+        }
+        key = {
+        }
+        default_action = set_port_to_mac_da_lsbs();
+    }
+    @name(".t_mark_max_resubmit_packet") table t_mark_max_resubmit_packet_0 {
+        actions = {
+            mark_max_resubmit_packet();
+        }
+        key = {
+        }
+        default_action = mark_max_resubmit_packet();
+    }
+    @name(".t_save_ing_instance_type") table t_save_ing_instance_type_0 {
+        actions = {
+            save_ing_instance_type();
+        }
+        key = {
+        }
+        default_action = save_ing_instance_type();
+    }
+    apply {
+        t_ing_debug_table1_0.apply();
+        if (hdr.ethernet.dstAddr == 48w0x1) 
+            if (meta.mymeta.resubmit_count < 8w3) 
+                t_do_resubmit_0.apply();
+            else 
+                t_mark_max_resubmit_packet_0.apply();
+        else 
+            t_ing_mac_da_0.apply();
+        t_save_ing_instance_type_0.apply();
+        t_ing_debug_table2_0.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-midend.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-midend.p4
@@ -1,0 +1,397 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct intrinsic_metadata_t {
+    bit<48> ingress_global_timestamp;
+    bit<48> egress_global_timestamp;
+    bit<8>  lf_field_list;
+    bit<16> mcast_grp;
+    bit<16> egress_rid;
+    bit<8>  resubmit_flag;
+    bit<8>  recirculate_flag;
+}
+
+struct mymeta_t {
+    bit<8> resubmit_count;
+    bit<8> recirculate_count;
+    bit<8> clone_e2e_count;
+    bit<8> last_ing_instance_type;
+    bit<8> f1;
+}
+
+struct temporaries_t {
+    bit<48> temp1;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+    @name(".intrinsic_metadata") 
+    intrinsic_metadata_t intrinsic_metadata;
+    @name(".mymeta") 
+    mymeta_t             mymeta;
+    @name(".temporaries") 
+    temporaries_t        temporaries;
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_ethernet") state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+    @name(".start") state start {
+        transition parse_ethernet;
+    }
+}
+
+struct tuple_0 {
+    mymeta_t field;
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_clone_e2e") action do_clone_e2e() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710633;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w23;
+        meta.mymeta.clone_e2e_count = meta.mymeta.clone_e2e_count + 8w1;
+        clone3<tuple_0>(CloneType.E2E, 32w1, { meta.mymeta });
+    }
+    @name(".do_recirculate") action do_recirculate() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710637;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w19;
+        meta.mymeta.recirculate_count = meta.mymeta.recirculate_count + 8w1;
+        recirculate<tuple_0>({ meta.mymeta });
+    }
+    @name("._nop") action _nop() {
+    }
+    @name("._nop") action _nop_2() {
+    }
+    @name(".mark_egr_resubmit_packet") action mark_egr_resubmit_packet() {
+        hdr.ethernet.dstAddr = 48w0;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.resubmit_count << 40;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.recirculate_count << 32;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.f1 << 16;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24 | (bit<48>)meta.mymeta.f1 << 16;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24 | (bit<48>)meta.mymeta.f1 << 16 | (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+    }
+    @name(".mark_max_clone_e2e_packet") action mark_max_clone_e2e_packet() {
+        hdr.ethernet.dstAddr = 48w0;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.resubmit_count << 40;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.recirculate_count << 32;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.f1 << 16;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24 | (bit<48>)meta.mymeta.f1 << 16;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24 | (bit<48>)meta.mymeta.f1 << 16 | (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.etherType = 16w0xce2e;
+    }
+    @name(".mark_max_recirculate_packet") action mark_max_recirculate_packet() {
+        hdr.ethernet.dstAddr = 48w0;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.resubmit_count << 40;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.recirculate_count << 32;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.f1 << 16;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24 | (bit<48>)meta.mymeta.f1 << 16;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24 | (bit<48>)meta.mymeta.f1 << 16 | (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.etherType = 16w0xec14;
+    }
+    @name(".mark_vanilla_packet") action mark_vanilla_packet() {
+        hdr.ethernet.dstAddr = 48w0;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.resubmit_count << 40;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.recirculate_count << 32;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.f1 << 16;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24 | (bit<48>)meta.mymeta.f1 << 16;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.dstAddr = 48w0 | (bit<48>)meta.mymeta.resubmit_count << 40 | (bit<48>)meta.mymeta.recirculate_count << 32 | (bit<48>)meta.mymeta.clone_e2e_count << 24 | (bit<48>)meta.mymeta.f1 << 16 | (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.etherType = 16w0xf00f;
+    }
+    @name(".t_do_clone_e2e") table t_do_clone_e2e_0 {
+        actions = {
+            do_clone_e2e();
+        }
+        key = {
+        }
+        default_action = do_clone_e2e();
+    }
+    @name(".t_do_recirculate") table t_do_recirculate_0 {
+        actions = {
+            do_recirculate();
+        }
+        key = {
+        }
+        default_action = do_recirculate();
+    }
+    @name(".t_egr_debug_table1") table t_egr_debug_table1_0 {
+        actions = {
+            _nop();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop();
+    }
+    @name(".t_egr_debug_table2") table t_egr_debug_table2_0 {
+        actions = {
+            _nop_2();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop_2();
+    }
+    @name(".t_egr_mark_resubmit_packet") table t_egr_mark_resubmit_packet_0 {
+        actions = {
+            mark_egr_resubmit_packet();
+        }
+        key = {
+        }
+        default_action = mark_egr_resubmit_packet();
+    }
+    @name(".t_mark_max_clone_e2e_packet") table t_mark_max_clone_e2e_packet_0 {
+        actions = {
+            mark_max_clone_e2e_packet();
+        }
+        key = {
+        }
+        default_action = mark_max_clone_e2e_packet();
+    }
+    @name(".t_mark_max_recirculate_packet") table t_mark_max_recirculate_packet_0 {
+        actions = {
+            mark_max_recirculate_packet();
+        }
+        key = {
+        }
+        default_action = mark_max_recirculate_packet();
+    }
+    @name(".t_mark_vanilla_packet") table t_mark_vanilla_packet_0 {
+        actions = {
+            mark_vanilla_packet();
+        }
+        key = {
+        }
+        default_action = mark_vanilla_packet();
+    }
+    apply {
+        t_egr_debug_table1_0.apply();
+        if (hdr.ethernet.dstAddr == 48w0x1) 
+            t_egr_mark_resubmit_packet_0.apply();
+        else 
+            if (hdr.ethernet.dstAddr == 48w0x2) 
+                if (meta.mymeta.recirculate_count < 8w5) 
+                    t_do_recirculate_0.apply();
+                else 
+                    t_mark_max_recirculate_packet_0.apply();
+            else 
+                if (hdr.ethernet.dstAddr == 48w0x3) 
+                    if (meta.mymeta.clone_e2e_count < 8w4) 
+                        t_do_clone_e2e_0.apply();
+                    else 
+                        t_mark_max_clone_e2e_packet_0.apply();
+                else 
+                    t_mark_vanilla_packet_0.apply();
+        t_egr_debug_table2_0.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_resubmit") action do_resubmit() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710639;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w17;
+        meta.mymeta.resubmit_count = meta.mymeta.resubmit_count + 8w1;
+        resubmit<tuple_0>({ meta.mymeta });
+    }
+    @name("._nop") action _nop_5() {
+    }
+    @name("._nop") action _nop_6() {
+    }
+    @name(".set_port_to_mac_da_lsbs") action set_port_to_mac_da_lsbs() {
+        standard_metadata.egress_spec = (bit<9>)hdr.ethernet.dstAddr & 9w0xf;
+    }
+    @name(".mark_max_resubmit_packet") action mark_max_resubmit_packet() {
+        hdr.ethernet.etherType = 16w0xe50b;
+    }
+    @name(".save_ing_instance_type") action save_ing_instance_type() {
+        meta.mymeta.last_ing_instance_type = (bit<8>)standard_metadata.instance_type;
+    }
+    @name(".t_do_resubmit") table t_do_resubmit_0 {
+        actions = {
+            do_resubmit();
+        }
+        key = {
+        }
+        default_action = do_resubmit();
+    }
+    @name(".t_ing_debug_table1") table t_ing_debug_table1_0 {
+        actions = {
+            _nop_5();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop_5();
+    }
+    @name(".t_ing_debug_table2") table t_ing_debug_table2_0 {
+        actions = {
+            _nop_6();
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact @name("standard_metadata.ingress_port") ;
+            standard_metadata.packet_length                 : exact @name("standard_metadata.packet_length") ;
+            standard_metadata.egress_spec                   : exact @name("standard_metadata.egress_spec") ;
+            standard_metadata.egress_port                   : exact @name("standard_metadata.egress_port") ;
+            standard_metadata.instance_type                 : exact @name("standard_metadata.instance_type") ;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact @name("intrinsic_metadata.ingress_global_timestamp") ;
+            meta.intrinsic_metadata.egress_global_timestamp : exact @name("intrinsic_metadata.egress_global_timestamp") ;
+            meta.intrinsic_metadata.lf_field_list           : exact @name("intrinsic_metadata.lf_field_list") ;
+            meta.intrinsic_metadata.mcast_grp               : exact @name("intrinsic_metadata.mcast_grp") ;
+            meta.intrinsic_metadata.egress_rid              : exact @name("intrinsic_metadata.egress_rid") ;
+            meta.intrinsic_metadata.resubmit_flag           : exact @name("intrinsic_metadata.resubmit_flag") ;
+            meta.intrinsic_metadata.recirculate_flag        : exact @name("intrinsic_metadata.recirculate_flag") ;
+            meta.mymeta.resubmit_count                      : exact @name("mymeta.resubmit_count") ;
+            meta.mymeta.recirculate_count                   : exact @name("mymeta.recirculate_count") ;
+            meta.mymeta.clone_e2e_count                     : exact @name("mymeta.clone_e2e_count") ;
+            meta.mymeta.f1                                  : exact @name("mymeta.f1") ;
+            meta.mymeta.last_ing_instance_type              : exact @name("mymeta.last_ing_instance_type") ;
+            hdr.ethernet.dstAddr                            : exact @name("ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr                            : exact @name("ethernet.srcAddr") ;
+            hdr.ethernet.etherType                          : exact @name("ethernet.etherType") ;
+        }
+        default_action = _nop_6();
+    }
+    @name(".t_ing_mac_da") table t_ing_mac_da_0 {
+        actions = {
+            set_port_to_mac_da_lsbs();
+        }
+        key = {
+        }
+        default_action = set_port_to_mac_da_lsbs();
+    }
+    @name(".t_mark_max_resubmit_packet") table t_mark_max_resubmit_packet_0 {
+        actions = {
+            mark_max_resubmit_packet();
+        }
+        key = {
+        }
+        default_action = mark_max_resubmit_packet();
+    }
+    @name(".t_save_ing_instance_type") table t_save_ing_instance_type_0 {
+        actions = {
+            save_ing_instance_type();
+        }
+        key = {
+        }
+        default_action = save_ing_instance_type();
+    }
+    apply {
+        t_ing_debug_table1_0.apply();
+        if (hdr.ethernet.dstAddr == 48w0x1) 
+            if (meta.mymeta.resubmit_count < 8w3) 
+                t_do_resubmit_0.apply();
+            else 
+                t_mark_max_resubmit_packet_0.apply();
+        else 
+            t_ing_mac_da_0.apply();
+        t_save_ing_instance_type_0.apply();
+        t_ing_debug_table2_0.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2.p4
@@ -1,0 +1,376 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct intrinsic_metadata_t {
+    bit<48> ingress_global_timestamp;
+    bit<48> egress_global_timestamp;
+    bit<8>  lf_field_list;
+    bit<16> mcast_grp;
+    bit<16> egress_rid;
+    bit<8>  resubmit_flag;
+    bit<8>  recirculate_flag;
+}
+
+struct mymeta_t {
+    bit<8> resubmit_count;
+    bit<8> recirculate_count;
+    bit<8> clone_e2e_count;
+    bit<8> last_ing_instance_type;
+    bit<8> f1;
+}
+
+struct temporaries_t {
+    bit<48> temp1;
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata {
+    @name(".intrinsic_metadata") 
+    intrinsic_metadata_t intrinsic_metadata;
+    @name(".mymeta") 
+    mymeta_t             mymeta;
+    @name(".temporaries") 
+    temporaries_t        temporaries;
+}
+
+struct headers {
+    @name(".ethernet") 
+    ethernet_t ethernet;
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".parse_ethernet") state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition accept;
+    }
+    @name(".start") state start {
+        transition parse_ethernet;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_clone_e2e") action do_clone_e2e() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr - 48w23;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w23;
+        meta.mymeta.clone_e2e_count = meta.mymeta.clone_e2e_count + 8w1;
+        clone3(CloneType.E2E, (bit<32>)32w1, { meta.mymeta });
+    }
+    @name(".do_recirculate") action do_recirculate() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr - 48w19;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w19;
+        meta.mymeta.recirculate_count = meta.mymeta.recirculate_count + 8w1;
+        recirculate({ meta.mymeta });
+    }
+    @name("._nop") action _nop() {
+    }
+    @name(".put_debug_vals_in_eth_dstaddr") action put_debug_vals_in_eth_dstaddr() {
+        hdr.ethernet.dstAddr = 48w0;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.resubmit_count << 40;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.recirculate_count << 32;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.clone_e2e_count << 24;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.f1 << 16;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+        meta.temporaries.temp1 = (bit<48>)meta.mymeta.last_ing_instance_type << 8;
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr | meta.temporaries.temp1;
+    }
+    @name(".mark_egr_resubmit_packet") action mark_egr_resubmit_packet() {
+        put_debug_vals_in_eth_dstaddr();
+    }
+    @name(".mark_max_clone_e2e_packet") action mark_max_clone_e2e_packet() {
+        put_debug_vals_in_eth_dstaddr();
+        hdr.ethernet.etherType = 16w0xce2e;
+    }
+    @name(".mark_max_recirculate_packet") action mark_max_recirculate_packet() {
+        put_debug_vals_in_eth_dstaddr();
+        hdr.ethernet.etherType = 16w0xec14;
+    }
+    @name(".mark_vanilla_packet") action mark_vanilla_packet() {
+        put_debug_vals_in_eth_dstaddr();
+        hdr.ethernet.etherType = 16w0xf00f;
+    }
+    @name(".t_do_clone_e2e") table t_do_clone_e2e {
+        actions = {
+            do_clone_e2e;
+        }
+        key = {
+        }
+        default_action = do_clone_e2e();
+    }
+    @name(".t_do_recirculate") table t_do_recirculate {
+        actions = {
+            do_recirculate;
+        }
+        key = {
+        }
+        default_action = do_recirculate();
+    }
+    @name(".t_egr_debug_table1") table t_egr_debug_table1 {
+        actions = {
+            _nop;
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact;
+            standard_metadata.packet_length                 : exact;
+            standard_metadata.egress_spec                   : exact;
+            standard_metadata.egress_port                   : exact;
+            standard_metadata.instance_type                 : exact;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact;
+            meta.intrinsic_metadata.egress_global_timestamp : exact;
+            meta.intrinsic_metadata.lf_field_list           : exact;
+            meta.intrinsic_metadata.mcast_grp               : exact;
+            meta.intrinsic_metadata.egress_rid              : exact;
+            meta.intrinsic_metadata.resubmit_flag           : exact;
+            meta.intrinsic_metadata.recirculate_flag        : exact;
+            meta.mymeta.resubmit_count                      : exact;
+            meta.mymeta.recirculate_count                   : exact;
+            meta.mymeta.clone_e2e_count                     : exact;
+            meta.mymeta.f1                                  : exact;
+            meta.mymeta.last_ing_instance_type              : exact;
+            hdr.ethernet.dstAddr                            : exact;
+            hdr.ethernet.srcAddr                            : exact;
+            hdr.ethernet.etherType                          : exact;
+        }
+        default_action = _nop();
+    }
+    @name(".t_egr_debug_table2") table t_egr_debug_table2 {
+        actions = {
+            _nop;
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact;
+            standard_metadata.packet_length                 : exact;
+            standard_metadata.egress_spec                   : exact;
+            standard_metadata.egress_port                   : exact;
+            standard_metadata.instance_type                 : exact;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact;
+            meta.intrinsic_metadata.egress_global_timestamp : exact;
+            meta.intrinsic_metadata.lf_field_list           : exact;
+            meta.intrinsic_metadata.mcast_grp               : exact;
+            meta.intrinsic_metadata.egress_rid              : exact;
+            meta.intrinsic_metadata.resubmit_flag           : exact;
+            meta.intrinsic_metadata.recirculate_flag        : exact;
+            meta.mymeta.resubmit_count                      : exact;
+            meta.mymeta.recirculate_count                   : exact;
+            meta.mymeta.clone_e2e_count                     : exact;
+            meta.mymeta.f1                                  : exact;
+            meta.mymeta.last_ing_instance_type              : exact;
+            hdr.ethernet.dstAddr                            : exact;
+            hdr.ethernet.srcAddr                            : exact;
+            hdr.ethernet.etherType                          : exact;
+        }
+        default_action = _nop();
+    }
+    @name(".t_egr_mark_resubmit_packet") table t_egr_mark_resubmit_packet {
+        actions = {
+            mark_egr_resubmit_packet;
+        }
+        key = {
+        }
+        default_action = mark_egr_resubmit_packet();
+    }
+    @name(".t_mark_max_clone_e2e_packet") table t_mark_max_clone_e2e_packet {
+        actions = {
+            mark_max_clone_e2e_packet;
+        }
+        key = {
+        }
+        default_action = mark_max_clone_e2e_packet();
+    }
+    @name(".t_mark_max_recirculate_packet") table t_mark_max_recirculate_packet {
+        actions = {
+            mark_max_recirculate_packet;
+        }
+        key = {
+        }
+        default_action = mark_max_recirculate_packet();
+    }
+    @name(".t_mark_vanilla_packet") table t_mark_vanilla_packet {
+        actions = {
+            mark_vanilla_packet;
+        }
+        key = {
+        }
+        default_action = mark_vanilla_packet();
+    }
+    apply {
+        t_egr_debug_table1.apply();
+        if (hdr.ethernet.dstAddr == 48w0x1) {
+            t_egr_mark_resubmit_packet.apply();
+        }
+        else {
+            if (hdr.ethernet.dstAddr == 48w0x2) {
+                if (meta.mymeta.recirculate_count < 8w5) {
+                    t_do_recirculate.apply();
+                }
+                else {
+                    t_mark_max_recirculate_packet.apply();
+                }
+            }
+            else {
+                if (hdr.ethernet.dstAddr == 48w0x3) {
+                    if (meta.mymeta.clone_e2e_count < 8w4) {
+                        t_do_clone_e2e.apply();
+                    }
+                    else {
+                        t_mark_max_clone_e2e_packet.apply();
+                    }
+                }
+                else {
+                    t_mark_vanilla_packet.apply();
+                }
+            }
+        }
+        t_egr_debug_table2.apply();
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".do_resubmit") action do_resubmit() {
+        hdr.ethernet.srcAddr = hdr.ethernet.srcAddr - 48w17;
+        meta.mymeta.f1 = meta.mymeta.f1 + 8w17;
+        meta.mymeta.resubmit_count = meta.mymeta.resubmit_count + 8w1;
+        resubmit({ meta.mymeta });
+    }
+    @name("._nop") action _nop() {
+    }
+    @name(".set_port_to_mac_da_lsbs") action set_port_to_mac_da_lsbs() {
+        standard_metadata.egress_spec = (bit<9>)hdr.ethernet.dstAddr & 9w0xf;
+    }
+    @name(".mark_max_resubmit_packet") action mark_max_resubmit_packet() {
+        hdr.ethernet.etherType = 16w0xe50b;
+    }
+    @name(".save_ing_instance_type") action save_ing_instance_type() {
+        meta.mymeta.last_ing_instance_type = (bit<8>)standard_metadata.instance_type;
+    }
+    @name(".t_do_resubmit") table t_do_resubmit {
+        actions = {
+            do_resubmit;
+        }
+        key = {
+        }
+        default_action = do_resubmit();
+    }
+    @name(".t_ing_debug_table1") table t_ing_debug_table1 {
+        actions = {
+            _nop;
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact;
+            standard_metadata.packet_length                 : exact;
+            standard_metadata.egress_spec                   : exact;
+            standard_metadata.egress_port                   : exact;
+            standard_metadata.instance_type                 : exact;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact;
+            meta.intrinsic_metadata.egress_global_timestamp : exact;
+            meta.intrinsic_metadata.lf_field_list           : exact;
+            meta.intrinsic_metadata.mcast_grp               : exact;
+            meta.intrinsic_metadata.egress_rid              : exact;
+            meta.intrinsic_metadata.resubmit_flag           : exact;
+            meta.intrinsic_metadata.recirculate_flag        : exact;
+            meta.mymeta.resubmit_count                      : exact;
+            meta.mymeta.recirculate_count                   : exact;
+            meta.mymeta.clone_e2e_count                     : exact;
+            meta.mymeta.f1                                  : exact;
+            meta.mymeta.last_ing_instance_type              : exact;
+            hdr.ethernet.dstAddr                            : exact;
+            hdr.ethernet.srcAddr                            : exact;
+            hdr.ethernet.etherType                          : exact;
+        }
+        default_action = _nop();
+    }
+    @name(".t_ing_debug_table2") table t_ing_debug_table2 {
+        actions = {
+            _nop;
+        }
+        key = {
+            standard_metadata.ingress_port                  : exact;
+            standard_metadata.packet_length                 : exact;
+            standard_metadata.egress_spec                   : exact;
+            standard_metadata.egress_port                   : exact;
+            standard_metadata.instance_type                 : exact;
+            meta.intrinsic_metadata.ingress_global_timestamp: exact;
+            meta.intrinsic_metadata.egress_global_timestamp : exact;
+            meta.intrinsic_metadata.lf_field_list           : exact;
+            meta.intrinsic_metadata.mcast_grp               : exact;
+            meta.intrinsic_metadata.egress_rid              : exact;
+            meta.intrinsic_metadata.resubmit_flag           : exact;
+            meta.intrinsic_metadata.recirculate_flag        : exact;
+            meta.mymeta.resubmit_count                      : exact;
+            meta.mymeta.recirculate_count                   : exact;
+            meta.mymeta.clone_e2e_count                     : exact;
+            meta.mymeta.f1                                  : exact;
+            meta.mymeta.last_ing_instance_type              : exact;
+            hdr.ethernet.dstAddr                            : exact;
+            hdr.ethernet.srcAddr                            : exact;
+            hdr.ethernet.etherType                          : exact;
+        }
+        default_action = _nop();
+    }
+    @name(".t_ing_mac_da") table t_ing_mac_da {
+        actions = {
+            set_port_to_mac_da_lsbs;
+        }
+        key = {
+        }
+        default_action = set_port_to_mac_da_lsbs();
+    }
+    @name(".t_mark_max_resubmit_packet") table t_mark_max_resubmit_packet {
+        actions = {
+            mark_max_resubmit_packet;
+        }
+        key = {
+        }
+        default_action = mark_max_resubmit_packet();
+    }
+    @name(".t_save_ing_instance_type") table t_save_ing_instance_type {
+        actions = {
+            save_ing_instance_type;
+        }
+        key = {
+        }
+        default_action = save_ing_instance_type();
+    }
+    apply {
+        t_ing_debug_table1.apply();
+        if (hdr.ethernet.dstAddr == 48w0x1) {
+            if (meta.mymeta.resubmit_count < 8w3) {
+                t_do_resubmit.apply();
+            }
+            else {
+                t_mark_max_resubmit_packet.apply();
+            }
+        }
+        else {
+            t_ing_mac_da.apply();
+        }
+        t_save_ing_instance_type.apply();
+        t_ing_debug_table2.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+


### PR DESCRIPTION
It is nearly identical to the test program p414-special-ops.p4
proposed to be added in the PR #1704, except that program explicitly
lists individual fields to be preserved during resubmit
etc. operations, whereas this one gives the name of an entire metadata
'header' to be preserved.

For p414-special-ops-2-bmv2.p4, p4c as of this writing introduces
temporary metadata variables and preserves those instead of the ones
named in the source file, and since the STF packet tests cases rely
for their correct operation on the metadata fields being preserved,
they fail.