### PR TITLE
Convert some error messages to the new format

### DIFF
--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -95,7 +95,7 @@ set (P4_XFAIL_TESTS
 p4c_add_tests_w_p4runtime("p4" ${P4TEST_DRIVER} "${P4TEST_SUITES}" "${P4_XFAIL_TESTS}" "${P4RUNTIME_EXCLUDE}" "-a '--maxErrorCount 100'")
 
 set (P4TEST_ERRORS "${P4C_SOURCE_DIR}/testdata/p4_16_errors/*.p4")
-p4c_add_tests("err" ${P4TEST_DRIVER} "${P4TEST_ERRORS}" "" "")
+p4c_add_tests_w_p4runtime("err" ${P4TEST_DRIVER} "${P4TEST_ERRORS}" "${P4_XFAIL_TESTS}" "${P4RUNTIME_EXCLUDE}" "-a '--maxErrorCount 100'")
 
 set (P4_14_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_14_samples/*.p4"

--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -49,10 +49,8 @@ add_dependencies(p4c_driver linkp4test)
 
 set(P4TEST_DRIVER ${P4C_SOURCE_DIR}/backends/p4test/run-p4-sample.py)
 
-set (P4TEST_SUITES
-  "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*.p4"
-  "${P4C_SOURCE_DIR}/testdata/p4_16_errors/*.p4"
-  )
+set (P4TEST_SUITES "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*.p4")
+
 # Builds a list of tests for which P4Info generation is not supported. It makes
 # sense not to fail the test just because P4Info generation fails. It probably
 # would not make sense to run all the tests twice (one with and one without
@@ -95,6 +93,9 @@ set (P4_XFAIL_TESTS
 # compilation, the P4Runtime serializer will not be invoked anyway and there
 # will be no P4Info file.
 p4c_add_tests_w_p4runtime("p4" ${P4TEST_DRIVER} "${P4TEST_SUITES}" "${P4_XFAIL_TESTS}" "${P4RUNTIME_EXCLUDE}" "-a '--maxErrorCount 100'")
+
+set (P4TEST_ERRORS "${P4C_SOURCE_DIR}/testdata/p4_16_errors/*.p4")
+p4c_add_tests("err" ${P4TEST_DRIVER} "${P4TEST_ERRORS}" "" "")
 
 set (P4_14_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_14_samples/*.p4"

--- a/frontends/p4/validateParsedProgram.cpp
+++ b/frontends/p4/validateParsedProgram.cpp
@@ -32,18 +32,19 @@ void ValidateParsedProgram::postorder(const IR::Constant* c) {
 /// Check that extern constructor names match the enclosing extern
 void ValidateParsedProgram::postorder(const IR::Method* m) {
     if (m->name.isDontCare())
-        ::error("%1%: Illegal method/function name", m->name);
+        ::error(ErrorType::ERR_INVALID, "%1%: Illegal method/function name", m->name);
     if (auto ext = findContext<IR::Type_Extern>()) {
         if (m->name == ext->name && m->type->returnType != nullptr)
-            ::error("%1%: Constructor cannot have a return type", m);
+            ::error(ErrorType::ERR_INVALID, "%1%: Constructor cannot have a return type", m);
         if (m->type->returnType == nullptr) {
             if (m->name != ext->name) {
-                ::error("%1%: Method has no return type", m);
+                ::error(ErrorType::ERR_INVALID, "%1%: Method has no return type", m);
                 return;
             }
             for (auto p : *m->type->parameters)
                 if (p->direction != IR::Direction::None)
-                    ::error("%1%: constructor parameters cannot have a direction", p);
+                    ::error(ErrorType::ERR_INVALID,
+                            "%1%: constructor parameters cannot have a direction", p);
         }
     }
 }
@@ -51,7 +52,7 @@ void ValidateParsedProgram::postorder(const IR::Method* m) {
 /// Struct field names cannot be underscore
 void ValidateParsedProgram::postorder(const IR::StructField* f) {
     if (f->name.isDontCare())
-        ::error("%1%: Illegal field name", f->name);
+        ::error(ErrorType::ERR_INVALID, "%1%: Illegal field name", f->name);
 }
 
 /// Width of a bit<> type is at least 0
@@ -61,9 +62,9 @@ void ValidateParsedProgram::postorder(const IR::Type_Bits* type) {
         // cannot validate yet
         return;
     if (type->size <= 0)
-        ::error("%1%: Illegal type size", type);
+        ::error(ErrorType::ERR_INVALID, "%1%: Illegal type size", type);
     if (type->size == 1 && type->isSigned)
-        ::error("%1%: Signed types cannot be 1-bit wide", type);
+        ::error(ErrorType::ERR_INVALID, "%1%: Signed types cannot be 1-bit wide", type);
 }
 
 void ValidateParsedProgram::postorder(const IR::Type_Varbits* type) {
@@ -71,14 +72,15 @@ void ValidateParsedProgram::postorder(const IR::Type_Varbits* type) {
         // cannot validate yet
         return;
     if (type->size <= 0)
-        ::error("%1%: Illegal type size", type);
+        ::error(ErrorType::ERR_INVALID, "%1%: Illegal type size", type);
 }
 
 /// The accept and reject states cannot be implemented
 void ValidateParsedProgram::postorder(const IR::ParserState* s) {
     if (s->name == IR::ParserState::accept ||
         s->name == IR::ParserState::reject)
-        ::error("%1%: parser state should not be implemented, it is built-in", s->name);
+        ::error(ErrorType::ERR_INVALID,
+                "%1%: parser state should not be implemented, it is built-in", s->name);
 }
 
 /// All parameters of a constructor must be directionless.
@@ -86,14 +88,16 @@ void ValidateParsedProgram::postorder(const IR::ParserState* s) {
 void ValidateParsedProgram::container(const IR::IContainer* type) {
     for (auto p : type->getConstructorParameters()->parameters)
         if (p->direction != IR::Direction::None)
-            ::error("%1%: constructor parameters cannot have a direction", p);
+            ::error(ErrorType::ERR_INVALID,
+                    "%1%: constructor parameters cannot have a direction", p);
 }
 
 /// Tables must have an 'actions' property.
 void ValidateParsedProgram::postorder(const IR::P4Table* t) {
     auto ac = t->getActionList();
     if (ac == nullptr)
-        ::error("Table %1% does not have an `%2%' property",
+        ::error(ErrorType::ERR_EXPECTED,
+                "Table %1% does not have an `%2%' property",
                 t->name, IR::TableProperties::actionsPropertyName);
 }
 
@@ -110,7 +114,8 @@ void ValidateParsedProgram::distinctParameters(
     for (auto p : apply->parameters) {
         auto it = found.find(p->getName());
         if (it != found.end())
-            ::error("Duplicated parameter name: %1% and %2%",
+            ::error(ErrorType::ERR_INVALID,
+                    "%1%: Duplicated parameter name %2%",
                     it->second, p);
         else
             found.emplace(p->getName(), p);
@@ -118,7 +123,8 @@ void ValidateParsedProgram::distinctParameters(
     for (auto p : constr->parameters) {
         auto it = found.find(p->getName());
         if (it != found.end())
-            ::error("Duplicated parameter name: %1% and %2%",
+            ::error(ErrorType::ERR_INVALID,
+                    "%1%: Duplicated parameter name %2%",
                     it->second, p);
     }
 }
@@ -127,36 +133,38 @@ void ValidateParsedProgram::distinctParameters(
 void ValidateParsedProgram::postorder(const IR::ConstructorCallExpression* expression) {
     auto inAction = findContext<IR::P4Action>();
     if (inAction != nullptr)
-        ::error("%1%: Constructor calls not allowed in actions", expression);
+        ::error(ErrorType::ERR_INVALID,
+                "%1%: Constructor calls not allowed in actions", expression);
 }
 
 /// Variable names cannot be underscore
 void ValidateParsedProgram::postorder(const IR::Declaration_Variable* decl) {
     if (decl->name.isDontCare())
-        ::error("%1%: illegal variable name", decl);
+        ::error(ErrorType::ERR_INVALID, "%1%: illegal variable name", decl);
 }
 
 /// Instance names cannot be don't care
 /// Do not declare instances in apply {} blocks, parser states or actions
 void ValidateParsedProgram::postorder(const IR::Declaration_Instance* decl) {
     if (decl->name.isDontCare())
-        ::error("%1%: illegal instance name", decl);
+        ::error(ErrorType::ERR_INVALID, "%1%: illegal instance name", decl);
     if (findContext<IR::BlockStatement>() &&  // we're looking for the apply block
         findContext<IR::P4Control>() &&       // of a control
         !findContext<IR::Declaration_Instance>()) {  // but not in an instance initializer
-        ::error("%1%: instances cannot be in a control 'apply' block", decl);
+        ::error(ErrorType::ERR_INVALID,
+                "%1%: instances cannot be in a control 'apply' block", decl);
     }
     if (findContext<IR::ParserState>())
-        ::error("%1%: instances cannot be in a parser state", decl);
+        ::error(ErrorType::ERR_INVALID, "%1%: instances cannot be in a parser state", decl);
     auto inAction = findContext<IR::P4Action>();
     if (inAction != nullptr)
-        ::error("%1%: Instantiations not allowed in actions", decl);
+        ::error(ErrorType::ERR_INVALID, "%1%: Instantiations not allowed in actions", decl);
 }
 
 /// Constant names cannot be underscore
 void ValidateParsedProgram::postorder(const IR::Declaration_Constant* decl) {
     if (decl->name.isDontCare())
-        ::error("%1%: illegal constant name", decl);
+        ::error(ErrorType::ERR_INVALID, "%1%: illegal constant name", decl);
 }
 
 /**
@@ -169,10 +177,10 @@ void ValidateParsedProgram::postorder(const IR::Declaration_Constant* decl) {
 void ValidateParsedProgram::postorder(const IR::EntriesList* l) {
     auto table = findContext<IR::P4Table>();
     if (table == nullptr)
-        ::error("%1%: table initialziers must belong to a table", l);
+        ::error(ErrorType::ERR_INVALID, "%1%: table initialziers must belong to a table", l);
     auto ep = table->properties->getProperty(IR::TableProperties::entriesPropertyName);
     if (!ep->isConstant)
-        ::error("%1%: table initializers must be constant", l);
+        ::error(ErrorType::ERR_INVALID, "%1%: table initializers must be constant", l);
 }
 
 /// Switch statements are not allowed in actions.
@@ -180,7 +188,8 @@ void ValidateParsedProgram::postorder(const IR::EntriesList* l) {
 void ValidateParsedProgram::postorder(const IR::SwitchStatement* statement) {
     auto inAction = findContext<IR::P4Action>();
     if (inAction != nullptr)
-        ::error("%1%: switch statements not allowed in actions", statement);
+        ::error(ErrorType::ERR_INVALID,
+                "%1%: switch statements not allowed in actions", statement);
     bool defaultFound = false;
     for (auto c : statement->cases) {
         if (defaultFound) {
@@ -196,16 +205,19 @@ void ValidateParsedProgram::postorder(const IR::SwitchStatement* statement) {
 void ValidateParsedProgram::postorder(const IR::ReturnStatement* statement) {
     auto inParser = findContext<IR::P4Parser>();
     if (inParser != nullptr)
-        ::error("%1%: return statements not allowed in parsers", statement);
+        ::error(ErrorType::ERR_INVALID,
+                "%1%: return statements not allowed in parsers", statement);
 }
 
 /// Exit statements are not allowed in parsers or functions
 void ValidateParsedProgram::postorder(const IR::ExitStatement* statement) {
     auto inParser = findContext<IR::P4Parser>();
     if (inParser != nullptr)
-        ::error("%1%: exit statements not allowed in parsers", statement);
+        ::error(ErrorType::ERR_INVALID,
+                "%1%: exit statements not allowed in parsers", statement);
     if (findContext<IR::Function>())
-        ::error("%1%: exit statements not allowed in functions", statement);
+        ::error(ErrorType::ERR_INVALID,
+                "%1%: exit statements not allowed in functions", statement);
 }
 
 void ValidateParsedProgram::postorder(const IR::P4Program* program) {
@@ -215,7 +227,7 @@ void ValidateParsedProgram::postorder(const IR::P4Program* program) {
         auto existing = declarations.getDeclaration(name);
         if (existing != nullptr) {
             if (!existing->is<IR::IFunctional>() || !decl->is<IR::IFunctional>()) {
-                ::error("Duplicate declaration of %1%: %2%",
+                ::error(ErrorType::ERR_INVALID, "Duplicate declaration of %1%: %2%",
                         decl->getName(), existing->getName());
             }
         } else {

--- a/frontends/p4/validateParsedProgram.cpp
+++ b/frontends/p4/validateParsedProgram.cpp
@@ -179,10 +179,12 @@ void ValidateParsedProgram::postorder(const IR::Declaration_Constant* decl) {
 void ValidateParsedProgram::postorder(const IR::EntriesList* l) {
     auto table = findContext<IR::P4Table>();
     if (table == nullptr)
-        ::error(ErrorType::ERR_INVALID, "initializer. Table initializers must belong to a table", l);
+        ::error(ErrorType::ERR_INVALID,
+                "initializer. Table initializers must belong to a table", l);
     auto ep = table->properties->getProperty(IR::TableProperties::entriesPropertyName);
     if (!ep->isConstant)
-        ::error(ErrorType::ERR_INVALID, "initializer. Table initializers must be constant", l);
+        ::error(ErrorType::ERR_INVALID,
+                "initializer. Table initializers must be constant", l);
 }
 
 /// Switch statements are not allowed in actions.

--- a/frontends/p4/validateParsedProgram.cpp
+++ b/frontends/p4/validateParsedProgram.cpp
@@ -32,13 +32,13 @@ void ValidateParsedProgram::postorder(const IR::Constant* c) {
 /// Check that extern constructor names match the enclosing extern
 void ValidateParsedProgram::postorder(const IR::Method* m) {
     if (m->name.isDontCare())
-        ::error(ErrorType::ERR_INVALID, "%1%: Illegal method/function name", m->name);
+        ::error(ErrorType::ERR_INVALID, "method/function name", m->name);
     if (auto ext = findContext<IR::Type_Extern>()) {
         if (m->name == ext->name && m->type->returnType != nullptr)
-            ::error(ErrorType::ERR_INVALID, "%1%: Constructor cannot have a return type", m);
+            ::error(ErrorType::ERR_INVALID, "type. Constructor cannot have a return type", m);
         if (m->type->returnType == nullptr) {
             if (m->name != ext->name) {
-                ::error(ErrorType::ERR_INVALID, "%1%: Method has no return type", m);
+                ::error(ErrorType::ERR_INVALID, "type. Method has no return type", m);
                 return;
             }
             for (auto p : *m->type->parameters)
@@ -52,7 +52,7 @@ void ValidateParsedProgram::postorder(const IR::Method* m) {
 /// Struct field names cannot be underscore
 void ValidateParsedProgram::postorder(const IR::StructField* f) {
     if (f->name.isDontCare())
-        ::error(ErrorType::ERR_INVALID, "%1%: Illegal field name", f->name);
+        ::error(ErrorType::ERR_INVALID, "field name", f->name);
 }
 
 /// Width of a bit<> type is at least 0

--- a/testdata/p4_16_errors_outputs/accept_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/accept_e.p4-stderr
@@ -1,3 +1,3 @@
-accept_e.p4(18): [--Werror=legacy] error: accept: parser state should not be implemented, it is built-in
+accept_e.p4(18): [--Werror=invalid] error: accept: Invalid accept: parser state should not be implemented, it is built-in
     state accept { // reserved name
           ^^^^^^

--- a/testdata/p4_16_errors_outputs/accept_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/accept_e.p4-stderr
@@ -1,3 +1,3 @@
-accept_e.p4(18): [--Werror=invalid] error: accept: Invalid accept: parser state should not be implemented, it is built-in
+accept_e.p4(18): [--Werror=invalid] error: accept: Invalid parser state.  accept should not be implemented, it is built-in
     state accept { // reserved name
           ^^^^^^

--- a/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
@@ -1,3 +1,3 @@
-constructor_e.p4(18): [--Werror=invalid] error: X: Invalid X: Constructor cannot have a return type
+constructor_e.p4(18): [--Werror=invalid] error: X: Invalid type. Constructor cannot have a return type
     void X(); // no return type allowed
          ^

--- a/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
@@ -1,3 +1,3 @@
-constructor_e.p4(18): [--Werror=legacy] error: X: Constructor cannot have a return type
+constructor_e.p4(18): [--Werror=invalid] error: X: Invalid X: Constructor cannot have a return type
     void X(); // no return type allowed
          ^

--- a/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor_e.p4-stderr
@@ -1,3 +1,3 @@
-constructor_e.p4(18): [--Werror=invalid] error: X: Invalid type. Constructor cannot have a return type
+constructor_e.p4(18): [--Werror=invalid] error: X: Invalid type. Constructor cannot have a return type.
     void X(); // no return type allowed
          ^

--- a/testdata/p4_16_errors_outputs/control-inline.p4-stderr
+++ b/testdata/p4_16_errors_outputs/control-inline.p4-stderr
@@ -1,3 +1,3 @@
-control-inline.p4(35): [--Werror=invalid] error: vc: Invalid vc: instances cannot be in a control 'apply' block
+control-inline.p4(35): [--Werror=invalid] error: vc: Invalid declaration. Instantiations cannot be in a control 'apply' block.
         VC() vc;
              ^^

--- a/testdata/p4_16_errors_outputs/control-inline.p4-stderr
+++ b/testdata/p4_16_errors_outputs/control-inline.p4-stderr
@@ -1,3 +1,3 @@
-control-inline.p4(35): [--Werror=legacy] error: vc: instances cannot be in a control 'apply' block
+control-inline.p4(35): [--Werror=invalid] error: vc: Invalid vc: instances cannot be in a control 'apply' block
         VC() vc;
              ^^

--- a/testdata/p4_16_errors_outputs/dup-param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param.p4-stderr
@@ -1,4 +1,4 @@
-dup-param.p4(17): [--Werror=legacy] error: Duplicated parameter name: p and p
+dup-param.p4(17): [--Werror=invalid] error: p: Invalid p: Duplicated parameter name p
 control c(bit<32> p)(bool p) {
                   ^
 dup-param.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param.p4-stderr
@@ -1,4 +1,4 @@
-dup-param.p4(17): [--Werror=invalid] error: p: Invalid name. Duplicates p
+dup-param.p4(17): [--Werror=duplicate] error: p duplicates p.
 control c(bit<32> p)(bool p) {
                   ^
 dup-param.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param.p4-stderr
@@ -1,4 +1,4 @@
-dup-param.p4(17): [--Werror=invalid] error: p: Invalid p: Duplicated parameter name p
+dup-param.p4(17): [--Werror=invalid] error: p: Invalid name. Duplicates p
 control c(bit<32> p)(bool p) {
                   ^
 dup-param.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
@@ -1,4 +1,4 @@
-dup-param1.p4(17): [--Werror=legacy] error: Duplicated parameter name: p and p
+dup-param1.p4(17): [--Werror=invalid] error: p: Invalid p: Duplicated parameter name p
 control MyIngress<p>(inout bit<32> p) {
                   ^
 dup-param1.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
@@ -1,4 +1,4 @@
-dup-param1.p4(17): [--Werror=invalid] error: p: Invalid name.  Duplicates p
+dup-param1.p4(17): [--Werror=duplicate] error: p duplicates p.
 control MyIngress<p>(inout bit<32> p) {
                   ^
 dup-param1.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
@@ -1,4 +1,4 @@
-dup-param1.p4(17): [--Werror=invalid] error: p: Invalid p: Duplicated parameter name p
+dup-param1.p4(17): [--Werror=invalid] error: p: Invalid name.  Duplicates p
 control MyIngress<p>(inout bit<32> p) {
                   ^
 dup-param1.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
@@ -1,4 +1,4 @@
-dup-param2.p4(17): [--Werror=invalid] error: p: Invalid name. Duplicates p
+dup-param2.p4(17): [--Werror=duplicate] error: p duplicates p.
 control MyIngress<p>(inout bit<32> x)(bit<32> p) {
                   ^
 dup-param2.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
@@ -1,4 +1,4 @@
-dup-param2.p4(17): [--Werror=legacy] error: Duplicated parameter name: p and p
+dup-param2.p4(17): [--Werror=invalid] error: p: Invalid p: Duplicated parameter name p
 control MyIngress<p>(inout bit<32> x)(bit<32> p) {
                   ^
 dup-param2.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param2.p4-stderr
@@ -1,4 +1,4 @@
-dup-param2.p4(17): [--Werror=invalid] error: p: Invalid p: Duplicated parameter name p
+dup-param2.p4(17): [--Werror=invalid] error: p: Invalid name. Duplicates p
 control MyIngress<p>(inout bit<32> x)(bit<32> p) {
                   ^
 dup-param2.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
@@ -1,4 +1,4 @@
-dup-param3.p4(17): [--Werror=invalid] error: p: Invalid p: Duplicated parameter name p
+dup-param3.p4(17): [--Werror=invalid] error: p: Invalid name.  Duplicates p
 control MyIngress<p>(inout bit<32> p)(bit<32> p) {
                   ^
 dup-param3.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
@@ -1,4 +1,4 @@
-dup-param3.p4(17): [--Werror=invalid] error: p: Invalid name.  Duplicates p
+dup-param3.p4(17): [--Werror=duplicate] error: p duplicates p.
 control MyIngress<p>(inout bit<32> p)(bit<32> p) {
                   ^
 dup-param3.p4(17)

--- a/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
@@ -1,4 +1,4 @@
-dup-param3.p4(17): [--Werror=legacy] error: Duplicated parameter name: p and p
+dup-param3.p4(17): [--Werror=invalid] error: p: Invalid p: Duplicated parameter name p
 control MyIngress<p>(inout bit<32> p)(bit<32> p) {
                   ^
 dup-param3.p4(17)

--- a/testdata/p4_16_errors_outputs/dupConst.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dupConst.p4-stderr
@@ -1,4 +1,4 @@
-dupConst.p4(17): [--Werror=invalid] error: a: Invalid declaration.  Duplicates a
+dupConst.p4(17): [--Werror=duplicate] error: a duplicates a.
 const bit<4> a = 2;
              ^
 dupConst.p4(16)

--- a/testdata/p4_16_errors_outputs/dupConst.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dupConst.p4-stderr
@@ -1,4 +1,4 @@
-dupConst.p4(17): [--Werror=legacy] error: Duplicate declaration of a: a
+dupConst.p4(17): [--Werror=invalid] error: a: Invalid Duplicate declaration of a: a
 const bit<4> a = 2;
              ^
 dupConst.p4(16)

--- a/testdata/p4_16_errors_outputs/dupConst.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dupConst.p4-stderr
@@ -1,4 +1,4 @@
-dupConst.p4(17): [--Werror=invalid] error: a: Invalid Duplicate declaration of a: a
+dupConst.p4(17): [--Werror=invalid] error: a: Invalid declaration.  Duplicates a
 const bit<4> a = 2;
              ^
 dupConst.p4(16)

--- a/testdata/p4_16_errors_outputs/issue435.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue435.p4-stderr
@@ -1,3 +1,3 @@
-issue435.p4(7): [--Werror=legacy] error: mystruct1: Method has no return type
+issue435.p4(7): [--Werror=invalid] error: mystruct1: Invalid mystruct1: Method has no return type
     mystruct1(in bit<8> a, out bit<16> b);
     ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue435.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue435.p4-stderr
@@ -1,3 +1,3 @@
-issue435.p4(7): [--Werror=invalid] error: mystruct1: Invalid mystruct1: Method has no return type
+issue435.p4(7): [--Werror=invalid] error: mystruct1: Invalid type. Method has no return type
     mystruct1(in bit<8> a, out bit<16> b);
     ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue435.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue435.p4-stderr
@@ -1,3 +1,3 @@
-issue435.p4(7): [--Werror=invalid] error: mystruct1: Invalid type. Method has no return type
+issue435.p4(7): [--Werror=invalid] error: mystruct1: Invalid type. Method has no return type.
     mystruct1(in bit<8> a, out bit<16> b);
     ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/local_instance.p4-stderr
+++ b/testdata/p4_16_errors_outputs/local_instance.p4-stderr
@@ -1,3 +1,3 @@
-local_instance.p4(33): [--Werror=legacy] error: vc: instances cannot be in a control 'apply' block
+local_instance.p4(33): [--Werror=invalid] error: vc: Invalid vc: instances cannot be in a control 'apply' block
         VC() vc; // illegal instance within an apply block
              ^^

--- a/testdata/p4_16_errors_outputs/local_instance.p4-stderr
+++ b/testdata/p4_16_errors_outputs/local_instance.p4-stderr
@@ -1,3 +1,3 @@
-local_instance.p4(33): [--Werror=invalid] error: vc: Invalid vc: instances cannot be in a control 'apply' block
+local_instance.p4(33): [--Werror=invalid] error: vc: Invalid declaration. Instantiations cannot be in a control 'apply' block.
         VC() vc; // illegal instance within an apply block
              ^^

--- a/testdata/p4_16_errors_outputs/missing_actions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/missing_actions.p4-stderr
@@ -1,3 +1,3 @@
-missing_actions.p4(19): [--Werror=expected] error: t: Expected Table t does not have an `actions' property
+missing_actions.p4(19): [--Werror=expected] error: t: Expected `actions' property
     table t {
           ^

--- a/testdata/p4_16_errors_outputs/missing_actions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/missing_actions.p4-stderr
@@ -1,3 +1,3 @@
-missing_actions.p4(19): [--Werror=legacy] error: Table t does not have an `actions' property
+missing_actions.p4(19): [--Werror=expected] error: t: Expected Table t does not have an `actions' property
     table t {
           ^

--- a/testdata/p4_16_errors_outputs/package.p4-stderr
+++ b/testdata/p4_16_errors_outputs/package.p4-stderr
@@ -1,3 +1,3 @@
-package.p4(18): [--Werror=invalid] error: _c: Invalid _c: constructor parameters cannot have a direction
+package.p4(18): [--Werror=invalid] error: _c: Invalid aragument. Constructor parameters cannot have a direction
 package top(in proto _c); // Package should not have in parameters
                      ^^

--- a/testdata/p4_16_errors_outputs/package.p4-stderr
+++ b/testdata/p4_16_errors_outputs/package.p4-stderr
@@ -1,3 +1,3 @@
-package.p4(18): [--Werror=legacy] error: _c: constructor parameters cannot have a direction
+package.p4(18): [--Werror=invalid] error: _c: Invalid _c: constructor parameters cannot have a direction
 package top(in proto _c); // Package should not have in parameters
                      ^^

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-non-const.p4(68): [--Werror=legacy] error: EntriesList: table initializers must be constant
+table-entries-non-const.p4(68): [--Werror=invalid] error: EntriesList: Invalid EntriesList: table initializers must be constant
         entries = {
         ^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-non-const.p4(68): [--Werror=invalid] error: EntriesList: Invalid EntriesList: table initializers must be constant
+table-entries-non-const.p4(68): [--Werror=invalid] error: EntriesList: Invalid initializer. Table initializers must be constant
         entries = {
         ^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-non-const.p4(68): [--Werror=invalid] error: EntriesList: Invalid initializer. Table initializers must be constant
+table-entries-non-const.p4(68): [--Werror=invalid] error: EntriesList: Invalid initializer. Table initializers must be constant.
         entries = {
         ^^^^^^^

--- a/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
@@ -58,5 +58,18 @@ type H2aD_t H2aDT_t; // error
 typedef-and-type-definitions.p4(153): error: h1StackDT_t: `type' can only be applied to base types
 type h1StackD_t h1StackDT_t; // error
                 ^^^^^^^^^^^
-Number of errors exceeded set maximum of 20
-
+typedef-and-type-definitions.p4(154): error: hu1DT_t: `type' can only be applied to base types
+type hu1D_t hu1DT_t; // error
+            ^^^^^^^
+typedef-and-type-definitions.p4(155): error: s1DT_t: `type' can only be applied to base types
+type s1D_t s1DT_t; // error
+           ^^^^^^
+typedef-and-type-definitions.p4(156): error: PointADT_t: `type' can only be applied to base types
+type PointAD_t PointADT_t; // error
+               ^^^^^^^^^^
+typedef-and-type-definitions.p4(157): error: Tuple1DT_t: `type' can only be applied to base types
+type Tuple1D_t Tuple1DT_t; // error
+               ^^^^^^^^^^
+typedef-and-type-definitions.p4(158): error: Tuple2DT_t: `type' can only be applied to base types
+type Tuple2D_t Tuple2DT_t; // error
+               ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
@@ -58,18 +58,5 @@ type H2aD_t H2aDT_t; // error
 typedef-and-type-definitions.p4(153): error: h1StackDT_t: `type' can only be applied to base types
 type h1StackD_t h1StackDT_t; // error
                 ^^^^^^^^^^^
-typedef-and-type-definitions.p4(154): error: hu1DT_t: `type' can only be applied to base types
-type hu1D_t hu1DT_t; // error
-            ^^^^^^^
-typedef-and-type-definitions.p4(155): error: s1DT_t: `type' can only be applied to base types
-type s1D_t s1DT_t; // error
-           ^^^^^^
-typedef-and-type-definitions.p4(156): error: PointADT_t: `type' can only be applied to base types
-type PointAD_t PointADT_t; // error
-               ^^^^^^^^^^
-typedef-and-type-definitions.p4(157): error: Tuple1DT_t: `type' can only be applied to base types
-type Tuple1D_t Tuple1DT_t; // error
-               ^^^^^^^^^^
-typedef-and-type-definitions.p4(158): error: Tuple2DT_t: `type' can only be applied to base types
-type Tuple2D_t Tuple2DT_t; // error
-               ^^^^^^^^^^
+Number of errors exceeded set maximum of 20
+

--- a/testdata/p4_16_samples_outputs/default-switch.p4-stderr
+++ b/testdata/p4_16_samples_outputs/default-switch.p4-stderr
@@ -1,4 +1,4 @@
-default-switch.p4(13): [--Wwarn=ordering] warning: SwitchCase: label following default label
+default-switch.p4(13): [--Wwarn=ordering] warning: SwitchCase: label following default label.
             b: { return; }
             ^^^^^^^^^^^^^^
 warning: Program does not contain a `main' module


### PR DESCRIPTION
I have also create a new class of tests in the CMakeFile, called "err". This includes all tests from testdata/p4_16_errors. Now you can say 'make check-err'.

I am not 100% happy about the way error messages are printed now. E.g. the following is a bit clumsy:
```
missing_actions.p4(19): [--Werror=expected] error: t: Expected Table t does not have an `actions' property
```

@cc10512 : maybe you have a suggestion on how to improve this.