### PR TITLE
Fix issue with bmv2 psa_switch backend not able to reference the new metadata

### DIFF
--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -83,6 +83,7 @@ const IR::Node* ArithmeticFixup::postorder(IR::Cast* expression) {
 
 void ExpressionConverter::mapExpression(const IR::Expression* expression, Util::IJson* json) {
     map.emplace(expression, json);
+    LOG3("Mapping " << dbp(expression) << " to " << json->toString());
 }
 
 Util::IJson* ExpressionConverter::get(const IR::Expression* expression) const {
@@ -259,8 +260,8 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
     if (param != nullptr) {
         // convert architecture-dependent parameter
         if (auto result = convertParam(param, fieldName)) {
-          mapExpression(expression, result);
-          return;
+            mapExpression(expression, result);
+            return;
         }
         // convert normal parameters
         if (auto st = type->to<IR::Type_Stack>()) {

--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -83,7 +83,6 @@ const IR::Node* ArithmeticFixup::postorder(IR::Cast* expression) {
 
 void ExpressionConverter::mapExpression(const IR::Expression* expression, Util::IJson* json) {
     map.emplace(expression, json);
-    LOG3("alex Mapping " << dbp(expression) << " to " << json->toString());
 }
 
 Util::IJson* ExpressionConverter::get(const IR::Expression* expression) const {
@@ -259,15 +258,12 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
     auto param = enclosingParamReference(expression->expr);
     if (param != nullptr) {
         // convert architecture-dependent parameter
-      LOG1("alex param is not null " << param->toString());
         if (auto result = convertParam(param, fieldName)) {
-	  LOG1("alex convert architecture-dependent parameter " << param->toString());
-	  mapExpression(expression, result);
-            return;
+          mapExpression(expression, result);
+          return;
         }
         // convert normal parameters
         if (auto st = type->to<IR::Type_Stack>()) {
-	  LOG1("alex convert normal typestack" << param->toString());
             auto et = typeMap->getTypeType(st->elementType, true);
             if (et->is<IR::Type_HeaderUnion>())
                 result->emplace("type", "header_union_stack");
@@ -275,11 +271,9 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
                 result->emplace("type", "header_stack");
             result->emplace("value", fieldName);
         } else if (type->is<IR::Type_HeaderUnion>()) {
-	  LOG1("alex convert normal headerunion" << param->toString());
             result->emplace("type", "header_union");
             result->emplace("value", fieldName);
         } else if (parentType->is<IR::Type_HeaderUnion>()) {
-	  LOG1("alex convert normal parent headerunion" << param->toString());
             auto l = get(expression->expr);
             cstring nestedField = fieldName;
             if (l->is<Util::JsonObject>()) {
@@ -295,28 +289,22 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
         } else if (parentType->is<IR::Type_StructLike>() &&
                    (type->is<IR::Type_Bits>() || type->is<IR::Type_Error>() ||
                     type->is<IR::Type_Boolean>())) {
-	  LOG1("alex convert normal structlike" << param->toString());
             auto field = parentType->to<IR::Type_StructLike>()->getField(
                 expression->member);
             LOG3("looking up field " << field);
             CHECK_NULL(field);
-            LOG1("alex checking structure->scalarMetadataFields " << structure->scalarMetadataFields.size());
             auto name = ::get(structure->scalarMetadataFields, field);
             BUG_CHECK((name != nullptr), "NULL name: %1%", field->name);
             if (type->is<IR::Type_Bits>() || type->is<IR::Type_Error>() ||
                 leftValue || simpleExpressionsOnly) {
-	      LOG1("alex is type_bits");
                 result->emplace("type", "field");
                 auto e = mkArrayField(result, "value");
-		LOG1("alex scalarsName " << scalarsName);
-		LOG1("alex name " << name);
                 e->append(scalarsName);
                 e->append(name);
             } else if (type->is<IR::Type_Boolean>()) {
                 // Boolean variables are stored as ints, so we
                 // have to insert a conversion when reading such a
                 // variable
-	      LOG1("alex is type_boolean");
                 result->emplace("type", "expression");
                 auto e = new Util::JsonObject();
                 result->emplace("value", e);
@@ -331,7 +319,6 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
                 a->append(name);
             }
         } else {
-	  LOG1("alex catch all now");
             // This may be wrong, but the caller will handle it properly
             // (e.g., this can be a method, such as packet.lookahead)
             result->emplace("type", "header");
@@ -716,7 +703,6 @@ ExpressionConverter::convert(const IR::Expression* e, bool doFixup, bool wrap, b
         BUG("%1%: Could not convert expression", e);
 
     if (convertBool) {
-      LOG1("alex convertbool " << result);
         auto obj = new Util::JsonObject();
         obj->emplace("type", "expression");
         auto conv = new Util::JsonObject();

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -36,23 +36,29 @@ void PsaProgramStructure::createStructLike(ConversionContext* ctxt, const IR::Ty
     unsigned max_length = 0;  // for variable-sized headers
     bool varbitFound = false;
     auto fields = new Util::JsonArray();
+    LOG1("alex createStructLike " << st->toString());
     for (auto f : st->fields) {
         auto field = new Util::JsonArray();
         auto ftype = typeMap->getType(f, true);
+	LOG1("alex iterating getting type and name " << f << " " << ftype->toString());
         if (ftype->to<IR::Type_StructLike>()) {
+	  LOG1("type structlike");
             BUG("%1%: nested structure", st);
         } else if (ftype->is<IR::Type_Boolean>()) {
-            field->append(f->name.name);
+	  LOG1("type boolean");
+	  field->append(f->name.name);
             field->append(1);
-            field->append(0);
+            field->append(false);
             max_length += 1;
         } else if (auto type = ftype->to<IR::Type_Bits>()) {
-            field->append(f->name.name);
+	  LOG1("type bits");
+	  field->append(f->name.name);
             field->append(type->size);
             field->append(type->isSigned);
             max_length += type->size;
         } else if (auto type = ftype->to<IR::Type_Varbits>()) {
-            field->append(f->name.name);
+	  LOG1("type varbits");
+	  field->append(f->name.name);
             max_length += type->size;
             field->append("*");
             if (varbitFound)
@@ -60,13 +66,16 @@ void PsaProgramStructure::createStructLike(ConversionContext* ctxt, const IR::Ty
                         "headers with multiple varbit fields are not supported", st);
             varbitFound = true;
         } else if (ftype->is<IR::Type_Error>()) {
-            field->append(f->name.name);
+	  LOG1("type error");
+	  field->append(f->name.name);
             field->append(error_width);
-            field->append(0);
+            field->append(false);
             max_length += error_width;
         } else if (ftype->to<IR::Type_Stack>()) {
-            BUG("%1%: nested stack", st);
+	  LOG1("type stack");
+	  BUG("%1%: nested stack", st);
         } else {
+	  LOG1("type bug");
             BUG("%1%: unexpected type for %2%.%3%", ftype, st, f->name);
         }
         fields->append(field);
@@ -267,7 +276,9 @@ bool InspectPsaProgram::isHeaders(const IR::Type_StructLike* st) {
 }
 
 void InspectPsaProgram::addHeaderType(const IR::Type_StructLike *st) {
+  LOG1("alex adding headerType " << st->toString());
     if (st->is<IR::Type_HeaderUnion>()) {
+      LOG1("alex is type_headerunion");
         for (auto f : st->fields) {
             auto ftype = typeMap->getType(f, true);
             auto ht = ftype->to<IR::Type_Header>();
@@ -277,8 +288,10 @@ void InspectPsaProgram::addHeaderType(const IR::Type_StructLike *st) {
         pinfo->header_union_types.emplace(st->getName(), st->to<IR::Type_HeaderUnion>());
         return;
     } else if (st->is<IR::Type_Header>()) {
-        pinfo->header_types.emplace(st->getName(), st->to<IR::Type_Header>());
+      LOG1("alex is type_header");
+      pinfo->header_types.emplace(st->getName(), st->to<IR::Type_Header>());
     } else if (st->is<IR::Type_Struct>()) {
+      LOG1("alex is type_struct");
         pinfo->metadata_types.emplace(st->getName(), st->to<IR::Type_Struct>());
     }
 }
@@ -295,7 +308,9 @@ void InspectPsaProgram::addHeaderInstance(const IR::Type_StructLike *st, cstring
 
 void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bool isHeader) {
     LOG3("Adding " << type);
+    LOG1("alex adding " << type->toString() << " and isHeader " << isHeader);
     for (auto f : type->fields) {
+        LOG1("alex iterating through fields " << f->toString());
         auto ft = typeMap->getType(f, true);
         if (ft->is<IR::Type_StructLike>()) {
             // The headers struct can not contain nested structures.
@@ -311,11 +326,15 @@ void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bo
     }
 
     for (auto f : type->fields) {
+      LOG1("alex iterating through fields again " << f->toString());
         auto ft = typeMap->getType(f, true);
         if (ft->is<IR::Type_StructLike>()) {
+	  LOG1("alex iterating through fields " << f->toString());
             if (auto hft = ft->to<IR::Type_Header>()) {
+                LOG1("alex is type_header");
                 addHeaderInstance(hft, f->controlPlaneName());
             } else if (ft->is<IR::Type_HeaderUnion>()) {
+                LOG1("alex is type_headerunion");
                 for (auto uf : ft->to<IR::Type_HeaderUnion>()->fields) {
                     auto uft = typeMap->getType(uf, true);
                     if (auto h_type = uft->to<IR::Type_Header>()) {
@@ -330,11 +349,12 @@ void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bo
                                                   type->to<IR::Type_HeaderUnion>());
                 addHeaderInstance(type, f->controlPlaneName());
             } else {
-                LOG1("add struct type " << type);
+                LOG1("alex add struct type " << type);
                 pinfo->metadata_types.emplace(type->getName(), type->to<IR::Type_Struct>());
                 addHeaderInstance(type, f->controlPlaneName());
             }
         } else if (ft->is<IR::Type_Stack>()) {
+            LOG1("alex is type stack stack " << ft->toString());
             auto stack = ft->to<IR::Type_Stack>();
             // auto stack_name = f->controlPlaneName();
             auto stack_size = stack->getSize();
@@ -353,19 +373,25 @@ void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bo
             }
             // addHeaderStackInstance();
         } else {
+            LOG1("alex is treating this field like a scalar local variable");
             // Treat this field like a scalar local variable
             cstring newName = refMap->newName(type->getName() + "." + f->name);
-            if (ft->is<IR::Type_Bits>()) {
+            LOG1("alex printing newname for scalarMetadataFields " << newName);
+	    if (ft->is<IR::Type_Bits>()) {
+	        LOG1("alex smdf is a type bit ");
                 auto tb = ft->to<IR::Type_Bits>();
                 pinfo->scalars_width += tb->size;
                 pinfo->scalarMetadataFields.emplace(f, newName);
             } else if (ft->is<IR::Type_Boolean>()) {
+	        LOG1("alex smdf is a type bit ");
                 pinfo->scalars_width += 1;
                 pinfo->scalarMetadataFields.emplace(f, newName);
-            } else if (ft->is<IR::Type_Error>()) {
+            } else if (ft->is<IR::Type_Error>()){
+	        LOG1("alex smdf is a type bit ");
                 pinfo->scalars_width += 32;
                 pinfo->scalarMetadataFields.emplace(f, newName);
             } else {
+	        LOG1("alex smdf is a bug ");
                 BUG("%1%: Unhandled type for %2%", ft, f);
             }
         }
@@ -387,20 +413,25 @@ bool InspectPsaProgram::preorder(const IR::Parameter* param) {
     auto ft = typeMap->getType(param->getNode(), true);
     LOG3("add param " << ft);
     // only convert parameters that are IR::Type_StructLike
-    if (!ft->is<IR::Type_StructLike>())
-        return false;
+    if (!ft->is<IR::Type_StructLike>()){
+      LOG1("alex is not type_structlike returning");
+      return false;
+    }
     auto st = ft->to<IR::Type_StructLike>();
     // check if it is psa specific standard metadata
     cstring ptName = param->type->toString();
+    // parameter must be a type that we have not seen before
+    if (pinfo->hasVisited(st)){
+      LOG1("alex is visited returning");
+      return false;
+    }
     if (isStandardMetadata(ptName)) {
+      LOG1("alex adding stdmeta");
       addHeaderType(st);
       // remove _t from type name
       cstring headerName = ptName.exceptLast(2);
       addHeaderInstance(st, headerName);
     }
-    // parameter must be a type that we have not seen before
-    if (pinfo->hasVisited(st))
-        return false;
     auto isHeader = isHeaders(st);
     addTypesAndInstances(st, isHeader);
     return false;
@@ -749,6 +780,7 @@ void ExternConverter_Counter::convertExternInstance(
     auto arg2 = tp->to<IR::Declaration_ID>();
     auto param2 = eb->getConstructorParameters()->getParameter(1);
     auto mem = arg2->toString();
+    LOG1("alex convertParam in ps.cpp for p2 " << param2->toString() << " and mem " << mem);
     auto jsn = ctxt->conv->convertParam(param2, mem);
     arr->append(jsn);
 }
@@ -793,6 +825,7 @@ void ExternConverter_DirectCounter::convertExternInstance(
         auto arg = tp->to<IR::Declaration_ID>();
         auto param = eb->getConstructorParameters()->getParameter(1);
         auto mem = arg->toString();
+	LOG1("alex convertParam in ps.cpp for param " << param->toString() << " and mem " << mem);
         auto jsn = ctxt->conv->convertParam(param, mem);
         arr->append(jsn);
     }

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -60,7 +60,7 @@ void PsaProgramStructure::createStructLike(ConversionContext* ctxt, const IR::Ty
             if (varbitFound)
                 ::error(ErrorType::ERR_UNSUPPORTED,
                         "headers with multiple varbit fields are not supported", st);
-          varbitFound = true;
+            varbitFound = true;
         } else if (ftype->is<IR::Type_Error>()) {
             field->append(f->name.name);
             field->append(error_width);
@@ -269,7 +269,7 @@ bool InspectPsaProgram::isHeaders(const IR::Type_StructLike* st) {
 }
 
 void InspectPsaProgram::addHeaderType(const IR::Type_StructLike *st) {
-  LOG1("cornell: adding headerType " << st->toString());
+    LOG1("cornell: adding headerType " << st->toString());
     if (st->is<IR::Type_HeaderUnion>()) {
       LOG1("cornell: is type_headerunion");
         for (auto f : st->fields) {

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -36,46 +36,39 @@ void PsaProgramStructure::createStructLike(ConversionContext* ctxt, const IR::Ty
     unsigned max_length = 0;  // for variable-sized headers
     bool varbitFound = false;
     auto fields = new Util::JsonArray();
-    LOG1("alex createStructLike " << st->toString());
+    LOG1("cornell: createStructLike " << st->toString());
     for (auto f : st->fields) {
         auto field = new Util::JsonArray();
         auto ftype = typeMap->getType(f, true);
-	LOG1("alex iterating getting type and name " << f << " " << ftype->toString());
+        LOG1("cornell: iterating getting type and name " << f << " " << ftype->toString());
         if (ftype->to<IR::Type_StructLike>()) {
-	  LOG1("type structlike");
             BUG("%1%: nested structure", st);
         } else if (ftype->is<IR::Type_Boolean>()) {
-	  LOG1("type boolean");
-	  field->append(f->name.name);
+            field->append(f->name.name);
             field->append(1);
             field->append(false);
             max_length += 1;
         } else if (auto type = ftype->to<IR::Type_Bits>()) {
-	  LOG1("type bits");
-	  field->append(f->name.name);
+            field->append(f->name.name);
             field->append(type->size);
             field->append(type->isSigned);
             max_length += type->size;
         } else if (auto type = ftype->to<IR::Type_Varbits>()) {
-	  LOG1("type varbits");
-	  field->append(f->name.name);
+            field->append(f->name.name);
             max_length += type->size;
             field->append("*");
             if (varbitFound)
                 ::error(ErrorType::ERR_UNSUPPORTED,
                         "headers with multiple varbit fields are not supported", st);
-            varbitFound = true;
+          varbitFound = true;
         } else if (ftype->is<IR::Type_Error>()) {
-	  LOG1("type error");
-	  field->append(f->name.name);
+            field->append(f->name.name);
             field->append(error_width);
             field->append(false);
             max_length += error_width;
         } else if (ftype->to<IR::Type_Stack>()) {
-	  LOG1("type stack");
-	  BUG("%1%: nested stack", st);
+            BUG("%1%: nested stack", st);
         } else {
-	  LOG1("type bug");
             BUG("%1%: unexpected type for %2%.%3%", ftype, st, f->name);
         }
         fields->append(field);
@@ -326,15 +319,13 @@ void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bo
     }
 
     for (auto f : type->fields) {
-      LOG1("alex iterating through fields again " << f->toString());
         auto ft = typeMap->getType(f, true);
         if (ft->is<IR::Type_StructLike>()) {
-	  LOG1("alex iterating through fields " << f->toString());
             if (auto hft = ft->to<IR::Type_Header>()) {
-                LOG1("alex is type_header");
+                LOG1("cornell: is type_header");
                 addHeaderInstance(hft, f->controlPlaneName());
             } else if (ft->is<IR::Type_HeaderUnion>()) {
-                LOG1("alex is type_headerunion");
+                LOG1("cornell: is type_headerunion");
                 for (auto uf : ft->to<IR::Type_HeaderUnion>()->fields) {
                     auto uft = typeMap->getType(uf, true);
                     if (auto h_type = uft->to<IR::Type_Header>()) {
@@ -349,12 +340,12 @@ void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bo
                                                   type->to<IR::Type_HeaderUnion>());
                 addHeaderInstance(type, f->controlPlaneName());
             } else {
-                LOG1("alex add struct type " << type);
+                LOG1("cornell: add struct type " << type);
                 pinfo->metadata_types.emplace(type->getName(), type->to<IR::Type_Struct>());
                 addHeaderInstance(type, f->controlPlaneName());
             }
         } else if (ft->is<IR::Type_Stack>()) {
-            LOG1("alex is type stack stack " << ft->toString());
+            LOG1("cornell: is type stack stack " << ft->toString());
             auto stack = ft->to<IR::Type_Stack>();
             // auto stack_name = f->controlPlaneName();
             auto stack_size = stack->getSize();
@@ -373,39 +364,28 @@ void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bo
             }
             // addHeaderStackInstance();
         } else {
-            LOG1("alex is treating this field like a scalar local variable");
             // Treat this field like a scalar local variable
             cstring newName = refMap->newName(type->getName() + "." + f->name);
-            LOG1("alex printing newname for scalarMetadataFields " << newName);
-	    if (ft->is<IR::Type_Bits>()) {
-	        LOG1("alex smdf is a type bit ");
+            LOG1("cornell: newname for scalarMetadataFields " << newName);
+            if (ft->is<IR::Type_Bits>()) {
+                LOG1("cornell: is a type bit ");
                 auto tb = ft->to<IR::Type_Bits>();
                 pinfo->scalars_width += tb->size;
                 pinfo->scalarMetadataFields.emplace(f, newName);
             } else if (ft->is<IR::Type_Boolean>()) {
-	        LOG1("alex smdf is a type bit ");
+                LOG1("cornell: smdf is a type bit ");
                 pinfo->scalars_width += 1;
                 pinfo->scalarMetadataFields.emplace(f, newName);
-            } else if (ft->is<IR::Type_Error>()){
-	        LOG1("alex smdf is a type bit ");
+            } else if (ft->is<IR::Type_Error>()) {
+                LOG1("cornell: smdf is a type bit ");
                 pinfo->scalars_width += 32;
                 pinfo->scalarMetadataFields.emplace(f, newName);
             } else {
-	        LOG1("alex smdf is a bug ");
+                LOG1("cornell: smdf is a bug ");
                 BUG("%1%: Unhandled type for %2%", ft, f);
             }
         }
     }
-}
-
-bool InspectPsaProgram::isStandardMetadata(cstring ptName) {
-    return (!strcmp(ptName, "psa_ingress_parser_input_metadata_t") ||
-        !strcmp(ptName, "psa_egress_parser_input_metadata_t") ||
-        !strcmp(ptName, "psa_ingress_input_metadata_t") ||
-        !strcmp(ptName, "psa_ingress_output_metadata_t") ||
-        !strcmp(ptName, "psa_egress_input_metadata_t") ||
-        !strcmp(ptName, "psa_egress_deparser_input_metadata_t") ||
-        !strcmp(ptName, "psa_egress_output_metadata_t"));
 }
 
 // This visitor only visits the parameter in the statement from architecture.
@@ -413,20 +393,19 @@ bool InspectPsaProgram::preorder(const IR::Parameter* param) {
     auto ft = typeMap->getType(param->getNode(), true);
     LOG3("add param " << ft);
     // only convert parameters that are IR::Type_StructLike
-    if (!ft->is<IR::Type_StructLike>()){
-      LOG1("alex is not type_structlike returning");
+    if (!ft->is<IR::Type_StructLike>()) {
       return false;
     }
     auto st = ft->to<IR::Type_StructLike>();
     // check if it is psa specific standard metadata
     cstring ptName = param->type->toString();
     // parameter must be a type that we have not seen before
-    if (pinfo->hasVisited(st)){
-      LOG1("alex is visited returning");
+    if (pinfo->hasVisited(st)) {
+      LOG1("cornell: is visited returning");
       return false;
     }
-    if (isStandardMetadata(ptName)) {
-      LOG1("alex adding stdmeta");
+    if (PsaSwitchExpressionConverter::isStandardMetadata(ptName)) {
+      LOG1("cornell: adding stdmeta");
       addHeaderType(st);
       // remove _t from type name
       cstring headerName = ptName.exceptLast(2);
@@ -780,7 +759,7 @@ void ExternConverter_Counter::convertExternInstance(
     auto arg2 = tp->to<IR::Declaration_ID>();
     auto param2 = eb->getConstructorParameters()->getParameter(1);
     auto mem = arg2->toString();
-    LOG1("alex convertParam in ps.cpp for p2 " << param2->toString() << " and mem " << mem);
+    LOG1("cornell: convertParam in ps.cpp for p2 " << param2->toString() << " and mem " << mem);
     auto jsn = ctxt->conv->convertParam(param2, mem);
     arr->append(jsn);
 }
@@ -825,7 +804,8 @@ void ExternConverter_DirectCounter::convertExternInstance(
         auto arg = tp->to<IR::Declaration_ID>();
         auto param = eb->getConstructorParameters()->getParameter(1);
         auto mem = arg->toString();
-	LOG1("alex convertParam in ps.cpp for param " << param->toString() << " and mem " << mem);
+        LOG1("cornell: convertParam in ps.cpp for param " << param->toString()
+          << " and mem " << mem);
         auto jsn = ctxt->conv->convertParam(param, mem);
         arr->append(jsn);
     }

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -269,9 +269,9 @@ bool InspectPsaProgram::isHeaders(const IR::Type_StructLike* st) {
 }
 
 void InspectPsaProgram::addHeaderType(const IR::Type_StructLike *st) {
-  LOG1("alex adding headerType " << st->toString());
+  LOG1("cornell: adding headerType " << st->toString());
     if (st->is<IR::Type_HeaderUnion>()) {
-      LOG1("alex is type_headerunion");
+      LOG1("cornell: is type_headerunion");
         for (auto f : st->fields) {
             auto ftype = typeMap->getType(f, true);
             auto ht = ftype->to<IR::Type_Header>();
@@ -281,10 +281,10 @@ void InspectPsaProgram::addHeaderType(const IR::Type_StructLike *st) {
         pinfo->header_union_types.emplace(st->getName(), st->to<IR::Type_HeaderUnion>());
         return;
     } else if (st->is<IR::Type_Header>()) {
-      LOG1("alex is type_header");
+      LOG1("cornell: is type_header");
       pinfo->header_types.emplace(st->getName(), st->to<IR::Type_Header>());
     } else if (st->is<IR::Type_Struct>()) {
-      LOG1("alex is type_struct");
+      LOG1("cornell: is type_struct");
         pinfo->metadata_types.emplace(st->getName(), st->to<IR::Type_Struct>());
     }
 }
@@ -301,9 +301,9 @@ void InspectPsaProgram::addHeaderInstance(const IR::Type_StructLike *st, cstring
 
 void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bool isHeader) {
     LOG3("Adding " << type);
-    LOG1("alex adding " << type->toString() << " and isHeader " << isHeader);
+    LOG1("cornell: adding " << type->toString() << " and isHeader " << isHeader);
     for (auto f : type->fields) {
-        LOG1("alex iterating through fields " << f->toString());
+        LOG1("cornell: iterating through fields " << f->toString());
         auto ft = typeMap->getType(f, true);
         if (ft->is<IR::Type_StructLike>()) {
             // The headers struct can not contain nested structures.

--- a/backends/bmv2/psa_switch/psaSwitch.h
+++ b/backends/bmv2/psa_switch/psaSwitch.h
@@ -60,8 +60,22 @@ class PsaSwitchExpressionConverter : public ExpressionConverter {
       return param->type->toString() == "PSA_CounterType_t";
     }
 
+    
+    bool isStandardMetadata(cstring ptName) {
+      return (!strcmp(ptName, "psa_ingress_parser_input_metadata_t") ||
+        !strcmp(ptName, "psa_egress_parser_input_metadata_t") ||
+        !strcmp(ptName, "psa_ingress_input_metadata_t") ||
+        !strcmp(ptName, "psa_ingress_output_metadata_t") ||
+        !strcmp(ptName, "psa_egress_input_metadata_t") ||
+        !strcmp(ptName, "psa_egress_deparser_input_metadata_t") ||
+        !strcmp(ptName, "psa_egress_output_metadata_t"));
+    }
+
+
     Util::IJson* convertParam(UNUSED const IR::Parameter* param, cstring fieldName) override {
-        if (isCounterMetaData(param)) {  // check if its counter metadata
+      LOG1("alex conertParam " << param->toString() << " fieldName " << fieldName);
+      cstring ptName = param->type->toString();
+      if (isCounterMetaData(param)) {  // check if its counter metadata
           auto jsn = new Util::JsonObject();
           jsn->emplace("name", param->toString());
           jsn->emplace("type", "hexstr");
@@ -82,7 +96,24 @@ class PsaSwitchExpressionConverter : public ExpressionConverter {
             return nullptr;
           }
           return jsn;
-        }
+      } else if (isStandardMetadata(ptName)) {
+	LOG1("alex is standardmetadata");
+	//TODO Alex: 
+	  auto jsn = new Util::JsonObject();
+	  //jsn->emplace("type", "field");
+	  //jsn->emplace("value", "coolbeans");
+	  jsn->emplace("type", "field");
+	  auto a = mkArrayField(jsn, "value");
+	  a->append(ptName.exceptLast(2));
+	  a->append(fieldName);
+	 
+	  //jsn->emplace("value", ptName.exceptLast(2), fieldName);
+	  
+          return jsn;
+      } else {
+	LOG1("alex return nullptr ");
+	return nullptr;
+      }
 
         LOG3("convert " << fieldName);
         return nullptr;

--- a/backends/bmv2/psa_switch/psaSwitch.h
+++ b/backends/bmv2/psa_switch/psaSwitch.h
@@ -53,15 +53,18 @@ class PsaSwitchExpressionConverter : public ExpressionConverter {
     }
 
     /**
-     * Checks if a Parameter is of type PSA_CounterType_t returns true
+     * Checks if a string is of type PSA_CounterType_t returns true
      * if it is, false otherwise.
      */
-    bool isCounterMetaData(const IR::Parameter* param) {
-      return param->type->toString() == "PSA_CounterType_t";
+    static bool isCounterMetadata(cstring ptName) {
+      return !strcmp(ptName, "PSA_CounterType_t");
     }
 
-    
-    bool isStandardMetadata(cstring ptName) {
+    /**
+     * Checks if a string is a psa metadata returns true
+     * if it is, false otherwise.
+     */
+    static bool isStandardMetadata(cstring ptName) {
       return (!strcmp(ptName, "psa_ingress_parser_input_metadata_t") ||
         !strcmp(ptName, "psa_egress_parser_input_metadata_t") ||
         !strcmp(ptName, "psa_ingress_input_metadata_t") ||
@@ -73,9 +76,8 @@ class PsaSwitchExpressionConverter : public ExpressionConverter {
 
 
     Util::IJson* convertParam(UNUSED const IR::Parameter* param, cstring fieldName) override {
-      LOG1("alex conertParam " << param->toString() << " fieldName " << fieldName);
       cstring ptName = param->type->toString();
-      if (isCounterMetaData(param)) {  // check if its counter metadata
+      if (isCounterMetadata(ptName)) {  // check if its counter metadata
           auto jsn = new Util::JsonObject();
           jsn->emplace("name", param->toString());
           jsn->emplace("type", "hexstr");
@@ -96,27 +98,20 @@ class PsaSwitchExpressionConverter : public ExpressionConverter {
             return nullptr;
           }
           return jsn;
-      } else if (isStandardMetadata(ptName)) {
-	LOG1("alex is standardmetadata");
-	//TODO Alex: 
-	  auto jsn = new Util::JsonObject();
-	  //jsn->emplace("type", "field");
-	  //jsn->emplace("value", "coolbeans");
-	  jsn->emplace("type", "field");
-	  auto a = mkArrayField(jsn, "value");
-	  a->append(ptName.exceptLast(2));
-	  a->append(fieldName);
-	 
-	  //jsn->emplace("value", ptName.exceptLast(2), fieldName);
-	  
+      } else if (isStandardMetadata(ptName)) {  // check if its psa metadata
+          auto jsn = new Util::JsonObject();
+
+          // encode the metadata type and field in json
+          jsn->emplace("type", "field");
+          auto a = mkArrayField(jsn, "value");
+          a->append(ptName.exceptLast(2));
+          a->append(fieldName);
           return jsn;
       } else {
-	LOG1("alex return nullptr ");
-	return nullptr;
-      }
-
-        LOG3("convert " << fieldName);
+        // not a special type
         return nullptr;
+      }
+      return nullptr;
     }
 };
 
@@ -219,7 +214,6 @@ class InspectPsaProgram : public Inspector {
     void postorder(const IR::Declaration_Instance* di) override;
 
     bool isHeaders(const IR::Type_StructLike* st);
-    bool isStandardMetadata(cstring ptName);
     void addTypesAndInstances(const IR::Type_StructLike* type, bool meta);
     void addHeaderType(const IR::Type_StructLike *st);
     void addHeaderInstance(const IR::Type_StructLike *st, cstring name);


### PR DESCRIPTION
Changelog:
Added referencing the metadata so ExpressionConverter::postorder actually uses the new ones. Small refactor of convertParam in psaSwitch.h and added a lot of logs so in the future I don't have to rewrite them (labeled with cornell: will remove once psa development is done). I can remove the logs if we'd like but they're helpful for development in the time being. 

Actually compiles https://github.com/jafingerhut/p4-guide/blob/master/psa-examples/psa-unicast-or-drop.p4 and https://github.com/jafingerhut/p4-guide/blob/master/psa-examples/psa-simple-reflector.p4 now.

Test:
All tests pass in travis in peteli3/p4c fork