### PR TITLE
Refactor GeneralInliner common code

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -177,7 +177,7 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/psa-example-counters-bmv2.p4
   testdata/p4_16_samples/psa-example-digest-bmv2.p4
   testdata/p4_16_samples/psa-example-register2-bmv2.p4
-  testdata/p4_16_samples/psa-fwd-bmv2.p4
+  # testdata/p4_16_samples/psa-fwd-bmv2.p4
   # This reads stack.next
   testdata/p4_16_samples/issue692-bmv2.p4
   # These test use computations in the verify/update checksum controls - unsupported

--- a/frontends/p4/inlining.h
+++ b/frontends/p4/inlining.h
@@ -225,6 +225,7 @@ class GeneralInliner : public AbstractInliner<InlineList, InlineSummary> {
     }
     // controlled visiting order
     const IR::Node* preorder(IR::MethodCallStatement* statement) override;
+    template<class T> void inline_subst(T *caller, IR::IndexedVector<IR::Declaration> T::*locals);
     const IR::Node* preorder(IR::P4Control* caller) override;
     const IR::Node* preorder(IR::P4Parser* caller) override;
     const IR::Node* preorder(IR::ParserState* state) override;

--- a/testdata/p4_16_samples_outputs/functors2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/functors2-frontend.p4
@@ -6,34 +6,28 @@ parser p2_0(out bit<2> z2) {
     bit<2> x1_0;
     bit<2> x2_0;
     bit<2> x3_0;
-    bit<2> z1_0;
-    bit<2> z1_1;
-    bit<2> z1_2;
     state start {
         transition p1_0_start;
     }
     state p1_0_start {
-        z1_0 = 2w0;
+        x1_0 = 2w0;
         transition start_0;
     }
     state start_0 {
-        x1_0 = z1_0;
         transition p1_1_start;
     }
     state p1_1_start {
-        z1_1 = 2w1;
+        x2_0 = 2w1;
         transition start_1;
     }
     state start_1 {
-        x2_0 = z1_1;
         transition p1_2_start;
     }
     state p1_2_start {
-        z1_2 = 2w2;
+        x3_0 = 2w2;
         transition start_2;
     }
     state start_2 {
-        x3_0 = z1_2;
         z2 = 2w3 | x1_0 | x2_0 | x3_0;
         transition accept;
     }

--- a/testdata/p4_16_samples_outputs/functors3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/functors3-frontend.p4
@@ -3,16 +3,14 @@
 parser simple(out bit<1> z);
 package m(simple n);
 parser p_0(out bit<1> z) {
-    bit<1> z1_0;
     state start {
         transition p1_0_start;
     }
     state p1_0_start {
-        z1_0 = 1w0;
+        z = 1w0;
         transition start_0;
     }
     state start_0 {
-        z = z1_0;
         z = z & 1w0 & 1w1;
         transition accept;
     }

--- a/testdata/p4_16_samples_outputs/functors4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/functors4-frontend.p4
@@ -1,16 +1,14 @@
 #include <core.p4>
 
 parser p(out bit<1> z) {
-    bit<1> z1_0;
     state start {
         transition p1_0_start;
     }
     state p1_0_start {
-        z1_0 = 1w0;
+        z = 1w0;
         transition start_0;
     }
     state start_0 {
-        z = z1_0;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/functors5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/functors5-frontend.p4
@@ -3,16 +3,14 @@
 parser simple(out bit<2> w);
 package m(simple n);
 parser p2_0(out bit<2> w) {
-    bit<2> w_0;
     state start {
         transition p1_0_start;
     }
     state p1_0_start {
-        w_0 = 2w2;
+        w = 2w2;
         transition start_0;
     }
     state start_0 {
-        w = w_0;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1470-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1470-bmv2-frontend.p4
@@ -31,25 +31,23 @@ struct headers_t {
 }
 
 parser OuterParser(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t meta) {
-    headers_t hdr_0;
     state start {
-        hdr_0.eth.setInvalid();
-        hdr_0.ipv4.setInvalid();
+        hdr.eth.setInvalid();
+        hdr.ipv4.setInvalid();
         transition InnerParser_start;
     }
     state InnerParser_start {
-        pkt.extract<eth_h>(hdr_0.eth);
-        transition select(hdr_0.eth.type) {
+        pkt.extract<eth_h>(hdr.eth);
+        transition select(hdr.eth.type) {
             16w0x800: InnerParser_parse_ipv4;
             default: start_0;
         }
     }
     state InnerParser_parse_ipv4 {
-        pkt.extract<ipv4_h>(hdr_0.ipv4);
+        pkt.extract<ipv4_h>(hdr.ipv4);
         transition start_0;
     }
     state start_0 {
-        hdr = hdr_0;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1470-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1470-bmv2-midend.p4
@@ -31,24 +31,20 @@ struct headers_t {
 }
 
 parser OuterParser(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t meta) {
-    eth_h hdr_0_eth;
-    ipv4_h hdr_0_ipv4;
     state start {
-        hdr_0_eth.setInvalid();
-        hdr_0_ipv4.setInvalid();
-        pkt.extract<eth_h>(hdr_0_eth);
-        transition select(hdr_0_eth.type) {
+        hdr.eth.setInvalid();
+        hdr.ipv4.setInvalid();
+        pkt.extract<eth_h>(hdr.eth);
+        transition select(hdr.eth.type) {
             16w0x800: InnerParser_parse_ipv4;
             default: start_0;
         }
     }
     state InnerParser_parse_ipv4 {
-        pkt.extract<ipv4_h>(hdr_0_ipv4);
+        pkt.extract<ipv4_h>(hdr.ipv4);
         transition start_0;
     }
     state start_0 {
-        hdr.eth = hdr_0_eth;
-        hdr.ipv4 = hdr_0_ipv4;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue281-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue281-frontend.p4
@@ -39,37 +39,29 @@ struct m {
 }
 
 parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t std) {
-    h hdr_0;
-    ethernet_t l2_ether;
-    h hdr_1;
     bit<16> l3_etherType;
-    ipv4_t l3_ipv4;
-    vlan_t l3_vlan;
     state start {
-        hdr_0.ether.setInvalid();
-        hdr_0.vlan.setInvalid();
-        hdr_0.ipv4.setInvalid();
+        hdr.ether.setInvalid();
+        hdr.vlan.setInvalid();
+        hdr.ipv4.setInvalid();
         transition L2_start;
     }
     state L2_start {
-        l2_ether.setInvalid();
+        hdr.ether.setInvalid();
         transition L2_EthernetParser_start;
     }
     state L2_EthernetParser_start {
-        b.extract<ethernet_t>(l2_ether);
+        b.extract<ethernet_t>(hdr.ether);
         transition L2_start_0;
     }
     state L2_start_0 {
-        hdr_0.ether = l2_ether;
         transition start_1;
     }
     state start_1 {
-        hdr = hdr_0;
-        hdr_1 = hdr;
         transition L3_start;
     }
     state L3_start {
-        l3_etherType = hdr_1.ether.etherType;
+        l3_etherType = hdr.ether.etherType;
         transition select(l3_etherType) {
             16w0x800: L3_ipv4;
             16w0x8100: L3_vlan;
@@ -77,31 +69,28 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
         }
     }
     state L3_ipv4 {
-        l3_ipv4.setInvalid();
+        hdr.ipv4.setInvalid();
         transition L3_Ipv4Parser_start;
     }
     state L3_Ipv4Parser_start {
-        b.extract<ipv4_t>(l3_ipv4);
+        b.extract<ipv4_t>(hdr.ipv4);
         transition L3_ipv4_0;
     }
     state L3_ipv4_0 {
-        hdr_1.ipv4 = l3_ipv4;
         transition start_2;
     }
     state L3_vlan {
-        l3_vlan.setInvalid();
+        hdr.vlan.setInvalid();
         transition L3_VlanParser_start;
     }
     state L3_VlanParser_start {
-        b.extract<vlan_t>(l3_vlan);
+        b.extract<vlan_t>(hdr.vlan);
         transition L3_vlan_0;
     }
     state L3_vlan_0 {
-        hdr_1.vlan = l3_vlan;
         transition L3_start;
     }
     state start_2 {
-        hdr = hdr_1;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue281-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue281-midend.p4
@@ -39,53 +39,32 @@ struct m {
 }
 
 parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t std) {
-    ethernet_t hdr_0_ether;
-    vlan_t hdr_0_vlan;
-    ipv4_t hdr_0_ipv4;
-    ethernet_t l2_ether;
-    ethernet_t hdr_1_ether;
-    vlan_t hdr_1_vlan;
-    ipv4_t hdr_1_ipv4;
-    ipv4_t l3_ipv4;
-    vlan_t l3_vlan;
     state start {
-        hdr_0_ether.setInvalid();
-        hdr_0_vlan.setInvalid();
-        hdr_0_ipv4.setInvalid();
-        l2_ether.setInvalid();
-        b.extract<ethernet_t>(l2_ether);
-        hdr_0_ether = l2_ether;
-        hdr.ether = l2_ether;
-        hdr.vlan = hdr_0_vlan;
-        hdr.ipv4 = hdr_0_ipv4;
-        hdr_1_ether = l2_ether;
-        hdr_1_vlan = hdr_0_vlan;
-        hdr_1_ipv4 = hdr_0_ipv4;
+        hdr.ether.setInvalid();
+        hdr.vlan.setInvalid();
+        hdr.ipv4.setInvalid();
+        hdr.ether.setInvalid();
+        b.extract<ethernet_t>(hdr.ether);
         transition L3_start;
     }
     state L3_start {
-        transition select(hdr_1_ether.etherType) {
+        transition select(hdr.ether.etherType) {
             16w0x800: L3_ipv4;
             16w0x8100: L3_vlan;
             default: start_2;
         }
     }
     state L3_ipv4 {
-        l3_ipv4.setInvalid();
-        b.extract<ipv4_t>(l3_ipv4);
-        hdr_1_ipv4 = l3_ipv4;
+        hdr.ipv4.setInvalid();
+        b.extract<ipv4_t>(hdr.ipv4);
         transition start_2;
     }
     state L3_vlan {
-        l3_vlan.setInvalid();
-        b.extract<vlan_t>(l3_vlan);
-        hdr_1_vlan = l3_vlan;
+        hdr.vlan.setInvalid();
+        b.extract<vlan_t>(hdr.vlan);
         transition L3_start;
     }
     state start_2 {
-        hdr.ether = hdr_1_ether;
-        hdr.vlan = hdr_1_vlan;
-        hdr.ipv4 = hdr_1_ipv4;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
@@ -102,9 +102,6 @@ struct Tcp_option_sack_top {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<4> tcp_hdr_data_offset_0;
-    Tcp_option_stack vec_0;
-    Tcp_option_padding_h padding_0;
     bit<7> Tcp_option_parser_tcp_hdr_bytes_left;
     bit<8> Tcp_option_parser_n_sack_bytes;
     bit<8> Tcp_option_parser_tmp;
@@ -125,63 +122,62 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     state parse_tcp {
         packet.extract<tcp_t>(hdr.tcp);
-        tcp_hdr_data_offset_0 = hdr.tcp.dataOffset;
-        vec_0[0].end.setInvalid();
-        vec_0[0].nop.setInvalid();
-        vec_0[0].ss.setInvalid();
-        vec_0[0].s.setInvalid();
-        vec_0[0].sack.setInvalid();
-        vec_0[1].end.setInvalid();
-        vec_0[1].nop.setInvalid();
-        vec_0[1].ss.setInvalid();
-        vec_0[1].s.setInvalid();
-        vec_0[1].sack.setInvalid();
-        vec_0[2].end.setInvalid();
-        vec_0[2].nop.setInvalid();
-        vec_0[2].ss.setInvalid();
-        vec_0[2].s.setInvalid();
-        vec_0[2].sack.setInvalid();
-        vec_0[3].end.setInvalid();
-        vec_0[3].nop.setInvalid();
-        vec_0[3].ss.setInvalid();
-        vec_0[3].s.setInvalid();
-        vec_0[3].sack.setInvalid();
-        vec_0[4].end.setInvalid();
-        vec_0[4].nop.setInvalid();
-        vec_0[4].ss.setInvalid();
-        vec_0[4].s.setInvalid();
-        vec_0[4].sack.setInvalid();
-        vec_0[5].end.setInvalid();
-        vec_0[5].nop.setInvalid();
-        vec_0[5].ss.setInvalid();
-        vec_0[5].s.setInvalid();
-        vec_0[5].sack.setInvalid();
-        vec_0[6].end.setInvalid();
-        vec_0[6].nop.setInvalid();
-        vec_0[6].ss.setInvalid();
-        vec_0[6].s.setInvalid();
-        vec_0[6].sack.setInvalid();
-        vec_0[7].end.setInvalid();
-        vec_0[7].nop.setInvalid();
-        vec_0[7].ss.setInvalid();
-        vec_0[7].s.setInvalid();
-        vec_0[7].sack.setInvalid();
-        vec_0[8].end.setInvalid();
-        vec_0[8].nop.setInvalid();
-        vec_0[8].ss.setInvalid();
-        vec_0[8].s.setInvalid();
-        vec_0[8].sack.setInvalid();
-        vec_0[9].end.setInvalid();
-        vec_0[9].nop.setInvalid();
-        vec_0[9].ss.setInvalid();
-        vec_0[9].s.setInvalid();
-        vec_0[9].sack.setInvalid();
-        padding_0.setInvalid();
+        hdr.tcp_options_vec[0].end.setInvalid();
+        hdr.tcp_options_vec[0].nop.setInvalid();
+        hdr.tcp_options_vec[0].ss.setInvalid();
+        hdr.tcp_options_vec[0].s.setInvalid();
+        hdr.tcp_options_vec[0].sack.setInvalid();
+        hdr.tcp_options_vec[1].end.setInvalid();
+        hdr.tcp_options_vec[1].nop.setInvalid();
+        hdr.tcp_options_vec[1].ss.setInvalid();
+        hdr.tcp_options_vec[1].s.setInvalid();
+        hdr.tcp_options_vec[1].sack.setInvalid();
+        hdr.tcp_options_vec[2].end.setInvalid();
+        hdr.tcp_options_vec[2].nop.setInvalid();
+        hdr.tcp_options_vec[2].ss.setInvalid();
+        hdr.tcp_options_vec[2].s.setInvalid();
+        hdr.tcp_options_vec[2].sack.setInvalid();
+        hdr.tcp_options_vec[3].end.setInvalid();
+        hdr.tcp_options_vec[3].nop.setInvalid();
+        hdr.tcp_options_vec[3].ss.setInvalid();
+        hdr.tcp_options_vec[3].s.setInvalid();
+        hdr.tcp_options_vec[3].sack.setInvalid();
+        hdr.tcp_options_vec[4].end.setInvalid();
+        hdr.tcp_options_vec[4].nop.setInvalid();
+        hdr.tcp_options_vec[4].ss.setInvalid();
+        hdr.tcp_options_vec[4].s.setInvalid();
+        hdr.tcp_options_vec[4].sack.setInvalid();
+        hdr.tcp_options_vec[5].end.setInvalid();
+        hdr.tcp_options_vec[5].nop.setInvalid();
+        hdr.tcp_options_vec[5].ss.setInvalid();
+        hdr.tcp_options_vec[5].s.setInvalid();
+        hdr.tcp_options_vec[5].sack.setInvalid();
+        hdr.tcp_options_vec[6].end.setInvalid();
+        hdr.tcp_options_vec[6].nop.setInvalid();
+        hdr.tcp_options_vec[6].ss.setInvalid();
+        hdr.tcp_options_vec[6].s.setInvalid();
+        hdr.tcp_options_vec[6].sack.setInvalid();
+        hdr.tcp_options_vec[7].end.setInvalid();
+        hdr.tcp_options_vec[7].nop.setInvalid();
+        hdr.tcp_options_vec[7].ss.setInvalid();
+        hdr.tcp_options_vec[7].s.setInvalid();
+        hdr.tcp_options_vec[7].sack.setInvalid();
+        hdr.tcp_options_vec[8].end.setInvalid();
+        hdr.tcp_options_vec[8].nop.setInvalid();
+        hdr.tcp_options_vec[8].ss.setInvalid();
+        hdr.tcp_options_vec[8].s.setInvalid();
+        hdr.tcp_options_vec[8].sack.setInvalid();
+        hdr.tcp_options_vec[9].end.setInvalid();
+        hdr.tcp_options_vec[9].nop.setInvalid();
+        hdr.tcp_options_vec[9].ss.setInvalid();
+        hdr.tcp_options_vec[9].s.setInvalid();
+        hdr.tcp_options_vec[9].sack.setInvalid();
+        hdr.tcp_options_padding.setInvalid();
         transition Tcp_option_parser_start;
     }
     state Tcp_option_parser_start {
-        verify(tcp_hdr_data_offset_0 >= 4w5, error.TcpDataOffsetTooSmall);
-        Tcp_option_parser_tcp_hdr_bytes_left = (bit<7>)(tcp_hdr_data_offset_0 + 4w11) << 2;
+        verify(hdr.tcp.dataOffset >= 4w5, error.TcpDataOffsetTooSmall);
+        Tcp_option_parser_tcp_hdr_bytes_left = (bit<7>)(hdr.tcp.dataOffset + 4w11) << 2;
         transition Tcp_option_parser_next_option;
     }
     state Tcp_option_parser_next_option {
@@ -201,26 +197,26 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state Tcp_option_parser_parse_tcp_option_end {
-        packet.extract<Tcp_option_end_h>(vec_0.next.end);
+        packet.extract<Tcp_option_end_h>(hdr.tcp_options_vec.next.end);
         Tcp_option_parser_tcp_hdr_bytes_left = Tcp_option_parser_tcp_hdr_bytes_left + 7w127;
-        packet.extract<Tcp_option_padding_h>(padding_0, (bit<32>)((bit<9>)Tcp_option_parser_tcp_hdr_bytes_left << 3));
+        packet.extract<Tcp_option_padding_h>(hdr.tcp_options_padding, (bit<32>)((bit<9>)Tcp_option_parser_tcp_hdr_bytes_left << 3));
         transition parse_tcp_0;
     }
     state Tcp_option_parser_parse_tcp_option_nop {
-        packet.extract<Tcp_option_nop_h>(vec_0.next.nop);
+        packet.extract<Tcp_option_nop_h>(hdr.tcp_options_vec.next.nop);
         Tcp_option_parser_tcp_hdr_bytes_left = Tcp_option_parser_tcp_hdr_bytes_left + 7w127;
         transition Tcp_option_parser_next_option;
     }
     state Tcp_option_parser_parse_tcp_option_ss {
         verify(Tcp_option_parser_tcp_hdr_bytes_left >= 7w5, error.TcpOptionTooLongForHeader);
         Tcp_option_parser_tcp_hdr_bytes_left = Tcp_option_parser_tcp_hdr_bytes_left + 7w123;
-        packet.extract<Tcp_option_ss_h>(vec_0.next.ss);
+        packet.extract<Tcp_option_ss_h>(hdr.tcp_options_vec.next.ss);
         transition Tcp_option_parser_next_option;
     }
     state Tcp_option_parser_parse_tcp_option_s {
         verify(Tcp_option_parser_tcp_hdr_bytes_left >= 7w4, error.TcpOptionTooLongForHeader);
         Tcp_option_parser_tcp_hdr_bytes_left = Tcp_option_parser_tcp_hdr_bytes_left + 7w124;
-        packet.extract<Tcp_option_s_h>(vec_0.next.s);
+        packet.extract<Tcp_option_s_h>(hdr.tcp_options_vec.next.s);
         transition Tcp_option_parser_next_option;
     }
     state Tcp_option_parser_parse_tcp_option_sack {
@@ -229,12 +225,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         verify(Tcp_option_parser_n_sack_bytes == 8w10 || Tcp_option_parser_n_sack_bytes == 8w18 || Tcp_option_parser_n_sack_bytes == 8w26 || Tcp_option_parser_n_sack_bytes == 8w34, error.TcpBadSackOptionLength);
         verify(Tcp_option_parser_tcp_hdr_bytes_left >= (bit<7>)Tcp_option_parser_n_sack_bytes, error.TcpOptionTooLongForHeader);
         Tcp_option_parser_tcp_hdr_bytes_left = Tcp_option_parser_tcp_hdr_bytes_left - (bit<7>)Tcp_option_parser_n_sack_bytes;
-        packet.extract<Tcp_option_sack_h>(vec_0.next.sack, (bit<32>)((Tcp_option_parser_n_sack_bytes << 3) + 8w240));
+        packet.extract<Tcp_option_sack_h>(hdr.tcp_options_vec.next.sack, (bit<32>)((Tcp_option_parser_n_sack_bytes << 3) + 8w240));
         transition Tcp_option_parser_next_option;
     }
     state parse_tcp_0 {
-        hdr.tcp_options_vec = vec_0;
-        hdr.tcp_options_padding = padding_0;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
@@ -103,8 +103,6 @@ struct Tcp_option_sack_top {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    Tcp_option_stack vec_0;
-    Tcp_option_padding_h padding_0;
     bit<7> Tcp_option_parser_tcp_hdr_bytes_left;
     bit<8> Tcp_option_parser_tmp;
     bit<16> tmp;
@@ -124,57 +122,57 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     state parse_tcp {
         packet.extract<tcp_t>(hdr.tcp);
-        vec_0[0].end.setInvalid();
-        vec_0[0].nop.setInvalid();
-        vec_0[0].ss.setInvalid();
-        vec_0[0].s.setInvalid();
-        vec_0[0].sack.setInvalid();
-        vec_0[1].end.setInvalid();
-        vec_0[1].nop.setInvalid();
-        vec_0[1].ss.setInvalid();
-        vec_0[1].s.setInvalid();
-        vec_0[1].sack.setInvalid();
-        vec_0[2].end.setInvalid();
-        vec_0[2].nop.setInvalid();
-        vec_0[2].ss.setInvalid();
-        vec_0[2].s.setInvalid();
-        vec_0[2].sack.setInvalid();
-        vec_0[3].end.setInvalid();
-        vec_0[3].nop.setInvalid();
-        vec_0[3].ss.setInvalid();
-        vec_0[3].s.setInvalid();
-        vec_0[3].sack.setInvalid();
-        vec_0[4].end.setInvalid();
-        vec_0[4].nop.setInvalid();
-        vec_0[4].ss.setInvalid();
-        vec_0[4].s.setInvalid();
-        vec_0[4].sack.setInvalid();
-        vec_0[5].end.setInvalid();
-        vec_0[5].nop.setInvalid();
-        vec_0[5].ss.setInvalid();
-        vec_0[5].s.setInvalid();
-        vec_0[5].sack.setInvalid();
-        vec_0[6].end.setInvalid();
-        vec_0[6].nop.setInvalid();
-        vec_0[6].ss.setInvalid();
-        vec_0[6].s.setInvalid();
-        vec_0[6].sack.setInvalid();
-        vec_0[7].end.setInvalid();
-        vec_0[7].nop.setInvalid();
-        vec_0[7].ss.setInvalid();
-        vec_0[7].s.setInvalid();
-        vec_0[7].sack.setInvalid();
-        vec_0[8].end.setInvalid();
-        vec_0[8].nop.setInvalid();
-        vec_0[8].ss.setInvalid();
-        vec_0[8].s.setInvalid();
-        vec_0[8].sack.setInvalid();
-        vec_0[9].end.setInvalid();
-        vec_0[9].nop.setInvalid();
-        vec_0[9].ss.setInvalid();
-        vec_0[9].s.setInvalid();
-        vec_0[9].sack.setInvalid();
-        padding_0.setInvalid();
+        hdr.tcp_options_vec[0].end.setInvalid();
+        hdr.tcp_options_vec[0].nop.setInvalid();
+        hdr.tcp_options_vec[0].ss.setInvalid();
+        hdr.tcp_options_vec[0].s.setInvalid();
+        hdr.tcp_options_vec[0].sack.setInvalid();
+        hdr.tcp_options_vec[1].end.setInvalid();
+        hdr.tcp_options_vec[1].nop.setInvalid();
+        hdr.tcp_options_vec[1].ss.setInvalid();
+        hdr.tcp_options_vec[1].s.setInvalid();
+        hdr.tcp_options_vec[1].sack.setInvalid();
+        hdr.tcp_options_vec[2].end.setInvalid();
+        hdr.tcp_options_vec[2].nop.setInvalid();
+        hdr.tcp_options_vec[2].ss.setInvalid();
+        hdr.tcp_options_vec[2].s.setInvalid();
+        hdr.tcp_options_vec[2].sack.setInvalid();
+        hdr.tcp_options_vec[3].end.setInvalid();
+        hdr.tcp_options_vec[3].nop.setInvalid();
+        hdr.tcp_options_vec[3].ss.setInvalid();
+        hdr.tcp_options_vec[3].s.setInvalid();
+        hdr.tcp_options_vec[3].sack.setInvalid();
+        hdr.tcp_options_vec[4].end.setInvalid();
+        hdr.tcp_options_vec[4].nop.setInvalid();
+        hdr.tcp_options_vec[4].ss.setInvalid();
+        hdr.tcp_options_vec[4].s.setInvalid();
+        hdr.tcp_options_vec[4].sack.setInvalid();
+        hdr.tcp_options_vec[5].end.setInvalid();
+        hdr.tcp_options_vec[5].nop.setInvalid();
+        hdr.tcp_options_vec[5].ss.setInvalid();
+        hdr.tcp_options_vec[5].s.setInvalid();
+        hdr.tcp_options_vec[5].sack.setInvalid();
+        hdr.tcp_options_vec[6].end.setInvalid();
+        hdr.tcp_options_vec[6].nop.setInvalid();
+        hdr.tcp_options_vec[6].ss.setInvalid();
+        hdr.tcp_options_vec[6].s.setInvalid();
+        hdr.tcp_options_vec[6].sack.setInvalid();
+        hdr.tcp_options_vec[7].end.setInvalid();
+        hdr.tcp_options_vec[7].nop.setInvalid();
+        hdr.tcp_options_vec[7].ss.setInvalid();
+        hdr.tcp_options_vec[7].s.setInvalid();
+        hdr.tcp_options_vec[7].sack.setInvalid();
+        hdr.tcp_options_vec[8].end.setInvalid();
+        hdr.tcp_options_vec[8].nop.setInvalid();
+        hdr.tcp_options_vec[8].ss.setInvalid();
+        hdr.tcp_options_vec[8].s.setInvalid();
+        hdr.tcp_options_vec[8].sack.setInvalid();
+        hdr.tcp_options_vec[9].end.setInvalid();
+        hdr.tcp_options_vec[9].nop.setInvalid();
+        hdr.tcp_options_vec[9].ss.setInvalid();
+        hdr.tcp_options_vec[9].s.setInvalid();
+        hdr.tcp_options_vec[9].sack.setInvalid();
+        hdr.tcp_options_padding.setInvalid();
         verify(hdr.tcp.dataOffset >= 4w5, error.TcpDataOffsetTooSmall);
         Tcp_option_parser_tcp_hdr_bytes_left = (bit<7>)(hdr.tcp.dataOffset + 4w11) << 2;
         transition Tcp_option_parser_next_option;
@@ -197,26 +195,26 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state Tcp_option_parser_parse_tcp_option_end {
-        packet.extract<Tcp_option_end_h>(vec_0.next.end);
+        packet.extract<Tcp_option_end_h>(hdr.tcp_options_vec.next.end);
         Tcp_option_parser_tcp_hdr_bytes_left = Tcp_option_parser_tcp_hdr_bytes_left + 7w127;
-        packet.extract<Tcp_option_padding_h>(padding_0, (bit<32>)((bit<9>)Tcp_option_parser_tcp_hdr_bytes_left << 3));
+        packet.extract<Tcp_option_padding_h>(hdr.tcp_options_padding, (bit<32>)((bit<9>)Tcp_option_parser_tcp_hdr_bytes_left << 3));
         transition parse_tcp_0;
     }
     state Tcp_option_parser_parse_tcp_option_nop {
-        packet.extract<Tcp_option_nop_h>(vec_0.next.nop);
+        packet.extract<Tcp_option_nop_h>(hdr.tcp_options_vec.next.nop);
         Tcp_option_parser_tcp_hdr_bytes_left = Tcp_option_parser_tcp_hdr_bytes_left + 7w127;
         transition Tcp_option_parser_next_option;
     }
     state Tcp_option_parser_parse_tcp_option_ss {
         verify(Tcp_option_parser_tcp_hdr_bytes_left >= 7w5, error.TcpOptionTooLongForHeader);
         Tcp_option_parser_tcp_hdr_bytes_left = Tcp_option_parser_tcp_hdr_bytes_left + 7w123;
-        packet.extract<Tcp_option_ss_h>(vec_0.next.ss);
+        packet.extract<Tcp_option_ss_h>(hdr.tcp_options_vec.next.ss);
         transition Tcp_option_parser_next_option;
     }
     state Tcp_option_parser_parse_tcp_option_s {
         verify(Tcp_option_parser_tcp_hdr_bytes_left >= 7w4, error.TcpOptionTooLongForHeader);
         Tcp_option_parser_tcp_hdr_bytes_left = Tcp_option_parser_tcp_hdr_bytes_left + 7w124;
-        packet.extract<Tcp_option_s_h>(vec_0.next.s);
+        packet.extract<Tcp_option_s_h>(hdr.tcp_options_vec.next.s);
         transition Tcp_option_parser_next_option;
     }
     state Tcp_option_parser_parse_tcp_option_sack {
@@ -224,12 +222,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         verify(tmp[7:0] == 8w10 || tmp[7:0] == 8w18 || tmp[7:0] == 8w26 || tmp[7:0] == 8w34, error.TcpBadSackOptionLength);
         verify(Tcp_option_parser_tcp_hdr_bytes_left >= (bit<7>)tmp[7:0], error.TcpOptionTooLongForHeader);
         Tcp_option_parser_tcp_hdr_bytes_left = Tcp_option_parser_tcp_hdr_bytes_left - (bit<7>)tmp[7:0];
-        packet.extract<Tcp_option_sack_h>(vec_0.next.sack, (bit<32>)((tmp[7:0] << 3) + 8w240));
+        packet.extract<Tcp_option_sack_h>(hdr.tcp_options_vec.next.sack, (bit<32>)((tmp[7:0] << 3) + 8w240));
         transition Tcp_option_parser_next_option;
     }
     state parse_tcp_0 {
-        hdr.tcp_options_vec = vec_0;
-        hdr.tcp_options_padding = padding_0;
         transition accept;
     }
     state noMatch {

--- a/testdata/p4_16_samples_outputs/issue823-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue823-frontend.p4
@@ -12,9 +12,8 @@ struct headers_t {
 }
 
 parser MyP1(packet_in pkt, out headers_t hdr) {
-    headers_t hdr_0;
     state start {
-        hdr_0.data.setInvalid();
+        hdr.data.setInvalid();
         transition MyP2_start;
     }
     state MyP2_start {

--- a/testdata/p4_16_samples_outputs/issue823-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue823-midend.p4
@@ -12,9 +12,8 @@ struct headers_t {
 }
 
 parser MyP1(packet_in pkt, out headers_t hdr) {
-    data_h hdr_0_data;
     state start {
-        hdr_0_data.setInvalid();
+        hdr.data.setInvalid();
         transition reject;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue982-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue982-frontend.p4
@@ -262,10 +262,6 @@ struct headers {
 }
 
 parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
-    headers parsed_hdr_0;
-    metadata user_meta_0;
-    psa_egress_parser_input_metadata_t istd_0;
-    metadata user_meta_1;
     state start {
         transition select(istd.instance_type) {
             InstanceType_t.CLONE: parse_clone_header;
@@ -273,51 +269,45 @@ parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata
         }
     }
     state parse_ethernet {
-        parsed_hdr_0.ethernet.setInvalid();
-        parsed_hdr_0.ipv4.setInvalid();
-        user_meta_0 = user_meta;
+        parsed_hdr.ethernet.setInvalid();
+        parsed_hdr.ipv4.setInvalid();
         transition CommonParser_start;
     }
     state CommonParser_start {
-        buffer.extract<ethernet_t>(parsed_hdr_0.ethernet);
-        transition select(parsed_hdr_0.ethernet.etherType) {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4;
             default: parse_ethernet_0;
         }
     }
     state CommonParser_parse_ipv4 {
-        buffer.extract<ipv4_t>(parsed_hdr_0.ipv4);
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
         transition parse_ethernet_0;
     }
     state parse_ethernet_0 {
-        parsed_hdr = parsed_hdr_0;
-        user_meta = user_meta_0;
         transition accept;
     }
     state parse_clone_header {
-        istd_0 = istd;
-        user_meta_1 = user_meta;
         transition CloneParser_start;
     }
     state CloneParser_start {
-        transition select(istd_0.clone_metadata.type) {
+        transition select(istd.clone_metadata.type) {
             3w0: CloneParser_parse_clone_header;
             3w1: CloneParser_parse_clone_header_0;
             default: reject;
         }
     }
     state CloneParser_parse_clone_header {
-        user_meta_1.custom_clone_id = istd_0.clone_metadata.type;
-        user_meta_1.clone_0 = istd_0.clone_metadata.data.h0;
+        user_meta.custom_clone_id = istd.clone_metadata.type;
+        user_meta.clone_0 = istd.clone_metadata.data.h0;
         transition parse_clone_header_2;
     }
     state CloneParser_parse_clone_header_0 {
-        user_meta_1.custom_clone_id = istd_0.clone_metadata.type;
-        user_meta_1.clone_1 = istd_0.clone_metadata.data.h1;
+        user_meta.custom_clone_id = istd.clone_metadata.type;
+        user_meta.clone_1 = istd.clone_metadata.data.h1;
         transition parse_clone_header_2;
     }
     state parse_clone_header_2 {
-        user_meta = user_meta_1;
         transition parse_ethernet;
     }
 }
@@ -348,28 +338,23 @@ control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_
 }
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
-    headers parsed_hdr_1;
-    metadata user_meta_2;
     state start {
-        parsed_hdr_1.ethernet.setInvalid();
-        parsed_hdr_1.ipv4.setInvalid();
-        user_meta_2 = user_meta;
+        parsed_hdr.ethernet.setInvalid();
+        parsed_hdr.ipv4.setInvalid();
         transition CommonParser_start_0;
     }
     state CommonParser_start_0 {
-        buffer.extract<ethernet_t>(parsed_hdr_1.ethernet);
-        transition select(parsed_hdr_1.ethernet.etherType) {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4_0;
             default: start_0;
         }
     }
     state CommonParser_parse_ipv4_0 {
-        buffer.extract<ipv4_t>(parsed_hdr_1.ipv4);
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
         transition start_0;
     }
     state start_0 {
-        parsed_hdr = parsed_hdr_1;
-        user_meta = user_meta_2;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue982-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue982-midend.p4
@@ -262,18 +262,6 @@ struct headers {
 }
 
 parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
-    ethernet_t parsed_hdr_0_ethernet;
-    ipv4_t parsed_hdr_0_ipv4;
-    fwd_metadata_t user_meta_0_fwd_metadata;
-    bit<3> user_meta_0_custom_clone_id;
-    clone_0_t user_meta_0_clone;
-    clone_1_t user_meta_0_clone_0;
-    bit<3> istd_0_clone_metadata_type;
-    clone_union_t istd_0_clone_metadata_data;
-    fwd_metadata_t user_meta_1_fwd_metadata;
-    bit<3> user_meta_1_custom_clone_id;
-    clone_0_t user_meta_1_clone;
-    clone_1_t user_meta_1_clone_0;
     state start {
         transition select(istd.instance_type) {
             InstanceType_t.CLONE: parse_clone_header;
@@ -282,39 +270,22 @@ parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata
         }
     }
     state parse_ethernet {
-        parsed_hdr_0_ethernet.setInvalid();
-        parsed_hdr_0_ipv4.setInvalid();
-        user_meta_0_fwd_metadata.outport = user_meta._fwd_metadata_outport0;
-        user_meta_0_custom_clone_id = user_meta._custom_clone_id1;
-        user_meta_0_clone = user_meta._clone_02;
-        user_meta_0_clone_0 = user_meta._clone_13;
-        buffer.extract<ethernet_t>(parsed_hdr_0_ethernet);
-        transition select(parsed_hdr_0_ethernet.etherType) {
+        parsed_hdr.ethernet.setInvalid();
+        parsed_hdr.ipv4.setInvalid();
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4;
             default: parse_ethernet_0;
         }
     }
     state CommonParser_parse_ipv4 {
-        buffer.extract<ipv4_t>(parsed_hdr_0_ipv4);
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
         transition parse_ethernet_0;
     }
     state parse_ethernet_0 {
-        parsed_hdr.ethernet = parsed_hdr_0_ethernet;
-        parsed_hdr.ipv4 = parsed_hdr_0_ipv4;
-        user_meta._fwd_metadata_outport0 = user_meta_0_fwd_metadata.outport;
-        user_meta._custom_clone_id1 = user_meta_0_custom_clone_id;
-        user_meta._clone_02 = user_meta_0_clone;
-        user_meta._clone_13 = user_meta_0_clone_0;
         transition accept;
     }
     state parse_clone_header {
-        istd_0_clone_metadata_type = istd.clone_metadata.type;
-        istd_0_clone_metadata_data.h0 = istd.clone_metadata.data.h0;
-        istd_0_clone_metadata_data.h1 = istd.clone_metadata.data.h1;
-        user_meta_1_fwd_metadata.outport = user_meta._fwd_metadata_outport0;
-        user_meta_1_custom_clone_id = user_meta._custom_clone_id1;
-        user_meta_1_clone = user_meta._clone_02;
-        user_meta_1_clone_0 = user_meta._clone_13;
         transition select(istd.clone_metadata.type) {
             3w0: CloneParser_parse_clone_header;
             3w1: CloneParser_parse_clone_header_0;
@@ -322,20 +293,16 @@ parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata
         }
     }
     state CloneParser_parse_clone_header {
-        user_meta_1_custom_clone_id = istd_0_clone_metadata_type;
-        user_meta_1_clone = istd_0_clone_metadata_data.h0;
+        user_meta._custom_clone_id1 = istd.clone_metadata.type;
+        user_meta._clone_02 = istd.clone_metadata.data.h0;
         transition parse_clone_header_2;
     }
     state CloneParser_parse_clone_header_0 {
-        user_meta_1_custom_clone_id = istd_0_clone_metadata_type;
-        user_meta_1_clone_0 = istd_0_clone_metadata_data.h1;
+        user_meta._custom_clone_id1 = istd.clone_metadata.type;
+        user_meta._clone_13 = istd.clone_metadata.data.h1;
         transition parse_clone_header_2;
     }
     state parse_clone_header_2 {
-        user_meta._fwd_metadata_outport0 = user_meta_1_fwd_metadata.outport;
-        user_meta._custom_clone_id1 = user_meta_1_custom_clone_id;
-        user_meta._clone_02 = user_meta_1_clone;
-        user_meta._clone_13 = user_meta_1_clone_0;
         transition parse_ethernet;
     }
     state noMatch {
@@ -370,36 +337,20 @@ control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_
 }
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
-    ethernet_t parsed_hdr_1_ethernet;
-    ipv4_t parsed_hdr_1_ipv4;
-    fwd_metadata_t user_meta_2_fwd_metadata;
-    bit<3> user_meta_2_custom_clone_id;
-    clone_0_t user_meta_2_clone;
-    clone_1_t user_meta_2_clone_0;
     state start {
-        parsed_hdr_1_ethernet.setInvalid();
-        parsed_hdr_1_ipv4.setInvalid();
-        user_meta_2_fwd_metadata.outport = user_meta._fwd_metadata_outport0;
-        user_meta_2_custom_clone_id = user_meta._custom_clone_id1;
-        user_meta_2_clone = user_meta._clone_02;
-        user_meta_2_clone_0 = user_meta._clone_13;
-        buffer.extract<ethernet_t>(parsed_hdr_1_ethernet);
-        transition select(parsed_hdr_1_ethernet.etherType) {
+        parsed_hdr.ethernet.setInvalid();
+        parsed_hdr.ipv4.setInvalid();
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4_0;
             default: start_0;
         }
     }
     state CommonParser_parse_ipv4_0 {
-        buffer.extract<ipv4_t>(parsed_hdr_1_ipv4);
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
         transition start_0;
     }
     state start_0 {
-        parsed_hdr.ethernet = parsed_hdr_1_ethernet;
-        parsed_hdr.ipv4 = parsed_hdr_1_ipv4;
-        user_meta._fwd_metadata_outport0 = user_meta_2_fwd_metadata.outport;
-        user_meta._custom_clone_id1 = user_meta_2_custom_clone_id;
-        user_meta._clone_02 = user_meta_2_clone;
-        user_meta._clone_13 = user_meta_2_clone_0;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/named-arg1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named-arg1-frontend.p4
@@ -2,18 +2,14 @@
 
 parser par(out bool b) {
     bit<32> x_0;
-    bit<32> y_0;
-    bit<32> x_1;
     state start {
-        y_0 = 32w0;
         transition adder_0_start;
     }
     state adder_0_start {
-        x_1 = y_0 + 32w6;
+        x_0 = 32w0 + 32w6;
         transition start_0;
     }
     state start_0 {
-        x_0 = x_1;
         b = x_0 == 32w0;
         transition accept;
     }
@@ -21,9 +17,9 @@ parser par(out bool b) {
 
 control c(out bool b) {
     bit<16> xv_0;
-    bit<16> x_2;
+    bit<16> x_1;
     bool b_0;
-    bit<16> x_3;
+    bit<16> x_2;
     bool b_1;
     @name("c.a") action a(in bit<16> bi, out bit<16> mb) {
         mb = -bi;
@@ -34,23 +30,23 @@ control c(out bool b) {
     apply {
         a(bi = 16w3, mb = xv_0);
         a_2(mb = xv_0, bi = 16w0);
-        x_2 = xv_0;
-        b_0 = x_2 == 16w0;
+        x_1 = xv_0;
+        b_0 = x_1 == 16w0;
         b = b_0;
+        xv_0 = x_1;
+        x_2 = xv_0;
+        b_1 = x_2 == 16w1;
         xv_0 = x_2;
-        x_3 = xv_0;
-        b_1 = x_3 == 16w1;
-        xv_0 = x_3;
         b = b_1;
         xv_0 = 16w1;
-        x_2 = xv_0;
-        b_0 = x_2 == 16w0;
-        xv_0 = x_2;
+        x_1 = xv_0;
+        b_0 = x_1 == 16w0;
+        xv_0 = x_1;
         b = b_0;
-        x_3 = xv_0;
-        b_1 = x_3 == 16w1;
+        x_2 = xv_0;
+        b_1 = x_2 == 16w1;
         b = b_1;
-        xv_0 = x_3;
+        xv_0 = x_2;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-fwd-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-fwd-bmv2-frontend.p4
@@ -23,39 +23,29 @@ struct headers {
 }
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
-    headers parsed_hdr_0;
-    metadata user_meta_0;
     state start {
-        parsed_hdr_0.ethernet.setInvalid();
-        user_meta_0 = user_meta;
+        parsed_hdr.ethernet.setInvalid();
         transition CommonParser_start;
     }
     state CommonParser_start {
-        buffer.extract<ethernet_t>(parsed_hdr_0.ethernet);
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition start_0;
     }
     state start_0 {
-        parsed_hdr = parsed_hdr_0;
-        user_meta = user_meta_0;
         transition accept;
     }
 }
 
 parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
-    headers parsed_hdr_1;
-    metadata user_meta_1;
     state start {
-        parsed_hdr_1.ethernet.setInvalid();
-        user_meta_1 = user_meta;
+        parsed_hdr.ethernet.setInvalid();
         transition CommonParser_start_0;
     }
     state CommonParser_start_0 {
-        buffer.extract<ethernet_t>(parsed_hdr_1.ethernet);
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition start_1;
     }
     state start_1 {
-        parsed_hdr = parsed_hdr_1;
-        user_meta = user_meta_1;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-fwd-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-fwd-bmv2-midend.p4
@@ -22,21 +22,17 @@ struct headers {
 }
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
-    ethernet_t parsed_hdr_0_ethernet;
     state start {
-        parsed_hdr_0_ethernet.setInvalid();
-        buffer.extract<ethernet_t>(parsed_hdr_0_ethernet);
-        parsed_hdr.ethernet = parsed_hdr_0_ethernet;
+        parsed_hdr.ethernet.setInvalid();
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition accept;
     }
 }
 
 parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
-    ethernet_t parsed_hdr_1_ethernet;
     state start {
-        parsed_hdr_1_ethernet.setInvalid();
-        buffer.extract<ethernet_t>(parsed_hdr_1_ethernet);
-        parsed_hdr.ethernet = parsed_hdr_1_ethernet;
+        parsed_hdr.ethernet.setInvalid();
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-frontend.p4
@@ -36,8 +36,6 @@ struct metadata {
 
 parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
     bit<8> my_next_hdr_type_0;
-    headers hdr_0;
-    bit<8> ret_next_hdr_type_0;
     state start {
         pkt.extract<h1_t>(hdr.h1);
         verify(hdr.h1.hdr_type == 8w1, error.BadHeaderType);
@@ -48,18 +46,15 @@ parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standa
         }
     }
     state parse_first_h2 {
-        hdr_0 = hdr;
         transition subParserImpl_start;
     }
     state subParserImpl_start {
-        pkt.extract<h2_t>(hdr_0.h2.next);
-        verify(hdr_0.h2.last.hdr_type == 8w2, error.BadHeaderType);
-        ret_next_hdr_type_0 = hdr_0.h2.last.next_hdr_type;
+        pkt.extract<h2_t>(hdr.h2.next);
+        verify(hdr.h2.last.hdr_type == 8w2, error.BadHeaderType);
+        my_next_hdr_type_0 = hdr.h2.last.next_hdr_type;
         transition parse_first_h2_0;
     }
     state parse_first_h2_0 {
-        hdr = hdr_0;
-        my_next_hdr_type_0 = ret_next_hdr_type_0;
         transition select(my_next_hdr_type_0) {
             8w2: parse_other_h2;
             8w3: parse_h3;

--- a/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-midend.p4
@@ -35,7 +35,6 @@ struct metadata {
 }
 
 parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
-    h2_t[5] hdr_0_h2;
     state start {
         pkt.extract<h1_t>(hdr.h1);
         verify(hdr.h1.hdr_type == 8w1, error.BadHeaderType);
@@ -46,11 +45,9 @@ parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standa
         }
     }
     state parse_first_h2 {
-        hdr_0_h2 = hdr.h2;
-        pkt.extract<h2_t>(hdr_0_h2.next);
-        verify(hdr_0_h2.last.hdr_type == 8w2, error.BadHeaderType);
-        hdr.h2 = hdr_0_h2;
-        transition select(hdr_0_h2.last.next_hdr_type) {
+        pkt.extract<h2_t>(hdr.h2.next);
+        verify(hdr.h2.last.hdr_type == 8w2, error.BadHeaderType);
+        transition select(hdr.h2.last.next_hdr_type) {
             8w2: parse_other_h2;
             8w3: parse_h3;
             default: accept;


### PR DESCRIPTION
- template combining P4Control and P4Parser inlining
- extend avoidance of unnecessary copying to parser inlining

This would be much simpler if P4Control and P4Parser had a common base class, but using a template allows the two cases to share common code.