### PR TITLE
Load support for ir enum map when --fromJSON is used (#1784)

### DIFF
--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -43,6 +43,7 @@ set (MIDEND_SRCS
   singleArgumentSelect.cpp
   tableHit.cpp
   validateProperties.cpp
+  fillEnumMap.cpp
   )
 
 set (MIDEND_HDRS
@@ -81,6 +82,7 @@ set (MIDEND_HDRS
   singleArgumentSelect.h
   tableHit.h
   validateProperties.h
+  fillEnumMap.h
   )
 
 add_cpplint_files (${CMAKE_CURRENT_SOURCE_DIR} "${MIDEND_SRCS};${MIDEND_HDRS}")

--- a/midend/convertEnums.cpp
+++ b/midend/convertEnums.cpp
@@ -19,7 +19,7 @@ const IR::Node* DoConvertEnums::preorder(IR::Type_Enum* type) {
     repr.emplace(canontype->to<IR::Type_Enum>(), r);
     for (auto d : type->members)
         r->add(d->name.name);
-    return nullptr;  // delete the declaration
+    return type;
 }
 
 const IR::Node* DoConvertEnums::postorder(IR::Type_Name* type) {

--- a/midend/fillEnumMap.cpp
+++ b/midend/fillEnumMap.cpp
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 RT-RK Computer Based Systems.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "fillEnumMap.h"
+#include "frontends/p4/enumInstance.h"
+
+namespace P4 {
+
+const IR::Node* FillEnumMap::preorder(IR::Type_Enum* type) {
+    if (strstr(type->srcInfo.filename, "v1model") == nullptr) {
+        unsigned long long count = type->members.size();
+        unsigned long long width = policy->enumSize(count);
+        auto r = new EnumRepresentation(type->srcInfo, width);
+        auto canontype = typeMap->getTypeType(getOriginal(), true);
+        BUG_CHECK(canontype->is<IR::Type_Enum>(),
+                  "canon type of enum %s is non enum %s?", type, canontype);
+        repr.emplace(canontype->to<IR::Type_Enum>(), r);
+        for (auto d : type->members)
+            r->add(d->name.name);
+    }
+    return type;
+}
+
+}  // namespace P4

--- a/midend/fillEnumMap.h
+++ b/midend/fillEnumMap.h
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 RT-RK Computer Based Systems.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _MIDEND_FILLENUMMAP_H_
+#define _MIDEND_FILLENUMMAP_H_
+
+#include "convertEnums.h"
+
+namespace P4 {
+
+class FillEnumMap : public Transform {
+ public:
+    std::map<const IR::Type_Enum*, EnumRepresentation*> repr;
+    ChooseEnumRepresentation* policy;
+    TypeMap* typeMap;
+    FillEnumMap(ChooseEnumRepresentation* policy, TypeMap* typeMap)
+            : policy(policy), typeMap(typeMap)
+    { CHECK_NULL(policy); CHECK_NULL(typeMap); setName("FillEnumMap"); }
+    const IR::Node* preorder(IR::Type_Enum* type) override;
+};
+
+}  // namespace P4
+
+#endif /* _MIDEND_FILLENUMMAP_H_ */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/source_file_test.cpp
   gtest/transforms.cpp
   gtest/stringify.cpp
+  gtest/load_ir_from_json.cpp
   )
 set (GTEST_UNITTEST_HEADERS
   gtest/helpers.h

--- a/test/gtest/load_ir_from_json.cpp
+++ b/test/gtest/load_ir_from_json.cpp
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 RT-RK Computer Based Systems.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <thread>
+#include <cstdlib>
+
+#include "gtest/gtest.h"
+#include "ir/ir.h"
+#include "helpers.h"
+#include "lib/log.h"
+
+using namespace P4;
+using namespace std;
+
+namespace Test {
+
+class FromJSONTest : public P4CTest { };
+
+TEST_F(FromJSONTest, load_ir_from_json) {
+    #if defined(__linux__)
+    pid_t pid = vfork();
+    if (pid == -1) {
+        ::error("fork() failed");
+    } else if (pid == 0) {
+        execlp("p4c-bm2-ss", "p4c-bm2-ss", "-o", "outputTO.json", "../test/test_fromJSON.p4", "--toJSON", "jsonFile.json", (char *)NULL);    //NOLINT
+    }
+    int child_status;
+    int child_pid = wait(&child_status);
+    pid_t pid2 = vfork();
+    if (pid2 == -1) {
+        ::error("fork() failed");
+    } else if (pid2 == 0) {
+        execlp("p4c-bm2-ss", "p4c-bm2-ss", "-o", "outputFROM.json", "--fromJSON", "jsonFile.json", (char *)NULL);   //NOLINT
+    }
+    int child_status2;
+    int child_pid2 = wait(&child_status2);
+
+    fstream file1("outputTO.json"), file2("outputFROM.json");
+    char string1[256], string2[256];
+    int j; j = 0;
+    while (!file1.eof()) {
+        file1.getline(string1, 256);
+        file2.getline(string2, 256);
+        j++;
+        if (strcmp(string1, string2) != 0) {
+            ASSERT_FALSE(strstr(string1, "program") == nullptr \
+                || strstr(string2, "program") == nullptr);
+        }
+    }
+    #endif
+    ASSERT_TRUE(true);
+}
+
+}  // namespace Test

--- a/test/test_fromJSON.p4
+++ b/test/test_fromJSON.p4
@@ -1,0 +1,143 @@
+/*
+Copyright 2019 RT-RK Computer Based Systems.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+#include <core.p4>
+#include <v1model.p4>
+
+const bit<16> TYPE_IPV4 = 0x800;
+
+typedef bit<9>  egressSpec_t;
+typedef bit<48> macAddr_t;
+typedef bit<32> ip4Addr_t;
+
+enum X {
+   Field_0,
+   Field_1,
+   Field_2
+}
+
+enum Y {
+   Field_00,
+   Field_01,
+   Field_02
+}
+
+header ethernet_t {
+    macAddr_t dstAddr;
+    macAddr_t srcAddr;
+    bit<16>   etherType;
+}
+
+header ipv4_t {
+    bit<4>    version;
+    bit<4>    ihl;
+    bit<8>    diffserv;
+    bit<16>   totalLen;
+    bit<16>   identification;
+    bit<3>    flags;
+    bit<13>   fragOffset;
+    bit<8>    ttl;
+    bit<8>    protocol;
+    bit<16>   hdrChecksum;
+    ip4Addr_t srcAddr;
+    ip4Addr_t dstAddr;
+}
+
+struct metadata {
+    /* empty */
+}
+
+struct headers {
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+}
+
+parser MyParser(packet_in packet,
+                out headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t standard_metadata) {
+
+    state start {
+        transition accept;
+    }
+
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {  }
+}
+
+control MyIngress(inout headers hdr,
+                  inout metadata meta,
+                  inout standard_metadata_t standard_metadata) {
+    action drop() {
+        mark_to_drop(standard_metadata);
+    }
+    action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
+    X tmp = X.Field_0;
+    Y tmp2 = Y.Field_00;
+      if (tmp == X.Field_0){
+        if (tmp2 == Y.Field_00){
+          standard_metadata.egress_spec = port;
+          hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
+          hdr.ethernet.dstAddr = dstAddr;
+          hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
+        }
+      }
+    }
+    table ipv4_lpm {
+        key = {
+            hdr.ipv4.dstAddr: lpm;
+        }
+        actions = {
+            ipv4_forward;
+            drop;
+            NoAction;
+        }
+        size = 1024;
+        default_action = drop();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_lpm.apply();
+        }
+    }
+}
+
+
+control MyEgress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply {  }
+}
+
+control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
+     apply {  }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply { }
+}
+
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;


### PR DESCRIPTION
*Modifed convertEnums to save user defined enums in program
instead of removing them.

*Added pass fillEnumMap, which is called in reduced midEnd branch,
that fills enumMap

Signed-off-by: Jelena Vidakovic <jelena.vidakovic@rt-rk.com>