### PR TITLE
Deprecate mark_to_drop(); replace with mark_to_drop(standard_metadata) function

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -172,7 +172,6 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/psa-example-counters-bmv2.p4
   testdata/p4_16_samples/psa-example-digest-bmv2.p4
   testdata/p4_16_samples/psa-example-register2-bmv2.p4
-  testdata/p4_16_samples/psa-fwd-bmv2.p4
   # This reads stack.next
   testdata/p4_16_samples/issue692-bmv2.p4
   # These test use computations in the verify/update checksum controls - unsupported

--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -144,11 +144,6 @@ set (XFAIL_TESTS
   testdata/p4_14_samples/issue60.p4
   # compiler claims (incorrectly?) that c2 has mulitple successors, so is not supported
   testdata/p4_14_samples/issue-1426.p4
-  # As of 2019-Feb-04 latest p4c, this program fails due to the root
-  # cause of both issues #1694, but is not affected by #1669.  I have
-  # tested it with the proposed fix for issue #1694 that is on PR
-  # #1704, and it passes.
-  testdata/p4_14_samples/p414-special-ops-3-bmv2.p4
   # As of 2019-Feb-04 latest p4c code, this program fails due to the
   # root cause of both issues #1694 and #1669.  I have tested it with
   # the proposed fix for issue #1694 that is on PR #1704, and while
@@ -177,7 +172,7 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/psa-example-counters-bmv2.p4
   testdata/p4_16_samples/psa-example-digest-bmv2.p4
   testdata/p4_16_samples/psa-example-register2-bmv2.p4
-  # testdata/p4_16_samples/psa-fwd-bmv2.p4
+  testdata/p4_16_samples/psa-fwd-bmv2.p4
   # This reads stack.next
   testdata/p4_16_samples/issue692-bmv2.p4
   # These test use computations in the verify/update checksum controls - unsupported

--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -592,9 +592,13 @@ void ExpressionConverter::postorder(const IR::PathExpression* expression)  {
             structure->nonActionParameters.end()) {
             auto type = typeMap->getType(param, true);
             if (type->is<IR::Type_StructLike>()) {
-                auto result = new Util::JsonObject();
-                result->emplace("type", "header");
-                result->emplace("value", param->name.name);
+                auto result = convertParam(param, "");
+                if (result == nullptr) {
+                    auto r = new Util::JsonObject();
+                    r->emplace("type", "header");
+                    r->emplace("value", param->name.name);
+                    result = r;
+                }
                 mapExpression(expression, result);
             } else {
                 mapExpression(expression, new Util::JsonValue(param->name.name));

--- a/backends/bmv2/common/extern.cpp
+++ b/backends/bmv2/common/extern.cpp
@@ -119,8 +119,9 @@ ExternConverter::convertExternFunction(ConversionContext* ctxt,
 
 void
 ExternConverter::modelError(const char* format, const IR::Node* node) const {
-    ::error(format, node);
-    ::error("Are you using an up-to-date v1model.p4?");
+    cstring errMsg = cstring(format) +
+                     ". Are you using an up-to-date v1model.p4?";
+    ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET, errMsg.c_str(), node);
 }
 
 void

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -330,17 +330,18 @@ Util::IJson* ExternConverter_recirculate::convertExternFunction(
     return primitive;
 }
 
-// TODO: this is deprecated.
 Util::IJson* ExternConverter_mark_to_drop::convertExternFunction(
     UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
     UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
     UNUSED const bool emitExterns) {
-    if (mc->arguments->size() != 0) {
-        modelError("Expected 0 arguments for %1%", mc);
+    if (mc->arguments->size() != 1) {
+        modelError("Expected 1 argument for %1%", mc);
         return nullptr;
     }
-    auto primitive = mkPrimitive("drop");
-    (void)mkParameters(primitive);
+    auto primitive = mkPrimitive("mark_to_drop");
+    auto params = mkParameters(primitive);
+    auto dest = ctxt->conv->convert(mc->arguments->at(0)->expression);
+    params->append(dest);
     primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
     return primitive;
 }

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -330,6 +330,7 @@ Util::IJson* ExternConverter_recirculate::convertExternFunction(
     return primitive;
 }
 
+// TODO: this is deprecated.
 Util::IJson* ExternConverter_mark_to_drop::convertExternFunction(
     UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
     UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,

--- a/backends/bmv2/simple_switch/simpleSwitch.h
+++ b/backends/bmv2/simple_switch/simpleSwitch.h
@@ -102,10 +102,15 @@ class SimpleSwitchExpressionConverter : public ExpressionConverter {
     Util::IJson* convertParam(const IR::Parameter* param, cstring fieldName) override {
         if (isStandardMetadataParameter(param)) {
             auto result = new Util::JsonObject();
-            result->emplace("type", "field");
-            auto e = BMV2::mkArrayField(result, "value");
-            e->append("standard_metadata");
-            e->append(fieldName);
+            if (fieldName != "") {
+                result->emplace("type", "field");
+                auto e = BMV2::mkArrayField(result, "value");
+                e->append("standard_metadata");
+                e->append(fieldName);
+            } else {
+                result->emplace("type", "header");
+                result->emplace("value", "standard_metadata");
+            }
             return result;
         }
         return nullptr;

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -169,7 +169,7 @@ class ProgramStructure {
 
  public:
     // output is constructed here
-    IR::IndexedVector<IR::Node>* declarations;
+    IR::Vector<IR::Node>* declarations;
 
  protected:
     virtual const IR::Statement* convertPrimitive(const IR::Primitive* primitive);

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -255,7 +255,7 @@ class V1Model : public ::Model::Model {
             tableAttributes(), rangeMatchType("range"), selectorMatchType("selector"),
             verify("verifyChecksum", headersType), compute("computeChecksum", headersType),
             digest_receiver(), hash(), algorithm(),
-            registers(), drop("mark_to_drop"),
+            registers(), drop("markToDrop"),
             recirculate("recirculate"), verify_checksum("verify_checksum"),
             update_checksum("update_checksum"),
             verify_checksum_with_payload("verify_checksum_with_payload"),

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -255,7 +255,7 @@ class V1Model : public ::Model::Model {
             tableAttributes(), rangeMatchType("range"), selectorMatchType("selector"),
             verify("verifyChecksum", headersType), compute("computeChecksum", headersType),
             digest_receiver(), hash(), algorithm(),
-            registers(), drop("markToDrop"),
+            registers(), drop("mark_to_drop"),
             recirculate("recirculate"), verify_checksum("verify_checksum"),
             update_checksum("update_checksum"),
             verify_checksum_with_payload("verify_checksum_with_payload"),

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -134,7 +134,13 @@ enum HashAlgorithm {
     xor16
 }
 
+@deprecated("Please use action markToDrop instead.")
 extern void mark_to_drop();
+
+action markToDrop(inout standard_metadata_t standard_metadata) {
+    standard_metadata.egress_spec = 511;
+    standard_metadata.mcast_grp = 0;
+}
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
 
 extern action_selector {

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -134,13 +134,10 @@ enum HashAlgorithm {
     xor16
 }
 
-@deprecated("Please use action markToDrop instead.")
+@deprecated("Please use mark_to_drop(standard_metadata) instead.")
 extern void mark_to_drop();
+extern void mark_to_drop(inout standard_metadata_t standard_metadata);
 
-action markToDrop(inout standard_metadata_t standard_metadata) {
-    standard_metadata.egress_spec = 511;
-    standard_metadata.mcast_grp = 0;
-}
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
 
 extern action_selector {

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -1201,7 +1201,7 @@ TEST_F(P4Runtime, Documentation) {
             @brief("This action does nothing duh!")
             action noop() { }
 
-            action drop() { markToDrop(sm); }
+            action drop() { mark_to_drop(sm); }
 
             // we cannot test a multi-line annotation here (with escaped new line)
             // because the preprocessor is not run

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -1201,7 +1201,7 @@ TEST_F(P4Runtime, Documentation) {
             @brief("This action does nothing duh!")
             action noop() { }
 
-            action drop() { mark_to_drop(); }
+            action drop() { markToDrop(sm); }
 
             // we cannot test a multi-line annotation here (with escaped new line)
             // because the preprocessor is not run

--- a/testdata/p4_14_samples/simple_nat.p4
+++ b/testdata/p4_14_samples/simple_nat.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
@@ -174,7 +174,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ing_metadata.egress_port = egress_port;
     }
     @name(".discard") action discard() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".send_packet") action send_packet() {
         standard_metadata.egress_spec = meta.ing_metadata.egress_port;

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
@@ -174,7 +174,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ing_metadata.egress_port = egress_port;
     }
     @name(".discard") action discard() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".send_packet") action send_packet() {
         standard_metadata.egress_spec = meta.ing_metadata.egress_port;

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
@@ -212,12 +212,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ing_metadata.egress_port = egress_port;
     }
     @name(".discard") action discard() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".send_packet") action send_packet() {
         standard_metadata.egress_spec = meta.ing_metadata.egress_port;

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
@@ -212,7 +212,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ing_metadata.egress_port = egress_port;
     }
     @name(".discard") action discard() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".send_packet") action send_packet() {
         standard_metadata.egress_spec = meta.ing_metadata.egress_port;

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
@@ -213,7 +213,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._ing_metadata_egress_port1 = egress_port;
     }
     @name(".discard") action discard() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".send_packet") action send_packet() {
         standard_metadata.egress_spec = meta._ing_metadata_egress_port1;

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
@@ -213,8 +213,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._ing_metadata_egress_port1 = egress_port;
     }
     @name(".discard") action discard() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".send_packet") action send_packet() {
         standard_metadata.egress_spec = meta._ing_metadata_egress_port1;

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
@@ -174,7 +174,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ing_metadata.egress_port = egress_port;
     }
     @name(".discard") action discard() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".send_packet") action send_packet() {
         standard_metadata.egress_spec = meta.ing_metadata.egress_port;

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
@@ -174,7 +174,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ing_metadata.egress_port = egress_port;
     }
     @name(".discard") action discard() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".send_packet") action send_packet() {
         standard_metadata.egress_spec = meta.ing_metadata.egress_port;

--- a/testdata/p4_14_samples_outputs/axon-first.p4
+++ b/testdata/p4_14_samples_outputs/axon-first.p4
@@ -81,7 +81,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.axon_fwdHop[0].port;

--- a/testdata/p4_14_samples_outputs/axon-first.p4
+++ b/testdata/p4_14_samples_outputs/axon-first.p4
@@ -81,7 +81,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.axon_fwdHop[0].port;

--- a/testdata/p4_14_samples_outputs/axon-frontend.p4
+++ b/testdata/p4_14_samples_outputs/axon-frontend.p4
@@ -87,20 +87,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_2() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.axon_fwdHop[0].port;

--- a/testdata/p4_14_samples_outputs/axon-frontend.p4
+++ b/testdata/p4_14_samples_outputs/axon-frontend.p4
@@ -87,10 +87,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.axon_fwdHop[0].port;

--- a/testdata/p4_14_samples_outputs/axon-midend.p4
+++ b/testdata/p4_14_samples_outputs/axon-midend.p4
@@ -88,10 +88,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.axon_fwdHop[0].port;

--- a/testdata/p4_14_samples_outputs/axon-midend.p4
+++ b/testdata/p4_14_samples_outputs/axon-midend.p4
@@ -88,12 +88,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_2() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.axon_fwdHop[0].port;

--- a/testdata/p4_14_samples_outputs/axon.p4
+++ b/testdata/p4_14_samples_outputs/axon.p4
@@ -81,7 +81,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.axon_fwdHop[0].port;

--- a/testdata/p4_14_samples_outputs/axon.p4
+++ b/testdata/p4_14_samples_outputs/axon.p4
@@ -81,7 +81,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.axon_fwdHop[0].port;

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
@@ -49,7 +49,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
@@ -49,7 +49,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
@@ -53,12 +53,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".NoAction") action NoAction_0() {
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
@@ -53,7 +53,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".NoAction") action NoAction_0() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
@@ -54,8 +54,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".NoAction") action NoAction_0() {
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
@@ -54,7 +54,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".NoAction") action NoAction_0() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();

--- a/testdata/p4_14_samples_outputs/copy_to_cpu.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu.p4
@@ -49,7 +49,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();

--- a/testdata/p4_14_samples_outputs/copy_to_cpu.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu.p4
@@ -49,7 +49,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();

--- a/testdata/p4_14_samples_outputs/counter-first.p4
+++ b/testdata/p4_14_samples_outputs/counter-first.p4
@@ -49,14 +49,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".my_indirect_counter") counter(32w16384, CounterType.packets) my_indirect_counter;
     @name(".m_action") action m_action(bit<32> idx) {
         my_indirect_counter.count(idx);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }
     @name(".m_action") action m_action_0(bit<32> idx) {
         my_direct_counter.count();
         my_indirect_counter.count(idx);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("._nop") action _nop_0() {
         my_direct_counter.count();

--- a/testdata/p4_14_samples_outputs/counter-first.p4
+++ b/testdata/p4_14_samples_outputs/counter-first.p4
@@ -49,14 +49,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".my_indirect_counter") counter(32w16384, CounterType.packets) my_indirect_counter;
     @name(".m_action") action m_action(bit<32> idx) {
         my_indirect_counter.count(idx);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }
     @name(".m_action") action m_action_0(bit<32> idx) {
         my_direct_counter.count();
         my_indirect_counter.count(idx);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {
         my_direct_counter.count();

--- a/testdata/p4_14_samples_outputs/counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter-frontend.p4
@@ -52,7 +52,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".m_action") action m_action_0(bit<32> idx) {
         my_direct_counter_0.count();
         my_indirect_counter_0.count(idx);
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("._nop") action _nop_0() {
         my_direct_counter_0.count();

--- a/testdata/p4_14_samples_outputs/counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter-frontend.p4
@@ -52,12 +52,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".m_action") action m_action_0(bit<32> idx) {
         my_direct_counter_0.count();
         my_indirect_counter_0.count(idx);
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {
         my_direct_counter_0.count();

--- a/testdata/p4_14_samples_outputs/counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter-midend.p4
@@ -52,8 +52,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".m_action") action m_action_0(bit<32> idx) {
         my_direct_counter_0.count();
         my_indirect_counter_0.count(idx);
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {
         my_direct_counter_0.count();

--- a/testdata/p4_14_samples_outputs/counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter-midend.p4
@@ -52,7 +52,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".m_action") action m_action_0(bit<32> idx) {
         my_direct_counter_0.count();
         my_indirect_counter_0.count(idx);
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._nop") action _nop_0() {
         my_direct_counter_0.count();

--- a/testdata/p4_14_samples_outputs/counter.p4
+++ b/testdata/p4_14_samples_outputs/counter.p4
@@ -49,14 +49,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".my_indirect_counter") counter(32w16384, CounterType.packets) my_indirect_counter;
     @name(".m_action") action m_action(bit<32> idx) {
         my_indirect_counter.count((bit<32>)idx);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }
     @name(".m_action") action m_action_0(bit<32> idx) {
         my_direct_counter.count();
         my_indirect_counter.count((bit<32>)idx);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {
         my_direct_counter.count();

--- a/testdata/p4_14_samples_outputs/counter.p4
+++ b/testdata/p4_14_samples_outputs/counter.p4
@@ -49,14 +49,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".my_indirect_counter") counter(32w16384, CounterType.packets) my_indirect_counter;
     @name(".m_action") action m_action(bit<32> idx) {
         my_indirect_counter.count((bit<32>)idx);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }
     @name(".m_action") action m_action_0(bit<32> idx) {
         my_direct_counter.count();
         my_indirect_counter.count((bit<32>)idx);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("._nop") action _nop_0() {
         my_direct_counter.count();

--- a/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
@@ -97,7 +97,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -122,7 +122,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
@@ -97,7 +97,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -122,7 +122,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
@@ -99,12 +99,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -139,28 +134,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_11() {
     }
     @name("._drop") action _drop_2() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_5() {
-        {
-            standard_metadata_t standard_metadata_4 = standard_metadata;
-            standard_metadata_4.egress_spec = 9w511;
-            standard_metadata_4.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_4;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_6() {
-        {
-            standard_metadata_t standard_metadata_5 = standard_metadata;
-            standard_metadata_5.egress_spec = 9w511;
-            standard_metadata_5.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_5;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
@@ -99,7 +99,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -134,13 +139,28 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_11() {
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name("._drop") action _drop_5() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_4 = standard_metadata;
+            standard_metadata_4.egress_spec = 9w511;
+            standard_metadata_4.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_4;
+        }
     }
     @name("._drop") action _drop_6() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_5 = standard_metadata;
+            standard_metadata_5.egress_spec = 9w511;
+            standard_metadata_5.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_5;
+        }
     }
     @name(".set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -105,8 +105,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -158,16 +157,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_11() {
     }
     @name("._drop") action _drop_2() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_5() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_6() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple_0, bit<20>>(meta._ingress_metadata_ecmp_offset4, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta._ingress_metadata_flowlet_id2 }, (bit<20>)ecmp_count);

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -105,7 +105,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -157,13 +158,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_11() {
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_5() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_6() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple_0, bit<20>>(meta._ingress_metadata_ecmp_offset4, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta._ingress_metadata_flowlet_id2 }, (bit<20>)ecmp_count);

--- a/testdata/p4_14_samples_outputs/flowlet_switching.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching.p4
@@ -97,7 +97,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -120,7 +120,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_14_samples_outputs/flowlet_switching.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching.p4
@@ -97,7 +97,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -120,7 +120,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_14_samples_outputs/gateway1-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-first.p4
@@ -25,7 +25,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway1-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-first.p4
@@ -25,7 +25,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-frontend.p4
@@ -29,7 +29,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-frontend.p4
@@ -29,12 +29,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway1-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-midend.p4
@@ -29,7 +29,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway1-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-midend.p4
@@ -29,8 +29,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway1.p4
+++ b/testdata/p4_14_samples_outputs/gateway1.p4
@@ -25,7 +25,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway1.p4
+++ b/testdata/p4_14_samples_outputs/gateway1.p4
@@ -25,7 +25,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway2-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-first.p4
@@ -27,7 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway2-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-first.p4
@@ -27,7 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-frontend.p4
@@ -31,7 +31,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-frontend.p4
@@ -31,12 +31,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-midend.p4
@@ -31,8 +31,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-midend.p4
@@ -31,7 +31,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway2.p4
+++ b/testdata/p4_14_samples_outputs/gateway2.p4
@@ -27,7 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway2.p4
+++ b/testdata/p4_14_samples_outputs/gateway2.p4
@@ -27,7 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway3-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-first.p4
@@ -27,7 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway3-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-first.p4
@@ -27,7 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-frontend.p4
@@ -31,7 +31,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-frontend.p4
@@ -31,12 +31,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway3-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-midend.p4
@@ -31,8 +31,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway3-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-midend.p4
@@ -31,7 +31,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway3.p4
+++ b/testdata/p4_14_samples_outputs/gateway3.p4
@@ -27,7 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway3.p4
+++ b/testdata/p4_14_samples_outputs/gateway3.p4
@@ -27,7 +27,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway4-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-first.p4
@@ -41,7 +41,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway4-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-first.p4
@@ -41,7 +41,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-frontend.p4
@@ -45,7 +45,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-frontend.p4
@@ -45,12 +45,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway4-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-midend.p4
@@ -45,8 +45,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway4-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-midend.p4
@@ -45,7 +45,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway4.p4
+++ b/testdata/p4_14_samples_outputs/gateway4.p4
@@ -41,7 +41,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/gateway4.p4
+++ b/testdata/p4_14_samples_outputs/gateway4.p4
@@ -41,7 +41,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".setb1") action setb1(bit<8> val, bit<9> port) {
         hdr.data.b1 = val;

--- a/testdata/p4_14_samples_outputs/issue-1426-first.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-first.p4
@@ -27,7 +27,7 @@ control c(inout headers hdr, inout metadata meta, inout standard_metadata_t stan
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".c1") table c1 {
         actions = {
@@ -71,7 +71,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".a1") table a1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue-1426-first.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-first.p4
@@ -27,7 +27,7 @@ control c(inout headers hdr, inout metadata meta, inout standard_metadata_t stan
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".c1") table c1 {
         actions = {
@@ -71,7 +71,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".a1") table a1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
@@ -43,10 +43,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".discard") action discard_2() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name(".a1") table a1_0 {
         actions = {
@@ -79,10 +89,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action _discard_0() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_4 = standard_metadata;
+            standard_metadata_4.egress_spec = 9w511;
+            standard_metadata_4.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_4;
+        }
     }
     @name(".discard") action _discard_2() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_5 = standard_metadata;
+            standard_metadata_5.egress_spec = 9w511;
+            standard_metadata_5.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_5;
+        }
     }
     @name(".c1") table _c1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
@@ -43,20 +43,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".discard") action discard_2() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".a1") table a1_0 {
         actions = {
@@ -89,20 +79,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action _discard_0() {
-        {
-            standard_metadata_t standard_metadata_4 = standard_metadata;
-            standard_metadata_4.egress_spec = 9w511;
-            standard_metadata_4.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_4;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".discard") action _discard_2() {
-        {
-            standard_metadata_t standard_metadata_5 = standard_metadata;
-            standard_metadata_5.egress_spec = 9w511;
-            standard_metadata_5.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_5;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".c1") table _c1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue-1426-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-midend.p4
@@ -43,10 +43,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".discard") action discard_2() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".a1") table a1_0 {
         actions = {
@@ -79,10 +81,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action _discard_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".discard") action _discard_2() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".c1") table _c1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue-1426-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-midend.p4
@@ -43,12 +43,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".discard") action discard_2() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".a1") table a1_0 {
         actions = {
@@ -81,12 +79,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action _discard_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".discard") action _discard_2() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".c1") table _c1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue-1426.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426.p4
@@ -27,7 +27,7 @@ control c(inout headers hdr, inout metadata meta, inout standard_metadata_t stan
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".c1") table c1 {
         actions = {
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".a1") table a1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue-1426.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426.p4
@@ -27,7 +27,7 @@ control c(inout headers hdr, inout metadata meta, inout standard_metadata_t stan
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".c1") table c1 {
         actions = {
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_port = port;
     }
     @name(".discard") action discard() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".a1") table a1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue583-first.p4
+++ b/testdata/p4_14_samples_outputs/issue583-first.p4
@@ -185,7 +185,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".cnt1") counter(32w32, CounterType.packets) cnt1;
     @name(".drop_pkt") action drop_pkt() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".hop") action hop(inout bit<8> ttl, bit<9> egress_spec) {
         ttl = ttl + 8w255;

--- a/testdata/p4_14_samples_outputs/issue583-first.p4
+++ b/testdata/p4_14_samples_outputs/issue583-first.p4
@@ -185,7 +185,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".cnt1") counter(32w32, CounterType.packets) cnt1;
     @name(".drop_pkt") action drop_pkt() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".hop") action hop(inout bit<8> ttl, bit<9> egress_spec) {
         ttl = ttl + 8w255;

--- a/testdata/p4_14_samples_outputs/issue583-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-frontend.p4
@@ -189,12 +189,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".cnt1") counter(32w32, CounterType.packets) cnt1_0;
     @name(".drop_pkt") action drop_pkt() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".hop_ipv4") action hop_ipv4(bit<9> egress_spec) {
         {

--- a/testdata/p4_14_samples_outputs/issue583-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-frontend.p4
@@ -189,7 +189,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".cnt1") counter(32w32, CounterType.packets) cnt1_0;
     @name(".drop_pkt") action drop_pkt() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".hop_ipv4") action hop_ipv4(bit<9> egress_spec) {
         {

--- a/testdata/p4_14_samples_outputs/issue583-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-midend.p4
@@ -196,8 +196,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".cnt1") counter(32w32, CounterType.packets) cnt1_0;
     @name(".drop_pkt") action drop_pkt() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".hop_ipv4") action hop_ipv4(bit<9> egress_spec) {
         standard_metadata.egress_spec[8:0] = egress_spec[8:0];

--- a/testdata/p4_14_samples_outputs/issue583-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-midend.p4
@@ -196,7 +196,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".cnt1") counter(32w32, CounterType.packets) cnt1_0;
     @name(".drop_pkt") action drop_pkt() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".hop_ipv4") action hop_ipv4(bit<9> egress_spec) {
         standard_metadata.egress_spec[8:0] = egress_spec[8:0];

--- a/testdata/p4_14_samples_outputs/issue583.p4
+++ b/testdata/p4_14_samples_outputs/issue583.p4
@@ -185,7 +185,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".cnt1") counter(32w32, CounterType.packets) cnt1;
     @name(".drop_pkt") action drop_pkt() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".hop") action hop(inout bit<8> ttl, bit<9> egress_spec) {
         ttl = ttl - 8w1;

--- a/testdata/p4_14_samples_outputs/issue583.p4
+++ b/testdata/p4_14_samples_outputs/issue583.p4
@@ -185,7 +185,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".cnt1") counter(32w32, CounterType.packets) cnt1;
     @name(".drop_pkt") action drop_pkt() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".hop") action hop(inout bit<8> ttl, bit<9> egress_spec) {
         ttl = ttl - 8w1;

--- a/testdata/p4_14_samples_outputs/issue894-first.p4
+++ b/testdata/p4_14_samples_outputs/issue894-first.p4
@@ -87,7 +87,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -112,7 +112,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/issue894-first.p4
+++ b/testdata/p4_14_samples_outputs/issue894-first.p4
@@ -87,7 +87,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -112,7 +112,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/issue894-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-frontend.p4
@@ -89,7 +89,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -122,13 +127,28 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_9() {
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name("._drop") action _drop_5() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_4 = standard_metadata;
+            standard_metadata_4.egress_spec = 9w511;
+            standard_metadata_4.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_4;
+        }
     }
     @name("._drop") action _drop_6() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_5 = standard_metadata;
+            standard_metadata_5.egress_spec = 9w511;
+            standard_metadata_5.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_5;
+        }
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/issue894-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-frontend.p4
@@ -89,12 +89,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -127,28 +122,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_9() {
     }
     @name("._drop") action _drop_2() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_5() {
-        {
-            standard_metadata_t standard_metadata_4 = standard_metadata;
-            standard_metadata_4.egress_spec = 9w511;
-            standard_metadata_4.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_4;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_6() {
-        {
-            standard_metadata_t standard_metadata_5 = standard_metadata;
-            standard_metadata_5.egress_spec = 9w511;
-            standard_metadata_5.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_5;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/issue894-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-midend.p4
@@ -92,8 +92,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -134,16 +133,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_9() {
     }
     @name("._drop") action _drop_2() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_5() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_6() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/issue894-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-midend.p4
@@ -92,7 +92,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -133,13 +134,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_9() {
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_5() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_6() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/issue894.p4
+++ b/testdata/p4_14_samples_outputs/issue894.p4
@@ -87,7 +87,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -110,7 +110,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/issue894.p4
+++ b/testdata/p4_14_samples_outputs/issue894.p4
@@ -87,7 +87,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -110,7 +110,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/meter-first.p4
+++ b/testdata/p4_14_samples_outputs/meter-first.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_meter") meter(32w16384, MeterType.packets) my_meter;
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter-first.p4
+++ b/testdata/p4_14_samples_outputs/meter-first.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_meter") meter(32w16384, MeterType.packets) my_meter;
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter-frontend.p4
@@ -51,7 +51,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".my_meter") meter(32w16384, MeterType.packets) my_meter_0;
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter-frontend.p4
@@ -51,12 +51,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".my_meter") meter(32w16384, MeterType.packets) my_meter_0;
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter-midend.p4
@@ -51,7 +51,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".my_meter") meter(32w16384, MeterType.packets) my_meter_0;
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter-midend.p4
@@ -51,8 +51,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".my_meter") meter(32w16384, MeterType.packets) my_meter_0;
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter.p4
+++ b/testdata/p4_14_samples_outputs/meter.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_meter") meter(32w16384, MeterType.packets) my_meter;
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter.p4
+++ b/testdata/p4_14_samples_outputs/meter.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_meter") meter(32w16384, MeterType.packets) my_meter;
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter1-first.p4
+++ b/testdata/p4_14_samples_outputs/meter1-first.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_meter") direct_meter<bit<32>>(MeterType.packets) my_meter;
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter1-first.p4
+++ b/testdata/p4_14_samples_outputs/meter1-first.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_meter") direct_meter<bit<32>>(MeterType.packets) my_meter;
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-frontend.p4
@@ -51,12 +51,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".my_meter") direct_meter<bit<32>>(MeterType.packets) my_meter_0;
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-frontend.p4
@@ -51,7 +51,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".my_meter") direct_meter<bit<32>>(MeterType.packets) my_meter_0;
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-midend.p4
@@ -51,8 +51,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".my_meter") direct_meter<bit<32>>(MeterType.packets) my_meter_0;
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-midend.p4
@@ -51,7 +51,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".my_meter") direct_meter<bit<32>>(MeterType.packets) my_meter_0;
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter1.p4
+++ b/testdata/p4_14_samples_outputs/meter1.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_meter") direct_meter<bit<32>>(MeterType.packets) my_meter;
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/meter1.p4
+++ b/testdata/p4_14_samples_outputs/meter1.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_meter") direct_meter<bit<32>>(MeterType.packets) my_meter;
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/queueing-first.p4
+++ b/testdata/p4_14_samples_outputs/queueing-first.p4
@@ -71,7 +71,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".t_ingress") table t_ingress {
         actions = {

--- a/testdata/p4_14_samples_outputs/queueing-first.p4
+++ b/testdata/p4_14_samples_outputs/queueing-first.p4
@@ -71,7 +71,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".t_ingress") table t_ingress {
         actions = {

--- a/testdata/p4_14_samples_outputs/queueing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-frontend.p4
@@ -75,7 +75,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".t_ingress") table t_ingress_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/queueing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-frontend.p4
@@ -75,12 +75,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".t_ingress") table t_ingress_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/queueing-midend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-midend.p4
@@ -77,7 +77,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".t_ingress") table t_ingress_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/queueing-midend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-midend.p4
@@ -77,8 +77,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".t_ingress") table t_ingress_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/queueing.p4
+++ b/testdata/p4_14_samples_outputs/queueing.p4
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".t_ingress") table t_ingress {
         actions = {

--- a/testdata/p4_14_samples_outputs/queueing.p4
+++ b/testdata/p4_14_samples_outputs/queueing.p4
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".t_ingress") table t_ingress {
         actions = {

--- a/testdata/p4_14_samples_outputs/repeater-first.p4
+++ b/testdata/p4_14_samples_outputs/repeater-first.p4
@@ -27,7 +27,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
         standard_metadata.egress_spec = egress_port;

--- a/testdata/p4_14_samples_outputs/repeater-first.p4
+++ b/testdata/p4_14_samples_outputs/repeater-first.p4
@@ -27,7 +27,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
         standard_metadata.egress_spec = egress_port;

--- a/testdata/p4_14_samples_outputs/repeater-frontend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-frontend.p4
@@ -29,12 +29,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name(".my_drop") action my_drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
         standard_metadata.egress_spec = egress_port;

--- a/testdata/p4_14_samples_outputs/repeater-frontend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-frontend.p4
@@ -29,7 +29,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
         standard_metadata.egress_spec = egress_port;

--- a/testdata/p4_14_samples_outputs/repeater-midend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-midend.p4
@@ -29,8 +29,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name(".my_drop") action my_drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
         standard_metadata.egress_spec = egress_port;

--- a/testdata/p4_14_samples_outputs/repeater-midend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-midend.p4
@@ -29,7 +29,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
         standard_metadata.egress_spec = egress_port;

--- a/testdata/p4_14_samples_outputs/repeater.p4
+++ b/testdata/p4_14_samples_outputs/repeater.p4
@@ -27,7 +27,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
         standard_metadata.egress_spec = egress_port;

--- a/testdata/p4_14_samples_outputs/repeater.p4
+++ b/testdata/p4_14_samples_outputs/repeater.p4
@@ -27,7 +27,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
         standard_metadata.egress_spec = egress_port;

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-first.p4
@@ -52,7 +52,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.data.res_16 = hdr.data.res_16 |-| hdr.data.opr2_16;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".t") table t {
         actions = {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-first.p4
@@ -52,7 +52,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.data.res_16 = hdr.data.res_16 |-| hdr.data.opr2_16;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".t") table t {
         actions = {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-frontend.p4
@@ -52,7 +52,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.data.res_16 = hdr.data.res_16 |-| hdr.data.opr2_16;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".t") table t_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-frontend.p4
@@ -52,12 +52,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.data.res_16 = hdr.data.res_16 |-| hdr.data.opr2_16;
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".t") table t_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-midend.p4
@@ -52,7 +52,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.data.res_16 = hdr.data.opr1_16 |-| hdr.data.opr2_16;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".t") table t_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-midend.p4
@@ -52,8 +52,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.data.res_16 = hdr.data.opr1_16 |-| hdr.data.opr2_16;
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".t") table t_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2.p4
@@ -52,7 +52,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.data.res_16 = hdr.data.res_16 |-| hdr.data.opr2_16;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".t") table t {
         actions = {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2.p4
@@ -52,7 +52,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.data.res_16 = hdr.data.res_16 |-| hdr.data.opr2_16;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".t") table t {
         actions = {

--- a/testdata/p4_14_samples_outputs/simple_nat-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-first.p4
@@ -128,7 +128,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.tcp.dstPort = meta.meta.tcp_dp;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();
@@ -169,7 +169,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
         meta.meta.if_ipv4_addr = ipv4_addr;
@@ -186,7 +186,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nat_miss_ext_to_int") action nat_miss_ext_to_int() {
         meta.meta.do_forward = 1w0;
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
         meta.meta.do_forward = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_nat-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-first.p4
@@ -128,7 +128,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.tcp.dstPort = meta.meta.tcp_dp;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();
@@ -169,7 +169,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
         meta.meta.if_ipv4_addr = ipv4_addr;
@@ -186,7 +186,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nat_miss_ext_to_int") action nat_miss_ext_to_int() {
         meta.meta.do_forward = 1w0;
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
         meta.meta.do_forward = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
@@ -134,7 +134,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.tcp.dstPort = meta.meta.tcp_dp;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();
@@ -183,16 +188,36 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name("._drop") action _drop_6() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_3 = standard_metadata;
+            standard_metadata_3.egress_spec = 9w511;
+            standard_metadata_3.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_3;
+        }
     }
     @name("._drop") action _drop_7() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_6 = standard_metadata;
+            standard_metadata_6.egress_spec = 9w511;
+            standard_metadata_6.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_6;
+        }
     }
     @name("._drop") action _drop_8() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_7 = standard_metadata;
