### PR TITLE
Handle @max_group_size annotation when generating P4Info

### DIFF
--- a/control-plane/p4RuntimeArchHandler.cpp
+++ b/control-plane/p4RuntimeArchHandler.cpp
@@ -125,16 +125,6 @@ std::string serializeOneAnnotation(const IR::Annotation* annotation) {
     return serializedAnnnotation;
 }
 
-void setPreamble(::p4::config::v1::Preamble* preamble,
-                 p4rt_id_t id, cstring name, cstring alias, const IR::IAnnotated* annotated) {
-    CHECK_NULL(preamble);
-    preamble->set_id(id);
-    preamble->set_name(name);
-    preamble->set_alias(alias);
-    addAnnotations(preamble, annotated);
-    addDocumentation(preamble, annotated);
-}
-
 }  // namespace Helpers
 
 }  // namespace ControlPlaneAPI

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -311,9 +311,27 @@ void addDocumentation(Message* message, const IR::IAnnotated* annotated) {
 }
 
 /// Set all the fields in the @preamble, including the 'annotations' and 'doc'
-/// fields.
+/// fields. '@name', '@id' and documentation annotations are ignored, as well as
+/// annotations whose name satisfies predicate @p.
+template <typename UnaryPredicate>
 void setPreamble(::p4::config::v1::Preamble* preamble,
-                 p4rt_id_t id, cstring name, cstring alias, const IR::IAnnotated* annotated);
+                 p4rt_id_t id, cstring name, cstring alias,
+                 const IR::IAnnotated* annotated, UnaryPredicate p) {
+    CHECK_NULL(preamble);
+    preamble->set_id(id);
+    preamble->set_name(name);
+    preamble->set_alias(alias);
+    addAnnotations(preamble, annotated, p);
+    addDocumentation(preamble, annotated);
+}
+
+/// Calls setPreamble with a unconditionally false predicate (no annotation
+/// filtered out).
+void setPreamble(::p4::config::v1::Preamble* preamble,
+                 p4rt_id_t id, cstring name, cstring alias,
+                 const IR::IAnnotated* annotated) {
+    setPreamble(preamble, id, name, alias, annotated, [](cstring){ return false; });
+}
 
 /// @return @table's size property if available, falling back to the
 /// architecture's default size.

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -668,12 +668,24 @@ getMatchFields(const IR::P4Table* table, ReferenceMap* refMap, TypeMap* typeMap)
 class ParseAnnotations : public P4::ParseAnnotations {
  public:
     ParseAnnotations() : P4::ParseAnnotations("P4Runtime", false, {
-                PARSE("controller_header", StringLiteral),
-                PARSE_EMPTY("hidden"),
-                PARSE("id", Constant),
-                PARSE("brief", StringLiteral),
-                PARSE("description", StringLiteral)
-            }) { }
+        PARSE("controller_header", StringLiteral),
+        PARSE_EMPTY("hidden"),
+        PARSE("id", Constant),
+        PARSE("brief", StringLiteral),
+        PARSE("description", StringLiteral),
+        // This annotation is architecture-specific in theory, but given that it
+        // is "reserved" by the P4Runtime specification, I don't really have any
+        // qualms about adding it here. I don't think it is possible to just run
+        // a different ParseAnnotations pass in the constructor of the
+        // architecture-specific P4RuntimeArchHandlerIface implementation, since
+        // ParseAnnotations modifies the program. I don't really like the
+        // possible alternatives either: 1) modify the P4RuntimeArchHandlerIface
+        // interface so that each implementation can provide a custom
+        // ParseAnnotations instance, or 2) run a ParseAnnotations pass
+        // "locally" (in this case on action profile instances since this
+        // annotation is for them).
+        PARSE("max_group_size", Constant)
+    }) { }
 };
 
 /// An analyzer which translates the information available in the P4 IR into a

