### PR TITLE
Generic control plane name generation from IR::Block

### DIFF
--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -133,6 +133,11 @@ class P4RuntimeSymbolTableIface {
 class P4RuntimeArchHandlerIface {
  public:
     virtual ~P4RuntimeArchHandlerIface() { }
+    /// Get control plane name for @Block
+    virtual cstring getControlPlaneName(const IR::Block* block) {
+        auto decl = block->getContainer();
+        return decl ? decl->controlPlaneName() : ""; 
+    }
     /// Collects architecture-specific properties for @tableBlock in @symbols
     /// table.
     virtual void collectTableProperties(P4RuntimeSymbolTableIface* symbols,
@@ -209,7 +214,7 @@ bool isExternPropertyConstructedInPlace(const IR::P4Table* table,
 /// Visit evaluated blocks under the provided top-level block. Guarantees that
 /// each block is visited only once, even if multiple paths to reach it exist.
 template <typename Func>
-void forAllEvaluatedBlocks(const IR::ToplevelBlock* aToplevelBlock, Func function) {
+void forAllEvaluatedBlocks(const IR::Block* aToplevelBlock, Func function) {
     std::set<const IR::Block*> visited;
     ordered_set<const IR::Block*> frontier{aToplevelBlock};
 

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -136,7 +136,7 @@ class P4RuntimeArchHandlerIface {
     /// Get control plane name for @Block
     virtual cstring getControlPlaneName(const IR::Block* block) {
         auto decl = block->getContainer();
-        return decl ? decl->controlPlaneName() : ""; 
+        return decl ? decl->controlPlaneName() : "";
     }
     /// Collects architecture-specific properties for @tableBlock in @symbols
     /// table.
@@ -211,8 +211,8 @@ getExternInstanceFromProperty(const IR::P4Table* table,
 bool isExternPropertyConstructedInPlace(const IR::P4Table* table,
                                         const cstring& propertyName);
 
-/// Visit evaluated blocks under the provided top-level block. Guarantees that
-/// each block is visited only once, even if multiple paths to reach it exist.
+/// Visit evaluated blocks under the provided block. Guarantees that each
+/// block is visited only once, even if multiple paths to reach it exist.
 template <typename Func>
 void forAllEvaluatedBlocks(const IR::Block* block, Func function) {
     std::set<const IR::Block*> visited;

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -214,9 +214,9 @@ bool isExternPropertyConstructedInPlace(const IR::P4Table* table,
 /// Visit evaluated blocks under the provided top-level block. Guarantees that
 /// each block is visited only once, even if multiple paths to reach it exist.
 template <typename Func>
-void forAllEvaluatedBlocks(const IR::Block* aToplevelBlock, Func function) {
+void forAllEvaluatedBlocks(const IR::Block* block, Func function) {
     std::set<const IR::Block*> visited;
-    ordered_set<const IR::Block*> frontier{aToplevelBlock};
+    ordered_set<const IR::Block*> frontier{block};
 
     while (!frontier.empty()) {
         // Pop a block off the frontier of blocks we haven't yet visited.

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -133,7 +133,7 @@ class P4RuntimeSymbolTableIface {
 class P4RuntimeArchHandlerIface {
  public:
     virtual ~P4RuntimeArchHandlerIface() { }
-    /// Get control plane name for @Block
+    /// Get control plane name for @block
     virtual cstring getControlPlaneName(const IR::Block* block) {
         auto decl = block->getContainer();
         return decl ? decl->controlPlaneName() : "";

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -769,7 +769,7 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
 };
 
 /// Implements @ref P4RuntimeArchHandlerIface for the v1model architecture. The
-/// overridden metods will be called by the @P4RuntimeSerializer to collect and
+/// overridden methods will be called by the @P4RuntimeSerializer to collect and
 /// serialize v1model-specific symbols which are exposed to the control-plane.
 class P4RuntimeArchHandlerV1Model final : public P4RuntimeArchHandlerCommon<Arch::V1MODEL> {
  public:
@@ -889,7 +889,7 @@ V1ModelArchHandlerBuilder::operator()(
 }
 
 /// Implements @ref P4RuntimeArchHandlerIface for the PSA architecture. The
-/// overridden metods will be called by the @P4RuntimeSerializer to collect and
+/// overridden methods will be called by the @P4RuntimeSerializer to collect and
 /// serialize PSA-specific symbols which are exposed to the control-plane.
 class P4RuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PSA> {
  public:

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -832,7 +832,7 @@ class P4RuntimeAnalyzer {
 
         bool isConstTable = getConstTable(tableDeclaration);
 
-        auto name = tableDeclaration->controlPlaneName();
+        auto name = archHandler->getControlPlaneName(tableBlock);
         auto annotations = tableDeclaration->to<IR::IAnnotated>();
 
         auto table = p4Info->add_tables();
@@ -1148,8 +1148,9 @@ static void collectTableSymbols(P4RuntimeSymbolTable& symbols,
                                 P4RuntimeArchHandlerIface* archHandler,
                                 const IR::TableBlock* tableBlock) {
     CHECK_NULL(tableBlock);
-    auto table = tableBlock->container;
-    symbols.add(P4RuntimeSymbolType::TABLE(), table);
+    auto name = archHandler->getControlPlaneName(tableBlock);
+    auto id = externalId(tableBlock->container);
+    symbols.add(P4RuntimeSymbolType::TABLE(), name, id);
     archHandler->collectTableProperties(&symbols, tableBlock);
 }
 

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -525,10 +525,12 @@ abstract Block : CompileTimeValue {
         BUG_CHECK(it != constantValue.end(), "%1%: No such node %2%", this, node);
         return it->second; }
     visit_children { (void)v; }
+    virtual const IDeclaration* getContainer() const { return nullptr; } 
 }
 
 class TableBlock : Block {
     P4Table container;
+    const IDeclaration* getContainer() const { return container; } 
 #nodbprint
 }
 
@@ -556,6 +558,7 @@ class ParserBlock : InstantiatedBlock {
         return container->constructorParams; }
     toString { return container->toString(); }
     ID getName() const override { return container->getName(); }
+    const IDeclaration* getContainer() const { return container; } 
 #nodbprint
 }
 
@@ -565,6 +568,7 @@ class ControlBlock : InstantiatedBlock {
         return container->constructorParams; }
     toString { return container->toString(); }
     ID getName() const override { return container->getName(); }
+    const IDeclaration* getContainer() const { return container; } 
 #nodbprint
 }
 

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -525,12 +525,12 @@ abstract Block : CompileTimeValue {
         BUG_CHECK(it != constantValue.end(), "%1%: No such node %2%", this, node);
         return it->second; }
     visit_children { (void)v; }
-    virtual const IDeclaration* getContainer() const { return nullptr; } 
+    virtual const IDeclaration* getContainer() const { return nullptr; }
 }
 
 class TableBlock : Block {
     P4Table container;
-    const IDeclaration* getContainer() const { return container; } 
+    const IDeclaration* getContainer() const { return container; }
 #nodbprint
 }
 
@@ -558,7 +558,7 @@ class ParserBlock : InstantiatedBlock {
         return container->constructorParams; }
     toString { return container->toString(); }
     ID getName() const override { return container->getName(); }
-    const IDeclaration* getContainer() const { return container; } 
+    const IDeclaration* getContainer() const { return container; }
 #nodbprint
 }
 
@@ -568,7 +568,7 @@ class ControlBlock : InstantiatedBlock {
         return container->constructorParams; }
     toString { return container->toString(); }
     ID getName() const override { return container->getName(); }
-    const IDeclaration* getContainer() const { return container; } 
+    const IDeclaration* getContainer() const { return container; }
 #nodbprint
 }
 


### PR DESCRIPTION
Making control plane name generation generic to an `IR::Block`. This allows overriding the function to have a different implementation if desired.