### PR TITLE
Make --p4runtime-entries outputs more conformant to P4Runtime spec

### DIFF
--- a/ir/expression.def
+++ b/ir/expression.def
@@ -218,7 +218,7 @@ class Constant : Literal {
     Constant operator-(const Constant &c) const;
     Constant operator-() const;
 #end
-    toString { return Util::toString(&value); }
+    toString { return Util::toString(&value, base); }
     visit_children { v.visit(type, "type"); }
 }
 

--- a/lib/stringify.cpp
+++ b/lib/stringify.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include <stdarg.h>
+#include <sstream>
 #include "stringify.h"
 
 namespace Util {
@@ -40,10 +41,32 @@ cstring toString(const void* value) {
     return result.str();
 }
 
-cstring toString(const mpz_class* value) {
+cstring toString(const mpz_class* value, unsigned int base) {
     if (value == nullptr)
         return cstring::literal("<nullptr>");
-    return cstring(value->get_str());
+    mpz_class v = *value;
+    std::ostringstream oss;
+    if (v < 0) {
+        oss << "-";
+        v = -v;
+    }
+    switch (base) {
+        case 2:
+            oss << "0b";
+            break;
+        case 8:
+            oss << "0o";
+            break;
+        case 16:
+            oss << "0x";
+            break;
+        case 10:
+            break;
+        default:
+            throw std::runtime_error("Unexpected base");
+    }
+    oss << v.get_str(static_cast<int>(base));
+    return oss.str();
 }
 
 cstring toString(cstring value) {

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -63,7 +63,7 @@ cstring toString(std::string value);
 cstring toString(const char* value);
 cstring toString(cstring value);
 cstring toString(StringRef value);
-cstring toString(const mpz_class* value);
+cstring toString(const mpz_class* value, unsigned int base = 10);
 cstring toString(const void* value);
 
 // printf into a string

--- a/testdata/p4_14_samples_outputs/issue583.p4-stderr
+++ b/testdata/p4_14_samples_outputs/issue583.p4-stderr
@@ -1,3 +1,3 @@
-issue583.p4(189): [--Wwarn=mismatch] warning: 4294967295: value does not fit in 9 bits
+issue583.p4(189): [--Wwarn=mismatch] warning: 0xffffffff: value does not fit in 9 bits
     modify_field(standard_metadata.egress_spec, egress_spec, 0xFFFFFFFF);
                                                              ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue413.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue413.p4-stderr
@@ -1,4 +1,4 @@
-issue413.p4(34): [--Wwarn=mismatch] warning: 3405691582: value does not fit in 16 bits
+issue413.p4(34): [--Wwarn=mismatch] warning: 0xcafebabe: value does not fit in 16 bits
     const bit<32> c1d = 32w0xcafebabe;
                         ^^^^^^^^^^^^^
 issue413.p4(41): [--Werror=type-error] error: foo2: Action calls are not allowed within parsers

--- a/testdata/p4_16_errors_outputs/issue584.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue584.p4-stderr
@@ -1,3 +1,3 @@
-issue584.p4(28): [--Werror=legacy] error: 65535: could not infer a width
+issue584.p4(28): [--Werror=legacy] error: 0xffff: could not infer a width
         hash(var, HashAlgorithm.crc16, 16w0, hdr, 0xFFFF);
                                                   ^^^^^^

--- a/testdata/p4_16_errors_outputs/width1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/width1_e.p4-stderr
@@ -1,4 +1,4 @@
-width1_e.p4(16): [--Wwarn=overflow] warning: 4294967295: signed value does not fit in 32 bits
+width1_e.p4(16): [--Wwarn=overflow] warning: 0xffffffff: signed value does not fit in 32 bits
 const int<32> c1 = 0xFFFFFFFF;
                    ^^^^^^^^^^
 width1_e.p4(17): [--Werror=invalid] error: int<-2>: Invalid type size

--- a/testdata/p4_16_samples_outputs/const.p4-stderr
+++ b/testdata/p4_16_samples_outputs/const.p4-stderr
@@ -1,4 +1,4 @@
-const.p4(19): [--Wwarn=mismatch] warning: 48057234611961600: value does not fit in 48 bits
+const.p4(19): [--Wwarn=mismatch] warning: 0xaabbccddeeff00: value does not fit in 48 bits
 const bit<48> tooLarge = 48w0xAA_BB_CC_DD_EE_FF_00
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/large.p4-stderr
+++ b/testdata/p4_16_samples_outputs/large.p4-stderr
@@ -1,4 +1,4 @@
-large.p4(17): [--Wwarn=mismatch] warning: 103929005307130220006098923584552504982110632080: value does not fit in 128 bits
+large.p4(17): [--Wwarn=mismatch] warning: 0x1234567890123456789012345678901234567890: value does not fit in 128 bits
 const bit<128> large = 0x1234567890123456789012345678901234567890;
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex04.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex04.p4-stderr
@@ -1,4 +1,4 @@
-spec-ex04.p4(24): [--Wwarn=overflow] warning: 170: signed value does not fit in 8 bits
+spec-ex04.p4(24): [--Wwarn=overflow] warning: 0b10101010: signed value does not fit in 8 bits
 const int<8> b8 = 8s0b1010_1010
                   ^^^^^^^^^^^^^
 warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/strength.p4-stderr
+++ b/testdata/p4_16_samples_outputs/strength.p4-stderr
@@ -1,4 +1,4 @@
-strength.p4(50): [--Wwarn=overflow] warning: 15: signed value does not fit in 4 bits
+strength.p4(50): [--Wwarn=overflow] warning: 0xf: signed value does not fit in 4 bits
         w = w - 4s0xF
                 ^^^^^
 strength.p4(38): [--Wwarn=mismatch] warning: 16: value does not fit in 4 bits

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4-stderr
@@ -1,6 +1,6 @@
-table-entries-exact-ternary-bmv2.p4(65): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4369 to conform to the P4Runtime specification
+table-entries-exact-ternary-bmv2.p4(65): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 0x1111 to conform to the P4Runtime specification
             (0x01, 0x1111 &&& 0xF ) : a_with_control_params(1);
                    ^^^^^^
-table-entries-exact-ternary-bmv2.p4(67): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4369 to conform to the P4Runtime specification
+table-entries-exact-ternary-bmv2.p4(67): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 0x1111 to conform to the P4Runtime specification
             (0x03, 0x1111 &&& 0xF000) : a_with_control_params(3);
                    ^^^^^^

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4-stderr
@@ -1,0 +1,6 @@
+table-entries-exact-ternary-bmv2.p4(65): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4369 to conform to the P4Runtime specification
+            (0x01, 0x1111 &&& 0xF ) : a_with_control_params(1);
+                   ^^^^^^
+table-entries-exact-ternary-bmv2.p4(67): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4369 to conform to the P4Runtime specification
+            (0x03, 0x1111 &&& 0xF000) : a_with_control_params(3);
+                   ^^^^^^

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4.entries.txt
@@ -12,7 +12,7 @@ updates {
       match {
         field_id: 2
         ternary {
-          value: "\021\021"
+          value: "\000\001"
           mask: "\000\017"
         }
       }
@@ -25,7 +25,7 @@ updates {
           }
         }
       }
-      priority: 1
+      priority: 4
     }
   }
 }
