### PR TITLE
Fix for the issue when number of error values is more than 9 (#1824)

### DIFF
--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -251,7 +251,9 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
         result->emplace("type", "hexstr");
         auto decl = type->to<IR::Type_Error>()->getDeclByName(expression->member.name);
         auto errorValue = structure->errorCodesMap.at(decl);
-        result->emplace("value", Util::toString(errorValue));
+        // this generates error constant like hex value
+        auto reprValue = stringRepr(errorValue);
+        result->emplace("value", reprValue);
         mapExpression(expression, result);
         return;
     }

--- a/testdata/p4_16_samples/issue1824-bmv2.p4
+++ b/testdata/p4_16_samples/issue1824-bmv2.p4
@@ -1,0 +1,89 @@
+/* Intended to test the fix for the issue1824 when
+ * exists more than 9 error values in p4 program.
+ * values should be represented as hex values. */
+
+#include <core.p4>
+#include <v1model.p4>
+
+header test_header {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+}
+
+struct headers {
+    test_header h1;
+}
+
+struct mystruct1_t {
+    bit<4>  a;
+    bit<4>  b;
+}
+
+struct metadata {
+    mystruct1_t mystruct1;
+}
+
+error {
+    IPv4OptionsNotSupported,
+    IPv4ChecksumError,
+    IPv4HeaderTooShort,
+    IPv4BadPacket
+}
+
+parser MyParser(packet_in pkt,
+               out headers hdr,
+               inout metadata meta,
+               inout standard_metadata_t stdmeta)
+{
+   state start {
+        pkt.extract(hdr.h1);
+        verify(false, error.IPv4BadPacket);
+        verify(false, error.IPv4HeaderTooShort);
+        transition accept;
+    }
+}
+
+control MyIngress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t stdmeta)
+{
+    apply {
+        if (stdmeta.parser_error != error.NoError) {
+            hdr.h1.dstAddr = 0xbad;
+        }
+    }
+}
+
+control MyEgress(inout headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t stdmeta)
+{
+    apply { }
+}
+
+control MyVerifyChecksum(inout headers hdr,
+           inout metadata meta)
+{
+    apply { }
+}
+
+control MyComputeChecksum(inout headers hdr,
+           inout metadata meta)
+{
+    apply { }
+}
+
+control MyDeparser(packet_out packet,
+                  in headers hdr)
+{
+    apply {
+        packet.emit(hdr.h1);
+    }
+}
+
+V1Switch(MyParser(),
+        MyVerifyChecksum(),
+        MyIngress(),
+        MyEgress(),
+        MyComputeChecksum(),
+        MyDeparser()) main;

--- a/testdata/p4_16_samples/issue1824-bmv2.stf
+++ b/testdata/p4_16_samples/issue1824-bmv2.stf
@@ -1,0 +1,2 @@
+packet 0 112233445566 778899aabbcc
+expect 0 000000000BAD 778899aabbcc

--- a/testdata/p4_16_samples_outputs/issue1824-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1824-bmv2-first.p4
@@ -1,0 +1,65 @@
+error {
+    IPv4OptionsNotSupported,
+    IPv4ChecksumError,
+    IPv4HeaderTooShort,
+    IPv4BadPacket
+}
+#include <core.p4>
+#include <v1model.p4>
+
+header test_header {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+}
+
+struct headers {
+    test_header h1;
+}
+
+struct mystruct1_t {
+    bit<4> a;
+    bit<4> b;
+}
+
+struct metadata {
+    mystruct1_t mystruct1;
+}
+
+parser MyParser(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract<test_header>(hdr.h1);
+        verify(false, error.IPv4BadPacket);
+        verify(false, error.IPv4HeaderTooShort);
+        transition accept;
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+        if (stdmeta.parser_error != error.NoError) 
+            hdr.h1.dstAddr = 48w0xbad;
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<test_header>(hdr.h1);
+    }
+}
+
+V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue1824-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1824-bmv2-frontend.p4
@@ -1,0 +1,65 @@
+error {
+    IPv4OptionsNotSupported,
+    IPv4ChecksumError,
+    IPv4HeaderTooShort,
+    IPv4BadPacket
+}
+#include <core.p4>
+#include <v1model.p4>
+
+header test_header {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+}
+
+struct headers {
+    test_header h1;
+}
+
+struct mystruct1_t {
+    bit<4> a;
+    bit<4> b;
+}
+
+struct metadata {
+    mystruct1_t mystruct1;
+}
+
+parser MyParser(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract<test_header>(hdr.h1);
+        verify(false, error.IPv4BadPacket);
+        verify(false, error.IPv4HeaderTooShort);
+        transition accept;
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+        if (stdmeta.parser_error != error.NoError) 
+            hdr.h1.dstAddr = 48w0xbad;
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<test_header>(hdr.h1);
+    }
+}
+
+V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue1824-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1824-bmv2-midend.p4
@@ -1,0 +1,75 @@
+error {
+    IPv4OptionsNotSupported,
+    IPv4ChecksumError,
+    IPv4HeaderTooShort,
+    IPv4BadPacket
+}
+#include <core.p4>
+#include <v1model.p4>
+
+header test_header {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+}
+
+struct headers {
+    test_header h1;
+}
+
+struct mystruct1_t {
+    bit<4> a;
+    bit<4> b;
+}
+
+struct metadata {
+    bit<4> _mystruct1_a0;
+    bit<4> _mystruct1_b1;
+}
+
+parser MyParser(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract<test_header>(hdr.h1);
+        verify(false, error.IPv4BadPacket);
+        verify(false, error.IPv4HeaderTooShort);
+        transition accept;
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    @hidden action act() {
+        hdr.h1.dstAddr = 48w0xbad;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        if (stdmeta.parser_error != error.NoError) 
+            tbl_act.apply();
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<test_header>(hdr.h1);
+    }
+}
+
+V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue1824-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1824-bmv2.p4
@@ -1,0 +1,66 @@
+error {
+    IPv4OptionsNotSupported,
+    IPv4ChecksumError,
+    IPv4HeaderTooShort,
+    IPv4BadPacket
+}
+#include <core.p4>
+#include <v1model.p4>
+
+header test_header {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+}
+
+struct headers {
+    test_header h1;
+}
+
+struct mystruct1_t {
+    bit<4> a;
+    bit<4> b;
+}
+
+struct metadata {
+    mystruct1_t mystruct1;
+}
+
+parser MyParser(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(hdr.h1);
+        verify(false, error.IPv4BadPacket);
+        verify(false, error.IPv4HeaderTooShort);
+        transition accept;
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+        if (stdmeta.parser_error != error.NoError) {
+            hdr.h1.dstAddr = 0xbad;
+        }
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.h1);
+    }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue1824-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1824-bmv2.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "v1model"
+}


### PR DESCRIPTION
Changed the way error code value is generated in bmv2 backend.
Instead of decimal value, it is generated as hex value into json file
(issue #1824)

Signed-off-by: Enisa Hadzic <enisa.hadzic@rt-rk.com>