### PR TITLE
Support multiple p4runtime files

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1501,11 +1501,43 @@ void P4RuntimeAPI::serializeEntriesTo(std::ostream* destination, P4RuntimeFormat
         ::error("Failed to serialize the P4Runtime static table entries to the output");
 }
 
+static bool parseFileNames(cstring fileNameVector,
+                           std::vector<cstring> &files,
+                           std::vector<P4::P4RuntimeFormat> &formats) {
+    for (auto current = fileNameVector; current; ) {
+        cstring name = current;
+        const char* comma = current.find(',');
+        if (comma != nullptr) {
+            name = current.before(comma);
+            current = comma + 1;
+        } else {
+            current = cstring();
+        }
+        files.push_back(name);
+
+        if (cstring suffix = name.find('.')) {
+            if (suffix == ".json") {
+                formats.push_back(P4::P4RuntimeFormat::JSON);
+            } else if (suffix == ".bin") {
+                formats.push_back(P4::P4RuntimeFormat::BINARY);
+            } else if (suffix == ".txt") {
+                formats.push_back(P4::P4RuntimeFormat::TEXT);
+            } else {
+                ::error("%1%: Could not detect p4runtime info file format from file suffix %2%",
+                        name, suffix);
+                return false;
+            }
+        } else {
+            ::error("%1%: unknown file kind; known suffixes are .bin, .txt, .json", name);
+            return false;
+        }
+    }
+    return true;
+}
+
 void
 P4RuntimeSerializer::serializeP4RuntimeIfRequired(const IR::P4Program* program,
                                                   const CompilerOptions& options) {
-    // The options parser in the frontend already prints a warning if
-    // '--p4runtime-entries-file' is used without '--p4runtime-file'.
     std::vector<cstring> files;
     std::vector<P4::P4RuntimeFormat> formats;
 
@@ -1513,67 +1545,61 @@ P4RuntimeSerializer::serializeP4RuntimeIfRequired(const IR::P4Program* program,
         files.push_back(options.p4RuntimeFile);
         formats.push_back(options.p4RuntimeFormat);
     }
-    if (!options.p4RuntimeFiles.isNullOrEmpty()) {
-        const char* current = options.p4RuntimeFiles.c_str();
-        while (current != nullptr) {
-            const char* comma = strchr(current, ',');
-            cstring name;
-            if (comma != nullptr) {
-                name = cstring(current, comma - current);
-                current = comma + 1;
-            } else {
-                name = cstring(current);
-                current = nullptr;
-            }
-            files.push_back(name);
+    if (!parseFileNames(options.p4RuntimeFiles, files, formats))
+        return;
 
-            const char* dot = name.find('.');
-            if (dot == nullptr) {
-                formats.push_back(options.p4RuntimeFormat);
-            } else {
-                cstring suffix = cstring(dot);
-                if (suffix == ".json") {
-                    formats.push_back(P4::P4RuntimeFormat::JSON);
-                } else if (suffix == ".p4info") {
-                    formats.push_back(P4::P4RuntimeFormat::BINARY);
-                } else if (suffix == ".txt") {
-                    formats.push_back(P4::P4RuntimeFormat::TEXT);
-                } else {
-                    ::error("%1%: Could not detect p4runtime info file format from file suffix %2%",
-                            name, suffix);
-                    return;
-                }
+    bool apiGenerated = false;
+    P4RuntimeAPI p4Runtime;
+    if (!files.empty()) {
+        auto arch = P4RuntimeSerializer::resolveArch(options);
+        if (Log::verbose())
+            std::cout << "Generating P4Runtime output for architecture " << arch << std::endl;
+        p4Runtime = get()->generateP4Runtime(program, arch);
+        apiGenerated = true;
+
+        for (unsigned i = 0; i < files.size(); i++) {
+            cstring file = files.at(i);
+            P4::P4RuntimeFormat format = formats.at(i);
+            std::ostream* out = openFile(file, false);
+            if (!out) {
+                ::error("Couldn't open P4Runtime API file: %1%", file);
+                continue;
             }
+            p4Runtime.serializeP4InfoTo(out, format);
         }
     }
-    if (files.empty()) return;
 
-    auto arch = P4RuntimeSerializer::resolveArch(options);
-
-    if (Log::verbose())
-        std::cout << "Generating P4Runtime output for architecture " << arch << std::endl;
-
-    auto p4Runtime = get()->generateP4Runtime(program, arch);
-
-    for (unsigned i = 0; i < files.size(); i++) {
-        cstring file = files.at(i);
-        P4::P4RuntimeFormat format = formats.at(i);
-        std::ostream* out = openFile(file, false);
-        if (!out) {
-            ::error("Couldn't open P4Runtime API file: %1%", file);
-            continue;
-        }
-        p4Runtime.serializeP4InfoTo(out, format);
-    }
-
+    // Do the same for the entries files
+    // The options parser in the frontend already prints a warning if
+    // '--p4runtime-entries-file' is used without '--p4runtime-file'.
+    files.clear();
+    formats.clear();
     if (!options.p4RuntimeEntriesFile.isNullOrEmpty()) {
-        std::ostream* out = openFile(options.p4RuntimeEntriesFile, false);
-        if (!out) {
-            ::error("Couldn't open P4Runtime static entries file: %1%",
-                    options.p4RuntimeEntriesFile);
-            return;
+        files.push_back(options.p4RuntimeEntriesFile);
+        formats.push_back(options.p4RuntimeFormat);
+    }
+
+    if (!parseFileNames(options.p4RuntimeEntriesFiles, files, formats))
+        return;
+    if (!files.empty()) {
+        if (!apiGenerated) {
+            auto arch = P4RuntimeSerializer::resolveArch(options);
+            if (Log::verbose())
+                std::cout << "Generating P4Runtime output for architecture " << arch << std::endl;
+            p4Runtime = get()->generateP4Runtime(program, arch);
         }
-        p4Runtime.serializeEntriesTo(out, options.p4RuntimeFormat);
+
+        for (unsigned i = 0; i < files.size(); i++) {
+            cstring file = files.at(i);
+            P4::P4RuntimeFormat format = formats.at(i);
+            std::ostream* out = openFile(file, false);
+            if (!out) {
+                ::error("Couldn't open P4Runtime static entries file: %1%",
+                        options.p4RuntimeEntriesFile);
+                continue;
+            }
+            p4Runtime.serializeEntriesTo(out, format);
+        }
     }
 }
 

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -111,9 +111,9 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                    "to the specified file.");
     registerOption("--p4runtime-entries-files", "files",
                    [this](const char* arg) { p4RuntimeEntriesFiles = arg; return true; },
-                   "Write static table entries as a P4Runtime WriteRequest message"
-                   "to the specified files; the file format is inferred from the suffix."
-                   "Legal suffixes are .json, .txt and .bin");
+                   "Write static table entries as a P4Runtime WriteRequest message\n"
+                   "to the specified files (comma-separated list); the file format is\n"
+                   "inferred from the suffix. Legal suffixes are .json, .txt and .bin");
     registerOption("--p4runtime-format", "{binary,json,text}",
                    [this](const char* arg) {
                        if (!strcmp(arg, "binary")) {

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -281,9 +281,10 @@ std::vector<const char*>* CompilerOptions::process(int argc, char* const argv[])
 void CompilerOptions::validateOptions() const {
     if (p4RuntimeFile.isNullOrEmpty() &&
         p4RuntimeFiles.isNullOrEmpty() &&
-        !p4RuntimeEntriesFile.isNullOrEmpty()) {
+        (!p4RuntimeEntriesFile.isNullOrEmpty() ||
+         !p4RuntimeEntriesFiles.isNullOrEmpty())) {
         ::warning(ErrorType::WARN_IGNORE,
-                  "When '--p4runtime-entries-file' is used without '--p4runtime-file(s)', "
+                  "When '--p4runtime-entries-file(s)' used without '--p4runtime-file(s)', "
                   "it is ignored");
     }
 }

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -97,6 +97,11 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
     registerOption("--toJSON", "file",
                    [this](const char* arg) { dumpJsonFile = arg; return true; },
                    "Dump the compiler IR after the midend as JSON in the specified file.");
+    registerOption("--p4runtime-files", "filelist",
+                   [this](const char* arg) { p4RuntimeFiles = arg; return true; },
+                   "Write the P4Runtime control plane API description to the specified\n"
+                   "files (comma-separated list).  The format is inferred from the file\n"
+                   "suffix: .info, .json, .p4info");
     registerOption("--p4runtime-file", "file",
                    [this](const char* arg) { p4RuntimeFile = arg; return true; },
                    "Write a P4Runtime control plane API description to the specified file.");
@@ -269,9 +274,11 @@ std::vector<const char*>* CompilerOptions::process(int argc, char* const argv[])
 }
 
 void CompilerOptions::validateOptions() const {
-    if (p4RuntimeFile.isNullOrEmpty() && !p4RuntimeEntriesFile.isNullOrEmpty()) {
+    if (p4RuntimeFile.isNullOrEmpty() &&
+        p4RuntimeFiles.isNullOrEmpty() &&
+        !p4RuntimeEntriesFile.isNullOrEmpty()) {
         ::warning(ErrorType::WARN_IGNORE,
-                  "When '--p4runtime-entries-file' is used without '--p4runtime-file', "
+                  "When '--p4runtime-entries-file' is used without '--p4runtime-file(s)', "
                   "it is ignored");
     }
 }

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -101,7 +101,7 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                    [this](const char* arg) { p4RuntimeFiles = arg; return true; },
                    "Write the P4Runtime control plane API description to the specified\n"
                    "files (comma-separated list).  The format is inferred from the file\n"
-                   "suffix: .info, .json, .p4info");
+                   "suffix: .txt, .json, .bin");
     registerOption("--p4runtime-file", "file",
                    [this](const char* arg) { p4RuntimeFile = arg; return true; },
                    "Write a P4Runtime control plane API description to the specified file.");
@@ -109,6 +109,11 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                    [this](const char* arg) { p4RuntimeEntriesFile = arg; return true; },
                    "Write static table entries as a P4Runtime WriteRequest message"
                    "to the specified file.");
+    registerOption("--p4runtime-entries-files", "files",
+                   [this](const char* arg) { p4RuntimeEntriesFiles = arg; return true; },
+                   "Write static table entries as a P4Runtime WriteRequest message"
+                   "to the specified files; the file format is inferred from the suffix."
+                   "Legal suffixes are .json, .txt and .bin");
     registerOption("--p4runtime-format", "{binary,json,text}",
                    [this](const char* arg) {
                        if (!strcmp(arg, "binary")) {

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -89,6 +89,9 @@ class CompilerOptions : public Util::Options {
     // Write P4Runtime control plane API description to the specified files.
     cstring p4RuntimeFiles = nullptr;
 
+    // Write static table entries as a P4Runtime WriteRequest message to the specified files.
+    cstring p4RuntimeEntriesFiles = nullptr;
+
     // Choose format for P4Runtime API description.
     P4::P4RuntimeFormat p4RuntimeFormat = P4::P4RuntimeFormat::BINARY;
 

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -86,6 +86,9 @@ class CompilerOptions : public Util::Options {
     // Write static table entries as a P4Runtime WriteRequest message to the specified file.
     cstring p4RuntimeEntriesFile = nullptr;
 
+    // Write P4Runtime control plane API description to the specified files.
+    cstring p4RuntimeFiles = nullptr;
+
     // Choose format for P4Runtime API description.
     P4::P4RuntimeFormat p4RuntimeFormat = P4::P4RuntimeFormat::BINARY;
 

--- a/tools/driver/p4c_src/main.py
+++ b/tools/driver/p4c_src/main.py
@@ -120,6 +120,11 @@ def main():
                         help="Write a P4Runtime control plane API description "
                         "to the specified file.",
                         action="store", default=None)
+    parser.add_argument("--p4runtime-files",
+                        help="Write a set of P4Runtime control plane API description "
+                        "to the specified files; format is detected based on file suffix."
+                        "Legal suffixes are .txt, .json, .bin",
+                        action="store", default=None)
     parser.add_argument("--p4runtime-format",
                         choices=["binary", "json", "text"],
                         help="Choose output format for the P4Runtime API "


### PR DESCRIPTION
Fixes #1705.

I haven't deleted the old options. Together they are a bit redundant, but I don't want to break any scripts.