+            standard_metadata_7.egress_spec = 9w511;
+            standard_metadata_7.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_7;
+        }
     }
     @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
         meta.meta.if_ipv4_addr = ipv4_addr;
@@ -209,7 +234,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nat_miss_ext_to_int") action nat_miss_ext_to_int() {
         meta.meta.do_forward = 1w0;
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_8 = standard_metadata;
+            standard_metadata_8.egress_spec = 9w511;
+            standard_metadata_8.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_8;
+        }
     }
     @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
         meta.meta.do_forward = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
@@ -134,12 +134,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.tcp.dstPort = meta.meta.tcp_dp;
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();
@@ -188,36 +183,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_6() {
-        {
-            standard_metadata_t standard_metadata_3 = standard_metadata;
-            standard_metadata_3.egress_spec = 9w511;
-            standard_metadata_3.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_3;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_7() {
-        {
-            standard_metadata_t standard_metadata_6 = standard_metadata;
-            standard_metadata_6.egress_spec = 9w511;
-            standard_metadata_6.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_6;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_8() {
-        {
-            standard_metadata_t standard_metadata_7 = standard_metadata;
-            standard_metadata_7.egress_spec = 9w511;
-            standard_metadata_7.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_7;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
         meta.meta.if_ipv4_addr = ipv4_addr;
@@ -234,12 +209,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nat_miss_ext_to_int") action nat_miss_ext_to_int() {
         meta.meta.do_forward = 1w0;
-        {
-            standard_metadata_t standard_metadata_8 = standard_metadata;
-            standard_metadata_8.egress_spec = 9w511;
-            standard_metadata_8.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_8;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
         meta.meta.do_forward = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_nat-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-midend.p4
@@ -222,18 +222,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         clone3<tuple_0>(CloneType.I2E, 32w250, { standard_metadata });
     }
     @name(".nat_miss_ext_to_int") action nat_miss_ext_to_int() {
-<<<<<<< 45707c3563244f920d5714e8f7fa43c8ff4d9521
         meta._meta_do_forward3 = 1w0;
-        mark_to_drop();
-=======
-        meta._meta_do_forward4 = 1w0;
-<<<<<<< 3831bdec3b7692a6f5ce2ab80be5778bb0ee15f2
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
->>>>>>> Deprecate @mark_to_drop; replace with markToDrop action
-=======
         mark_to_drop(standard_metadata);
->>>>>>> Reference outputs for p4-14 programs
     }
     @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
         meta._meta_do_forward3 = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_nat-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-midend.p4
@@ -144,7 +144,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.tcp.dstPort = meta._meta_tcp_dp7;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();
@@ -197,16 +198,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_6() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_7() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_8() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
         meta._meta_if_ipv4_addr9 = ipv4_addr;
@@ -222,8 +227,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         clone3<tuple_0>(CloneType.I2E, 32w250, { standard_metadata });
     }
     @name(".nat_miss_ext_to_int") action nat_miss_ext_to_int() {
+<<<<<<< 45707c3563244f920d5714e8f7fa43c8ff4d9521
         meta._meta_do_forward3 = 1w0;
         mark_to_drop();
+=======
+        meta._meta_do_forward4 = 1w0;
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
+>>>>>>> Deprecate @mark_to_drop; replace with markToDrop action
     }
     @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
         meta._meta_do_forward3 = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_nat-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-midend.p4
@@ -144,8 +144,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.tcp.dstPort = meta._meta_tcp_dp7;
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();
@@ -198,20 +197,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_6() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_7() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_8() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
         meta._meta_if_ipv4_addr9 = ipv4_addr;
@@ -232,9 +227,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop();
 =======
         meta._meta_do_forward4 = 1w0;
+<<<<<<< 3831bdec3b7692a6f5ce2ab80be5778bb0ee15f2
         standard_metadata.egress_spec = 9w511;
         standard_metadata.mcast_grp = 16w0;
 >>>>>>> Deprecate @mark_to_drop; replace with markToDrop action
+=======
+        mark_to_drop(standard_metadata);
+>>>>>>> Reference outputs for p4-14 programs
     }
     @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
         meta._meta_do_forward3 = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_nat.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat.p4
@@ -128,7 +128,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.tcp.dstPort = meta.meta.tcp_dp;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();
@@ -167,7 +167,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
         meta.meta.if_ipv4_addr = ipv4_addr;
@@ -184,7 +184,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nat_miss_ext_to_int") action nat_miss_ext_to_int() {
         meta.meta.do_forward = 1w0;
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
         meta.meta.do_forward = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_nat.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat.p4
@@ -128,7 +128,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.tcp.dstPort = meta.meta.tcp_dp;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".do_cpu_encap") action do_cpu_encap() {
         hdr.cpu_header.setValid();
@@ -167,7 +167,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
         meta.meta.if_ipv4_addr = ipv4_addr;
@@ -184,7 +184,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nat_miss_ext_to_int") action nat_miss_ext_to_int() {
         meta.meta.do_forward = 1w0;
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
         meta.meta.do_forward = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_router-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-first.p4
@@ -60,7 +60,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -81,7 +81,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/simple_router-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-first.p4
@@ -60,7 +60,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -81,7 +81,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/simple_router-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-frontend.p4
@@ -62,7 +62,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -85,13 +90,28 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_1() {
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name("._drop") action _drop_5() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_4 = standard_metadata;
+            standard_metadata_4.egress_spec = 9w511;
+            standard_metadata_4.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_4;
+        }
     }
     @name("._drop") action _drop_6() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_5 = standard_metadata;
+            standard_metadata_5.egress_spec = 9w511;
+            standard_metadata_5.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_5;
+        }
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/simple_router-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-frontend.p4
@@ -62,12 +62,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -90,28 +85,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_1() {
     }
     @name("._drop") action _drop_2() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_5() {
-        {
-            standard_metadata_t standard_metadata_4 = standard_metadata;
-            standard_metadata_4.egress_spec = 9w511;
-            standard_metadata_4.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_4;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_6() {
-        {
-            standard_metadata_t standard_metadata_5 = standard_metadata;
-            standard_metadata_5.egress_spec = 9w511;
-            standard_metadata_5.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_5;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/simple_router-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-midend.p4
@@ -61,8 +61,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -85,16 +84,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_1() {
     }
     @name("._drop") action _drop_2() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_5() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_6() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/simple_router-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-midend.p4
@@ -61,7 +61,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -84,13 +85,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_1() {
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_5() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_6() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/simple_router.p4
+++ b/testdata/p4_14_samples_outputs/simple_router.p4
@@ -60,7 +60,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -79,7 +79,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/simple_router.p4
+++ b/testdata/p4_14_samples_outputs/simple_router.p4
@@ -60,7 +60,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".send_frame") table send_frame {
         actions = {
@@ -79,7 +79,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_14_samples_outputs/source_routing-first.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-first.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.easyroute_port.port;

--- a/testdata/p4_14_samples_outputs/source_routing-first.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-first.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.easyroute_port.port;

--- a/testdata/p4_14_samples_outputs/source_routing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-frontend.p4
@@ -51,12 +51,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.easyroute_port.port;

--- a/testdata/p4_14_samples_outputs/source_routing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-frontend.p4
@@ -51,7 +51,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.easyroute_port.port;

--- a/testdata/p4_14_samples_outputs/source_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-midend.p4
@@ -51,8 +51,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.easyroute_port.port;

--- a/testdata/p4_14_samples_outputs/source_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-midend.p4
@@ -51,7 +51,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.easyroute_port.port;

--- a/testdata/p4_14_samples_outputs/source_routing.p4
+++ b/testdata/p4_14_samples_outputs/source_routing.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.easyroute_port.port;

--- a/testdata/p4_14_samples_outputs/source_routing.p4
+++ b/testdata/p4_14_samples_outputs/source_routing.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".route") action route() {
         standard_metadata.egress_spec = (bit<9>)hdr.easyroute_port.port;

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
@@ -2734,7 +2734,7 @@ control process_vlan_xlate(inout headers hdr, inout metadata meta, inout standar
 
 control process_egress_filter(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_egress_filter_drop") action set_egress_filter_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_egress_ifindex") action set_egress_ifindex(bit<16> egress_ifindex) {
         meta.egress_filter_metadata.ifindex = meta.ingress_metadata.ifindex ^ egress_ifindex;
@@ -2775,7 +2775,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_mirror_drop") action egress_mirror_drop(bit<32> session_id) {
         egress_mirror(session_id);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_copy_to_cpu") action egress_copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
@@ -2783,7 +2783,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_redirect_to_cpu") action egress_redirect_to_cpu(bit<16> reason_code) {
         egress_copy_to_cpu(reason_code);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_acl") table egress_acl {
         actions = {
@@ -3707,7 +3707,7 @@ control process_mac(inout headers hdr, inout metadata meta, inout standard_metad
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action dmac_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".smac_miss") action smac_miss() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -4763,19 +4763,19 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
         copy_to_cpu(reason_code);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".drop_packet") action drop_packet() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
         drop_stats.count(drop_reason);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {
         clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".deflect_on_drop") action deflect_on_drop() {
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
@@ -2734,7 +2734,7 @@ control process_vlan_xlate(inout headers hdr, inout metadata meta, inout standar
 
 control process_egress_filter(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_egress_filter_drop") action set_egress_filter_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_egress_ifindex") action set_egress_ifindex(bit<16> egress_ifindex) {
         meta.egress_filter_metadata.ifindex = meta.ingress_metadata.ifindex ^ egress_ifindex;
@@ -2775,7 +2775,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_mirror_drop") action egress_mirror_drop(bit<32> session_id) {
         egress_mirror(session_id);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".egress_copy_to_cpu") action egress_copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
@@ -2783,7 +2783,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_redirect_to_cpu") action egress_redirect_to_cpu(bit<16> reason_code) {
         egress_copy_to_cpu(reason_code);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".egress_acl") table egress_acl {
         actions = {
@@ -3707,7 +3707,7 @@ control process_mac(inout headers hdr, inout metadata meta, inout standard_metad
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action dmac_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".smac_miss") action smac_miss() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -4763,19 +4763,19 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
         copy_to_cpu(reason_code);
-        mark_to_drop();
+        markToDrop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".drop_packet") action drop_packet() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
         drop_stats.count(drop_reason);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {
         clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".deflect_on_drop") action deflect_on_drop() {
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -2799,7 +2799,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         default_action = NoAction_110();
     }
     @name(".set_egress_filter_drop") action _set_egress_filter_drop_0() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".set_egress_ifindex") action _set_egress_ifindex_0(bit<16> egress_ifindex) {
         meta.egress_filter_metadata.ifindex = meta.ingress_metadata.ifindex ^ egress_ifindex;
@@ -2832,12 +2837,22 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".egress_mirror_drop") action _egress_mirror_drop_0(bit<32> session_id) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.E2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.E2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_3 = standard_metadata;
+            standard_metadata_3.egress_spec = 9w511;
+            standard_metadata_3.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_3;
+        }
     }
     @name(".egress_acl") table _egress_acl {
         actions = {
@@ -3726,7 +3741,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action _dmac_drop_0() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_4 = standard_metadata;
+            standard_metadata_4.egress_spec = 9w511;
+            standard_metadata_4.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_4;
+        }
     }
     @name(".smac_miss") action _smac_miss_0() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -4682,19 +4702,39 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".redirect_to_cpu") action _redirect_to_cpu_0(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.I2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_5 = standard_metadata;
+            standard_metadata_5.egress_spec = 9w511;
+            standard_metadata_5.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_5;
+        }
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".drop_packet") action _drop_packet_0() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_6 = standard_metadata;
+            standard_metadata_6.egress_spec = 9w511;
+            standard_metadata_6.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_6;
+        }
     }
     @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<32> drop_reason) {
         _drop_stats.count(drop_reason);
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_7 = standard_metadata;
+            standard_metadata_7.egress_spec = 9w511;
+            standard_metadata_7.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_7;
+        }
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {
         clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_8 = standard_metadata;
+            standard_metadata_8.egress_spec = 9w511;
+            standard_metadata_8.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_8;
+        }
     }
     @name(".congestion_mirror_set") action _congestion_mirror_set_0() {
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -2799,12 +2799,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         default_action = NoAction_110();
     }
     @name(".set_egress_filter_drop") action _set_egress_filter_drop_0() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".set_egress_ifindex") action _set_egress_ifindex_0(bit<16> egress_ifindex) {
         meta.egress_filter_metadata.ifindex = meta.ingress_metadata.ifindex ^ egress_ifindex;
@@ -2837,22 +2832,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".egress_mirror_drop") action _egress_mirror_drop_0(bit<32> session_id) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.E2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.E2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
-        {
-            standard_metadata_t standard_metadata_3 = standard_metadata;
-            standard_metadata_3.egress_spec = 9w511;
-            standard_metadata_3.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_3;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_acl") table _egress_acl {
         actions = {
@@ -3741,12 +3726,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action _dmac_drop_0() {
-        {
-            standard_metadata_t standard_metadata_4 = standard_metadata;
-            standard_metadata_4.egress_spec = 9w511;
-            standard_metadata_4.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_4;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".smac_miss") action _smac_miss_0() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -4702,39 +4682,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".redirect_to_cpu") action _redirect_to_cpu_0(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.I2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
-        {
-            standard_metadata_t standard_metadata_5 = standard_metadata;
-            standard_metadata_5.egress_spec = 9w511;
-            standard_metadata_5.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_5;
-        }
+        mark_to_drop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".drop_packet") action _drop_packet_0() {
-        {
-            standard_metadata_t standard_metadata_6 = standard_metadata;
-            standard_metadata_6.egress_spec = 9w511;
-            standard_metadata_6.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_6;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<32> drop_reason) {
         _drop_stats.count(drop_reason);
-        {
-            standard_metadata_t standard_metadata_7 = standard_metadata;
-            standard_metadata_7.egress_spec = 9w511;
-            standard_metadata_7.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_7;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {
         clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        {
-            standard_metadata_t standard_metadata_8 = standard_metadata;
-            standard_metadata_8.egress_spec = 9w511;
-            standard_metadata_8.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_8;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".congestion_mirror_set") action _congestion_mirror_set_0() {
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -2913,8 +2913,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         default_action = NoAction_110();
     }
     @name(".set_egress_filter_drop") action _set_egress_filter_drop_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".set_egress_ifindex") action _set_egress_ifindex_0(bit<16> egress_ifindex) {
         meta._egress_filter_metadata_ifindex12 = meta._ingress_metadata_ifindex36 ^ egress_ifindex;
@@ -2947,14 +2946,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".egress_mirror_drop") action _egress_mirror_drop_0(bit<32> session_id) {
         meta._i2e_metadata_mirror_session_id34 = (bit<16>)session_id;
         clone3<tuple_0>(CloneType.E2E, session_id, { meta._i2e_metadata_ingress_tstamp33, (bit<16>)session_id });
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(bit<16> reason_code) {
         meta._fabric_metadata_reason_code27 = reason_code;
         clone3<tuple_1>(CloneType.E2E, 32w250, { meta._ingress_metadata_bd40, meta._ingress_metadata_ifindex36, reason_code, meta._ingress_metadata_ingress_port35 });
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_acl") table _egress_acl {
         actions = {
@@ -3891,8 +3888,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._l2_metadata_l2_nexthop_type73 = 1w1;
     }
     @name(".dmac_drop") action _dmac_drop_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".smac_miss") action _smac_miss_0() {
         meta._l2_metadata_l2_src_miss75 = 1w1;
@@ -4848,23 +4844,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".redirect_to_cpu") action _redirect_to_cpu_0(bit<16> reason_code) {
         meta._fabric_metadata_reason_code27 = reason_code;
         clone3<tuple_1>(CloneType.I2E, 32w250, { meta._ingress_metadata_bd40, meta._ingress_metadata_ifindex36, reason_code, meta._ingress_metadata_ingress_port35 });
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
         meta._fabric_metadata_dst_device28 = 8w0;
     }
     @name(".drop_packet") action _drop_packet_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<32> drop_reason) {
         _drop_stats.count(drop_reason);
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {
         clone3<tuple_7>(CloneType.I2E, session_id, { meta._ingress_metadata_ifindex36, meta._ingress_metadata_drop_reason42 });
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".congestion_mirror_set") action _congestion_mirror_set_0() {
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -2913,7 +2913,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         default_action = NoAction_110();
     }
     @name(".set_egress_filter_drop") action _set_egress_filter_drop_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".set_egress_ifindex") action _set_egress_ifindex_0(bit<16> egress_ifindex) {
         meta._egress_filter_metadata_ifindex12 = meta._ingress_metadata_ifindex36 ^ egress_ifindex;
@@ -2946,12 +2947,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".egress_mirror_drop") action _egress_mirror_drop_0(bit<32> session_id) {
         meta._i2e_metadata_mirror_session_id34 = (bit<16>)session_id;
         clone3<tuple_0>(CloneType.E2E, session_id, { meta._i2e_metadata_ingress_tstamp33, (bit<16>)session_id });
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(bit<16> reason_code) {
         meta._fabric_metadata_reason_code27 = reason_code;
         clone3<tuple_1>(CloneType.E2E, 32w250, { meta._ingress_metadata_bd40, meta._ingress_metadata_ifindex36, reason_code, meta._ingress_metadata_ingress_port35 });
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".egress_acl") table _egress_acl {
         actions = {
@@ -3888,7 +3891,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._l2_metadata_l2_nexthop_type73 = 1w1;
     }
     @name(".dmac_drop") action _dmac_drop_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".smac_miss") action _smac_miss_0() {
         meta._l2_metadata_l2_src_miss75 = 1w1;
@@ -4844,19 +4848,23 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".redirect_to_cpu") action _redirect_to_cpu_0(bit<16> reason_code) {
         meta._fabric_metadata_reason_code27 = reason_code;
         clone3<tuple_1>(CloneType.I2E, 32w250, { meta._ingress_metadata_bd40, meta._ingress_metadata_ifindex36, reason_code, meta._ingress_metadata_ingress_port35 });
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
         meta._fabric_metadata_dst_device28 = 8w0;
     }
     @name(".drop_packet") action _drop_packet_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<32> drop_reason) {
         _drop_stats.count(drop_reason);
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {
         clone3<tuple_7>(CloneType.I2E, session_id, { meta._ingress_metadata_ifindex36, meta._ingress_metadata_drop_reason42 });
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".congestion_mirror_set") action _congestion_mirror_set_0() {
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
@@ -2700,7 +2700,7 @@ control process_vlan_xlate(inout headers hdr, inout metadata meta, inout standar
 
 control process_egress_filter(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_egress_filter_drop") action set_egress_filter_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_egress_ifindex") action set_egress_ifindex(bit<16> egress_ifindex) {
         meta.egress_filter_metadata.ifindex = meta.ingress_metadata.ifindex ^ egress_ifindex;
@@ -2739,7 +2739,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_mirror_drop") action egress_mirror_drop(bit<32> session_id) {
         egress_mirror(session_id);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_copy_to_cpu") action egress_copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
@@ -2747,7 +2747,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_redirect_to_cpu") action egress_redirect_to_cpu(bit<16> reason_code) {
         egress_copy_to_cpu(reason_code);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_acl") table egress_acl {
         actions = {
@@ -3647,7 +3647,7 @@ control process_mac(inout headers hdr, inout metadata meta, inout standard_metad
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action dmac_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".smac_miss") action smac_miss() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -4652,19 +4652,19 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
         copy_to_cpu(reason_code);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".drop_packet") action drop_packet() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
         drop_stats.count((bit<32>)drop_reason);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".deflect_on_drop") action deflect_on_drop() {
     }

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
@@ -2700,7 +2700,7 @@ control process_vlan_xlate(inout headers hdr, inout metadata meta, inout standar
 
 control process_egress_filter(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_egress_filter_drop") action set_egress_filter_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_egress_ifindex") action set_egress_ifindex(bit<16> egress_ifindex) {
         meta.egress_filter_metadata.ifindex = meta.ingress_metadata.ifindex ^ egress_ifindex;
@@ -2739,7 +2739,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_mirror_drop") action egress_mirror_drop(bit<32> session_id) {
         egress_mirror(session_id);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".egress_copy_to_cpu") action egress_copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
@@ -2747,7 +2747,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_redirect_to_cpu") action egress_redirect_to_cpu(bit<16> reason_code) {
         egress_copy_to_cpu(reason_code);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".egress_acl") table egress_acl {
         actions = {
@@ -3647,7 +3647,7 @@ control process_mac(inout headers hdr, inout metadata meta, inout standard_metad
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action dmac_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".smac_miss") action smac_miss() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -4652,19 +4652,19 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
         copy_to_cpu(reason_code);
-        mark_to_drop();
+        markToDrop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".drop_packet") action drop_packet() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
         drop_stats.count((bit<32>)drop_reason);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".deflect_on_drop") action deflect_on_drop() {
     }

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -2930,7 +2930,7 @@ control process_egress_filter(inout headers hdr, inout metadata meta, inout stan
         meta.egress_filter_metadata.inner_bd = meta.ingress_metadata.bd ^ meta.egress_metadata.bd;
     }
     @name(".set_egress_filter_drop") action set_egress_filter_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".egress_filter") table egress_filter {
         actions = {
@@ -2963,7 +2963,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_mirror_drop") action egress_mirror_drop(bit<32> session_id) {
         egress_mirror(session_id);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".egress_copy_to_cpu") action egress_copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
@@ -2971,7 +2971,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_redirect_to_cpu") action egress_redirect_to_cpu(bit<16> reason_code) {
         egress_copy_to_cpu(reason_code);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".egress_acl") table egress_acl {
         actions = {
@@ -4427,7 +4427,7 @@ control process_mac(inout headers hdr, inout metadata meta, inout standard_metad
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action dmac_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".smac_miss") action smac_miss() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -5411,14 +5411,14 @@ control process_meter_action(inout headers hdr, inout metadata meta, inout stand
     @name(".meter_permit") action meter_permit() {
     }
     @name(".meter_deny") action meter_deny() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".meter_permit") action meter_permit_0() {
         meter_stats.count();
     }
     @name(".meter_deny") action meter_deny_0() {
         meter_stats.count();
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".meter_action") table meter_action {
         actions = {
@@ -5792,22 +5792,22 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
         copy_to_cpu_with_reason(reason_code);
-        mark_to_drop();
+        markToDrop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".copy_to_cpu") action copy_to_cpu() {
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.I2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name(".drop_packet") action drop_packet() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
         drop_stats.count(drop_reason);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {
         clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".drop_stats") table drop_stats_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -2930,7 +2930,7 @@ control process_egress_filter(inout headers hdr, inout metadata meta, inout stan
         meta.egress_filter_metadata.inner_bd = meta.ingress_metadata.bd ^ meta.egress_metadata.bd;
     }
     @name(".set_egress_filter_drop") action set_egress_filter_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_filter") table egress_filter {
         actions = {
@@ -2963,7 +2963,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_mirror_drop") action egress_mirror_drop(bit<32> session_id) {
         egress_mirror(session_id);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_copy_to_cpu") action egress_copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
@@ -2971,7 +2971,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_redirect_to_cpu") action egress_redirect_to_cpu(bit<16> reason_code) {
         egress_copy_to_cpu(reason_code);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_acl") table egress_acl {
         actions = {
@@ -4427,7 +4427,7 @@ control process_mac(inout headers hdr, inout metadata meta, inout standard_metad
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action dmac_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".smac_miss") action smac_miss() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -5411,14 +5411,14 @@ control process_meter_action(inout headers hdr, inout metadata meta, inout stand
     @name(".meter_permit") action meter_permit() {
     }
     @name(".meter_deny") action meter_deny() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".meter_permit") action meter_permit_0() {
         meter_stats.count();
     }
     @name(".meter_deny") action meter_deny_0() {
         meter_stats.count();
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".meter_action") table meter_action {
         actions = {
@@ -5792,22 +5792,22 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
         copy_to_cpu_with_reason(reason_code);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".copy_to_cpu") action copy_to_cpu() {
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.I2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name(".drop_packet") action drop_packet() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
         drop_stats.count(drop_reason);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {
         clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_stats") table drop_stats_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -3011,7 +3011,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta.egress_filter_metadata.inner_bd = meta.ingress_metadata.bd ^ meta.egress_metadata.bd;
     }
     @name(".set_egress_filter_drop") action _set_egress_filter_drop_0() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name(".egress_filter") table _egress_filter {
         actions = {
@@ -3036,12 +3041,22 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".egress_mirror_drop") action _egress_mirror_drop_0(bit<32> session_id) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.E2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.E2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_3 = standard_metadata;
+            standard_metadata_3.egress_spec = 9w511;
+            standard_metadata_3.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_3;
+        }
     }
     @name(".egress_acl") table _egress_acl {
         actions = {
@@ -4436,7 +4451,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action _dmac_drop_0() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_4 = standard_metadata;
+            standard_metadata_4.egress_spec = 9w511;
+            standard_metadata_4.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_4;
+        }
     }
     @name(".smac_miss") action _smac_miss_0() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -5277,7 +5297,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".meter_deny") action _meter_deny_0() {
         _meter_stats.count();
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_5 = standard_metadata;
+            standard_metadata_5.egress_spec = 9w511;
+            standard_metadata_5.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_5;
+        }
     }
     @name(".meter_action") table _meter_action {
         actions = {
@@ -5580,22 +5605,42 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".redirect_to_cpu") action _redirect_to_cpu_0(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.I2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_6 = standard_metadata;
+            standard_metadata_6.egress_spec = 9w511;
+            standard_metadata_6.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_6;
+        }
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".copy_to_cpu") action _copy_to_cpu_0() {
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.I2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name(".drop_packet") action _drop_packet_0() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_7 = standard_metadata;
+            standard_metadata_7.egress_spec = 9w511;
+            standard_metadata_7.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_7;
+        }
     }
     @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<32> drop_reason) {
         _drop_stats.count(drop_reason);
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_8 = standard_metadata;
+            standard_metadata_8.egress_spec = 9w511;
+            standard_metadata_8.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_8;
+        }
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {
         clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_9 = standard_metadata;
+            standard_metadata_9.egress_spec = 9w511;
+            standard_metadata_9.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_9;
+        }
     }
     @name(".drop_stats") table _drop_stats_1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -3011,12 +3011,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta.egress_filter_metadata.inner_bd = meta.ingress_metadata.bd ^ meta.egress_metadata.bd;
     }
     @name(".set_egress_filter_drop") action _set_egress_filter_drop_0() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_filter") table _egress_filter {
         actions = {
@@ -3041,22 +3036,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".egress_mirror_drop") action _egress_mirror_drop_0(bit<32> session_id) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.E2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.E2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
-        {
-            standard_metadata_t standard_metadata_3 = standard_metadata;
-            standard_metadata_3.egress_spec = 9w511;
-            standard_metadata_3.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_3;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_acl") table _egress_acl {
         actions = {
@@ -4451,12 +4436,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action _dmac_drop_0() {
-        {
-            standard_metadata_t standard_metadata_4 = standard_metadata;
-            standard_metadata_4.egress_spec = 9w511;
-            standard_metadata_4.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_4;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".smac_miss") action _smac_miss_0() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -5297,12 +5277,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".meter_deny") action _meter_deny_0() {
         _meter_stats.count();
-        {
-            standard_metadata_t standard_metadata_5 = standard_metadata;
-            standard_metadata_5.egress_spec = 9w511;
-            standard_metadata_5.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_5;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".meter_action") table _meter_action {
         actions = {
@@ -5605,42 +5580,22 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".redirect_to_cpu") action _redirect_to_cpu_0(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.I2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
-        {
-            standard_metadata_t standard_metadata_6 = standard_metadata;
-            standard_metadata_6.egress_spec = 9w511;
-            standard_metadata_6.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_6;
-        }
+        mark_to_drop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".copy_to_cpu") action _copy_to_cpu_0() {
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.I2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name(".drop_packet") action _drop_packet_0() {
-        {
-            standard_metadata_t standard_metadata_7 = standard_metadata;
-            standard_metadata_7.egress_spec = 9w511;
-            standard_metadata_7.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_7;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<32> drop_reason) {
         _drop_stats.count(drop_reason);
-        {
-            standard_metadata_t standard_metadata_8 = standard_metadata;
-            standard_metadata_8.egress_spec = 9w511;
-            standard_metadata_8.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_8;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {
         clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        {
-            standard_metadata_t standard_metadata_9 = standard_metadata;
-            standard_metadata_9.egress_spec = 9w511;
-            standard_metadata_9.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_9;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_stats") table _drop_stats_1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -3134,7 +3134,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_filter_metadata_inner_bd14 = meta._ingress_metadata_bd42 ^ meta._egress_metadata_bd19;
     }
     @name(".set_egress_filter_drop") action _set_egress_filter_drop_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".egress_filter") table _egress_filter {
         actions = {
@@ -3159,12 +3160,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".egress_mirror_drop") action _egress_mirror_drop_0(bit<32> session_id) {
         meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id;
         clone3<tuple_0>(CloneType.E2E, session_id, { meta._i2e_metadata_ingress_tstamp35, (bit<16>)session_id });
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(bit<16> reason_code) {
         meta._fabric_metadata_reason_code28 = reason_code;
         clone3<tuple_1>(CloneType.E2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code, meta._ingress_metadata_ingress_port37 });
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".egress_acl") table _egress_acl {
         actions = {
@@ -4618,7 +4621,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._l2_metadata_l2_nexthop_type76 = 1w1;
     }
     @name(".dmac_drop") action _dmac_drop_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".smac_miss") action _smac_miss_0() {
         meta._l2_metadata_l2_src_miss78 = 1w1;
@@ -5459,7 +5463,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".meter_deny") action _meter_deny_0() {
         _meter_stats.count();
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".meter_action") table _meter_action {
         actions = {
@@ -5762,22 +5767,26 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".redirect_to_cpu") action _redirect_to_cpu_0(bit<16> reason_code) {
         meta._fabric_metadata_reason_code28 = reason_code;
         clone3<tuple_1>(CloneType.I2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code, meta._ingress_metadata_ingress_port37 });
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
         meta._fabric_metadata_dst_device29 = 8w0;
     }
     @name(".copy_to_cpu") action _copy_to_cpu_0() {
         clone3<tuple_1>(CloneType.I2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, meta._fabric_metadata_reason_code28, meta._ingress_metadata_ingress_port37 });
     }
     @name(".drop_packet") action _drop_packet_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<32> drop_reason) {
         _drop_stats.count(drop_reason);
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {
         clone3<tuple_9>(CloneType.I2E, session_id, { meta._ingress_metadata_ifindex38, meta._ingress_metadata_drop_reason44 });
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".drop_stats") table _drop_stats_1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -3134,8 +3134,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_filter_metadata_inner_bd14 = meta._ingress_metadata_bd42 ^ meta._egress_metadata_bd19;
     }
     @name(".set_egress_filter_drop") action _set_egress_filter_drop_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_filter") table _egress_filter {
         actions = {
@@ -3160,14 +3159,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".egress_mirror_drop") action _egress_mirror_drop_0(bit<32> session_id) {
         meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id;
         clone3<tuple_0>(CloneType.E2E, session_id, { meta._i2e_metadata_ingress_tstamp35, (bit<16>)session_id });
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(bit<16> reason_code) {
         meta._fabric_metadata_reason_code28 = reason_code;
         clone3<tuple_1>(CloneType.E2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code, meta._ingress_metadata_ingress_port37 });
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_acl") table _egress_acl {
         actions = {
@@ -4621,8 +4618,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._l2_metadata_l2_nexthop_type76 = 1w1;
     }
     @name(".dmac_drop") action _dmac_drop_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".smac_miss") action _smac_miss_0() {
         meta._l2_metadata_l2_src_miss78 = 1w1;
@@ -5463,8 +5459,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".meter_deny") action _meter_deny_0() {
         _meter_stats.count();
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".meter_action") table _meter_action {
         actions = {
@@ -5767,26 +5762,22 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".redirect_to_cpu") action _redirect_to_cpu_0(bit<16> reason_code) {
         meta._fabric_metadata_reason_code28 = reason_code;
         clone3<tuple_1>(CloneType.I2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code, meta._ingress_metadata_ingress_port37 });
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
         meta._fabric_metadata_dst_device29 = 8w0;
     }
     @name(".copy_to_cpu") action _copy_to_cpu_0() {
         clone3<tuple_1>(CloneType.I2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, meta._fabric_metadata_reason_code28, meta._ingress_metadata_ingress_port37 });
     }
     @name(".drop_packet") action _drop_packet_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<32> drop_reason) {
         _drop_stats.count(drop_reason);
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {
         clone3<tuple_9>(CloneType.I2E, session_id, { meta._ingress_metadata_ifindex38, meta._ingress_metadata_drop_reason44 });
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_stats") table _drop_stats_1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -2887,7 +2887,7 @@ control process_egress_filter(inout headers hdr, inout metadata meta, inout stan
         meta.egress_filter_metadata.inner_bd = meta.ingress_metadata.bd ^ meta.egress_metadata.bd;
     }
     @name(".set_egress_filter_drop") action set_egress_filter_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".egress_filter") table egress_filter {
         actions = {
@@ -2918,7 +2918,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_mirror_drop") action egress_mirror_drop(bit<32> session_id) {
         egress_mirror(session_id);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".egress_copy_to_cpu") action egress_copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
@@ -2926,7 +2926,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_redirect_to_cpu") action egress_redirect_to_cpu(bit<16> reason_code) {
         egress_copy_to_cpu(reason_code);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".egress_acl") table egress_acl {
         actions = {
@@ -4336,7 +4336,7 @@ control process_mac(inout headers hdr, inout metadata meta, inout standard_metad
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action dmac_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".smac_miss") action smac_miss() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -5282,14 +5282,14 @@ control process_meter_action(inout headers hdr, inout metadata meta, inout stand
     @name(".meter_permit") action meter_permit() {
     }
     @name(".meter_deny") action meter_deny() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".meter_permit") action meter_permit_0() {
         meter_stats.count();
     }
     @name(".meter_deny") action meter_deny_0() {
         meter_stats.count();
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".meter_action") table meter_action {
         actions = {
@@ -5646,22 +5646,22 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
         copy_to_cpu_with_reason(reason_code);
-        mark_to_drop();
+        markToDrop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".copy_to_cpu") action copy_to_cpu() {
         clone3(CloneType.I2E, (bit<32>)32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name(".drop_packet") action drop_packet() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
         drop_stats.count((bit<32>)drop_reason);
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".drop_stats") table drop_stats_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -2887,7 +2887,7 @@ control process_egress_filter(inout headers hdr, inout metadata meta, inout stan
         meta.egress_filter_metadata.inner_bd = meta.ingress_metadata.bd ^ meta.egress_metadata.bd;
     }
     @name(".set_egress_filter_drop") action set_egress_filter_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_filter") table egress_filter {
         actions = {
@@ -2918,7 +2918,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_mirror_drop") action egress_mirror_drop(bit<32> session_id) {
         egress_mirror(session_id);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_copy_to_cpu") action egress_copy_to_cpu(bit<16> reason_code) {
         meta.fabric_metadata.reason_code = reason_code;
@@ -2926,7 +2926,7 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".egress_redirect_to_cpu") action egress_redirect_to_cpu(bit<16> reason_code) {
         egress_copy_to_cpu(reason_code);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".egress_acl") table egress_acl {
         actions = {
@@ -4336,7 +4336,7 @@ control process_mac(inout headers hdr, inout metadata meta, inout standard_metad
         meta.l2_metadata.l2_nexthop_type = 1w1;
     }
     @name(".dmac_drop") action dmac_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".smac_miss") action smac_miss() {
         meta.l2_metadata.l2_src_miss = 1w1;
@@ -5282,14 +5282,14 @@ control process_meter_action(inout headers hdr, inout metadata meta, inout stand
     @name(".meter_permit") action meter_permit() {
     }
     @name(".meter_deny") action meter_deny() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".meter_permit") action meter_permit_0() {
         meter_stats.count();
     }
     @name(".meter_deny") action meter_deny_0() {
         meter_stats.count();
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".meter_action") table meter_action {
         actions = {
@@ -5646,22 +5646,22 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     }
     @name(".redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
         copy_to_cpu_with_reason(reason_code);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
     }
     @name(".copy_to_cpu") action copy_to_cpu() {
         clone3(CloneType.I2E, (bit<32>)32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
     @name(".drop_packet") action drop_packet() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
         drop_stats.count((bit<32>)drop_reason);
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".drop_stats") table drop_stats_0 {
         actions = {

--- a/testdata/p4_16_errors/issue1803_same_table_name.p4
+++ b/testdata/p4_16_errors/issue1803_same_table_name.p4
@@ -13,7 +13,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 action empty() { }
 
 control MyC(inout standard_metadata_t smeta)() {
-    action drop() { mark_to_drop(); }
+    action drop() { mark_to_drop(smeta); }
 
     @name(".t0")
     table t0 {

--- a/testdata/p4_16_errors_outputs/issue1541.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1541.p4-stderr
@@ -1,7 +1,7 @@
 issue1541.p4(25): [--Wwarn=shadow] warning: hash shadows hash
     action hash() {
            ^^^^
-v1model.p4(144)
+v1model.p4(141)
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
             ^^^^
 issue1541.p4(26): [--Werror=type-error] error: hash: Recursive action call

--- a/testdata/p4_16_errors_outputs/issue1541.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1541.p4-stderr
@@ -1,7 +1,7 @@
 issue1541.p4(25): [--Wwarn=shadow] warning: hash shadows hash
     action hash() {
            ^^^^
-v1model.p4(138)
+v1model.p4(144)
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
             ^^^^
 issue1541.p4(26): [--Werror=type-error] error: hash: Recursive action call

--- a/testdata/p4_16_errors_outputs/issue1803_same_table_name-first.p4
+++ b/testdata/p4_16_errors_outputs/issue1803_same_table_name-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control MyC(inout standard_metadata_t smeta) {
     action drop() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name(".t0") table t0 {
         key = {

--- a/testdata/p4_16_errors_outputs/issue1803_same_table_name-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue1803_same_table_name-frontend.p4
@@ -20,7 +20,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.c1.drop") action c1_drop_0() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name(".t0") table _t0 {
         key = {
@@ -33,7 +33,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         const default_action = NoAction_0();
     }
     @name("IngressI.c2.drop") action c2_drop_0() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name(".t0") table _t0_0 {
         key = {

--- a/testdata/p4_16_errors_outputs/issue1803_same_table_name-midend.p4
+++ b/testdata/p4_16_errors_outputs/issue1803_same_table_name-midend.p4
@@ -20,7 +20,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.c1.drop") action c1_drop_0() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name(".t0") table _t0 {
         key = {
@@ -33,7 +33,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         const default_action = NoAction_0();
     }
     @name("IngressI.c2.drop") action c2_drop_0() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name(".t0") table _t0_0 {
         key = {

--- a/testdata/p4_16_errors_outputs/issue1803_same_table_name.p4
+++ b/testdata/p4_16_errors_outputs/issue1803_same_table_name.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control MyC(inout standard_metadata_t smeta) {
     action drop() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name(".t0") table t0 {
         key = {

--- a/testdata/p4_16_errors_outputs/issue513.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue513.p4-stderr
@@ -1,4 +1,4 @@
-issue513.p4(60): [--Wwarn=deprecated] warning: mark_to_drop: Using deprecated feature mark_to_drop. Please use action markToDrop instead.
+issue513.p4(60): [--Wwarn=deprecated] warning: mark_to_drop: Using deprecated feature mark_to_drop. Please use mark_to_drop(standard_metadata) instead.
             mark_to_drop();
             ^^^^^^^^^^^^
 v1model.p4(138)

--- a/testdata/p4_16_errors_outputs/issue513.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue513.p4-stderr
@@ -1,3 +1,9 @@
+issue513.p4(60): [--Wwarn=deprecated] warning: mark_to_drop: Using deprecated feature mark_to_drop. Please use action markToDrop instead.
+            mark_to_drop();
+            ^^^^^^^^^^^^
+v1model.p4(138)
+extern void mark_to_drop();
+            ^^^^^^^^^^^^
 issue513.p4(60): [--Werror=legacy] error: MethodCallStatement: Conditional execution in actions is not supported on this target
             mark_to_drop();
             ^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples/action-two-params.p4
+++ b/testdata/p4_16_samples/action-two-params.p4
@@ -59,7 +59,7 @@ inout standard_metadata_t standard_metadata) {
 
 control MyIngress(inout headers hdr, inout metadata meta,
 inout standard_metadata_t standard_metadata) {
-    action drop() { markToDrop(standard_metadata); }
+    action drop() { mark_to_drop(standard_metadata); }
     action actTbl(bit<24> id, bit<32> ip) {
     }
     table ingress_tbl {

--- a/testdata/p4_16_samples/action-two-params.p4
+++ b/testdata/p4_16_samples/action-two-params.p4
@@ -59,7 +59,7 @@ inout standard_metadata_t standard_metadata) {
 
 control MyIngress(inout headers hdr, inout metadata meta,
 inout standard_metadata_t standard_metadata) {
-    action drop() { mark_to_drop(); }
+    action drop() { markToDrop(standard_metadata); }
     action actTbl(bit<24> id, bit<32> ip) {
     }
     table ingress_tbl {
@@ -99,4 +99,3 @@ control MyComputeChecksum(inout headers hdr, inout metadata meta) {
 
 V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(),
 MyComputeChecksum(), MyDeparser()) main;
-

--- a/testdata/p4_16_samples/action_profile-bmv2.p4
+++ b/testdata/p4_16_samples/action_profile-bmv2.p4
@@ -30,7 +30,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { markToDrop(smeta); }
+    action drop() { mark_to_drop(smeta); }
 
     table indirect {
         key = { }

--- a/testdata/p4_16_samples/action_profile-bmv2.p4
+++ b/testdata/p4_16_samples/action_profile-bmv2.p4
@@ -30,7 +30,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { mark_to_drop(); }
+    action drop() { markToDrop(smeta); }
 
     table indirect {
         key = { }

--- a/testdata/p4_16_samples/action_profile_max_group_size_annotation.p4
+++ b/testdata/p4_16_samples/action_profile_max_group_size_annotation.p4
@@ -30,7 +30,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { markToDrop(smeta); }
+    action drop() { mark_to_drop(smeta); }
 
     table indirect {
         key = { }

--- a/testdata/p4_16_samples/action_profile_max_group_size_annotation.p4
+++ b/testdata/p4_16_samples/action_profile_max_group_size_annotation.p4
@@ -30,7 +30,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { mark_to_drop(); }
+    action drop() { markToDrop(smeta); }
 
     table indirect {
         key = { }

--- a/testdata/p4_16_samples/action_selector_shared-bmv2.p4
+++ b/testdata/p4_16_samples/action_selector_shared-bmv2.p4
@@ -30,7 +30,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { markToDrop(smeta); }
+    action drop() { mark_to_drop(smeta); }
 
     action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
 

--- a/testdata/p4_16_samples/action_selector_shared-bmv2.p4
+++ b/testdata/p4_16_samples/action_selector_shared-bmv2.p4
@@ -30,7 +30,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { mark_to_drop(); }
+    action drop() { markToDrop(smeta); }
 
     action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
 

--- a/testdata/p4_16_samples/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples/action_selector_unused-bmv2.p4
@@ -15,7 +15,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { mark_to_drop(); }
+    action drop() { markToDrop(smeta); }
 
     action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
     apply { }

--- a/testdata/p4_16_samples/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples/action_selector_unused-bmv2.p4
@@ -15,7 +15,7 @@ action empty() { }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 
-    action drop() { markToDrop(smeta); }
+    action drop() { mark_to_drop(smeta); }
 
     action_selector (HashAlgorithm.identity, 32w1024, 32w10) as;
     apply { }

--- a/testdata/p4_16_samples/crc32-bmv2.p4
+++ b/testdata/p4_16_samples/crc32-bmv2.p4
@@ -197,7 +197,7 @@ control MyIngress(inout headers hdr,
     }
 
     action operation_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
 
     table calculate {

--- a/testdata/p4_16_samples/crc32-bmv2.p4
+++ b/testdata/p4_16_samples/crc32-bmv2.p4
@@ -197,7 +197,7 @@ control MyIngress(inout headers hdr,
     }
 
     action operation_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
 
     table calculate {

--- a/testdata/p4_16_samples/drop-bmv2.p4
+++ b/testdata/p4_16_samples/drop-bmv2.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
     state start { transition accept; }
 }
 
-action drop(out standard_metadata_t smeta) { mark_to_drop(); } // this global action seems to cause the problem
+action drop(inout standard_metadata_t smeta) { markToDrop(smeta); } // this global action seems to cause the problem
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 

--- a/testdata/p4_16_samples/drop-bmv2.p4
+++ b/testdata/p4_16_samples/drop-bmv2.p4
@@ -24,7 +24,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
     state start { transition accept; }
 }
 
-action drop(inout standard_metadata_t smeta) { markToDrop(smeta); } // this global action seems to cause the problem
+action drop(inout standard_metadata_t smeta) { mark_to_drop(smeta); } // this global action seems to cause the problem
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
 

--- a/testdata/p4_16_samples/flag_lost-bmv2.p4
+++ b/testdata/p4_16_samples/flag_lost-bmv2.p4
@@ -63,7 +63,7 @@ control verifyChecksum(inout headers hdr, inout metadata meta) {
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
 
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {

--- a/testdata/p4_16_samples/flag_lost-bmv2.p4
+++ b/testdata/p4_16_samples/flag_lost-bmv2.p4
@@ -63,7 +63,7 @@ control verifyChecksum(inout headers hdr, inout metadata meta) {
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
 
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {

--- a/testdata/p4_16_samples/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples/flowlet_switching-bmv2.p4
@@ -88,7 +88,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -111,7 +111,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
     @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_16_samples/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples/flowlet_switching-bmv2.p4
@@ -88,7 +88,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -111,7 +111,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
     @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_16_samples/issue1079-bmv2.p4
+++ b/testdata/p4_16_samples/issue1079-bmv2.p4
@@ -44,7 +44,7 @@ control EmptyEgress(inout headers_t hdr,
                     inout standard_metadata_t standard_metadata)
 {
   apply {
-    markToDrop(standard_metadata);
+    mark_to_drop(standard_metadata);
   }
 }
 

--- a/testdata/p4_16_samples/issue1079-bmv2.p4
+++ b/testdata/p4_16_samples/issue1079-bmv2.p4
@@ -44,7 +44,7 @@ control EmptyEgress(inout headers_t hdr,
                     inout standard_metadata_t standard_metadata)
 {
   apply {
-    mark_to_drop();
+    markToDrop(standard_metadata);
   }
 }
 

--- a/testdata/p4_16_samples/issue1325-bmv2.p4
+++ b/testdata/p4_16_samples/issue1325-bmv2.p4
@@ -28,7 +28,7 @@ control ingress(inout parsed_packet_t hdr,
 	        inout standard_metadata_t standard_metadata) {
     apply {
         if (local_metadata.test.test_error == error.Unused)
-            mark_to_drop();
+            markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples/issue1325-bmv2.p4
+++ b/testdata/p4_16_samples/issue1325-bmv2.p4
@@ -28,7 +28,7 @@ control ingress(inout parsed_packet_t hdr,
 	        inout standard_metadata_t standard_metadata) {
     apply {
         if (local_metadata.test.test_error == error.Unused)
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples/issue1352-bmv2.p4
+++ b/testdata/p4_16_samples/issue1352-bmv2.p4
@@ -98,7 +98,7 @@ control MyIngress(inout headers hdr,
 				  inout standard_metadata_t standard_metadata) {
 
 	action drop() {
-		mark_to_drop();
+		markToDrop(standard_metadata);
 	}
 
 

--- a/testdata/p4_16_samples/issue1352-bmv2.p4
+++ b/testdata/p4_16_samples/issue1352-bmv2.p4
@@ -98,7 +98,7 @@ control MyIngress(inout headers hdr,
 				  inout standard_metadata_t standard_metadata) {
 
 	action drop() {
-		markToDrop(standard_metadata);
+		mark_to_drop(standard_metadata);
 	}
 
 

--- a/testdata/p4_16_samples/issue1517-bmv2.p4
+++ b/testdata/p4_16_samples/issue1517-bmv2.p4
@@ -59,7 +59,7 @@ control ingress(inout headers_t hdr,
         //random<bit<16>>(rand_int, 0, (bit<16>) 48*1024-1);
 
         if (rand_int < 32*1024) {
-            mark_to_drop();
+            markToDrop(standard_metadata);
         }
     }
 }

--- a/testdata/p4_16_samples/issue1517-bmv2.p4
+++ b/testdata/p4_16_samples/issue1517-bmv2.p4
@@ -59,7 +59,7 @@ control ingress(inout headers_t hdr,
         //random<bit<16>>(rand_int, 0, (bit<16>) 48*1024-1);
 
         if (rand_int < 32*1024) {
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
         }
     }
 }

--- a/testdata/p4_16_samples/issue1535.p4
+++ b/testdata/p4_16_samples/issue1535.p4
@@ -58,8 +58,8 @@ struct headers {
 // You must use 'compound actions', i.e. ones explicitly defined with
 // the 'action' keyword like below.
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 
 parser ParserImpl(packet_in packet,

--- a/testdata/p4_16_samples/issue1535.p4
+++ b/testdata/p4_16_samples/issue1535.p4
@@ -59,7 +59,7 @@ struct headers {
 // the 'action' keyword like below.
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 
 parser ParserImpl(packet_in packet,

--- a/testdata/p4_16_samples/issue1538.p4
+++ b/testdata/p4_16_samples/issue1538.p4
@@ -44,8 +44,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 
 parser ParserImpl(packet_in packet,
@@ -79,9 +79,9 @@ control ingress(inout headers hdr,
         }
         actions = {
             set_port;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples/issue1538.p4
+++ b/testdata/p4_16_samples/issue1538.p4
@@ -45,7 +45,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 
 parser ParserImpl(packet_in packet,

--- a/testdata/p4_16_samples/issue1544-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue1544-1-bmv2.p4
@@ -43,8 +43,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 
 parser ParserImpl(packet_in packet,
@@ -74,9 +74,9 @@ control ingress(inout headers hdr,
         }
         actions = {
             set_port;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples/issue1544-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue1544-1-bmv2.p4
@@ -44,7 +44,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 
 parser ParserImpl(packet_in packet,

--- a/testdata/p4_16_samples/issue1544-2-bmv2.p4
+++ b/testdata/p4_16_samples/issue1544-2-bmv2.p4
@@ -41,8 +41,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 
 parser ParserImpl(packet_in packet,
@@ -72,9 +72,9 @@ control ingress(inout headers hdr,
         }
         actions = {
             set_port;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples/issue1544-2-bmv2.p4
+++ b/testdata/p4_16_samples/issue1544-2-bmv2.p4
@@ -42,7 +42,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 
 parser ParserImpl(packet_in packet,

--- a/testdata/p4_16_samples/issue1544-bmv2.p4
+++ b/testdata/p4_16_samples/issue1544-bmv2.p4
@@ -41,8 +41,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 
 parser ParserImpl(packet_in packet,
@@ -72,9 +72,9 @@ control ingress(inout headers hdr,
         }
         actions = {
             set_port;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples/issue1544-bmv2.p4
+++ b/testdata/p4_16_samples/issue1544-bmv2.p4
@@ -42,7 +42,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 
 parser ParserImpl(packet_in packet,

--- a/testdata/p4_16_samples/issue1630-bmv2.p4
+++ b/testdata/p4_16_samples/issue1630-bmv2.p4
@@ -107,7 +107,7 @@ control MyIngress(inout headers hdr,
                   inout standard_metadata_t standard_metadata) {
 
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
 
     //debug_std_meta() debug;

--- a/testdata/p4_16_samples/issue1630-bmv2.p4
+++ b/testdata/p4_16_samples/issue1630-bmv2.p4
@@ -107,7 +107,7 @@ control MyIngress(inout headers hdr,
                   inout standard_metadata_t standard_metadata) {
 
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
 
     //debug_std_meta() debug;

--- a/testdata/p4_16_samples/issue1739-bmv2.p4
+++ b/testdata/p4_16_samples/issue1739-bmv2.p4
@@ -57,7 +57,7 @@ struct headers_t {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 
 parser ParserImpl(packet_in packet,

--- a/testdata/p4_16_samples/issue1739-bmv2.p4
+++ b/testdata/p4_16_samples/issue1739-bmv2.p4
@@ -56,8 +56,8 @@ struct headers_t {
     ipv4_t     ipv4;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 
 parser ParserImpl(packet_in packet,
@@ -96,9 +96,9 @@ control ingress(inout headers_t hdr,
         }
         actions = {
             set_output;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
 
     table ipv4_sa_filter {
@@ -106,7 +106,7 @@ control ingress(inout headers_t hdr,
             hdr.ipv4.srcAddr : ternary;
         }
         actions = {
-            my_drop;
+            my_drop(standard_metadata);
             NoAction;
         }
         const default_action = NoAction;

--- a/testdata/p4_16_samples/issue1765-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue1765-1-bmv2.p4
@@ -195,7 +195,7 @@ control MyComputeChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action set_egress_port(port_t out_port) {
         standard_metadata.egress_spec = out_port;

--- a/testdata/p4_16_samples/issue1765-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue1765-1-bmv2.p4
@@ -195,7 +195,7 @@ control MyComputeChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action set_egress_port(port_t out_port) {
         standard_metadata.egress_spec = out_port;
@@ -350,4 +350,3 @@ control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata
 }
 
 V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;
-

--- a/testdata/p4_16_samples/issue1768-bmv2.p4
+++ b/testdata/p4_16_samples/issue1768-bmv2.p4
@@ -29,7 +29,7 @@ control MyIngress(inout headers hdr,
                   inout standard_metadata_t standard_metadata) {
     apply {
         if (standard_metadata.parser_error != error.NoError)
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples/issue1768-bmv2.p4
+++ b/testdata/p4_16_samples/issue1768-bmv2.p4
@@ -29,7 +29,7 @@ control MyIngress(inout headers hdr,
                   inout standard_metadata_t standard_metadata) {
     apply {
         if (standard_metadata.parser_error != error.NoError)
-            mark_to_drop();
+            markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples/issue1814-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue1814-1-bmv2.p4
@@ -20,7 +20,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     register<bit<1>>(1) testRegister;
 
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
 
     action forward() {

--- a/testdata/p4_16_samples/issue1814-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue1814-1-bmv2.p4
@@ -20,7 +20,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     register<bit<1>>(1) testRegister;
 
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
 
     action forward() {

--- a/testdata/p4_16_samples/issue297-bmv2.p4
+++ b/testdata/p4_16_samples/issue297-bmv2.p4
@@ -31,7 +31,7 @@ action empty() { }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action_profile(32w128) ap;
 
-    action drop() { mark_to_drop(); }
+    action drop() { markToDrop(smeta); }
 
     table indirect {
         key = { }

--- a/testdata/p4_16_samples/issue297-bmv2.p4
+++ b/testdata/p4_16_samples/issue297-bmv2.p4
@@ -31,7 +31,7 @@ action empty() { }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action_profile(32w128) ap;
 
-    action drop() { markToDrop(smeta); }
+    action drop() { mark_to_drop(smeta); }
 
     table indirect {
         key = { }

--- a/testdata/p4_16_samples/issue298-bmv2.p4
+++ b/testdata/p4_16_samples/issue298-bmv2.p4
@@ -147,7 +147,7 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
 
     action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
 
     table drop_tbl {

--- a/testdata/p4_16_samples/issue298-bmv2.p4
+++ b/testdata/p4_16_samples/issue298-bmv2.p4
@@ -147,7 +147,7 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
 
     action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
 
     table drop_tbl {

--- a/testdata/p4_16_samples/issue461-bmv2.p4
+++ b/testdata/p4_16_samples/issue461-bmv2.p4
@@ -52,8 +52,8 @@ struct headers {
     ipv4_t     ipv4;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 
 parser ParserImpl(packet_in packet,
@@ -94,7 +94,7 @@ control ingress(inout headers hdr,
     }
     action drop_with_count() {
         ipv4_da_lpm_stats.count();
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;
@@ -116,12 +116,12 @@ control ingress(inout headers hdr,
     table mac_da {
         actions = {
             set_bd_dmac_intf;
-            my_drop;
+            my_drop(standard_metadata);
         }
         key = {
             meta.fwd_metadata.l2ptr: exact;
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         ipv4_da_lpm.apply();
@@ -139,12 +139,12 @@ control egress(inout headers hdr,
     table send_frame {
         actions = {
             rewrite_mac;
-            my_drop;
+            my_drop(standard_metadata);
         }
         key = {
             meta.fwd_metadata.out_bd: exact;
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         send_frame.apply();

--- a/testdata/p4_16_samples/issue461-bmv2.p4
+++ b/testdata/p4_16_samples/issue461-bmv2.p4
@@ -53,7 +53,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 
 parser ParserImpl(packet_in packet,
@@ -94,7 +94,7 @@ control ingress(inout headers hdr,
     }
     action drop_with_count() {
         ipv4_da_lpm_stats.count();
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;

--- a/testdata/p4_16_samples/issue561-bmv2.p4
+++ b/testdata/p4_16_samples/issue561-bmv2.p4
@@ -264,7 +264,7 @@ parser ParserImpl(packet_in packet,
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 
 control ingress(inout headers hdr,

--- a/testdata/p4_16_samples/issue561-bmv2.p4
+++ b/testdata/p4_16_samples/issue561-bmv2.p4
@@ -263,8 +263,8 @@ parser ParserImpl(packet_in packet,
     }
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 
 control ingress(inout headers hdr,
@@ -280,9 +280,9 @@ control ingress(inout headers hdr,
         }
         actions = {
             set_l2ptr;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
 
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
@@ -297,9 +297,9 @@ control ingress(inout headers hdr,
         }
         actions = {
             set_bd_dmac_intf;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
 
     apply {
@@ -321,9 +321,9 @@ control egress(inout headers hdr,
         }
         actions = {
             rewrite_mac;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
 
     apply {

--- a/testdata/p4_16_samples/multicast-bmv2.p4
+++ b/testdata/p4_16_samples/multicast-bmv2.p4
@@ -66,7 +66,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -91,7 +91,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.routing_metadata.nhop_ipv4 = nhop_ipv4;

--- a/testdata/p4_16_samples/multicast-bmv2.p4
+++ b/testdata/p4_16_samples/multicast-bmv2.p4
@@ -27,14 +27,20 @@ header ipv4_t {
 }
 
 struct metadata {
+<<<<<<< 45707c3563244f920d5714e8f7fa43c8ff4d9521
     @name("routing_metadata") 
+=======
+    @name("intrinsic_metadata")
+    intrinsic_metadata_t intrinsic_metadata;
+    @name("routing_metadata")
+>>>>>>> Deprecate @mark_to_drop; replace with markToDrop action
     routing_metadata_t   routing_metadata;
 }
 
 struct headers {
-    @name("ethernet") 
+    @name("ethernet")
     ethernet_t ethernet;
-    @name("ipv4") 
+    @name("ipv4")
     ipv4_t     ipv4;
 }
 
@@ -60,7 +66,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -85,7 +91,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.routing_metadata.nhop_ipv4 = nhop_ipv4;

--- a/testdata/p4_16_samples/multicast-bmv2.p4
+++ b/testdata/p4_16_samples/multicast-bmv2.p4
@@ -27,13 +27,7 @@ header ipv4_t {
 }
 
 struct metadata {
-<<<<<<< 45707c3563244f920d5714e8f7fa43c8ff4d9521
-    @name("routing_metadata") 
-=======
-    @name("intrinsic_metadata")
-    intrinsic_metadata_t intrinsic_metadata;
     @name("routing_metadata")
->>>>>>> Deprecate @mark_to_drop; replace with markToDrop action
     routing_metadata_t   routing_metadata;
 }
 

--- a/testdata/p4_16_samples/named_meter_1-bmv2.p4
+++ b/testdata/p4_16_samples/named_meter_1-bmv2.p4
@@ -56,7 +56,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples/named_meter_1-bmv2.p4
+++ b/testdata/p4_16_samples/named_meter_1-bmv2.p4
@@ -56,7 +56,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples/named_meter_bmv2.p4
+++ b/testdata/p4_16_samples/named_meter_bmv2.p4
@@ -55,7 +55,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("namedmeter") direct_meter<bit<32>>(MeterType.packets) my_meter;
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples/named_meter_bmv2.p4
+++ b/testdata/p4_16_samples/named_meter_bmv2.p4
@@ -55,7 +55,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("namedmeter") direct_meter<bit<32>>(MeterType.packets) my_meter;
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples/same_name_for_table_and_action.p4
+++ b/testdata/p4_16_samples/same_name_for_table_and_action.p4
@@ -20,7 +20,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     // through a @name annotation.
 
     @name("do_something")
-    action do_something_0() { mark_to_drop(); }
+    action do_something_0() { mark_to_drop(smeta); }
 
     @name("do_something")
     table do_something {

--- a/testdata/p4_16_samples/saturated-bmv2.p4
+++ b/testdata/p4_16_samples/saturated-bmv2.p4
@@ -71,7 +71,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
 
-    action drop() { mark_to_drop(); }
+    action drop() { markToDrop(standard_meta); }
 
     USat_t ru;
     Sat_t r;

--- a/testdata/p4_16_samples/saturated-bmv2.p4
+++ b/testdata/p4_16_samples/saturated-bmv2.p4
@@ -71,7 +71,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
 
-    action drop() { markToDrop(standard_meta); }
+    action drop() { mark_to_drop(standard_meta); }
 
     USat_t ru;
     Sat_t r;

--- a/testdata/p4_16_samples/v1model-special-ops-bmv2.p4
+++ b/testdata/p4_16_samples/v1model-special-ops-bmv2.p4
@@ -85,7 +85,7 @@ struct headers_t {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 
 parser ParserImpl(packet_in packet,

--- a/testdata/p4_16_samples/v1model-special-ops-bmv2.p4
+++ b/testdata/p4_16_samples/v1model-special-ops-bmv2.p4
@@ -84,8 +84,8 @@ struct headers_t {
     ipv4_t     ipv4;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 
 parser ParserImpl(packet_in packet,
@@ -260,9 +260,9 @@ control ingress(inout headers_t hdr,
             set_mcast_grp;
             do_resubmit;
             do_clone_i2e;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
 
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
@@ -277,9 +277,9 @@ control ingress(inout headers_t hdr,
         }
         actions = {
             set_bd_dmac_intf;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
 
     apply {
@@ -374,9 +374,9 @@ control egress(inout headers_t hdr,
             rewrite_mac;
             do_recirculate;
             do_clone_e2e;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
 
     apply {

--- a/testdata/p4_16_samples_outputs/action-two-params-first.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-first.p4
@@ -40,7 +40,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action actTbl(bit<24> id, bit<32> ip) {
     }

--- a/testdata/p4_16_samples_outputs/action-two-params-first.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-first.p4
@@ -40,7 +40,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action actTbl(bit<24> id, bit<32> ip) {
     }

--- a/testdata/p4_16_samples_outputs/action-two-params-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-frontend.p4
@@ -40,12 +40,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("MyIngress.drop") action drop_1() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.actTbl") action actTbl(bit<24> id, bit<32> ip) {
     }

--- a/testdata/p4_16_samples_outputs/action-two-params-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-frontend.p4
@@ -40,7 +40,12 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("MyIngress.drop") action drop_1() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("MyIngress.actTbl") action actTbl(bit<24> id, bit<32> ip) {
     }

--- a/testdata/p4_16_samples_outputs/action-two-params-midend.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-midend.p4
@@ -40,8 +40,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("MyIngress.drop") action drop_1() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.actTbl") action actTbl(bit<24> id, bit<32> ip) {
     }

--- a/testdata/p4_16_samples_outputs/action-two-params-midend.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-midend.p4
@@ -40,7 +40,8 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("MyIngress.drop") action drop_1() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("MyIngress.actTbl") action actTbl(bit<24> id, bit<32> ip) {
     }

--- a/testdata/p4_16_samples_outputs/action-two-params.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params.p4
@@ -40,7 +40,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action actTbl(bit<24> id, bit<32> ip) {
     }

--- a/testdata/p4_16_samples_outputs/action-two-params.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params.p4
@@ -40,7 +40,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action actTbl(bit<24> id, bit<32> ip) {
     }

--- a/testdata/p4_16_samples_outputs/action-two-params.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action-two-params.p4.p4info.txt
@@ -47,5 +47,3 @@ actions {
     bitwidth: 32
   }
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/action-two-params.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action-two-params.p4.p4info.txt
@@ -47,3 +47,5 @@ actions {
     bitwidth: 32
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        mark_to_drop();
+        markToDrop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        markToDrop(smeta);
+        mark_to_drop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-frontend.p4
@@ -20,10 +20,20 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_1() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
     @name("IngressI.drop") action drop_3() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = smeta;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            smeta = standard_metadata_2;
+        }
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-frontend.p4
@@ -20,20 +20,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_1() {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     @name("IngressI.drop") action drop_3() {
-        {
-            standard_metadata_t standard_metadata_2 = smeta;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            smeta = standard_metadata_2;
-        }
+        mark_to_drop(smeta);
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
@@ -20,10 +20,12 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_1() {
-        mark_to_drop();
+        smeta.egress_spec = 9w511;
+        smeta.mcast_grp = 16w0;
     }
     @name("IngressI.drop") action drop_3() {
-        mark_to_drop();
+        smeta.egress_spec = 9w511;
+        smeta.mcast_grp = 16w0;
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
@@ -20,12 +20,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_1() {
-        smeta.egress_spec = 9w511;
-        smeta.mcast_grp = 16w0;
+        mark_to_drop(smeta);
     }
     @name("IngressI.drop") action drop_3() {
-        smeta.egress_spec = 9w511;
-        smeta.mcast_grp = 16w0;
+        mark_to_drop(smeta);
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        mark_to_drop();
+        markToDrop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        markToDrop(smeta);
+        mark_to_drop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2.p4.p4info.txt
@@ -66,5 +66,3 @@ action_profiles {
   with_selector: true
   size: 1024
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2.p4.p4info.txt
@@ -66,3 +66,5 @@ action_profiles {
   with_selector: true
   size: 1024
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-first.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        mark_to_drop();
+        markToDrop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-first.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        markToDrop(smeta);
+        mark_to_drop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-frontend.p4
@@ -20,10 +20,20 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_1() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
     @name("IngressI.drop") action drop_3() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = smeta;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            smeta = standard_metadata_2;
+        }
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-frontend.p4
@@ -20,20 +20,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_1() {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     @name("IngressI.drop") action drop_3() {
-        {
-            standard_metadata_t standard_metadata_2 = smeta;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            smeta = standard_metadata_2;
-        }
+        mark_to_drop(smeta);
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-midend.p4
@@ -20,10 +20,12 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_1() {
-        mark_to_drop();
+        smeta.egress_spec = 9w511;
+        smeta.mcast_grp = 16w0;
     }
     @name("IngressI.drop") action drop_3() {
-        mark_to_drop();
+        smeta.egress_spec = 9w511;
+        smeta.mcast_grp = 16w0;
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-midend.p4
@@ -20,12 +20,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_1() {
-        smeta.egress_spec = 9w511;
-        smeta.mcast_grp = 16w0;
+        mark_to_drop(smeta);
     }
     @name("IngressI.drop") action drop_3() {
-        smeta.egress_spec = 9w511;
-        smeta.mcast_grp = 16w0;
+        mark_to_drop(smeta);
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        mark_to_drop();
+        markToDrop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        markToDrop(smeta);
+        mark_to_drop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4.p4info.txt
@@ -67,5 +67,3 @@ action_profiles {
   size: 1024
   max_group_size: 200
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4.p4info.txt
@@ -67,3 +67,5 @@ action_profiles {
   size: 1024
   max_group_size: 200
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     table indirect_ws {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-frontend.p4
@@ -20,10 +20,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_1() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name("IngressI.drop") action drop_3() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name("IngressI.as") action_selector(HashAlgorithm.identity, 32w1024, 32w10) as_0;
     @name("IngressI.indirect_ws") table indirect_ws_0 {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-midend.p4
@@ -20,10 +20,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_3() {
     }
     @name("IngressI.drop") action drop_1() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name("IngressI.drop") action drop_3() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name("IngressI.as") action_selector(HashAlgorithm.identity, 32w1024, 32w10) as_0;
     @name("IngressI.indirect_ws") table indirect_ws_0 {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     table indirect_ws {

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        markToDrop(smeta);
+        mark_to_drop(smeta);
     }
     action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     apply {

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        mark_to_drop();
+        markToDrop(smeta);
     }
     action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     apply {

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        markToDrop(smeta);
+        mark_to_drop(smeta);
     }
     action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     apply {

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action drop() {
-        mark_to_drop();
+        markToDrop(smeta);
     }
     action_selector(HashAlgorithm.identity, 32w1024, 32w10) as;
     apply {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-first.p4
@@ -93,7 +93,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         send_back(nselect);
     }
     action operation_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     table calculate {
         key = {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-first.p4
@@ -93,7 +93,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         send_back(nselect);
     }
     action operation_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     table calculate {
         key = {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-frontend.p4
@@ -109,10 +109,20 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         standard_metadata.egress_spec = standard_metadata.ingress_port;
     }
     @name("MyIngress.operation_drop") action operation_drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("MyIngress.operation_drop") action operation_drop_2() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name("MyIngress.calculate") table calculate_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-frontend.p4
@@ -109,20 +109,10 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         standard_metadata.egress_spec = standard_metadata.ingress_port;
     }
     @name("MyIngress.operation_drop") action operation_drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.operation_drop") action operation_drop_2() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.calculate") table calculate_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-midend.p4
@@ -134,10 +134,12 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         standard_metadata.egress_spec = standard_metadata.ingress_port;
     }
     @name("MyIngress.operation_drop") action operation_drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("MyIngress.operation_drop") action operation_drop_2() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("MyIngress.calculate") table calculate_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-midend.p4
@@ -134,12 +134,10 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         standard_metadata.egress_spec = standard_metadata.ingress_port;
     }
     @name("MyIngress.operation_drop") action operation_drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.operation_drop") action operation_drop_2() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.calculate") table calculate_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2.p4
@@ -93,7 +93,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         send_back(nselect);
     }
     action operation_drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     table calculate {
         key = {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2.p4
@@ -93,7 +93,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         send_back(nselect);
     }
     action operation_drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     table calculate {
         key = {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-first.p4
@@ -13,8 +13,8 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
     }
 }
 
-action drop(out standard_metadata_t smeta) {
-    mark_to_drop();
+action drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     table forward {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-first.p4
@@ -14,7 +14,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 action drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     table forward {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
@@ -15,12 +15,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".drop") action drop_0(inout standard_metadata_t smeta_1) {
-        {
-            standard_metadata_t standard_metadata_1 = smeta_1;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta_1 = standard_metadata_1;
-        }
+        mark_to_drop(smeta_1);
     }
     @name("IngressI.forward") table forward_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
@@ -14,8 +14,13 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
-    @name(".drop") action drop_0(out standard_metadata_t smeta_1) {
-        mark_to_drop();
+    @name(".drop") action drop_0(inout standard_metadata_t smeta_1) {
+        {
+            standard_metadata_t standard_metadata_1 = smeta_1;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta_1 = standard_metadata_1;
+        }
     }
     @name("IngressI.forward") table forward_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
@@ -14,30 +14,9 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
-    standard_metadata_t smeta_1;
     @name(".drop") action drop_0() {
-        mark_to_drop();
-        smeta.ingress_port = smeta_1.ingress_port;
-        smeta.egress_spec = smeta_1.egress_spec;
-        smeta.egress_port = smeta_1.egress_port;
-        smeta.clone_spec = smeta_1.clone_spec;
-        smeta.instance_type = smeta_1.instance_type;
-        smeta.drop = smeta_1.drop;
-        smeta.recirculate_port = smeta_1.recirculate_port;
-        smeta.packet_length = smeta_1.packet_length;
-        smeta.enq_timestamp = smeta_1.enq_timestamp;
-        smeta.enq_qdepth = smeta_1.enq_qdepth;
-        smeta.deq_timedelta = smeta_1.deq_timedelta;
-        smeta.deq_qdepth = smeta_1.deq_qdepth;
-        smeta.ingress_global_timestamp = smeta_1.ingress_global_timestamp;
-        smeta.egress_global_timestamp = smeta_1.egress_global_timestamp;
-        smeta.lf_field_list = smeta_1.lf_field_list;
-        smeta.mcast_grp = smeta_1.mcast_grp;
-        smeta.resubmit_flag = smeta_1.resubmit_flag;
-        smeta.egress_rid = smeta_1.egress_rid;
-        smeta.checksum_error = smeta_1.checksum_error;
-        smeta.recirculate_flag = smeta_1.recirculate_flag;
-        smeta.parser_error = smeta_1.parser_error;
+        smeta.egress_spec = 9w511;
+        smeta.mcast_grp = 16w0;
     }
     @name("IngressI.forward") table forward_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
@@ -14,9 +14,51 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    standard_metadata_t smeta_1;
     @name(".drop") action drop_0() {
-        smeta.egress_spec = 9w511;
-        smeta.mcast_grp = 16w0;
+        smeta_1.ingress_port = smeta.ingress_port;
+        smeta_1.egress_spec = smeta.egress_spec;
+        smeta_1.egress_port = smeta.egress_port;
+        smeta_1.clone_spec = smeta.clone_spec;
+        smeta_1.instance_type = smeta.instance_type;
+        smeta_1.drop = smeta.drop;
+        smeta_1.recirculate_port = smeta.recirculate_port;
+        smeta_1.packet_length = smeta.packet_length;
+        smeta_1.enq_timestamp = smeta.enq_timestamp;
+        smeta_1.enq_qdepth = smeta.enq_qdepth;
+        smeta_1.deq_timedelta = smeta.deq_timedelta;
+        smeta_1.deq_qdepth = smeta.deq_qdepth;
+        smeta_1.ingress_global_timestamp = smeta.ingress_global_timestamp;
+        smeta_1.egress_global_timestamp = smeta.egress_global_timestamp;
+        smeta_1.lf_field_list = smeta.lf_field_list;
+        smeta_1.mcast_grp = smeta.mcast_grp;
+        smeta_1.resubmit_flag = smeta.resubmit_flag;
+        smeta_1.egress_rid = smeta.egress_rid;
+        smeta_1.checksum_error = smeta.checksum_error;
+        smeta_1.recirculate_flag = smeta.recirculate_flag;
+        smeta_1.parser_error = smeta.parser_error;
+        mark_to_drop(smeta_1);
+        smeta.ingress_port = smeta_1.ingress_port;
+        smeta.egress_spec = smeta_1.egress_spec;
+        smeta.egress_port = smeta_1.egress_port;
+        smeta.clone_spec = smeta_1.clone_spec;
+        smeta.instance_type = smeta_1.instance_type;
+        smeta.drop = smeta_1.drop;
+        smeta.recirculate_port = smeta_1.recirculate_port;
+        smeta.packet_length = smeta_1.packet_length;
+        smeta.enq_timestamp = smeta_1.enq_timestamp;
+        smeta.enq_qdepth = smeta_1.enq_qdepth;
+        smeta.deq_timedelta = smeta_1.deq_timedelta;
+        smeta.deq_qdepth = smeta_1.deq_qdepth;
+        smeta.ingress_global_timestamp = smeta_1.ingress_global_timestamp;
+        smeta.egress_global_timestamp = smeta_1.egress_global_timestamp;
+        smeta.lf_field_list = smeta_1.lf_field_list;
+        smeta.mcast_grp = smeta_1.mcast_grp;
+        smeta.resubmit_flag = smeta_1.resubmit_flag;
+        smeta.egress_rid = smeta_1.egress_rid;
+        smeta.checksum_error = smeta_1.checksum_error;
+        smeta.recirculate_flag = smeta_1.recirculate_flag;
+        smeta.parser_error = smeta_1.parser_error;
     }
     @name("IngressI.forward") table forward_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4
@@ -13,8 +13,8 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
     }
 }
 
-action drop(out standard_metadata_t smeta) {
-    mark_to_drop();
+action drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     table forward {

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4
@@ -14,7 +14,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 action drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     table forward {

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4-stderr
@@ -1,6 +1,0 @@
-drop-bmv2.p4(27): [--Wwarn=uninitialized_out_param] warning: out parameter smeta may be uninitialized when drop terminates
-action drop(out standard_metadata_t smeta) { mark_to_drop(); } // this global action seems to cause the problem
-                                    ^^^^^
-drop-bmv2.p4(27)
-action drop(out standard_metadata_t smeta) { mark_to_drop(); } // this global action seems to cause the problem
-       ^^^^

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4.p4info.txt
@@ -20,5 +20,3 @@ actions {
     alias: "drop"
   }
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "drop"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-first.p4
@@ -55,7 +55,7 @@ control verifyChecksum(inout headers hdr, inout metadata meta) {
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         meta.test_bool = true;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-first.p4
@@ -55,7 +55,7 @@ control verifyChecksum(inout headers hdr, inout metadata meta) {
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         meta.test_bool = true;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-frontend.p4
@@ -57,20 +57,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.drop") action drop_1() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("ingress.drop") action drop_3() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("ingress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         meta.test_bool = true;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-frontend.p4
@@ -57,10 +57,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.drop") action drop_1() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("ingress.drop") action drop_3() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name("ingress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         meta.test_bool = true;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-midend.p4
@@ -57,10 +57,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.drop") action drop_1() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.drop") action drop_3() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         meta.test_bool = true;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-midend.p4
@@ -57,12 +57,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.drop") action drop_1() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("ingress.drop") action drop_3() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("ingress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         meta.test_bool = true;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4
@@ -55,7 +55,7 @@ control verifyChecksum(inout headers hdr, inout metadata meta) {
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         meta.test_bool = true;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4
@@ -55,7 +55,7 @@ control verifyChecksum(inout headers hdr, inout metadata meta) {
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         meta.test_bool = true;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4.p4info.txt
@@ -55,5 +55,3 @@ actions {
     bitwidth: 9
   }
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4.p4info.txt
@@ -55,3 +55,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
@@ -88,7 +88,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -111,7 +111,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
     @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
@@ -88,7 +88,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -111,7 +111,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
     @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
@@ -90,7 +90,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("egress.send_frame") table send_frame_0 {
         actions = {
@@ -123,13 +128,28 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress.flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
     @name("ingress.flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
     @name("ingress._drop") action _drop_2() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name("ingress._drop") action _drop_5() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_4 = standard_metadata;
+            standard_metadata_4.egress_spec = 9w511;
+            standard_metadata_4.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_4;
+        }
     }
     @name("ingress._drop") action _drop_6() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_5 = standard_metadata;
+            standard_metadata_5.egress_spec = 9w511;
+            standard_metadata_5.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_5;
+        }
     }
     @name("ingress.set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
@@ -90,12 +90,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("egress.send_frame") table send_frame_0 {
         actions = {
@@ -128,28 +123,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress.flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
     @name("ingress.flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
     @name("ingress._drop") action _drop_2() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("ingress._drop") action _drop_5() {
-        {
-            standard_metadata_t standard_metadata_4 = standard_metadata;
-            standard_metadata_4.egress_spec = 9w511;
-            standard_metadata_4.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_4;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("ingress._drop") action _drop_6() {
-        {
-            standard_metadata_t standard_metadata_5 = standard_metadata;
-            standard_metadata_5.egress_spec = 9w511;
-            standard_metadata_5.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_5;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("ingress.set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -94,8 +94,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("egress.send_frame") table send_frame_0 {
         actions = {
@@ -145,16 +144,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress.flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
     @name("ingress.flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
     @name("ingress._drop") action _drop_2() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("ingress._drop") action _drop_5() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("ingress._drop") action _drop_6() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("ingress.set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple_0, bit<20>>(meta._ingress_metadata_ecmp_offset4, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta._ingress_metadata_flowlet_id2 }, (bit<20>)ecmp_count);

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -94,7 +94,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("egress.send_frame") table send_frame_0 {
         actions = {
@@ -144,13 +145,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress.flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
     @name("ingress.flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
     @name("ingress._drop") action _drop_2() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress._drop") action _drop_5() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress._drop") action _drop_6() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple_0, bit<20>>(meta._ingress_metadata_ecmp_offset4, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta._ingress_metadata_flowlet_id2 }, (bit<20>)ecmp_count);

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
@@ -88,7 +88,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -111,7 +111,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
     @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
@@ -88,7 +88,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -111,7 +111,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
     @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
         hash(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2-first.p4
@@ -36,7 +36,7 @@ control EmptyIngress(inout headers_t headers, inout metadata_t meta, inout stand
 
 control EmptyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
     apply {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2-first.p4
@@ -36,7 +36,7 @@ control EmptyIngress(inout headers_t headers, inout metadata_t meta, inout stand
 
 control EmptyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
     apply {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2-frontend.p4
@@ -35,8 +35,12 @@ control EmptyIngress(inout headers_t headers, inout metadata_t meta, inout stand
 }
 
 control EmptyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    @name(".markToDrop") action markToDrop(inout standard_metadata_t standard_metadata_1) {
+        standard_metadata_1.egress_spec = 9w511;
+        standard_metadata_1.mcast_grp = 16w0;
+    }
     apply {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2-frontend.p4
@@ -35,12 +35,8 @@ control EmptyIngress(inout headers_t headers, inout metadata_t meta, inout stand
 }
 
 control EmptyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
-    @name(".markToDrop") action markToDrop(inout standard_metadata_t standard_metadata_1) {
-        standard_metadata_1.egress_spec = 9w511;
-        standard_metadata_1.mcast_grp = 16w0;
-    }
     apply {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2-midend.p4
@@ -39,18 +39,17 @@ control EmptyIngress(inout headers_t headers, inout metadata_t meta, inout stand
 }
 
 control EmptyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
-    @name(".markToDrop") action markToDrop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+    @hidden action act() {
+        mark_to_drop(standard_metadata);
     }
-    @hidden table tbl_markToDrop {
+    @hidden table tbl_act {
         actions = {
-            markToDrop();
+            act();
         }
-        const default_action = markToDrop();
+        const default_action = act();
     }
     apply {
-        tbl_markToDrop.apply();
+        tbl_act.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2-midend.p4
@@ -39,17 +39,18 @@ control EmptyIngress(inout headers_t headers, inout metadata_t meta, inout stand
 }
 
 control EmptyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
-        mark_to_drop();
+    @name(".markToDrop") action markToDrop() {
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_markToDrop {
         actions = {
-            act();
+            markToDrop();
         }
-        const default_action = act();
+        const default_action = markToDrop();
     }
     apply {
-        tbl_act.apply();
+        tbl_markToDrop.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2.p4
@@ -36,7 +36,7 @@ control EmptyIngress(inout headers_t headers, inout metadata_t meta, inout stand
 
 control EmptyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
     apply {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2.p4
@@ -36,7 +36,7 @@ control EmptyIngress(inout headers_t headers, inout metadata_t meta, inout stand
 
 control EmptyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
     apply {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2.p4.p4info.txt
@@ -1,5 +1,12 @@
 pkg_info {
   arch: "v1model"
 }
+actions {
+  preamble {
+    id: 16788389
+    name: "markToDrop"
+    alias: "markToDrop"
+  }
+}
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2.p4.p4info.txt
@@ -1,12 +1,5 @@
 pkg_info {
   arch: "v1model"
 }
-actions {
-  preamble {
-    id: 16788389
-    name: "markToDrop"
-    alias: "markToDrop"
-  }
-}
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-first.p4
@@ -24,7 +24,7 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     apply {
         if (local_metadata.test.test_error == error.Unused) 
-            mark_to_drop();
+            markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-first.p4
@@ -24,7 +24,7 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     apply {
         if (local_metadata.test.test_error == error.Unused) 
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-frontend.p4
@@ -22,13 +22,9 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 }
 
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @name(".markToDrop") action markToDrop(inout standard_metadata_t standard_metadata_1) {
-        standard_metadata_1.egress_spec = 9w511;
-        standard_metadata_1.mcast_grp = 16w0;
-    }
     apply {
         if (local_metadata.test.test_error == error.Unused) 
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-frontend.p4
@@ -22,9 +22,13 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 }
 
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    @name(".markToDrop") action markToDrop(inout standard_metadata_t standard_metadata_1) {
+        standard_metadata_1.egress_spec = 9w511;
+        standard_metadata_1.mcast_grp = 16w0;
+    }
     apply {
         if (local_metadata.test.test_error == error.Unused) 
-            mark_to_drop();
+            markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-midend.p4
@@ -22,19 +22,18 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 }
 
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @name(".markToDrop") action markToDrop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+    @hidden action act() {
+        mark_to_drop(standard_metadata);
     }
-    @hidden table tbl_markToDrop {
+    @hidden table tbl_act {
         actions = {
-            markToDrop();
+            act();
         }
-        const default_action = markToDrop();
+        const default_action = act();
     }
     apply {
         if (local_metadata._test_test_error0 == error.Unused) 
-            tbl_markToDrop.apply();
+            tbl_act.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-midend.p4
@@ -22,18 +22,19 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 }
 
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
-        mark_to_drop();
+    @name(".markToDrop") action markToDrop() {
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_markToDrop {
         actions = {
-            act();
+            markToDrop();
         }
-        const default_action = act();
+        const default_action = markToDrop();
     }
     apply {
         if (local_metadata._test_test_error0 == error.Unused) 
-            tbl_act.apply();
+            tbl_markToDrop.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2.p4
@@ -24,7 +24,7 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     apply {
         if (local_metadata.test.test_error == error.Unused) 
-            mark_to_drop();
+            markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2.p4
@@ -24,7 +24,7 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     apply {
         if (local_metadata.test.test_error == error.Unused) 
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2.p4.p4info.txt
@@ -1,10 +1,5 @@
 pkg_info {
   arch: "v1model"
 }
-actions {
-  preamble {
-    id: 16788389
-    name: "markToDrop"
-    alias: "markToDrop"
-  }
+type_info {
 }

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2.p4.p4info.txt
@@ -1,5 +1,10 @@
 pkg_info {
   arch: "v1model"
 }
-type_info {
+actions {
+  preamble {
+    id: 16788389
+    name: "markToDrop"
+    alias: "markToDrop"
+  }
 }

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-first.p4
@@ -70,7 +70,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action set_dmac(macAddr_t dstAddr) {
         hdr.ethernet.dstAddr = dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-first.p4
@@ -70,7 +70,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action set_dmac(macAddr_t dstAddr) {
         hdr.ethernet.dstAddr = dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-frontend.p4
@@ -66,20 +66,10 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name(".NoAction") action NoAction_1() {
     }
     @name("MyIngress.drop") action drop_1() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.drop") action drop_3() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.set_dmac") action set_dmac(macAddr_t dstAddr) {
         hdr.ethernet.dstAddr = dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-frontend.p4
@@ -66,10 +66,20 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name(".NoAction") action NoAction_1() {
     }
     @name("MyIngress.drop") action drop_1() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("MyIngress.drop") action drop_3() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name("MyIngress.set_dmac") action set_dmac(macAddr_t dstAddr) {
         hdr.ethernet.dstAddr = dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-midend.p4
@@ -66,12 +66,10 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name(".NoAction") action NoAction_1() {
     }
     @name("MyIngress.drop") action drop_1() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.drop") action drop_3() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.set_dmac") action set_dmac(macAddr_t dstAddr) {
         hdr.ethernet.dstAddr = dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-midend.p4
@@ -66,10 +66,12 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name(".NoAction") action NoAction_1() {
     }
     @name("MyIngress.drop") action drop_1() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("MyIngress.drop") action drop_3() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("MyIngress.set_dmac") action set_dmac(macAddr_t dstAddr) {
         hdr.ethernet.dstAddr = dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2.p4
@@ -70,7 +70,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action set_dmac(macAddr_t dstAddr) {
         hdr.ethernet.dstAddr = dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2.p4
@@ -70,7 +70,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action set_dmac(macAddr_t dstAddr) {
         hdr.ethernet.dstAddr = dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2-first.p4
@@ -29,7 +29,7 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         bit<16> rand_int;
         random<bit<16>>(rand_int, 16w0, 16w49151);
         if (rand_int < 16w32768) 
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2-first.p4
@@ -29,7 +29,7 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         bit<16> rand_int;
         random<bit<16>>(rand_int, 16w0, 16w49151);
         if (rand_int < 16w32768) 
-            mark_to_drop();
+            markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2-frontend.p4
@@ -22,11 +22,15 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
+    @name(".markToDrop") action markToDrop(inout standard_metadata_t standard_metadata_1) {
+        standard_metadata_1.egress_spec = 9w511;
+        standard_metadata_1.mcast_grp = 16w0;
+    }
     bit<16> rand_int_0;
     apply {
         random<bit<16>>(rand_int_0, 16w0, 16w49151);
         if (rand_int_0 < 16w32768) 
-            mark_to_drop();
+            markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2-frontend.p4
@@ -22,15 +22,11 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
-    @name(".markToDrop") action markToDrop(inout standard_metadata_t standard_metadata_1) {
-        standard_metadata_1.egress_spec = 9w511;
-        standard_metadata_1.mcast_grp = 16w0;
-    }
     bit<16> rand_int_0;
     apply {
         random<bit<16>>(rand_int_0, 16w0, 16w49151);
         if (rand_int_0 < 16w32768) 
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2-midend.p4
@@ -23,29 +23,28 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     bit<16> rand_int_0;
-    @name(".markToDrop") action markToDrop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
-    }
     @hidden action act() {
+        mark_to_drop(standard_metadata);
+    }
+    @hidden action act_0() {
         random<bit<16>>(rand_int_0, 16w0, 16w49151);
     }
     @hidden table tbl_act {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    @hidden table tbl_act_0 {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_markToDrop {
-        actions = {
-            markToDrop();
-        }
-        const default_action = markToDrop();
-    }
     apply {
         tbl_act.apply();
         if (rand_int_0 < 16w32768) 
-            tbl_markToDrop.apply();
+            tbl_act_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2-midend.p4
@@ -23,28 +23,29 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     bit<16> rand_int_0;
-    @hidden action act() {
-        mark_to_drop();
+    @name(".markToDrop") action markToDrop() {
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
-    @hidden action act_0() {
+    @hidden action act() {
         random<bit<16>>(rand_int_0, 16w0, 16w49151);
     }
     @hidden table tbl_act {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
-    @hidden table tbl_act_0 {
         actions = {
             act();
         }
         const default_action = act();
     }
+    @hidden table tbl_markToDrop {
+        actions = {
+            markToDrop();
+        }
+        const default_action = markToDrop();
+    }
     apply {
         tbl_act.apply();
         if (rand_int_0 < 16w32768) 
-            tbl_act_0.apply();
+            tbl_markToDrop.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2.p4
@@ -29,7 +29,7 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         bit<16> rand_int;
         random<bit<16>>(rand_int, 0, 48 * 1024 - 1);
         if (rand_int < 32 * 1024) {
-            mark_to_drop();
+            markToDrop(standard_metadata);
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2.p4
@@ -29,7 +29,7 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         bit<16> rand_int;
         random<bit<16>>(rand_int, 0, 48 * 1024 - 1);
         if (rand_int < 32 * 1024) {
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2.p4.p4info.txt
@@ -1,5 +1,12 @@
 pkg_info {
   arch: "v1model"
 }
+actions {
+  preamble {
+    id: 16788389
+    name: "markToDrop"
+    alias: "markToDrop"
+  }
+}
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2.p4.p4info.txt
@@ -1,12 +1,5 @@
 pkg_info {
   arch: "v1model"
 }
-actions {
-  preamble {
-    id: 16788389
-    name: "markToDrop"
-    alias: "markToDrop"
-  }
-}
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/issue1535-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1535-first.p4
@@ -17,8 +17,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {

--- a/testdata/p4_16_samples_outputs/issue1535-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1535-first.p4
@@ -18,7 +18,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {

--- a/testdata/p4_16_samples_outputs/issue1535.p4
+++ b/testdata/p4_16_samples_outputs/issue1535.p4
@@ -17,8 +17,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {

--- a/testdata/p4_16_samples_outputs/issue1535.p4
+++ b/testdata/p4_16_samples_outputs/issue1535.p4
@@ -18,7 +18,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {

--- a/testdata/p4_16_samples_outputs/issue1538-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-first.p4
@@ -21,8 +21,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<16> tmp_port = incr((bit<16>)standard_metadata.ingress_port);
@@ -47,9 +47,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples_outputs/issue1538-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-first.p4
@@ -22,7 +22,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<16> tmp_port = incr((bit<16>)standard_metadata.ingress_port);

--- a/testdata/p4_16_samples_outputs/issue1538-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-frontend.p4
@@ -46,12 +46,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     bit<16> tmp_1;
     bit<16> tmp_2;

--- a/testdata/p4_16_samples_outputs/issue1538-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-frontend.p4
@@ -45,8 +45,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
     bit<16> tmp_1;
     bit<16> tmp_2;
@@ -60,9 +65,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da_0.apply();

--- a/testdata/p4_16_samples_outputs/issue1538-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-midend.p4
@@ -26,7 +26,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.set_port") action set_port(bit<9> output_port) {
         standard_metadata.egress_spec = output_port;

--- a/testdata/p4_16_samples_outputs/issue1538-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-midend.p4
@@ -25,9 +25,51 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    standard_metadata_t smeta;
     @name(".my_drop") action my_drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta.ingress_port = standard_metadata.ingress_port;
+        smeta.egress_spec = standard_metadata.egress_spec;
+        smeta.egress_port = standard_metadata.egress_port;
+        smeta.clone_spec = standard_metadata.clone_spec;
+        smeta.instance_type = standard_metadata.instance_type;
+        smeta.drop = standard_metadata.drop;
+        smeta.recirculate_port = standard_metadata.recirculate_port;
+        smeta.packet_length = standard_metadata.packet_length;
+        smeta.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta.lf_field_list = standard_metadata.lf_field_list;
+        smeta.mcast_grp = standard_metadata.mcast_grp;
+        smeta.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta.egress_rid = standard_metadata.egress_rid;
+        smeta.checksum_error = standard_metadata.checksum_error;
+        smeta.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta);
+        standard_metadata.ingress_port = smeta.ingress_port;
+        standard_metadata.egress_spec = smeta.egress_spec;
+        standard_metadata.egress_port = smeta.egress_port;
+        standard_metadata.clone_spec = smeta.clone_spec;
+        standard_metadata.instance_type = smeta.instance_type;
+        standard_metadata.drop = smeta.drop;
+        standard_metadata.recirculate_port = smeta.recirculate_port;
+        standard_metadata.packet_length = smeta.packet_length;
+        standard_metadata.enq_timestamp = smeta.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta.lf_field_list;
+        standard_metadata.mcast_grp = smeta.mcast_grp;
+        standard_metadata.resubmit_flag = smeta.resubmit_flag;
+        standard_metadata.egress_rid = smeta.egress_rid;
+        standard_metadata.checksum_error = smeta.checksum_error;
+        standard_metadata.recirculate_flag = smeta.recirculate_flag;
+        standard_metadata.parser_error = smeta.parser_error;
     }
     @name("ingress.set_port") action set_port(bit<9> output_port) {
         standard_metadata.egress_spec = output_port;

--- a/testdata/p4_16_samples_outputs/issue1538.p4
+++ b/testdata/p4_16_samples_outputs/issue1538.p4
@@ -22,7 +22,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<16> tmp_port = incr((bit<16>)standard_metadata.ingress_port);

--- a/testdata/p4_16_samples_outputs/issue1538.p4
+++ b/testdata/p4_16_samples_outputs/issue1538.p4
@@ -21,8 +21,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<16> tmp_port = incr((bit<16>)standard_metadata.ingress_port);
@@ -47,9 +47,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples_outputs/issue1538.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1538.p4.p4info.txt
@@ -40,5 +40,3 @@ actions {
     bitwidth: 9
   }
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/issue1538.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1538.p4.p4info.txt
@@ -40,3 +40,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-first.p4
@@ -22,8 +22,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {
@@ -45,9 +45,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-first.p4
@@ -23,7 +23,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-frontend.p4
@@ -23,12 +23,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     bit<16> tmp;
     @name("ingress.set_port") action set_port(bit<9> output_port) {

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-frontend.p4
@@ -22,8 +22,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
     bit<16> tmp;
     @name("ingress.set_port") action set_port(bit<9> output_port) {
@@ -35,9 +40,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da_0.apply();

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-midend.p4
@@ -23,9 +23,51 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<16> tmp_0;
+    standard_metadata_t smeta;
     @name(".my_drop") action my_drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta.ingress_port = standard_metadata.ingress_port;
+        smeta.egress_spec = standard_metadata.egress_spec;
+        smeta.egress_port = standard_metadata.egress_port;
+        smeta.clone_spec = standard_metadata.clone_spec;
+        smeta.instance_type = standard_metadata.instance_type;
+        smeta.drop = standard_metadata.drop;
+        smeta.recirculate_port = standard_metadata.recirculate_port;
+        smeta.packet_length = standard_metadata.packet_length;
+        smeta.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta.lf_field_list = standard_metadata.lf_field_list;
+        smeta.mcast_grp = standard_metadata.mcast_grp;
+        smeta.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta.egress_rid = standard_metadata.egress_rid;
+        smeta.checksum_error = standard_metadata.checksum_error;
+        smeta.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta);
+        standard_metadata.ingress_port = smeta.ingress_port;
+        standard_metadata.egress_spec = smeta.egress_spec;
+        standard_metadata.egress_port = smeta.egress_port;
+        standard_metadata.clone_spec = smeta.clone_spec;
+        standard_metadata.instance_type = smeta.instance_type;
+        standard_metadata.drop = smeta.drop;
+        standard_metadata.recirculate_port = smeta.recirculate_port;
+        standard_metadata.packet_length = smeta.packet_length;
+        standard_metadata.enq_timestamp = smeta.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta.lf_field_list;
+        standard_metadata.mcast_grp = smeta.mcast_grp;
+        standard_metadata.resubmit_flag = smeta.resubmit_flag;
+        standard_metadata.egress_rid = smeta.egress_rid;
+        standard_metadata.checksum_error = smeta.checksum_error;
+        standard_metadata.recirculate_flag = smeta.recirculate_flag;
+        standard_metadata.parser_error = smeta.parser_error;
     }
     @name("ingress.set_port") action set_port(bit<9> output_port) {
         standard_metadata.egress_spec = output_port;

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-midend.p4
@@ -24,7 +24,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<16> tmp_0;
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.set_port") action set_port(bit<9> output_port) {
         standard_metadata.egress_spec = output_port;

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4
@@ -24,8 +24,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {
@@ -47,9 +47,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4
@@ -25,7 +25,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4.p4info.txt
@@ -40,5 +40,3 @@ actions {
     bitwidth: 9
   }
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4.p4info.txt
@@ -40,3 +40,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-first.p4
@@ -20,8 +20,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {
@@ -43,9 +43,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-first.p4
@@ -21,7 +21,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-frontend.p4
@@ -23,12 +23,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     bit<16> tmp;
     @name("ingress.set_port") action set_port(bit<9> output_port) {

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-frontend.p4
@@ -22,8 +22,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
     bit<16> tmp;
     @name("ingress.set_port") action set_port(bit<9> output_port) {
@@ -35,9 +40,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da_0.apply();

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-midend.p4
@@ -23,9 +23,51 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<16> tmp_0;
+    standard_metadata_t smeta;
     @name(".my_drop") action my_drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta.ingress_port = standard_metadata.ingress_port;
+        smeta.egress_spec = standard_metadata.egress_spec;
+        smeta.egress_port = standard_metadata.egress_port;
+        smeta.clone_spec = standard_metadata.clone_spec;
+        smeta.instance_type = standard_metadata.instance_type;
+        smeta.drop = standard_metadata.drop;
+        smeta.recirculate_port = standard_metadata.recirculate_port;
+        smeta.packet_length = standard_metadata.packet_length;
+        smeta.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta.lf_field_list = standard_metadata.lf_field_list;
+        smeta.mcast_grp = standard_metadata.mcast_grp;
+        smeta.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta.egress_rid = standard_metadata.egress_rid;
+        smeta.checksum_error = standard_metadata.checksum_error;
+        smeta.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta);
+        standard_metadata.ingress_port = smeta.ingress_port;
+        standard_metadata.egress_spec = smeta.egress_spec;
+        standard_metadata.egress_port = smeta.egress_port;
+        standard_metadata.clone_spec = smeta.clone_spec;
+        standard_metadata.instance_type = smeta.instance_type;
+        standard_metadata.drop = smeta.drop;
+        standard_metadata.recirculate_port = smeta.recirculate_port;
+        standard_metadata.packet_length = smeta.packet_length;
+        standard_metadata.enq_timestamp = smeta.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta.lf_field_list;
+        standard_metadata.mcast_grp = smeta.mcast_grp;
+        standard_metadata.resubmit_flag = smeta.resubmit_flag;
+        standard_metadata.egress_rid = smeta.egress_rid;
+        standard_metadata.checksum_error = smeta.checksum_error;
+        standard_metadata.recirculate_flag = smeta.recirculate_flag;
+        standard_metadata.parser_error = smeta.parser_error;
     }
     @name("ingress.set_port") action set_port(bit<9> output_port) {
         standard_metadata.egress_spec = output_port;

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-midend.p4
@@ -24,7 +24,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<16> tmp_0;
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.set_port") action set_port(bit<9> output_port) {
         standard_metadata.egress_spec = output_port;

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4
@@ -22,7 +22,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4
@@ -21,8 +21,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {
@@ -44,9 +44,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4.p4info.txt
@@ -40,5 +40,3 @@ actions {
     bitwidth: 9
   }
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4.p4info.txt
@@ -40,3 +40,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-first.p4
@@ -20,8 +20,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {
@@ -43,9 +43,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-first.p4
@@ -21,7 +21,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-frontend.p4
@@ -23,12 +23,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     bit<16> tmp;
     @name("ingress.set_port") action set_port(bit<9> output_port) {

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-frontend.p4
@@ -22,8 +22,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
     bit<16> tmp;
     @name("ingress.set_port") action set_port(bit<9> output_port) {
@@ -35,9 +40,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da_0.apply();

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-midend.p4
@@ -23,9 +23,51 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<16> retval;
+    standard_metadata_t smeta;
     @name(".my_drop") action my_drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta.ingress_port = standard_metadata.ingress_port;
+        smeta.egress_spec = standard_metadata.egress_spec;
+        smeta.egress_port = standard_metadata.egress_port;
+        smeta.clone_spec = standard_metadata.clone_spec;
+        smeta.instance_type = standard_metadata.instance_type;
+        smeta.drop = standard_metadata.drop;
+        smeta.recirculate_port = standard_metadata.recirculate_port;
+        smeta.packet_length = standard_metadata.packet_length;
+        smeta.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta.lf_field_list = standard_metadata.lf_field_list;
+        smeta.mcast_grp = standard_metadata.mcast_grp;
+        smeta.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta.egress_rid = standard_metadata.egress_rid;
+        smeta.checksum_error = standard_metadata.checksum_error;
+        smeta.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta);
+        standard_metadata.ingress_port = smeta.ingress_port;
+        standard_metadata.egress_spec = smeta.egress_spec;
+        standard_metadata.egress_port = smeta.egress_port;
+        standard_metadata.clone_spec = smeta.clone_spec;
+        standard_metadata.instance_type = smeta.instance_type;
+        standard_metadata.drop = smeta.drop;
+        standard_metadata.recirculate_port = smeta.recirculate_port;
+        standard_metadata.packet_length = smeta.packet_length;
+        standard_metadata.enq_timestamp = smeta.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta.lf_field_list;
+        standard_metadata.mcast_grp = smeta.mcast_grp;
+        standard_metadata.resubmit_flag = smeta.resubmit_flag;
+        standard_metadata.egress_rid = smeta.egress_rid;
+        standard_metadata.checksum_error = smeta.checksum_error;
+        standard_metadata.recirculate_flag = smeta.recirculate_flag;
+        standard_metadata.parser_error = smeta.parser_error;
     }
     @name("ingress.set_port") action set_port(bit<9> output_port) {
         standard_metadata.egress_spec = output_port;

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-midend.p4
@@ -24,7 +24,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     bit<16> retval;
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.set_port") action set_port(bit<9> output_port) {
         standard_metadata.egress_spec = output_port;

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2.p4
@@ -22,8 +22,8 @@ struct headers {
     ethernet_t ethernet;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {
@@ -45,9 +45,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_port;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         mac_da.apply();

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2.p4
@@ -23,7 +23,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2.p4.p4info.txt
@@ -40,5 +40,3 @@ actions {
     bitwidth: 9
   }
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2.p4.p4info.txt
@@ -40,3 +40,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-first.p4
@@ -56,7 +56,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-first.p4
@@ -56,7 +56,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-frontend.p4
@@ -57,12 +57,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name(".NoAction") action NoAction_0() {
     }
     @name("MyIngress.drop") action drop_1() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-frontend.p4
@@ -57,7 +57,12 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name(".NoAction") action NoAction_0() {
     }
     @name("MyIngress.drop") action drop_1() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("MyIngress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-midend.p4
@@ -71,7 +71,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name(".NoAction") action NoAction_0() {
     }
     @name("MyIngress.drop") action drop_1() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("MyIngress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-midend.p4
@@ -71,8 +71,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name(".NoAction") action NoAction_0() {
     }
     @name("MyIngress.drop") action drop_1() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("MyIngress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2.p4
@@ -56,7 +56,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2.p4
@@ -56,7 +56,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-first.p4
@@ -35,8 +35,8 @@ struct headers_t {
     ipv4_t     ipv4;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;
@@ -66,16 +66,16 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         }
         actions = {
             set_output();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     table ipv4_sa_filter {
         key = {
             hdr.ipv4.srcAddr: ternary @name("hdr.ipv4.srcAddr") ;
         }
         actions = {
-            my_drop();
+            my_drop(standard_metadata);
             NoAction();
         }
         const default_action = NoAction();

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-first.p4
@@ -36,7 +36,7 @@ struct headers_t {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-frontend.p4
@@ -50,11 +50,21 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
-    @name(".my_drop") action my_drop_0() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
+        {
+            standard_metadata_t standard_metadata_2 = smeta_1;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            smeta_1 = standard_metadata_2;
+        }
     }
     @name(".NoAction") action NoAction_0() {
     }
@@ -67,16 +77,16 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         }
         actions = {
             set_output();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     @name("ingress.ipv4_sa_filter") table ipv4_sa_filter_0 {
         key = {
             hdr.ipv4.srcAddr: ternary @name("hdr.ipv4.srcAddr") ;
         }
         actions = {
-            my_drop_0();
+            my_drop_0(standard_metadata);
             NoAction_0();
         }
         const default_action = NoAction_0();

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-frontend.p4
@@ -51,20 +51,10 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
-        {
-            standard_metadata_t standard_metadata_2 = smeta_1;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            smeta_1 = standard_metadata_2;
-        }
+        mark_to_drop(smeta_1);
     }
     @name(".NoAction") action NoAction_0() {
     }

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-midend.p4
@@ -50,13 +50,97 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
+    standard_metadata_t smeta;
+    standard_metadata_t smeta_1;
     @name(".my_drop") action my_drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta.ingress_port = standard_metadata.ingress_port;
+        smeta.egress_spec = standard_metadata.egress_spec;
+        smeta.egress_port = standard_metadata.egress_port;
+        smeta.clone_spec = standard_metadata.clone_spec;
+        smeta.instance_type = standard_metadata.instance_type;
+        smeta.drop = standard_metadata.drop;
+        smeta.recirculate_port = standard_metadata.recirculate_port;
+        smeta.packet_length = standard_metadata.packet_length;
+        smeta.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta.lf_field_list = standard_metadata.lf_field_list;
+        smeta.mcast_grp = standard_metadata.mcast_grp;
+        smeta.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta.egress_rid = standard_metadata.egress_rid;
+        smeta.checksum_error = standard_metadata.checksum_error;
+        smeta.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta);
+        standard_metadata.ingress_port = smeta.ingress_port;
+        standard_metadata.egress_spec = smeta.egress_spec;
+        standard_metadata.egress_port = smeta.egress_port;
+        standard_metadata.clone_spec = smeta.clone_spec;
+        standard_metadata.instance_type = smeta.instance_type;
+        standard_metadata.drop = smeta.drop;
+        standard_metadata.recirculate_port = smeta.recirculate_port;
+        standard_metadata.packet_length = smeta.packet_length;
+        standard_metadata.enq_timestamp = smeta.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta.lf_field_list;
+        standard_metadata.mcast_grp = smeta.mcast_grp;
+        standard_metadata.resubmit_flag = smeta.resubmit_flag;
+        standard_metadata.egress_rid = smeta.egress_rid;
+        standard_metadata.checksum_error = smeta.checksum_error;
+        standard_metadata.recirculate_flag = smeta.recirculate_flag;
+        standard_metadata.parser_error = smeta.parser_error;
     }
     @name(".my_drop") action my_drop_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta_1.ingress_port = standard_metadata.ingress_port;
+        smeta_1.egress_spec = standard_metadata.egress_spec;
+        smeta_1.egress_port = standard_metadata.egress_port;
+        smeta_1.clone_spec = standard_metadata.clone_spec;
+        smeta_1.instance_type = standard_metadata.instance_type;
+        smeta_1.drop = standard_metadata.drop;
+        smeta_1.recirculate_port = standard_metadata.recirculate_port;
+        smeta_1.packet_length = standard_metadata.packet_length;
+        smeta_1.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta_1.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta_1.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta_1.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta_1.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta_1.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta_1.lf_field_list = standard_metadata.lf_field_list;
+        smeta_1.mcast_grp = standard_metadata.mcast_grp;
+        smeta_1.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta_1.egress_rid = standard_metadata.egress_rid;
+        smeta_1.checksum_error = standard_metadata.checksum_error;
+        smeta_1.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta_1.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta_1);
+        standard_metadata.ingress_port = smeta_1.ingress_port;
+        standard_metadata.egress_spec = smeta_1.egress_spec;
+        standard_metadata.egress_port = smeta_1.egress_port;
+        standard_metadata.clone_spec = smeta_1.clone_spec;
+        standard_metadata.instance_type = smeta_1.instance_type;
+        standard_metadata.drop = smeta_1.drop;
+        standard_metadata.recirculate_port = smeta_1.recirculate_port;
+        standard_metadata.packet_length = smeta_1.packet_length;
+        standard_metadata.enq_timestamp = smeta_1.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta_1.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta_1.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta_1.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta_1.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta_1.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta_1.lf_field_list;
+        standard_metadata.mcast_grp = smeta_1.mcast_grp;
+        standard_metadata.resubmit_flag = smeta_1.resubmit_flag;
+        standard_metadata.egress_rid = smeta_1.egress_rid;
+        standard_metadata.checksum_error = smeta_1.checksum_error;
+        standard_metadata.recirculate_flag = smeta_1.recirculate_flag;
+        standard_metadata.parser_error = smeta_1.parser_error;
     }
     @name(".NoAction") action NoAction_0() {
     }

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-midend.p4
@@ -51,10 +51,12 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".my_drop") action my_drop_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".NoAction") action NoAction_0() {
     }

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2.p4
@@ -35,8 +35,8 @@ struct headers_t {
     ipv4_t     ipv4;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;
@@ -66,16 +66,16 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         }
         actions = {
             set_output;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     table ipv4_sa_filter {
         key = {
             hdr.ipv4.srcAddr: ternary;
         }
         actions = {
-            my_drop;
+            my_drop(standard_metadata);
             NoAction;
         }
         const default_action = NoAction;

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2.p4
@@ -36,7 +36,7 @@ struct headers_t {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2-first.p4
@@ -195,7 +195,7 @@ control MyComputeChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action set_egress_port(port_t out_port) {
         standard_metadata.egress_spec = out_port;

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2-first.p4
@@ -195,7 +195,7 @@ control MyComputeChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action set_egress_port(port_t out_port) {
         standard_metadata.egress_spec = out_port;

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2.p4
@@ -195,7 +195,7 @@ control MyComputeChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action set_egress_port(port_t out_port) {
         standard_metadata.egress_spec = out_port;

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2.p4
@@ -195,7 +195,7 @@ control MyComputeChecksum(inout headers hdr, inout metadata meta) {
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action set_egress_port(port_t out_port) {
         standard_metadata.egress_spec = out_port;

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2-first.p4
@@ -26,7 +26,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     apply {
         if (standard_metadata.parser_error != error.NoError) 
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2-first.p4
@@ -26,7 +26,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     apply {
         if (standard_metadata.parser_error != error.NoError) 
-            mark_to_drop();
+            markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2-frontend.p4
@@ -24,13 +24,9 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".markToDrop") action markToDrop(inout standard_metadata_t standard_metadata_1) {
-        standard_metadata_1.egress_spec = 9w511;
-        standard_metadata_1.mcast_grp = 16w0;
-    }
     apply {
         if (standard_metadata.parser_error != error.NoError) 
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2-frontend.p4
@@ -24,9 +24,13 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".markToDrop") action markToDrop(inout standard_metadata_t standard_metadata_1) {
+        standard_metadata_1.egress_spec = 9w511;
+        standard_metadata_1.mcast_grp = 16w0;
+    }
     apply {
         if (standard_metadata.parser_error != error.NoError) 
-            mark_to_drop();
+            markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2-midend.p4
@@ -24,18 +24,19 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
-        mark_to_drop();
+    @name(".markToDrop") action markToDrop() {
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_markToDrop {
         actions = {
-            act();
+            markToDrop();
         }
-        const default_action = act();
+        const default_action = markToDrop();
     }
     apply {
         if (standard_metadata.parser_error != error.NoError) 
-            tbl_act.apply();
+            tbl_markToDrop.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2-midend.p4
@@ -24,19 +24,18 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".markToDrop") action markToDrop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+    @hidden action act() {
+        mark_to_drop(standard_metadata);
     }
-    @hidden table tbl_markToDrop {
+    @hidden table tbl_act {
         actions = {
-            markToDrop();
+            act();
         }
-        const default_action = markToDrop();
+        const default_action = act();
     }
     apply {
         if (standard_metadata.parser_error != error.NoError) 
-            tbl_markToDrop.apply();
+            tbl_act.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2.p4
@@ -26,7 +26,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     apply {
         if (standard_metadata.parser_error != error.NoError) 
-            markToDrop(standard_metadata);
+            mark_to_drop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2.p4
@@ -26,7 +26,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     apply {
         if (standard_metadata.parser_error != error.NoError) 
-            mark_to_drop();
+            markToDrop(standard_metadata);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2.p4.p4info.txt
@@ -1,10 +1,5 @@
 pkg_info {
   arch: "v1model"
 }
-actions {
-  preamble {
-    id: 16788389
-    name: "markToDrop"
-    alias: "markToDrop"
-  }
+type_info {
 }

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2.p4.p4info.txt
@@ -1,5 +1,10 @@
 pkg_info {
   arch: "v1model"
 }
-type_info {
+actions {
+  preamble {
+    id: 16788389
+    name: "markToDrop"
+    alias: "markToDrop"
+  }
 }

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2-first.p4
@@ -17,7 +17,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     register<bit<1>>(32w1) testRegister;
     action drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     action forward() {
         standard_metadata.egress_spec = 9w1;

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2-frontend.p4
@@ -20,7 +20,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     bit<1> registerData_0;
     @name("IngressImpl.testRegister") register<bit<1>>(32w1) testRegister_0;
     @name("IngressImpl.drop") action drop_1() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     @name("IngressImpl.forward") action forward() {
         standard_metadata.egress_spec = 9w1;

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2-midend.p4
@@ -20,7 +20,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     }
     @name("IngressImpl.testRegister") register<bit<1>>(32w1) testRegister_0;
     @name("IngressImpl.drop") action drop_1() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     @name("IngressImpl.forward") action forward() {
         standard_metadata.egress_spec = 9w1;

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2.p4
@@ -17,7 +17,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     register<bit<1>>(1) testRegister;
     action drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
     action forward() {
         standard_metadata.egress_spec = 1;

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-first.p4
@@ -19,7 +19,7 @@ action empty() {
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action_profile(32w128) ap;
     action drop() {
-        markToDrop(smeta);
+        mark_to_drop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-first.p4
@@ -19,7 +19,7 @@ action empty() {
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action_profile(32w128) ap;
     action drop() {
-        mark_to_drop();
+        markToDrop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
@@ -21,10 +21,20 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     }
     @name("IngressI.ap") action_profile(32w128) ap_0;
     @name("IngressI.drop") action drop_1() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
     @name("IngressI.drop") action drop_3() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = smeta;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            smeta = standard_metadata_2;
+        }
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
@@ -21,20 +21,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     }
     @name("IngressI.ap") action_profile(32w128) ap_0;
     @name("IngressI.drop") action drop_1() {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     @name("IngressI.drop") action drop_3() {
-        {
-            standard_metadata_t standard_metadata_2 = smeta;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            smeta = standard_metadata_2;
-        }
+        mark_to_drop(smeta);
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
@@ -21,12 +21,10 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     }
     @name("IngressI.ap") action_profile(32w128) ap_0;
     @name("IngressI.drop") action drop_1() {
-        smeta.egress_spec = 9w511;
-        smeta.mcast_grp = 16w0;
+        mark_to_drop(smeta);
     }
     @name("IngressI.drop") action drop_3() {
-        smeta.egress_spec = 9w511;
-        smeta.mcast_grp = 16w0;
+        mark_to_drop(smeta);
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
@@ -21,10 +21,12 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     }
     @name("IngressI.ap") action_profile(32w128) ap_0;
     @name("IngressI.drop") action drop_1() {
-        mark_to_drop();
+        smeta.egress_spec = 9w511;
+        smeta.mcast_grp = 16w0;
     }
     @name("IngressI.drop") action drop_3() {
-        mark_to_drop();
+        smeta.egress_spec = 9w511;
+        smeta.mcast_grp = 16w0;
     }
     @name("IngressI.indirect") table indirect_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2.p4
@@ -19,7 +19,7 @@ action empty() {
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action_profile(32w128) ap;
     action drop() {
-        markToDrop(smeta);
+        mark_to_drop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2.p4
@@ -19,7 +19,7 @@ action empty() {
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     action_profile(32w128) ap;
     action drop() {
-        mark_to_drop();
+        markToDrop(smeta);
     }
     table indirect {
         key = {

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
@@ -113,7 +113,7 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     table drop_tbl {
         key = {

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
@@ -113,7 +113,7 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     table drop_tbl {
         key = {

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
@@ -110,12 +110,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".NoAction") action NoAction_0() {
     }
     @name("egress._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("egress.drop_tbl") table drop_tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
@@ -110,7 +110,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".NoAction") action NoAction_0() {
     }
     @name("egress._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("egress.drop_tbl") table drop_tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
@@ -129,8 +129,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".NoAction") action NoAction_0() {
     }
     @name("egress._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("egress.drop_tbl") table drop_tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
@@ -129,7 +129,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".NoAction") action NoAction_0() {
     }
     @name("egress._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("egress.drop_tbl") table drop_tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue298-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2.p4
@@ -113,7 +113,7 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     table drop_tbl {
         key = {

--- a/testdata/p4_16_samples_outputs/issue298-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2.p4
@@ -113,7 +113,7 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     table drop_tbl {
         key = {

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-first.p4
@@ -36,8 +36,8 @@ struct headers {
     ipv4_t     ipv4;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;
@@ -65,7 +65,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     action drop_with_count() {
         ipv4_da_lpm_stats.count();
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;
@@ -87,12 +87,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     table mac_da {
         actions = {
             set_bd_dmac_intf();
-            my_drop();
+            my_drop(standard_metadata);
         }
         key = {
             meta.fwd_metadata.l2ptr: exact @name("meta.fwd_metadata.l2ptr") ;
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         ipv4_da_lpm.apply();
@@ -107,12 +107,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     table send_frame {
         actions = {
             rewrite_mac();
-            my_drop();
+            my_drop(standard_metadata);
         }
         key = {
             meta.fwd_metadata.out_bd: exact @name("meta.fwd_metadata.out_bd") ;
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         send_frame.apply();

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-first.p4
@@ -37,7 +37,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;
@@ -65,7 +65,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     action drop_with_count() {
         ipv4_da_lpm_stats.count();
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-frontend.p4
@@ -52,12 +52,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     @name("ingress.ipv4_da_lpm_stats") direct_counter(CounterType.packets) ipv4_da_lpm_stats_0;
     @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
@@ -66,12 +61,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.drop_with_count") action drop_with_count() {
         ipv4_da_lpm_stats_0.count();
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;
@@ -108,12 +98,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
-        {
-            standard_metadata_t standard_metadata_4 = smeta_1;
-            standard_metadata_4.egress_spec = 9w511;
-            standard_metadata_4.mcast_grp = 16w0;
-            smeta_1 = standard_metadata_4;
-        }
+        mark_to_drop(smeta_1);
     }
     @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-frontend.p4
@@ -51,8 +51,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
     @name("ingress.ipv4_da_lpm_stats") direct_counter(CounterType.packets) ipv4_da_lpm_stats_0;
     @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
@@ -61,7 +66,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.drop_with_count") action drop_with_count() {
         ipv4_da_lpm_stats_0.count();
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;
@@ -83,12 +93,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress.mac_da") table mac_da_0 {
         actions = {
             set_bd_dmac_intf();
-            my_drop();
+            my_drop(standard_metadata);
         }
         key = {
             meta.fwd_metadata.l2ptr: exact @name("meta.fwd_metadata.l2ptr") ;
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         ipv4_da_lpm_0.apply();
@@ -97,8 +107,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop_0() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
+        {
+            standard_metadata_t standard_metadata_4 = smeta_1;
+            standard_metadata_4.egress_spec = 9w511;
+            standard_metadata_4.mcast_grp = 16w0;
+            smeta_1 = standard_metadata_4;
+        }
     }
     @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
@@ -106,12 +121,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name("egress.send_frame") table send_frame_0 {
         actions = {
             rewrite_mac();
-            my_drop_0();
+            my_drop_0(standard_metadata);
         }
         key = {
             meta.fwd_metadata.out_bd: exact @name("meta.fwd_metadata.out_bd") ;
         }
-        default_action = my_drop_0();
+        default_action = my_drop_0(standard_metadata);
     }
     apply {
         send_frame_0.apply();

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-midend.p4
@@ -53,7 +53,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.ipv4_da_lpm_stats") direct_counter(CounterType.packets) ipv4_da_lpm_stats_0;
     @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
@@ -62,7 +63,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.drop_with_count") action drop_with_count() {
         ipv4_da_lpm_stats_0.count();
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta._fwd_metadata_out_bd1 = bd;
@@ -99,7 +101,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-midend.p4
@@ -52,9 +52,51 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    standard_metadata_t smeta;
     @name(".my_drop") action my_drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta.ingress_port = standard_metadata.ingress_port;
+        smeta.egress_spec = standard_metadata.egress_spec;
+        smeta.egress_port = standard_metadata.egress_port;
+        smeta.clone_spec = standard_metadata.clone_spec;
+        smeta.instance_type = standard_metadata.instance_type;
+        smeta.drop = standard_metadata.drop;
+        smeta.recirculate_port = standard_metadata.recirculate_port;
+        smeta.packet_length = standard_metadata.packet_length;
+        smeta.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta.lf_field_list = standard_metadata.lf_field_list;
+        smeta.mcast_grp = standard_metadata.mcast_grp;
+        smeta.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta.egress_rid = standard_metadata.egress_rid;
+        smeta.checksum_error = standard_metadata.checksum_error;
+        smeta.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta);
+        standard_metadata.ingress_port = smeta.ingress_port;
+        standard_metadata.egress_spec = smeta.egress_spec;
+        standard_metadata.egress_port = smeta.egress_port;
+        standard_metadata.clone_spec = smeta.clone_spec;
+        standard_metadata.instance_type = smeta.instance_type;
+        standard_metadata.drop = smeta.drop;
+        standard_metadata.recirculate_port = smeta.recirculate_port;
+        standard_metadata.packet_length = smeta.packet_length;
+        standard_metadata.enq_timestamp = smeta.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta.lf_field_list;
+        standard_metadata.mcast_grp = smeta.mcast_grp;
+        standard_metadata.resubmit_flag = smeta.resubmit_flag;
+        standard_metadata.egress_rid = smeta.egress_rid;
+        standard_metadata.checksum_error = smeta.checksum_error;
+        standard_metadata.recirculate_flag = smeta.recirculate_flag;
+        standard_metadata.parser_error = smeta.parser_error;
     }
     @name("ingress.ipv4_da_lpm_stats") direct_counter(CounterType.packets) ipv4_da_lpm_stats_0;
     @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
@@ -63,8 +105,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.drop_with_count") action drop_with_count() {
         ipv4_da_lpm_stats_0.count();
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta._fwd_metadata_out_bd1 = bd;
@@ -100,9 +141,51 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    standard_metadata_t smeta_1;
     @name(".my_drop") action my_drop_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta_1.ingress_port = standard_metadata.ingress_port;
+        smeta_1.egress_spec = standard_metadata.egress_spec;
+        smeta_1.egress_port = standard_metadata.egress_port;
+        smeta_1.clone_spec = standard_metadata.clone_spec;
+        smeta_1.instance_type = standard_metadata.instance_type;
+        smeta_1.drop = standard_metadata.drop;
+        smeta_1.recirculate_port = standard_metadata.recirculate_port;
+        smeta_1.packet_length = standard_metadata.packet_length;
+        smeta_1.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta_1.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta_1.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta_1.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta_1.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta_1.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta_1.lf_field_list = standard_metadata.lf_field_list;
+        smeta_1.mcast_grp = standard_metadata.mcast_grp;
+        smeta_1.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta_1.egress_rid = standard_metadata.egress_rid;
+        smeta_1.checksum_error = standard_metadata.checksum_error;
+        smeta_1.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta_1.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta_1);
+        standard_metadata.ingress_port = smeta_1.ingress_port;
+        standard_metadata.egress_spec = smeta_1.egress_spec;
+        standard_metadata.egress_port = smeta_1.egress_port;
+        standard_metadata.clone_spec = smeta_1.clone_spec;
+        standard_metadata.instance_type = smeta_1.instance_type;
+        standard_metadata.drop = smeta_1.drop;
+        standard_metadata.recirculate_port = smeta_1.recirculate_port;
+        standard_metadata.packet_length = smeta_1.packet_length;
+        standard_metadata.enq_timestamp = smeta_1.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta_1.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta_1.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta_1.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta_1.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta_1.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta_1.lf_field_list;
+        standard_metadata.mcast_grp = smeta_1.mcast_grp;
+        standard_metadata.resubmit_flag = smeta_1.resubmit_flag;
+        standard_metadata.egress_rid = smeta_1.egress_rid;
+        standard_metadata.checksum_error = smeta_1.checksum_error;
+        standard_metadata.recirculate_flag = smeta_1.recirculate_flag;
+        standard_metadata.parser_error = smeta_1.parser_error;
     }
     @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;

--- a/testdata/p4_16_samples_outputs/issue461-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2.p4
@@ -37,7 +37,7 @@ struct headers {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;
@@ -65,7 +65,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     action drop_with_count() {
         ipv4_da_lpm_stats.count();
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;

--- a/testdata/p4_16_samples_outputs/issue461-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2.p4
@@ -36,8 +36,8 @@ struct headers {
     ipv4_t     ipv4;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;
@@ -65,7 +65,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     action drop_with_count() {
         ipv4_da_lpm_stats.count();
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;
@@ -87,12 +87,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     table mac_da {
         actions = {
             set_bd_dmac_intf;
-            my_drop;
+            my_drop(standard_metadata);
         }
         key = {
             meta.fwd_metadata.l2ptr: exact;
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         ipv4_da_lpm.apply();
@@ -107,12 +107,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     table send_frame {
         actions = {
             rewrite_mac;
-            my_drop;
+            my_drop(standard_metadata);
         }
         key = {
             meta.fwd_metadata.out_bd: exact;
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         send_frame.apply();

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-first.p4
@@ -186,8 +186,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action set_l2ptr(bit<32> l2ptr) {
@@ -199,9 +199,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_l2ptr();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;
@@ -215,9 +215,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_bd_dmac_intf();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         ipv4_da_lpm.apply();
@@ -235,9 +235,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         }
         actions = {
             rewrite_mac();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         send_frame.apply();

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-first.p4
@@ -187,7 +187,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action set_l2ptr(bit<32> l2ptr) {

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
@@ -235,20 +235,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
-        {
-            standard_metadata_t standard_metadata_2 = smeta_1;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            smeta_1 = standard_metadata_2;
-        }
+        mark_to_drop(smeta_1);
     }
     @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
         meta.fwd_metadata.l2ptr = l2ptr;
@@ -287,12 +277,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop_1(inout standard_metadata_t smeta_2) {
-        {
-            standard_metadata_t standard_metadata_3 = smeta_2;
-            standard_metadata_3.egress_spec = 9w511;
-            standard_metadata_3.mcast_grp = 16w0;
-            smeta_2 = standard_metadata_3;
-        }
+        mark_to_drop(smeta_2);
     }
     @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
@@ -234,11 +234,21 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
-    @name(".my_drop") action my_drop_0() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
+        {
+            standard_metadata_t standard_metadata_2 = smeta_1;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            smeta_1 = standard_metadata_2;
+        }
     }
     @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
         meta.fwd_metadata.l2ptr = l2ptr;
@@ -249,9 +259,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_l2ptr();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;
@@ -265,9 +275,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_bd_dmac_intf();
-            my_drop_0();
+            my_drop_0(standard_metadata);
         }
-        default_action = my_drop_0();
+        default_action = my_drop_0(standard_metadata);
     }
     apply {
         ipv4_da_lpm_0.apply();
@@ -276,8 +286,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop_1() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop_1(inout standard_metadata_t smeta_2) {
+        {
+            standard_metadata_t standard_metadata_3 = smeta_2;
+            standard_metadata_3.egress_spec = 9w511;
+            standard_metadata_3.mcast_grp = 16w0;
+            smeta_2 = standard_metadata_3;
+        }
     }
     @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
@@ -288,9 +303,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         }
         actions = {
             rewrite_mac();
-            my_drop_1();
+            my_drop_1(standard_metadata);
         }
-        default_action = my_drop_1();
+        default_action = my_drop_1(standard_metadata);
     }
     apply {
         send_frame_0.apply();

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
@@ -235,13 +235,97 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    standard_metadata_t smeta;
+    standard_metadata_t smeta_1;
     @name(".my_drop") action my_drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta.ingress_port = standard_metadata.ingress_port;
+        smeta.egress_spec = standard_metadata.egress_spec;
+        smeta.egress_port = standard_metadata.egress_port;
+        smeta.clone_spec = standard_metadata.clone_spec;
+        smeta.instance_type = standard_metadata.instance_type;
+        smeta.drop = standard_metadata.drop;
+        smeta.recirculate_port = standard_metadata.recirculate_port;
+        smeta.packet_length = standard_metadata.packet_length;
+        smeta.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta.lf_field_list = standard_metadata.lf_field_list;
+        smeta.mcast_grp = standard_metadata.mcast_grp;
+        smeta.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta.egress_rid = standard_metadata.egress_rid;
+        smeta.checksum_error = standard_metadata.checksum_error;
+        smeta.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta);
+        standard_metadata.ingress_port = smeta.ingress_port;
+        standard_metadata.egress_spec = smeta.egress_spec;
+        standard_metadata.egress_port = smeta.egress_port;
+        standard_metadata.clone_spec = smeta.clone_spec;
+        standard_metadata.instance_type = smeta.instance_type;
+        standard_metadata.drop = smeta.drop;
+        standard_metadata.recirculate_port = smeta.recirculate_port;
+        standard_metadata.packet_length = smeta.packet_length;
+        standard_metadata.enq_timestamp = smeta.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta.lf_field_list;
+        standard_metadata.mcast_grp = smeta.mcast_grp;
+        standard_metadata.resubmit_flag = smeta.resubmit_flag;
+        standard_metadata.egress_rid = smeta.egress_rid;
+        standard_metadata.checksum_error = smeta.checksum_error;
+        standard_metadata.recirculate_flag = smeta.recirculate_flag;
+        standard_metadata.parser_error = smeta.parser_error;
     }
     @name(".my_drop") action my_drop_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta_1.ingress_port = standard_metadata.ingress_port;
+        smeta_1.egress_spec = standard_metadata.egress_spec;
+        smeta_1.egress_port = standard_metadata.egress_port;
+        smeta_1.clone_spec = standard_metadata.clone_spec;
+        smeta_1.instance_type = standard_metadata.instance_type;
+        smeta_1.drop = standard_metadata.drop;
+        smeta_1.recirculate_port = standard_metadata.recirculate_port;
+        smeta_1.packet_length = standard_metadata.packet_length;
+        smeta_1.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta_1.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta_1.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta_1.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta_1.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta_1.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta_1.lf_field_list = standard_metadata.lf_field_list;
+        smeta_1.mcast_grp = standard_metadata.mcast_grp;
+        smeta_1.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta_1.egress_rid = standard_metadata.egress_rid;
+        smeta_1.checksum_error = standard_metadata.checksum_error;
+        smeta_1.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta_1.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta_1);
+        standard_metadata.ingress_port = smeta_1.ingress_port;
+        standard_metadata.egress_spec = smeta_1.egress_spec;
+        standard_metadata.egress_port = smeta_1.egress_port;
+        standard_metadata.clone_spec = smeta_1.clone_spec;
+        standard_metadata.instance_type = smeta_1.instance_type;
+        standard_metadata.drop = smeta_1.drop;
+        standard_metadata.recirculate_port = smeta_1.recirculate_port;
+        standard_metadata.packet_length = smeta_1.packet_length;
+        standard_metadata.enq_timestamp = smeta_1.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta_1.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta_1.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta_1.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta_1.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta_1.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta_1.lf_field_list;
+        standard_metadata.mcast_grp = smeta_1.mcast_grp;
+        standard_metadata.resubmit_flag = smeta_1.resubmit_flag;
+        standard_metadata.egress_rid = smeta_1.egress_rid;
+        standard_metadata.checksum_error = smeta_1.checksum_error;
+        standard_metadata.recirculate_flag = smeta_1.recirculate_flag;
+        standard_metadata.parser_error = smeta_1.parser_error;
     }
     @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
         meta._fwd_metadata_l2ptr0 = l2ptr;
@@ -279,9 +363,51 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    standard_metadata_t smeta_2;
     @name(".my_drop") action my_drop_1() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta_2.ingress_port = standard_metadata.ingress_port;
+        smeta_2.egress_spec = standard_metadata.egress_spec;
+        smeta_2.egress_port = standard_metadata.egress_port;
+        smeta_2.clone_spec = standard_metadata.clone_spec;
+        smeta_2.instance_type = standard_metadata.instance_type;
+        smeta_2.drop = standard_metadata.drop;
+        smeta_2.recirculate_port = standard_metadata.recirculate_port;
+        smeta_2.packet_length = standard_metadata.packet_length;
+        smeta_2.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta_2.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta_2.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta_2.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta_2.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta_2.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta_2.lf_field_list = standard_metadata.lf_field_list;
+        smeta_2.mcast_grp = standard_metadata.mcast_grp;
+        smeta_2.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta_2.egress_rid = standard_metadata.egress_rid;
+        smeta_2.checksum_error = standard_metadata.checksum_error;
+        smeta_2.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta_2.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta_2);
+        standard_metadata.ingress_port = smeta_2.ingress_port;
+        standard_metadata.egress_spec = smeta_2.egress_spec;
+        standard_metadata.egress_port = smeta_2.egress_port;
+        standard_metadata.clone_spec = smeta_2.clone_spec;
+        standard_metadata.instance_type = smeta_2.instance_type;
+        standard_metadata.drop = smeta_2.drop;
+        standard_metadata.recirculate_port = smeta_2.recirculate_port;
+        standard_metadata.packet_length = smeta_2.packet_length;
+        standard_metadata.enq_timestamp = smeta_2.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta_2.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta_2.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta_2.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta_2.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta_2.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta_2.lf_field_list;
+        standard_metadata.mcast_grp = smeta_2.mcast_grp;
+        standard_metadata.resubmit_flag = smeta_2.resubmit_flag;
+        standard_metadata.egress_rid = smeta_2.egress_rid;
+        standard_metadata.checksum_error = smeta_2.checksum_error;
+        standard_metadata.recirculate_flag = smeta_2.recirculate_flag;
+        standard_metadata.parser_error = smeta_2.parser_error;
     }
     @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
@@ -236,10 +236,12 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".my_drop") action my_drop_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
         meta._fwd_metadata_l2ptr0 = l2ptr;
@@ -278,7 +280,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop_1() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
         hdr.ethernet.srcAddr = smac;

--- a/testdata/p4_16_samples_outputs/issue561-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2.p4
@@ -185,8 +185,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action set_l2ptr(bit<32> l2ptr) {
@@ -198,9 +198,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_l2ptr;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;
@@ -214,9 +214,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         actions = {
             set_bd_dmac_intf;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         ipv4_da_lpm.apply();
@@ -234,9 +234,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         }
         actions = {
             rewrite_mac;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         send_frame.apply();

--- a/testdata/p4_16_samples_outputs/issue561-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2.p4
@@ -186,7 +186,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     action set_l2ptr(bit<32> l2ptr) {

--- a/testdata/p4_16_samples_outputs/issue561-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2.p4.p4info.txt
@@ -114,5 +114,3 @@ actions {
     bitwidth: 48
   }
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/issue561-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2.p4.p4info.txt
@@ -114,3 +114,5 @@ actions {
     bitwidth: 48
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue841.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue841.p4-stderr
@@ -1,6 +1,6 @@
 issue841.p4(39): [--Wwarn=deprecated] warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
     Checksum16() checksum;
     ^^^^^^^^^^
-v1model.p4(156)
+v1model.p4(153)
 extern Checksum16 {
        ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue841.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue841.p4-stderr
@@ -1,6 +1,6 @@
 issue841.p4(39): [--Wwarn=deprecated] warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
     Checksum16() checksum;
     ^^^^^^^^^^
-v1model.p4(150)
+v1model.p4(156)
 extern Checksum16 {
        ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-first.p4
@@ -60,7 +60,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -87,7 +87,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.routing_metadata.nhop_ipv4 = nhop_ipv4;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-first.p4
@@ -60,7 +60,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -87,7 +87,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.routing_metadata.nhop_ipv4 = nhop_ipv4;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-frontend.p4
@@ -62,7 +62,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("egress.send_frame") table send_frame_0 {
         actions = {
@@ -95,10 +100,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_2 = standard_metadata;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_2;
+        }
     }
     @name("._drop") action _drop_4() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_4 = standard_metadata;
+            standard_metadata_4.egress_spec = 9w511;
+            standard_metadata_4.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_4;
+        }
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.routing_metadata.nhop_ipv4 = nhop_ipv4;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-frontend.p4
@@ -62,12 +62,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("egress.send_frame") table send_frame_0 {
         actions = {
@@ -100,20 +95,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
-        {
-            standard_metadata_t standard_metadata_2 = standard_metadata;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_2;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_4() {
-        {
-            standard_metadata_t standard_metadata_4 = standard_metadata;
-            standard_metadata_4.egress_spec = 9w511;
-            standard_metadata_4.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_4;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.routing_metadata.nhop_ipv4 = nhop_ipv4;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-midend.p4
@@ -61,8 +61,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("egress.send_frame") table send_frame_0 {
         actions = {
@@ -95,12 +94,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("._drop") action _drop_4() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta._routing_metadata_nhop_ipv40 = nhop_ipv4;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-midend.p4
@@ -61,7 +61,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("egress.send_frame") table send_frame_0 {
         actions = {
@@ -94,10 +95,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("._drop") action _drop_4() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta._routing_metadata_nhop_ipv40 = nhop_ipv4;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2.p4
@@ -60,7 +60,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -85,7 +85,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.routing_metadata.nhop_ipv4 = nhop_ipv4;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2.p4
@@ -60,7 +60,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("send_frame") table send_frame {
         actions = {
@@ -85,7 +85,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
         meta.routing_metadata.nhop_ipv4 = nhop_ipv4;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2.p4.p4info.txt
@@ -154,3 +154,5 @@ actions {
     bitwidth: 48
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/multicast-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2.p4.p4info.txt
@@ -154,5 +154,3 @@ actions {
     bitwidth: 48
   }
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-first.p4
@@ -40,7 +40,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-first.p4
@@ -40,7 +40,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-frontend.p4
@@ -44,12 +44,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("ingress._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("ingress._nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-frontend.p4
@@ -44,7 +44,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("ingress._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("ingress._nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-midend.p4
@@ -43,8 +43,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("ingress._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("ingress._nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-midend.p4
@@ -43,7 +43,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_3() {
     }
     @name("ingress._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress._nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4
@@ -40,7 +40,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4
@@ -40,7 +40,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-first.p4
@@ -39,7 +39,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("namedmeter") direct_meter<bit<32>>(MeterType.packets) my_meter;
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-first.p4
@@ -39,7 +39,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("namedmeter") direct_meter<bit<32>>(MeterType.packets) my_meter;
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
@@ -43,7 +43,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.namedmeter") direct_meter<bit<32>>(MeterType.packets) my_meter_0;
     @name("ingress._drop") action _drop() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_metadata;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_metadata = standard_metadata_1;
+        }
     }
     @name("ingress._nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
@@ -43,12 +43,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.namedmeter") direct_meter<bit<32>>(MeterType.packets) my_meter_0;
     @name("ingress._drop") action _drop() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_metadata;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_metadata = standard_metadata_1;
-        }
+        mark_to_drop(standard_metadata);
     }
     @name("ingress._nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
@@ -42,8 +42,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.namedmeter") direct_meter<bit<32>>(MeterType.packets) my_meter_0;
     @name("ingress._drop") action _drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        mark_to_drop(standard_metadata);
     }
     @name("ingress._nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
@@ -42,7 +42,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.namedmeter") direct_meter<bit<32>>(MeterType.packets) my_meter_0;
     @name("ingress._drop") action _drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress._nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2.p4
@@ -39,7 +39,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("namedmeter") direct_meter<bit<32>>(MeterType.packets) my_meter;
     @name("_drop") action _drop() {
-        markToDrop(standard_metadata);
+        mark_to_drop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2.p4
@@ -39,7 +39,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("namedmeter") direct_meter<bit<32>>(MeterType.packets) my_meter;
     @name("_drop") action _drop() {
-        mark_to_drop();
+        markToDrop(standard_metadata);
     }
     @name("_nop") action _nop() {
     }

--- a/testdata/p4_16_samples_outputs/psa-drop-all-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-bmv2-first.p4
@@ -1,0 +1,100 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+}
+
+struct metadata_t {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control ingress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-drop-all-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-bmv2-frontend.p4
@@ -1,0 +1,90 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+}
+
+struct metadata_t {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control ingress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-drop-all-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-bmv2-midend.p4
@@ -1,0 +1,107 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control ingress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action act() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action act_0() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    apply {
+        tbl_act_0.apply();
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4
@@ -1,0 +1,100 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+}
+
+struct metadata_t {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control ingress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "psa"
+}

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2-first.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+        multicast(ostd, (MulticastGroup_t)hdr.ethernet.dstAddr[31:0]);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2-frontend.p4
@@ -1,0 +1,66 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".multicast") action multicast(inout psa_ingress_output_metadata_t meta_1, in MulticastGroup_t multicast_group_1) {
+        meta_1.drop = false;
+        meta_1.multicast_group = multicast_group_1;
+    }
+    apply {
+        multicast(ostd, (MulticastGroup_t)hdr.ethernet.dstAddr[31:0]);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2-midend.p4
@@ -1,0 +1,90 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".multicast") action multicast() {
+        ostd.drop = false;
+        ostd.multicast_group = hdr.ethernet.dstAddr[31:0];
+    }
+    @hidden table tbl_multicast {
+        actions = {
+            multicast();
+        }
+        const default_action = multicast();
+    }
+    apply {
+        tbl_multicast.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action act() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action act_0() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    apply {
+        tbl_act_0.apply();
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+        multicast(ostd, (MulticastGroup_t)hdr.ethernet.dstAddr[31:0]);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.p4info.txt
@@ -1,0 +1,10 @@
+pkg_info {
+  arch: "psa"
+}
+actions {
+  preamble {
+    id: 16807491
+    name: "multicast"
+    alias: "multicast"
+  }
+}

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-first.p4
@@ -1,0 +1,84 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+        if (hdr.ethernet.dstAddr[3:0] >= 4w4) 
+            send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[3:0]);
+        else 
+            send_to_port(ostd, (PortId_t)32w0xfffffffa);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    action add() {
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr + hdr.ethernet.srcAddr;
+    }
+    table e {
+        actions = {
+            add();
+        }
+        default_action = add();
+    }
+    apply {
+        e.apply();
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-frontend.p4
@@ -1,0 +1,86 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_1, in PortId_t egress_port_1) {
+        meta_1.drop = false;
+        meta_1.multicast_group = (MulticastGroup_t)32w0;
+        meta_1.egress_port = egress_port_1;
+    }
+    @name(".send_to_port") action send_to_port_0(inout psa_ingress_output_metadata_t meta_2, in PortId_t egress_port_2) {
+        meta_2.drop = false;
+        meta_2.multicast_group = (MulticastGroup_t)32w0;
+        meta_2.egress_port = egress_port_2;
+    }
+    apply {
+        if (hdr.ethernet.dstAddr[3:0] >= 4w4) 
+            send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[3:0]);
+        else 
+            send_to_port_0(ostd, (PortId_t)32w0xfffffffa);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    @name("cEgress.add") action add_1() {
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr + hdr.ethernet.srcAddr;
+    }
+    @name("cEgress.e") table e_0 {
+        actions = {
+            add_1();
+        }
+        default_action = add_1();
+    }
+    apply {
+        e_0.apply();
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-midend.p4
@@ -1,0 +1,116 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".send_to_port") action send_to_port() {
+        ostd.drop = false;
+        ostd.multicast_group = 32w0;
+        ostd.egress_port = (PortIdUint_t)hdr.ethernet.dstAddr[3:0];
+    }
+    @name(".send_to_port") action send_to_port_0() {
+        ostd.drop = false;
+        ostd.multicast_group = 32w0;
+        ostd.egress_port = 32w0xfffffffa;
+    }
+    @hidden table tbl_send_to_port {
+        actions = {
+            send_to_port();
+        }
+        const default_action = send_to_port();
+    }
+    @hidden table tbl_send_to_port_0 {
+        actions = {
+            send_to_port_0();
+        }
+        const default_action = send_to_port_0();
+    }
+    apply {
+        if (hdr.ethernet.dstAddr[3:0] >= 4w4) 
+            tbl_send_to_port.apply();
+        else 
+            tbl_send_to_port_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    @name("cEgress.add") action add_1() {
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr + hdr.ethernet.srcAddr;
+    }
+    @name("cEgress.e") table e_0 {
+        actions = {
+            add_1();
+        }
+        default_action = add_1();
+    }
+    apply {
+        e_0.apply();
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action act() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action act_0() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    apply {
+        tbl_act_0.apply();
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4
@@ -1,0 +1,86 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+        if (hdr.ethernet.dstAddr[3:0] >= 4) {
+            send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[3:0]);
+        }
+        else {
+            send_to_port(ostd, PSA_PORT_RECIRCULATE);
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    action add() {
+        hdr.ethernet.dstAddr = hdr.ethernet.dstAddr + hdr.ethernet.srcAddr;
+    }
+    table e {
+        actions = {
+            add;
+        }
+        default_action = add;
+    }
+    apply {
+        e.apply();
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txt
@@ -1,0 +1,29 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 33603093
+    name: "cEgress.e"
+    alias: "e"
+  }
+  action_refs {
+    id: 16829978
+  }
+  size: 1024
+  idle_timeout_behavior: NOTIFY_CONTROL
+}
+actions {
+  preamble {
+    id: 16833049
+    name: "send_to_port"
+    alias: "send_to_port"
+  }
+}
+actions {
+  preamble {
+    id: 16829978
+    name: "cEgress.add"
+    alias: "add"
+  }
+}

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2-first.p4
@@ -1,0 +1,72 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+        send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[1:0]);
+        if (hdr.ethernet.dstAddr[1:0] == 2w0) 
+            ingress_drop(ostd);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2-frontend.p4
@@ -1,0 +1,72 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_2, in PortId_t egress_port_1) {
+        meta_2.drop = false;
+        meta_2.multicast_group = (MulticastGroup_t)32w0;
+        meta_2.egress_port = egress_port_1;
+    }
+    @name(".ingress_drop") action ingress_drop(inout psa_ingress_output_metadata_t meta_3) {
+        meta_3.drop = true;
+    }
+    apply {
+        send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[1:0]);
+        if (hdr.ethernet.dstAddr[1:0] == 2w0) 
+            ingress_drop(ostd);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2-midend.p4
@@ -1,0 +1,102 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".send_to_port") action send_to_port() {
+        ostd.drop = false;
+        ostd.multicast_group = 32w0;
+        ostd.egress_port = (PortIdUint_t)hdr.ethernet.dstAddr[1:0];
+    }
+    @name(".ingress_drop") action ingress_drop() {
+        ostd.drop = true;
+    }
+    @hidden table tbl_send_to_port {
+        actions = {
+            send_to_port();
+        }
+        const default_action = send_to_port();
+    }
+    @hidden table tbl_ingress_drop {
+        actions = {
+            ingress_drop();
+        }
+        const default_action = ingress_drop();
+    }
+    apply {
+        tbl_send_to_port.apply();
+        if (hdr.ethernet.dstAddr[1:0] == 2w0) 
+            tbl_ingress_drop.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action act() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action act_0() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    apply {
+        tbl_act_0.apply();
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4
@@ -1,0 +1,73 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+        send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[1:0]);
+        if (hdr.ethernet.dstAddr[1:0] == 0) {
+            ingress_drop(ostd);
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.p4info.txt
@@ -1,0 +1,17 @@
+pkg_info {
+  arch: "psa"
+}
+actions {
+  preamble {
+    id: 16833049
+    name: "send_to_port"
+    alias: "send_to_port"
+  }
+}
+actions {
+  preamble {
+    id: 16829615
+    name: "ingress_drop"
+    alias: "ingress_drop"
+  }
+}

--- a/testdata/p4_16_samples_outputs/same_name_for_table_and_action-first.p4
+++ b/testdata/p4_16_samples_outputs/same_name_for_table_and_action-first.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name("do_something") action do_something_0() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name("do_something") table do_something {
         key = {

--- a/testdata/p4_16_samples_outputs/same_name_for_table_and_action-frontend.p4
+++ b/testdata/p4_16_samples_outputs/same_name_for_table_and_action-frontend.p4
@@ -18,7 +18,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_0() {
     }
     @name("IngressI.do_something") action do_something() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name("IngressI.do_something") table do_something_2 {
         key = {

--- a/testdata/p4_16_samples_outputs/same_name_for_table_and_action-midend.p4
+++ b/testdata/p4_16_samples_outputs/same_name_for_table_and_action-midend.p4
@@ -18,7 +18,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name(".NoAction") action NoAction_0() {
     }
     @name("IngressI.do_something") action do_something() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name("IngressI.do_something") table do_something_2 {
         key = {

--- a/testdata/p4_16_samples_outputs/same_name_for_table_and_action.p4
+++ b/testdata/p4_16_samples_outputs/same_name_for_table_and_action.p4
@@ -18,7 +18,7 @@ action empty() {
 }
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name("do_something") action do_something_0() {
-        mark_to_drop();
+        mark_to_drop(smeta);
     }
     @name("do_something") table do_something {
         key = {

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
@@ -66,7 +66,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_meta);
     }
     USat_t ru;
     Sat_t r;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
@@ -66,7 +66,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     action drop() {
-        markToDrop(standard_meta);
+        mark_to_drop(standard_meta);
     }
     USat_t ru;
     Sat_t r;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
@@ -66,12 +66,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     @name("ingress.drop") action drop_1() {
-        {
-            standard_metadata_t standard_metadata_1 = standard_meta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            standard_meta = standard_metadata_1;
-        }
+        mark_to_drop(standard_meta);
     }
     @name("ingress.t") table t_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
@@ -66,7 +66,12 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     @name("ingress.drop") action drop_1() {
-        mark_to_drop();
+        {
+            standard_metadata_t standard_metadata_1 = standard_meta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            standard_meta = standard_metadata_1;
+        }
     }
     @name("ingress.t") table t_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
@@ -66,8 +66,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     @name("ingress.drop") action drop_1() {
-        standard_meta.egress_spec = 9w511;
-        standard_meta.mcast_grp = 16w0;
+        mark_to_drop(standard_meta);
     }
     @name("ingress.t") table t_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
@@ -66,7 +66,8 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     @name("ingress.drop") action drop_1() {
-        mark_to_drop();
+        standard_meta.egress_spec = 9w511;
+        standard_meta.mcast_grp = 16w0;
     }
     @name("ingress.t") table t_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4
@@ -66,7 +66,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     action drop() {
-        mark_to_drop();
+        markToDrop(standard_meta);
     }
     USat_t ru;
     Sat_t r;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4
@@ -66,7 +66,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         h.h.res_16 = h.h.opr1_16 |-| h.h.opr2_16;
     }
     action drop() {
-        markToDrop(standard_meta);
+        mark_to_drop(standard_meta);
     }
     USat_t ru;
     Sat_t r;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4.p4info.txt
@@ -66,5 +66,3 @@ actions {
     alias: "drop"
   }
 }
-type_info {
-}

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4.p4info.txt
@@ -66,3 +66,5 @@ actions {
     alias: "drop"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-first.p4
@@ -51,8 +51,8 @@ struct headers_t {
     ipv4_t                 ipv4;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;
@@ -105,9 +105,9 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
             set_mcast_grp();
             do_resubmit();
             do_clone_i2e();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd.out_bd = bd;
@@ -121,9 +121,9 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         }
         actions = {
             set_bd_dmac_intf();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         if (standard_metadata.instance_type == 32w6) {
@@ -176,9 +176,9 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
             rewrite_mac();
             do_recirculate();
             do_clone_e2e();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     apply {
         if (standard_metadata.instance_type == 32w1) {

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-first.p4
@@ -52,7 +52,7 @@ struct headers_t {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-frontend.p4
@@ -58,20 +58,10 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
-        {
-            standard_metadata_t standard_metadata_1 = smeta;
-            standard_metadata_1.egress_spec = 9w511;
-            standard_metadata_1.mcast_grp = 16w0;
-            smeta = standard_metadata_1;
-        }
+        mark_to_drop(smeta);
     }
     @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
-        {
-            standard_metadata_t standard_metadata_2 = smeta_1;
-            standard_metadata_2.egress_spec = 9w511;
-            standard_metadata_2.mcast_grp = 16w0;
-            smeta_1 = standard_metadata_2;
-        }
+        mark_to_drop(smeta_1);
     }
     bit<32> ipv4_address_0;
     bit<8> byte0_0;
@@ -152,12 +142,7 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
     @name(".NoAction") action NoAction_0() {
     }
     @name(".my_drop") action my_drop_1(inout standard_metadata_t smeta_2) {
-        {
-            standard_metadata_t standard_metadata_3 = smeta_2;
-            standard_metadata_3.egress_spec = 9w511;
-            standard_metadata_3.mcast_grp = 16w0;
-            smeta_2 = standard_metadata_3;
-        }
+        mark_to_drop(smeta_2);
     }
     @name("egress.set_out_bd") action set_out_bd(bit<24> bd) {
         meta.fwd.out_bd = bd;

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-frontend.p4
@@ -57,11 +57,21 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+        {
+            standard_metadata_t standard_metadata_1 = smeta;
+            standard_metadata_1.egress_spec = 9w511;
+            standard_metadata_1.mcast_grp = 16w0;
+            smeta = standard_metadata_1;
+        }
     }
-    @name(".my_drop") action my_drop_0() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
+        {
+            standard_metadata_t standard_metadata_2 = smeta_1;
+            standard_metadata_2.egress_spec = 9w511;
+            standard_metadata_2.mcast_grp = 16w0;
+            smeta_1 = standard_metadata_2;
+        }
     }
     bit<32> ipv4_address_0;
     bit<8> byte0_0;
@@ -91,9 +101,9 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
             set_mcast_grp();
             do_resubmit();
             do_clone_i2e();
-            my_drop();
+            my_drop(standard_metadata);
         }
-        default_action = my_drop();
+        default_action = my_drop(standard_metadata);
     }
     @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd.out_bd = bd;
@@ -107,9 +117,9 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         }
         actions = {
             set_bd_dmac_intf();
-            my_drop_0();
+            my_drop_0(standard_metadata);
         }
-        default_action = my_drop_0();
+        default_action = my_drop_0(standard_metadata);
     }
     apply {
         if (standard_metadata.instance_type == 32w6) {
@@ -141,8 +151,13 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
 control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     @name(".NoAction") action NoAction_0() {
     }
-    @name(".my_drop") action my_drop_1() {
-        mark_to_drop();
+    @name(".my_drop") action my_drop_1(inout standard_metadata_t smeta_2) {
+        {
+            standard_metadata_t standard_metadata_3 = smeta_2;
+            standard_metadata_3.egress_spec = 9w511;
+            standard_metadata_3.mcast_grp = 16w0;
+            smeta_2 = standard_metadata_3;
+        }
     }
     @name("egress.set_out_bd") action set_out_bd(bit<24> bd) {
         meta.fwd.out_bd = bd;
@@ -177,9 +192,9 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
             rewrite_mac();
             do_recirculate();
             do_clone_e2e();
-            my_drop_1();
+            my_drop_1(standard_metadata);
         }
-        default_action = my_drop_1();
+        default_action = my_drop_1(standard_metadata);
     }
     apply {
         if (standard_metadata.instance_type == 32w1) {

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
@@ -62,10 +62,12 @@ struct tuple_0 {
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     @name(".my_drop") action my_drop() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name(".my_drop") action my_drop_0() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
         meta._fwd_l2ptr0 = l2ptr;
@@ -149,7 +151,8 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
     @name(".NoAction") action NoAction_0() {
     }
     @name(".my_drop") action my_drop_1() {
-        mark_to_drop();
+        standard_metadata.egress_spec = 9w511;
+        standard_metadata.mcast_grp = 16w0;
     }
     @name("egress.set_out_bd") action set_out_bd(bit<24> bd) {
         meta._fwd_out_bd1 = bd;

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
@@ -61,13 +61,97 @@ struct tuple_0 {
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
+    standard_metadata_t smeta;
+    standard_metadata_t smeta_1;
     @name(".my_drop") action my_drop() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta.ingress_port = standard_metadata.ingress_port;
+        smeta.egress_spec = standard_metadata.egress_spec;
+        smeta.egress_port = standard_metadata.egress_port;
+        smeta.clone_spec = standard_metadata.clone_spec;
+        smeta.instance_type = standard_metadata.instance_type;
+        smeta.drop = standard_metadata.drop;
+        smeta.recirculate_port = standard_metadata.recirculate_port;
+        smeta.packet_length = standard_metadata.packet_length;
+        smeta.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta.lf_field_list = standard_metadata.lf_field_list;
+        smeta.mcast_grp = standard_metadata.mcast_grp;
+        smeta.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta.egress_rid = standard_metadata.egress_rid;
+        smeta.checksum_error = standard_metadata.checksum_error;
+        smeta.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta);
+        standard_metadata.ingress_port = smeta.ingress_port;
+        standard_metadata.egress_spec = smeta.egress_spec;
+        standard_metadata.egress_port = smeta.egress_port;
+        standard_metadata.clone_spec = smeta.clone_spec;
+        standard_metadata.instance_type = smeta.instance_type;
+        standard_metadata.drop = smeta.drop;
+        standard_metadata.recirculate_port = smeta.recirculate_port;
+        standard_metadata.packet_length = smeta.packet_length;
+        standard_metadata.enq_timestamp = smeta.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta.lf_field_list;
+        standard_metadata.mcast_grp = smeta.mcast_grp;
+        standard_metadata.resubmit_flag = smeta.resubmit_flag;
+        standard_metadata.egress_rid = smeta.egress_rid;
+        standard_metadata.checksum_error = smeta.checksum_error;
+        standard_metadata.recirculate_flag = smeta.recirculate_flag;
+        standard_metadata.parser_error = smeta.parser_error;
     }
     @name(".my_drop") action my_drop_0() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta_1.ingress_port = standard_metadata.ingress_port;
+        smeta_1.egress_spec = standard_metadata.egress_spec;
+        smeta_1.egress_port = standard_metadata.egress_port;
+        smeta_1.clone_spec = standard_metadata.clone_spec;
+        smeta_1.instance_type = standard_metadata.instance_type;
+        smeta_1.drop = standard_metadata.drop;
+        smeta_1.recirculate_port = standard_metadata.recirculate_port;
+        smeta_1.packet_length = standard_metadata.packet_length;
+        smeta_1.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta_1.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta_1.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta_1.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta_1.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta_1.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta_1.lf_field_list = standard_metadata.lf_field_list;
+        smeta_1.mcast_grp = standard_metadata.mcast_grp;
+        smeta_1.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta_1.egress_rid = standard_metadata.egress_rid;
+        smeta_1.checksum_error = standard_metadata.checksum_error;
+        smeta_1.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta_1.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta_1);
+        standard_metadata.ingress_port = smeta_1.ingress_port;
+        standard_metadata.egress_spec = smeta_1.egress_spec;
+        standard_metadata.egress_port = smeta_1.egress_port;
+        standard_metadata.clone_spec = smeta_1.clone_spec;
+        standard_metadata.instance_type = smeta_1.instance_type;
+        standard_metadata.drop = smeta_1.drop;
+        standard_metadata.recirculate_port = smeta_1.recirculate_port;
+        standard_metadata.packet_length = smeta_1.packet_length;
+        standard_metadata.enq_timestamp = smeta_1.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta_1.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta_1.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta_1.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta_1.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta_1.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta_1.lf_field_list;
+        standard_metadata.mcast_grp = smeta_1.mcast_grp;
+        standard_metadata.resubmit_flag = smeta_1.resubmit_flag;
+        standard_metadata.egress_rid = smeta_1.egress_rid;
+        standard_metadata.checksum_error = smeta_1.checksum_error;
+        standard_metadata.recirculate_flag = smeta_1.recirculate_flag;
+        standard_metadata.parser_error = smeta_1.parser_error;
     }
     @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
         meta._fwd_l2ptr0 = l2ptr;
@@ -148,11 +232,53 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
 }
 
 control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
+    standard_metadata_t smeta_2;
     @name(".NoAction") action NoAction_0() {
     }
     @name(".my_drop") action my_drop_1() {
-        standard_metadata.egress_spec = 9w511;
-        standard_metadata.mcast_grp = 16w0;
+        smeta_2.ingress_port = standard_metadata.ingress_port;
+        smeta_2.egress_spec = standard_metadata.egress_spec;
+        smeta_2.egress_port = standard_metadata.egress_port;
+        smeta_2.clone_spec = standard_metadata.clone_spec;
+        smeta_2.instance_type = standard_metadata.instance_type;
+        smeta_2.drop = standard_metadata.drop;
+        smeta_2.recirculate_port = standard_metadata.recirculate_port;
+        smeta_2.packet_length = standard_metadata.packet_length;
+        smeta_2.enq_timestamp = standard_metadata.enq_timestamp;
+        smeta_2.enq_qdepth = standard_metadata.enq_qdepth;
+        smeta_2.deq_timedelta = standard_metadata.deq_timedelta;
+        smeta_2.deq_qdepth = standard_metadata.deq_qdepth;
+        smeta_2.ingress_global_timestamp = standard_metadata.ingress_global_timestamp;
+        smeta_2.egress_global_timestamp = standard_metadata.egress_global_timestamp;
+        smeta_2.lf_field_list = standard_metadata.lf_field_list;
+        smeta_2.mcast_grp = standard_metadata.mcast_grp;
+        smeta_2.resubmit_flag = standard_metadata.resubmit_flag;
+        smeta_2.egress_rid = standard_metadata.egress_rid;
+        smeta_2.checksum_error = standard_metadata.checksum_error;
+        smeta_2.recirculate_flag = standard_metadata.recirculate_flag;
+        smeta_2.parser_error = standard_metadata.parser_error;
+        mark_to_drop(smeta_2);
+        standard_metadata.ingress_port = smeta_2.ingress_port;
+        standard_metadata.egress_spec = smeta_2.egress_spec;
+        standard_metadata.egress_port = smeta_2.egress_port;
+        standard_metadata.clone_spec = smeta_2.clone_spec;
+        standard_metadata.instance_type = smeta_2.instance_type;
+        standard_metadata.drop = smeta_2.drop;
+        standard_metadata.recirculate_port = smeta_2.recirculate_port;
+        standard_metadata.packet_length = smeta_2.packet_length;
+        standard_metadata.enq_timestamp = smeta_2.enq_timestamp;
+        standard_metadata.enq_qdepth = smeta_2.enq_qdepth;
+        standard_metadata.deq_timedelta = smeta_2.deq_timedelta;
+        standard_metadata.deq_qdepth = smeta_2.deq_qdepth;
+        standard_metadata.ingress_global_timestamp = smeta_2.ingress_global_timestamp;
+        standard_metadata.egress_global_timestamp = smeta_2.egress_global_timestamp;
+        standard_metadata.lf_field_list = smeta_2.lf_field_list;
+        standard_metadata.mcast_grp = smeta_2.mcast_grp;
+        standard_metadata.resubmit_flag = smeta_2.resubmit_flag;
+        standard_metadata.egress_rid = smeta_2.egress_rid;
+        standard_metadata.checksum_error = smeta_2.checksum_error;
+        standard_metadata.recirculate_flag = smeta_2.recirculate_flag;
+        standard_metadata.parser_error = smeta_2.parser_error;
     }
     @name("egress.set_out_bd") action set_out_bd(bit<24> bd) {
         meta._fwd_out_bd1 = bd;

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4
@@ -52,7 +52,7 @@ struct headers_t {
 }
 
 action my_drop(inout standard_metadata_t smeta) {
-    markToDrop(smeta);
+    mark_to_drop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4
@@ -51,8 +51,8 @@ struct headers_t {
     ipv4_t                 ipv4;
 }
 
-action my_drop() {
-    mark_to_drop();
+action my_drop(inout standard_metadata_t smeta) {
+    markToDrop(smeta);
 }
 parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     const bit<16> ETHERTYPE_IPV4 = 16w0x800;
@@ -105,9 +105,9 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
             set_mcast_grp;
             do_resubmit;
             do_clone_i2e;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
         meta.fwd.out_bd = bd;
@@ -121,9 +121,9 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         }
         actions = {
             set_bd_dmac_intf;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         if (standard_metadata.instance_type == BMV2_V1MODEL_INSTANCE_TYPE_RESUBMIT) {
@@ -176,9 +176,9 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
             rewrite_mac;
             do_recirculate;
             do_clone_e2e;
-            my_drop;
+            my_drop(standard_metadata);
         }
-        default_action = my_drop;
+        default_action = my_drop(standard_metadata);
     }
     apply {
         if (standard_metadata.instance_type == BMV2_V1MODEL_INSTANCE_TYPE_INGRESS_CLONE) {


### PR DESCRIPTION
Fixes #1828. 
This also replaces some IndexedVectors with Vectors - because the top-level program can contains multiple declarations with the same name.