### PR TITLE
Added support for --fromJSON flag (#1280)

### DIFF
--- a/backends/bmv2/common/header.cpp
+++ b/backends/bmv2/common/header.cpp
@@ -263,7 +263,17 @@ void HeaderConverter::addHeaderType(const IR::Type_StructLike *st) {
         if (auto aliasAnnotation = f->getAnnotation("alias")) {
             auto container = new Util::JsonArray();
             auto alias = new Util::JsonArray();
-            auto target_name = aliasAnnotation->expr.front()->to<IR::StringLiteral>()->value;
+            auto target_name = "";
+            if (BMV2::BMV2Context::get().options().loadIRFromJson == false) {
+                target_name = aliasAnnotation->expr.front()->to<IR::StringLiteral>()->value;
+            } else {
+                if (aliasAnnotation->body.size() != 0) {
+                    target_name = aliasAnnotation->body.at(0)->text;
+                } else {
+                    // aliasAnnotation->body is empty or not saved correctly
+                    ::error("There is no saved data for aliases target_name.");
+                }
+            }
             LOG2("field alias " << target_name);
             container->append(target_name);  // name on target
             // break down the alias into meta . field

--- a/backends/bmv2/common/header.h
+++ b/backends/bmv2/common/header.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "helpers.h"
 #include "JsonObjects.h"
 #include "programStructure.h"
+#include "backends/bmv2/common/options.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/common/options.h
+++ b/backends/bmv2/common/options.h
@@ -28,6 +28,8 @@ class BMV2Options : public CompilerOptions {
     bool emitExterns = false;
     // file to output to
     cstring outputFile = nullptr;
+    // read from json
+    bool loadIRFromJson = false;
 
     BMV2Options() {
         registerOption("--emit-externs", nullptr,
@@ -37,6 +39,10 @@ class BMV2Options : public CompilerOptions {
         registerOption("-o", "outfile",
                 [this](const char* arg) { outputFile = arg; return true; },
                 "Write output to outfile");
+        registerOption("--fromJSON", "file",
+                [this](const char* arg) { loadIRFromJson = true; file = arg; return true; },
+                "Use IR representation from JsonFile dumped previously,"\
+                "the compilation starts with reduced midEnd.");
     }
 };
 

--- a/backends/bmv2/psa_switch/midend.cpp
+++ b/backends/bmv2/psa_switch/midend.cpp
@@ -86,54 +86,63 @@ class PsaEnumOn32Bits : public P4::ChooseEnumRepresentation {
 PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions& options) : MidEnd(options) {
     auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
     auto convertEnums = new P4::ConvertEnums(&refMap, &typeMap, new PsaEnumOn32Bits("psa.p4"));
-    addPasses({
-        new P4::EliminateNewtype(&refMap, &typeMap),
-        new P4::EliminateSerEnums(&refMap, &typeMap),
-        new P4::RemoveActionParameters(&refMap, &typeMap),
-        convertEnums,
-        new VisitFunctor([this, convertEnums]() { enumMap = convertEnums->getEnumMapping(); }),
-        new P4::OrderArguments(&refMap, &typeMap),
-        new P4::TypeChecking(&refMap, &typeMap),
-        new P4::SimplifyKey(&refMap, &typeMap,
-                            new P4::OrPolicy(
-                                new P4::IsValid(&refMap, &typeMap),
-                                new P4::IsMask())),
-        new P4::ConstantFolding(&refMap, &typeMap),
-        new P4::StrengthReduction(&refMap, &typeMap),
-        new P4::SimplifySelectCases(&refMap, &typeMap, true),  // require constant keysets
-        new P4::ExpandLookahead(&refMap, &typeMap),
-        new P4::ExpandEmit(&refMap, &typeMap),
-        new P4::SimplifyParsers(&refMap),
-        new P4::StrengthReduction(&refMap, &typeMap),
-        new P4::EliminateTuples(&refMap, &typeMap),
-        new P4::SimplifyComparisons(&refMap, &typeMap),
-        new P4::CopyStructures(&refMap, &typeMap),
-        new P4::NestedStructs(&refMap, &typeMap),
-        new P4::SimplifySelectList(&refMap, &typeMap),
-        new P4::RemoveSelectBooleans(&refMap, &typeMap),
-        new P4::FlattenHeaders(&refMap, &typeMap),
-        new P4::FlattenInterfaceStructs(&refMap, &typeMap),
-        new P4::Predication(&refMap),
-        new P4::MoveDeclarations(),  // more may have been introduced
-        new P4::ConstantFolding(&refMap, &typeMap),
-        new P4::LocalCopyPropagation(&refMap, &typeMap),
-        new P4::ConstantFolding(&refMap, &typeMap),
-        new P4::MoveDeclarations(),
-        new P4::ValidateTableProperties({ "psa_implementation",
-                                          "psa_direct_counter",
-                                          "psa_direct_meter",
-                                          "psa_idle_timeout",
-                                          "size" }),
-        new P4::SimplifyControlFlow(&refMap, &typeMap),
-        new P4::CompileTimeOperations(),
-        new P4::TableHit(&refMap, &typeMap),
-        new P4::MoveActionsToTables(&refMap, &typeMap),
-        new P4::RemoveLeftSlices(&refMap, &typeMap),
-        new P4::TypeChecking(&refMap, &typeMap),
-        new P4::MidEndLast(),
-        evaluator,
-        new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
-    });
+    if (BMV2::BMV2Context::get().options().loadIRFromJson == false) {
+        addPasses({
+            new P4::EliminateNewtype(&refMap, &typeMap),
+            new P4::EliminateSerEnums(&refMap, &typeMap),
+            new P4::RemoveActionParameters(&refMap, &typeMap),
+            convertEnums,
+            new VisitFunctor([this, convertEnums]() { enumMap = convertEnums->getEnumMapping(); }),
+            new P4::OrderArguments(&refMap, &typeMap),
+            new P4::TypeChecking(&refMap, &typeMap),
+            new P4::SimplifyKey(&refMap, &typeMap,
+                                new P4::OrPolicy(
+                                    new P4::IsValid(&refMap, &typeMap),
+                                    new P4::IsMask())),
+            new P4::ConstantFolding(&refMap, &typeMap),
+            new P4::StrengthReduction(&refMap, &typeMap),
+            new P4::SimplifySelectCases(&refMap, &typeMap, true),  // require constant keysets
+            new P4::ExpandLookahead(&refMap, &typeMap),
+            new P4::ExpandEmit(&refMap, &typeMap),
+            new P4::SimplifyParsers(&refMap),
+            new P4::StrengthReduction(&refMap, &typeMap),
+            new P4::EliminateTuples(&refMap, &typeMap),
+            new P4::SimplifyComparisons(&refMap, &typeMap),
+            new P4::CopyStructures(&refMap, &typeMap),
+            new P4::NestedStructs(&refMap, &typeMap),
+            new P4::SimplifySelectList(&refMap, &typeMap),
+            new P4::RemoveSelectBooleans(&refMap, &typeMap),
+            new P4::FlattenHeaders(&refMap, &typeMap),
+            new P4::FlattenInterfaceStructs(&refMap, &typeMap),
+            new P4::Predication(&refMap),
+            new P4::MoveDeclarations(),  // more may have been introduced
+            new P4::ConstantFolding(&refMap, &typeMap),
+            new P4::LocalCopyPropagation(&refMap, &typeMap),
+            new P4::ConstantFolding(&refMap, &typeMap),
+            new P4::MoveDeclarations(),
+            new P4::ValidateTableProperties({ "psa_implementation",
+                                              "psa_direct_counter",
+                                              "psa_direct_meter",
+                                              "psa_idle_timeout",
+                                              "size" }),
+            new P4::SimplifyControlFlow(&refMap, &typeMap),
+            new P4::CompileTimeOperations(),
+            new P4::TableHit(&refMap, &typeMap),
+            new P4::MoveActionsToTables(&refMap, &typeMap),
+            new P4::RemoveLeftSlices(&refMap, &typeMap),
+            new P4::TypeChecking(&refMap, &typeMap),
+            new P4::MidEndLast(),
+            evaluator,
+            new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
+        });
+    } else {
+        addPasses({
+            new P4::ResolveReferences(&refMap),
+            new P4::TypeChecking(&refMap, &typeMap),
+            evaluator,
+            new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
+        });
+    }
 }
 
 }  // namespace BMV2

--- a/backends/bmv2/psa_switch/midend.h
+++ b/backends/bmv2/psa_switch/midend.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "frontends/common/options.h"
 #include "midend/convertEnums.h"
 #include "backends/bmv2/common/midend.h"
+#include "backends/bmv2/common/options.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/simple_switch/main.cpp
+++ b/backends/bmv2/simple_switch/main.cpp
@@ -32,6 +32,8 @@ limitations under the License.
 #include "backends/bmv2/simple_switch/midend.h"
 #include "backends/bmv2/simple_switch/simpleSwitch.h"
 #include "backends/bmv2/simple_switch/version.h"
+#include "ir/json_loader.h"
+#include "fstream"
 
 int main(int argc, char *const argv[]) {
     setup_gc_logging();
@@ -41,8 +43,10 @@ int main(int argc, char *const argv[]) {
     options.langVersion = CompilerOptions::FrontendVersion::P4_16;
     options.compilerVersion = BMV2_SIMPLESWITCH_VERSION_STRING;
 
-    if (options.process(argc, argv) != nullptr)
-        options.setInputFile();
+    if (options.process(argc, argv) != nullptr) {
+            if (options.loadIRFromJson == false)
+                    options.setInputFile();
+    }
     if (::errorCount() > 0)
         return 1;
 
@@ -50,28 +54,49 @@ int main(int argc, char *const argv[]) {
 
     // BMV2 is required for compatibility with the previous compiler.
     options.preprocessor_options += " -D__TARGET_BMV2__";
-    auto program = P4::parseP4File(options);
-    if (program == nullptr || ::errorCount() > 0)
-        return 1;
-    try {
-        P4::P4COptionPragmaParser optionsPragmaParser;
-        program->apply(P4::ApplyOptionsPragmas(optionsPragmaParser));
 
-        P4::FrontEnd frontend;
-        frontend.addDebugHook(hook);
-        program = frontend.run(options, program);
-    } catch (const Util::P4CExceptionBase &bug) {
-        std::cerr << bug.what() << std::endl;
-        return 1;
+    const IR::P4Program *program = nullptr;
+    const IR::ToplevelBlock* toplevel = nullptr;
+
+
+    if (options.loadIRFromJson == false) {
+        program = P4::parseP4File(options);
+
+        if (program == nullptr || ::errorCount() > 0)
+            return 1;
+        try {
+            P4::P4COptionPragmaParser optionsPragmaParser;
+            program->apply(P4::ApplyOptionsPragmas(optionsPragmaParser));
+
+            P4::FrontEnd frontend;
+            frontend.addDebugHook(hook);
+            program = frontend.run(options, program);
+        } catch (const Util::P4CExceptionBase &bug) {
+            std::cerr << bug.what() << std::endl;
+            return 1;
+        }
+        if (program == nullptr || ::errorCount() > 0)
+            return 1;
+    } else {
+        std::filebuf fb;
+        if (fb.open(options.file, std::ios::in) == nullptr) {
+            ::error("%s: No such file or directory.", options.file);
+            return 1;
+        }
+        std::istream inJson(&fb);
+        JSONLoader jsonFileLoader(inJson);
+        if (jsonFileLoader.json == nullptr) {
+            ::error("Not valid input file");
+            return 1;
+        }
+        program = new IR::P4Program(jsonFileLoader);
+        fb.close();
     }
-    if (program == nullptr || ::errorCount() > 0)
-        return 1;
 
     P4::serializeP4RuntimeIfRequired(program, options);
     if (::errorCount() > 0)
         return 1;
 
-    const IR::ToplevelBlock* toplevel = nullptr;
     BMV2::SimpleSwitchMidEnd midEnd(options);
     midEnd.addDebugHook(hook);
     try {
@@ -79,8 +104,8 @@ int main(int argc, char *const argv[]) {
         if (::errorCount() > 1 || toplevel == nullptr ||
             toplevel->getMain() == nullptr)
             return 1;
-        if (options.dumpJsonFile)
-            JSONGenerator(*openFile(options.dumpJsonFile, true)) << program << std::endl;
+        if (options.dumpJsonFile && !options.loadIRFromJson)
+            JSONGenerator(*openFile(options.dumpJsonFile, true), true) << program << std::endl;
     } catch (const Util::P4CExceptionBase &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;

--- a/backends/bmv2/simple_switch/midend.cpp
+++ b/backends/bmv2/simple_switch/midend.cpp
@@ -58,65 +58,77 @@ limitations under the License.
 namespace BMV2 {
 
 SimpleSwitchMidEnd::SimpleSwitchMidEnd(CompilerOptions& options) : MidEnd(options) {
-    auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
-    auto convertEnums = new P4::ConvertEnums(&refMap, &typeMap, new EnumOn32Bits("v1model.p4"));
-    addPasses({
-        new P4::CheckTableSize(),
-        new P4::EliminateNewtype(&refMap, &typeMap),
-        new P4::EliminateSerEnums(&refMap, &typeMap),
-        new P4::RemoveActionParameters(&refMap, &typeMap),
-        convertEnums,
-        new VisitFunctor([this, convertEnums]() { enumMap = convertEnums->getEnumMapping(); }),
-        new P4::OrderArguments(&refMap, &typeMap),
-        new P4::TypeChecking(&refMap, &typeMap),
-        new P4::SimplifyKey(&refMap, &typeMap,
-                            new P4::OrPolicy(
-                                new P4::IsValid(&refMap, &typeMap),
-                                new P4::IsMask())),
-        new P4::ConstantFolding(&refMap, &typeMap),
-        new P4::StrengthReduction(&refMap, &typeMap),
-        new P4::SimplifySelectCases(&refMap, &typeMap, true),  // require constant keysets
-        new P4::ExpandLookahead(&refMap, &typeMap),
-        new P4::ExpandEmit(&refMap, &typeMap),
-        new P4::SimplifyParsers(&refMap),
-        new P4::StrengthReduction(&refMap, &typeMap),
-        new P4::EliminateTuples(&refMap, &typeMap),
-        new P4::SimplifyComparisons(&refMap, &typeMap),
-        new P4::CopyStructures(&refMap, &typeMap),
-        new P4::NestedStructs(&refMap, &typeMap),
-        new P4::SimplifySelectList(&refMap, &typeMap),
-        new P4::RemoveSelectBooleans(&refMap, &typeMap),
-        new P4::FlattenHeaders(&refMap, &typeMap),
-        new P4::FlattenInterfaceStructs(&refMap, &typeMap),
-        new P4::Predication(&refMap),
-        new P4::MoveDeclarations(),  // more may have been introduced
-        new P4::ConstantFolding(&refMap, &typeMap),
-        new P4::LocalCopyPropagation(&refMap, &typeMap),
-        new P4::ConstantFolding(&refMap, &typeMap),
-        new P4::SimplifyKey(&refMap, &typeMap,
-                            new P4::OrPolicy(
-                                new P4::IsValid(&refMap, &typeMap),
-                                new P4::IsMask())),
-        new P4::MoveDeclarations(),
-        new P4::ValidateTableProperties({ "implementation",
-                                          "size",
-                                          "counters",
-                                          "meters",
-                                          "support_timeout" }),
-        new P4::SimplifyControlFlow(&refMap, &typeMap),
-        new P4::CompileTimeOperations(),
-        new P4::TableHit(&refMap, &typeMap),
-        new P4::RemoveLeftSlices(&refMap, &typeMap),
+    if (BMV2::BMV2Context::get().options().loadIRFromJson == false) {
+        auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
+        auto convertEnums = new P4::ConvertEnums(&refMap, &typeMap, new EnumOn32Bits("v1model.p4"));
+        addPasses({
+            new P4::CheckTableSize(),
+            new P4::EliminateNewtype(&refMap, &typeMap),
+            new P4::EliminateSerEnums(&refMap, &typeMap),
+            new P4::RemoveActionParameters(&refMap, &typeMap),
+            convertEnums,
+            new VisitFunctor([this, convertEnums]() { enumMap = convertEnums->getEnumMapping(); }),
+            new P4::OrderArguments(&refMap, &typeMap),
+            new P4::TypeChecking(&refMap, &typeMap),
+            new P4::SimplifyKey(&refMap, &typeMap,
+                                new P4::OrPolicy(
+                                    new P4::IsValid(&refMap, &typeMap),
+                                    new P4::IsMask())),
+            new P4::ConstantFolding(&refMap, &typeMap),
+            new P4::StrengthReduction(&refMap, &typeMap),
+            new P4::SimplifySelectCases(&refMap, &typeMap, true),  // require constant keysets
+            new P4::ExpandLookahead(&refMap, &typeMap),
+            new P4::ExpandEmit(&refMap, &typeMap),
+            new P4::SimplifyParsers(&refMap),
+            new P4::StrengthReduction(&refMap, &typeMap),
+            new P4::EliminateTuples(&refMap, &typeMap),
+            new P4::SimplifyComparisons(&refMap, &typeMap),
+            new P4::CopyStructures(&refMap, &typeMap),
+            new P4::NestedStructs(&refMap, &typeMap),
+            new P4::SimplifySelectList(&refMap, &typeMap),
+            new P4::RemoveSelectBooleans(&refMap, &typeMap),
+            new P4::FlattenHeaders(&refMap, &typeMap),
+            new P4::FlattenInterfaceStructs(&refMap, &typeMap),
+            new P4::Predication(&refMap),
+            new P4::MoveDeclarations(),  // more may have been introduced
+            new P4::ConstantFolding(&refMap, &typeMap),
+            new P4::LocalCopyPropagation(&refMap, &typeMap),
+            new P4::ConstantFolding(&refMap, &typeMap),
+            new P4::SimplifyKey(&refMap, &typeMap,
+                                new P4::OrPolicy(
+                                    new P4::IsValid(&refMap, &typeMap),
+                                    new P4::IsMask())),
+            new P4::MoveDeclarations(),
+            new P4::ValidateTableProperties({ "implementation",
+                                              "size",
+                                              "counters",
+                                              "meters",
+                                              "support_timeout" }),
+            new P4::SimplifyControlFlow(&refMap, &typeMap),
+            new P4::CompileTimeOperations(),
+            new P4::TableHit(&refMap, &typeMap),
+            new P4::RemoveLeftSlices(&refMap, &typeMap),
 
-        // p4c-bm removed unused action parameters. To produce a compatible
-        // control plane API, we remove them as well for P4-14 programs.
-        isv1 ? new P4::RemoveUnusedActionParameters(&refMap) : nullptr,
+            // p4c-bm removed unused action parameters. To produce a compatible
+            // control plane API, we remove them as well for P4-14 programs.
+            isv1 ? new P4::RemoveUnusedActionParameters(&refMap) : nullptr,
 
-        new P4::TypeChecking(&refMap, &typeMap),
-        new P4::MidEndLast(),
-        evaluator,
-        new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
-    });
+            new P4::TypeChecking(&refMap, &typeMap),
+            new P4::MidEndLast(),
+            evaluator,
+            new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
+        });
+    } else {
+        addPasses({
+            new P4::ResolveReferences(&refMap),
+            new P4::TypeChecking(&refMap, &typeMap),
+        });
+        auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
+        addPasses({
+            evaluator,
+            new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
+        });
+    }
 }
 
 }  // namespace BMV2

--- a/backends/bmv2/simple_switch/midend.h
+++ b/backends/bmv2/simple_switch/midend.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "frontends/common/options.h"
 #include "midend/convertEnums.h"
 #include "backends/bmv2/common/midend.h"
+#include "backends/bmv2/common/options.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -936,8 +936,17 @@ SimpleSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
     auto evaluator = new P4::EvaluatorPass(refMap, typeMap);
     auto program = tlb->getProgram();
     // These passes are logically bmv2-specific
-    PassManager simplify = {
-        new ParseAnnotations(),
+    PassManager simplify = {};
+
+    if (BMV2::BMV2Context::get().options().loadIRFromJson == false) {
+        // ParseAnnotations is added only in case of not using --fromJson flag
+        simplify.addPasses({
+            new ParseAnnotations(),
+        });
+    }
+    simplify.addPasses({
+        // Because --fromJSON flag is used, input sources are empty
+        // and ParseAnnotations should be skipped
         new RenameUserMetadata(refMap, userMetaType, userMetaName),
         new P4::ClearTypeMap(typeMap),  // because the user metadata type has changed
         new P4::SynthesizeActions(refMap, typeMap,
@@ -954,7 +963,7 @@ SimpleSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
         new P4::RemoveAllUnusedDeclarations(refMap),
         evaluator,
         new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
-    };
+    });
 
     auto hook = options.getDebugHook();
     simplify.addDebugHook(hook);

--- a/backends/bmv2/simple_switch/simpleSwitch.h
+++ b/backends/bmv2/simple_switch/simpleSwitch.h
@@ -35,6 +35,7 @@ limitations under the License.
 #include "backends/bmv2/common/parser.h"
 #include "backends/bmv2/common/programStructure.h"
 #include "backends/bmv2/common/sharedActionSelectorCheck.h"
+#include "backends/bmv2/common/options.h"
 
 namespace BMV2 {
 

--- a/backends/ebpf/ebpfOptions.h
+++ b/backends/ebpf/ebpfOptions.h
@@ -24,12 +24,18 @@ class EbpfOptions : public CompilerOptions {
  public:
     // file to output to
     cstring outputFile = nullptr;
+    // read from json
+    bool loadIRFromJson = false;
 
     EbpfOptions() {
         langVersion = CompilerOptions::FrontendVersion::P4_16;
         registerOption("-o", "outfile",
                 [this](const char* arg) { outputFile = arg; return true; },
                 "Write output to outfile");
+        registerOption("--fromJSON", "file",
+                [this](const char* arg) { loadIRFromJson = true; file = arg; return true; },
+                "Use IR representation from JsonFile dumped previously,"\
+                "the compilation starts with reduced midEnd.");
     }
 };
 

--- a/backends/ebpf/midend.cpp
+++ b/backends/ebpf/midend.cpp
@@ -71,38 +71,47 @@ const IR::ToplevelBlock* MidEnd::run(EbpfOptions& options, const IR::P4Program* 
     refMap.setIsV1(isv1);
     auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
 
-    PassManager midEnd = {
-        new P4::ConvertEnums(&refMap, &typeMap, new EnumOn32Bits()),
-        new P4::ClearTypeMap(&typeMap),
-        new P4::EliminateNewtype(&refMap, &typeMap),
-        new P4::SimplifyControlFlow(&refMap, &typeMap),
-        new P4::RemoveActionParameters(&refMap, &typeMap),
-        new P4::SimplifyKey(&refMap, &typeMap,
-                            new P4::OrPolicy(
-                                new P4::IsValid(&refMap, &typeMap),
-                                new P4::IsLikeLeftValue())),
-        new P4::RemoveExits(&refMap, &typeMap),
-        new P4::ConstantFolding(&refMap, &typeMap),
-        new P4::SimplifySelectCases(&refMap, &typeMap, false),  // accept non-constant keysets
-        new P4::HandleNoMatch(&refMap),
-        new P4::SimplifyParsers(&refMap),
-        new P4::StrengthReduction(&refMap, &typeMap),
-        new P4::SimplifyComparisons(&refMap, &typeMap),
-        new P4::EliminateTuples(&refMap, &typeMap),
-        new P4::LocalCopyPropagation(&refMap, &typeMap),
-        new P4::SimplifySelectList(&refMap, &typeMap),
-        new P4::MoveDeclarations(),  // more may have been introduced
-        new P4::RemoveSelectBooleans(&refMap, &typeMap),
-        new P4::SingleArgumentSelect(),
-        new P4::ConstantFolding(&refMap, &typeMap),
-        new P4::SimplifyControlFlow(&refMap, &typeMap),
-        new P4::TableHit(&refMap, &typeMap),
-        new P4::ValidateTableProperties({"implementation"}),
-        new P4::RemoveLeftSlices(&refMap, &typeMap),
-        new EBPF::Lower(&refMap, &typeMap),
-        evaluator,
-        new P4::MidEndLast()
-    };
+    PassManager midEnd = {};
+    if (options.loadIRFromJson == false) {
+        midEnd = {
+            new P4::ConvertEnums(&refMap, &typeMap, new EnumOn32Bits()),
+            new P4::ClearTypeMap(&typeMap),
+            new P4::EliminateNewtype(&refMap, &typeMap),
+            new P4::SimplifyControlFlow(&refMap, &typeMap),
+            new P4::RemoveActionParameters(&refMap, &typeMap),
+            new P4::SimplifyKey(&refMap, &typeMap,
+                                new P4::OrPolicy(
+                                    new P4::IsValid(&refMap, &typeMap),
+                                    new P4::IsLikeLeftValue())),
+           new P4::RemoveExits(&refMap, &typeMap),
+            new P4::ConstantFolding(&refMap, &typeMap),
+           new P4::SimplifySelectCases(&refMap, &typeMap, false),  // accept non-constant keysets
+            new P4::HandleNoMatch(&refMap),
+            new P4::SimplifyParsers(&refMap),
+            new P4::StrengthReduction(&refMap, &typeMap),
+            new P4::SimplifyComparisons(&refMap, &typeMap),
+            new P4::EliminateTuples(&refMap, &typeMap),
+            new P4::LocalCopyPropagation(&refMap, &typeMap),
+            new P4::SimplifySelectList(&refMap, &typeMap),
+            new P4::MoveDeclarations(),  // more may have been introduced
+            new P4::RemoveSelectBooleans(&refMap, &typeMap),
+            new P4::SingleArgumentSelect(),
+            new P4::ConstantFolding(&refMap, &typeMap),
+            new P4::SimplifyControlFlow(&refMap, &typeMap),
+            new P4::TableHit(&refMap, &typeMap),
+            new P4::ValidateTableProperties({"implementation"}),
+            new P4::RemoveLeftSlices(&refMap, &typeMap),
+            new EBPF::Lower(&refMap, &typeMap),
+            evaluator,
+            new P4::MidEndLast()
+       };
+    } else {
+        midEnd = {
+            new P4::ResolveReferences(&refMap),
+            new P4::TypeChecking(&refMap, &typeMap),
+            evaluator
+        };
+    }
     midEnd.setName("MidEnd");
     midEnd.addDebugHooks(hooks);
     program = program->apply(midEnd);

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -32,6 +32,8 @@ limitations under the License.
 #include "frontends/common/applyOptionsPragmas.h"
 #include "frontends/common/parseInput.h"
 #include "frontends/p4/frontend.h"
+#include "ir/json_loader.h"
+#include "fstream"
 
 void compile(EbpfOptions& options) {
     auto hook = options.getDebugHook();
@@ -40,19 +42,37 @@ void compile(EbpfOptions& options) {
         ::error("This compiler only handles P4-16");
         return;
     }
-    auto program = P4::parseP4File(options);
-    if (::errorCount() > 0)
-        return;
+    const IR::P4Program *program = nullptr;
 
-    P4::P4COptionPragmaParser optionsPragmaParser;
-    program->apply(P4::ApplyOptionsPragmas(optionsPragmaParser));
+    if (options.loadIRFromJson) {
+        std::filebuf fb;
+        if (fb.open(options.file, std::ios::in) == nullptr) {
+            ::error("%s: No such file or directory.", options.file);
+            return;
+        }
 
-    P4::FrontEnd frontend;
-    frontend.addDebugHook(hook);
-    program = frontend.run(options, program);
-    if (::errorCount() > 0)
-        return;
+        std::istream inJson(&fb);
+        JSONLoader jsonFileLoader(inJson);
+        if (jsonFileLoader.json == nullptr) {
+            ::error("Not valid input file");
+            return;
+        }
+        program = new IR::P4Program(jsonFileLoader);
+        fb.close();
+    } else {
+        program = P4::parseP4File(options);
+        if (::errorCount() > 0)
+            return;
 
+        P4::P4COptionPragmaParser optionsPragmaParser;
+        program->apply(P4::ApplyOptionsPragmas(optionsPragmaParser));
+
+        P4::FrontEnd frontend;
+        frontend.addDebugHook(hook);
+        program = frontend.run(options, program);
+        if (::errorCount() > 0)
+            return;
+    }
     EBPF::MidEnd midend;
     midend.addDebugHook(hook);
     auto toplevel = midend.run(options, program);
@@ -72,8 +92,10 @@ int main(int argc, char *const argv[]) {
     auto& options = EbpfContext::get().options();
     options.compilerVersion = P4C_EBPF_VERSION_STRING;
 
-    if (options.process(argc, argv) != nullptr)
-        options.setInputFile();
+    if (options.process(argc, argv) != nullptr) {
+            if (options.loadIRFromJson == false)
+                    options.setInputFile();
+    }
     if (::errorCount() > 0)
         exit(1);
 

--- a/ir/json_parser.cpp
+++ b/ir/json_parser.cpp
@@ -32,6 +32,44 @@ std::string JsonObject::get_type() const {
         return *(dynamic_cast<JsonString*>(find("Node_Type")->second));
 }
 
+std::string JsonObject::get_filename() const {
+    if (find("filename") == end())
+        return "";
+    else
+        return *(dynamic_cast<JsonString*>(find("filename")->second));
+}
+
+std::string JsonObject::get_sourceFragment() const {
+    if (find("source_fragment") == end())
+        return "";
+    else
+        return *(dynamic_cast<JsonString*>(find("source_fragment")->second));
+}
+
+int JsonObject::get_line() const {
+    if (find("line") == end())
+        return -1;
+    else
+        return *(find("line")->second->to<JsonNumber>());
+}
+
+int JsonObject::get_column() const {
+    if (find("column") == end())
+        return -1;
+    else
+        return *(find("column")->second->to<JsonNumber>());
+}
+
+JsonObject JsonObject::get_sourceJson() const {
+    if (find("Source_Info") == end()) {
+        JsonObject obj;
+        obj.setSrcInfo(false);
+        return obj;
+    } else {
+        return *(dynamic_cast<JsonObject*>(find("Source_Info")->second));
+    }
+}
+
 // Hack to make << operator work multi-threaded
 static thread_local int level = 0;
 

--- a/ir/json_parser.h
+++ b/ir/json_parser.h
@@ -7,6 +7,7 @@
 #include "lib/cstring.h"
 #include "lib/gmputil.h"
 #include "lib/ordered_map.h"
+#include "lib/source_file.h"
 
 class JsonData {
  public:
@@ -56,12 +57,22 @@ class JsonVector : public JsonData, public std::vector<JsonData*> {
 };
 
 class JsonObject : public JsonData, public ordered_map<std::string, JsonData*>  {
+    bool _hasSrcInfo = true;
  public:
+    JsonObject() {}
+    JsonObject(const JsonObject& obj) = default;
     JsonObject &operator=(JsonObject&&) & = default;
     JsonObject(const ordered_map<std::string, JsonData*> & v)  // NOLINT(runtime/explicit)
     : ordered_map<std::string, JsonData*>(v) {}
     int get_id() const;
     std::string get_type() const;
+    std::string get_filename() const;
+    std::string get_sourceFragment() const;
+    int get_line() const;
+    int get_column() const;
+    JsonObject get_sourceJson() const;
+    bool hasSrcInfo() { return _hasSrcInfo; }
+    void setSrcInfo(bool value) { _hasSrcInfo = value; }
 };
 
 class JsonNull : public JsonData {};

--- a/ir/node.cpp
+++ b/ir/node.cpp
@@ -87,19 +87,28 @@ Util::JsonObject* IR::Node::sourceInfoJsonObj() const {
     unsigned lineNumber, columnNumber;
     cstring fName = prepareSourceInfoForJSON(si, &lineNumber, &columnNumber);
     if (fName == nullptr) {
-        // Do not add anything to the bmv2 JSON file for this, as this
-        // is likely a statement synthesized by the compiler, and
-        // either not easy, or it is impossible, to correlate it
-        // directly with anything in the user's P4 source code.
-        return nullptr;
+        if (si.line == -1) {
+            // -1 is default value for objects when SourceInfo
+            // was not read from jsonFile using "--fromJSON" flag
+            return nullptr;
+        } else {
+            // Added source_info for jsonObject when "--fromJSON" flag is used
+            // which parameters are saved in srcInfo fileds(filename, line, column and srcBrief)
+            auto json1 = new Util::JsonObject();
+            json1->emplace("filename", srcInfo.filename);
+            json1->emplace("line", srcInfo.line);
+            json1->emplace("column", srcInfo.column);
+            json1->emplace("source_fragment", srcInfo.srcBrief);
+            return json1;
+        }
+    } else {
+        auto json = new Util::JsonObject();
+        json->emplace("filename", fName);
+        json->emplace("line", lineNumber);
+        json->emplace("column", columnNumber);
+        json->emplace("source_fragment", si.toBriefSourceFragment());
+        return json;
     }
-
-    auto json = new Util::JsonObject();
-    json->emplace("filename", fName);
-    json->emplace("line", lineNumber);
-    json->emplace("column", columnNumber);
-    json->emplace("source_fragment", si.toBriefSourceFragment());
-    return json;
 }
 
 void IR::Node::sourceInfoToJSON(JSONGenerator &json) const {

--- a/ir/pass_manager.h
+++ b/ir/pass_manager.h
@@ -33,9 +33,6 @@ class PassManager : virtual public Visitor, virtual public Backtrack {
     bool                stop_on_error = true;
     bool                running = false;
     unsigned            seqNo = 0;
-    void addPasses(const std::initializer_list<Visitor *> &init) {
-        never_backtracks_cache = -1;
-        for (auto p : init) if (p) passes.emplace_back(p); }
     void runDebugHooks(const char* visitorName, const IR::Node* node);
     profile_t init_apply(const IR::Node *root) override {
         running = true;
@@ -45,6 +42,9 @@ class PassManager : virtual public Visitor, virtual public Backtrack {
     PassManager() = default;
     PassManager(const std::initializer_list<Visitor *> &init)
     { addPasses(init); }
+    void addPasses(const std::initializer_list<Visitor *> &init) {
+        never_backtracks_cache = -1;
+        for (auto p : init) if (p) passes.emplace_back(p); }
     const IR::Node *apply_visitor(const IR::Node *, const char * = 0) override;
     bool backtrack(trigger &trig) override;
     bool never_backtracks() override;

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -138,6 +138,16 @@ SourceInfo can also be "invalid"
 */
 class SourceInfo final {
  public:
+    cstring filename = "";
+    int line = -1;
+    int column = -1;
+    cstring srcBrief = "";
+    SourceInfo(cstring filename, int line, int column, cstring srcBrief) {
+        this->filename = filename;
+        this->line = line;
+        this->column = column;
+        this->srcBrief = srcBrief;
+    }
     /// Creates an "invalid" SourceInfo
     SourceInfo()
         : sources(nullptr), start(SourcePosition()), end(SourcePosition()) {}

--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -170,6 +170,8 @@ class BackendDriver:
                 self.add_command_option('compiler', "--dump {}".format(opts.dump_dir))
             if opts.json:
                 self.add_command_option('compiler', "--toJSON {}".format(opts.json))
+            if opts.json_source:
+                self.add_command_option('compiler', "--fromJSON {}".format(opts.json_source))
             if opts.pretty_print:
                 self.add_command_option('compiler', "--pp {}".format(opts.pretty_print))
 

--- a/tools/driver/p4c_src/main.py
+++ b/tools/driver/p4c_src/main.py
@@ -59,6 +59,9 @@ def add_developer_options(parser):
                         help="[Compiler debugging] Folder where P4 programs are dumped.")
     parser.add_argument("--toJson", dest="json", default=None,
                         help="Dump IR to JSON in the specified file.")
+    parser.add_argument("--fromJson", dest="json_source", default=None,
+                        help="Use IR from JSON representation dumped previously. \
+                        the compilation starts with reduced midEnd.")
     parser.add_argument("--pp", dest="pretty_print", default=None,
                         help="Pretty-print the program in the specified file.")
 
@@ -181,8 +184,10 @@ def main():
         print display_supported_targets(cfg)
         sys.exit(0)
 
-    if not opts.source_file:
+    if not opts.source_file and not opts.json_source:
         parser.error('No input specified.')
+    elif opts.json_source:
+        opts.source_file = opts.json_source
 
     if not os.path.isfile(opts.source_file):
         print >> sys.stderr, 'Input file ' + opts.source_file + ' does not exist'


### PR DESCRIPTION
* Added --fromJSON flag, as registerOption for all backends.
* Construction : "--fromJSON" "file", where file represents
IR representation json instead of p4 file.

* Modified all backends to skip parsing stage and FrontEnd pass.

* ConvertEnums is skipped in MidEnd pass(when --fromJson flag is used)
since it was already processed during initial IR generation
(checksum already been computed).

* ParseAnnotation is skipped in backend(while using --fromJSON flag),
because InputSources are empty

* Extended class JsonObject with fields and methods
for making JsonObject object, when program is reading from jsonFile
dumped after midEnd previously

* Extended class SourceInfo,
to make object SourceInfo from parameters read from the jsonFile

* Modified function IR::Node::sourceInfoJsonObj() to generate
source_info information when --fromJson flag is used.

Signed-off-by: Jelena Vidakovic <jelena.vidakovic@rt-rk.com>