### PR TITLE
move annotations on header to fields

### DIFF
--- a/midend/flattenHeaders.cpp
+++ b/midend/flattenHeaders.cpp
@@ -19,17 +19,6 @@ limitations under the License.
 
 namespace P4 {
 
-template <typename Func>
-const IR::Annotations* filterAnnotation(const IR::Annotations* annot, Func function) {
-    auto annotations = new IR::Annotations();
-    for (auto an : annot->annotations) {
-        if (function(an))
-            continue;
-        annotations->add(an);
-    }
-    return annotations;
-}
-
 void HeaderTypeReplacement::flatten(const P4::TypeMap* typeMap,
                                     cstring prefix,
                                     const IR::Type* type,

--- a/midend/flattenHeaders.cpp
+++ b/midend/flattenHeaders.cpp
@@ -26,6 +26,8 @@ void FindHeaderTypesToReplace::HeaderTypeReplacement::flatten(cstring prefix,
     if (auto st = type->to<IR::Type_StructLike>()) {
         std::function<bool(const IR::Annotation *)> selector =
                 [&policy](const IR::Annotation *annot) {
+                    if (!policy)
+                        return false;
                     return policy->keep(annot);
                 };
         auto annotations = st->annotations->where(selector);

--- a/midend/flattenHeaders.cpp
+++ b/midend/flattenHeaders.cpp
@@ -39,12 +39,6 @@ void FindHeaderTypesToReplace::HeaderTypeReplacement::flatten(cstring prefix,
     cstring fieldName = prefix.replace(".", "_") +
                         cstring::to_cstring(fieldNameRemap.size());
     fieldNameRemap.emplace(prefix, fieldName);
-#if 0  // TODO once behavioral model is fixed.
-    const IR::Annotations* annos = IR::Annotations::empty;
-        auto ann = annos->addAnnotation(IR::Annotation::nameAnnotation,
-                                        new IR::StringLiteral(originalName));
-#endif
-
     fields->push_back(new IR::StructField(IR::ID(fieldName), annos, type->getP4Type()));
     LOG3("Flatten: " << type << " | " << prefix);
 }

--- a/midend/flattenHeaders.cpp
+++ b/midend/flattenHeaders.cpp
@@ -19,22 +19,19 @@ limitations under the License.
 
 namespace P4 {
 
-void HeaderTypeReplacement::flatten(const P4::TypeMap* typeMap,
-                                    cstring prefix,
-                                    const IR::Type* type,
-                                    const IR::Annotations* annos,
-                                    IR::IndexedVector<IR::StructField> *fields) {
+void FindHeaderTypesToReplace::HeaderTypeReplacement::flatten(cstring prefix,
+        const IR::Type* type, const IR::Annotations* annos,
+        IR::IndexedVector<IR::StructField> *fields,
+        AnnotationSelectionPolicy *policy) {
     if (auto st = type->to<IR::Type_StructLike>()) {
-        std::function<bool(const IR::Annotation*)> nameFilter =
-            [](const IR::Annotation* annot) {
-                if (annot->name == IR::Annotation::nameAnnotation)
-                    return true;
-                return false;
-            };
-        auto annotations = st->annotations->where(nameFilter);
+        std::function<bool(const IR::Annotation *)> selector =
+                [&policy](const IR::Annotation *annot) {
+                    return policy->keep(annot);
+                };
+        auto annotations = st->annotations->where(selector);
         for (auto f : st->fields) {
             auto ft = typeMap->getType(f, true);
-            flatten(typeMap, prefix + "." + f->name, ft, annotations, fields);
+            flatten(prefix + "." + f->name, ft, annotations, fields, policy);
         }
         return;
     }
@@ -44,36 +41,35 @@ void HeaderTypeReplacement::flatten(const P4::TypeMap* typeMap,
     fieldNameRemap.emplace(prefix, fieldName);
 #if 0  // TODO once behavioral model is fixed.
     const IR::Annotations* annos = IR::Annotations::empty;
-    auto ann = annos->addAnnotation(IR::Annotation::nameAnnotation,
-                                    new IR::StringLiteral(originalName));
+        auto ann = annos->addAnnotation(IR::Annotation::nameAnnotation,
+                                        new IR::StringLiteral(originalName));
 #endif
 
     fields->push_back(new IR::StructField(IR::ID(fieldName), annos, type->getP4Type()));
     LOG3("Flatten: " << type << " | " << prefix);
 }
 
-HeaderTypeReplacement::HeaderTypeReplacement(
-    const P4::TypeMap* typeMap, const IR::Type_Header* type) {
+FindHeaderTypesToReplace::HeaderTypeReplacement::HeaderTypeReplacement(
+    const P4::TypeMap* typeMap, const IR::Type_Header* type, AnnotationSelectionPolicy *policy) :
+    typeMap(typeMap) {
     auto vec = new IR::IndexedVector<IR::StructField>();
-    flatten(typeMap, "", type, IR::Annotations::empty, vec);
+    flatten("", type, IR::Annotations::empty, vec, policy);
     replacementType = new IR::Type_Header(type->name, IR::Annotations::empty, *vec);
 }
 
-void NestedHeaderMap::createReplacement(const IR::Type_Header* type) {
-    auto repl = ::get(replacement, type->name);
-    if (repl != nullptr)
+void FindHeaderTypesToReplace::createReplacement(const IR::Type_Header* type,
+        AnnotationSelectionPolicy *policy) {
+    if (replacement.count(type->name))
         return;
-    repl = new HeaderTypeReplacement(typeMap, type);
-    LOG3("Replacement for " << type << " is " << repl);
-    replacement.emplace(type->name, repl);
+    replacement.emplace(type->name, new HeaderTypeReplacement(typeMap, type, policy));
 }
 
 bool FindHeaderTypesToReplace::preorder(const IR::Type_Header* type) {
     // check if header has structs in it and create flat replacement if it does
     for (auto f : type->fields) {
-        auto ft = map->typeMap->getType(f, true);
+        auto ft = typeMap->getType(f, true);
         if (ft->is<IR::Type_Struct>()) {
-            map->createReplacement(type);
+            createReplacement(type, policy);
             break;
         }
     }
@@ -83,7 +79,7 @@ bool FindHeaderTypesToReplace::preorder(const IR::Type_Header* type) {
 /////////////////////////////////
 
 const IR::Node* ReplaceHeaders::preorder(IR::P4Program* program) {
-    if (replacementMap->empty()) {
+    if (findHeaderTypesToReplace->empty()) {
         // nothing to do
         prune();
     }
@@ -91,9 +87,9 @@ const IR::Node* ReplaceHeaders::preorder(IR::P4Program* program) {
 }
 
 const IR::Node* ReplaceHeaders::postorder(IR::Type_Header* type) {
-    auto canon = replacementMap->typeMap->getTypeType(getOriginal(), true);
+    auto canon = typeMap->getTypeType(getOriginal(), true);
     auto name = canon->to<IR::Type_Header>()->name;
-    auto repl = replacementMap->getReplacement(name);
+    auto repl = findHeaderTypesToReplace->getReplacement(name);
     if (repl != nullptr) {
         LOG3("Replace " << type << " with " << repl->replacementType);
         return repl->replacementType;
@@ -109,13 +105,13 @@ const IR::Node* ReplaceHeaders::postorder(IR::Member* expression) {
     while (auto mem = e->to<IR::Member>()) {
         e = mem->expr;
         prefix = cstring(".") + mem->member + prefix;
-        auto type = replacementMap->typeMap->getType(e, true);
+        auto type = typeMap->getType(e, true);
         if ((h = type->to<IR::Type_Header>())) break;
     }
     if (h == nullptr)
         return expression;
 
-    auto repl = replacementMap->getReplacement(h->name);
+    auto repl = findHeaderTypesToReplace->getReplacement(h->name);
     if (repl == nullptr) {
         return expression;
     }
@@ -124,7 +120,7 @@ const IR::Node* ReplaceHeaders::postorder(IR::Member* expression) {
     auto newFieldName = ::get(repl->fieldNameRemap, prefix);
     const IR::Expression* result;
     if (newFieldName.isNullOrEmpty()) {
-        auto type = replacementMap->typeMap->getType(getOriginal(), true);
+        auto type = typeMap->getType(getOriginal(), true);
         // This could be, for example, a method like setValid.
         if (!type->is<IR::Type_Struct>())
             return expression;

--- a/midend/flattenHeaders.cpp
+++ b/midend/flattenHeaders.cpp
@@ -36,11 +36,13 @@ void HeaderTypeReplacement::flatten(const P4::TypeMap* typeMap,
                                     const IR::Annotations* annos,
                                     IR::IndexedVector<IR::StructField> *fields) {
     if (auto st = type->to<IR::Type_StructLike>()) {
-        auto annotations = filterAnnotation(st->annotations, [&](const IR::Annotation* annot) {
-            if (annot->name == IR::Annotation::nameAnnotation)
-                return true;
-            return false;
-        });
+        std::function<bool(const IR::Annotation*)> nameFilter =
+            [](const IR::Annotation* annot) {
+                if (annot->name == IR::Annotation::nameAnnotation)
+                    return true;
+                return false;
+            };
+        auto annotations = st->annotations->where(nameFilter);
         for (auto f : st->fields) {
             auto ft = typeMap->getType(f, true);
             flatten(typeMap, prefix + "." + f->name, ft, annotations, fields);

--- a/midend/flattenHeaders.h
+++ b/midend/flattenHeaders.h
@@ -94,7 +94,7 @@ class FindHeaderTypesToReplace : public Inspector {
     }
     bool preorder(const IR::Type_Header* type) override;
     void createReplacement(const IR::Type_Header* type, AnnotationSelectionPolicy *policy);
-    HeaderTypeReplacement* getReplacement(const cstring name) const { 
+    HeaderTypeReplacement* getReplacement(const cstring name) const {
         return ::get(replacement, name); }
     bool empty() const { return replacement.empty(); }
 };

--- a/midend/flattenHeaders.h
+++ b/midend/flattenHeaders.h
@@ -49,6 +49,7 @@ struct HeaderTypeReplacement : public IHasDbPrint {
     void flatten(const P4::TypeMap* typeMap,
                  cstring prefix,
                  const IR::Type* type,
+                 const IR::Annotations* annos,
                  IR::IndexedVector<IR::StructField> *fields);
 };
 
@@ -177,6 +178,7 @@ class FlattenHeaders final : public PassManager {
         passes.push_back(new FindHeaderTypesToReplace(sm));
         passes.push_back(new ReplaceHeaders(sm));
         passes.push_back(new ClearTypeMap(typeMap));
+        passes.push_back(new TypeChecking(refMap, typeMap, true));
         setName("FlattenHeaders");
     }
 };

--- a/midend/flattenHeaders.h
+++ b/midend/flattenHeaders.h
@@ -178,7 +178,6 @@ class FlattenHeaders final : public PassManager {
         passes.push_back(new FindHeaderTypesToReplace(sm));
         passes.push_back(new ReplaceHeaders(sm));
         passes.push_back(new ClearTypeMap(typeMap));
-        passes.push_back(new TypeChecking(refMap, typeMap, true));
         setName("FlattenHeaders");
     }
 };

--- a/midend/flattenHeaders.h
+++ b/midend/flattenHeaders.h
@@ -23,66 +23,80 @@ limitations under the License.
 
 namespace P4 {
 
-struct HeaderTypeReplacement : public IHasDbPrint {
-    HeaderTypeReplacement(const P4::TypeMap* typeMap, const IR::Type_Header* type);
-
-    // Maps nested field names to final field names.
-    // In our example this could be:
-    // .t.s.a -> _t_s_a0;
-    // .t.s.b -> _t_s_b1;
-    // .t.y -> _t_y2;
-    // .x -> _x3;
-    std::map<cstring, cstring> fieldNameRemap;
-    // Holds a new flat type
-    // struct M {
-    //    bit _t_s_a0;
-    //    bool _t_s_b1;
-    //    bit<6> _t_y2;
-    //    bit<3> _x3;
-    // }
-    const IR::Type* replacementType;
-    virtual void dbprint(std::ostream& out) const {
-        out << replacementType;
-    }
-
-    // Helper for constructor
-    void flatten(const P4::TypeMap* typeMap,
-                 cstring prefix,
-                 const IR::Type* type,
-                 const IR::Annotations* annos,
-                 IR::IndexedVector<IR::StructField> *fields);
-};
-
 /**
- * Maintains a map between an original header type and its
- * replacement.
+ * Policy to select which annotations of the nested struct to attach
+ * to the struct fields after the nest struct is flattened.
  */
-struct NestedHeaderMap {
-    P4::ReferenceMap* refMap;
-    P4::TypeMap* typeMap;
+class AnnotationSelectionPolicy {
+ public:
+    virtual ~AnnotationSelectionPolicy() {}
 
-    ordered_map<cstring, HeaderTypeReplacement*> replacement;
-
-    NestedHeaderMap(P4::ReferenceMap* refMap, P4::TypeMap* typeMap):
-            refMap(refMap), typeMap(typeMap)
-    { CHECK_NULL(refMap); CHECK_NULL(typeMap); }
-    void createReplacement(const IR::Type_Header* type);
-    HeaderTypeReplacement* getReplacement(const cstring name) const
-    { return ::get(replacement, name); }
-    bool empty() const { return replacement.empty(); }
+    /**
+     * Call for each nested struct to check if the annotation of the nested
+     * struct should be kept on its fields.
+     *
+     * @return
+     *  true if the annotation should be kept on the field.
+     *  false if the annotation should be discarded.
+     */
+    virtual bool keep(const IR::Annotation*) {
+        return false;
+    }
 };
 
 /**
 Find the types to replace and insert them in the nested struct map.
  */
 class FindHeaderTypesToReplace : public Inspector {
-    NestedHeaderMap* map;
+    P4::TypeMap* typeMap;
+    AnnotationSelectionPolicy *policy;
+
+    struct HeaderTypeReplacement : public IHasDbPrint {
+        HeaderTypeReplacement(const P4::TypeMap* typeMap, const IR::Type_Header* type,
+                AnnotationSelectionPolicy *policy);
+        const P4::TypeMap *typeMap;
+
+        // Maps nested field names to final field names.
+        // In our example this could be:
+        // .t.s.a -> _t_s_a0;
+        // .t.s.b -> _t_s_b1;
+        // .t.y -> _t_y2;
+        // .x -> _x3;
+        std::map<cstring, cstring> fieldNameRemap;
+        // Holds a new flat type
+        // struct M {
+        //    bit _t_s_a0;
+        //    bool _t_s_b1;
+        //    bit<6> _t_y2;
+        //    bit<3> _x3;
+        // }
+        const IR::Type* replacementType;
+        virtual void dbprint(std::ostream& out) const {
+            out << replacementType;
+        }
+
+        // Helper for constructor
+        void flatten(cstring prefix,
+                     const IR::Type* type,
+                     const IR::Annotations* annos,
+                     IR::IndexedVector<IR::StructField> *fields,
+                     AnnotationSelectionPolicy *policy);
+    };
+
+    ordered_map<cstring, HeaderTypeReplacement*> replacement;
+
  public:
-    explicit FindHeaderTypesToReplace(NestedHeaderMap* map): map(map) {
+    explicit FindHeaderTypesToReplace(P4::TypeMap *typeMap,
+            AnnotationSelectionPolicy *policy):
+        typeMap(typeMap), policy(policy) {
         setName("FindHeaderTypesToReplace");
-        CHECK_NULL(map);
+        CHECK_NULL(typeMap);
     }
     bool preorder(const IR::Type_Header* type) override;
+    void createReplacement(const IR::Type_Header* type, AnnotationSelectionPolicy *policy);
+    HeaderTypeReplacement* getReplacement(const cstring name) const { 
+        return ::get(replacement, name); }
+    bool empty() const { return replacement.empty(); }
 };
 
 /**
@@ -157,11 +171,15 @@ struct local_metadata_t {
 	
 */
 class ReplaceHeaders : public Transform {
-    NestedHeaderMap* replacementMap;
+    P4::TypeMap *typeMap;
+    FindHeaderTypesToReplace* findHeaderTypesToReplace;
 
  public:
-    explicit ReplaceHeaders(NestedHeaderMap* sm): replacementMap(sm) {
-        CHECK_NULL(sm);
+    explicit ReplaceHeaders(P4::TypeMap *typeMap,
+                            FindHeaderTypesToReplace* findHeaderTypesToReplace):
+                            typeMap(typeMap),
+                            findHeaderTypesToReplace(findHeaderTypesToReplace) {
+        CHECK_NULL(typeMap); CHECK_NULL(findHeaderTypesToReplace);
         setName("ReplaceHeaders");
     }
 
@@ -172,11 +190,12 @@ class ReplaceHeaders : public Transform {
 
 class FlattenHeaders final : public PassManager {
  public:
-    FlattenHeaders(ReferenceMap* refMap, TypeMap* typeMap) {
-        auto sm = new NestedHeaderMap(refMap, typeMap);
+    FlattenHeaders(ReferenceMap* refMap, TypeMap* typeMap,
+            AnnotationSelectionPolicy *policy = nullptr) {
+        auto findHeadersToReplace = new FindHeaderTypesToReplace(typeMap, policy);
         passes.push_back(new TypeChecking(refMap, typeMap));
-        passes.push_back(new FindHeaderTypesToReplace(sm));
-        passes.push_back(new ReplaceHeaders(sm));
+        passes.push_back(findHeadersToReplace);
+        passes.push_back(new ReplaceHeaders(typeMap, findHeadersToReplace));
         passes.push_back(new ClearTypeMap(typeMap));
         setName("FlattenHeaders");
     }


### PR DESCRIPTION
This change will keep the annot on struct with the fields that the struct is flattened to.
```
@my_annot
struct st {
    bit<8> f0; 
}

header hd{
   st s;
}
```

```
header hd {
   @my_annot _s_f0;
}
```
