### PR TITLE
actionSynthesis propagate source info

### DIFF
--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -55,7 +55,7 @@ ResolutionContext::resolve(IR::ID name, P4::ResolutionType type, bool forwardOK)
                 BUG("Unexpected enumeration value %1%", static_cast<int>(type));
             }
 
-            if (!forwardOK) {
+            if (!forwardOK && name.srcInfo.isValid()) {
                 std::function<bool(const IR::IDeclaration*)> locationFilter =
                         [name](const IR::IDeclaration* d) {
                     Util::SourceInfo nsi = name.srcInfo;
@@ -96,7 +96,7 @@ ResolutionContext::resolve(IR::ID name, P4::ResolutionType type, bool forwardOK)
                 BUG("Unexpected enumeration value %1%", static_cast<int>(type));
             }
 
-            if (!forwardOK) {
+            if (!forwardOK && name.srcInfo.isValid()) {
                 Util::SourceInfo nsi = name.srcInfo;
                 Util::SourceInfo dsi = decl->getNode()->srcInfo;
                 bool before = dsi <= nsi;

--- a/midend/actionSynthesis.cpp
+++ b/midend/actionSynthesis.cpp
@@ -73,7 +73,7 @@ const IR::Node* DoMoveActionsToTables::postorder(IR::MethodCallStatement* statem
 
     auto annos = new IR::Annotations();
     annos->add(new IR::Annotation(IR::Annotation::hiddenAnnotation, {}));
-    auto tbl = new IR::P4Table(tblName, annos, props);
+    auto tbl = new IR::P4Table(statement->srcInfo, tblName, annos, props);
     tables.push_back(tbl);
 
     // Table invocation statement
@@ -138,6 +138,7 @@ const IR::Node* DoSynthesizeActions::preorder(IR::BlockStatement* statement) {
                     left->push_back(action);
                     actbody = new IR::BlockStatement; }
                 actbody->push_back(c);
+                actbody->srcInfo += c->srcInfo;
                 continue; }
         } else if (c->is<IR::MethodCallStatement>()) {
             if (mustMove(c->to<IR::MethodCallStatement>())) {
@@ -147,6 +148,7 @@ const IR::Node* DoSynthesizeActions::preorder(IR::BlockStatement* statement) {
                     left->push_back(action);
                     actbody = new IR::BlockStatement; }
                 actbody->push_back(c);
+                actbody->srcInfo += c->srcInfo;
                 continue;
             }
         } else {
@@ -190,8 +192,8 @@ const IR::Statement* DoSynthesizeActions::createAction(const IR::Statement* toAd
     auto action = new IR::P4Action(name, annos, new IR::ParameterList(), body);
     actions.push_back(action);
     auto actpath = new IR::PathExpression(name);
-    auto repl = new IR::MethodCallExpression(actpath);
-    auto result = new IR::MethodCallStatement(repl->srcInfo, repl);
+    auto repl = new IR::MethodCallExpression(toAdd->srcInfo, actpath);
+    auto result = new IR::MethodCallStatement(toAdd->srcInfo, repl);
     return result;
 }
 


### PR DESCRIPTION
- propagate source info from statements to newly created actions and
  tables; allows later passes to generate errors/warnings referring to
  the code that the tables were created from rather than just a
  meaningless name like tbl_act_14