### PR TITLE
allow customizing typeChecker in some midend passes

### DIFF
--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -147,9 +147,12 @@ class DoConstantFolding : public Transform {
  */
 class ConstantFolding : public PassManager {
  public:
-    ConstantFolding(ReferenceMap* refMap, TypeMap* typeMap, bool warnings = true) {
-        if (typeMap != nullptr)
-            passes.push_back(new TypeChecking(refMap, typeMap));
+    ConstantFolding(ReferenceMap* refMap, TypeMap* typeMap, bool warnings = true,
+            TypeChecking* typeChecking = nullptr) {
+        if (typeMap != nullptr) {
+            if (!typeChecking)
+                typeChecking = new TypeChecking(refMap, typeMap);
+            passes.push_back(typeChecking); }
         passes.push_back(new DoConstantFolding(refMap, typeMap, warnings));
         if (typeMap != nullptr)
             passes.push_back(new ClearTypeMap(typeMap));

--- a/frontends/p4/simplify.h
+++ b/frontends/p4/simplify.h
@@ -65,8 +65,11 @@ class DoSimplifyControlFlow : public Transform {
 /// steps enable further simplification.
 class SimplifyControlFlow : public PassRepeated {
  public:
-    SimplifyControlFlow(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    SimplifyControlFlow(ReferenceMap* refMap, TypeMap* typeMap,
+            TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoSimplifyControlFlow(refMap, typeMap));
         setName("SimplifyControlFlow");
     }

--- a/frontends/p4/strengthReduction.h
+++ b/frontends/p4/strengthReduction.h
@@ -86,8 +86,11 @@ class DoStrengthReduction final : public Transform {
 
 class StrengthReduction : public PassManager {
  public:
-    StrengthReduction(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap, true));
+    StrengthReduction(ReferenceMap* refMap, TypeMap* typeMap,
+            TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap, true);
+        passes.push_back(typeChecking);
         passes.push_back(new DoStrengthReduction());
     }
 };

--- a/midend/actionSynthesis.h
+++ b/midend/actionSynthesis.h
@@ -144,8 +144,11 @@ class DoSynthesizeActions : public Transform {
 class SynthesizeActions : public PassManager {
  public:
     SynthesizeActions(ReferenceMap* refMap, TypeMap* typeMap,
-                      ActionSynthesisPolicy* policy = nullptr) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+                      ActionSynthesisPolicy* policy = nullptr,
+                      TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoSynthesizeActions(refMap, typeMap, policy));
         setName("SynthesizeActions");
     }
@@ -153,8 +156,11 @@ class SynthesizeActions : public PassManager {
 
 class MoveActionsToTables : public PassManager {
  public:
-    MoveActionsToTables(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    MoveActionsToTables(ReferenceMap* refMap, TypeMap* typeMap,
+            TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoMoveActionsToTables(refMap, typeMap));
         setName("MoveActionsToTables");
     }

--- a/midend/complexComparison.h
+++ b/midend/complexComparison.h
@@ -46,8 +46,11 @@ class RemoveComplexComparisons : public Transform {
 
 class SimplifyComparisons final : public PassManager {
  public:
-    SimplifyComparisons(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    SimplifyComparisons(ReferenceMap* refMap, TypeMap* typeMap,
+            TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new RemoveComplexComparisons(refMap, typeMap));
         setName("SimplifyComparisons");
     }

--- a/midend/convertEnums.h
+++ b/midend/convertEnums.h
@@ -109,9 +109,12 @@ class ConvertEnums : public PassManager {
  public:
     using EnumMapping = decltype(DoConvertEnums::repr);
     ConvertEnums(ReferenceMap* refMap, TypeMap* typeMap,
-                 ChooseEnumRepresentation* policy)
+                 ChooseEnumRepresentation* policy,
+                 TypeChecking* typeChecking = nullptr)
         : convertEnums(new DoConvertEnums(policy, typeMap)) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(convertEnums);
         passes.push_back(new ClearTypeMap(typeMap));
         setName("ConvertEnums");

--- a/midend/copyStructures.h
+++ b/midend/copyStructures.h
@@ -69,10 +69,13 @@ class DoCopyStructures : public Transform {
 class CopyStructures : public PassRepeated {
  public:
     CopyStructures(ReferenceMap* refMap, TypeMap* typeMap,
-                   bool errorOnMethodCall = true) :
+                   bool errorOnMethodCall = true,
+                   TypeChecking* typeChecking = nullptr) :
             PassManager({}) {
         CHECK_NULL(refMap); CHECK_NULL(typeMap); setName("CopyStructures");
-        passes.emplace_back(new TypeChecking(refMap, typeMap));
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.emplace_back(typeChecking);
         passes.emplace_back(new DoCopyStructures(typeMap, errorOnMethodCall));
     }
 };

--- a/midend/eliminateNewtype.h
+++ b/midend/eliminateNewtype.h
@@ -41,8 +41,11 @@ class DoReplaceNewtype final : public Transform {
 
 class EliminateNewtype final : public PassManager {
  public:
-    EliminateNewtype(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    EliminateNewtype(ReferenceMap* refMap, TypeMap* typeMap,
+                     TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoReplaceNewtype(typeMap));
         passes.push_back(new ClearTypeMap(typeMap));
         setName("EliminateNewtype");

--- a/midend/eliminateSerEnums.h
+++ b/midend/eliminateSerEnums.h
@@ -37,8 +37,11 @@ class DoEliminateSerEnums final : public Transform {
 
 class EliminateSerEnums final : public PassManager {
  public:
-    EliminateSerEnums(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    EliminateSerEnums(ReferenceMap* refMap, TypeMap* typeMap,
+                      TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoEliminateSerEnums(typeMap));
         passes.push_back(new ClearTypeMap(typeMap));
         setName("EliminateSerEnums");

--- a/midend/expandEmit.h
+++ b/midend/expandEmit.h
@@ -57,9 +57,12 @@ class DoExpandEmit : public Transform {
 
 class ExpandEmit : public PassManager {
  public:
-    ExpandEmit(ReferenceMap* refMap, TypeMap* typeMap) {
+    ExpandEmit(ReferenceMap* refMap, TypeMap* typeMap,
+            TypeChecking* typeChecking = nullptr) {
         setName("ExpandEmit");
-        passes.push_back(new TypeChecking(refMap, typeMap));
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoExpandEmit(refMap, typeMap));
     }
 };

--- a/midend/expandLookahead.h
+++ b/midend/expandLookahead.h
@@ -57,8 +57,11 @@ class DoExpandLookahead : public Transform {
 
 class ExpandLookahead : public PassManager {
  public:
-    ExpandLookahead(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    ExpandLookahead(ReferenceMap* refMap, TypeMap* typeMap,
+            TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoExpandLookahead(refMap, typeMap));
         setName("ExpandLookahead");
     }

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -121,10 +121,13 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
 class LocalCopyPropagation : public PassManager {
  public:
     LocalCopyPropagation(ReferenceMap* refMap, TypeMap* typeMap,
+        TypeChecking* typeChecking = nullptr,
         std::function<bool(const Context *, const IR::Expression *)> policy =
             [](const Context *, const IR::Expression *) -> bool { return true; }
     ) {
-        passes.push_back(new TypeChecking(refMap, typeMap, true));
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap, true);
+        passes.push_back(typeChecking);
         passes.push_back(new DoLocalCopyPropagation(refMap, typeMap, policy));
         setName("LocalCopyPropagation");
     }

--- a/midend/nestedStructs.h
+++ b/midend/nestedStructs.h
@@ -137,9 +137,12 @@ class RemoveNestedStructs final : public Transform {
 
 class NestedStructs final : public PassManager {
  public:
-    NestedStructs(ReferenceMap* refMap, TypeMap* typeMap) {
+    NestedStructs(ReferenceMap* refMap, TypeMap* typeMap,
+            TypeChecking* typeChecking = nullptr) {
         auto values = new ComplexValues(refMap, typeMap);
-        passes.push_back(new TypeChecking(refMap, typeMap));
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new RemoveNestedStructs(values));
         passes.push_back(new ClearTypeMap(typeMap));
         setName("NestedStructs");

--- a/midend/orderArguments.h
+++ b/midend/orderArguments.h
@@ -43,8 +43,11 @@ class DoOrderArguments : public Transform {
 
 class OrderArguments : public PassManager {
  public:
-    OrderArguments(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    OrderArguments(ReferenceMap* refMap, TypeMap* typeMap,
+            TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoOrderArguments(refMap, typeMap));
         setName("OrderArguments");
     }

--- a/midend/removeExits.h
+++ b/midend/removeExits.h
@@ -56,8 +56,11 @@ class DoRemoveExits : public DoRemoveReturns {
 
 class RemoveExits : public PassManager {
  public:
-    RemoveExits(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    RemoveExits(ReferenceMap* refMap, TypeMap* typeMap,
+                TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoRemoveExits(refMap, typeMap));
         setName("RemoveExits");
     }

--- a/midend/removeParameters.cpp
+++ b/midend/removeParameters.cpp
@@ -153,7 +153,8 @@ const IR::Node* DoRemoveActionParameters::postorder(IR::MethodCallExpression* ex
     return expression;
 }
 
-RemoveActionParameters::RemoveActionParameters(ReferenceMap* refMap, TypeMap* typeMap) {
+RemoveActionParameters::RemoveActionParameters(ReferenceMap* refMap, TypeMap* typeMap,
+                                               TypeChecking* typeChecking) {
     setName("RemoveActionParameters");
     auto ai = new ActionInvocation();
     // MoveDeclarations() is needed because of this case:
@@ -165,7 +166,9 @@ RemoveActionParameters::RemoveActionParameters(ReferenceMap* refMap, TypeMap* ty
     // bit<32> w;
     // table t() { actions = a(); ... }
     passes.emplace_back(new MoveDeclarations());
-    passes.emplace_back(new TypeChecking(refMap, typeMap));
+    if (!typeChecking)
+        typeChecking = new TypeChecking(refMap, typeMap);
+    passes.emplace_back(typeChecking);
     passes.emplace_back(new FindActionParameters(refMap, typeMap, ai));
     passes.emplace_back(new DoRemoveActionParameters(ai));
     passes.emplace_back(new ClearTypeMap(typeMap));

--- a/midend/removeParameters.h
+++ b/midend/removeParameters.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define _MIDEND_REMOVEPARAMETERS_H_
 
 #include "ir/ir.h"
+#include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeMap.h"
 
@@ -125,7 +126,8 @@ class DoRemoveActionParameters : public Transform {
 
 class RemoveActionParameters : public PassManager {
  public:
-    RemoveActionParameters(ReferenceMap* refMap, TypeMap* typeMap);
+    RemoveActionParameters(ReferenceMap* refMap, TypeMap* typeMap,
+                           TypeChecking* typeChecking = nullptr);
 };
 
 }  // namespace P4

--- a/midend/removeSelectBooleans.h
+++ b/midend/removeSelectBooleans.h
@@ -47,8 +47,11 @@ class DoRemoveSelectBooleans : public Transform {
 
 class RemoveSelectBooleans : public PassManager {
  public:
-    RemoveSelectBooleans(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    RemoveSelectBooleans(ReferenceMap* refMap, TypeMap* typeMap,
+                         TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoRemoveSelectBooleans(typeMap));
         passes.push_back(new ClearTypeMap(typeMap));  // some types have changed
         setName("RemoveSelectBooleans");

--- a/midend/simplifyKey.h
+++ b/midend/simplifyKey.h
@@ -175,8 +175,11 @@ class DoSimplifyKey : public Transform {
  */
 class SimplifyKey : public PassManager {
  public:
-    SimplifyKey(ReferenceMap* refMap, TypeMap* typeMap, KeyIsSimple* key_policy) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    SimplifyKey(ReferenceMap* refMap, TypeMap* typeMap, KeyIsSimple* key_policy,
+                TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoSimplifyKey(refMap, typeMap, key_policy));
         setName("SimplifyKey");
     }

--- a/midend/simplifySelectCases.h
+++ b/midend/simplifySelectCases.h
@@ -50,8 +50,11 @@ class DoSimplifySelectCases : public Transform {
 
 class SimplifySelectCases : public PassManager {
  public:
-    SimplifySelectCases(ReferenceMap* refMap, TypeMap* typeMap, bool requireConstants) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    SimplifySelectCases(ReferenceMap* refMap, TypeMap* typeMap, bool requireConstants,
+            TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoSimplifySelectCases(typeMap, requireConstants));
         setName("SimplifySelectCases");
     }

--- a/midend/simplifySelectList.h
+++ b/midend/simplifySelectList.h
@@ -76,10 +76,13 @@ class UnnestSelectList : public Transform {
 
 class SimplifySelectList : public PassManager {
  public:
-    SimplifySelectList(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    SimplifySelectList(ReferenceMap* refMap, TypeMap* typeMap,
+                       TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new SubstituteStructures(typeMap));
-        passes.push_back(new TypeChecking(refMap, typeMap));
+        passes.push_back(typeChecking);
         passes.push_back(new UnnestSelectList);
         setName("SimplifySelectList");
     }

--- a/midend/tableHit.h
+++ b/midend/tableHit.h
@@ -44,8 +44,11 @@ class DoTableHit : public Transform {
 
 class TableHit : public PassManager {
  public:
-    TableHit(ReferenceMap* refMap, TypeMap* typeMap) {
-        passes.push_back(new TypeChecking(refMap, typeMap));
+    TableHit(ReferenceMap* refMap, TypeMap* typeMap,
+             TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
         passes.push_back(new DoTableHit(refMap, typeMap));
         setName("TableHit");
     }


### PR DESCRIPTION
To allow some target to experiment with new IR types and reuse existing midend passes.