### PR TITLE
Add program that tests p4c's error-detection capability for bad type's

### DIFF
--- a/testdata/p4_16_errors/typedef-and-type-definitions.p4
+++ b/testdata/p4_16_errors/typedef-and-type-definitions.p4
@@ -106,7 +106,7 @@ typedef tuple<bit<8>, varbit<17> > Tuple2D_t;
 // Every line marked '// error' below causes the compiler to issue an
 // error message of this form:
 
-// error: <type_name>: 'type' can only be applied to base types or tuple types
+// error: <type_name>: 'type' can only be applied to base types
 
 
 type    int        intT_t;
@@ -123,8 +123,8 @@ type    h1_t[3]    h1StackT_t;  // error
 type    hu1_t      hu1T_t;  // error
 type    s1_t       s1T_t;  // error
 type    struct PointB_t { int<32> x; int<32> y; } PointBD_t;  // error
-type    tuple<bit<8>, bit<17> > Tuple1T_t;
-type    tuple<bit<8>, varbit<17> > Tuple2T_t;  // should this be an error, since it contains a varbit element?
+type    tuple<bit<8>, bit<17> > Tuple1T_t;  // error
+type    tuple<bit<8>, varbit<17> > Tuple2T_t;  // error
 
 
 // typedef on top of another typedef or type are allowed
@@ -140,7 +140,7 @@ type    bT_t bTT_t;
 // Every line marked '// error' below causes the compiler to issue an
 // error message of this form:
 
-// error: <type_name>: 'type' can only be applied to base types or tuple types
+// error: <type_name>: 'type' can only be applied to base types
 
 type    iD_t iDT_t;
 type    vD_t vDT_t;  // error
@@ -154,5 +154,5 @@ type    h1StackD_t h1StackDT_t;  // error
 type    hu1D_t hu1DT_t;  // error
 type    s1D_t s1DT_t;  // error
 type    PointAD_t PointADT_t;  // error
-type    Tuple1D_t Tuple1DT_t;
-type    Tuple2D_t Tuple2DT_t;  // should this be an error, since it contains a varbit element?
+type    Tuple1D_t Tuple1DT_t;  // error
+type    Tuple2D_t Tuple2DT_t;  // error