--- a/testdata/p4_16_samples/action_profile_max_group_size_annotation.p4
+++ b/testdata/p4_16_samples/action_profile_max_group_size_annotation.p4
@@ -1,0 +1,73 @@
+/*
+Copyright 2019-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+struct H { };
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start { transition accept; }
+}
+
+action empty() { }
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+
+    action drop() { mark_to_drop(); }
+
+    table indirect {
+        key = { }
+        actions = { drop; NoAction; }
+        const default_action = NoAction();
+        @name("ap") @max_group_size(200) implementation = action_profile(32w128);
+    }
+
+    table indirect_ws {
+        key = { meta.hash1 : selector; }
+        actions = { drop; NoAction; }
+        const default_action = NoAction();
+        @name("ap_ws") @max_group_size(200) implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+    }
+
+    apply {
+        indirect.apply();
+        indirect_ws.apply();
+    }
+
+};
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply { }
+};
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply { }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(),
+         ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-first.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-first.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+action empty() {
+}
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    action drop() {
+        mark_to_drop();
+    }
+    table indirect {
+        key = {
+        }
+        actions = {
+            drop();
+            NoAction();
+        }
+        const default_action = NoAction();
+        @name("ap") @max_group_size(200) implementation = action_profile(32w128);
+    }
+    table indirect_ws {
+        key = {
+            meta.hash1: selector @name("meta.hash1") ;
+        }
+        actions = {
+            drop();
+            NoAction();
+        }
+        const default_action = NoAction();
+        @name("ap_ws") @max_group_size(200) implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+    }
+    apply {
+        indirect.apply();
+        indirect_ws.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-frontend.p4
@@ -1,0 +1,76 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name(".NoAction") action NoAction_3() {
+    }
+    @name("IngressI.drop") action drop_1() {
+        mark_to_drop();
+    }
+    @name("IngressI.drop") action drop_3() {
+        mark_to_drop();
+    }
+    @name("IngressI.indirect") table indirect_0 {
+        key = {
+        }
+        actions = {
+            drop_1();
+            NoAction_0();
+        }
+        const default_action = NoAction_0();
+        @name("ap") @max_group_size(200) implementation = action_profile(32w128);
+    }
+    @name("IngressI.indirect_ws") table indirect_ws_0 {
+        key = {
+            meta.hash1: selector @name("meta.hash1") ;
+        }
+        actions = {
+            drop_3();
+            NoAction_3();
+        }
+        const default_action = NoAction_3();
+        @name("ap_ws") @max_group_size(200) implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+    }
+    apply {
+        indirect_0.apply();
+        indirect_ws_0.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-midend.p4
@@ -1,0 +1,76 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name(".NoAction") action NoAction_3() {
+    }
+    @name("IngressI.drop") action drop_1() {
+        mark_to_drop();
+    }
+    @name("IngressI.drop") action drop_3() {
+        mark_to_drop();
+    }
+    @name("IngressI.indirect") table indirect_0 {
+        key = {
+        }
+        actions = {
+            drop_1();
+            NoAction_0();
+        }
+        const default_action = NoAction_0();
+        @name("ap") @max_group_size(200) implementation = action_profile(32w128);
+    }
+    @name("IngressI.indirect_ws") table indirect_ws_0 {
+        key = {
+            meta.hash1: selector @name("meta.hash1") ;
+        }
+        actions = {
+            drop_3();
+            NoAction_3();
+        }
+        const default_action = NoAction_3();
+        @name("ap_ws") @max_group_size(200) implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+    }
+    apply {
+        indirect_0.apply();
+        indirect_ws_0.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <v1model.p4>
+
+struct H {
+}
+
+struct M {
+    bit<32> hash1;
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+action empty() {
+}
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    action drop() {
+        mark_to_drop();
+    }
+    table indirect {
+        key = {
+        }
+        actions = {
+            drop;
+            NoAction;
+        }
+        const default_action = NoAction();
+        @name("ap") @max_group_size(200) implementation = action_profile(32w128);
+    }
+    table indirect_ws {
+        key = {
+            meta.hash1: selector;
+        }
+        actions = {
+            drop;
+            NoAction;
+        }
+        const default_action = NoAction();
+        @name("ap_ws") @max_group_size(200) implementation = action_selector(HashAlgorithm.identity, 32w1024, 32w10);
+    }
+    apply {
+        indirect.apply();
+        indirect_ws.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4-stderr
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4-stderr
@@ -1,0 +1,3 @@
+action_profile_max_group_size_annotation.p4(39): [--Wwarn=ignore] warning: Ignoring annotation @max_group_size on action profile 'ap', which does not have a selector
+        @name("ap") @max_group_size(200) implementation = action_profile(32w128);
+                                         ^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4.p4info.txt
@@ -1,0 +1,71 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 33568532
+    name: "IngressI.indirect"
+    alias: "indirect"
+  }
+  action_refs {
+    id: 16836747
+  }
+  action_refs {
+    id: 16800567
+  }
+  const_default_action_id: 16800567
+  implementation_id: 285227422
+  size: 1024
+}
+tables {
+  preamble {
+    id: 33594274
+    name: "IngressI.indirect_ws"
+    alias: "indirect_ws"
+  }
+  action_refs {
+    id: 16836747
+  }
+  action_refs {
+    id: 16800567
+  }
+  const_default_action_id: 16800567
+  implementation_id: 285251566
+  size: 1024
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16836747
+    name: "IngressI.drop"
+    alias: "drop"
+  }
+}
+action_profiles {
+  preamble {
+    id: 285227422
+    name: "ap"
+    alias: "ap"
+  }
+  table_ids: 33568532
+  size: 128
+}
+action_profiles {
+  preamble {
+    id: 285251566
+    name: "ap_ws"
+    alias: "ap_ws"
+  }
+  table_ids: 33594274
+  with_selector: true
+  size: 1024
+  max_group_size: 200
+}
+type_info {
+}


### PR DESCRIPTION
This annotation is standardized by the P4Runtime specification and
enables the P4 programmer to specify the maximum group size (sum of
weights across all members in a group) for a given v1model / PSA
action selector.