@@ -56,7 +56,7 @@ updates {
           }
         }
       }
-      priority: 2
+      priority: 3
     }
   }
 }
@@ -74,7 +74,7 @@ updates {
       match {
         field_id: 2
         ternary {
-          value: "\021\021"
+          value: "\020\000"
           mask: "\360\000"
         }
       }
@@ -87,7 +87,7 @@ updates {
           }
         }
       }
-      priority: 3
+      priority: 2
     }
   }
 }
@@ -102,13 +102,6 @@ updates {
           value: "\004"
         }
       }
-      match {
-        field_id: 2
-        ternary {
-          value: "\000\000"
-          mask: "\000\000"
-        }
-      }
       action {
         action {
           action_id: 16837978
@@ -118,7 +111,7 @@ updates {
           }
         }
       }
-      priority: 4
+      priority: 1
     }
   }
 }

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-lpm-bmv2.p4(64): [--Wwarn=mismatch] warning: P4Runtime requires that LPM matches have masked-off bits set to 0, updating value 17 to conform to the P4Runtime specification
+table-entries-lpm-bmv2.p4(64): [--Wwarn=mismatch] warning: P4Runtime requires that LPM matches have masked-off bits set to 0, updating value 0x11 to conform to the P4Runtime specification
             0x11 &&& 0xF0 : a_with_control_params(11);
             ^^^^

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4-stderr
@@ -1,0 +1,3 @@
+table-entries-lpm-bmv2.p4(64): [--Wwarn=mismatch] warning: P4Runtime requires that LPM matches have masked-off bits set to 0, updating value 17 to conform to the P4Runtime specification
+            0x11 &&& 0xF0 : a_with_control_params(11);
+            ^^^^

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4.entries.txt
@@ -6,7 +6,7 @@ updates {
       match {
         field_id: 1
         lpm {
-          value: "\021"
+          value: "\020"
           prefix_len: 4
         }
       }
@@ -51,12 +51,6 @@ updates {
   entity {
     table_entry {
       table_id: 33555353
-      match {
-        field_id: 1
-        lpm {
-          value: "\000"
-        }
-      }
       action {
         action {
           action_id: 16837978

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4-stderr
@@ -1,0 +1,12 @@
+table-entries-priority-bmv2.p4(66): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4369 to conform to the P4Runtime specification
+            0x1111 &&& 0xF : a_with_control_params(1) @priority(3);
+            ^^^^^^
+table-entries-priority-bmv2.p4(66): [--Wwarn=deprecated] warning: The @priority annotation on Entry is not part of the P4 specification, nor of the P4Runtime specification, and will be ignored
+            0x1111 &&& 0xF : a_with_control_params(1) @priority(3);
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+table-entries-priority-bmv2.p4(68): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4481 to conform to the P4Runtime specification
+            0x1181 &&& 0xF00F : a_with_control_params(3) @priority(1);
+            ^^^^^^
+table-entries-priority-bmv2.p4(68): [--Wwarn=deprecated] warning: The @priority annotation on Entry is not part of the P4 specification, nor of the P4Runtime specification, and will be ignored
+            0x1181 &&& 0xF00F : a_with_control_params(3) @priority(1);
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4-stderr
@@ -1,10 +1,10 @@
-table-entries-priority-bmv2.p4(66): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4369 to conform to the P4Runtime specification
+table-entries-priority-bmv2.p4(66): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 0x1111 to conform to the P4Runtime specification
             0x1111 &&& 0xF : a_with_control_params(1) @priority(3);
             ^^^^^^
 table-entries-priority-bmv2.p4(66): [--Wwarn=deprecated] warning: The @priority annotation on Entry is not part of the P4 specification, nor of the P4Runtime specification, and will be ignored
             0x1111 &&& 0xF : a_with_control_params(1) @priority(3);
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-table-entries-priority-bmv2.p4(68): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4481 to conform to the P4Runtime specification
+table-entries-priority-bmv2.p4(68): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 0x1181 to conform to the P4Runtime specification
             0x1181 &&& 0xF00F : a_with_control_params(3) @priority(1);
             ^^^^^^
 table-entries-priority-bmv2.p4(68): [--Wwarn=deprecated] warning: The @priority annotation on Entry is not part of the P4 specification, nor of the P4Runtime specification, and will be ignored

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4.entries.txt
@@ -6,7 +6,7 @@ updates {
       match {
         field_id: 1
         ternary {
-          value: "\021\021"
+          value: "\000\001"
           mask: "\000\017"
         }
       }
@@ -19,7 +19,7 @@ updates {
           }
         }
       }
-      priority: 1
+      priority: 3
     }
   }
 }
@@ -56,7 +56,7 @@ updates {
       match {
         field_id: 1
         ternary {
-          value: "\021\201"
+          value: "\020\001"
           mask: "\360\017"
         }
       }
@@ -69,7 +69,7 @@ updates {
           }
         }
       }
-      priority: 3
+      priority: 1
     }
   }
 }

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.entries.txt
@@ -19,7 +19,7 @@ updates {
           }
         }
       }
