### PR TITLE
Show both expected and received packet when STF test fails

### DIFF
--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -687,7 +687,8 @@ class RunBMV2(object):
             if expected[i] != received[i]:
                 reportError("Received packet ", received)
                 reportError("Packet different at position", i, ": expected", expected[i], ", received", received[i])
-                reportError("Full received packed is ", received)
+                reportError("Full expected packet is ", expected)
+                reportError("Full received packet is ", received)
                 return FAILURE
         return SUCCESS
     def showLog(self):


### PR DESCRIPTION
When there are multiple expected output packets, this can help in more
quickly determining why the STF test is failing.