### PR TITLE
Add support for multiple parsers / deparsers in bmv2 backend

### DIFF
--- a/backends/bmv2/common/deparser.cpp
+++ b/backends/bmv2/common/deparser.cpp
@@ -75,7 +75,7 @@ void DeparserConverter::convertDeparserBody(const IR::Vector<IR::StatOrDecl>* bo
 
 Util::IJson* DeparserConverter::convertDeparser(const IR::P4Control* ctrl) {
     auto result = new Util::JsonObject();
-    result->emplace("name", "deparser");  // at least in simple_router this name is hardwired
+    result->emplace("name", name);
     result->emplace("id", nextId("deparser"));
     result->emplace_non_null("source_info", ctrl->sourceInfoJsonObj());
     auto order = mkArrayField(result, "order");

--- a/backends/bmv2/common/deparser.h
+++ b/backends/bmv2/common/deparser.h
@@ -28,6 +28,7 @@ namespace BMV2 {
 
 class DeparserConverter : public Inspector {
     ConversionContext*     ctxt;
+    cstring                name;
     P4::P4CoreLibrary&     corelib;
 
  protected:
@@ -36,9 +37,10 @@ class DeparserConverter : public Inspector {
  public:
     bool preorder(const IR::P4Control* ctrl);
 
-    explicit DeparserConverter(ConversionContext* ctxt) :
-        ctxt(ctxt), corelib(P4::P4CoreLibrary::instance) {
-        setName("DeparserConverter"); }
+    explicit DeparserConverter(ConversionContext* ctxt, cstring name = "deparser")
+        : ctxt(ctxt), name(name), corelib(P4::P4CoreLibrary::instance) {
+        setName("DeparserConverter");
+    }
 };
 
 }  // namespace BMV2

--- a/backends/bmv2/common/parser.cpp
+++ b/backends/bmv2/common/parser.cpp
@@ -374,8 +374,7 @@ ParserConverter::createDefaultTransition() {
 }
 
 bool ParserConverter::preorder(const IR::P4Parser* parser) {
-    // hanw hard-coded parser name assumed by BMv2
-    auto parser_id = ctxt->json->add_parser("parser");
+    auto parser_id = ctxt->json->add_parser(name);
 
     for (auto s : parser->parserLocals) {
         if (auto inst = s->to<IR::P4ValueSet>()) {

--- a/backends/bmv2/common/parser.h
+++ b/backends/bmv2/common/parser.h
@@ -30,6 +30,7 @@ class JsonObjects;
 
 class ParserConverter : public Inspector {
     ConversionContext*   ctxt;
+    cstring              name;
     P4::P4CoreLibrary&   corelib;
 
  protected:
@@ -46,8 +47,8 @@ class ParserConverter : public Inspector {
 
  public:
     bool preorder(const IR::P4Parser* p) override;
-    explicit ParserConverter(ConversionContext* ctxt) :
-        ctxt(ctxt), corelib(P4::P4CoreLibrary::instance) {
+    explicit ParserConverter(ConversionContext* ctxt, cstring name = "parser")
+        : ctxt(ctxt), name(name), corelib(P4::P4CoreLibrary::instance) {
         setName("ParserConverter");
     }
 };

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -146,9 +146,15 @@ void PsaProgramStructure::createHeaders(ConversionContext* ctxt) {
 }
 
 void PsaProgramStructure::createParsers(ConversionContext* ctxt) {
-    auto cvt = new ParserConverter(ctxt);
-    for (auto kv : parsers) {
-        kv.second->apply(*cvt);
+    {
+        auto cvt = new ParserConverter(ctxt, "ingress_parser");
+        auto ingress = parsers.at("ingress");
+        ingress->apply(*cvt);
+    }
+    {
+        auto cvt = new ParserConverter(ctxt, "egress_parser");
+        auto ingress = parsers.at("egress");
+        ingress->apply(*cvt);
     }
 }
 
@@ -183,11 +189,16 @@ void PsaProgramStructure::createControls(ConversionContext* ctxt) {
 }
 
 void PsaProgramStructure::createDeparsers(ConversionContext* ctxt) {
-    auto cvt = new DeparserConverter(ctxt);
-    auto ingress = deparsers.at("ingress");
-    ingress->apply(*cvt);
-    auto egress = deparsers.at("egress");
-    egress->apply(*cvt);
+    {
+        auto cvt = new DeparserConverter(ctxt, "ingress_deparser");
+        auto ingress = deparsers.at("ingress");
+        ingress->apply(*cvt);
+    }
+    {
+        auto cvt = new DeparserConverter(ctxt, "egress_deparser");
+        auto egress = deparsers.at("egress");
+        egress->apply(*cvt);
+    }
 }
 
 void PsaProgramStructure::createGlobals() {

--- a/backends/bmv2/psa_switch/psaSwitch.h
+++ b/backends/bmv2/psa_switch/psaSwitch.h
@@ -44,7 +44,7 @@ namespace BMV2 {
 class PsaSwitchExpressionConverter : public ExpressionConverter {
  public:
     PsaSwitchExpressionConverter(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
-                                      ProgramStructure* structure, cstring scalarsName) :
+                                 ProgramStructure* structure, cstring scalarsName) :
     BMV2::ExpressionConverter(refMap, typeMap, structure, scalarsName) { }
 
     Util::IJson* convertParam(UNUSED const IR::Parameter* param, cstring fieldName) override {


### PR DESCRIPTION
This is useful for PSA, for which there are 2 parsers and 2
deparsers.
The bmv2 PSA backend now uses the following names:
 * ingress_parser
 * egress_parser
 * ingress_deparser
 * egress_deparser