-      priority: 1
+      priority: 3
     }
   }
 }
@@ -53,13 +53,6 @@ updates {
   entity {
     table_entry {
       table_id: 33595117
-      match {
-        field_id: 1
-        range {
-          low: "\000"
-          high: "\377"
-        }
-      }
       action {
         action {
           action_id: 16837978
@@ -69,7 +62,7 @@ updates {
           }
         }
       }
-      priority: 3
+      priority: 1
     }
   }
 }

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4-stderr
@@ -1,0 +1,6 @@
+table-entries-ternary-bmv2.p4(65): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4369 to conform to the P4Runtime specification
+            0x1111 &&& 0xF : a_with_control_params(1);
+            ^^^^^^
+table-entries-ternary-bmv2.p4(67): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4369 to conform to the P4Runtime specification
+            0x1111 &&& 0xF000 : a_with_control_params(3);
+            ^^^^^^

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4-stderr
@@ -1,6 +1,6 @@
-table-entries-ternary-bmv2.p4(65): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4369 to conform to the P4Runtime specification
+table-entries-ternary-bmv2.p4(65): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 0x1111 to conform to the P4Runtime specification
             0x1111 &&& 0xF : a_with_control_params(1);
             ^^^^^^
-table-entries-ternary-bmv2.p4(67): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 4369 to conform to the P4Runtime specification
+table-entries-ternary-bmv2.p4(67): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 0x1111 to conform to the P4Runtime specification
             0x1111 &&& 0xF000 : a_with_control_params(3);
             ^^^^^^

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4.entries.txt
@@ -6,7 +6,7 @@ updates {
       match {
         field_id: 1
         ternary {
-          value: "\021\021"
+          value: "\000\001"
           mask: "\000\017"
         }
       }
@@ -19,7 +19,7 @@ updates {
           }
         }
       }