--- a/testdata/p4_16_errors/typedef-and-type-definitions.p4
+++ b/testdata/p4_16_errors/typedef-and-type-definitions.p4
@@ -1,0 +1,158 @@
+/*
+Copyright 2019 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+
+
+header h1_t {
+    bit<8> f1;
+}
+
+header h2_t {
+    bit<8> f2;
+}
+
+header_union hu1_t {
+    h1_t h1;
+    h2_t h2;
+}
+
+struct s1_t {
+    bit<8> f2;
+}
+
+enum enum1_t {
+    A,
+    B
+}
+
+enum bit<7> serializable_enum1_t {
+    C = 3,
+    D = 8
+}
+
+// Naming convention used here:
+
+// D is abbreviation for `typedef`
+// T is abbrevation for `type`
+
+// Since types and typedefs can be defined in terms of each other, the
+// names I use here contain sequences of Ds and Ts to indicate the
+// order in which they have been "stacked", e.g. EthDT_t is a `type`
+// (the T is last) defined on type of a `typedef` (the D just before
+// the T).
+
+
+//////////////////////////////////////////////////////////////////////
+// typdef
+//////////////////////////////////////////////////////////////////////
+
+// int, void, match_kind cause syntax error that causes compiler to
+// stop immediately without looking for further errors.
+
+// syntax error, unexpected IDENTIFIER, expecting <
+//typedef int        intD_t;
+// syntax error, unexpected VOID, expecting ENUM or HEADER or HEADER_UNION or STRUCT
+//typedef void       voidD_t;
+//syntax error, unexpected MATCH_KIND, expecting ENUM or HEADER or HEADER_UNION or STRUCT
+//typedef match_kind matchD_t;
+
+// The compiler allows all of the typedef definitions below, without
+// error.
+
+typedef bit<8>     bD_t;
+typedef int<8>     iD_t;
+typedef varbit<8>  vD_t;
+typedef error      errorD_t;
+typedef bool       boolD_t;
+typedef enum1_t    enum1D_t;
+typedef serializable_enum1_t serializable_enum1D_t;
+typedef h1_t       H1D_t;
+typedef header h2a_t { bit<16> f2; bit<8> f3; } H2aD_t;
+typedef h1_t[3]    h1StackD_t;
+typedef hu1_t      hu1D_t;
+typedef s1_t       s1D_t;
+typedef struct PointA_t { int<32> x; int<32> y; } PointAD_t;
+typedef tuple<bit<8>, bit<17> > Tuple1D_t;
+typedef tuple<bit<8>, varbit<17> > Tuple2D_t;
+
+
+//////////////////////////////////////////////////////////////////////
+// type
+//////////////////////////////////////////////////////////////////////
+
+// int, void, match_kind cause syntax error that causes compiler to
+// stop immediately without looking for further errors.
+
+// syntax error, unexpected IDENTIFIER, expecting <
+//type    int        intT_t;
+// syntax error, unexpected VOID, expecting ENUM or HEADER or HEADER_UNION or STRUCT
+//type    void       voidT_t;
+// syntax error, unexpected MATCH_KIND, expecting ENUM or HEADER or HEADER_UNION or STRUCT
+//type    match_kind matchT_t;
+
+
+// Every line marked '// error' below causes the compiler to issue an
+// error message of this form:
+
+// error: <type_name>: 'type' can only be applied to base types or tuple types
+
+type    bit<8>     bT_t;
+type    int<8>     iT_t;
+type    varbit<8>  vT_t;  // error
+type    error      errorT_t;  // error
+type    bool       boolT_t;
+type    enum1_t    enum1T_t;  // error
+type    serializable_enum1_t serializable_enum1T_t;  // error
+type    h1_t       H1T_t;  // error
+type    header h2b_t { bit<16> f2; bit<8> f3; } H2bT_t;  // error
+type    h1_t[3]    h1StackT_t;  // error
+type    hu1_t      hu1T_t;  // error
+type    s1_t       s1T_t;  // error
+type    struct PointB_t { int<32> x; int<32> y; } PointBD_t;  // error
+type    tuple<bit<8>, bit<17> > Tuple1T_t;
+type    tuple<bit<8>, varbit<17> > Tuple2T_t;  // should this be an error, since it contains a varbit element?
+
+
+// typedef on top of another typedef or type are allowed
+typedef bD_t bDD_t;
+typedef bT_t bTD_t;
+
+// type on top of another typedef or type are allowed, at least if the
+// base type is allowed directly in a type definition.
+
+type    bD_t bDT_t;
+type    bT_t bTT_t;
+
+// Every line marked '// error' below causes the compiler to issue an
+// error message of this form:
+
+// error: <type_name>: 'type' can only be applied to base types or tuple types
+
+type    iD_t iDT_t;
+type    vD_t vDT_t;  // error
+type    errorD_t errorDT_t;  // error
+type    boolD_t boolDT_t;
+type    enum1D_t enum1DT_t;  // error
+type    serializable_enum1D_t serializable_enum1DT_t;  // error
+type    H1D_t H1DT_t;  // error
+type    H2aD_t H2aDT_t;  // error
+type    h1StackD_t h1StackDT_t;  // error
+type    hu1D_t hu1DT_t;  // error
+type    s1D_t s1DT_t;  // error
+type    PointAD_t PointADT_t;  // error
+type    Tuple1D_t Tuple1DT_t;
+type    Tuple2D_t Tuple2DT_t;  // should this be an error, since it contains a varbit element?

--- a/testdata/p4_16_errors/typedef-and-type-definitions.p4
+++ b/testdata/p4_16_errors/typedef-and-type-definitions.p4
@@ -60,11 +60,9 @@ enum bit<7> serializable_enum1_t {
 // typdef
 //////////////////////////////////////////////////////////////////////
 
-// int, void, match_kind cause syntax error that causes compiler to
+// void, match_kind cause syntax error that causes compiler to
 // stop immediately without looking for further errors.
 
-// syntax error, unexpected IDENTIFIER, expecting <
-//typedef int        intD_t;
 // syntax error, unexpected VOID, expecting ENUM or HEADER or HEADER_UNION or STRUCT
 //typedef void       voidD_t;
 //syntax error, unexpected MATCH_KIND, expecting ENUM or HEADER or HEADER_UNION or STRUCT
@@ -73,6 +71,8 @@ enum bit<7> serializable_enum1_t {
 // The compiler allows all of the typedef definitions below, without
 // error.
 
+
+typedef int        intD_t;
 typedef bit<8>     bD_t;
 typedef int<8>     iD_t;
 typedef varbit<8>  vD_t;
@@ -94,11 +94,9 @@ typedef tuple<bit<8>, varbit<17> > Tuple2D_t;
 // type
 //////////////////////////////////////////////////////////////////////
 
-// int, void, match_kind cause syntax error that causes compiler to
+// void, match_kind cause syntax error that causes compiler to
 // stop immediately without looking for further errors.
 
-// syntax error, unexpected IDENTIFIER, expecting <
-//type    int        intT_t;
 // syntax error, unexpected VOID, expecting ENUM or HEADER or HEADER_UNION or STRUCT
 //type    void       voidT_t;
 // syntax error, unexpected MATCH_KIND, expecting ENUM or HEADER or HEADER_UNION or STRUCT
@@ -110,6 +108,8 @@ typedef tuple<bit<8>, varbit<17> > Tuple2D_t;
 
 // error: <type_name>: 'type' can only be applied to base types or tuple types
 
+
+type    int        intT_t;
 type    bit<8>     bT_t;
 type    int<8>     iT_t;
 type    varbit<8>  vT_t;  // error

--- a/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4
+++ b/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4
@@ -27,6 +27,7 @@ enum bit<7> serializable_enum1_t {
     D = 8
 }
 
+typedef int intD_t;
 typedef bit<8> bD_t;
 typedef int<8> iD_t;
 typedef varbit<8> vD_t;
@@ -50,6 +51,7 @@ typedef struct PointA_t {
 PointAD_t;
 typedef tuple<bit<8>, bit<17>> Tuple1D_t;
 typedef tuple<bit<8>, varbit<17>> Tuple2D_t;
+type int intT_t;
 type bit<8> bT_t;
 type int<8> iT_t;
 type varbit<8> vT_t;

--- a/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4
+++ b/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+
+header h1_t {
+    bit<8> f1;
+}
+
+header h2_t {
+    bit<8> f2;
+}
+
+header_union hu1_t {
+    h1_t h1;
+    h2_t h2;
+}
+
+struct s1_t {
+    bit<8> f2;
+}
+
+enum enum1_t {
+    A,
+    B
+}
+
+enum bit<7> serializable_enum1_t {
+    C = 3,
+    D = 8
+}
+
+typedef bit<8> bD_t;
+typedef int<8> iD_t;
+typedef varbit<8> vD_t;
+typedef error errorD_t;
+typedef bool boolD_t;
+typedef enum1_t enum1D_t;
+typedef serializable_enum1_t serializable_enum1D_t;
+typedef h1_t H1D_t;
+typedef header h2a_t {
+    bit<16> f2;
+    bit<8>  f3;
+}
+H2aD_t;
+typedef h1_t[3] h1StackD_t;
+typedef hu1_t hu1D_t;
+typedef s1_t s1D_t;
+typedef struct PointA_t {
+    int<32> x;
+    int<32> y;
+}
+PointAD_t;
+typedef tuple<bit<8>, bit<17>> Tuple1D_t;
+typedef tuple<bit<8>, varbit<17>> Tuple2D_t;
+type bit<8> bT_t;
+type int<8> iT_t;
+type varbit<8> vT_t;
+type error errorT_t;
+type bool boolT_t;
+type enum1_t enum1T_t;
+type serializable_enum1_t serializable_enum1T_t;
+type h1_t H1T_t;
+type header h2b_t {
+    bit<16> f2;
+    bit<8>  f3;
+}
+H2bT_t;
+type h1_t[3] h1StackT_t;
+type hu1_t hu1T_t;
+type s1_t s1T_t;
+type struct PointB_t {
+    int<32> x;
+    int<32> y;
+}
+PointBD_t;
+type tuple<bit<8>, bit<17>> Tuple1T_t;
+type tuple<bit<8>, varbit<17>> Tuple2T_t;
+typedef bD_t bDD_t;
+typedef bT_t bTD_t;
+type bD_t bDT_t;
+type bT_t bTT_t;
+type iD_t iDT_t;
+type vD_t vDT_t;
+type errorD_t errorDT_t;
+type boolD_t boolDT_t;
+type enum1D_t enum1DT_t;
+type serializable_enum1D_t serializable_enum1DT_t;
+type H1D_t H1DT_t;
+type H2aD_t H2aDT_t;
+type h1StackD_t h1StackDT_t;
+type hu1D_t hu1DT_t;
+type s1D_t s1DT_t;
+type PointAD_t PointADT_t;
+type Tuple1D_t Tuple1DT_t;
+type Tuple2D_t Tuple2DT_t;

--- a/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
@@ -1,0 +1,60 @@
+typedef-and-type-definitions.p4(115): error: vT_t: `type' can only be applied to base types or tuple types
+type varbit<8> vT_t; // error
+               ^^^^
+typedef-and-type-definitions.p4(116): error: errorT_t: `type' can only be applied to base types or tuple types
+type error errorT_t; // error
+           ^^^^^^^^
+typedef-and-type-definitions.p4(118): error: enum1T_t: `type' can only be applied to base types or tuple types
+type enum1_t enum1T_t; // error
+             ^^^^^^^^
+typedef-and-type-definitions.p4(119): error: serializable_enum1T_t: `type' can only be applied to base types or tuple types
+type serializable_enum1_t serializable_enum1T_t; // error
+                          ^^^^^^^^^^^^^^^^^^^^^
+typedef-and-type-definitions.p4(120): error: H1T_t: `type' can only be applied to base types or tuple types
+type h1_t H1T_t; // error
+          ^^^^^
+typedef-and-type-definitions.p4(121): error: H2bT_t: `type' can only be applied to base types or tuple types
+type header h2b_t { bit<16> f2; bit<8> f3; } H2bT_t; // error
+                                             ^^^^^^
+typedef-and-type-definitions.p4(122): error: h1StackT_t: `type' can only be applied to base types or tuple types
+type h1_t[3] h1StackT_t; // error
+             ^^^^^^^^^^
+typedef-and-type-definitions.p4(123): error: hu1T_t: `type' can only be applied to base types or tuple types
+type hu1_t hu1T_t; // error
+           ^^^^^^
+typedef-and-type-definitions.p4(124): error: s1T_t: `type' can only be applied to base types or tuple types
+type s1_t s1T_t; // error
+          ^^^^^
+typedef-and-type-definitions.p4(125): error: PointBD_t: `type' can only be applied to base types or tuple types
+type struct PointB_t { int<32> x; int<32> y; } PointBD_t; // error
+                                               ^^^^^^^^^
+typedef-and-type-definitions.p4(146): error: vDT_t: `type' can only be applied to base types or tuple types
+type vD_t vDT_t; // error
+          ^^^^^
+typedef-and-type-definitions.p4(147): error: errorDT_t: `type' can only be applied to base types or tuple types
+type errorD_t errorDT_t; // error
+              ^^^^^^^^^
+typedef-and-type-definitions.p4(149): error: enum1DT_t: `type' can only be applied to base types or tuple types
+type enum1D_t enum1DT_t; // error
+              ^^^^^^^^^
+typedef-and-type-definitions.p4(150): error: serializable_enum1DT_t: `type' can only be applied to base types or tuple types
+type serializable_enum1D_t serializable_enum1DT_t; // error
+                           ^^^^^^^^^^^^^^^^^^^^^^
+typedef-and-type-definitions.p4(151): error: H1DT_t: `type' can only be applied to base types or tuple types
+type H1D_t H1DT_t; // error
+           ^^^^^^
+typedef-and-type-definitions.p4(152): error: H2aDT_t: `type' can only be applied to base types or tuple types
+type H2aD_t H2aDT_t; // error
+            ^^^^^^^
+typedef-and-type-definitions.p4(153): error: h1StackDT_t: `type' can only be applied to base types or tuple types
+type h1StackD_t h1StackDT_t; // error
+                ^^^^^^^^^^^
+typedef-and-type-definitions.p4(154): error: hu1DT_t: `type' can only be applied to base types or tuple types
+type hu1D_t hu1DT_t; // error
+            ^^^^^^^
+typedef-and-type-definitions.p4(155): error: s1DT_t: `type' can only be applied to base types or tuple types
+type s1D_t s1DT_t; // error
+           ^^^^^^
+typedef-and-type-definitions.p4(156): error: PointADT_t: `type' can only be applied to base types or tuple types
+type PointAD_t PointADT_t; // error
+               ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
@@ -1,3 +1,6 @@
+typedef-and-type-definitions.p4(112): error: intT_t: `type' can only be applied to base types or tuple types
+type int intT_t;
+         ^^^^^^
 typedef-and-type-definitions.p4(115): error: vT_t: `type' can only be applied to base types or tuple types
 type varbit<8> vT_t; // error
                ^^^^

--- a/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
@@ -1,63 +1,75 @@
-typedef-and-type-definitions.p4(112): error: intT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(112): error: intT_t: `type' can only be applied to base types
 type int intT_t;
          ^^^^^^
-typedef-and-type-definitions.p4(115): error: vT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(115): error: vT_t: `type' can only be applied to base types
 type varbit<8> vT_t; // error
                ^^^^
-typedef-and-type-definitions.p4(116): error: errorT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(116): error: errorT_t: `type' can only be applied to base types
 type error errorT_t; // error
            ^^^^^^^^
-typedef-and-type-definitions.p4(118): error: enum1T_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(118): error: enum1T_t: `type' can only be applied to base types
 type enum1_t enum1T_t; // error
              ^^^^^^^^
-typedef-and-type-definitions.p4(119): error: serializable_enum1T_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(119): error: serializable_enum1T_t: `type' can only be applied to base types
 type serializable_enum1_t serializable_enum1T_t; // error
                           ^^^^^^^^^^^^^^^^^^^^^
-typedef-and-type-definitions.p4(120): error: H1T_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(120): error: H1T_t: `type' can only be applied to base types
 type h1_t H1T_t; // error
           ^^^^^
-typedef-and-type-definitions.p4(121): error: H2bT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(121): error: H2bT_t: `type' can only be applied to base types
 type header h2b_t { bit<16> f2; bit<8> f3; } H2bT_t; // error
                                              ^^^^^^
-typedef-and-type-definitions.p4(122): error: h1StackT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(122): error: h1StackT_t: `type' can only be applied to base types
 type h1_t[3] h1StackT_t; // error
              ^^^^^^^^^^
-typedef-and-type-definitions.p4(123): error: hu1T_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(123): error: hu1T_t: `type' can only be applied to base types
 type hu1_t hu1T_t; // error
            ^^^^^^
-typedef-and-type-definitions.p4(124): error: s1T_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(124): error: s1T_t: `type' can only be applied to base types
 type s1_t s1T_t; // error
           ^^^^^
-typedef-and-type-definitions.p4(125): error: PointBD_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(125): error: PointBD_t: `type' can only be applied to base types
 type struct PointB_t { int<32> x; int<32> y; } PointBD_t; // error
                                                ^^^^^^^^^
-typedef-and-type-definitions.p4(146): error: vDT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(126): error: Tuple1T_t: `type' can only be applied to base types
+type tuple<bit<8>, bit<17> > Tuple1T_t; // error
+                             ^^^^^^^^^
+typedef-and-type-definitions.p4(127): error: Tuple2T_t: `type' can only be applied to base types
+type tuple<bit<8>, varbit<17> > Tuple2T_t; // error
+                                ^^^^^^^^^
+typedef-and-type-definitions.p4(146): error: vDT_t: `type' can only be applied to base types
 type vD_t vDT_t; // error
           ^^^^^
-typedef-and-type-definitions.p4(147): error: errorDT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(147): error: errorDT_t: `type' can only be applied to base types
 type errorD_t errorDT_t; // error
               ^^^^^^^^^
-typedef-and-type-definitions.p4(149): error: enum1DT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(149): error: enum1DT_t: `type' can only be applied to base types
 type enum1D_t enum1DT_t; // error
               ^^^^^^^^^
-typedef-and-type-definitions.p4(150): error: serializable_enum1DT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(150): error: serializable_enum1DT_t: `type' can only be applied to base types
 type serializable_enum1D_t serializable_enum1DT_t; // error
                            ^^^^^^^^^^^^^^^^^^^^^^
-typedef-and-type-definitions.p4(151): error: H1DT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(151): error: H1DT_t: `type' can only be applied to base types
 type H1D_t H1DT_t; // error
            ^^^^^^
-typedef-and-type-definitions.p4(152): error: H2aDT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(152): error: H2aDT_t: `type' can only be applied to base types
 type H2aD_t H2aDT_t; // error
             ^^^^^^^
-typedef-and-type-definitions.p4(153): error: h1StackDT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(153): error: h1StackDT_t: `type' can only be applied to base types
 type h1StackD_t h1StackDT_t; // error
                 ^^^^^^^^^^^
-typedef-and-type-definitions.p4(154): error: hu1DT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(154): error: hu1DT_t: `type' can only be applied to base types
 type hu1D_t hu1DT_t; // error
             ^^^^^^^
-typedef-and-type-definitions.p4(155): error: s1DT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(155): error: s1DT_t: `type' can only be applied to base types
 type s1D_t s1DT_t; // error
            ^^^^^^
-typedef-and-type-definitions.p4(156): error: PointADT_t: `type' can only be applied to base types or tuple types
+typedef-and-type-definitions.p4(156): error: PointADT_t: `type' can only be applied to base types
 type PointAD_t PointADT_t; // error
+               ^^^^^^^^^^
+typedef-and-type-definitions.p4(157): error: Tuple1DT_t: `type' can only be applied to base types
+type Tuple1D_t Tuple1DT_t; // error
+               ^^^^^^^^^^
+typedef-and-type-definitions.p4(158): error: Tuple2DT_t: `type' can only be applied to base types
+type Tuple2D_t Tuple2DT_t; // error
                ^^^^^^^^^^


### PR DESCRIPTION
This is the test program I wrote while determining which types were
supported for typedef and type while creating this proposed table to
add to the P4_16 language spec:

https://github.com/p4lang/p4-spec/pull/731