### PR TITLE
Fix Type_InfInt::equiv (all InfInt types are the same)

### DIFF
--- a/backends/ebpf/targets/xdp_target.py
+++ b/backends/ebpf/targets/xdp_target.py
@@ -1,1 +1,0 @@
-/home/mbudiu/git/p4c/extensions/p4c-xdp/xdp_target.py

--- a/ir/type.def
+++ b/ir/type.def
@@ -169,6 +169,7 @@ class Type_InfInt : Type, ITypeVar {
     dbprint { out << "int/" << declid; }
     toString { return "int"; }
     operator== { return declid == a.declid; }
+    equiv { return true; /* ignore declid */ }
     const Type* getP4Type() const override { return this; }
 }
 


### PR DESCRIPTION
also delete spurious sym-link that somehow got checked in.