-      priority: 1
+      priority: 4
     }
   }
 }
@@ -44,31 +44,6 @@ updates {
           }
         }
       }
-      priority: 2
-    }
-  }
-}
-updates {
-  type: INSERT
-  entity {
-    table_entry {
-      table_id: 33556639
-      match {
-        field_id: 1
-        ternary {
-          value: "\021\021"
-          mask: "\360\000"
-        }
-      }
-      action {
-        action {
-          action_id: 16837978
-          params {
-            param_id: 1
-            value: "\000\003"
-          }
-        }
-      }
       priority: 3
     }
   }
@@ -81,10 +56,28 @@ updates {
       match {
         field_id: 1
         ternary {
-          value: "\000\000"
-          mask: "\000\000"
+          value: "\020\000"
+          mask: "\360\000"
         }
       }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\003"
+          }
+        }
+      }
+      priority: 2
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33556639
       action {
         action {
           action_id: 16837978
@@ -94,7 +87,7 @@ updates {
           }
         }
       }
-      priority: 4
+      priority: 1
     }
   }
 }


### PR DESCRIPTION
See #1805

 * omit don't care matches
 * toggle off value bits which are masked off for ternary and LPM
 * emit a warning for ignored @priority annotation, and generate correct
   priority values
 * I couldn't move to the canonical binary string representation for
   bit<W> values because it is not currently supported by p4lang/PI