### PR TITLE
Remove old intrinsic_metadata fields

### DIFF
--- a/testdata/p4_14_samples/TLV_parsing.p4
+++ b/testdata/p4_14_samples/TLV_parsing.p4
@@ -79,7 +79,6 @@ header_type intrinsic_metadata_t {
     fields {
         mcast_grp : 4;
         egress_rid : 4;
-        mcast_hash : 16;
         lf_field_list: 32;
     }
 }

--- a/testdata/p4_14_samples/copy_to_cpu.p4
+++ b/testdata/p4_14_samples/copy_to_cpu.p4
@@ -26,7 +26,6 @@ header_type intrinsic_metadata_t {
     fields {
         mcast_grp : 4;
         egress_rid : 4;
-        mcast_hash : 16;
         lf_field_list: 32;
     }
 }

--- a/testdata/p4_14_samples/counter.p4
+++ b/testdata/p4_14_samples/counter.p4
@@ -26,7 +26,6 @@ header_type intrinsic_metadata_t {
     fields {
         mcast_grp : 4;
         egress_rid : 4;
-        mcast_hash : 16;
         lf_field_list: 32;
     }
 }

--- a/testdata/p4_14_samples/issue1058.p4
+++ b/testdata/p4_14_samples/issue1058.p4
@@ -22,7 +22,7 @@ header_type meta_t {
 // declare the special timestamp metadata
 header_type intrinsic_metadata_t {
     fields {
-        ingress_global_tstamp : 48;
+        ingress_global_timestamp : 48;
     }
 }
 

--- a/testdata/p4_14_samples/meter.p4
+++ b/testdata/p4_14_samples/meter.p4
@@ -26,7 +26,6 @@ header_type intrinsic_metadata_t {
     fields {
         mcast_grp : 4;
         egress_rid : 4;
-        mcast_hash : 16;
         lf_field_list: 32;
     }
 }

--- a/testdata/p4_14_samples/meter1.p4
+++ b/testdata/p4_14_samples/meter1.p4
@@ -26,7 +26,6 @@ header_type intrinsic_metadata_t {
     fields {
         mcast_grp : 4;
         egress_rid : 4;
-        mcast_hash : 16;
         lf_field_list: 32;
     }
 }

--- a/testdata/p4_14_samples/packet_redirect.p4
+++ b/testdata/p4_14_samples/packet_redirect.p4
@@ -44,7 +44,6 @@ header_type intrinsic_metadata_t {
     fields {
         mcast_grp : 4;
         egress_rid : 4;
-        mcast_hash : 16;
         lf_field_list: 32;
         ingress_global_timestamp : 64;
         resubmit_flag : 16;

--- a/testdata/p4_14_samples/register.p4
+++ b/testdata/p4_14_samples/register.p4
@@ -26,7 +26,6 @@ header_type intrinsic_metadata_t {
     fields {
         mcast_grp : 4;
         egress_rid : 4;
-        mcast_hash : 16;
         lf_field_list: 32;
     }
 }

--- a/testdata/p4_14_samples/resubmit.p4
+++ b/testdata/p4_14_samples/resubmit.p4
@@ -26,7 +26,6 @@ header_type intrinsic_metadata_t {
     fields {
         mcast_grp : 4;
         egress_rid : 4;
-        mcast_hash : 16;
         lf_field_list : 32;
         resubmit_flag : 16;
     }

--- a/testdata/p4_14_samples/sai_p4.p4
+++ b/testdata/p4_14_samples/sai_p4.p4
@@ -206,7 +206,6 @@ header_type ingress_intrinsic_metadata_t {
     fields {
         ingress_port : 9;               // ingress physical port id.
         lf_field_list : 32;             // hack for learn filter.
-        ucast_egress_port : 9;          // outgoing port
     }
 }
 metadata ingress_intrinsic_metadata_t intrinsic_metadata;
@@ -382,7 +381,6 @@ table learn_notify {
 
 action fdb_set(type_, port_id) {
     modify_field(ingress_metadata.mac_type, type_);
-    modify_field(intrinsic_metadata.ucast_egress_port, port_id);
     modify_field(standard_metadata.egress_spec, port_id);
     modify_field(ingress_metadata.routed, 0);
 }
@@ -556,7 +554,7 @@ table cos_map {
 action set_router_interface(virtual_router_id, type_, port_id, vlan_id, src_mac_address, admin_v4_state, admin_v6_state, mtu) {
     modify_field(ingress_metadata.vrf, virtual_router_id);
     modify_field(ingress_metadata.interface_type, type_);
-    modify_field(intrinsic_metadata.ucast_egress_port, port_id);
+    modify_field(standard_metadata.egress_spec, port_id);
     modify_field(ingress_metadata.vlan_id, vlan_id);
     modify_field(ingress_metadata.def_smac, src_mac_address);
     modify_field(ingress_metadata.v4_enable, admin_v4_state);
@@ -598,7 +596,6 @@ table virtual_router {
 action set_dmac(dst_mac_address, port_id) {
     modify_field(eth.dstAddr, dst_mac_address);
     modify_field(eth.srcAddr, ingress_metadata.def_smac);
-    modify_field(intrinsic_metadata.ucast_egress_port, port_id);
     modify_field(standard_metadata.egress_spec, port_id);
 }
 

--- a/testdata/p4_14_samples/simple_nat.p4
+++ b/testdata/p4_14_samples/simple_nat.p4
@@ -181,7 +181,6 @@ header_type intrinsic_metadata_t {
     fields {
         mcast_grp : 4;
         egress_rid : 4;
-        mcast_hash : 16;
         lf_field_list: 32;
     }
 }

--- a/testdata/p4_14_samples/switch_20160226/acl.p4
+++ b/testdata/p4_14_samples/switch_20160226/acl.p4
@@ -581,7 +581,9 @@ action egress_copy_to_cpu(reason_code) {
 table egress_acl {
     reads {
         standard_metadata.egress_port : ternary;
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
         intrinsic_metadata.deflection_flag : ternary;
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
         l3_metadata.l3_mtu_check : ternary;
     }
     actions {

--- a/testdata/p4_14_samples/switch_20160226/hashes.p4
+++ b/testdata/p4_14_samples/switch_20160226/hashes.p4
@@ -163,13 +163,17 @@ table compute_non_ip_hashes {
 }
 
 action computed_two_hashes() {
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
     modify_field(intrinsic_metadata.mcast_hash, hash_metadata.hash1);
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
     modify_field(hash_metadata.entropy_hash, hash_metadata.hash2);
 }
 
 action computed_one_hash() {
     modify_field(hash_metadata.hash1, hash_metadata.hash2);
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
     modify_field(intrinsic_metadata.mcast_hash, hash_metadata.hash2);
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
     modify_field(hash_metadata.entropy_hash, hash_metadata.hash2);
 }
 

--- a/testdata/p4_14_samples/switch_20160226/includes/intrinsic.p4
+++ b/testdata/p4_14_samples/switch_20160226/includes/intrinsic.p4
@@ -19,32 +19,18 @@ header_type ingress_intrinsic_metadata_t {
         resubmit_flag : 1;              // flag distinguishing original packets
                                         // from resubmitted packets.
 
-        ingress_global_tstamp : 48;     // global timestamp (ns) taken upon
+        ingress_global_timestamp : 48;  // global timestamp (ns) taken upon
                                         // arrival at ingress.
 
         mcast_grp : 16;                 // multicast group id (key for the
                                         // mcast replication table)
-
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
         deflection_flag : 1;            // flag indicating whether a packet is
                                         // deflected due to deflect_on_drop.
         deflect_on_drop : 1;            // flag indicating whether a packet can
                                         // be deflected by TM on congestion drop
-
-        enq_qdepth : 19;                // queue depth at the packet enqueue
-                                        // time.
-        enq_tstamp : 32;                // time snapshot taken when the packet
-                                        // is enqueued (in nsec).
-        enq_congest_stat : 2;           // queue congestion status at the packet
-                                        // enqueue time.
-
-        deq_qdepth : 19;                // queue depth at the packet dequeue
-                                        // time.
-        deq_congest_stat : 2;           // queue congestion status at the packet
-                                        // dequeue time.
-        deq_timedelta : 32;             // time delta between the packet's
-                                        // enqueue and dequeue time.
-
         mcast_hash : 13;                // multicast hashing
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
         egress_rid : 16;                // Replication ID for multicast
         lf_field_list : 32;             // Learn filter field list
         priority : 3;                   // set packet priority
@@ -52,11 +38,27 @@ header_type ingress_intrinsic_metadata_t {
 }
 metadata ingress_intrinsic_metadata_t intrinsic_metadata;
 
-#define _ingress_global_tstamp_     intrinsic_metadata.ingress_global_tstamp
+#define _ingress_global_tstamp_     intrinsic_metadata.ingress_global_timestamp
 
 action deflect_on_drop() {
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
     modify_field(intrinsic_metadata.deflect_on_drop, 1);
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
 }
+
+header_type queueing_metadata_t {
+    fields {
+        enq_timestamp : 48;             // time snapshot taken when the packet
+                                        // is enqueued (in microsec).
+        enq_qdepth : 16;                // queue depth at the packet enqueue
+                                        // time.
+        deq_timedelta : 32;             // time delta between the packet's
+                                        // enqueue and dequeue time.
+        deq_qdepth : 16;                // queue depth at the packet dequeue
+                                        // time.
+    }
+}
+metadata queueing_metadata_t queueing_metadata;
 
 #define PKT_INSTANCE_TYPE_NORMAL 0
 #define PKT_INSTANCE_TYPE_INGRESS_CLONE 1

--- a/testdata/p4_14_samples/switch_20160226/int_transit.p4
+++ b/testdata/p4_14_samples/switch_20160226/int_transit.p4
@@ -57,13 +57,13 @@ action int_set_header_1() { /* ingress_port_id */
 action int_set_header_2() { /* hop_latency */
     add_header(int_hop_latency_header);
     modify_field(int_hop_latency_header.hop_latency,
-                                       intrinsic_metadata.deq_timedelta);
+                                       queueing_metadata.deq_timedelta);
 }
 /* Instr Bit 3 */
 action int_set_header_3() { /* q_occupancy */
     add_header(int_q_occupancy_header);
     modify_field(int_q_occupancy_header.q_occupancy,
-                    intrinsic_metadata.enq_qdepth); 
+                    queueing_metadata.enq_qdepth);
 }
 /* Instr Bit 4 */
 action int_set_header_4() { /* ingress_tstamp */

--- a/testdata/p4_14_samples/switch_20160226/switch.p4
+++ b/testdata/p4_14_samples/switch_20160226/switch.p4
@@ -218,7 +218,10 @@ control egress {
     } else {
 #endif /* OPENFLOW_ENABLE */
         /* check for -ve mirrored pkt */
-        if ((intrinsic_metadata.deflection_flag == FALSE) and
+        if (
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
+            (intrinsic_metadata.deflection_flag == FALSE) and
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
             (egress_metadata.bypass == FALSE)) {
 
             /* check if pkt is mirrored */

--- a/testdata/p4_14_samples/switch_20160512/acl.p4
+++ b/testdata/p4_14_samples/switch_20160512/acl.p4
@@ -586,7 +586,9 @@ action egress_copy_to_cpu(reason_code) {
 table egress_acl {
     reads {
         standard_metadata.egress_port : ternary;
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
         intrinsic_metadata.deflection_flag : ternary;
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
         l3_metadata.l3_mtu_check : ternary;
     }
     actions {

--- a/testdata/p4_14_samples/switch_20160512/hashes.p4
+++ b/testdata/p4_14_samples/switch_20160512/hashes.p4
@@ -143,13 +143,17 @@ table compute_non_ip_hashes {
 }
 
 action computed_two_hashes() {
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
     modify_field(intrinsic_metadata.mcast_hash, hash_metadata.hash1);
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
     modify_field(hash_metadata.entropy_hash, hash_metadata.hash2);
 }
 
 action computed_one_hash() {
     modify_field(hash_metadata.hash1, hash_metadata.hash2);
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
     modify_field(intrinsic_metadata.mcast_hash, hash_metadata.hash2);
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
     modify_field(hash_metadata.entropy_hash, hash_metadata.hash2);
 }
 

--- a/testdata/p4_14_samples/switch_20160512/includes/intrinsic.p4
+++ b/testdata/p4_14_samples/switch_20160512/includes/intrinsic.p4
@@ -19,32 +19,18 @@ header_type ingress_intrinsic_metadata_t {
         resubmit_flag : 1;              // flag distinguishing original packets
                                         // from resubmitted packets.
 
-        ingress_global_tstamp : 48;     // global timestamp (ns) taken upon
+        ingress_global_timestamp : 48;  // global timestamp (ns) taken upon
                                         // arrival at ingress.
 
         mcast_grp : 16;                 // multicast group id (key for the
                                         // mcast replication table)
-
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
         deflection_flag : 1;            // flag indicating whether a packet is
                                         // deflected due to deflect_on_drop.
         deflect_on_drop : 1;            // flag indicating whether a packet can
                                         // be deflected by TM on congestion drop
-
-        enq_qdepth : 19;                // queue depth at the packet enqueue
-                                        // time.
-        enq_tstamp : 32;                // time snapshot taken when the packet
-                                        // is enqueued (in nsec).
-        enq_congest_stat : 2;           // queue congestion status at the packet
-                                        // enqueue time.
-
-        deq_qdepth : 19;                // queue depth at the packet dequeue
-                                        // time.
-        deq_congest_stat : 2;           // queue congestion status at the packet
-                                        // dequeue time.
-        deq_timedelta : 32;             // time delta between the packet's
-                                        // enqueue and dequeue time.
-
         mcast_hash : 13;                // multicast hashing
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
         egress_rid : 16;                // Replication ID for multicast
         lf_field_list : 32;             // Learn filter field list
         priority : 3;                   // set packet priority
@@ -52,12 +38,28 @@ header_type ingress_intrinsic_metadata_t {
 }
 metadata ingress_intrinsic_metadata_t intrinsic_metadata;
 
-#define _ingress_global_tstamp_         intrinsic_metadata.ingress_global_tstamp
+#define _ingress_global_tstamp_         intrinsic_metadata.ingress_global_timestamp
 #define modify_field_from_rng(_d, _w)   modify_field_rng_uniform(_d, 0, (1<<(_w))-1)
 
 action deflect_on_drop(enable_dod) {
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
     modify_field(intrinsic_metadata.deflect_on_drop, enable_dod);
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
 }
+
+header_type queueing_metadata_t {
+    fields {
+        enq_timestamp : 48;             // time snapshot taken when the packet
+                                        // is enqueued (in microsec).
+        enq_qdepth : 16;                // queue depth at the packet enqueue
+                                        // time.
+        deq_timedelta : 32;             // time delta between the packet's
+                                        // enqueue and dequeue time.
+        deq_qdepth : 16;                // queue depth at the packet dequeue
+                                        // time.
+    }
+}
+metadata queueing_metadata_t queueing_metadata;
 
 #define PKT_INSTANCE_TYPE_NORMAL 0
 #define PKT_INSTANCE_TYPE_INGRESS_CLONE 1

--- a/testdata/p4_14_samples/switch_20160512/int_transit.p4
+++ b/testdata/p4_14_samples/switch_20160512/int_transit.p4
@@ -57,14 +57,14 @@ action int_set_header_1() { //ingress_port_id
 action int_set_header_2() { //hop_latency
     add_header(int_hop_latency_header);
     modify_field(int_hop_latency_header.hop_latency,
-                    intrinsic_metadata.deq_timedelta);
+                    queueing_metadata.deq_timedelta);
 }
 /* Instr Bit 3 */
 action int_set_header_3() { //q_occupancy
     add_header(int_q_occupancy_header);
     modify_field(int_q_occupancy_header.q_occupancy1, 0);
     modify_field(int_q_occupancy_header.q_occupancy0,
-                    intrinsic_metadata.enq_qdepth);
+                    queueing_metadata.enq_qdepth);
 }
 /* Instr Bit 4 */
 action int_set_header_4() { //ingress_tstamp

--- a/testdata/p4_14_samples/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples/switch_20160512/switch.p4
@@ -242,7 +242,10 @@ control egress {
     } else {
 #endif /* OPENFLOW_ENABLE */
         /* check for -ve mirrored pkt */
-        if ((intrinsic_metadata.deflection_flag == FALSE) and
+        if (
+#ifdef INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
+            (intrinsic_metadata.deflection_flag == FALSE) and
+#endif // INCLUDE_OLD_INTRINSIC_METADATA_FIELDS
             (egress_metadata.bypass == FALSE)) {
 
             /* check if pkt is mirrored */

--- a/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
@@ -9,7 +9,6 @@ header ipv4_option_timestamp_t_1 {
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
@@ -9,7 +9,6 @@ header ipv4_option_timestamp_t_1 {
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
@@ -9,7 +9,6 @@ header ipv4_option_timestamp_t_1 {
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 
@@ -62,9 +61,8 @@ header ipv4_option_NOP_t {
 struct metadata {
     bit<4>  _intrinsic_metadata_mcast_grp0;
     bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<8>  _my_metadata_parse_ipv4_counter4;
+    bit<32> _intrinsic_metadata_lf_field_list2;
+    bit<8>  _my_metadata_parse_ipv4_counter3;
 }
 
 struct headers {
@@ -96,7 +94,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_ipv4") state parse_ipv4 {
         packet.extract<ipv4_base_t>(hdr.ipv4_base);
-        meta._my_metadata_parse_ipv4_counter4 = (bit<8>)((hdr.ipv4_base.ihl << 2) + 4w12);
+        meta._my_metadata_parse_ipv4_counter3 = (bit<8>)((hdr.ipv4_base.ihl << 2) + 4w12);
         transition select(hdr.ipv4_base.ihl) {
             4w0x5: accept;
             default: parse_ipv4_options;
@@ -104,17 +102,17 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_ipv4_option_EOL") state parse_ipv4_option_EOL {
         packet.extract<ipv4_option_EOL_t>(hdr.ipv4_option_EOL.next);
-        meta._my_metadata_parse_ipv4_counter4 = meta._my_metadata_parse_ipv4_counter4 + 8w255;
+        meta._my_metadata_parse_ipv4_counter3 = meta._my_metadata_parse_ipv4_counter3 + 8w255;
         transition parse_ipv4_options;
     }
     @name(".parse_ipv4_option_NOP") state parse_ipv4_option_NOP {
         packet.extract<ipv4_option_EOL_t>(hdr.ipv4_option_NOP.next);
-        meta._my_metadata_parse_ipv4_counter4 = meta._my_metadata_parse_ipv4_counter4 + 8w255;
+        meta._my_metadata_parse_ipv4_counter3 = meta._my_metadata_parse_ipv4_counter3 + 8w255;
         transition parse_ipv4_options;
     }
     @name(".parse_ipv4_option_security") state parse_ipv4_option_security {
         packet.extract<ipv4_option_security_t>(hdr.ipv4_option_security);
-        meta._my_metadata_parse_ipv4_counter4 = meta._my_metadata_parse_ipv4_counter4 + 8w245;
+        meta._my_metadata_parse_ipv4_counter3 = meta._my_metadata_parse_ipv4_counter3 + 8w245;
         transition parse_ipv4_options;
     }
     @name(".parse_ipv4_option_timestamp") state parse_ipv4_option_timestamp {
@@ -124,12 +122,12 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         tmp.len = tmp_1[7:0];
         tmp_hdr_0 = tmp;
         packet.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)tmp_hdr_0.len << 3) + 32w4294967280);
-        meta._my_metadata_parse_ipv4_counter4 = meta._my_metadata_parse_ipv4_counter4 - hdr.ipv4_option_timestamp.len;
+        meta._my_metadata_parse_ipv4_counter3 = meta._my_metadata_parse_ipv4_counter3 - hdr.ipv4_option_timestamp.len;
         transition parse_ipv4_options;
     }
     @name(".parse_ipv4_options") state parse_ipv4_options {
         tmp_0 = packet.lookahead<bit<8>>();
-        transition select(meta._my_metadata_parse_ipv4_counter4, tmp_0[7:0]) {
+        transition select(meta._my_metadata_parse_ipv4_counter3, tmp_0[7:0]) {
             (8w0x0 &&& 8w0xff, 8w0x0 &&& 8w0x0): accept;
             (8w0x0 &&& 8w0x0, 8w0x0 &&& 8w0xff): parse_ipv4_option_EOL;
             (8w0x0 &&& 8w0x0, 8w0x1 &&& 8w0xff): parse_ipv4_option_NOP;

--- a/testdata/p4_14_samples_outputs/TLV_parsing.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing.p4
@@ -9,7 +9,6 @@ header ipv4_option_timestamp_t_1 {
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/TLV_parsing.p4-stderr
+++ b/testdata/p4_14_samples_outputs/TLV_parsing.p4-stderr
@@ -1,4 +1,4 @@
-TLV_parsing.p4(118): [--Wwarn=mismatch] warning: 20: value does not fit in 4 bits
+TLV_parsing.p4(117): [--Wwarn=mismatch] warning: 20: value does not fit in 4 bits
     set_metadata(my_metadata.parse_ipv4_counter, ipv4_base.ihl * 4 - 20);
                                                                      ^^
 [--Wwarn=ordering] warning: "start": the order of headers in deparser is not uniquely determined by parser!

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 
@@ -22,8 +21,7 @@ header ethernet_t {
 struct metadata {
     bit<4>  _intrinsic_metadata_mcast_grp0;
     bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
+    bit<32> _intrinsic_metadata_lf_field_list2;
 }
 
 struct headers {

--- a/testdata/p4_14_samples_outputs/copy_to_cpu.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/counter-first.p4
+++ b/testdata/p4_14_samples_outputs/counter-first.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter-frontend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter-midend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 
@@ -21,9 +20,8 @@ header ethernet_t {
 struct metadata {
     bit<4>  _intrinsic_metadata_mcast_grp0;
     bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<32> _meta_register_tmp4;
+    bit<32> _intrinsic_metadata_lf_field_list2;
+    bit<32> _meta_register_tmp3;
 }
 
 struct headers {

--- a/testdata/p4_14_samples_outputs/counter.p4
+++ b/testdata/p4_14_samples_outputs/counter.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/issue1058-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1058-first.p4
@@ -2,7 +2,7 @@
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
 }
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/issue1058-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1058-frontend.p4
@@ -2,7 +2,7 @@
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
 }
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/issue1058-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1058-midend.p4
@@ -2,7 +2,7 @@
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
 }
 
 struct meta_t {
@@ -16,7 +16,7 @@ header ethernet_t {
 }
 
 struct metadata {
-    bit<48> _intrinsic_metadata_ingress_global_tstamp0;
+    bit<48> _intrinsic_metadata_ingress_global_timestamp0;
     bit<16> _meta_val161;
 }
 

--- a/testdata/p4_14_samples_outputs/issue1058.p4
+++ b/testdata/p4_14_samples_outputs/issue1058.p4
@@ -2,7 +2,7 @@
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
 }
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/meter-first.p4
+++ b/testdata/p4_14_samples_outputs/meter-first.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/meter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter-frontend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/meter-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter-midend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 
@@ -21,9 +20,8 @@ header ethernet_t {
 struct metadata {
     bit<4>  _intrinsic_metadata_mcast_grp0;
     bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<32> _meta_meter_tag4;
+    bit<32> _intrinsic_metadata_lf_field_list2;
+    bit<32> _meta_meter_tag3;
 }
 
 struct headers {
@@ -60,7 +58,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._nop") action _nop_2() {
     }
     @name(".m_action") action m_action(bit<32> meter_idx) {
-        my_meter_0.execute_meter<bit<32>>(meter_idx, meta._meta_meter_tag4);
+        my_meter_0.execute_meter<bit<32>>(meter_idx, meta._meta_meter_tag3);
         standard_metadata.egress_spec = 9w1;
     }
     @name(".m_filter") table m_filter_0 {
@@ -70,7 +68,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_0();
         }
         key = {
-            meta._meta_meter_tag4: exact @name("meta.meter_tag") ;
+            meta._meta_meter_tag3: exact @name("meta.meter_tag") ;
         }
         size = 16;
         default_action = NoAction_0();

--- a/testdata/p4_14_samples_outputs/meter.p4
+++ b/testdata/p4_14_samples_outputs/meter.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/meter1-first.p4
+++ b/testdata/p4_14_samples_outputs/meter1-first.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/meter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-frontend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/meter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-midend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 
@@ -21,9 +20,8 @@ header ethernet_t {
 struct metadata {
     bit<4>  _intrinsic_metadata_mcast_grp0;
     bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<32> _meta_meter_tag4;
+    bit<32> _intrinsic_metadata_lf_field_list2;
+    bit<32> _meta_meter_tag3;
 }
 
 struct headers {
@@ -64,17 +62,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_0();
         }
         key = {
-            meta._meta_meter_tag4: exact @name("meta.meter_tag") ;
+            meta._meta_meter_tag3: exact @name("meta.meter_tag") ;
         }
         size = 16;
         default_action = NoAction_0();
     }
     @name(".m_action") action m_action_0(bit<9> meter_idx) {
-        my_meter_0.read(meta._meta_meter_tag4);
+        my_meter_0.read(meta._meta_meter_tag3);
         standard_metadata.egress_spec = 9w1;
     }
     @name("._nop") action _nop_0() {
-        my_meter_0.read(meta._meta_meter_tag4);
+        my_meter_0.read(meta._meta_meter_tag3);
     }
     @name(".m_table") table m_table_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/meter1.p4
+++ b/testdata/p4_14_samples_outputs/meter1.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/packet_redirect-first.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-first.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
     bit<64> ingress_global_timestamp;
     bit<16> resubmit_flag;

--- a/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
     bit<64> ingress_global_timestamp;
     bit<16> resubmit_flag;

--- a/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
     bit<64> ingress_global_timestamp;
     bit<16> resubmit_flag;
@@ -29,15 +28,14 @@ header hdrA_t {
 struct metadata {
     bit<4>  _intrinsic_metadata_mcast_grp0;
     bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<64> _intrinsic_metadata_ingress_global_timestamp4;
-    bit<16> _intrinsic_metadata_resubmit_flag5;
-    bit<16> _intrinsic_metadata_recirculate_flag6;
-    bit<8>  _metaA_f17;
-    bit<8>  _metaA_f28;
-    bit<8>  _metaB_f19;
-    bit<8>  _metaB_f210;
+    bit<32> _intrinsic_metadata_lf_field_list2;
+    bit<64> _intrinsic_metadata_ingress_global_timestamp3;
+    bit<16> _intrinsic_metadata_resubmit_flag4;
+    bit<16> _intrinsic_metadata_recirculate_flag5;
+    bit<8>  _metaA_f16;
+    bit<8>  _metaA_f27;
+    bit<8>  _metaB_f18;
+    bit<8>  _metaB_f29;
 }
 
 struct headers {
@@ -63,10 +61,10 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name("._nop") action _nop() {
     }
     @name("._recirculate") action _recirculate() {
-        recirculate<tuple_0>({ standard_metadata, {meta._metaA_f17,meta._metaA_f28} });
+        recirculate<tuple_0>({ standard_metadata, {meta._metaA_f16,meta._metaA_f27} });
     }
     @name("._clone_e2e") action _clone_e2e(bit<32> mirror_id) {
-        clone3<tuple_0>(CloneType.E2E, mirror_id, { standard_metadata, {meta._metaA_f17,meta._metaA_f28} });
+        clone3<tuple_0>(CloneType.E2E, mirror_id, { standard_metadata, {meta._metaA_f16,meta._metaA_f27} });
     }
     @name(".t_egress") table t_egress_0 {
         actions = {
@@ -98,16 +96,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._set_port") action _set_port(bit<9> port) {
         standard_metadata.egress_spec = port;
-        meta._metaA_f17 = 8w1;
+        meta._metaA_f16 = 8w1;
     }
     @name("._multicast") action _multicast(bit<4> mgrp) {
         meta._intrinsic_metadata_mcast_grp0 = mgrp;
     }
     @name("._resubmit") action _resubmit() {
-        resubmit<tuple_0>({ standard_metadata, {meta._metaA_f17,meta._metaA_f28} });
+        resubmit<tuple_0>({ standard_metadata, {meta._metaA_f16,meta._metaA_f27} });
     }
     @name("._clone_i2e") action _clone_i2e(bit<32> mirror_id) {
-        clone3<tuple_0>(CloneType.I2E, mirror_id, { standard_metadata, {meta._metaA_f17,meta._metaA_f28} });
+        clone3<tuple_0>(CloneType.I2E, mirror_id, { standard_metadata, {meta._metaA_f16,meta._metaA_f27} });
     }
     @name(".t_ingress_1") table t_ingress {
         actions = {
@@ -118,7 +116,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             hdr.hdrA.f1    : exact @name("hdrA.f1") ;
-            meta._metaA_f17: exact @name("metaA.f1") ;
+            meta._metaA_f16: exact @name("metaA.f1") ;
         }
         size = 128;
         default_action = NoAction_1();

--- a/testdata/p4_14_samples_outputs/packet_redirect.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
     bit<64> ingress_global_timestamp;
     bit<16> resubmit_flag;

--- a/testdata/p4_14_samples_outputs/register-first.p4
+++ b/testdata/p4_14_samples_outputs/register-first.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/register-frontend.p4
+++ b/testdata/p4_14_samples_outputs/register-frontend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/register-midend.p4
+++ b/testdata/p4_14_samples_outputs/register-midend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 
@@ -21,9 +20,8 @@ header ethernet_t {
 struct metadata {
     bit<4>  _intrinsic_metadata_mcast_grp0;
     bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<32> _meta_register_tmp4;
+    bit<32> _intrinsic_metadata_lf_field_list2;
+    bit<32> _meta_register_tmp3;
 }
 
 struct headers {
@@ -52,7 +50,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name(".m_action") action m_action(bit<8> register_idx) {
-        my_register.read(meta._meta_register_tmp4, (bit<32>)register_idx);
+        my_register.read(meta._meta_register_tmp3, (bit<32>)register_idx);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/register.p4
+++ b/testdata/p4_14_samples_outputs/register.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/register.p4-stderr
+++ b/testdata/p4_14_samples_outputs/register.p4-stderr
@@ -1,3 +1,3 @@
-register.p4(67): [--Wwarn=type-inference] warning: Could not infer type for register_idx, using bit<8>
+register.p4(66): [--Wwarn=type-inference] warning: Could not infer type for register_idx, using bit<8>
 action m_action(register_idx) {
                 ^^^^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/resubmit-first.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-first.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
     bit<16> resubmit_flag;
 }

--- a/testdata/p4_14_samples_outputs/resubmit-frontend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-frontend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
     bit<16> resubmit_flag;
 }

--- a/testdata/p4_14_samples_outputs/resubmit-midend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-midend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
     bit<16> resubmit_flag;
 }
@@ -22,10 +21,9 @@ header ethernet_t {
 struct metadata {
     bit<4>  _intrinsic_metadata_mcast_grp0;
     bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<16> _intrinsic_metadata_resubmit_flag4;
-    bit<8>  _mymeta_f15;
+    bit<32> _intrinsic_metadata_lf_field_list2;
+    bit<16> _intrinsic_metadata_resubmit_flag3;
+    bit<8>  _mymeta_f14;
 }
 
 struct headers {
@@ -66,7 +64,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name("._resubmit") action _resubmit() {
-        meta._mymeta_f15 = 8w1;
+        meta._mymeta_f14 = 8w1;
         resubmit<tuple_0>({ standard_metadata, {8w1} });
     }
     @name(".t_ingress_1") table t_ingress {
@@ -76,7 +74,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_0();
         }
         key = {
-            meta._mymeta_f15: exact @name("mymeta.f1") ;
+            meta._mymeta_f14: exact @name("mymeta.f1") ;
         }
         size = 128;
         default_action = NoAction_0();
@@ -88,7 +86,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_3();
         }
         key = {
-            meta._mymeta_f15: exact @name("mymeta.f1") ;
+            meta._mymeta_f14: exact @name("mymeta.f1") ;
         }
         size = 128;
         default_action = NoAction_3();

--- a/testdata/p4_14_samples_outputs/resubmit.p4
+++ b/testdata/p4_14_samples_outputs/resubmit.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
     bit<16> resubmit_flag;
 }

--- a/testdata/p4_14_samples_outputs/sai_p4-first.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-first.p4
@@ -51,7 +51,6 @@ struct ingress_metadata_t {
 struct ingress_intrinsic_metadata_t {
     bit<9>  ingress_port;
     bit<32> lf_field_list;
-    bit<9>  ucast_egress_port;
 }
 
 header ethernet_t {
@@ -142,7 +141,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".port_counters") direct_counter(CounterType.packets) port_counters;
     @name(".fdb_set") action fdb_set(bit<1> type_, bit<9> port_id) {
         meta.ingress_metadata.mac_type = type_;
-        meta.intrinsic_metadata.ucast_egress_port = port_id;
         standard_metadata.egress_spec = port_id;
         meta.ingress_metadata.routed = 1w0;
     }
@@ -154,7 +152,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_dmac") action set_dmac(bit<48> dst_mac_address, bit<9> port_id) {
         hdr.eth.dstAddr = dst_mac_address;
         hdr.eth.srcAddr = meta.ingress_metadata.def_smac;
-        meta.intrinsic_metadata.ucast_egress_port = port_id;
         standard_metadata.egress_spec = port_id;
     }
     @name(".set_next_hop") action set_next_hop(bit<8> type_, bit<8> ip, bit<16> router_interface_id) {
@@ -199,7 +196,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_router_interface") action set_router_interface(bit<16> virtual_router_id, bit<1> type_, bit<9> port_id, bit<12> vlan_id, bit<48> src_mac_address, bit<1> admin_v4_state, bit<1> admin_v6_state, bit<14> mtu) {
         meta.ingress_metadata.vrf = virtual_router_id;
         meta.ingress_metadata.interface_type = type_;
-        meta.intrinsic_metadata.ucast_egress_port = port_id;
+        standard_metadata.egress_spec = port_id;
         meta.ingress_metadata.vlan_id = vlan_id;
         meta.ingress_metadata.def_smac = src_mac_address;
         meta.ingress_metadata.v4_enable = admin_v4_state;

--- a/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
@@ -51,7 +51,6 @@ struct ingress_metadata_t {
 struct ingress_intrinsic_metadata_t {
     bit<9>  ingress_port;
     bit<32> lf_field_list;
-    bit<9>  ucast_egress_port;
 }
 
 header ethernet_t {
@@ -160,7 +159,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".port_counters") direct_counter(CounterType.packets) port_counters_0;
     @name(".fdb_set") action fdb_set(bit<1> type_, bit<9> port_id) {
         meta.ingress_metadata.mac_type = type_;
-        meta.intrinsic_metadata.ucast_egress_port = port_id;
         standard_metadata.egress_spec = port_id;
         meta.ingress_metadata.routed = 1w0;
     }
@@ -172,7 +170,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_dmac") action set_dmac(bit<48> dst_mac_address, bit<9> port_id) {
         hdr.eth.dstAddr = dst_mac_address;
         hdr.eth.srcAddr = meta.ingress_metadata.def_smac;
-        meta.intrinsic_metadata.ucast_egress_port = port_id;
         standard_metadata.egress_spec = port_id;
     }
     @name(".set_next_hop") action set_next_hop(bit<8> type_, bit<8> ip, bit<16> router_interface_id) {
@@ -197,7 +194,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_router_interface") action set_router_interface(bit<16> virtual_router_id, bit<1> type_, bit<9> port_id, bit<12> vlan_id, bit<48> src_mac_address, bit<1> admin_v4_state, bit<1> admin_v6_state, bit<14> mtu) {
         meta.ingress_metadata.vrf = virtual_router_id;
         meta.ingress_metadata.interface_type = type_;
-        meta.intrinsic_metadata.ucast_egress_port = port_id;
+        standard_metadata.egress_spec = port_id;
         meta.ingress_metadata.vlan_id = vlan_id;
         meta.ingress_metadata.def_smac = src_mac_address;
         meta.ingress_metadata.v4_enable = admin_v4_state;

--- a/testdata/p4_14_samples_outputs/sai_p4-midend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-midend.p4
@@ -51,7 +51,6 @@ struct ingress_metadata_t {
 struct ingress_intrinsic_metadata_t {
     bit<9>  ingress_port;
     bit<32> lf_field_list;
-    bit<9>  ucast_egress_port;
 }
 
 header ethernet_t {
@@ -126,7 +125,6 @@ struct metadata {
     bit<1>  _ingress_metadata_router_mac40;
     bit<9>  _intrinsic_metadata_ingress_port41;
     bit<32> _intrinsic_metadata_lf_field_list42;
-    bit<9>  _intrinsic_metadata_ucast_egress_port43;
 }
 
 struct headers {
@@ -198,7 +196,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".port_counters") direct_counter(CounterType.packets) port_counters_0;
     @name(".fdb_set") action fdb_set(bit<1> type_, bit<9> port_id) {
         meta._ingress_metadata_mac_type21 = type_;
-        meta._intrinsic_metadata_ucast_egress_port43 = port_id;
         standard_metadata.egress_spec = port_id;
         meta._ingress_metadata_routed5 = 1w0;
     }
@@ -210,7 +207,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_dmac") action set_dmac(bit<48> dst_mac_address, bit<9> port_id) {
         hdr.eth.dstAddr = dst_mac_address;
         hdr.eth.srcAddr = meta._ingress_metadata_def_smac18;
-        meta._intrinsic_metadata_ucast_egress_port43 = port_id;
         standard_metadata.egress_spec = port_id;
     }
     @name(".set_next_hop") action set_next_hop(bit<8> type_, bit<8> ip, bit<16> router_interface_id) {
@@ -235,7 +231,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_router_interface") action set_router_interface(bit<16> virtual_router_id, bit<1> type_, bit<9> port_id, bit<12> vlan_id, bit<48> src_mac_address, bit<1> admin_v4_state, bit<1> admin_v6_state, bit<14> mtu) {
         meta._ingress_metadata_vrf6 = virtual_router_id;
         meta._ingress_metadata_interface_type34 = type_;
-        meta._intrinsic_metadata_ucast_egress_port43 = port_id;
+        standard_metadata.egress_spec = port_id;
         meta._ingress_metadata_vlan_id37 = vlan_id;
         meta._ingress_metadata_def_smac18 = src_mac_address;
         meta._ingress_metadata_v4_enable35 = admin_v4_state;

--- a/testdata/p4_14_samples_outputs/sai_p4.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4.p4
@@ -51,7 +51,6 @@ struct ingress_metadata_t {
 struct ingress_intrinsic_metadata_t {
     bit<9>  ingress_port;
     bit<32> lf_field_list;
-    bit<9>  ucast_egress_port;
 }
 
 header ethernet_t {
@@ -144,7 +143,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".port_counters") direct_counter(CounterType.packets) port_counters;
     @name(".fdb_set") action fdb_set(bit<1> type_, bit<9> port_id) {
         meta.ingress_metadata.mac_type = type_;
-        meta.intrinsic_metadata.ucast_egress_port = port_id;
         standard_metadata.egress_spec = port_id;
         meta.ingress_metadata.routed = 1w0;
     }
@@ -156,7 +154,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_dmac") action set_dmac(bit<48> dst_mac_address, bit<9> port_id) {
         hdr.eth.dstAddr = dst_mac_address;
         hdr.eth.srcAddr = meta.ingress_metadata.def_smac;
-        meta.intrinsic_metadata.ucast_egress_port = port_id;
         standard_metadata.egress_spec = port_id;
     }
     @name(".set_next_hop") action set_next_hop(bit<8> type_, bit<8> ip, bit<16> router_interface_id) {
@@ -201,7 +198,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_router_interface") action set_router_interface(bit<16> virtual_router_id, bit<1> type_, bit<9> port_id, bit<12> vlan_id, bit<48> src_mac_address, bit<1> admin_v4_state, bit<1> admin_v6_state, bit<14> mtu) {
         meta.ingress_metadata.vrf = virtual_router_id;
         meta.ingress_metadata.interface_type = type_;
-        meta.intrinsic_metadata.ucast_egress_port = port_id;
+        standard_metadata.egress_spec = port_id;
         meta.ingress_metadata.vlan_id = vlan_id;
         meta.ingress_metadata.def_smac = src_mac_address;
         meta.ingress_metadata.v4_enable = admin_v4_state;

--- a/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
+++ b/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
@@ -1,85 +1,85 @@
-sai_p4.p4(432): [--Wwarn=type-inference] warning: Could not infer type for type_, using bit<8>
+sai_p4.p4(430): [--Wwarn=type-inference] warning: Could not infer type for type_, using bit<8>
 action set_next_hop(type_, ip, router_interface_id) {
                     ^^^^^
-sai_p4.p4(432): [--Wwarn=type-inference] warning: Could not infer type for ip, using bit<8>
+sai_p4.p4(430): [--Wwarn=type-inference] warning: Could not infer type for ip, using bit<8>
 action set_next_hop(type_, ip, router_interface_id) {
                            ^^
-sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for admin_state, using bit<8>
+sai_p4.p4(281): [--Wwarn=type-inference] warning: Could not infer type for admin_state, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                     ^^^^^^^^^^^
-sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for default_vlan_priority, using bit<8>
+sai_p4.p4(281): [--Wwarn=type-inference] warning: Could not infer type for default_vlan_priority, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                ^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for sflow, using bit<8>
+sai_p4.p4(281): [--Wwarn=type-inference] warning: Could not infer type for sflow, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                     ^^^^^
-sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for flood_storm_control, using bit<8>
+sai_p4.p4(281): [--Wwarn=type-inference] warning: Could not infer type for flood_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for broadcast_storm_control, using bit<8>
+sai_p4.p4(281): [--Wwarn=type-inference] warning: Could not infer type for broadcast_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for multicast_storm_control, using bit<8>
+sai_p4.p4(281): [--Wwarn=type-inference] warning: Could not infer type for multicast_storm_control, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                                          ^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): [--Wwarn=type-inference] warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
+sai_p4.p4(281): [--Wwarn=type-inference] warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                                                                                                                                                                                                                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for max_virtual_routers, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for max_virtual_routers, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                          ^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for fdb_table_size, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for fdb_table_size, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                               ^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for on_link_route_supported, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for on_link_route_supported, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                               ^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for max_temp, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for max_temp, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                     ^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for switching_mode, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for switching_mode, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                               ^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for cpu_flood_enable, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for cpu_flood_enable, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                               ^^^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for ttl1_action, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for ttl1_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                 ^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for fdb_aging_time, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for fdb_aging_time, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                             ^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for fdb_unicast_miss_action, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for fdb_unicast_miss_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                             ^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for fdb_broadcast_miss_action, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for fdb_broadcast_miss_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for fdb_multicast_miss_action, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for fdb_multicast_miss_action, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_seed, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_seed, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_type, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_type, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_fields, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_fields, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^
-sai_p4.p4(265): [--Wwarn=type-inference] warning: Could not infer type for ecmp_max_paths, using bit<8>
+sai_p4.p4(264): [--Wwarn=type-inference] warning: Could not infer type for ecmp_max_paths, using bit<8>
 action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
                                                                                                                                                                                                                                                                                                                                                              ^^^^^^^^^^^^^^
-sai_p4.p4(583): [--Wwarn=type-inference] warning: Could not infer type for violation_ttl1_action, using bit<8>
+sai_p4.p4(581): [--Wwarn=type-inference] warning: Could not infer type for violation_ttl1_action, using bit<8>
 action set_router(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
                                                                    ^^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(583): [--Wwarn=type-inference] warning: Could not infer type for violation_ip_options, using bit<8>
+sai_p4.p4(581): [--Wwarn=type-inference] warning: Could not infer type for violation_ip_options, using bit<8>
 action set_router(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
                                                                                           ^^^^^^^^^^^^^^^^^^^^
-sai_p4.p4(282): [--Wwarn=shadow] warning: port shadows .port
+sai_p4.p4(281): [--Wwarn=shadow] warning: port shadows .port
 action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
                    ^^^^
-sai_p4.p4(305)
+sai_p4.p4(304)
 table port {
 ^
 [--Wwarn=unused] warning: .next_hop_group: unused instance

--- a/testdata/p4_14_samples_outputs/simple_nat-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-first.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/simple_nat-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-midend.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 
@@ -66,19 +65,18 @@ header tcp_t {
 struct metadata {
     bit<4>  _intrinsic_metadata_mcast_grp0;
     bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<1>  _meta_do_forward4;
-    bit<32> _meta_ipv4_sa5;
-    bit<32> _meta_ipv4_da6;
-    bit<16> _meta_tcp_sp7;
-    bit<16> _meta_tcp_dp8;
-    bit<32> _meta_nhop_ipv49;
-    bit<32> _meta_if_ipv4_addr10;
-    bit<48> _meta_if_mac_addr11;
-    bit<1>  _meta_is_ext_if12;
-    bit<16> _meta_tcpLength13;
-    bit<8>  _meta_if_index14;
+    bit<32> _intrinsic_metadata_lf_field_list2;
+    bit<1>  _meta_do_forward3;
+    bit<32> _meta_ipv4_sa4;
+    bit<32> _meta_ipv4_da5;
+    bit<16> _meta_tcp_sp6;
+    bit<16> _meta_tcp_dp7;
+    bit<32> _meta_nhop_ipv48;
+    bit<32> _meta_if_ipv4_addr9;
+    bit<48> _meta_if_mac_addr10;
+    bit<1>  _meta_is_ext_if11;
+    bit<16> _meta_tcpLength12;
+    bit<8>  _meta_if_index13;
 }
 
 struct headers {
@@ -96,7 +94,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     bit<64> tmp;
     @name(".parse_cpu_header") state parse_cpu_header {
         packet.extract<cpu_header_t>(hdr.cpu_header);
-        meta._meta_if_index14 = hdr.cpu_header.if_index;
+        meta._meta_if_index13 = hdr.cpu_header.if_index;
         transition parse_ethernet;
     }
     @name(".parse_ethernet") state parse_ethernet {
@@ -108,9 +106,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_ipv4") state parse_ipv4 {
         packet.extract<ipv4_t>(hdr.ipv4);
-        meta._meta_ipv4_sa5 = hdr.ipv4.srcAddr;
-        meta._meta_ipv4_da6 = hdr.ipv4.dstAddr;
-        meta._meta_tcpLength13 = hdr.ipv4.totalLen + 16w65516;
+        meta._meta_ipv4_sa4 = hdr.ipv4.srcAddr;
+        meta._meta_ipv4_da5 = hdr.ipv4.dstAddr;
+        meta._meta_tcpLength12 = hdr.ipv4.totalLen + 16w65516;
         transition select(hdr.ipv4.protocol) {
             8w0x6: parse_tcp;
             default: accept;
@@ -118,12 +116,12 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_tcp") state parse_tcp {
         packet.extract<tcp_t>(hdr.tcp);
-        meta._meta_tcp_sp7 = hdr.tcp.srcPort;
-        meta._meta_tcp_dp8 = hdr.tcp.dstPort;
+        meta._meta_tcp_sp6 = hdr.tcp.srcPort;
+        meta._meta_tcp_dp7 = hdr.tcp.dstPort;
         transition accept;
     }
     @name(".start") state start {
-        meta._meta_if_index14 = (bit<8>)standard_metadata.ingress_port;
+        meta._meta_if_index13 = (bit<8>)standard_metadata.ingress_port;
         tmp = packet.lookahead<bit<64>>();
         transition select(tmp[63:0]) {
             64w0: parse_cpu_header;
@@ -140,10 +138,10 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".do_rewrites") action do_rewrites(bit<48> smac) {
         hdr.cpu_header.setInvalid();
         hdr.ethernet.srcAddr = smac;
-        hdr.ipv4.srcAddr = meta._meta_ipv4_sa5;
-        hdr.ipv4.dstAddr = meta._meta_ipv4_da6;
-        hdr.tcp.srcPort = meta._meta_tcp_sp7;
-        hdr.tcp.dstPort = meta._meta_tcp_dp8;
+        hdr.ipv4.srcAddr = meta._meta_ipv4_sa4;
+        hdr.ipv4.dstAddr = meta._meta_ipv4_da5;
+        hdr.tcp.srcPort = meta._meta_tcp_sp6;
+        hdr.tcp.dstPort = meta._meta_tcp_dp7;
     }
     @name("._drop") action _drop() {
         mark_to_drop();
@@ -153,7 +151,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.cpu_header.preamble = 64w0;
         hdr.cpu_header.device = 8w0;
         hdr.cpu_header.reason = 8w0xab;
-        hdr.cpu_header.if_index = meta._meta_if_index14;
+        hdr.cpu_header.if_index = meta._meta_if_index13;
     }
     @name(".send_frame") table send_frame_0 {
         actions = {
@@ -211,12 +209,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop();
     }
     @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
-        meta._meta_if_ipv4_addr10 = ipv4_addr;
-        meta._meta_if_mac_addr11 = mac_addr;
-        meta._meta_is_ext_if12 = is_ext;
+        meta._meta_if_ipv4_addr9 = ipv4_addr;
+        meta._meta_if_mac_addr10 = mac_addr;
+        meta._meta_is_ext_if11 = is_ext;
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta._meta_nhop_ipv49 = nhop_ipv4;
+        meta._meta_nhop_ipv48 = nhop_ipv4;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
@@ -224,21 +222,21 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         clone3<tuple_0>(CloneType.I2E, 32w250, { standard_metadata });
     }
     @name(".nat_miss_ext_to_int") action nat_miss_ext_to_int() {
-        meta._meta_do_forward4 = 1w0;
+        meta._meta_do_forward3 = 1w0;
         mark_to_drop();
     }
     @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
-        meta._meta_do_forward4 = 1w1;
-        meta._meta_ipv4_sa5 = srcAddr;
-        meta._meta_tcp_sp7 = srcPort;
+        meta._meta_do_forward3 = 1w1;
+        meta._meta_ipv4_sa4 = srcAddr;
+        meta._meta_tcp_sp6 = srcPort;
     }
     @name(".nat_hit_ext_to_int") action nat_hit_ext_to_int(bit<32> dstAddr, bit<16> dstPort) {
-        meta._meta_do_forward4 = 1w1;
-        meta._meta_ipv4_da6 = dstAddr;
-        meta._meta_tcp_dp8 = dstPort;
+        meta._meta_do_forward3 = 1w1;
+        meta._meta_ipv4_da5 = dstAddr;
+        meta._meta_tcp_dp7 = dstPort;
     }
     @name(".nat_no_nat") action nat_no_nat() {
-        meta._meta_do_forward4 = 1w1;
+        meta._meta_do_forward3 = 1w1;
     }
     @name(".forward") table forward_0 {
         actions = {
@@ -247,7 +245,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_8();
         }
         key = {
-            meta._meta_nhop_ipv49: exact @name("meta.nhop_ipv4") ;
+            meta._meta_nhop_ipv48: exact @name("meta.nhop_ipv4") ;
         }
         size = 512;
         default_action = NoAction_8();
@@ -259,7 +257,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_9();
         }
         key = {
-            meta._meta_if_index14: exact @name("meta.if_index") ;
+            meta._meta_if_index13: exact @name("meta.if_index") ;
         }
         default_action = NoAction_9();
     }
@@ -270,7 +268,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_10();
         }
         key = {
-            meta._meta_ipv4_da6: lpm @name("meta.ipv4_da") ;
+            meta._meta_ipv4_da5: lpm @name("meta.ipv4_da") ;
         }
         size = 1024;
         default_action = NoAction_10();
@@ -286,7 +284,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_11();
         }
         key = {
-            meta._meta_is_ext_if12: exact @name("meta.is_ext_if") ;
+            meta._meta_is_ext_if11: exact @name("meta.is_ext_if") ;
             hdr.ipv4.isValid()    : exact @name("ipv4.$valid$") ;
             hdr.tcp.isValid()     : exact @name("tcp.$valid$") ;
             hdr.ipv4.srcAddr      : ternary @name("ipv4.srcAddr") ;
@@ -300,7 +298,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     apply {
         if_info_0.apply();
         nat_0.apply();
-        if (meta._meta_do_forward4 == 1w1 && hdr.ipv4.ttl > 8w0) {
+        if (meta._meta_do_forward3 == 1w1 && hdr.ipv4.ttl > 8w0) {
             ipv4_lpm_0.apply();
             forward_0.apply();
         }
@@ -350,14 +348,14 @@ struct tuple_2 {
 control verifyChecksum(inout headers hdr, inout metadata meta) {
     apply {
         verify_checksum<tuple_1, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
-        verify_checksum_with_payload<tuple_2, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta._meta_tcpLength13, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
+        verify_checksum_with_payload<tuple_2, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta._meta_tcpLength12, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
     }
 }
 
 control computeChecksum(inout headers hdr, inout metadata meta) {
     apply {
         update_checksum<tuple_1, bit<16>>(true, { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
-        update_checksum_with_payload<tuple_2, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta._meta_tcpLength13, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
+        update_checksum_with_payload<tuple_2, bit<16>>(hdr.tcp.isValid(), { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, 8w0, hdr.ipv4.protocol, meta._meta_tcpLength12, hdr.tcp.srcPort, hdr.tcp.dstPort, hdr.tcp.seqNo, hdr.tcp.ackNo, hdr.tcp.dataOffset, hdr.tcp.res, hdr.tcp.flags, hdr.tcp.window, hdr.tcp.urgentPtr }, hdr.tcp.checksum, HashAlgorithm.csum16);
     }
 }
 

--- a/testdata/p4_14_samples_outputs/simple_nat.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat.p4
@@ -4,7 +4,6 @@
 struct intrinsic_metadata_t {
     bit<4>  mcast_grp;
     bit<4>  egress_rid;
-    bit<16> mcast_hash;
     bit<32> lf_field_list;
 }
 

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-first.p4
@@ -83,17 +83,8 @@ struct int_metadata_i2e_t {
 
 struct ingress_intrinsic_metadata_t {
     bit<1>  resubmit_flag;
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
     bit<16> mcast_grp;
-    bit<1>  deflection_flag;
-    bit<1>  deflect_on_drop;
-    bit<19> enq_qdepth;
-    bit<32> enq_tstamp;
-    bit<2>  enq_congest_stat;
-    bit<19> deq_qdepth;
-    bit<2>  deq_congest_stat;
-    bit<32> deq_timedelta;
-    bit<13> mcast_hash;
     bit<16> egress_rid;
     bit<32> lf_field_list;
     bit<3>  priority;
@@ -179,6 +170,13 @@ struct qos_metadata_t {
     bit<3> marked_cos;
     bit<8> marked_dscp;
     bit<3> marked_exp;
+}
+
+struct queueing_metadata_t {
+    bit<48> enq_timestamp;
+    bit<16> enq_qdepth;
+    bit<32> deq_timedelta;
+    bit<16> deq_qdepth;
 }
 
 struct security_metadata_t {
@@ -640,6 +638,8 @@ struct metadata {
     nexthop_metadata_t           nexthop_metadata;
     @name(".qos_metadata") 
     qos_metadata_t               qos_metadata;
+    @name(".queueing_metadata") 
+    queueing_metadata_t          queueing_metadata;
     @name(".security_metadata") 
     security_metadata_t          security_metadata;
     @name(".tunnel_metadata") 
@@ -1778,14 +1778,14 @@ control process_int_insertion(inout headers hdr, inout metadata meta, inout stan
     }
     @name(".int_set_header_3") action int_set_header_3() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.queueing_metadata.enq_qdepth;
     }
     @name(".int_set_header_0003_i1") action int_set_header_0003_i1() {
         int_set_header_3();
     }
     @name(".int_set_header_2") action int_set_header_2() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
     }
     @name(".int_set_header_0003_i2") action int_set_header_0003_i2() {
         int_set_header_2();
@@ -2794,9 +2794,8 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
             @defaultonly NoAction();
         }
         key = {
-            standard_metadata.egress_port          : ternary @name("standard_metadata.egress_port") ;
-            meta.intrinsic_metadata.deflection_flag: ternary @name("intrinsic_metadata.deflection_flag") ;
-            meta.l3_metadata.l3_mtu_check          : ternary @name("l3_metadata.l3_mtu_check") ;
+            standard_metadata.egress_port: ternary @name("standard_metadata.egress_port") ;
+            meta.l3_metadata.l3_mtu_check: ternary @name("l3_metadata.l3_mtu_check") ;
         }
         size = 512;
         default_action = NoAction();
@@ -2865,7 +2864,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".process_egress_filter") process_egress_filter() process_egress_filter_0;
     @name(".process_egress_acl") process_egress_acl() process_egress_acl_0;
     apply {
-        if (meta.intrinsic_metadata.deflection_flag == 1w0 && meta.egress_metadata.bypass == 1w0) {
+        if (meta.egress_metadata.bypass == 1w0) {
             if (standard_metadata.instance_type != 32w0 && standard_metadata.instance_type != 32w5) 
                 mirror.apply();
             else 
@@ -3022,7 +3021,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3030,7 +3029,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3038,7 +3037,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3046,7 +3045,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3054,7 +3053,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3062,7 +3061,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3070,7 +3069,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3078,7 +3077,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3086,7 +3085,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3094,7 +3093,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3102,7 +3101,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3110,7 +3109,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3773,7 +3772,7 @@ control process_mac_acl(inout headers hdr, inout metadata meta, inout standard_m
     }
     @name(".acl_mirror") action acl_mirror(bit<32> session_id, bit<16> acl_stats_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
@@ -3820,7 +3819,7 @@ control process_ip_acl(inout headers hdr, inout metadata meta, inout standard_me
     }
     @name(".acl_mirror") action acl_mirror(bit<32> session_id, bit<16> acl_stats_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
@@ -4418,12 +4417,10 @@ control process_hashes(inout headers hdr, inout metadata meta, inout standard_me
         hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
     }
     @name(".computed_two_hashes") action computed_two_hashes() {
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".computed_one_hash") action computed_one_hash() {
         meta.hash_metadata.hash1 = meta.hash_metadata.hash2;
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash2;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".compute_ipv4_hashes") table compute_ipv4_hashes {
@@ -4781,7 +4778,6 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
         mark_to_drop();
     }
     @name(".deflect_on_drop") action deflect_on_drop() {
-        meta.intrinsic_metadata.deflect_on_drop = 1w1;
     }
     @name(".congestion_mirror_set") action congestion_mirror_set() {
         deflect_on_drop();

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-frontend.p4
@@ -83,17 +83,8 @@ struct int_metadata_i2e_t {
 
 struct ingress_intrinsic_metadata_t {
     bit<1>  resubmit_flag;
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
     bit<16> mcast_grp;
-    bit<1>  deflection_flag;
-    bit<1>  deflect_on_drop;
-    bit<19> enq_qdepth;
-    bit<32> enq_tstamp;
-    bit<2>  enq_congest_stat;
-    bit<19> deq_qdepth;
-    bit<2>  deq_congest_stat;
-    bit<32> deq_timedelta;
-    bit<13> mcast_hash;
     bit<16> egress_rid;
     bit<32> lf_field_list;
     bit<3>  priority;
@@ -179,6 +170,13 @@ struct qos_metadata_t {
     bit<3> marked_cos;
     bit<8> marked_dscp;
     bit<3> marked_exp;
+}
+
+struct queueing_metadata_t {
+    bit<48> enq_timestamp;
+    bit<16> enq_qdepth;
+    bit<32> deq_timedelta;
+    bit<16> deq_qdepth;
 }
 
 struct security_metadata_t {
@@ -640,6 +638,8 @@ struct metadata {
     nexthop_metadata_t           nexthop_metadata;
     @name(".qos_metadata") 
     qos_metadata_t               qos_metadata;
+    @name(".queueing_metadata") 
+    queueing_metadata_t          queueing_metadata;
     @name(".security_metadata") 
     security_metadata_t          security_metadata;
     @name(".tunnel_metadata") 
@@ -1762,17 +1762,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i1") action _int_set_header_0003_i1_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.queueing_metadata.enq_qdepth;
     }
     @name(".int_set_header_0003_i2") action _int_set_header_0003_i2_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
     }
     @name(".int_set_header_0003_i3") action _int_set_header_0003_i3_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.queueing_metadata.enq_qdepth;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
     }
     @name(".int_set_header_0003_i4") action _int_set_header_0003_i4_0() {
         hdr.int_ingress_port_id_header.setValid();
@@ -1780,21 +1780,21 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i5") action _int_set_header_0003_i5_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.queueing_metadata.enq_qdepth;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta.ingress_metadata.ifindex;
     }
     @name(".int_set_header_0003_i6") action _int_set_header_0003_i6_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta.ingress_metadata.ifindex;
     }
     @name(".int_set_header_0003_i7") action _int_set_header_0003_i7_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.queueing_metadata.enq_qdepth;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta.ingress_metadata.ifindex;
     }
@@ -1804,21 +1804,21 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i9") action _int_set_header_0003_i9_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.queueing_metadata.enq_qdepth;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta.int_metadata.switch_id;
     }
     @name(".int_set_header_0003_i10") action _int_set_header_0003_i10_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta.int_metadata.switch_id;
     }
     @name(".int_set_header_0003_i11") action _int_set_header_0003_i11_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.queueing_metadata.enq_qdepth;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta.int_metadata.switch_id;
     }
@@ -1830,7 +1830,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i13") action _int_set_header_0003_i13_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.queueing_metadata.enq_qdepth;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta.ingress_metadata.ifindex;
         hdr.int_switch_id_header.setValid();
@@ -1838,7 +1838,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i14") action _int_set_header_0003_i14_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta.ingress_metadata.ifindex;
         hdr.int_switch_id_header.setValid();
@@ -1846,9 +1846,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i15") action _int_set_header_0003_i15_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.queueing_metadata.enq_qdepth;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta.ingress_metadata.ifindex;
         hdr.int_switch_id_header.setValid();
@@ -2848,15 +2848,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_113();
         }
         key = {
-            standard_metadata.egress_port          : ternary @name("standard_metadata.egress_port") ;
-            meta.intrinsic_metadata.deflection_flag: ternary @name("intrinsic_metadata.deflection_flag") ;
-            meta.l3_metadata.l3_mtu_check          : ternary @name("l3_metadata.l3_mtu_check") ;
+            standard_metadata.egress_port: ternary @name("standard_metadata.egress_port") ;
+            meta.l3_metadata.l3_mtu_check: ternary @name("l3_metadata.l3_mtu_check") ;
         }
         size = 512;
         default_action = NoAction_113();
     }
     apply {
-        if (meta.intrinsic_metadata.deflection_flag == 1w0 && meta.egress_metadata.bypass == 1w0) {
+        if (meta.egress_metadata.bypass == 1w0) {
             if (standard_metadata.instance_type != 32w0 && standard_metadata.instance_type != 32w5) 
                 mirror_0.apply();
             else 
@@ -3077,7 +3076,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3085,7 +3084,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3093,7 +3092,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3101,7 +3100,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3109,7 +3108,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3117,7 +3116,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3125,7 +3124,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3133,7 +3132,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3141,7 +3140,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3149,7 +3148,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3157,7 +3156,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3165,7 +3164,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3785,7 +3784,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".acl_mirror") action _acl_mirror_1(bit<32> session_id, bit<16> acl_stats_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
@@ -3841,14 +3840,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".acl_mirror") action _acl_mirror_2(bit<32> session_id, bit<16> acl_stats_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
     }
     @name(".acl_mirror") action _acl_mirror_4(bit<32> session_id, bit<16> acl_stats_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
@@ -4405,12 +4404,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
     }
     @name(".computed_two_hashes") action _computed_two_hashes_0() {
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".computed_one_hash") action _computed_one_hash_0() {
         meta.hash_metadata.hash1 = meta.hash_metadata.hash2;
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash2;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".compute_ipv4_hashes") table _compute_ipv4_hashes {
@@ -4700,7 +4697,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop();
     }
     @name(".congestion_mirror_set") action _congestion_mirror_set_0() {
-        meta.intrinsic_metadata.deflect_on_drop = 1w1;
     }
     @name(".drop_stats") table _drop_stats_1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch-midend.p4
@@ -83,17 +83,8 @@ struct int_metadata_i2e_t {
 
 struct ingress_intrinsic_metadata_t {
     bit<1>  resubmit_flag;
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
     bit<16> mcast_grp;
-    bit<1>  deflection_flag;
-    bit<1>  deflect_on_drop;
-    bit<19> enq_qdepth;
-    bit<32> enq_tstamp;
-    bit<2>  enq_congest_stat;
-    bit<19> deq_qdepth;
-    bit<2>  deq_congest_stat;
-    bit<32> deq_timedelta;
-    bit<13> mcast_hash;
     bit<16> egress_rid;
     bit<32> lf_field_list;
     bit<3>  priority;
@@ -179,6 +170,13 @@ struct qos_metadata_t {
     bit<3> marked_cos;
     bit<8> marked_dscp;
     bit<3> marked_exp;
+}
+
+struct queueing_metadata_t {
+    bit<48> enq_timestamp;
+    bit<16> enq_qdepth;
+    bit<32> deq_timedelta;
+    bit<16> deq_qdepth;
 }
 
 struct security_metadata_t {
@@ -660,99 +658,94 @@ struct metadata {
     bit<1>   _int_metadata_i2e_sink51;
     bit<1>   _int_metadata_i2e_source52;
     bit<1>   _intrinsic_metadata_resubmit_flag53;
-    bit<48>  _intrinsic_metadata_ingress_global_tstamp54;
+    bit<48>  _intrinsic_metadata_ingress_global_timestamp54;
     bit<16>  _intrinsic_metadata_mcast_grp55;
-    bit<1>   _intrinsic_metadata_deflection_flag56;
-    bit<1>   _intrinsic_metadata_deflect_on_drop57;
-    bit<19>  _intrinsic_metadata_enq_qdepth58;
-    bit<32>  _intrinsic_metadata_enq_tstamp59;
-    bit<2>   _intrinsic_metadata_enq_congest_stat60;
-    bit<19>  _intrinsic_metadata_deq_qdepth61;
-    bit<2>   _intrinsic_metadata_deq_congest_stat62;
-    bit<32>  _intrinsic_metadata_deq_timedelta63;
-    bit<13>  _intrinsic_metadata_mcast_hash64;
-    bit<16>  _intrinsic_metadata_egress_rid65;
-    bit<32>  _intrinsic_metadata_lf_field_list66;
-    bit<3>   _intrinsic_metadata_priority67;
-    bit<32>  _ipv4_metadata_lkp_ipv4_sa68;
-    bit<32>  _ipv4_metadata_lkp_ipv4_da69;
-    bit<1>   _ipv4_metadata_ipv4_unicast_enabled70;
-    bit<2>   _ipv4_metadata_ipv4_urpf_mode71;
-    bit<128> _ipv6_metadata_lkp_ipv6_sa72;
-    bit<128> _ipv6_metadata_lkp_ipv6_da73;
-    bit<1>   _ipv6_metadata_ipv6_unicast_enabled74;
-    bit<1>   _ipv6_metadata_ipv6_src_is_link_local75;
-    bit<2>   _ipv6_metadata_ipv6_urpf_mode76;
-    bit<3>   _l2_metadata_lkp_pkt_type77;
-    bit<48>  _l2_metadata_lkp_mac_sa78;
-    bit<48>  _l2_metadata_lkp_mac_da79;
-    bit<16>  _l2_metadata_lkp_mac_type80;
-    bit<16>  _l2_metadata_l2_nexthop81;
-    bit<1>   _l2_metadata_l2_nexthop_type82;
-    bit<1>   _l2_metadata_l2_redirect83;
-    bit<1>   _l2_metadata_l2_src_miss84;
-    bit<16>  _l2_metadata_l2_src_move85;
-    bit<10>  _l2_metadata_stp_group86;
-    bit<3>   _l2_metadata_stp_state87;
-    bit<16>  _l2_metadata_bd_stats_idx88;
-    bit<1>   _l2_metadata_learning_enabled89;
-    bit<1>   _l2_metadata_port_vlan_mapping_miss90;
-    bit<16>  _l2_metadata_same_if_check91;
-    bit<2>   _l3_metadata_lkp_ip_type92;
-    bit<4>   _l3_metadata_lkp_ip_version93;
-    bit<8>   _l3_metadata_lkp_ip_proto94;
-    bit<8>   _l3_metadata_lkp_ip_tc95;
-    bit<8>   _l3_metadata_lkp_ip_ttl96;
-    bit<16>  _l3_metadata_lkp_l4_sport97;
-    bit<16>  _l3_metadata_lkp_l4_dport98;
-    bit<16>  _l3_metadata_lkp_inner_l4_sport99;
-    bit<16>  _l3_metadata_lkp_inner_l4_dport100;
-    bit<12>  _l3_metadata_vrf101;
-    bit<10>  _l3_metadata_rmac_group102;
-    bit<1>   _l3_metadata_rmac_hit103;
-    bit<2>   _l3_metadata_urpf_mode104;
-    bit<1>   _l3_metadata_urpf_hit105;
-    bit<1>   _l3_metadata_urpf_check_fail106;
-    bit<16>  _l3_metadata_urpf_bd_group107;
-    bit<1>   _l3_metadata_fib_hit108;
-    bit<16>  _l3_metadata_fib_nexthop109;
-    bit<1>   _l3_metadata_fib_nexthop_type110;
-    bit<16>  _l3_metadata_same_bd_check111;
-    bit<16>  _l3_metadata_nexthop_index112;
-    bit<1>   _l3_metadata_routed113;
-    bit<1>   _l3_metadata_outer_routed114;
-    bit<8>   _l3_metadata_mtu_index115;
-    bit<16>  _l3_metadata_l3_mtu_check116;
-    bit<1>   _multicast_metadata_ip_multicast117;
-    bit<1>   _multicast_metadata_igmp_snooping_enabled118;
-    bit<1>   _multicast_metadata_mld_snooping_enabled119;
-    bit<1>   _multicast_metadata_inner_replica120;
-    bit<1>   _multicast_metadata_replica121;
-    bit<16>  _multicast_metadata_mcast_grp122;
-    bit<1>   _nexthop_metadata_nexthop_type123;
-    bit<8>   _qos_metadata_outer_dscp124;
-    bit<3>   _qos_metadata_marked_cos125;
-    bit<8>   _qos_metadata_marked_dscp126;
-    bit<3>   _qos_metadata_marked_exp127;
-    bit<1>   _security_metadata_storm_control_color128;
-    bit<1>   _security_metadata_ipsg_enabled129;
-    bit<1>   _security_metadata_ipsg_check_fail130;
-    bit<5>   _tunnel_metadata_ingress_tunnel_type131;
-    bit<24>  _tunnel_metadata_tunnel_vni132;
-    bit<1>   _tunnel_metadata_mpls_enabled133;
-    bit<20>  _tunnel_metadata_mpls_label134;
-    bit<3>   _tunnel_metadata_mpls_exp135;
-    bit<8>   _tunnel_metadata_mpls_ttl136;
-    bit<5>   _tunnel_metadata_egress_tunnel_type137;
-    bit<14>  _tunnel_metadata_tunnel_index138;
-    bit<9>   _tunnel_metadata_tunnel_src_index139;
-    bit<9>   _tunnel_metadata_tunnel_smac_index140;
-    bit<14>  _tunnel_metadata_tunnel_dst_index141;
-    bit<14>  _tunnel_metadata_tunnel_dmac_index142;
-    bit<24>  _tunnel_metadata_vnid143;
-    bit<1>   _tunnel_metadata_tunnel_terminate144;
-    bit<1>   _tunnel_metadata_tunnel_if_check145;
-    bit<4>   _tunnel_metadata_egress_header_count146;
+    bit<16>  _intrinsic_metadata_egress_rid56;
+    bit<32>  _intrinsic_metadata_lf_field_list57;
+    bit<3>   _intrinsic_metadata_priority58;
+    bit<32>  _ipv4_metadata_lkp_ipv4_sa59;
+    bit<32>  _ipv4_metadata_lkp_ipv4_da60;
+    bit<1>   _ipv4_metadata_ipv4_unicast_enabled61;
+    bit<2>   _ipv4_metadata_ipv4_urpf_mode62;
+    bit<128> _ipv6_metadata_lkp_ipv6_sa63;
+    bit<128> _ipv6_metadata_lkp_ipv6_da64;
+    bit<1>   _ipv6_metadata_ipv6_unicast_enabled65;
+    bit<1>   _ipv6_metadata_ipv6_src_is_link_local66;
+    bit<2>   _ipv6_metadata_ipv6_urpf_mode67;
+    bit<3>   _l2_metadata_lkp_pkt_type68;
+    bit<48>  _l2_metadata_lkp_mac_sa69;
+    bit<48>  _l2_metadata_lkp_mac_da70;
+    bit<16>  _l2_metadata_lkp_mac_type71;
+    bit<16>  _l2_metadata_l2_nexthop72;
+    bit<1>   _l2_metadata_l2_nexthop_type73;
+    bit<1>   _l2_metadata_l2_redirect74;
+    bit<1>   _l2_metadata_l2_src_miss75;
+    bit<16>  _l2_metadata_l2_src_move76;
+    bit<10>  _l2_metadata_stp_group77;
+    bit<3>   _l2_metadata_stp_state78;
+    bit<16>  _l2_metadata_bd_stats_idx79;
+    bit<1>   _l2_metadata_learning_enabled80;
+    bit<1>   _l2_metadata_port_vlan_mapping_miss81;
+    bit<16>  _l2_metadata_same_if_check82;
+    bit<2>   _l3_metadata_lkp_ip_type83;
+    bit<4>   _l3_metadata_lkp_ip_version84;
+    bit<8>   _l3_metadata_lkp_ip_proto85;
+    bit<8>   _l3_metadata_lkp_ip_tc86;
+    bit<8>   _l3_metadata_lkp_ip_ttl87;
+    bit<16>  _l3_metadata_lkp_l4_sport88;
+    bit<16>  _l3_metadata_lkp_l4_dport89;
+    bit<16>  _l3_metadata_lkp_inner_l4_sport90;
+    bit<16>  _l3_metadata_lkp_inner_l4_dport91;
+    bit<12>  _l3_metadata_vrf92;
+    bit<10>  _l3_metadata_rmac_group93;
+    bit<1>   _l3_metadata_rmac_hit94;
+    bit<2>   _l3_metadata_urpf_mode95;
+    bit<1>   _l3_metadata_urpf_hit96;
+    bit<1>   _l3_metadata_urpf_check_fail97;
+    bit<16>  _l3_metadata_urpf_bd_group98;
+    bit<1>   _l3_metadata_fib_hit99;
+    bit<16>  _l3_metadata_fib_nexthop100;
+    bit<1>   _l3_metadata_fib_nexthop_type101;
+    bit<16>  _l3_metadata_same_bd_check102;
+    bit<16>  _l3_metadata_nexthop_index103;
+    bit<1>   _l3_metadata_routed104;
+    bit<1>   _l3_metadata_outer_routed105;
+    bit<8>   _l3_metadata_mtu_index106;
+    bit<16>  _l3_metadata_l3_mtu_check107;
+    bit<1>   _multicast_metadata_ip_multicast108;
+    bit<1>   _multicast_metadata_igmp_snooping_enabled109;
+    bit<1>   _multicast_metadata_mld_snooping_enabled110;
+    bit<1>   _multicast_metadata_inner_replica111;
+    bit<1>   _multicast_metadata_replica112;
+    bit<16>  _multicast_metadata_mcast_grp113;
+    bit<1>   _nexthop_metadata_nexthop_type114;
+    bit<8>   _qos_metadata_outer_dscp115;
+    bit<3>   _qos_metadata_marked_cos116;
+    bit<8>   _qos_metadata_marked_dscp117;
+    bit<3>   _qos_metadata_marked_exp118;
+    bit<48>  _queueing_metadata_enq_timestamp119;
+    bit<16>  _queueing_metadata_enq_qdepth120;
+    bit<32>  _queueing_metadata_deq_timedelta121;
+    bit<16>  _queueing_metadata_deq_qdepth122;
+    bit<1>   _security_metadata_storm_control_color123;
+    bit<1>   _security_metadata_ipsg_enabled124;
+    bit<1>   _security_metadata_ipsg_check_fail125;
+    bit<5>   _tunnel_metadata_ingress_tunnel_type126;
+    bit<24>  _tunnel_metadata_tunnel_vni127;
+    bit<1>   _tunnel_metadata_mpls_enabled128;
+    bit<20>  _tunnel_metadata_mpls_label129;
+    bit<3>   _tunnel_metadata_mpls_exp130;
+    bit<8>   _tunnel_metadata_mpls_ttl131;
+    bit<5>   _tunnel_metadata_egress_tunnel_type132;
+    bit<14>  _tunnel_metadata_tunnel_index133;
+    bit<9>   _tunnel_metadata_tunnel_src_index134;
+    bit<9>   _tunnel_metadata_tunnel_smac_index135;
+    bit<14>  _tunnel_metadata_tunnel_dst_index136;
+    bit<14>  _tunnel_metadata_tunnel_dmac_index137;
+    bit<24>  _tunnel_metadata_vnid138;
+    bit<1>   _tunnel_metadata_tunnel_terminate139;
+    bit<1>   _tunnel_metadata_tunnel_if_check140;
+    bit<4>   _tunnel_metadata_egress_header_count141;
 }
 
 struct headers {
@@ -897,7 +890,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition parse_set_prio_med;
     }
     @name(".parse_eompls") state parse_eompls {
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w6;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w6;
         transition parse_inner_ethernet;
     }
     @name(".parse_erspan_t3") state parse_erspan_t3 {
@@ -906,8 +899,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_ethernet") state parse_ethernet {
         packet.extract<ethernet_t>(hdr.ethernet);
-        meta._l2_metadata_lkp_mac_sa78 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da79 = hdr.ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_sa69 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da70 = hdr.ethernet.dstAddr;
         transition select(hdr.ethernet.etherType) {
             16w0 &&& 16w0xfe00: parse_llc_header;
             16w0 &&& 16w0xfa00: parse_llc_header;
@@ -967,8 +960,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_geneve") state parse_geneve {
         packet.extract<genv_t>(hdr.genv);
-        meta._tunnel_metadata_tunnel_vni132 = hdr.genv.vni;
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w4;
+        meta._tunnel_metadata_tunnel_vni127 = hdr.genv.vni;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w4;
         transition select(hdr.genv.ver, hdr.genv.optLen, hdr.genv.protoType) {
             (2w0x0, 6w0x0, 16w0x6558): parse_inner_ethernet;
             (2w0x0, 6w0x0, 16w0x800): parse_inner_ipv4;
@@ -992,16 +985,16 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_gre_ipv4") state parse_gre_ipv4 {
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w2;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w2;
         transition parse_inner_ipv4;
     }
     @name(".parse_gre_ipv6") state parse_gre_ipv6 {
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w2;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w2;
         transition parse_inner_ipv6;
     }
     @name(".parse_icmp") state parse_icmp {
         packet.extract<icmp_t>(hdr.icmp);
-        meta._l3_metadata_lkp_l4_sport97 = hdr.icmp.typeCode;
+        meta._l3_metadata_lkp_l4_sport88 = hdr.icmp.typeCode;
         transition select(hdr.icmp.typeCode) {
             16w0x8200 &&& 16w0xfe00: parse_set_prio_med;
             16w0x8400 &&& 16w0xfc00: parse_set_prio_med;
@@ -1019,7 +1012,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_inner_icmp") state parse_inner_icmp {
         packet.extract<icmp_t>(hdr.inner_icmp);
-        meta._l3_metadata_lkp_inner_l4_sport99 = hdr.inner_icmp.typeCode;
+        meta._l3_metadata_lkp_inner_l4_sport90 = hdr.inner_icmp.typeCode;
         transition accept;
     }
     @name(".parse_inner_ipv4") state parse_inner_ipv4 {
@@ -1042,14 +1035,14 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_inner_tcp") state parse_inner_tcp {
         packet.extract<tcp_t>(hdr.inner_tcp);
-        meta._l3_metadata_lkp_inner_l4_sport99 = hdr.inner_tcp.srcPort;
-        meta._l3_metadata_lkp_inner_l4_dport100 = hdr.inner_tcp.dstPort;
+        meta._l3_metadata_lkp_inner_l4_sport90 = hdr.inner_tcp.srcPort;
+        meta._l3_metadata_lkp_inner_l4_dport91 = hdr.inner_tcp.dstPort;
         transition accept;
     }
     @name(".parse_inner_udp") state parse_inner_udp {
         packet.extract<udp_t>(hdr.inner_udp);
-        meta._l3_metadata_lkp_inner_l4_sport99 = hdr.inner_udp.srcPort;
-        meta._l3_metadata_lkp_inner_l4_dport100 = hdr.inner_udp.dstPort;
+        meta._l3_metadata_lkp_inner_l4_sport90 = hdr.inner_udp.srcPort;
+        meta._l3_metadata_lkp_inner_l4_dport91 = hdr.inner_udp.dstPort;
         transition accept;
     }
     @name(".parse_int_header") state parse_int_header {
@@ -1063,10 +1056,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_ipv4") state parse_ipv4 {
         packet.extract<ipv4_t>(hdr.ipv4);
-        meta._ipv4_metadata_lkp_ipv4_sa68 = hdr.ipv4.srcAddr;
-        meta._ipv4_metadata_lkp_ipv4_da69 = hdr.ipv4.dstAddr;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.ipv4.protocol;
-        meta._l3_metadata_lkp_ip_ttl96 = hdr.ipv4.ttl;
+        meta._ipv4_metadata_lkp_ipv4_sa59 = hdr.ipv4.srcAddr;
+        meta._ipv4_metadata_lkp_ipv4_da60 = hdr.ipv4.dstAddr;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.ipv4.protocol;
+        meta._l3_metadata_lkp_ip_ttl87 = hdr.ipv4.ttl;
         transition select(hdr.ipv4.fragOffset, hdr.ipv4.ihl, hdr.ipv4.protocol) {
             (13w0x0, 4w0x5, 8w0x1): parse_icmp;
             (13w0x0, 4w0x5, 8w0x6): parse_tcp;
@@ -1083,15 +1076,15 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_ipv4_in_ip") state parse_ipv4_in_ip {
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w3;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w3;
         transition parse_inner_ipv4;
     }
     @name(".parse_ipv6") state parse_ipv6 {
         packet.extract<ipv6_t>(hdr.ipv6);
-        meta._ipv6_metadata_lkp_ipv6_sa72 = hdr.ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da73 = hdr.ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.ipv6.nextHdr;
-        meta._l3_metadata_lkp_ip_ttl96 = hdr.ipv6.hopLimit;
+        meta._ipv6_metadata_lkp_ipv6_sa63 = hdr.ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da64 = hdr.ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.ipv6.nextHdr;
+        meta._l3_metadata_lkp_ip_ttl87 = hdr.ipv6.hopLimit;
         transition select(hdr.ipv6.nextHdr) {
             8w58: parse_icmp;
             8w6: parse_tcp;
@@ -1107,7 +1100,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_ipv6_in_ip") state parse_ipv6_in_ip {
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w3;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w3;
         transition parse_inner_ipv6;
     }
     @name(".parse_llc_header") state parse_llc_header {
@@ -1135,17 +1128,17 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_mpls_inner_ipv4") state parse_mpls_inner_ipv4 {
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w9;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w9;
         transition parse_inner_ipv4;
     }
     @name(".parse_mpls_inner_ipv6") state parse_mpls_inner_ipv6 {
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w9;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w9;
         transition parse_inner_ipv6;
     }
     @name(".parse_nvgre") state parse_nvgre {
         packet.extract<nvgre_t>(hdr.nvgre);
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w5;
-        meta._tunnel_metadata_tunnel_vni132 = hdr.nvgre.tni;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w5;
+        meta._tunnel_metadata_tunnel_vni127 = hdr.nvgre.tni;
         transition parse_inner_ethernet;
     }
     @name(".parse_qinq") state parse_qinq {
@@ -1168,11 +1161,11 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_set_prio_high") state parse_set_prio_high {
-        meta._intrinsic_metadata_priority67 = 3w5;
+        meta._intrinsic_metadata_priority58 = 3w5;
         transition accept;
     }
     @name(".parse_set_prio_med") state parse_set_prio_med {
-        meta._intrinsic_metadata_priority67 = 3w3;
+        meta._intrinsic_metadata_priority58 = 3w3;
         transition accept;
     }
     @name(".parse_snap_header") state parse_snap_header {
@@ -1191,8 +1184,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_tcp") state parse_tcp {
         packet.extract<tcp_t>(hdr.tcp);
-        meta._l3_metadata_lkp_l4_sport97 = hdr.tcp.srcPort;
-        meta._l3_metadata_lkp_l4_dport98 = hdr.tcp.dstPort;
+        meta._l3_metadata_lkp_l4_sport88 = hdr.tcp.srcPort;
+        meta._l3_metadata_lkp_l4_dport89 = hdr.tcp.dstPort;
         transition select(hdr.tcp.dstPort) {
             16w179: parse_set_prio_med;
             16w639: parse_set_prio_med;
@@ -1201,8 +1194,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_udp") state parse_udp {
         packet.extract<udp_t>(hdr.udp);
-        meta._l3_metadata_lkp_l4_sport97 = hdr.udp.srcPort;
-        meta._l3_metadata_lkp_l4_dport98 = hdr.udp.dstPort;
+        meta._l3_metadata_lkp_l4_sport88 = hdr.udp.srcPort;
+        meta._l3_metadata_lkp_l4_dport89 = hdr.udp.dstPort;
         transition select(hdr.udp.dstPort) {
             16w4789: parse_vxlan;
             16w6081: parse_geneve;
@@ -1231,14 +1224,14 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_vxlan") state parse_vxlan {
         packet.extract<vxlan_t>(hdr.vxlan);
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w1;
-        meta._tunnel_metadata_tunnel_vni132 = hdr.vxlan.vni;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w1;
+        meta._tunnel_metadata_tunnel_vni127 = hdr.vxlan.vni;
         transition parse_inner_ethernet;
     }
     @name(".parse_vxlan_gpe") state parse_vxlan_gpe {
         packet.extract<vxlan_gpe_t>(hdr.vxlan_gpe);
-        meta._tunnel_metadata_ingress_tunnel_type131 = 5w12;
-        meta._tunnel_metadata_tunnel_vni132 = hdr.vxlan_gpe.vni;
+        meta._tunnel_metadata_ingress_tunnel_type126 = 5w12;
+        meta._tunnel_metadata_tunnel_vni127 = hdr.vxlan_gpe.vni;
         transition select(hdr.vxlan_gpe.flags, hdr.vxlan_gpe.next_proto) {
             (8w0x8 &&& 8w0x8, 8w0x5 &&& 8w0xff): parse_gpe_int_header;
             default: parse_inner_ethernet;
@@ -1335,16 +1328,16 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".egress_port_type_fabric") action egress_port_type_fabric() {
         meta._egress_metadata_port_type16 = 2w1;
-        meta._tunnel_metadata_egress_tunnel_type137 = 5w15;
+        meta._tunnel_metadata_egress_tunnel_type132 = 5w15;
     }
     @name(".egress_port_type_cpu") action egress_port_type_cpu() {
         meta._egress_metadata_port_type16 = 2w2;
-        meta._tunnel_metadata_egress_tunnel_type137 = 5w16;
+        meta._tunnel_metadata_egress_tunnel_type132 = 5w16;
     }
     @name(".nop") action nop() {
     }
     @name(".set_mirror_nhop") action set_mirror_nhop(bit<16> nhop_idx) {
-        meta._l3_metadata_nexthop_index112 = nhop_idx;
+        meta._l3_metadata_nexthop_index103 = nhop_idx;
     }
     @name(".set_mirror_bd") action set_mirror_bd(bit<16> bd) {
         meta._egress_metadata_bd19 = bd;
@@ -1384,41 +1377,41 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".outer_replica_from_rid") action _outer_replica_from_rid_0(bit<16> bd, bit<14> tunnel_index, bit<5> tunnel_type) {
         meta._egress_metadata_bd19 = bd;
-        meta._multicast_metadata_replica121 = 1w1;
-        meta._multicast_metadata_inner_replica120 = 1w0;
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed113;
+        meta._multicast_metadata_replica112 = 1w1;
+        meta._multicast_metadata_inner_replica111 = 1w0;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed104;
         meta._egress_metadata_same_bd_check23 = bd ^ meta._ingress_metadata_bd40;
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type137 = tunnel_type;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
+        meta._tunnel_metadata_egress_tunnel_type132 = tunnel_type;
     }
     @name(".outer_replica_from_rid_with_nexthop") action _outer_replica_from_rid_with_nexthop_0(bit<16> bd, bit<16> nexthop_index, bit<14> tunnel_index, bit<5> tunnel_type) {
         meta._egress_metadata_bd19 = bd;
-        meta._multicast_metadata_replica121 = 1w1;
-        meta._multicast_metadata_inner_replica120 = 1w0;
-        meta._egress_metadata_routed22 = meta._l3_metadata_outer_routed114;
-        meta._l3_metadata_nexthop_index112 = nexthop_index;
+        meta._multicast_metadata_replica112 = 1w1;
+        meta._multicast_metadata_inner_replica111 = 1w0;
+        meta._egress_metadata_routed22 = meta._l3_metadata_outer_routed105;
+        meta._l3_metadata_nexthop_index103 = nexthop_index;
         meta._egress_metadata_same_bd_check23 = bd ^ meta._ingress_metadata_bd40;
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type137 = tunnel_type;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
+        meta._tunnel_metadata_egress_tunnel_type132 = tunnel_type;
     }
     @name(".inner_replica_from_rid") action _inner_replica_from_rid_0(bit<16> bd, bit<14> tunnel_index, bit<5> tunnel_type) {
         meta._egress_metadata_bd19 = bd;
-        meta._multicast_metadata_replica121 = 1w1;
-        meta._multicast_metadata_inner_replica120 = 1w1;
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed113;
+        meta._multicast_metadata_replica112 = 1w1;
+        meta._multicast_metadata_inner_replica111 = 1w1;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed104;
         meta._egress_metadata_same_bd_check23 = bd ^ meta._ingress_metadata_bd40;
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type137 = tunnel_type;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
+        meta._tunnel_metadata_egress_tunnel_type132 = tunnel_type;
     }
     @name(".inner_replica_from_rid_with_nexthop") action _inner_replica_from_rid_with_nexthop_0(bit<16> bd, bit<16> nexthop_index, bit<14> tunnel_index, bit<5> tunnel_type) {
         meta._egress_metadata_bd19 = bd;
-        meta._multicast_metadata_replica121 = 1w1;
-        meta._multicast_metadata_inner_replica120 = 1w1;
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed113;
-        meta._l3_metadata_nexthop_index112 = nexthop_index;
+        meta._multicast_metadata_replica112 = 1w1;
+        meta._multicast_metadata_inner_replica111 = 1w1;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed104;
+        meta._l3_metadata_nexthop_index103 = nexthop_index;
         meta._egress_metadata_same_bd_check23 = bd ^ meta._ingress_metadata_bd40;
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type137 = tunnel_type;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
+        meta._tunnel_metadata_egress_tunnel_type132 = tunnel_type;
     }
     @name(".replica_type") table _replica_type {
         actions = {
@@ -1427,7 +1420,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_86();
         }
         key = {
-            meta._multicast_metadata_replica121  : exact @name("multicast_metadata.replica") ;
+            meta._multicast_metadata_replica112  : exact @name("multicast_metadata.replica") ;
             meta._egress_metadata_same_bd_check23: ternary @name("egress_metadata.same_bd_check") ;
         }
         size = 512;
@@ -1443,7 +1436,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_87();
         }
         key = {
-            meta._intrinsic_metadata_egress_rid65: exact @name("intrinsic_metadata.egress_rid") ;
+            meta._intrinsic_metadata_egress_rid56: exact @name("intrinsic_metadata.egress_rid") ;
         }
         size = 1024;
         default_action = NoAction_87();
@@ -1728,7 +1721,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_90();
         }
         key = {
-            meta._tunnel_metadata_ingress_tunnel_type131: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._tunnel_metadata_ingress_tunnel_type126: exact @name("tunnel_metadata.ingress_tunnel_type") ;
             hdr.inner_ipv4.isValid()                    : exact @name("inner_ipv4.$valid$") ;
             hdr.inner_ipv6.isValid()                    : exact @name("inner_ipv6.$valid$") ;
         }
@@ -1762,8 +1755,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_metadata_routed22 = 1w0;
         meta._egress_metadata_bd19 = meta._ingress_metadata_bd40;
         meta._egress_metadata_outer_bd20 = meta._ingress_metadata_bd40;
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type137 = tunnel_type;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
+        meta._tunnel_metadata_egress_tunnel_type132 = tunnel_type;
     }
     @name(".set_l3_rewrite") action _set_l3_rewrite_0(bit<16> bd, bit<8> mtu_index, bit<9> smac_idx, bit<48> dmac) {
         meta._egress_metadata_routed22 = 1w1;
@@ -1771,7 +1764,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_metadata_mac_da21 = dmac;
         meta._egress_metadata_bd19 = bd;
         meta._egress_metadata_outer_bd20 = bd;
-        meta._l3_metadata_mtu_index115 = mtu_index;
+        meta._l3_metadata_mtu_index106 = mtu_index;
     }
     @name(".set_l3_rewrite_with_tunnel") action _set_l3_rewrite_with_tunnel_0(bit<16> bd, bit<9> smac_idx, bit<48> dmac, bit<14> tunnel_index, bit<5> tunnel_type) {
         meta._egress_metadata_routed22 = 1w1;
@@ -1779,42 +1772,42 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_metadata_mac_da21 = dmac;
         meta._egress_metadata_bd19 = bd;
         meta._egress_metadata_outer_bd20 = bd;
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type137 = tunnel_type;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
+        meta._tunnel_metadata_egress_tunnel_type132 = tunnel_type;
     }
     @name(".set_mpls_swap_push_rewrite_l2") action _set_mpls_swap_push_rewrite_l2_0(bit<20> label, bit<14> tunnel_index, bit<4> header_count) {
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed113;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed104;
         meta._egress_metadata_bd19 = meta._ingress_metadata_bd40;
         hdr.mpls[0].label = label;
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count146 = header_count;
-        meta._tunnel_metadata_egress_tunnel_type137 = 5w13;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
+        meta._tunnel_metadata_egress_header_count141 = header_count;
+        meta._tunnel_metadata_egress_tunnel_type132 = 5w13;
     }
     @name(".set_mpls_push_rewrite_l2") action _set_mpls_push_rewrite_l2_0(bit<14> tunnel_index, bit<4> header_count) {
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed113;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed104;
         meta._egress_metadata_bd19 = meta._ingress_metadata_bd40;
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count146 = header_count;
-        meta._tunnel_metadata_egress_tunnel_type137 = 5w13;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
+        meta._tunnel_metadata_egress_header_count141 = header_count;
+        meta._tunnel_metadata_egress_tunnel_type132 = 5w13;
     }
     @name(".set_mpls_swap_push_rewrite_l3") action _set_mpls_swap_push_rewrite_l3_0(bit<16> bd, bit<9> smac_idx, bit<48> dmac, bit<20> label, bit<14> tunnel_index, bit<4> header_count) {
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed113;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed104;
         meta._egress_metadata_bd19 = bd;
         hdr.mpls[0].label = label;
         meta._egress_metadata_smac_idx18 = smac_idx;
         meta._egress_metadata_mac_da21 = dmac;
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count146 = header_count;
-        meta._tunnel_metadata_egress_tunnel_type137 = 5w14;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
+        meta._tunnel_metadata_egress_header_count141 = header_count;
+        meta._tunnel_metadata_egress_tunnel_type132 = 5w14;
     }
     @name(".set_mpls_push_rewrite_l3") action _set_mpls_push_rewrite_l3_0(bit<16> bd, bit<9> smac_idx, bit<48> dmac, bit<14> tunnel_index, bit<4> header_count) {
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed113;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed104;
         meta._egress_metadata_bd19 = bd;
         meta._egress_metadata_smac_idx18 = smac_idx;
         meta._egress_metadata_mac_da21 = dmac;
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count146 = header_count;
-        meta._tunnel_metadata_egress_tunnel_type137 = 5w14;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
+        meta._tunnel_metadata_egress_header_count141 = header_count;
+        meta._tunnel_metadata_egress_tunnel_type132 = 5w14;
     }
     @name(".rewrite") table _rewrite {
         actions = {
@@ -1830,7 +1823,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_92();
         }
         key = {
-            meta._l3_metadata_nexthop_index112: exact @name("l3_metadata.nexthop_index") ;
+            meta._l3_metadata_nexthop_index103: exact @name("l3_metadata.nexthop_index") ;
         }
         size = 1024;
         default_action = NoAction_92();
@@ -1883,17 +1876,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i1") action _int_set_header_0003_i1_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._intrinsic_metadata_enq_qdepth58;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._queueing_metadata_enq_qdepth120;
     }
     @name(".int_set_header_0003_i2") action _int_set_header_0003_i2_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta63;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta121;
     }
     @name(".int_set_header_0003_i3") action _int_set_header_0003_i3_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._intrinsic_metadata_enq_qdepth58;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._queueing_metadata_enq_qdepth120;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta63;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta121;
     }
     @name(".int_set_header_0003_i4") action _int_set_header_0003_i4_0() {
         hdr.int_ingress_port_id_header.setValid();
@@ -1901,21 +1894,21 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i5") action _int_set_header_0003_i5_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._intrinsic_metadata_enq_qdepth58;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._queueing_metadata_enq_qdepth120;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta._ingress_metadata_ifindex36;
     }
     @name(".int_set_header_0003_i6") action _int_set_header_0003_i6_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta63;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta121;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta._ingress_metadata_ifindex36;
     }
     @name(".int_set_header_0003_i7") action _int_set_header_0003_i7_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._intrinsic_metadata_enq_qdepth58;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._queueing_metadata_enq_qdepth120;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta63;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta121;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta._ingress_metadata_ifindex36;
     }
@@ -1925,21 +1918,21 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i9") action _int_set_header_0003_i9_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._intrinsic_metadata_enq_qdepth58;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._queueing_metadata_enq_qdepth120;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta._int_metadata_switch_id45;
     }
     @name(".int_set_header_0003_i10") action _int_set_header_0003_i10_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta63;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta121;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta._int_metadata_switch_id45;
     }
     @name(".int_set_header_0003_i11") action _int_set_header_0003_i11_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._intrinsic_metadata_enq_qdepth58;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._queueing_metadata_enq_qdepth120;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta63;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta121;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta._int_metadata_switch_id45;
     }
@@ -1951,7 +1944,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i13") action _int_set_header_0003_i13_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._intrinsic_metadata_enq_qdepth58;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._queueing_metadata_enq_qdepth120;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta._ingress_metadata_ifindex36;
         hdr.int_switch_id_header.setValid();
@@ -1959,7 +1952,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i14") action _int_set_header_0003_i14_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta63;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta121;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta._ingress_metadata_ifindex36;
         hdr.int_switch_id_header.setValid();
@@ -1967,9 +1960,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i15") action _int_set_header_0003_i15_0() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._intrinsic_metadata_enq_qdepth58;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta._queueing_metadata_enq_qdepth120;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta63;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta121;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id = (bit<31>)meta._ingress_metadata_ifindex36;
         hdr.int_switch_id_header.setValid();
@@ -2261,7 +2254,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".nop") action _nop_42() {
     }
     @name(".set_egress_tunnel_vni") action _set_egress_tunnel_vni_0(bit<24> vnid) {
-        meta._tunnel_metadata_vnid143 = vnid;
+        meta._tunnel_metadata_vnid138 = vnid;
     }
     @name(".rewrite_tunnel_dmac") action _rewrite_tunnel_dmac_0(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
@@ -2336,7 +2329,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.udp.length_ = meta._egress_metadata_payload_length17 + 16w30;
         hdr.vxlan.flags = 8w0x8;
         hdr.vxlan.reserved = 24w0;
-        hdr.vxlan.vni = meta._tunnel_metadata_vnid143;
+        hdr.vxlan.vni = meta._tunnel_metadata_vnid138;
         hdr.vxlan.reserved2 = 8w0;
         hdr.ipv4.setValid();
         hdr.ipv4.protocol = 8w17;
@@ -2357,7 +2350,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.udp.length_ = meta._egress_metadata_payload_length17 + 16w30;
         hdr.vxlan.flags = 8w0x8;
         hdr.vxlan.reserved = 24w0;
-        hdr.vxlan.vni = meta._tunnel_metadata_vnid143;
+        hdr.vxlan.vni = meta._tunnel_metadata_vnid138;
         hdr.vxlan.reserved2 = 8w0;
         hdr.ipv6.setValid();
         hdr.ipv6.version = 4w0x6;
@@ -2381,7 +2374,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.genv.critical = 1w0;
         hdr.genv.optLen = 6w0;
         hdr.genv.protoType = 16w0x6558;
-        hdr.genv.vni = meta._tunnel_metadata_vnid143;
+        hdr.genv.vni = meta._tunnel_metadata_vnid138;
         hdr.genv.reserved = 6w0;
         hdr.genv.reserved2 = 8w0;
         hdr.ipv4.setValid();
@@ -2406,7 +2399,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.genv.critical = 1w0;
         hdr.genv.optLen = 6w0;
         hdr.genv.protoType = 16w0x6558;
-        hdr.genv.vni = meta._tunnel_metadata_vnid143;
+        hdr.genv.vni = meta._tunnel_metadata_vnid138;
         hdr.genv.reserved = 6w0;
         hdr.genv.reserved2 = 8w0;
         hdr.ipv6.setValid();
@@ -2431,7 +2424,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.gre.C = 1w0;
         hdr.gre.S = 1w0;
         hdr.gre.s = 1w0;
-        hdr.nvgre.tni = meta._tunnel_metadata_vnid143;
+        hdr.nvgre.tni = meta._tunnel_metadata_vnid138;
         hdr.nvgre.flow_id[7:0] = ((bit<8>)meta._hash_metadata_entropy_hash32)[7:0];
         hdr.ipv4.setValid();
         hdr.ipv4.protocol = 8w47;
@@ -2455,7 +2448,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.gre.C = 1w0;
         hdr.gre.S = 1w0;
         hdr.gre.s = 1w0;
-        hdr.nvgre.tni = meta._tunnel_metadata_vnid143;
+        hdr.nvgre.tni = meta._tunnel_metadata_vnid138;
         hdr.nvgre.flow_id[7:0] = ((bit<8>)meta._hash_metadata_entropy_hash32)[7:0];
         hdr.ipv6.setValid();
         hdr.ipv6.version = 4w0x6;
@@ -2620,23 +2613,23 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.etherType = 16w0x8847;
     }
     @name(".fabric_rewrite") action _fabric_rewrite_0(bit<14> tunnel_index) {
-        meta._tunnel_metadata_tunnel_index138 = tunnel_index;
+        meta._tunnel_metadata_tunnel_index133 = tunnel_index;
     }
     @name(".set_tunnel_rewrite_details") action _set_tunnel_rewrite_details_0(bit<16> outer_bd, bit<8> mtu_index, bit<9> smac_idx, bit<14> dmac_idx, bit<9> sip_index, bit<14> dip_index) {
         meta._egress_metadata_outer_bd20 = outer_bd;
-        meta._tunnel_metadata_tunnel_smac_index140 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index142 = dmac_idx;
-        meta._tunnel_metadata_tunnel_src_index139 = sip_index;
-        meta._tunnel_metadata_tunnel_dst_index141 = dip_index;
-        meta._l3_metadata_mtu_index115 = mtu_index;
+        meta._tunnel_metadata_tunnel_smac_index135 = smac_idx;
+        meta._tunnel_metadata_tunnel_dmac_index137 = dmac_idx;
+        meta._tunnel_metadata_tunnel_src_index134 = sip_index;
+        meta._tunnel_metadata_tunnel_dst_index136 = dip_index;
+        meta._l3_metadata_mtu_index106 = mtu_index;
     }
     @name(".set_mpls_rewrite_push1") action _set_mpls_rewrite_push1_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<9> smac_idx, bit<14> dmac_idx) {
         hdr.mpls[0].label = label1;
         hdr.mpls[0].exp = exp1;
         hdr.mpls[0].bos = 1w0x1;
         hdr.mpls[0].ttl = ttl1;
-        meta._tunnel_metadata_tunnel_smac_index140 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index142 = dmac_idx;
+        meta._tunnel_metadata_tunnel_smac_index135 = smac_idx;
+        meta._tunnel_metadata_tunnel_dmac_index137 = dmac_idx;
     }
     @name(".set_mpls_rewrite_push2") action _set_mpls_rewrite_push2_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<20> label2, bit<3> exp2, bit<8> ttl2, bit<9> smac_idx, bit<14> dmac_idx) {
         hdr.mpls[0].label = label1;
@@ -2647,8 +2640,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.mpls[1].exp = exp2;
         hdr.mpls[1].ttl = ttl2;
         hdr.mpls[1].bos = 1w0x1;
-        meta._tunnel_metadata_tunnel_smac_index140 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index142 = dmac_idx;
+        meta._tunnel_metadata_tunnel_smac_index135 = smac_idx;
+        meta._tunnel_metadata_tunnel_dmac_index137 = dmac_idx;
     }
     @name(".set_mpls_rewrite_push3") action _set_mpls_rewrite_push3_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<20> label2, bit<3> exp2, bit<8> ttl2, bit<20> label3, bit<3> exp3, bit<8> ttl3, bit<9> smac_idx, bit<14> dmac_idx) {
         hdr.mpls[0].label = label1;
@@ -2663,8 +2656,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.mpls[2].exp = exp3;
         hdr.mpls[2].ttl = ttl3;
         hdr.mpls[2].bos = 1w0x1;
-        meta._tunnel_metadata_tunnel_smac_index140 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index142 = dmac_idx;
+        meta._tunnel_metadata_tunnel_smac_index135 = smac_idx;
+        meta._tunnel_metadata_tunnel_dmac_index137 = dmac_idx;
     }
     @name(".cpu_rx_rewrite") action _cpu_rx_rewrite_0() {
         hdr.fabric_header.setValid();
@@ -2690,11 +2683,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.fabric_header.dstDevice = meta._fabric_metadata_dst_device28;
         hdr.fabric_header.dstPortOrGroup = meta._fabric_metadata_dst_port29;
         hdr.fabric_header_unicast.setValid();
-        hdr.fabric_header_unicast.tunnelTerminate = meta._tunnel_metadata_tunnel_terminate144;
-        hdr.fabric_header_unicast.routed = meta._l3_metadata_routed113;
-        hdr.fabric_header_unicast.outerRouted = meta._l3_metadata_outer_routed114;
-        hdr.fabric_header_unicast.ingressTunnelType = meta._tunnel_metadata_ingress_tunnel_type131;
-        hdr.fabric_header_unicast.nexthopIndex = meta._l3_metadata_nexthop_index112;
+        hdr.fabric_header_unicast.tunnelTerminate = meta._tunnel_metadata_tunnel_terminate139;
+        hdr.fabric_header_unicast.routed = meta._l3_metadata_routed104;
+        hdr.fabric_header_unicast.outerRouted = meta._l3_metadata_outer_routed105;
+        hdr.fabric_header_unicast.ingressTunnelType = meta._tunnel_metadata_ingress_tunnel_type126;
+        hdr.fabric_header_unicast.nexthopIndex = meta._l3_metadata_nexthop_index103;
         hdr.fabric_payload_header.setValid();
         hdr.fabric_payload_header.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = 16w0x9000;
@@ -2710,11 +2703,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.fabric_header_multicast.ingressIfindex = meta._ingress_metadata_ifindex36;
         hdr.fabric_header_multicast.ingressBd = meta._ingress_metadata_bd40;
         hdr.fabric_header_multicast.setValid();
-        hdr.fabric_header_multicast.tunnelTerminate = meta._tunnel_metadata_tunnel_terminate144;
-        hdr.fabric_header_multicast.routed = meta._l3_metadata_routed113;
-        hdr.fabric_header_multicast.outerRouted = meta._l3_metadata_outer_routed114;
-        hdr.fabric_header_multicast.ingressTunnelType = meta._tunnel_metadata_ingress_tunnel_type131;
-        hdr.fabric_header_multicast.mcastGrp = meta._multicast_metadata_mcast_grp122;
+        hdr.fabric_header_multicast.tunnelTerminate = meta._tunnel_metadata_tunnel_terminate139;
+        hdr.fabric_header_multicast.routed = meta._l3_metadata_routed104;
+        hdr.fabric_header_multicast.outerRouted = meta._l3_metadata_outer_routed105;
+        hdr.fabric_header_multicast.ingressTunnelType = meta._tunnel_metadata_ingress_tunnel_type126;
+        hdr.fabric_header_multicast.mcastGrp = meta._multicast_metadata_mcast_grp113;
         hdr.fabric_payload_header.setValid();
         hdr.fabric_payload_header.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = 16w0x9000;
@@ -2736,7 +2729,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         }
         key = {
             meta._egress_metadata_bd19                 : exact @name("egress_metadata.bd") ;
-            meta._tunnel_metadata_egress_tunnel_type137: exact @name("tunnel_metadata.egress_tunnel_type") ;
+            meta._tunnel_metadata_egress_tunnel_type132: exact @name("tunnel_metadata.egress_tunnel_type") ;
         }
         size = 1024;
         default_action = NoAction_101();
@@ -2748,7 +2741,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_102();
         }
         key = {
-            meta._tunnel_metadata_tunnel_dmac_index142: exact @name("tunnel_metadata.tunnel_dmac_index") ;
+            meta._tunnel_metadata_tunnel_dmac_index137: exact @name("tunnel_metadata.tunnel_dmac_index") ;
         }
         size = 1024;
         default_action = NoAction_102();
@@ -2761,7 +2754,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_103();
         }
         key = {
-            meta._tunnel_metadata_tunnel_dst_index141: exact @name("tunnel_metadata.tunnel_dst_index") ;
+            meta._tunnel_metadata_tunnel_dst_index136: exact @name("tunnel_metadata.tunnel_dst_index") ;
         }
         size = 1024;
         default_action = NoAction_103();
@@ -2816,9 +2809,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_105();
         }
         key = {
-            meta._tunnel_metadata_egress_tunnel_type137 : exact @name("tunnel_metadata.egress_tunnel_type") ;
-            meta._tunnel_metadata_egress_header_count146: exact @name("tunnel_metadata.egress_header_count") ;
-            meta._multicast_metadata_replica121         : exact @name("multicast_metadata.replica") ;
+            meta._tunnel_metadata_egress_tunnel_type132 : exact @name("tunnel_metadata.egress_tunnel_type") ;
+            meta._tunnel_metadata_egress_header_count141: exact @name("tunnel_metadata.egress_header_count") ;
+            meta._multicast_metadata_replica112         : exact @name("multicast_metadata.replica") ;
         }
         size = 1024;
         default_action = NoAction_105();
@@ -2836,7 +2829,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_106();
         }
         key = {
-            meta._tunnel_metadata_tunnel_index138: exact @name("tunnel_metadata.tunnel_index") ;
+            meta._tunnel_metadata_tunnel_index133: exact @name("tunnel_metadata.tunnel_index") ;
         }
         size = 1024;
         default_action = NoAction_106();
@@ -2848,7 +2841,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_107();
         }
         key = {
-            meta._tunnel_metadata_tunnel_smac_index140: exact @name("tunnel_metadata.tunnel_smac_index") ;
+            meta._tunnel_metadata_tunnel_smac_index135: exact @name("tunnel_metadata.tunnel_smac_index") ;
         }
         size = 1024;
         default_action = NoAction_107();
@@ -2861,7 +2854,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_108();
         }
         key = {
-            meta._tunnel_metadata_tunnel_src_index139: exact @name("tunnel_metadata.tunnel_src_index") ;
+            meta._tunnel_metadata_tunnel_src_index134: exact @name("tunnel_metadata.tunnel_src_index") ;
         }
         size = 1024;
         default_action = NoAction_108();
@@ -2883,7 +2876,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             hdr.ipv4.isValid()                         : exact @name("ipv4.$valid$") ;
             hdr.vxlan_gpe.isValid()                    : exact @name("vxlan_gpe.$valid$") ;
             meta._int_metadata_i2e_source52            : exact @name("int_metadata_i2e.source") ;
-            meta._tunnel_metadata_egress_tunnel_type137: ternary @name("tunnel_metadata.egress_tunnel_type") ;
+            meta._tunnel_metadata_egress_tunnel_type132: ternary @name("tunnel_metadata.egress_tunnel_type") ;
         }
         size = 8;
         default_action = NoAction_109();
@@ -2969,19 +2962,18 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_113();
         }
         key = {
-            standard_metadata.egress_port             : ternary @name("standard_metadata.egress_port") ;
-            meta._intrinsic_metadata_deflection_flag56: ternary @name("intrinsic_metadata.deflection_flag") ;
-            meta._l3_metadata_l3_mtu_check116         : ternary @name("l3_metadata.l3_mtu_check") ;
+            standard_metadata.egress_port    : ternary @name("standard_metadata.egress_port") ;
+            meta._l3_metadata_l3_mtu_check107: ternary @name("l3_metadata.l3_mtu_check") ;
         }
         size = 512;
         default_action = NoAction_113();
     }
     apply {
-        if (meta._intrinsic_metadata_deflection_flag56 == 1w0 && meta._egress_metadata_bypass15 == 1w0) {
+        if (meta._egress_metadata_bypass15 == 1w0) {
             if (standard_metadata.instance_type != 32w0 && standard_metadata.instance_type != 32w5) 
                 mirror_0.apply();
             else 
-                if (meta._intrinsic_metadata_egress_rid65 != 16w0) {
+                if (meta._intrinsic_metadata_egress_rid56 != 16w0) {
                     _rid.apply();
                     _replica_type.apply();
                 }
@@ -2989,8 +2981,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
                 egress_port_type_normal: {
                     if (standard_metadata.instance_type == 32w0 || standard_metadata.instance_type == 32w5) 
                         _vlan_decap.apply();
-                    if (meta._tunnel_metadata_tunnel_terminate144 == 1w1) 
-                        if (meta._multicast_metadata_inner_replica120 == 1w1 || meta._multicast_metadata_replica121 == 1w0) {
+                    if (meta._tunnel_metadata_tunnel_terminate139 == 1w1) 
+                        if (meta._multicast_metadata_inner_replica111 == 1w1 || meta._multicast_metadata_replica112 == 1w0) {
                             _tunnel_decap_process_outer.apply();
                             _tunnel_decap_process_inner.apply();
                         }
@@ -3014,9 +3006,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
                 }
             }
 
-            if (meta._fabric_metadata_fabric_header_present26 == 1w0 && meta._tunnel_metadata_egress_tunnel_type137 != 5w0) {
+            if (meta._fabric_metadata_fabric_header_present26 == 1w0 && meta._tunnel_metadata_egress_tunnel_type132 != 5w0) {
                 _egress_vni.apply();
-                if (meta._tunnel_metadata_egress_tunnel_type137 != 5w15 && meta._tunnel_metadata_egress_tunnel_type137 != 5w16) 
+                if (meta._tunnel_metadata_egress_tunnel_type132 != 5w15 && meta._tunnel_metadata_egress_tunnel_type132 != 5w16) 
                     _tunnel_encap_process_inner.apply();
                 _tunnel_encap_process_outer.apply();
                 _tunnel_rewrite.apply();
@@ -3030,8 +3022,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             if (meta._egress_metadata_port_type16 == 2w0) 
                 _egress_vlan_xlate.apply();
             _egress_lag.apply();
-            if (meta._multicast_metadata_inner_replica120 == 1w1) 
-                if (meta._tunnel_metadata_egress_tunnel_type137 != 5w0 && meta._egress_filter_metadata_inner_bd14 == 16w0 || meta._egress_filter_metadata_ifindex12 == 16w0 && meta._egress_filter_metadata_bd13 == 16w0) 
+            if (meta._multicast_metadata_inner_replica111 == 1w1) 
+                if (meta._tunnel_metadata_egress_tunnel_type132 != 5w0 && meta._egress_filter_metadata_inner_bd14 == 16w0 || meta._egress_filter_metadata_ifindex12 == 16w0 && meta._egress_filter_metadata_bd13 == 16w0) 
                     _egress_filter.apply();
         }
         _egress_acl.apply();
@@ -3202,10 +3194,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_167() {
     }
     @name(".rmac_hit") action rmac_hit_1() {
-        meta._l3_metadata_rmac_hit103 = 1w1;
+        meta._l3_metadata_rmac_hit94 = 1w1;
     }
     @name(".rmac_miss") action rmac_miss() {
-        meta._l3_metadata_rmac_hit103 = 1w0;
+        meta._l3_metadata_rmac_hit94 = 1w0;
     }
     @name(".rmac") table rmac_0 {
         actions = {
@@ -3214,8 +3206,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_114();
         }
         key = {
-            meta._l3_metadata_rmac_group102: exact @name("l3_metadata.rmac_group") ;
-            meta._l2_metadata_lkp_mac_da79 : exact @name("l2_metadata.lkp_mac_da") ;
+            meta._l3_metadata_rmac_group93: exact @name("l3_metadata.rmac_group") ;
+            meta._l2_metadata_lkp_mac_da70: exact @name("l2_metadata.lkp_mac_da") ;
         }
         size = 1024;
         default_action = NoAction_114();
@@ -3240,103 +3232,103 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._ingress_metadata_drop_flag41 = 1w1;
         meta._ingress_metadata_drop_reason42 = drop_reason;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_unicast_packet_untagged") action _set_valid_outer_unicast_packet_untagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w1;
-        meta._l2_metadata_lkp_mac_type80 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w1;
+        meta._l2_metadata_lkp_mac_type71 = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_unicast_packet_single_tagged") action _set_valid_outer_unicast_packet_single_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w1;
-        meta._l2_metadata_lkp_mac_type80 = hdr.vlan_tag_[0].etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w1;
+        meta._l2_metadata_lkp_mac_type71 = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_unicast_packet_double_tagged") action _set_valid_outer_unicast_packet_double_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w1;
-        meta._l2_metadata_lkp_mac_type80 = hdr.vlan_tag_[1].etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w1;
+        meta._l2_metadata_lkp_mac_type71 = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_unicast_packet_qinq_tagged") action _set_valid_outer_unicast_packet_qinq_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w1;
-        meta._l2_metadata_lkp_mac_type80 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w1;
+        meta._l2_metadata_lkp_mac_type71 = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_multicast_packet_untagged") action _set_valid_outer_multicast_packet_untagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w2;
-        meta._l2_metadata_lkp_mac_type80 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w2;
+        meta._l2_metadata_lkp_mac_type71 = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_multicast_packet_single_tagged") action _set_valid_outer_multicast_packet_single_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w2;
-        meta._l2_metadata_lkp_mac_type80 = hdr.vlan_tag_[0].etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w2;
+        meta._l2_metadata_lkp_mac_type71 = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_multicast_packet_double_tagged") action _set_valid_outer_multicast_packet_double_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w2;
-        meta._l2_metadata_lkp_mac_type80 = hdr.vlan_tag_[1].etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w2;
+        meta._l2_metadata_lkp_mac_type71 = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_multicast_packet_qinq_tagged") action _set_valid_outer_multicast_packet_qinq_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w2;
-        meta._l2_metadata_lkp_mac_type80 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w2;
+        meta._l2_metadata_lkp_mac_type71 = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_broadcast_packet_untagged") action _set_valid_outer_broadcast_packet_untagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w4;
-        meta._l2_metadata_lkp_mac_type80 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w4;
+        meta._l2_metadata_lkp_mac_type71 = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_broadcast_packet_single_tagged") action _set_valid_outer_broadcast_packet_single_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w4;
-        meta._l2_metadata_lkp_mac_type80 = hdr.vlan_tag_[0].etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w4;
+        meta._l2_metadata_lkp_mac_type71 = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_broadcast_packet_double_tagged") action _set_valid_outer_broadcast_packet_double_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w4;
-        meta._l2_metadata_lkp_mac_type80 = hdr.vlan_tag_[1].etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w4;
+        meta._l2_metadata_lkp_mac_type71 = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".set_valid_outer_broadcast_packet_qinq_tagged") action _set_valid_outer_broadcast_packet_qinq_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w4;
-        meta._l2_metadata_lkp_mac_type80 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type68 = 3w4;
+        meta._l2_metadata_lkp_mac_type71 = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_ingress_port35 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check91 = meta._ingress_metadata_ifindex36;
+        meta._l2_metadata_same_if_check82 = meta._ingress_metadata_ifindex36;
     }
     @name(".validate_outer_ethernet") table _validate_outer_ethernet {
         actions = {
@@ -3356,8 +3348,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_116();
         }
         key = {
-            meta._l2_metadata_lkp_mac_sa78: ternary @name("l2_metadata.lkp_mac_sa") ;
-            meta._l2_metadata_lkp_mac_da79: ternary @name("l2_metadata.lkp_mac_da") ;
+            meta._l2_metadata_lkp_mac_sa69: ternary @name("l2_metadata.lkp_mac_sa") ;
+            meta._l2_metadata_lkp_mac_da70: ternary @name("l2_metadata.lkp_mac_da") ;
             hdr.vlan_tag_[0].isValid()    : exact @name("vlan_tag_[0].$valid$") ;
             hdr.vlan_tag_[1].isValid()    : exact @name("vlan_tag_[1].$valid$") ;
         }
@@ -3365,9 +3357,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_116();
     }
     @name(".set_valid_outer_ipv4_packet") action _set_valid_outer_ipv4_packet() {
-        meta._l3_metadata_lkp_ip_type92 = 2w1;
-        meta._l3_metadata_lkp_ip_tc95 = hdr.ipv4.diffserv;
-        meta._l3_metadata_lkp_ip_version93 = 4w4;
+        meta._l3_metadata_lkp_ip_type83 = 2w1;
+        meta._l3_metadata_lkp_ip_tc86 = hdr.ipv4.diffserv;
+        meta._l3_metadata_lkp_ip_version84 = 4w4;
     }
     @name(".set_malformed_outer_ipv4_packet") action _set_malformed_outer_ipv4_packet(bit<8> drop_reason) {
         meta._ingress_metadata_drop_flag41 = 1w1;
@@ -3381,16 +3373,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             hdr.ipv4.version                        : ternary @name("ipv4.version") ;
-            meta._l3_metadata_lkp_ip_ttl96          : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta._ipv4_metadata_lkp_ipv4_sa68[31:24]: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._l3_metadata_lkp_ip_ttl87          : ternary @name("l3_metadata.lkp_ip_ttl") ;
+            meta._ipv4_metadata_lkp_ipv4_sa59[31:24]: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 512;
         default_action = NoAction_117();
     }
     @name(".set_valid_outer_ipv6_packet") action _set_valid_outer_ipv6_packet() {
-        meta._l3_metadata_lkp_ip_type92 = 2w2;
-        meta._l3_metadata_lkp_ip_tc95 = hdr.ipv6.trafficClass;
-        meta._l3_metadata_lkp_ip_version93 = 4w6;
+        meta._l3_metadata_lkp_ip_type83 = 2w2;
+        meta._l3_metadata_lkp_ip_tc86 = hdr.ipv6.trafficClass;
+        meta._l3_metadata_lkp_ip_version84 = 4w6;
     }
     @name(".set_malformed_outer_ipv6_packet") action _set_malformed_outer_ipv6_packet(bit<8> drop_reason) {
         meta._ingress_metadata_drop_flag41 = 1w1;
@@ -3404,23 +3396,23 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             hdr.ipv6.version                          : ternary @name("ipv6.version") ;
-            meta._l3_metadata_lkp_ip_ttl96            : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta._ipv6_metadata_lkp_ipv6_sa72[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._l3_metadata_lkp_ip_ttl87            : ternary @name("l3_metadata.lkp_ip_ttl") ;
+            meta._ipv6_metadata_lkp_ipv6_sa63[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_118();
     }
     @name(".set_valid_mpls_label1") action _set_valid_mpls_label1() {
-        meta._tunnel_metadata_mpls_label134 = hdr.mpls[0].label;
-        meta._tunnel_metadata_mpls_exp135 = hdr.mpls[0].exp;
+        meta._tunnel_metadata_mpls_label129 = hdr.mpls[0].label;
+        meta._tunnel_metadata_mpls_exp130 = hdr.mpls[0].exp;
     }
     @name(".set_valid_mpls_label2") action _set_valid_mpls_label2() {
-        meta._tunnel_metadata_mpls_label134 = hdr.mpls[1].label;
-        meta._tunnel_metadata_mpls_exp135 = hdr.mpls[1].exp;
+        meta._tunnel_metadata_mpls_label129 = hdr.mpls[1].label;
+        meta._tunnel_metadata_mpls_exp130 = hdr.mpls[1].exp;
     }
     @name(".set_valid_mpls_label3") action _set_valid_mpls_label3() {
-        meta._tunnel_metadata_mpls_label134 = hdr.mpls[2].label;
-        meta._tunnel_metadata_mpls_exp135 = hdr.mpls[2].exp;
+        meta._tunnel_metadata_mpls_label129 = hdr.mpls[2].label;
+        meta._tunnel_metadata_mpls_exp130 = hdr.mpls[2].exp;
     }
     @name(".validate_mpls_packet") table _validate_mpls_packet_0 {
         actions = {
@@ -3447,7 +3439,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_45() {
     }
     @name(".set_storm_control_meter") action _set_storm_control_meter_0(bit<32> meter_idx) {
-        _storm_control_meter.execute_meter<bit<1>>(meter_idx, meta._security_metadata_storm_control_color128);
+        _storm_control_meter.execute_meter<bit<1>>(meter_idx, meta._security_metadata_storm_control_color123);
     }
     @name(".storm_control") table _storm_control {
         actions = {
@@ -3457,29 +3449,29 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_ifindex36: exact @name("ingress_metadata.ifindex") ;
-            meta._l2_metadata_lkp_pkt_type77: ternary @name("l2_metadata.lkp_pkt_type") ;
+            meta._l2_metadata_lkp_pkt_type68: ternary @name("l2_metadata.lkp_pkt_type") ;
         }
         size = 512;
         default_action = NoAction_120();
     }
     @name(".set_bd") action _set_bd_0(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<16> bd_label, bit<10> stp_group, bit<16> stats_idx, bit<1> learning_enabled) {
-        meta._l3_metadata_vrf101 = vrf;
-        meta._ipv4_metadata_ipv4_unicast_enabled70 = ipv4_unicast_enabled;
-        meta._ipv6_metadata_ipv6_unicast_enabled74 = ipv6_unicast_enabled;
-        meta._ipv4_metadata_ipv4_urpf_mode71 = ipv4_urpf_mode;
-        meta._ipv6_metadata_ipv6_urpf_mode76 = ipv6_urpf_mode;
-        meta._l3_metadata_rmac_group102 = rmac_group;
+        meta._l3_metadata_vrf92 = vrf;
+        meta._ipv4_metadata_ipv4_unicast_enabled61 = ipv4_unicast_enabled;
+        meta._ipv6_metadata_ipv6_unicast_enabled65 = ipv6_unicast_enabled;
+        meta._ipv4_metadata_ipv4_urpf_mode62 = ipv4_urpf_mode;
+        meta._ipv6_metadata_ipv6_urpf_mode67 = ipv6_urpf_mode;
+        meta._l3_metadata_rmac_group93 = rmac_group;
         meta._acl_metadata_bd_label9 = bd_label;
         meta._ingress_metadata_bd40 = bd;
         meta._ingress_metadata_outer_bd39 = bd;
-        meta._l2_metadata_stp_group86 = stp_group;
-        meta._l2_metadata_bd_stats_idx88 = stats_idx;
-        meta._l2_metadata_learning_enabled89 = learning_enabled;
-        meta._multicast_metadata_igmp_snooping_enabled118 = igmp_snooping_enabled;
-        meta._multicast_metadata_mld_snooping_enabled119 = mld_snooping_enabled;
+        meta._l2_metadata_stp_group77 = stp_group;
+        meta._l2_metadata_bd_stats_idx79 = stats_idx;
+        meta._l2_metadata_learning_enabled80 = learning_enabled;
+        meta._multicast_metadata_igmp_snooping_enabled109 = igmp_snooping_enabled;
+        meta._multicast_metadata_mld_snooping_enabled110 = mld_snooping_enabled;
     }
     @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss_0() {
-        meta._l2_metadata_port_vlan_mapping_miss90 = 1w1;
+        meta._l2_metadata_port_vlan_mapping_miss81 = 1w1;
     }
     @name(".port_vlan_mapping") table _port_vlan_mapping {
         actions = {
@@ -3499,7 +3491,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_121();
     }
     @name(".set_stp_state") action _set_stp_state_0(bit<3> stp_state) {
-        meta._l2_metadata_stp_state87 = stp_state;
+        meta._l2_metadata_stp_state78 = stp_state;
     }
     @name(".spanning_tree") table _spanning_tree {
         actions = {
@@ -3508,7 +3500,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_ifindex36: exact @name("ingress_metadata.ifindex") ;
-            meta._l2_metadata_stp_group86   : exact @name("l2_metadata.stp_group") ;
+            meta._l2_metadata_stp_group77   : exact @name("l2_metadata.stp_group") ;
         }
         size = 1024;
         default_action = NoAction_122();
@@ -3516,7 +3508,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss() {
     }
     @name(".ipsg_miss") action _ipsg_miss_0() {
-        meta._security_metadata_ipsg_check_fail130 = 1w1;
+        meta._security_metadata_ipsg_check_fail125 = 1w1;
     }
     @name(".ipsg") table _ipsg {
         actions = {
@@ -3526,8 +3518,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             meta._ingress_metadata_ifindex36 : exact @name("ingress_metadata.ifindex") ;
             meta._ingress_metadata_bd40      : exact @name("ingress_metadata.bd") ;
-            meta._l2_metadata_lkp_mac_sa78   : exact @name("l2_metadata.lkp_mac_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_sa68: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._l2_metadata_lkp_mac_sa69   : exact @name("l2_metadata.lkp_mac_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_sa59: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 1024;
         default_action = NoAction_123();
@@ -3538,9 +3530,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_124();
         }
         key = {
-            meta._l3_metadata_lkp_ip_proto94 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_l4_dport98 : ternary @name("l3_metadata.lkp_l4_dport") ;
-            meta._ipv4_metadata_lkp_ipv4_da69: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_lkp_ip_proto85 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_l4_dport89 : ternary @name("l3_metadata.lkp_l4_dport") ;
+            meta._ipv4_metadata_lkp_ipv4_da60: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
         }
         size = 512;
         default_action = NoAction_124();
@@ -3548,101 +3540,101 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_0() {
     }
     @name(".outer_rmac_hit") action _outer_rmac_hit_0() {
-        meta._l3_metadata_rmac_hit103 = 1w1;
+        meta._l3_metadata_rmac_hit94 = 1w1;
     }
     @name(".nop") action _nop_46() {
     }
     @name(".terminate_tunnel_inner_non_ip") action _terminate_tunnel_inner_non_ip_0(bit<16> bd, bit<16> bd_label, bit<16> stats_idx) {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
         meta._ingress_metadata_bd40 = bd;
-        meta._l3_metadata_lkp_ip_type92 = 2w0;
-        meta._l2_metadata_lkp_mac_sa78 = hdr.inner_ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da79 = hdr.inner_ethernet.dstAddr;
-        meta._l2_metadata_lkp_mac_type80 = hdr.inner_ethernet.etherType;
+        meta._l3_metadata_lkp_ip_type83 = 2w0;
+        meta._l2_metadata_lkp_mac_sa69 = hdr.inner_ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da70 = hdr.inner_ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_type71 = hdr.inner_ethernet.etherType;
         meta._acl_metadata_bd_label9 = bd_label;
-        meta._l2_metadata_bd_stats_idx88 = stats_idx;
+        meta._l2_metadata_bd_stats_idx79 = stats_idx;
     }
     @name(".terminate_tunnel_inner_ethernet_ipv4") action _terminate_tunnel_inner_ethernet_ipv4_0(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<16> bd_label, bit<1> ipv4_unicast_enabled, bit<2> ipv4_urpf_mode, bit<1> igmp_snooping_enabled, bit<16> stats_idx) {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
         meta._ingress_metadata_bd40 = bd;
-        meta._l3_metadata_vrf101 = vrf;
-        meta._qos_metadata_outer_dscp124 = meta._l3_metadata_lkp_ip_tc95;
-        meta._l2_metadata_lkp_mac_sa78 = hdr.inner_ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da79 = hdr.inner_ethernet.dstAddr;
-        meta._l2_metadata_lkp_mac_type80 = hdr.inner_ethernet.etherType;
-        meta._l3_metadata_lkp_ip_type92 = 2w1;
-        meta._ipv4_metadata_lkp_ipv4_sa68 = hdr.inner_ipv4.srcAddr;
-        meta._ipv4_metadata_lkp_ipv4_da69 = hdr.inner_ipv4.dstAddr;
-        meta._l3_metadata_lkp_ip_version93 = hdr.inner_ipv4.version;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.inner_ipv4.protocol;
-        meta._l3_metadata_lkp_ip_ttl96 = hdr.inner_ipv4.ttl;
-        meta._l3_metadata_lkp_ip_tc95 = hdr.inner_ipv4.diffserv;
-        meta._l3_metadata_lkp_l4_sport97 = meta._l3_metadata_lkp_inner_l4_sport99;
-        meta._l3_metadata_lkp_l4_dport98 = meta._l3_metadata_lkp_inner_l4_dport100;
-        meta._ipv4_metadata_ipv4_unicast_enabled70 = ipv4_unicast_enabled;
-        meta._ipv4_metadata_ipv4_urpf_mode71 = ipv4_urpf_mode;
-        meta._l3_metadata_rmac_group102 = rmac_group;
+        meta._l3_metadata_vrf92 = vrf;
+        meta._qos_metadata_outer_dscp115 = meta._l3_metadata_lkp_ip_tc86;
+        meta._l2_metadata_lkp_mac_sa69 = hdr.inner_ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da70 = hdr.inner_ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_type71 = hdr.inner_ethernet.etherType;
+        meta._l3_metadata_lkp_ip_type83 = 2w1;
+        meta._ipv4_metadata_lkp_ipv4_sa59 = hdr.inner_ipv4.srcAddr;
+        meta._ipv4_metadata_lkp_ipv4_da60 = hdr.inner_ipv4.dstAddr;
+        meta._l3_metadata_lkp_ip_version84 = hdr.inner_ipv4.version;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.inner_ipv4.protocol;
+        meta._l3_metadata_lkp_ip_ttl87 = hdr.inner_ipv4.ttl;
+        meta._l3_metadata_lkp_ip_tc86 = hdr.inner_ipv4.diffserv;
+        meta._l3_metadata_lkp_l4_sport88 = meta._l3_metadata_lkp_inner_l4_sport90;
+        meta._l3_metadata_lkp_l4_dport89 = meta._l3_metadata_lkp_inner_l4_dport91;
+        meta._ipv4_metadata_ipv4_unicast_enabled61 = ipv4_unicast_enabled;
+        meta._ipv4_metadata_ipv4_urpf_mode62 = ipv4_urpf_mode;
+        meta._l3_metadata_rmac_group93 = rmac_group;
         meta._acl_metadata_bd_label9 = bd_label;
-        meta._l2_metadata_bd_stats_idx88 = stats_idx;
-        meta._multicast_metadata_igmp_snooping_enabled118 = igmp_snooping_enabled;
+        meta._l2_metadata_bd_stats_idx79 = stats_idx;
+        meta._multicast_metadata_igmp_snooping_enabled109 = igmp_snooping_enabled;
     }
     @name(".terminate_tunnel_inner_ipv4") action _terminate_tunnel_inner_ipv4_0(bit<12> vrf, bit<10> rmac_group, bit<2> ipv4_urpf_mode, bit<1> ipv4_unicast_enabled) {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
-        meta._l3_metadata_vrf101 = vrf;
-        meta._qos_metadata_outer_dscp124 = meta._l3_metadata_lkp_ip_tc95;
-        meta._l3_metadata_lkp_ip_type92 = 2w1;
-        meta._ipv4_metadata_lkp_ipv4_sa68 = hdr.inner_ipv4.srcAddr;
-        meta._ipv4_metadata_lkp_ipv4_da69 = hdr.inner_ipv4.dstAddr;
-        meta._l3_metadata_lkp_ip_version93 = hdr.inner_ipv4.version;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.inner_ipv4.protocol;
-        meta._l3_metadata_lkp_ip_ttl96 = hdr.inner_ipv4.ttl;
-        meta._l3_metadata_lkp_ip_tc95 = hdr.inner_ipv4.diffserv;
-        meta._l3_metadata_lkp_l4_sport97 = meta._l3_metadata_lkp_inner_l4_sport99;
-        meta._l3_metadata_lkp_l4_dport98 = meta._l3_metadata_lkp_inner_l4_dport100;
-        meta._ipv4_metadata_ipv4_unicast_enabled70 = ipv4_unicast_enabled;
-        meta._ipv4_metadata_ipv4_urpf_mode71 = ipv4_urpf_mode;
-        meta._l3_metadata_rmac_group102 = rmac_group;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
+        meta._l3_metadata_vrf92 = vrf;
+        meta._qos_metadata_outer_dscp115 = meta._l3_metadata_lkp_ip_tc86;
+        meta._l3_metadata_lkp_ip_type83 = 2w1;
+        meta._ipv4_metadata_lkp_ipv4_sa59 = hdr.inner_ipv4.srcAddr;
+        meta._ipv4_metadata_lkp_ipv4_da60 = hdr.inner_ipv4.dstAddr;
+        meta._l3_metadata_lkp_ip_version84 = hdr.inner_ipv4.version;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.inner_ipv4.protocol;
+        meta._l3_metadata_lkp_ip_ttl87 = hdr.inner_ipv4.ttl;
+        meta._l3_metadata_lkp_ip_tc86 = hdr.inner_ipv4.diffserv;
+        meta._l3_metadata_lkp_l4_sport88 = meta._l3_metadata_lkp_inner_l4_sport90;
+        meta._l3_metadata_lkp_l4_dport89 = meta._l3_metadata_lkp_inner_l4_dport91;
+        meta._ipv4_metadata_ipv4_unicast_enabled61 = ipv4_unicast_enabled;
+        meta._ipv4_metadata_ipv4_urpf_mode62 = ipv4_urpf_mode;
+        meta._l3_metadata_rmac_group93 = rmac_group;
     }
     @name(".terminate_tunnel_inner_ethernet_ipv6") action _terminate_tunnel_inner_ethernet_ipv6_0(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<16> bd_label, bit<1> ipv6_unicast_enabled, bit<2> ipv6_urpf_mode, bit<1> mld_snooping_enabled, bit<16> stats_idx) {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
         meta._ingress_metadata_bd40 = bd;
-        meta._l3_metadata_vrf101 = vrf;
-        meta._qos_metadata_outer_dscp124 = meta._l3_metadata_lkp_ip_tc95;
-        meta._l2_metadata_lkp_mac_sa78 = hdr.inner_ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da79 = hdr.inner_ethernet.dstAddr;
-        meta._l2_metadata_lkp_mac_type80 = hdr.inner_ethernet.etherType;
-        meta._l3_metadata_lkp_ip_type92 = 2w2;
-        meta._ipv6_metadata_lkp_ipv6_sa72 = hdr.inner_ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da73 = hdr.inner_ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_version93 = hdr.inner_ipv6.version;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.inner_ipv6.nextHdr;
-        meta._l3_metadata_lkp_ip_ttl96 = hdr.inner_ipv6.hopLimit;
-        meta._l3_metadata_lkp_ip_tc95 = hdr.inner_ipv6.trafficClass;
-        meta._l3_metadata_lkp_l4_sport97 = meta._l3_metadata_lkp_inner_l4_sport99;
-        meta._l3_metadata_lkp_l4_dport98 = meta._l3_metadata_lkp_inner_l4_dport100;
-        meta._ipv6_metadata_ipv6_unicast_enabled74 = ipv6_unicast_enabled;
-        meta._ipv6_metadata_ipv6_urpf_mode76 = ipv6_urpf_mode;
-        meta._l3_metadata_rmac_group102 = rmac_group;
+        meta._l3_metadata_vrf92 = vrf;
+        meta._qos_metadata_outer_dscp115 = meta._l3_metadata_lkp_ip_tc86;
+        meta._l2_metadata_lkp_mac_sa69 = hdr.inner_ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da70 = hdr.inner_ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_type71 = hdr.inner_ethernet.etherType;
+        meta._l3_metadata_lkp_ip_type83 = 2w2;
+        meta._ipv6_metadata_lkp_ipv6_sa63 = hdr.inner_ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da64 = hdr.inner_ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_version84 = hdr.inner_ipv6.version;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.inner_ipv6.nextHdr;
+        meta._l3_metadata_lkp_ip_ttl87 = hdr.inner_ipv6.hopLimit;
+        meta._l3_metadata_lkp_ip_tc86 = hdr.inner_ipv6.trafficClass;
+        meta._l3_metadata_lkp_l4_sport88 = meta._l3_metadata_lkp_inner_l4_sport90;
+        meta._l3_metadata_lkp_l4_dport89 = meta._l3_metadata_lkp_inner_l4_dport91;
+        meta._ipv6_metadata_ipv6_unicast_enabled65 = ipv6_unicast_enabled;
+        meta._ipv6_metadata_ipv6_urpf_mode67 = ipv6_urpf_mode;
+        meta._l3_metadata_rmac_group93 = rmac_group;
         meta._acl_metadata_bd_label9 = bd_label;
-        meta._l2_metadata_bd_stats_idx88 = stats_idx;
-        meta._multicast_metadata_mld_snooping_enabled119 = mld_snooping_enabled;
+        meta._l2_metadata_bd_stats_idx79 = stats_idx;
+        meta._multicast_metadata_mld_snooping_enabled110 = mld_snooping_enabled;
     }
     @name(".terminate_tunnel_inner_ipv6") action _terminate_tunnel_inner_ipv6_0(bit<12> vrf, bit<10> rmac_group, bit<1> ipv6_unicast_enabled, bit<2> ipv6_urpf_mode) {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
-        meta._l3_metadata_vrf101 = vrf;
-        meta._qos_metadata_outer_dscp124 = meta._l3_metadata_lkp_ip_tc95;
-        meta._l3_metadata_lkp_ip_type92 = 2w2;
-        meta._ipv6_metadata_lkp_ipv6_sa72 = hdr.inner_ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da73 = hdr.inner_ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_version93 = hdr.inner_ipv6.version;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.inner_ipv6.nextHdr;
-        meta._l3_metadata_lkp_ip_ttl96 = hdr.inner_ipv6.hopLimit;
-        meta._l3_metadata_lkp_ip_tc95 = hdr.inner_ipv6.trafficClass;
-        meta._l3_metadata_lkp_l4_sport97 = meta._l3_metadata_lkp_inner_l4_sport99;
-        meta._l3_metadata_lkp_l4_dport98 = meta._l3_metadata_lkp_inner_l4_dport100;
-        meta._ipv6_metadata_ipv6_unicast_enabled74 = ipv6_unicast_enabled;
-        meta._ipv6_metadata_ipv6_urpf_mode76 = ipv6_urpf_mode;
-        meta._l3_metadata_rmac_group102 = rmac_group;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
+        meta._l3_metadata_vrf92 = vrf;
+        meta._qos_metadata_outer_dscp115 = meta._l3_metadata_lkp_ip_tc86;
+        meta._l3_metadata_lkp_ip_type83 = 2w2;
+        meta._ipv6_metadata_lkp_ipv6_sa63 = hdr.inner_ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da64 = hdr.inner_ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_version84 = hdr.inner_ipv6.version;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.inner_ipv6.nextHdr;
+        meta._l3_metadata_lkp_ip_ttl87 = hdr.inner_ipv6.hopLimit;
+        meta._l3_metadata_lkp_ip_tc86 = hdr.inner_ipv6.trafficClass;
+        meta._l3_metadata_lkp_l4_sport88 = meta._l3_metadata_lkp_inner_l4_sport90;
+        meta._l3_metadata_lkp_l4_dport89 = meta._l3_metadata_lkp_inner_l4_dport91;
+        meta._ipv6_metadata_ipv6_unicast_enabled65 = ipv6_unicast_enabled;
+        meta._ipv6_metadata_ipv6_urpf_mode67 = ipv6_urpf_mode;
+        meta._l3_metadata_rmac_group93 = rmac_group;
     }
     @name(".outer_rmac") table _outer_rmac {
         actions = {
@@ -3651,8 +3643,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_125();
         }
         key = {
-            meta._l3_metadata_rmac_group102: exact @name("l3_metadata.rmac_group") ;
-            meta._l2_metadata_lkp_mac_da79 : exact @name("l2_metadata.lkp_mac_da") ;
+            meta._l3_metadata_rmac_group93: exact @name("l3_metadata.rmac_group") ;
+            meta._l2_metadata_lkp_mac_da70: exact @name("l2_metadata.lkp_mac_da") ;
         }
         size = 1024;
         default_action = NoAction_125();
@@ -3668,8 +3660,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_126();
         }
         key = {
-            meta._tunnel_metadata_tunnel_vni132         : exact @name("tunnel_metadata.tunnel_vni") ;
-            meta._tunnel_metadata_ingress_tunnel_type131: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._tunnel_metadata_tunnel_vni127         : exact @name("tunnel_metadata.tunnel_vni") ;
+            meta._tunnel_metadata_ingress_tunnel_type126: exact @name("tunnel_metadata.ingress_tunnel_type") ;
             hdr.inner_ipv4.isValid()                    : exact @name("inner_ipv4.$valid$") ;
             hdr.inner_ipv6.isValid()                    : exact @name("inner_ipv6.$valid$") ;
         }
@@ -3679,7 +3671,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_47() {
     }
     @name(".set_tunnel_termination_flag") action _set_tunnel_termination_flag() {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
     }
     @name(".on_miss") action _on_miss_9() {
     }
@@ -3693,9 +3685,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_127();
         }
         key = {
-            meta._l3_metadata_vrf101                    : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_da69           : exact @name("ipv4_metadata.lkp_ipv4_da") ;
-            meta._tunnel_metadata_ingress_tunnel_type131: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._l3_metadata_vrf92                     : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_da60           : exact @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._tunnel_metadata_ingress_tunnel_type126: exact @name("tunnel_metadata.ingress_tunnel_type") ;
         }
         size = 1024;
         default_action = NoAction_127();
@@ -3707,8 +3699,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_128();
         }
         key = {
-            meta._l3_metadata_vrf101         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_sa68: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._l3_metadata_vrf92          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_sa59: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 1024;
         default_action = NoAction_128();
@@ -3716,7 +3708,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_48() {
     }
     @name(".set_tunnel_termination_flag") action _set_tunnel_termination_flag_0() {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
     }
     @name(".on_miss") action _on_miss_10() {
     }
@@ -3730,9 +3722,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_129();
         }
         key = {
-            meta._l3_metadata_vrf101                    : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_da73           : exact @name("ipv6_metadata.lkp_ipv6_da") ;
-            meta._tunnel_metadata_ingress_tunnel_type131: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._l3_metadata_vrf92                     : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_da64           : exact @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._tunnel_metadata_ingress_tunnel_type126: exact @name("tunnel_metadata.ingress_tunnel_type") ;
         }
         size = 1024;
         default_action = NoAction_129();
@@ -3744,63 +3736,63 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_130();
         }
         key = {
-            meta._l3_metadata_vrf101         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_sa72: exact @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._l3_metadata_vrf92          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_sa63: exact @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 1024;
         default_action = NoAction_130();
     }
     @name(".terminate_eompls") action _terminate_eompls(bit<16> bd, bit<5> tunnel_type) {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type131 = tunnel_type;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
+        meta._tunnel_metadata_ingress_tunnel_type126 = tunnel_type;
         meta._ingress_metadata_bd40 = bd;
-        meta._l2_metadata_lkp_mac_sa78 = hdr.inner_ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da79 = hdr.inner_ethernet.dstAddr;
-        meta._l2_metadata_lkp_mac_type80 = hdr.inner_ethernet.etherType;
+        meta._l2_metadata_lkp_mac_sa69 = hdr.inner_ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da70 = hdr.inner_ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_type71 = hdr.inner_ethernet.etherType;
     }
     @name(".terminate_vpls") action _terminate_vpls(bit<16> bd, bit<5> tunnel_type) {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type131 = tunnel_type;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
+        meta._tunnel_metadata_ingress_tunnel_type126 = tunnel_type;
         meta._ingress_metadata_bd40 = bd;
-        meta._l2_metadata_lkp_mac_sa78 = hdr.inner_ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da79 = hdr.inner_ethernet.dstAddr;
-        meta._l2_metadata_lkp_mac_type80 = hdr.inner_ethernet.etherType;
+        meta._l2_metadata_lkp_mac_sa69 = hdr.inner_ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da70 = hdr.inner_ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_type71 = hdr.inner_ethernet.etherType;
     }
     @name(".terminate_ipv4_over_mpls") action _terminate_ipv4_over_mpls(bit<12> vrf, bit<5> tunnel_type) {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type131 = tunnel_type;
-        meta._l3_metadata_vrf101 = vrf;
-        meta._l3_metadata_lkp_ip_type92 = 2w1;
-        meta._ipv4_metadata_lkp_ipv4_sa68 = hdr.inner_ipv4.srcAddr;
-        meta._ipv4_metadata_lkp_ipv4_da69 = hdr.inner_ipv4.dstAddr;
-        meta._l3_metadata_lkp_ip_version93 = hdr.inner_ipv4.version;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.inner_ipv4.protocol;
-        meta._l3_metadata_lkp_ip_tc95 = hdr.inner_ipv4.diffserv;
-        meta._l3_metadata_lkp_ip_ttl96 = hdr.inner_ipv4.ttl;
-        meta._l3_metadata_lkp_l4_sport97 = meta._l3_metadata_lkp_inner_l4_sport99;
-        meta._l3_metadata_lkp_l4_dport98 = meta._l3_metadata_lkp_inner_l4_dport100;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
+        meta._tunnel_metadata_ingress_tunnel_type126 = tunnel_type;
+        meta._l3_metadata_vrf92 = vrf;
+        meta._l3_metadata_lkp_ip_type83 = 2w1;
+        meta._ipv4_metadata_lkp_ipv4_sa59 = hdr.inner_ipv4.srcAddr;
+        meta._ipv4_metadata_lkp_ipv4_da60 = hdr.inner_ipv4.dstAddr;
+        meta._l3_metadata_lkp_ip_version84 = hdr.inner_ipv4.version;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.inner_ipv4.protocol;
+        meta._l3_metadata_lkp_ip_tc86 = hdr.inner_ipv4.diffserv;
+        meta._l3_metadata_lkp_ip_ttl87 = hdr.inner_ipv4.ttl;
+        meta._l3_metadata_lkp_l4_sport88 = meta._l3_metadata_lkp_inner_l4_sport90;
+        meta._l3_metadata_lkp_l4_dport89 = meta._l3_metadata_lkp_inner_l4_dport91;
     }
     @name(".terminate_ipv6_over_mpls") action _terminate_ipv6_over_mpls(bit<12> vrf, bit<5> tunnel_type) {
-        meta._tunnel_metadata_tunnel_terminate144 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type131 = tunnel_type;
-        meta._l3_metadata_vrf101 = vrf;
-        meta._l3_metadata_lkp_ip_type92 = 2w2;
-        meta._ipv6_metadata_lkp_ipv6_sa72 = hdr.inner_ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da73 = hdr.inner_ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_version93 = hdr.inner_ipv6.version;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.inner_ipv6.nextHdr;
-        meta._l3_metadata_lkp_ip_tc95 = hdr.inner_ipv6.trafficClass;
-        meta._l3_metadata_lkp_ip_ttl96 = hdr.inner_ipv6.hopLimit;
-        meta._l3_metadata_lkp_l4_sport97 = meta._l3_metadata_lkp_inner_l4_sport99;
-        meta._l3_metadata_lkp_l4_dport98 = meta._l3_metadata_lkp_inner_l4_dport100;
+        meta._tunnel_metadata_tunnel_terminate139 = 1w1;
+        meta._tunnel_metadata_ingress_tunnel_type126 = tunnel_type;
+        meta._l3_metadata_vrf92 = vrf;
+        meta._l3_metadata_lkp_ip_type83 = 2w2;
+        meta._ipv6_metadata_lkp_ipv6_sa63 = hdr.inner_ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da64 = hdr.inner_ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_version84 = hdr.inner_ipv6.version;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.inner_ipv6.nextHdr;
+        meta._l3_metadata_lkp_ip_tc86 = hdr.inner_ipv6.trafficClass;
+        meta._l3_metadata_lkp_ip_ttl87 = hdr.inner_ipv6.hopLimit;
+        meta._l3_metadata_lkp_l4_sport88 = meta._l3_metadata_lkp_inner_l4_sport90;
+        meta._l3_metadata_lkp_l4_dport89 = meta._l3_metadata_lkp_inner_l4_dport91;
     }
     @name(".terminate_pw") action _terminate_pw(bit<16> ifindex) {
         meta._ingress_metadata_egress_ifindex37 = ifindex;
     }
     @name(".forward_mpls") action _forward_mpls(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_nexthop109 = nexthop_index;
-        meta._l3_metadata_fib_nexthop_type110 = 1w0;
-        meta._l3_metadata_fib_hit108 = 1w1;
+        meta._l3_metadata_fib_nexthop100 = nexthop_index;
+        meta._l3_metadata_fib_nexthop_type101 = 1w0;
+        meta._l3_metadata_fib_hit99 = 1w1;
     }
     @name(".mpls") table _mpls_0 {
         actions = {
@@ -3813,7 +3805,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_131();
         }
         key = {
-            meta._tunnel_metadata_mpls_label134: exact @name("tunnel_metadata.mpls_label") ;
+            meta._tunnel_metadata_mpls_label129: exact @name("tunnel_metadata.mpls_label") ;
             hdr.inner_ipv4.isValid()           : exact @name("inner_ipv4.$valid$") ;
             hdr.inner_ipv6.isValid()           : exact @name("inner_ipv6.$valid$") ;
         }
@@ -3823,24 +3815,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_49() {
     }
     @name(".set_unicast") action _set_unicast_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w1;
+        meta._l2_metadata_lkp_pkt_type68 = 3w1;
     }
     @name(".set_unicast_and_ipv6_src_is_link_local") action _set_unicast_and_ipv6_src_is_link_local_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w1;
-        meta._ipv6_metadata_ipv6_src_is_link_local75 = 1w1;
+        meta._l2_metadata_lkp_pkt_type68 = 3w1;
+        meta._ipv6_metadata_ipv6_src_is_link_local66 = 1w1;
     }
     @name(".set_multicast") action _set_multicast_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w2;
-        meta._l2_metadata_bd_stats_idx88 = meta._l2_metadata_bd_stats_idx88 + 16w1;
+        meta._l2_metadata_lkp_pkt_type68 = 3w2;
+        meta._l2_metadata_bd_stats_idx79 = meta._l2_metadata_bd_stats_idx79 + 16w1;
     }
     @name(".set_multicast_and_ipv6_src_is_link_local") action _set_multicast_and_ipv6_src_is_link_local_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w2;
-        meta._ipv6_metadata_ipv6_src_is_link_local75 = 1w1;
-        meta._l2_metadata_bd_stats_idx88 = meta._l2_metadata_bd_stats_idx88 + 16w1;
+        meta._l2_metadata_lkp_pkt_type68 = 3w2;
+        meta._ipv6_metadata_ipv6_src_is_link_local66 = 1w1;
+        meta._l2_metadata_bd_stats_idx79 = meta._l2_metadata_bd_stats_idx79 + 16w1;
     }
     @name(".set_broadcast") action _set_broadcast_0() {
-        meta._l2_metadata_lkp_pkt_type77 = 3w4;
-        meta._l2_metadata_bd_stats_idx88 = meta._l2_metadata_bd_stats_idx88 + 16w2;
+        meta._l2_metadata_lkp_pkt_type68 = 3w4;
+        meta._l2_metadata_bd_stats_idx79 = meta._l2_metadata_bd_stats_idx79 + 16w2;
     }
     @name(".set_malformed_packet") action _set_malformed_packet_0(bit<8> drop_reason) {
         meta._ingress_metadata_drop_flag41 = 1w1;
@@ -3858,13 +3850,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_132();
         }
         key = {
-            meta._l2_metadata_lkp_mac_sa78[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
-            meta._l2_metadata_lkp_mac_da79            : ternary @name("l2_metadata.lkp_mac_da") ;
-            meta._l3_metadata_lkp_ip_type92           : ternary @name("l3_metadata.lkp_ip_type") ;
-            meta._l3_metadata_lkp_ip_ttl96            : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta._l3_metadata_lkp_ip_version93        : ternary @name("l3_metadata.lkp_ip_version") ;
-            meta._ipv4_metadata_lkp_ipv4_sa68[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv6_metadata_lkp_ipv6_sa72[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._l2_metadata_lkp_mac_sa69[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
+            meta._l2_metadata_lkp_mac_da70            : ternary @name("l2_metadata.lkp_mac_da") ;
+            meta._l3_metadata_lkp_ip_type83           : ternary @name("l3_metadata.lkp_ip_type") ;
+            meta._l3_metadata_lkp_ip_ttl87            : ternary @name("l3_metadata.lkp_ip_ttl") ;
+            meta._l3_metadata_lkp_ip_version84        : ternary @name("l3_metadata.lkp_ip_version") ;
+            meta._ipv4_metadata_lkp_ipv4_sa59[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv6_metadata_lkp_ipv6_sa63[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_132();
@@ -3875,7 +3867,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".dmac_hit") action _dmac_hit_0(bit<16> ifindex) {
         meta._ingress_metadata_egress_ifindex37 = ifindex;
-        meta._l2_metadata_same_if_check91 = meta._l2_metadata_same_if_check91 ^ ifindex;
+        meta._l2_metadata_same_if_check82 = meta._l2_metadata_same_if_check82 ^ ifindex;
     }
     @name(".dmac_multicast_hit") action _dmac_multicast_hit_0(bit<16> mc_index) {
         meta._intrinsic_metadata_mcast_grp55 = mc_index;
@@ -3886,23 +3878,23 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._fabric_metadata_dst_device28 = 8w127;
     }
     @name(".dmac_redirect_nexthop") action _dmac_redirect_nexthop_0(bit<16> nexthop_index) {
-        meta._l2_metadata_l2_redirect83 = 1w1;
-        meta._l2_metadata_l2_nexthop81 = nexthop_index;
-        meta._l2_metadata_l2_nexthop_type82 = 1w0;
+        meta._l2_metadata_l2_redirect74 = 1w1;
+        meta._l2_metadata_l2_nexthop72 = nexthop_index;
+        meta._l2_metadata_l2_nexthop_type73 = 1w0;
     }
     @name(".dmac_redirect_ecmp") action _dmac_redirect_ecmp_0(bit<16> ecmp_index) {
-        meta._l2_metadata_l2_redirect83 = 1w1;
-        meta._l2_metadata_l2_nexthop81 = ecmp_index;
-        meta._l2_metadata_l2_nexthop_type82 = 1w1;
+        meta._l2_metadata_l2_redirect74 = 1w1;
+        meta._l2_metadata_l2_nexthop72 = ecmp_index;
+        meta._l2_metadata_l2_nexthop_type73 = 1w1;
     }
     @name(".dmac_drop") action _dmac_drop_0() {
         mark_to_drop();
     }
     @name(".smac_miss") action _smac_miss_0() {
-        meta._l2_metadata_l2_src_miss84 = 1w1;
+        meta._l2_metadata_l2_src_miss75 = 1w1;
     }
     @name(".smac_hit") action _smac_hit_0(bit<16> ifindex) {
-        meta._l2_metadata_l2_src_move85 = meta._ingress_metadata_ifindex36 ^ ifindex;
+        meta._l2_metadata_l2_src_move76 = meta._ingress_metadata_ifindex36 ^ ifindex;
     }
     @name(".dmac") table _dmac {
         support_timeout = true;
@@ -3918,7 +3910,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_bd40   : exact @name("ingress_metadata.bd") ;
-            meta._l2_metadata_lkp_mac_da79: exact @name("l2_metadata.lkp_mac_da") ;
+            meta._l2_metadata_lkp_mac_da70: exact @name("l2_metadata.lkp_mac_da") ;
         }
         size = 1024;
         default_action = NoAction_133();
@@ -3932,7 +3924,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_bd40   : exact @name("ingress_metadata.bd") ;
-            meta._l2_metadata_lkp_mac_sa78: exact @name("l2_metadata.lkp_mac_sa") ;
+            meta._l2_metadata_lkp_mac_sa69: exact @name("l2_metadata.lkp_mac_sa") ;
         }
         size = 1024;
         default_action = NoAction_134();
@@ -3954,9 +3946,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".acl_mirror") action _acl_mirror_1(bit<32> session_id, bit<16> acl_stats_index) {
         meta._i2e_metadata_mirror_session_id34 = (bit<16>)session_id;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_enable_dod44 = 1w0;
-        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54, (bit<16>)session_id });
+        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54, (bit<16>)session_id });
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
     }
     @name(".mac_acl") table _mac_acl {
@@ -3971,9 +3963,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             meta._acl_metadata_if_label8    : ternary @name("acl_metadata.if_label") ;
             meta._acl_metadata_bd_label9    : ternary @name("acl_metadata.bd_label") ;
-            meta._l2_metadata_lkp_mac_sa78  : ternary @name("l2_metadata.lkp_mac_sa") ;
-            meta._l2_metadata_lkp_mac_da79  : ternary @name("l2_metadata.lkp_mac_da") ;
-            meta._l2_metadata_lkp_mac_type80: ternary @name("l2_metadata.lkp_mac_type") ;
+            meta._l2_metadata_lkp_mac_sa69  : ternary @name("l2_metadata.lkp_mac_sa") ;
+            meta._l2_metadata_lkp_mac_da70  : ternary @name("l2_metadata.lkp_mac_da") ;
+            meta._l2_metadata_lkp_mac_type71: ternary @name("l2_metadata.lkp_mac_type") ;
         }
         size = 512;
         default_action = NoAction_135();
@@ -4010,16 +4002,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".acl_mirror") action _acl_mirror_2(bit<32> session_id, bit<16> acl_stats_index) {
         meta._i2e_metadata_mirror_session_id34 = (bit<16>)session_id;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_enable_dod44 = 1w0;
-        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54, (bit<16>)session_id });
+        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54, (bit<16>)session_id });
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
     }
     @name(".acl_mirror") action _acl_mirror_4(bit<32> session_id, bit<16> acl_stats_index) {
         meta._i2e_metadata_mirror_session_id34 = (bit<16>)session_id;
-        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54;
+        meta._i2e_metadata_ingress_tstamp33 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54;
         meta._ingress_metadata_enable_dod44 = 1w0;
-        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp54, (bit<16>)session_id });
+        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp54, (bit<16>)session_id });
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
     }
     @name(".acl_dod_en") action _acl_dod_en_0() {
@@ -4068,13 +4060,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             meta._acl_metadata_if_label8     : ternary @name("acl_metadata.if_label") ;
             meta._acl_metadata_bd_label9     : ternary @name("acl_metadata.bd_label") ;
-            meta._ipv4_metadata_lkp_ipv4_sa68: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_da69: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
-            meta._l3_metadata_lkp_ip_proto94 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_l4_sport97 : ternary @name("l3_metadata.lkp_l4_sport") ;
-            meta._l3_metadata_lkp_l4_dport98 : ternary @name("l3_metadata.lkp_l4_dport") ;
+            meta._ipv4_metadata_lkp_ipv4_sa59: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da60: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_lkp_ip_proto85 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_l4_sport88 : ternary @name("l3_metadata.lkp_l4_sport") ;
+            meta._l3_metadata_lkp_l4_dport89 : ternary @name("l3_metadata.lkp_l4_dport") ;
             hdr.tcp.flags                    : ternary @name("tcp.flags") ;
-            meta._l3_metadata_lkp_ip_ttl96   : ternary @name("l3_metadata.lkp_ip_ttl") ;
+            meta._l3_metadata_lkp_ip_ttl87   : ternary @name("l3_metadata.lkp_ip_ttl") ;
         }
         size = 512;
         default_action = NoAction_136();
@@ -4093,13 +4085,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             meta._acl_metadata_if_label8     : ternary @name("acl_metadata.if_label") ;
             meta._acl_metadata_bd_label9     : ternary @name("acl_metadata.bd_label") ;
-            meta._ipv6_metadata_lkp_ipv6_sa72: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
-            meta._ipv6_metadata_lkp_ipv6_da73: ternary @name("ipv6_metadata.lkp_ipv6_da") ;
-            meta._l3_metadata_lkp_ip_proto94 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_l4_sport97 : ternary @name("l3_metadata.lkp_l4_sport") ;
-            meta._l3_metadata_lkp_l4_dport98 : ternary @name("l3_metadata.lkp_l4_dport") ;
+            meta._ipv6_metadata_lkp_ipv6_sa63: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._ipv6_metadata_lkp_ipv6_da64: ternary @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._l3_metadata_lkp_ip_proto85 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_l4_sport88 : ternary @name("l3_metadata.lkp_l4_sport") ;
+            meta._l3_metadata_lkp_l4_dport89 : ternary @name("l3_metadata.lkp_l4_dport") ;
             hdr.tcp.flags                    : ternary @name("tcp.flags") ;
-            meta._l3_metadata_lkp_ip_ttl96   : ternary @name("l3_metadata.lkp_ip_ttl") ;
+            meta._l3_metadata_lkp_ip_ttl87   : ternary @name("l3_metadata.lkp_ip_ttl") ;
         }
         size = 512;
         default_action = NoAction_137();
@@ -4107,13 +4099,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_68() {
     }
     @name(".apply_cos_marking") action _apply_cos_marking_0(bit<3> cos) {
-        meta._qos_metadata_marked_cos125 = cos;
+        meta._qos_metadata_marked_cos116 = cos;
     }
     @name(".apply_dscp_marking") action _apply_dscp_marking_0(bit<8> dscp) {
-        meta._qos_metadata_marked_dscp126 = dscp;
+        meta._qos_metadata_marked_dscp117 = dscp;
     }
     @name(".apply_tc_marking") action _apply_tc_marking_0(bit<3> tc) {
-        meta._qos_metadata_marked_exp127 = tc;
+        meta._qos_metadata_marked_exp118 = tc;
     }
     @name(".qos") table _qos {
         actions = {
@@ -4125,12 +4117,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._acl_metadata_if_label8     : ternary @name("acl_metadata.if_label") ;
-            meta._ipv4_metadata_lkp_ipv4_sa68: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_da69: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
-            meta._l3_metadata_lkp_ip_proto94 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_ip_tc95    : ternary @name("l3_metadata.lkp_ip_tc") ;
-            meta._tunnel_metadata_mpls_exp135: ternary @name("tunnel_metadata.mpls_exp") ;
-            meta._qos_metadata_outer_dscp124 : ternary @name("qos_metadata.outer_dscp") ;
+            meta._ipv4_metadata_lkp_ipv4_sa59: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da60: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_lkp_ip_proto85 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_ip_tc86    : ternary @name("l3_metadata.lkp_ip_tc") ;
+            meta._tunnel_metadata_mpls_exp130: ternary @name("tunnel_metadata.mpls_exp") ;
+            meta._qos_metadata_outer_dscp115 : ternary @name("qos_metadata.outer_dscp") ;
         }
         size = 512;
         default_action = NoAction_138();
@@ -4171,11 +4163,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._acl_metadata_bd_label9     : ternary @name("acl_metadata.bd_label") ;
-            meta._ipv4_metadata_lkp_ipv4_sa68: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_da69: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
-            meta._l3_metadata_lkp_ip_proto94 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_l4_sport97 : ternary @name("l3_metadata.lkp_l4_sport") ;
-            meta._l3_metadata_lkp_l4_dport98 : ternary @name("l3_metadata.lkp_l4_dport") ;
+            meta._ipv4_metadata_lkp_ipv4_sa59: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da60: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_lkp_ip_proto85 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_l4_sport88 : ternary @name("l3_metadata.lkp_l4_sport") ;
+            meta._l3_metadata_lkp_l4_dport89 : ternary @name("l3_metadata.lkp_l4_dport") ;
         }
         size = 512;
         default_action = NoAction_139();
@@ -4183,17 +4175,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_11() {
     }
     @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_0(bit<16> urpf_bd_group) {
-        meta._l3_metadata_urpf_hit105 = 1w1;
-        meta._l3_metadata_urpf_bd_group107 = urpf_bd_group;
-        meta._l3_metadata_urpf_mode104 = meta._ipv4_metadata_ipv4_urpf_mode71;
+        meta._l3_metadata_urpf_hit96 = 1w1;
+        meta._l3_metadata_urpf_bd_group98 = urpf_bd_group;
+        meta._l3_metadata_urpf_mode95 = meta._ipv4_metadata_ipv4_urpf_mode62;
     }
     @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_2(bit<16> urpf_bd_group) {
-        meta._l3_metadata_urpf_hit105 = 1w1;
-        meta._l3_metadata_urpf_bd_group107 = urpf_bd_group;
-        meta._l3_metadata_urpf_mode104 = meta._ipv4_metadata_ipv4_urpf_mode71;
+        meta._l3_metadata_urpf_hit96 = 1w1;
+        meta._l3_metadata_urpf_bd_group98 = urpf_bd_group;
+        meta._l3_metadata_urpf_mode95 = meta._ipv4_metadata_ipv4_urpf_mode62;
     }
     @name(".urpf_miss") action _urpf_miss_1() {
-        meta._l3_metadata_urpf_check_fail106 = 1w1;
+        meta._l3_metadata_urpf_check_fail97 = 1w1;
     }
     @name(".ipv4_urpf") table _ipv4_urpf {
         actions = {
@@ -4202,8 +4194,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_140();
         }
         key = {
-            meta._l3_metadata_vrf101         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_sa68: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._l3_metadata_vrf92          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_sa59: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 1024;
         default_action = NoAction_140();
@@ -4215,8 +4207,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_141();
         }
         key = {
-            meta._l3_metadata_vrf101         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_sa68: lpm @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._l3_metadata_vrf92          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_sa59: lpm @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 512;
         default_action = NoAction_141();
@@ -4226,24 +4218,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_13() {
     }
     @name(".fib_hit_nexthop") action _fib_hit_nexthop_1(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_hit108 = 1w1;
-        meta._l3_metadata_fib_nexthop109 = nexthop_index;
-        meta._l3_metadata_fib_nexthop_type110 = 1w0;
+        meta._l3_metadata_fib_hit99 = 1w1;
+        meta._l3_metadata_fib_nexthop100 = nexthop_index;
+        meta._l3_metadata_fib_nexthop_type101 = 1w0;
     }
     @name(".fib_hit_nexthop") action _fib_hit_nexthop_2(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_hit108 = 1w1;
-        meta._l3_metadata_fib_nexthop109 = nexthop_index;
-        meta._l3_metadata_fib_nexthop_type110 = 1w0;
+        meta._l3_metadata_fib_hit99 = 1w1;
+        meta._l3_metadata_fib_nexthop100 = nexthop_index;
+        meta._l3_metadata_fib_nexthop_type101 = 1w0;
     }
     @name(".fib_hit_ecmp") action _fib_hit_ecmp_1(bit<16> ecmp_index) {
-        meta._l3_metadata_fib_hit108 = 1w1;
-        meta._l3_metadata_fib_nexthop109 = ecmp_index;
-        meta._l3_metadata_fib_nexthop_type110 = 1w1;
+        meta._l3_metadata_fib_hit99 = 1w1;
+        meta._l3_metadata_fib_nexthop100 = ecmp_index;
+        meta._l3_metadata_fib_nexthop_type101 = 1w1;
     }
     @name(".fib_hit_ecmp") action _fib_hit_ecmp_2(bit<16> ecmp_index) {
-        meta._l3_metadata_fib_hit108 = 1w1;
-        meta._l3_metadata_fib_nexthop109 = ecmp_index;
-        meta._l3_metadata_fib_nexthop_type110 = 1w1;
+        meta._l3_metadata_fib_hit99 = 1w1;
+        meta._l3_metadata_fib_nexthop100 = ecmp_index;
+        meta._l3_metadata_fib_nexthop_type101 = 1w1;
     }
     @name(".ipv4_fib") table _ipv4_fib {
         actions = {
@@ -4253,8 +4245,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_142();
         }
         key = {
-            meta._l3_metadata_vrf101         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_da69: exact @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_vrf92          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_da60: exact @name("ipv4_metadata.lkp_ipv4_da") ;
         }
         size = 1024;
         default_action = NoAction_142();
@@ -4267,8 +4259,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_143();
         }
         key = {
-            meta._l3_metadata_vrf101         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_da69: lpm @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_vrf92          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_da60: lpm @name("ipv4_metadata.lkp_ipv4_da") ;
         }
         size = 512;
         default_action = NoAction_143();
@@ -4309,11 +4301,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._acl_metadata_bd_label9     : ternary @name("acl_metadata.bd_label") ;
-            meta._ipv6_metadata_lkp_ipv6_sa72: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
-            meta._ipv6_metadata_lkp_ipv6_da73: ternary @name("ipv6_metadata.lkp_ipv6_da") ;
-            meta._l3_metadata_lkp_ip_proto94 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_l4_sport97 : ternary @name("l3_metadata.lkp_l4_sport") ;
-            meta._l3_metadata_lkp_l4_dport98 : ternary @name("l3_metadata.lkp_l4_dport") ;
+            meta._ipv6_metadata_lkp_ipv6_sa63: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._ipv6_metadata_lkp_ipv6_da64: ternary @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._l3_metadata_lkp_ip_proto85 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_l4_sport88 : ternary @name("l3_metadata.lkp_l4_sport") ;
+            meta._l3_metadata_lkp_l4_dport89 : ternary @name("l3_metadata.lkp_l4_dport") ;
         }
         size = 512;
         default_action = NoAction_144();
@@ -4321,17 +4313,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_14() {
     }
     @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_0(bit<16> urpf_bd_group) {
-        meta._l3_metadata_urpf_hit105 = 1w1;
-        meta._l3_metadata_urpf_bd_group107 = urpf_bd_group;
-        meta._l3_metadata_urpf_mode104 = meta._ipv6_metadata_ipv6_urpf_mode76;
+        meta._l3_metadata_urpf_hit96 = 1w1;
+        meta._l3_metadata_urpf_bd_group98 = urpf_bd_group;
+        meta._l3_metadata_urpf_mode95 = meta._ipv6_metadata_ipv6_urpf_mode67;
     }
     @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_2(bit<16> urpf_bd_group) {
-        meta._l3_metadata_urpf_hit105 = 1w1;
-        meta._l3_metadata_urpf_bd_group107 = urpf_bd_group;
-        meta._l3_metadata_urpf_mode104 = meta._ipv6_metadata_ipv6_urpf_mode76;
+        meta._l3_metadata_urpf_hit96 = 1w1;
+        meta._l3_metadata_urpf_bd_group98 = urpf_bd_group;
+        meta._l3_metadata_urpf_mode95 = meta._ipv6_metadata_ipv6_urpf_mode67;
     }
     @name(".urpf_miss") action _urpf_miss_2() {
-        meta._l3_metadata_urpf_check_fail106 = 1w1;
+        meta._l3_metadata_urpf_check_fail97 = 1w1;
     }
     @name(".ipv6_urpf") table _ipv6_urpf {
         actions = {
@@ -4340,8 +4332,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_145();
         }
         key = {
-            meta._l3_metadata_vrf101         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_sa72: exact @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._l3_metadata_vrf92          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_sa63: exact @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 1024;
         default_action = NoAction_145();
@@ -4353,8 +4345,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_146();
         }
         key = {
-            meta._l3_metadata_vrf101         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_sa72: lpm @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._l3_metadata_vrf92          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_sa63: lpm @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_146();
@@ -4364,24 +4356,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_18() {
     }
     @name(".fib_hit_nexthop") action _fib_hit_nexthop_5(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_hit108 = 1w1;
-        meta._l3_metadata_fib_nexthop109 = nexthop_index;
-        meta._l3_metadata_fib_nexthop_type110 = 1w0;
+        meta._l3_metadata_fib_hit99 = 1w1;
+        meta._l3_metadata_fib_nexthop100 = nexthop_index;
+        meta._l3_metadata_fib_nexthop_type101 = 1w0;
     }
     @name(".fib_hit_nexthop") action _fib_hit_nexthop_6(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_hit108 = 1w1;
-        meta._l3_metadata_fib_nexthop109 = nexthop_index;
-        meta._l3_metadata_fib_nexthop_type110 = 1w0;
+        meta._l3_metadata_fib_hit99 = 1w1;
+        meta._l3_metadata_fib_nexthop100 = nexthop_index;
+        meta._l3_metadata_fib_nexthop_type101 = 1w0;
     }
     @name(".fib_hit_ecmp") action _fib_hit_ecmp_5(bit<16> ecmp_index) {
-        meta._l3_metadata_fib_hit108 = 1w1;
-        meta._l3_metadata_fib_nexthop109 = ecmp_index;
-        meta._l3_metadata_fib_nexthop_type110 = 1w1;
+        meta._l3_metadata_fib_hit99 = 1w1;
+        meta._l3_metadata_fib_nexthop100 = ecmp_index;
+        meta._l3_metadata_fib_nexthop_type101 = 1w1;
     }
     @name(".fib_hit_ecmp") action _fib_hit_ecmp_6(bit<16> ecmp_index) {
-        meta._l3_metadata_fib_hit108 = 1w1;
-        meta._l3_metadata_fib_nexthop109 = ecmp_index;
-        meta._l3_metadata_fib_nexthop_type110 = 1w1;
+        meta._l3_metadata_fib_hit99 = 1w1;
+        meta._l3_metadata_fib_nexthop100 = ecmp_index;
+        meta._l3_metadata_fib_nexthop_type101 = 1w1;
     }
     @name(".ipv6_fib") table _ipv6_fib {
         actions = {
@@ -4391,8 +4383,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_147();
         }
         key = {
-            meta._l3_metadata_vrf101         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_da73: exact @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._l3_metadata_vrf92          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_da64: exact @name("ipv6_metadata.lkp_ipv6_da") ;
         }
         size = 1024;
         default_action = NoAction_147();
@@ -4405,8 +4397,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_148();
         }
         key = {
-            meta._l3_metadata_vrf101         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_da73: lpm @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._l3_metadata_vrf92          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_da64: lpm @name("ipv6_metadata.lkp_ipv6_da") ;
         }
         size = 512;
         default_action = NoAction_148();
@@ -4414,7 +4406,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_71() {
     }
     @name(".urpf_bd_miss") action _urpf_bd_miss_0() {
-        meta._l3_metadata_urpf_check_fail106 = 1w1;
+        meta._l3_metadata_urpf_check_fail97 = 1w1;
     }
     @name(".urpf_bd") table _urpf_bd {
         actions = {
@@ -4423,8 +4415,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_149();
         }
         key = {
-            meta._l3_metadata_urpf_bd_group107: exact @name("l3_metadata.urpf_bd_group") ;
-            meta._ingress_metadata_bd40       : exact @name("ingress_metadata.bd") ;
+            meta._l3_metadata_urpf_bd_group98: exact @name("l3_metadata.urpf_bd_group") ;
+            meta._ingress_metadata_bd40      : exact @name("ingress_metadata.bd") ;
         }
         size = 1024;
         default_action = NoAction_149();
@@ -4448,11 +4440,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".terminate_fabric_unicast_packet") action _terminate_fabric_unicast_packet_0() {
         standard_metadata.egress_spec = (bit<9>)hdr.fabric_header.dstPortOrGroup;
-        meta._tunnel_metadata_tunnel_terminate144 = hdr.fabric_header_unicast.tunnelTerminate;
-        meta._tunnel_metadata_ingress_tunnel_type131 = hdr.fabric_header_unicast.ingressTunnelType;
-        meta._l3_metadata_nexthop_index112 = hdr.fabric_header_unicast.nexthopIndex;
-        meta._l3_metadata_routed113 = hdr.fabric_header_unicast.routed;
-        meta._l3_metadata_outer_routed114 = hdr.fabric_header_unicast.outerRouted;
+        meta._tunnel_metadata_tunnel_terminate139 = hdr.fabric_header_unicast.tunnelTerminate;
+        meta._tunnel_metadata_ingress_tunnel_type126 = hdr.fabric_header_unicast.ingressTunnelType;
+        meta._l3_metadata_nexthop_index103 = hdr.fabric_header_unicast.nexthopIndex;
+        meta._l3_metadata_routed104 = hdr.fabric_header_unicast.routed;
+        meta._l3_metadata_outer_routed105 = hdr.fabric_header_unicast.outerRouted;
         hdr.ethernet.etherType = hdr.fabric_payload_header.etherType;
         hdr.fabric_header.setInvalid();
         hdr.fabric_header_unicast.setInvalid();
@@ -4463,11 +4455,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._intrinsic_metadata_mcast_grp55 = hdr.fabric_header.dstPortOrGroup;
     }
     @name(".terminate_fabric_multicast_packet") action _terminate_fabric_multicast_packet_0() {
-        meta._tunnel_metadata_tunnel_terminate144 = hdr.fabric_header_multicast.tunnelTerminate;
-        meta._tunnel_metadata_ingress_tunnel_type131 = hdr.fabric_header_multicast.ingressTunnelType;
-        meta._l3_metadata_nexthop_index112 = 16w0;
-        meta._l3_metadata_routed113 = hdr.fabric_header_multicast.routed;
-        meta._l3_metadata_outer_routed114 = hdr.fabric_header_multicast.outerRouted;
+        meta._tunnel_metadata_tunnel_terminate139 = hdr.fabric_header_multicast.tunnelTerminate;
+        meta._tunnel_metadata_ingress_tunnel_type126 = hdr.fabric_header_multicast.ingressTunnelType;
+        meta._l3_metadata_nexthop_index103 = 16w0;
+        meta._l3_metadata_routed104 = hdr.fabric_header_multicast.routed;
+        meta._l3_metadata_outer_routed105 = hdr.fabric_header_multicast.outerRouted;
         meta._intrinsic_metadata_mcast_grp55 = hdr.fabric_header_multicast.mcastGrp;
         hdr.ethernet.etherType = hdr.fabric_payload_header.etherType;
         hdr.fabric_header.setInvalid();
@@ -4477,46 +4469,46 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_ingress_ifindex_properties") action _set_ingress_ifindex_properties_0() {
     }
     @name(".terminate_inner_ethernet_non_ip_over_fabric") action _terminate_inner_ethernet_non_ip_over_fabric_0() {
-        meta._l2_metadata_lkp_mac_sa78 = hdr.inner_ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da79 = hdr.inner_ethernet.dstAddr;
-        meta._l2_metadata_lkp_mac_type80 = hdr.inner_ethernet.etherType;
+        meta._l2_metadata_lkp_mac_sa69 = hdr.inner_ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da70 = hdr.inner_ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_type71 = hdr.inner_ethernet.etherType;
     }
     @name(".terminate_inner_ethernet_ipv4_over_fabric") action _terminate_inner_ethernet_ipv4_over_fabric_0() {
-        meta._l2_metadata_lkp_mac_sa78 = hdr.inner_ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da79 = hdr.inner_ethernet.dstAddr;
-        meta._l2_metadata_lkp_mac_type80 = hdr.inner_ethernet.etherType;
-        meta._ipv4_metadata_lkp_ipv4_sa68 = hdr.inner_ipv4.srcAddr;
-        meta._ipv4_metadata_lkp_ipv4_da69 = hdr.inner_ipv4.dstAddr;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.inner_ipv4.protocol;
-        meta._l3_metadata_lkp_l4_sport97 = meta._l3_metadata_lkp_inner_l4_sport99;
-        meta._l3_metadata_lkp_l4_dport98 = meta._l3_metadata_lkp_inner_l4_dport100;
+        meta._l2_metadata_lkp_mac_sa69 = hdr.inner_ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da70 = hdr.inner_ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_type71 = hdr.inner_ethernet.etherType;
+        meta._ipv4_metadata_lkp_ipv4_sa59 = hdr.inner_ipv4.srcAddr;
+        meta._ipv4_metadata_lkp_ipv4_da60 = hdr.inner_ipv4.dstAddr;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.inner_ipv4.protocol;
+        meta._l3_metadata_lkp_l4_sport88 = meta._l3_metadata_lkp_inner_l4_sport90;
+        meta._l3_metadata_lkp_l4_dport89 = meta._l3_metadata_lkp_inner_l4_dport91;
     }
     @name(".terminate_inner_ipv4_over_fabric") action _terminate_inner_ipv4_over_fabric_0() {
-        meta._ipv4_metadata_lkp_ipv4_sa68 = hdr.inner_ipv4.srcAddr;
-        meta._ipv4_metadata_lkp_ipv4_da69 = hdr.inner_ipv4.dstAddr;
-        meta._l3_metadata_lkp_ip_version93 = hdr.inner_ipv4.version;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.inner_ipv4.protocol;
-        meta._l3_metadata_lkp_ip_ttl96 = hdr.inner_ipv4.ttl;
-        meta._l3_metadata_lkp_ip_tc95 = hdr.inner_ipv4.diffserv;
-        meta._l3_metadata_lkp_l4_sport97 = meta._l3_metadata_lkp_inner_l4_sport99;
-        meta._l3_metadata_lkp_l4_dport98 = meta._l3_metadata_lkp_inner_l4_dport100;
+        meta._ipv4_metadata_lkp_ipv4_sa59 = hdr.inner_ipv4.srcAddr;
+        meta._ipv4_metadata_lkp_ipv4_da60 = hdr.inner_ipv4.dstAddr;
+        meta._l3_metadata_lkp_ip_version84 = hdr.inner_ipv4.version;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.inner_ipv4.protocol;
+        meta._l3_metadata_lkp_ip_ttl87 = hdr.inner_ipv4.ttl;
+        meta._l3_metadata_lkp_ip_tc86 = hdr.inner_ipv4.diffserv;
+        meta._l3_metadata_lkp_l4_sport88 = meta._l3_metadata_lkp_inner_l4_sport90;
+        meta._l3_metadata_lkp_l4_dport89 = meta._l3_metadata_lkp_inner_l4_dport91;
     }
     @name(".terminate_inner_ethernet_ipv6_over_fabric") action _terminate_inner_ethernet_ipv6_over_fabric_0() {
-        meta._l2_metadata_lkp_mac_sa78 = hdr.inner_ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da79 = hdr.inner_ethernet.dstAddr;
-        meta._l2_metadata_lkp_mac_type80 = hdr.inner_ethernet.etherType;
-        meta._ipv6_metadata_lkp_ipv6_sa72 = hdr.inner_ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da73 = hdr.inner_ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.inner_ipv6.nextHdr;
-        meta._l3_metadata_lkp_l4_sport97 = meta._l3_metadata_lkp_inner_l4_sport99;
-        meta._l3_metadata_lkp_l4_dport98 = meta._l3_metadata_lkp_inner_l4_dport100;
+        meta._l2_metadata_lkp_mac_sa69 = hdr.inner_ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da70 = hdr.inner_ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_type71 = hdr.inner_ethernet.etherType;
+        meta._ipv6_metadata_lkp_ipv6_sa63 = hdr.inner_ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da64 = hdr.inner_ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.inner_ipv6.nextHdr;
+        meta._l3_metadata_lkp_l4_sport88 = meta._l3_metadata_lkp_inner_l4_sport90;
+        meta._l3_metadata_lkp_l4_dport89 = meta._l3_metadata_lkp_inner_l4_dport91;
     }
     @name(".terminate_inner_ipv6_over_fabric") action _terminate_inner_ipv6_over_fabric_0() {
-        meta._ipv6_metadata_lkp_ipv6_sa72 = hdr.inner_ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da73 = hdr.inner_ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_proto94 = hdr.inner_ipv6.nextHdr;
-        meta._l3_metadata_lkp_l4_sport97 = meta._l3_metadata_lkp_inner_l4_sport99;
-        meta._l3_metadata_lkp_l4_dport98 = meta._l3_metadata_lkp_inner_l4_dport100;
+        meta._ipv6_metadata_lkp_ipv6_sa63 = hdr.inner_ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da64 = hdr.inner_ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_proto85 = hdr.inner_ipv6.nextHdr;
+        meta._l3_metadata_lkp_l4_sport88 = meta._l3_metadata_lkp_inner_l4_sport90;
+        meta._l3_metadata_lkp_l4_dport89 = meta._l3_metadata_lkp_inner_l4_dport91;
     }
     @name(".fabric_ingress_dst_lkp") table _fabric_ingress_dst_lkp {
         actions = {
@@ -4555,7 +4547,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_152();
         }
         key = {
-            meta._tunnel_metadata_ingress_tunnel_type131: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._tunnel_metadata_ingress_tunnel_type126: exact @name("tunnel_metadata.ingress_tunnel_type") ;
             hdr.inner_ipv4.isValid()                    : exact @name("inner_ipv4.$valid$") ;
             hdr.inner_ipv6.isValid()                    : exact @name("inner_ipv6.$valid$") ;
         }
@@ -4563,23 +4555,21 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_152();
     }
     @name(".compute_lkp_ipv4_hash") action _compute_lkp_ipv4_hash_0() {
-        hash<bit<16>, bit<16>, tuple_2, bit<32>>(meta._hash_metadata_hash130, HashAlgorithm.crc16, 16w0, { meta._ipv4_metadata_lkp_ipv4_sa68, meta._ipv4_metadata_lkp_ipv4_da69, meta._l3_metadata_lkp_ip_proto94, meta._l3_metadata_lkp_l4_sport97, meta._l3_metadata_lkp_l4_dport98 }, 32w65536);
-        hash<bit<16>, bit<16>, tuple_3, bit<32>>(meta._hash_metadata_hash231, HashAlgorithm.crc16, 16w0, { meta._l2_metadata_lkp_mac_sa78, meta._l2_metadata_lkp_mac_da79, meta._ipv4_metadata_lkp_ipv4_sa68, meta._ipv4_metadata_lkp_ipv4_da69, meta._l3_metadata_lkp_ip_proto94, meta._l3_metadata_lkp_l4_sport97, meta._l3_metadata_lkp_l4_dport98 }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_2, bit<32>>(meta._hash_metadata_hash130, HashAlgorithm.crc16, 16w0, { meta._ipv4_metadata_lkp_ipv4_sa59, meta._ipv4_metadata_lkp_ipv4_da60, meta._l3_metadata_lkp_ip_proto85, meta._l3_metadata_lkp_l4_sport88, meta._l3_metadata_lkp_l4_dport89 }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_3, bit<32>>(meta._hash_metadata_hash231, HashAlgorithm.crc16, 16w0, { meta._l2_metadata_lkp_mac_sa69, meta._l2_metadata_lkp_mac_da70, meta._ipv4_metadata_lkp_ipv4_sa59, meta._ipv4_metadata_lkp_ipv4_da60, meta._l3_metadata_lkp_ip_proto85, meta._l3_metadata_lkp_l4_sport88, meta._l3_metadata_lkp_l4_dport89 }, 32w65536);
     }
     @name(".compute_lkp_ipv6_hash") action _compute_lkp_ipv6_hash_0() {
-        hash<bit<16>, bit<16>, tuple_4, bit<32>>(meta._hash_metadata_hash130, HashAlgorithm.crc16, 16w0, { meta._ipv6_metadata_lkp_ipv6_sa72, meta._ipv6_metadata_lkp_ipv6_da73, meta._l3_metadata_lkp_ip_proto94, meta._l3_metadata_lkp_l4_sport97, meta._l3_metadata_lkp_l4_dport98 }, 32w65536);
-        hash<bit<16>, bit<16>, tuple_5, bit<32>>(meta._hash_metadata_hash231, HashAlgorithm.crc16, 16w0, { meta._l2_metadata_lkp_mac_sa78, meta._l2_metadata_lkp_mac_da79, meta._ipv6_metadata_lkp_ipv6_sa72, meta._ipv6_metadata_lkp_ipv6_da73, meta._l3_metadata_lkp_ip_proto94, meta._l3_metadata_lkp_l4_sport97, meta._l3_metadata_lkp_l4_dport98 }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_4, bit<32>>(meta._hash_metadata_hash130, HashAlgorithm.crc16, 16w0, { meta._ipv6_metadata_lkp_ipv6_sa63, meta._ipv6_metadata_lkp_ipv6_da64, meta._l3_metadata_lkp_ip_proto85, meta._l3_metadata_lkp_l4_sport88, meta._l3_metadata_lkp_l4_dport89 }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_5, bit<32>>(meta._hash_metadata_hash231, HashAlgorithm.crc16, 16w0, { meta._l2_metadata_lkp_mac_sa69, meta._l2_metadata_lkp_mac_da70, meta._ipv6_metadata_lkp_ipv6_sa63, meta._ipv6_metadata_lkp_ipv6_da64, meta._l3_metadata_lkp_ip_proto85, meta._l3_metadata_lkp_l4_sport88, meta._l3_metadata_lkp_l4_dport89 }, 32w65536);
     }
     @name(".compute_lkp_non_ip_hash") action _compute_lkp_non_ip_hash_0() {
-        hash<bit<16>, bit<16>, tuple_6, bit<32>>(meta._hash_metadata_hash231, HashAlgorithm.crc16, 16w0, { meta._ingress_metadata_ifindex36, meta._l2_metadata_lkp_mac_sa78, meta._l2_metadata_lkp_mac_da79, meta._l2_metadata_lkp_mac_type80 }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_6, bit<32>>(meta._hash_metadata_hash231, HashAlgorithm.crc16, 16w0, { meta._ingress_metadata_ifindex36, meta._l2_metadata_lkp_mac_sa69, meta._l2_metadata_lkp_mac_da70, meta._l2_metadata_lkp_mac_type71 }, 32w65536);
     }
     @name(".computed_two_hashes") action _computed_two_hashes_0() {
-        meta._intrinsic_metadata_mcast_hash64 = (bit<13>)meta._hash_metadata_hash130;
         meta._hash_metadata_entropy_hash32 = meta._hash_metadata_hash231;
     }
     @name(".computed_one_hash") action _computed_one_hash_0() {
         meta._hash_metadata_hash130 = meta._hash_metadata_hash231;
-        meta._intrinsic_metadata_mcast_hash64 = (bit<13>)meta._hash_metadata_hash231;
         meta._hash_metadata_entropy_hash32 = meta._hash_metadata_hash231;
     }
     @name(".compute_ipv4_hashes") table _compute_ipv4_hashes {
@@ -4625,7 +4615,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @min_width(32) @name(".ingress_bd_stats_count") counter(32w1024, CounterType.packets_and_bytes) _ingress_bd_stats_count;
     @name(".update_ingress_bd_stats") action _update_ingress_bd_stats_0() {
-        _ingress_bd_stats_count.count((bit<32>)meta._l2_metadata_bd_stats_idx88);
+        _ingress_bd_stats_count.count((bit<32>)meta._l2_metadata_bd_stats_idx79);
     }
     @name(".ingress_bd_stats") table _ingress_bd_stats {
         actions = {
@@ -4653,31 +4643,31 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_74() {
     }
     @name(".set_l2_redirect_action") action _set_l2_redirect_action_0() {
-        meta._l3_metadata_nexthop_index112 = meta._l2_metadata_l2_nexthop81;
-        meta._nexthop_metadata_nexthop_type123 = meta._l2_metadata_l2_nexthop_type82;
+        meta._l3_metadata_nexthop_index103 = meta._l2_metadata_l2_nexthop72;
+        meta._nexthop_metadata_nexthop_type114 = meta._l2_metadata_l2_nexthop_type73;
     }
     @name(".set_fib_redirect_action") action _set_fib_redirect_action_0() {
-        meta._l3_metadata_nexthop_index112 = meta._l3_metadata_fib_nexthop109;
-        meta._nexthop_metadata_nexthop_type123 = meta._l3_metadata_fib_nexthop_type110;
-        meta._l3_metadata_routed113 = 1w1;
+        meta._l3_metadata_nexthop_index103 = meta._l3_metadata_fib_nexthop100;
+        meta._nexthop_metadata_nexthop_type114 = meta._l3_metadata_fib_nexthop_type101;
+        meta._l3_metadata_routed104 = 1w1;
         meta._intrinsic_metadata_mcast_grp55 = 16w0;
         meta._fabric_metadata_dst_device28 = 8w0;
     }
     @name(".set_cpu_redirect_action") action _set_cpu_redirect_action_0() {
-        meta._l3_metadata_routed113 = 1w0;
+        meta._l3_metadata_routed104 = 1w0;
         meta._intrinsic_metadata_mcast_grp55 = 16w0;
         standard_metadata.egress_spec = 9w64;
         meta._ingress_metadata_egress_ifindex37 = 16w0;
         meta._fabric_metadata_dst_device28 = 8w0;
     }
     @name(".set_acl_redirect_action") action _set_acl_redirect_action_0() {
-        meta._l3_metadata_nexthop_index112 = meta._acl_metadata_acl_nexthop2;
-        meta._nexthop_metadata_nexthop_type123 = meta._acl_metadata_acl_nexthop_type4;
+        meta._l3_metadata_nexthop_index103 = meta._acl_metadata_acl_nexthop2;
+        meta._nexthop_metadata_nexthop_type114 = meta._acl_metadata_acl_nexthop_type4;
     }
     @name(".set_racl_redirect_action") action _set_racl_redirect_action_0() {
-        meta._l3_metadata_nexthop_index112 = meta._acl_metadata_racl_nexthop3;
-        meta._nexthop_metadata_nexthop_type123 = meta._acl_metadata_racl_nexthop_type5;
-        meta._l3_metadata_routed113 = 1w1;
+        meta._l3_metadata_nexthop_index103 = meta._acl_metadata_racl_nexthop3;
+        meta._nexthop_metadata_nexthop_type114 = meta._acl_metadata_racl_nexthop_type5;
+        meta._l3_metadata_routed104 = 1w1;
     }
     @name(".fwd_result") table _fwd_result {
         actions = {
@@ -4690,11 +4680,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_159();
         }
         key = {
-            meta._l2_metadata_l2_redirect83  : ternary @name("l2_metadata.l2_redirect") ;
+            meta._l2_metadata_l2_redirect74  : ternary @name("l2_metadata.l2_redirect") ;
             meta._acl_metadata_acl_redirect6 : ternary @name("acl_metadata.acl_redirect") ;
             meta._acl_metadata_racl_redirect7: ternary @name("acl_metadata.racl_redirect") ;
-            meta._l3_metadata_rmac_hit103    : ternary @name("l3_metadata.rmac_hit") ;
-            meta._l3_metadata_fib_hit108     : ternary @name("l3_metadata.fib_hit") ;
+            meta._l3_metadata_rmac_hit94     : ternary @name("l3_metadata.rmac_hit") ;
+            meta._l3_metadata_fib_hit99      : ternary @name("l3_metadata.fib_hit") ;
         }
         size = 512;
         default_action = NoAction_159();
@@ -4705,28 +4695,28 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_ecmp_nexthop_details") action _set_ecmp_nexthop_details_0(bit<16> ifindex, bit<16> bd, bit<16> nhop_index, bit<1> tunnel) {
         meta._ingress_metadata_egress_ifindex37 = ifindex;
-        meta._l3_metadata_nexthop_index112 = nhop_index;
-        meta._l3_metadata_same_bd_check111 = meta._ingress_metadata_bd40 ^ bd;
-        meta._l2_metadata_same_if_check91 = meta._l2_metadata_same_if_check91 ^ ifindex;
-        meta._tunnel_metadata_tunnel_if_check145 = meta._tunnel_metadata_tunnel_terminate144 ^ tunnel;
+        meta._l3_metadata_nexthop_index103 = nhop_index;
+        meta._l3_metadata_same_bd_check102 = meta._ingress_metadata_bd40 ^ bd;
+        meta._l2_metadata_same_if_check82 = meta._l2_metadata_same_if_check82 ^ ifindex;
+        meta._tunnel_metadata_tunnel_if_check140 = meta._tunnel_metadata_tunnel_terminate139 ^ tunnel;
     }
     @name(".set_ecmp_nexthop_details_for_post_routed_flood") action _set_ecmp_nexthop_details_for_post_routed_flood_0(bit<16> bd, bit<16> uuc_mc_index, bit<16> nhop_index) {
         meta._intrinsic_metadata_mcast_grp55 = uuc_mc_index;
-        meta._l3_metadata_nexthop_index112 = nhop_index;
+        meta._l3_metadata_nexthop_index103 = nhop_index;
         meta._ingress_metadata_egress_ifindex37 = 16w0;
-        meta._l3_metadata_same_bd_check111 = meta._ingress_metadata_bd40 ^ bd;
+        meta._l3_metadata_same_bd_check102 = meta._ingress_metadata_bd40 ^ bd;
         meta._fabric_metadata_dst_device28 = 8w127;
     }
     @name(".set_nexthop_details") action _set_nexthop_details_0(bit<16> ifindex, bit<16> bd, bit<1> tunnel) {
         meta._ingress_metadata_egress_ifindex37 = ifindex;
-        meta._l3_metadata_same_bd_check111 = meta._ingress_metadata_bd40 ^ bd;
-        meta._l2_metadata_same_if_check91 = meta._l2_metadata_same_if_check91 ^ ifindex;
-        meta._tunnel_metadata_tunnel_if_check145 = meta._tunnel_metadata_tunnel_terminate144 ^ tunnel;
+        meta._l3_metadata_same_bd_check102 = meta._ingress_metadata_bd40 ^ bd;
+        meta._l2_metadata_same_if_check82 = meta._l2_metadata_same_if_check82 ^ ifindex;
+        meta._tunnel_metadata_tunnel_if_check140 = meta._tunnel_metadata_tunnel_terminate139 ^ tunnel;
     }
     @name(".set_nexthop_details_for_post_routed_flood") action _set_nexthop_details_for_post_routed_flood_0(bit<16> bd, bit<16> uuc_mc_index) {
         meta._intrinsic_metadata_mcast_grp55 = uuc_mc_index;
         meta._ingress_metadata_egress_ifindex37 = 16w0;
-        meta._l3_metadata_same_bd_check111 = meta._ingress_metadata_bd40 ^ bd;
+        meta._l3_metadata_same_bd_check102 = meta._ingress_metadata_bd40 ^ bd;
         meta._fabric_metadata_dst_device28 = 8w127;
     }
     @name(".ecmp_group") table _ecmp_group {
@@ -4737,7 +4727,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_160();
         }
         key = {
-            meta._l3_metadata_nexthop_index112: exact @name("l3_metadata.nexthop_index") ;
+            meta._l3_metadata_nexthop_index103: exact @name("l3_metadata.nexthop_index") ;
             meta._hash_metadata_hash130       : selector @name("hash_metadata.hash1") ;
         }
         size = 1024;
@@ -4752,7 +4742,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_161();
         }
         key = {
-            meta._l3_metadata_nexthop_index112: exact @name("l3_metadata.nexthop_index") ;
+            meta._l3_metadata_nexthop_index103: exact @name("l3_metadata.nexthop_index") ;
         }
         size = 1024;
         default_action = NoAction_161();
@@ -4770,7 +4760,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_bd40     : exact @name("ingress_metadata.bd") ;
-            meta._l2_metadata_lkp_pkt_type77: exact @name("l2_metadata.lkp_pkt_type") ;
+            meta._l2_metadata_lkp_pkt_type68: exact @name("l2_metadata.lkp_pkt_type") ;
         }
         size = 1024;
         default_action = NoAction_162();
@@ -4802,7 +4792,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_78() {
     }
     @name(".generate_learn_notify") action _generate_learn_notify_0() {
-        digest<mac_learn_digest>(32w1024, {meta._ingress_metadata_bd40,meta._l2_metadata_lkp_mac_sa78,meta._ingress_metadata_ifindex36});
+        digest<mac_learn_digest>(32w1024, {meta._ingress_metadata_bd40,meta._l2_metadata_lkp_mac_sa69,meta._ingress_metadata_ifindex36});
     }
     @name(".learn_notify") table _learn_notify {
         actions = {
@@ -4811,9 +4801,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_164();
         }
         key = {
-            meta._l2_metadata_l2_src_miss84: ternary @name("l2_metadata.l2_src_miss") ;
-            meta._l2_metadata_l2_src_move85: ternary @name("l2_metadata.l2_src_move") ;
-            meta._l2_metadata_stp_state87  : ternary @name("l2_metadata.stp_state") ;
+            meta._l2_metadata_l2_src_miss75: ternary @name("l2_metadata.l2_src_miss") ;
+            meta._l2_metadata_l2_src_move76: ternary @name("l2_metadata.l2_src_move") ;
+            meta._l2_metadata_stp_state78  : ternary @name("l2_metadata.stp_state") ;
         }
         size = 512;
         default_action = NoAction_164();
@@ -4824,7 +4814,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".set_fabric_multicast") action _set_fabric_multicast_0(bit<8> fabric_mgid) {
-        meta._multicast_metadata_mcast_grp122 = meta._intrinsic_metadata_mcast_grp55;
+        meta._multicast_metadata_mcast_grp113 = meta._intrinsic_metadata_mcast_grp55;
     }
     @name(".fabric_lag") table _fabric_lag {
         actions = {
@@ -4869,7 +4859,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop();
     }
     @name(".congestion_mirror_set") action _congestion_mirror_set_0() {
-        meta._intrinsic_metadata_deflect_on_drop57 = 1w1;
     }
     @name(".drop_stats") table _drop_stats_1 {
         actions = {
@@ -4893,29 +4882,29 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             meta._acl_metadata_if_label8                : ternary @name("acl_metadata.if_label") ;
             meta._acl_metadata_bd_label9                : ternary @name("acl_metadata.bd_label") ;
-            meta._ipv4_metadata_lkp_ipv4_sa68           : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_da69           : ternary @name("ipv4_metadata.lkp_ipv4_da") ;
-            meta._l3_metadata_lkp_ip_proto94            : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l2_metadata_lkp_mac_sa78              : ternary @name("l2_metadata.lkp_mac_sa") ;
-            meta._l2_metadata_lkp_mac_da79              : ternary @name("l2_metadata.lkp_mac_da") ;
-            meta._l2_metadata_lkp_mac_type80            : ternary @name("l2_metadata.lkp_mac_type") ;
+            meta._ipv4_metadata_lkp_ipv4_sa59           : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da60           : ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_lkp_ip_proto85            : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l2_metadata_lkp_mac_sa69              : ternary @name("l2_metadata.lkp_mac_sa") ;
+            meta._l2_metadata_lkp_mac_da70              : ternary @name("l2_metadata.lkp_mac_da") ;
+            meta._l2_metadata_lkp_mac_type71            : ternary @name("l2_metadata.lkp_mac_type") ;
             meta._ingress_metadata_ifindex36            : ternary @name("ingress_metadata.ifindex") ;
-            meta._l2_metadata_port_vlan_mapping_miss90  : ternary @name("l2_metadata.port_vlan_mapping_miss") ;
-            meta._security_metadata_ipsg_check_fail130  : ternary @name("security_metadata.ipsg_check_fail") ;
+            meta._l2_metadata_port_vlan_mapping_miss81  : ternary @name("l2_metadata.port_vlan_mapping_miss") ;
+            meta._security_metadata_ipsg_check_fail125  : ternary @name("security_metadata.ipsg_check_fail") ;
             meta._acl_metadata_acl_deny0                : ternary @name("acl_metadata.acl_deny") ;
             meta._acl_metadata_racl_deny1               : ternary @name("acl_metadata.racl_deny") ;
-            meta._l3_metadata_urpf_check_fail106        : ternary @name("l3_metadata.urpf_check_fail") ;
+            meta._l3_metadata_urpf_check_fail97         : ternary @name("l3_metadata.urpf_check_fail") ;
             meta._ingress_metadata_drop_flag41          : ternary @name("ingress_metadata.drop_flag") ;
-            meta._l3_metadata_rmac_hit103               : ternary @name("l3_metadata.rmac_hit") ;
-            meta._l3_metadata_routed113                 : ternary @name("l3_metadata.routed") ;
-            meta._ipv6_metadata_ipv6_src_is_link_local75: ternary @name("ipv6_metadata.ipv6_src_is_link_local") ;
-            meta._l2_metadata_same_if_check91           : ternary @name("l2_metadata.same_if_check") ;
-            meta._tunnel_metadata_tunnel_if_check145    : ternary @name("tunnel_metadata.tunnel_if_check") ;
-            meta._l3_metadata_same_bd_check111          : ternary @name("l3_metadata.same_bd_check") ;
-            meta._l3_metadata_lkp_ip_ttl96              : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta._l2_metadata_stp_state87               : ternary @name("l2_metadata.stp_state") ;
+            meta._l3_metadata_rmac_hit94                : ternary @name("l3_metadata.rmac_hit") ;
+            meta._l3_metadata_routed104                 : ternary @name("l3_metadata.routed") ;
+            meta._ipv6_metadata_ipv6_src_is_link_local66: ternary @name("ipv6_metadata.ipv6_src_is_link_local") ;
+            meta._l2_metadata_same_if_check82           : ternary @name("l2_metadata.same_if_check") ;
+            meta._tunnel_metadata_tunnel_if_check140    : ternary @name("tunnel_metadata.tunnel_if_check") ;
+            meta._l3_metadata_same_bd_check102          : ternary @name("l3_metadata.same_bd_check") ;
+            meta._l3_metadata_lkp_ip_ttl87              : ternary @name("l3_metadata.lkp_ip_ttl") ;
+            meta._l2_metadata_stp_state78               : ternary @name("l2_metadata.stp_state") ;
             meta._ingress_metadata_control_frame43      : ternary @name("ingress_metadata.control_frame") ;
-            meta._ipv4_metadata_ipv4_unicast_enabled70  : ternary @name("ipv4_metadata.ipv4_unicast_enabled") ;
+            meta._ipv4_metadata_ipv4_unicast_enabled61  : ternary @name("ipv4_metadata.ipv4_unicast_enabled") ;
             meta._ingress_metadata_egress_ifindex37     : ternary @name("ingress_metadata.egress_ifindex") ;
             meta._ingress_metadata_enable_dod44         : ternary @name("ingress_metadata.enable_dod") ;
         }
@@ -4942,9 +4931,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         if (meta._ingress_metadata_port_type38 == 2w0) {
             _storm_control.apply();
             _port_vlan_mapping.apply();
-            if (meta._l2_metadata_stp_group86 != 10w0) 
+            if (meta._l2_metadata_stp_group77 != 10w0) 
                 _spanning_tree.apply();
-            if (meta._security_metadata_ipsg_enabled129 == 1w1) 
+            if (meta._security_metadata_ipsg_enabled124 == 1w1) 
                 switch (_ipsg.apply().action_run) {
                     _on_miss: {
                         _ipsg_permit_special.apply();
@@ -4974,27 +4963,27 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 }
             }
 
-            if (meta._tunnel_metadata_tunnel_terminate144 == 1w1) 
+            if (meta._tunnel_metadata_tunnel_terminate139 == 1w1) 
                 _tunnel.apply();
-            if (!hdr.mpls[0].isValid() || hdr.mpls[0].isValid() && meta._tunnel_metadata_tunnel_terminate144 == 1w1) {
+            if (!hdr.mpls[0].isValid() || hdr.mpls[0].isValid() && meta._tunnel_metadata_tunnel_terminate139 == 1w1) {
                 if (meta._ingress_metadata_drop_flag41 == 1w0) 
                     _validate_packet.apply();
                 _smac.apply();
                 _dmac.apply();
-                if (meta._l3_metadata_lkp_ip_type92 == 2w0) 
+                if (meta._l3_metadata_lkp_ip_type83 == 2w0) 
                     _mac_acl.apply();
                 else 
-                    if (meta._l3_metadata_lkp_ip_type92 == 2w1) 
+                    if (meta._l3_metadata_lkp_ip_type83 == 2w1) 
                         _ip_acl.apply();
                     else 
-                        if (meta._l3_metadata_lkp_ip_type92 == 2w2) 
+                        if (meta._l3_metadata_lkp_ip_type83 == 2w2) 
                             _ipv6_acl.apply();
                 _qos.apply();
                 switch (rmac_0.apply().action_run) {
                     rmac_hit_1: {
-                        if (meta._l3_metadata_lkp_ip_type92 == 2w1 && meta._ipv4_metadata_ipv4_unicast_enabled70 == 1w1) {
+                        if (meta._l3_metadata_lkp_ip_type83 == 2w1 && meta._ipv4_metadata_ipv4_unicast_enabled61 == 1w1) {
                             _ipv4_racl.apply();
-                            if (meta._ipv4_metadata_ipv4_urpf_mode71 != 2w0) 
+                            if (meta._ipv4_metadata_ipv4_urpf_mode62 != 2w0) 
                                 switch (_ipv4_urpf.apply().action_run) {
                                     _on_miss_11: {
                                         _ipv4_urpf_lpm.apply();
@@ -5009,9 +4998,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 
                         }
                         else 
-                            if (meta._l3_metadata_lkp_ip_type92 == 2w2 && meta._ipv6_metadata_ipv6_unicast_enabled74 == 1w1) {
+                            if (meta._l3_metadata_lkp_ip_type83 == 2w2 && meta._ipv6_metadata_ipv6_unicast_enabled65 == 1w1) {
                                 _ipv6_racl.apply();
-                                if (meta._ipv6_metadata_ipv6_urpf_mode76 != 2w0) 
+                                if (meta._ipv6_metadata_ipv6_urpf_mode67 != 2w0) 
                                     switch (_ipv6_urpf.apply().action_run) {
                                         _on_miss_14: {
                                             _ipv6_urpf_lpm.apply();
@@ -5025,7 +5014,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                 }
 
                             }
-                        if (meta._l3_metadata_urpf_mode104 == 2w2 && meta._l3_metadata_urpf_hit105 == 1w1) 
+                        if (meta._l3_metadata_urpf_mode95 == 2w2 && meta._l3_metadata_urpf_hit96 == 1w1) 
                             _urpf_bd.apply();
                     }
                 }
@@ -5036,13 +5025,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             _fabric_ingress_dst_lkp.apply();
             if (hdr.fabric_header_multicast.isValid()) 
                 _fabric_ingress_src_lkp.apply();
-            if (meta._tunnel_metadata_tunnel_terminate144 == 1w1) 
+            if (meta._tunnel_metadata_tunnel_terminate139 == 1w1) 
                 _tunneled_packet_over_fabric.apply();
         }
-        if (meta._tunnel_metadata_tunnel_terminate144 == 1w0 && hdr.ipv4.isValid() || meta._tunnel_metadata_tunnel_terminate144 == 1w1 && hdr.inner_ipv4.isValid()) 
+        if (meta._tunnel_metadata_tunnel_terminate139 == 1w0 && hdr.ipv4.isValid() || meta._tunnel_metadata_tunnel_terminate139 == 1w1 && hdr.inner_ipv4.isValid()) 
             _compute_ipv4_hashes.apply();
         else 
-            if (meta._tunnel_metadata_tunnel_terminate144 == 1w0 && hdr.ipv6.isValid() || meta._tunnel_metadata_tunnel_terminate144 == 1w1 && hdr.inner_ipv6.isValid()) 
+            if (meta._tunnel_metadata_tunnel_terminate139 == 1w0 && hdr.ipv6.isValid() || meta._tunnel_metadata_tunnel_terminate139 == 1w1 && hdr.inner_ipv6.isValid()) 
                 _compute_ipv6_hashes.apply();
             else 
                 _compute_non_ip_hashes.apply();
@@ -5051,7 +5040,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             _ingress_bd_stats.apply();
             _acl_stats.apply();
             _fwd_result.apply();
-            if (meta._nexthop_metadata_nexthop_type123 == 1w1) 
+            if (meta._nexthop_metadata_nexthop_type114 == 1w1) 
                 _ecmp_group.apply();
             else 
                 _nexthop.apply();
@@ -5059,7 +5048,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 _bd_flood.apply();
             else 
                 _lag_group.apply();
-            if (meta._l2_metadata_learning_enabled89 == 1w1) 
+            if (meta._l2_metadata_learning_enabled80 == 1w1) 
                 _learn_notify.apply();
         }
         _fabric_lag.apply();

--- a/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160226/switch.p4
@@ -83,17 +83,8 @@ struct int_metadata_i2e_t {
 
 struct ingress_intrinsic_metadata_t {
     bit<1>  resubmit_flag;
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
     bit<16> mcast_grp;
-    bit<1>  deflection_flag;
-    bit<1>  deflect_on_drop;
-    bit<19> enq_qdepth;
-    bit<32> enq_tstamp;
-    bit<2>  enq_congest_stat;
-    bit<19> deq_qdepth;
-    bit<2>  deq_congest_stat;
-    bit<32> deq_timedelta;
-    bit<13> mcast_hash;
     bit<16> egress_rid;
     bit<32> lf_field_list;
     bit<3>  priority;
@@ -179,6 +170,13 @@ struct qos_metadata_t {
     bit<3> marked_cos;
     bit<8> marked_dscp;
     bit<3> marked_exp;
+}
+
+struct queueing_metadata_t {
+    bit<48> enq_timestamp;
+    bit<16> enq_qdepth;
+    bit<32> deq_timedelta;
+    bit<16> deq_qdepth;
 }
 
 struct security_metadata_t {
@@ -640,6 +638,8 @@ struct metadata {
     nexthop_metadata_t           nexthop_metadata;
     @name(".qos_metadata") 
     qos_metadata_t               qos_metadata;
+    @name(".queueing_metadata") 
+    queueing_metadata_t          queueing_metadata;
     @name(".security_metadata") 
     security_metadata_t          security_metadata;
     @name(".tunnel_metadata") 
@@ -1765,14 +1765,14 @@ control process_int_insertion(inout headers hdr, inout metadata meta, inout stan
     }
     @name(".int_set_header_3") action int_set_header_3() {
         hdr.int_q_occupancy_header.setValid();
-        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy = (bit<31>)meta.queueing_metadata.enq_qdepth;
     }
     @name(".int_set_header_0003_i1") action int_set_header_0003_i1() {
         int_set_header_3();
     }
     @name(".int_set_header_2") action int_set_header_2() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
     }
     @name(".int_set_header_0003_i2") action int_set_header_0003_i2() {
         int_set_header_2();
@@ -2757,9 +2757,8 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
             egress_redirect_to_cpu;
         }
         key = {
-            standard_metadata.egress_port          : ternary;
-            meta.intrinsic_metadata.deflection_flag: ternary;
-            meta.l3_metadata.l3_mtu_check          : ternary;
+            standard_metadata.egress_port: ternary;
+            meta.l3_metadata.l3_mtu_check: ternary;
         }
         size = 512;
     }
@@ -2823,7 +2822,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".process_egress_filter") process_egress_filter() process_egress_filter_0;
     @name(".process_egress_acl") process_egress_acl() process_egress_acl_0;
     apply {
-        if (meta.intrinsic_metadata.deflection_flag == 1w0 && meta.egress_metadata.bypass == 1w0) {
+        if (meta.egress_metadata.bypass == 1w0) {
             if (standard_metadata.instance_type != 32w0 && standard_metadata.instance_type != 32w5) {
                 mirror.apply();
             }
@@ -2976,7 +2975,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -2984,7 +2983,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -2992,7 +2991,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3000,7 +2999,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w1;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3008,7 +3007,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3016,7 +3015,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3024,7 +3023,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3032,7 +3031,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w2;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3040,7 +3039,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3048,7 +3047,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[0].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3056,7 +3055,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.vlan_tag_[1].etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3064,7 +3063,7 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.lkp_mac_type = hdr.ethernet.etherType;
         standard_metadata.egress_spec = 9w511;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
     }
@@ -3709,7 +3708,7 @@ control process_mac_acl(inout headers hdr, inout metadata meta, inout standard_m
     }
     @name(".acl_mirror") action acl_mirror(bit<32> session_id, bit<16> acl_stats_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
@@ -3754,7 +3753,7 @@ control process_ip_acl(inout headers hdr, inout metadata meta, inout standard_me
     }
     @name(".acl_mirror") action acl_mirror(bit<32> session_id, bit<16> acl_stats_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.enable_dod = 1w0;
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
@@ -4326,12 +4325,10 @@ control process_hashes(inout headers hdr, inout metadata meta, inout standard_me
         hash(meta.hash_metadata.hash2, HashAlgorithm.crc16, (bit<16>)0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, (bit<32>)65536);
     }
     @name(".computed_two_hashes") action computed_two_hashes() {
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".computed_one_hash") action computed_one_hash() {
         meta.hash_metadata.hash1 = meta.hash_metadata.hash2;
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash2;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".compute_ipv4_hashes") table compute_ipv4_hashes {
@@ -4670,7 +4667,6 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
         mark_to_drop();
     }
     @name(".deflect_on_drop") action deflect_on_drop() {
-        meta.intrinsic_metadata.deflect_on_drop = 1w1;
     }
     @name(".congestion_mirror_set") action congestion_mirror_set() {
         deflect_on_drop();

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -90,17 +90,8 @@ struct int_metadata_i2e_t {
 
 struct ingress_intrinsic_metadata_t {
     bit<1>  resubmit_flag;
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
     bit<16> mcast_grp;
-    bit<1>  deflection_flag;
-    bit<1>  deflect_on_drop;
-    bit<19> enq_qdepth;
-    bit<32> enq_tstamp;
-    bit<2>  enq_congest_stat;
-    bit<19> deq_qdepth;
-    bit<2>  deq_congest_stat;
-    bit<32> deq_timedelta;
-    bit<13> mcast_hash;
     bit<16> egress_rid;
     bit<32> lf_field_list;
     bit<3>  priority;
@@ -206,6 +197,13 @@ struct qos_metadata_t {
     bit<3> marked_cos;
     bit<8> marked_dscp;
     bit<3> marked_exp;
+}
+
+struct queueing_metadata_t {
+    bit<48> enq_timestamp;
+    bit<16> enq_qdepth;
+    bit<32> deq_timedelta;
+    bit<16> deq_qdepth;
 }
 
 struct security_metadata_t {
@@ -681,6 +679,8 @@ struct metadata {
     nexthop_metadata_t           nexthop_metadata;
     @name(".qos_metadata") 
     qos_metadata_t               qos_metadata;
+    @name(".queueing_metadata") 
+    queueing_metadata_t          queueing_metadata;
     @name(".security_metadata") 
     security_metadata_t          security_metadata;
     @name(".sflow_metadata") 
@@ -1970,14 +1970,14 @@ control process_int_insertion(inout headers hdr, inout metadata meta, inout stan
     @name(".int_set_header_3") action int_set_header_3() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.queueing_metadata.enq_qdepth;
     }
     @name(".int_set_header_0003_i1") action int_set_header_0003_i1() {
         int_set_header_3();
     }
     @name(".int_set_header_2") action int_set_header_2() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
     }
     @name(".int_set_header_0003_i2") action int_set_header_0003_i2() {
         int_set_header_2();
@@ -2982,9 +2982,8 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
             @defaultonly NoAction();
         }
         key = {
-            standard_metadata.egress_port          : ternary @name("standard_metadata.egress_port") ;
-            meta.intrinsic_metadata.deflection_flag: ternary @name("intrinsic_metadata.deflection_flag") ;
-            meta.l3_metadata.l3_mtu_check          : ternary @name("l3_metadata.l3_mtu_check") ;
+            standard_metadata.egress_port: ternary @name("standard_metadata.egress_port") ;
+            meta.l3_metadata.l3_mtu_check: ternary @name("l3_metadata.l3_mtu_check") ;
         }
         size = 512;
         default_action = NoAction();
@@ -3066,7 +3065,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".process_egress_filter") process_egress_filter() process_egress_filter_0;
     @name(".process_egress_acl") process_egress_acl() process_egress_acl_0;
     apply {
-        if (meta.intrinsic_metadata.deflection_flag == 1w0 && meta.egress_metadata.bypass == 1w0) {
+        if (meta.egress_metadata.bypass == 1w0) {
             if (standard_metadata.instance_type != 32w0 && standard_metadata.instance_type != 32w5) 
                 mirror.apply();
             else 
@@ -3330,12 +3329,11 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
 }
 
 control process_global_params(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".deflect_on_drop") action deflect_on_drop(bit<1> enable_dod) {
-        meta.intrinsic_metadata.deflect_on_drop = enable_dod;
+    @name(".deflect_on_drop") action deflect_on_drop(bit<8> enable_dod) {
     }
-    @name(".set_config_parameters") action set_config_parameters(bit<1> enable_dod) {
+    @name(".set_config_parameters") action set_config_parameters(bit<8> enable_dod) {
         deflect_on_drop(enable_dod);
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
         standard_metadata.egress_spec = 9w511;
@@ -4496,7 +4494,7 @@ control process_mac_acl(inout headers hdr, inout metadata meta, inout standard_m
     }
     @name(".acl_mirror") action acl_mirror(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
         meta.meter_metadata.meter_index = acl_meter_index;
@@ -4563,7 +4561,7 @@ control process_ip_acl(inout headers hdr, inout metadata meta, inout standard_me
     }
     @name(".acl_mirror") action acl_mirror(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
         meta.meter_metadata.meter_index = acl_meter_index;
@@ -5349,12 +5347,10 @@ control process_hashes(inout headers hdr, inout metadata meta, inout standard_me
         hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
     }
     @name(".computed_two_hashes") action computed_two_hashes() {
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".computed_one_hash") action computed_one_hash() {
         meta.hash_metadata.hash1 = meta.hash_metadata.hash2;
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash2;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".compute_ipv4_hashes") table compute_ipv4_hashes {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -90,17 +90,8 @@ struct int_metadata_i2e_t {
 
 struct ingress_intrinsic_metadata_t {
     bit<1>  resubmit_flag;
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
     bit<16> mcast_grp;
-    bit<1>  deflection_flag;
-    bit<1>  deflect_on_drop;
-    bit<19> enq_qdepth;
-    bit<32> enq_tstamp;
-    bit<2>  enq_congest_stat;
-    bit<19> deq_qdepth;
-    bit<2>  deq_congest_stat;
-    bit<32> deq_timedelta;
-    bit<13> mcast_hash;
     bit<16> egress_rid;
     bit<32> lf_field_list;
     bit<3>  priority;
@@ -206,6 +197,13 @@ struct qos_metadata_t {
     bit<3> marked_cos;
     bit<8> marked_dscp;
     bit<3> marked_exp;
+}
+
+struct queueing_metadata_t {
+    bit<48> enq_timestamp;
+    bit<16> enq_qdepth;
+    bit<32> deq_timedelta;
+    bit<16> deq_qdepth;
 }
 
 struct security_metadata_t {
@@ -681,6 +679,8 @@ struct metadata {
     nexthop_metadata_t           nexthop_metadata;
     @name(".qos_metadata") 
     qos_metadata_t               qos_metadata;
+    @name(".queueing_metadata") 
+    queueing_metadata_t          queueing_metadata;
     @name(".security_metadata") 
     security_metadata_t          security_metadata;
     @name(".sflow_metadata") 
@@ -1968,18 +1968,18 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i1") action _int_set_header_0003_i1_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.queueing_metadata.enq_qdepth;
     }
     @name(".int_set_header_0003_i2") action _int_set_header_0003_i2_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
     }
     @name(".int_set_header_0003_i3") action _int_set_header_0003_i3_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.queueing_metadata.enq_qdepth;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
     }
     @name(".int_set_header_0003_i4") action _int_set_header_0003_i4_0() {
         hdr.int_ingress_port_id_header.setValid();
@@ -1989,14 +1989,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i5") action _int_set_header_0003_i5_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.queueing_metadata.enq_qdepth;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta.ingress_metadata.ifindex;
     }
     @name(".int_set_header_0003_i6") action _int_set_header_0003_i6_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta.ingress_metadata.ifindex;
@@ -2004,9 +2004,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i7") action _int_set_header_0003_i7_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.queueing_metadata.enq_qdepth;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta.ingress_metadata.ifindex;
@@ -2018,22 +2018,22 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i9") action _int_set_header_0003_i9_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.queueing_metadata.enq_qdepth;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta.int_metadata.switch_id;
     }
     @name(".int_set_header_0003_i10") action _int_set_header_0003_i10_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta.int_metadata.switch_id;
     }
     @name(".int_set_header_0003_i11") action _int_set_header_0003_i11_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.queueing_metadata.enq_qdepth;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta.int_metadata.switch_id;
     }
@@ -2047,7 +2047,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i13") action _int_set_header_0003_i13_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.queueing_metadata.enq_qdepth;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta.ingress_metadata.ifindex;
@@ -2056,7 +2056,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i14") action _int_set_header_0003_i14_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta.ingress_metadata.ifindex;
@@ -2066,9 +2066,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i15") action _int_set_header_0003_i15_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.queueing_metadata.enq_qdepth;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta.ingress_metadata.ifindex;
@@ -3052,15 +3052,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_147();
         }
         key = {
-            standard_metadata.egress_port          : ternary @name("standard_metadata.egress_port") ;
-            meta.intrinsic_metadata.deflection_flag: ternary @name("intrinsic_metadata.deflection_flag") ;
-            meta.l3_metadata.l3_mtu_check          : ternary @name("l3_metadata.l3_mtu_check") ;
+            standard_metadata.egress_port: ternary @name("standard_metadata.egress_port") ;
+            meta.l3_metadata.l3_mtu_check: ternary @name("l3_metadata.l3_mtu_check") ;
         }
         size = 512;
         default_action = NoAction_147();
     }
     apply {
-        if (meta.intrinsic_metadata.deflection_flag == 1w0 && meta.egress_metadata.bypass == 1w0) {
+        if (meta.egress_metadata.bypass == 1w0) {
             if (standard_metadata.instance_type != 32w0 && standard_metadata.instance_type != 32w5) 
                 mirror_0.apply();
             else 
@@ -3498,9 +3497,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 512;
         default_action = NoAction_154();
     }
-    @name(".set_config_parameters") action _set_config_parameters_0(bit<1> enable_dod) {
-        meta.intrinsic_metadata.deflect_on_drop = enable_dod;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+    @name(".set_config_parameters") action _set_config_parameters_0(bit<8> enable_dod) {
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
         standard_metadata.egress_spec = 9w511;
@@ -4496,7 +4494,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".acl_mirror") action _acl_mirror_1(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
         meta.meter_metadata.meter_index = acl_meter_index;
@@ -4571,14 +4569,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".acl_mirror") action _acl_mirror_2(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
         meta.meter_metadata.meter_index = acl_meter_index;
     }
     @name(".acl_mirror") action _acl_mirror_4(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
         meta.meter_metadata.meter_index = acl_meter_index;
@@ -5226,12 +5224,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hash<bit<16>, bit<16>, tuple<bit<16>, bit<48>, bit<48>, bit<16>>, bit<32>>(meta.hash_metadata.hash2, HashAlgorithm.crc16, 16w0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, 32w65536);
     }
     @name(".computed_two_hashes") action _computed_two_hashes_0() {
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".computed_one_hash") action _computed_one_hash_0() {
         meta.hash_metadata.hash1 = meta.hash_metadata.hash2;
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash2;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".compute_ipv4_hashes") table _compute_ipv4_hashes {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -90,17 +90,8 @@ struct int_metadata_i2e_t {
 
 struct ingress_intrinsic_metadata_t {
     bit<1>  resubmit_flag;
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
     bit<16> mcast_grp;
-    bit<1>  deflection_flag;
-    bit<1>  deflect_on_drop;
-    bit<19> enq_qdepth;
-    bit<32> enq_tstamp;
-    bit<2>  enq_congest_stat;
-    bit<19> deq_qdepth;
-    bit<2>  deq_congest_stat;
-    bit<32> deq_timedelta;
-    bit<13> mcast_hash;
     bit<16> egress_rid;
     bit<32> lf_field_list;
     bit<3>  priority;
@@ -206,6 +197,13 @@ struct qos_metadata_t {
     bit<3> marked_cos;
     bit<8> marked_dscp;
     bit<3> marked_exp;
+}
+
+struct queueing_metadata_t {
+    bit<48> enq_timestamp;
+    bit<16> enq_qdepth;
+    bit<32> deq_timedelta;
+    bit<16> deq_qdepth;
 }
 
 struct security_metadata_t {
@@ -700,118 +698,113 @@ struct metadata {
     bit<1>   _int_metadata_i2e_sink54;
     bit<1>   _int_metadata_i2e_source55;
     bit<1>   _intrinsic_metadata_resubmit_flag56;
-    bit<48>  _intrinsic_metadata_ingress_global_tstamp57;
+    bit<48>  _intrinsic_metadata_ingress_global_timestamp57;
     bit<16>  _intrinsic_metadata_mcast_grp58;
-    bit<1>   _intrinsic_metadata_deflection_flag59;
-    bit<1>   _intrinsic_metadata_deflect_on_drop60;
-    bit<19>  _intrinsic_metadata_enq_qdepth61;
-    bit<32>  _intrinsic_metadata_enq_tstamp62;
-    bit<2>   _intrinsic_metadata_enq_congest_stat63;
-    bit<19>  _intrinsic_metadata_deq_qdepth64;
-    bit<2>   _intrinsic_metadata_deq_congest_stat65;
-    bit<32>  _intrinsic_metadata_deq_timedelta66;
-    bit<13>  _intrinsic_metadata_mcast_hash67;
-    bit<16>  _intrinsic_metadata_egress_rid68;
-    bit<32>  _intrinsic_metadata_lf_field_list69;
-    bit<3>   _intrinsic_metadata_priority70;
-    bit<32>  _ipv4_metadata_lkp_ipv4_sa71;
-    bit<32>  _ipv4_metadata_lkp_ipv4_da72;
-    bit<1>   _ipv4_metadata_ipv4_unicast_enabled73;
-    bit<2>   _ipv4_metadata_ipv4_urpf_mode74;
-    bit<128> _ipv6_metadata_lkp_ipv6_sa75;
-    bit<128> _ipv6_metadata_lkp_ipv6_da76;
-    bit<1>   _ipv6_metadata_ipv6_unicast_enabled77;
-    bit<1>   _ipv6_metadata_ipv6_src_is_link_local78;
-    bit<2>   _ipv6_metadata_ipv6_urpf_mode79;
-    bit<48>  _l2_metadata_lkp_mac_sa80;
-    bit<48>  _l2_metadata_lkp_mac_da81;
-    bit<3>   _l2_metadata_lkp_pkt_type82;
-    bit<16>  _l2_metadata_lkp_mac_type83;
-    bit<16>  _l2_metadata_l2_nexthop84;
-    bit<1>   _l2_metadata_l2_nexthop_type85;
-    bit<1>   _l2_metadata_l2_redirect86;
-    bit<1>   _l2_metadata_l2_src_miss87;
-    bit<16>  _l2_metadata_l2_src_move88;
-    bit<10>  _l2_metadata_stp_group89;
-    bit<3>   _l2_metadata_stp_state90;
-    bit<16>  _l2_metadata_bd_stats_idx91;
-    bit<1>   _l2_metadata_learning_enabled92;
-    bit<1>   _l2_metadata_port_vlan_mapping_miss93;
-    bit<16>  _l2_metadata_same_if_check94;
-    bit<2>   _l3_metadata_lkp_ip_type95;
-    bit<4>   _l3_metadata_lkp_ip_version96;
-    bit<8>   _l3_metadata_lkp_ip_proto97;
-    bit<8>   _l3_metadata_lkp_ip_tc98;
-    bit<8>   _l3_metadata_lkp_ip_ttl99;
-    bit<16>  _l3_metadata_lkp_l4_sport100;
-    bit<16>  _l3_metadata_lkp_l4_dport101;
-    bit<16>  _l3_metadata_lkp_outer_l4_sport102;
-    bit<16>  _l3_metadata_lkp_outer_l4_dport103;
-    bit<16>  _l3_metadata_vrf104;
-    bit<10>  _l3_metadata_rmac_group105;
-    bit<1>   _l3_metadata_rmac_hit106;
-    bit<2>   _l3_metadata_urpf_mode107;
-    bit<1>   _l3_metadata_urpf_hit108;
-    bit<1>   _l3_metadata_urpf_check_fail109;
-    bit<16>  _l3_metadata_urpf_bd_group110;
-    bit<1>   _l3_metadata_fib_hit111;
-    bit<16>  _l3_metadata_fib_nexthop112;
-    bit<1>   _l3_metadata_fib_nexthop_type113;
-    bit<16>  _l3_metadata_same_bd_check114;
-    bit<16>  _l3_metadata_nexthop_index115;
-    bit<1>   _l3_metadata_routed116;
-    bit<1>   _l3_metadata_outer_routed117;
-    bit<8>   _l3_metadata_mtu_index118;
-    bit<1>   _l3_metadata_l3_copy119;
-    bit<16>  _l3_metadata_l3_mtu_check120;
-    bit<2>   _meter_metadata_meter_color121;
-    bit<16>  _meter_metadata_meter_index122;
-    bit<1>   _multicast_metadata_ipv4_mcast_key_type123;
-    bit<16>  _multicast_metadata_ipv4_mcast_key124;
-    bit<1>   _multicast_metadata_ipv6_mcast_key_type125;
-    bit<16>  _multicast_metadata_ipv6_mcast_key126;
-    bit<1>   _multicast_metadata_outer_mcast_route_hit127;
-    bit<2>   _multicast_metadata_outer_mcast_mode128;
-    bit<1>   _multicast_metadata_mcast_route_hit129;
-    bit<1>   _multicast_metadata_mcast_bridge_hit130;
-    bit<1>   _multicast_metadata_ipv4_multicast_enabled131;
-    bit<1>   _multicast_metadata_ipv6_multicast_enabled132;
-    bit<1>   _multicast_metadata_igmp_snooping_enabled133;
-    bit<1>   _multicast_metadata_mld_snooping_enabled134;
-    bit<16>  _multicast_metadata_bd_mrpf_group135;
-    bit<16>  _multicast_metadata_mcast_rpf_group136;
-    bit<2>   _multicast_metadata_mcast_mode137;
-    bit<16>  _multicast_metadata_multicast_route_mc_index138;
-    bit<16>  _multicast_metadata_multicast_bridge_mc_index139;
-    bit<1>   _multicast_metadata_inner_replica140;
-    bit<1>   _multicast_metadata_replica141;
-    bit<16>  _multicast_metadata_mcast_grp142;
-    bit<1>   _nexthop_metadata_nexthop_type143;
-    bit<8>   _qos_metadata_outer_dscp144;
-    bit<3>   _qos_metadata_marked_cos145;
-    bit<8>   _qos_metadata_marked_dscp146;
-    bit<3>   _qos_metadata_marked_exp147;
-    bit<1>   _security_metadata_storm_control_color148;
-    bit<1>   _security_metadata_ipsg_enabled149;
-    bit<1>   _security_metadata_ipsg_check_fail150;
-    bit<16>  _sflow_metadata_sflow_session_id151;
-    bit<5>   _tunnel_metadata_ingress_tunnel_type152;
-    bit<24>  _tunnel_metadata_tunnel_vni153;
-    bit<1>   _tunnel_metadata_mpls_enabled154;
-    bit<20>  _tunnel_metadata_mpls_label155;
-    bit<3>   _tunnel_metadata_mpls_exp156;
-    bit<8>   _tunnel_metadata_mpls_ttl157;
-    bit<5>   _tunnel_metadata_egress_tunnel_type158;
-    bit<14>  _tunnel_metadata_tunnel_index159;
-    bit<9>   _tunnel_metadata_tunnel_src_index160;
-    bit<9>   _tunnel_metadata_tunnel_smac_index161;
-    bit<14>  _tunnel_metadata_tunnel_dst_index162;
-    bit<14>  _tunnel_metadata_tunnel_dmac_index163;
-    bit<24>  _tunnel_metadata_vnid164;
-    bit<1>   _tunnel_metadata_tunnel_terminate165;
-    bit<1>   _tunnel_metadata_tunnel_if_check166;
-    bit<4>   _tunnel_metadata_egress_header_count167;
-    bit<8>   _tunnel_metadata_inner_ip_proto168;
+    bit<16>  _intrinsic_metadata_egress_rid59;
+    bit<32>  _intrinsic_metadata_lf_field_list60;
+    bit<3>   _intrinsic_metadata_priority61;
+    bit<32>  _ipv4_metadata_lkp_ipv4_sa62;
+    bit<32>  _ipv4_metadata_lkp_ipv4_da63;
+    bit<1>   _ipv4_metadata_ipv4_unicast_enabled64;
+    bit<2>   _ipv4_metadata_ipv4_urpf_mode65;
+    bit<128> _ipv6_metadata_lkp_ipv6_sa66;
+    bit<128> _ipv6_metadata_lkp_ipv6_da67;
+    bit<1>   _ipv6_metadata_ipv6_unicast_enabled68;
+    bit<1>   _ipv6_metadata_ipv6_src_is_link_local69;
+    bit<2>   _ipv6_metadata_ipv6_urpf_mode70;
+    bit<48>  _l2_metadata_lkp_mac_sa71;
+    bit<48>  _l2_metadata_lkp_mac_da72;
+    bit<3>   _l2_metadata_lkp_pkt_type73;
+    bit<16>  _l2_metadata_lkp_mac_type74;
+    bit<16>  _l2_metadata_l2_nexthop75;
+    bit<1>   _l2_metadata_l2_nexthop_type76;
+    bit<1>   _l2_metadata_l2_redirect77;
+    bit<1>   _l2_metadata_l2_src_miss78;
+    bit<16>  _l2_metadata_l2_src_move79;
+    bit<10>  _l2_metadata_stp_group80;
+    bit<3>   _l2_metadata_stp_state81;
+    bit<16>  _l2_metadata_bd_stats_idx82;
+    bit<1>   _l2_metadata_learning_enabled83;
+    bit<1>   _l2_metadata_port_vlan_mapping_miss84;
+    bit<16>  _l2_metadata_same_if_check85;
+    bit<2>   _l3_metadata_lkp_ip_type86;
+    bit<4>   _l3_metadata_lkp_ip_version87;
+    bit<8>   _l3_metadata_lkp_ip_proto88;
+    bit<8>   _l3_metadata_lkp_ip_tc89;
+    bit<8>   _l3_metadata_lkp_ip_ttl90;
+    bit<16>  _l3_metadata_lkp_l4_sport91;
+    bit<16>  _l3_metadata_lkp_l4_dport92;
+    bit<16>  _l3_metadata_lkp_outer_l4_sport93;
+    bit<16>  _l3_metadata_lkp_outer_l4_dport94;
+    bit<16>  _l3_metadata_vrf95;
+    bit<10>  _l3_metadata_rmac_group96;
+    bit<1>   _l3_metadata_rmac_hit97;
+    bit<2>   _l3_metadata_urpf_mode98;
+    bit<1>   _l3_metadata_urpf_hit99;
+    bit<1>   _l3_metadata_urpf_check_fail100;
+    bit<16>  _l3_metadata_urpf_bd_group101;
+    bit<1>   _l3_metadata_fib_hit102;
+    bit<16>  _l3_metadata_fib_nexthop103;
+    bit<1>   _l3_metadata_fib_nexthop_type104;
+    bit<16>  _l3_metadata_same_bd_check105;
+    bit<16>  _l3_metadata_nexthop_index106;
+    bit<1>   _l3_metadata_routed107;
+    bit<1>   _l3_metadata_outer_routed108;
+    bit<8>   _l3_metadata_mtu_index109;
+    bit<1>   _l3_metadata_l3_copy110;
+    bit<16>  _l3_metadata_l3_mtu_check111;
+    bit<2>   _meter_metadata_meter_color112;
+    bit<16>  _meter_metadata_meter_index113;
+    bit<1>   _multicast_metadata_ipv4_mcast_key_type114;
+    bit<16>  _multicast_metadata_ipv4_mcast_key115;
+    bit<1>   _multicast_metadata_ipv6_mcast_key_type116;
+    bit<16>  _multicast_metadata_ipv6_mcast_key117;
+    bit<1>   _multicast_metadata_outer_mcast_route_hit118;
+    bit<2>   _multicast_metadata_outer_mcast_mode119;
+    bit<1>   _multicast_metadata_mcast_route_hit120;
+    bit<1>   _multicast_metadata_mcast_bridge_hit121;
+    bit<1>   _multicast_metadata_ipv4_multicast_enabled122;
+    bit<1>   _multicast_metadata_ipv6_multicast_enabled123;
+    bit<1>   _multicast_metadata_igmp_snooping_enabled124;
+    bit<1>   _multicast_metadata_mld_snooping_enabled125;
+    bit<16>  _multicast_metadata_bd_mrpf_group126;
+    bit<16>  _multicast_metadata_mcast_rpf_group127;
+    bit<2>   _multicast_metadata_mcast_mode128;
+    bit<16>  _multicast_metadata_multicast_route_mc_index129;
+    bit<16>  _multicast_metadata_multicast_bridge_mc_index130;
+    bit<1>   _multicast_metadata_inner_replica131;
+    bit<1>   _multicast_metadata_replica132;
+    bit<16>  _multicast_metadata_mcast_grp133;
+    bit<1>   _nexthop_metadata_nexthop_type134;
+    bit<8>   _qos_metadata_outer_dscp135;
+    bit<3>   _qos_metadata_marked_cos136;
+    bit<8>   _qos_metadata_marked_dscp137;
+    bit<3>   _qos_metadata_marked_exp138;
+    bit<48>  _queueing_metadata_enq_timestamp139;
+    bit<16>  _queueing_metadata_enq_qdepth140;
+    bit<32>  _queueing_metadata_deq_timedelta141;
+    bit<16>  _queueing_metadata_deq_qdepth142;
+    bit<1>   _security_metadata_storm_control_color143;
+    bit<1>   _security_metadata_ipsg_enabled144;
+    bit<1>   _security_metadata_ipsg_check_fail145;
+    bit<16>  _sflow_metadata_sflow_session_id146;
+    bit<5>   _tunnel_metadata_ingress_tunnel_type147;
+    bit<24>  _tunnel_metadata_tunnel_vni148;
+    bit<1>   _tunnel_metadata_mpls_enabled149;
+    bit<20>  _tunnel_metadata_mpls_label150;
+    bit<3>   _tunnel_metadata_mpls_exp151;
+    bit<8>   _tunnel_metadata_mpls_ttl152;
+    bit<5>   _tunnel_metadata_egress_tunnel_type153;
+    bit<14>  _tunnel_metadata_tunnel_index154;
+    bit<9>   _tunnel_metadata_tunnel_src_index155;
+    bit<9>   _tunnel_metadata_tunnel_smac_index156;
+    bit<14>  _tunnel_metadata_tunnel_dst_index157;
+    bit<14>  _tunnel_metadata_tunnel_dmac_index158;
+    bit<24>  _tunnel_metadata_vnid159;
+    bit<1>   _tunnel_metadata_tunnel_terminate160;
+    bit<1>   _tunnel_metadata_tunnel_if_check161;
+    bit<4>   _tunnel_metadata_egress_header_count162;
+    bit<8>   _tunnel_metadata_inner_ip_proto163;
 }
 
 struct headers {
@@ -947,7 +940,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition parse_set_prio_med;
     }
     @name(".parse_eompls") state parse_eompls {
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w6;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w6;
         transition parse_inner_ethernet;
     }
     @name(".parse_erspan_t3") state parse_erspan_t3 {
@@ -1023,8 +1016,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_geneve") state parse_geneve {
         packet.extract<genv_t>(hdr.genv);
-        meta._tunnel_metadata_tunnel_vni153 = hdr.genv.vni;
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w4;
+        meta._tunnel_metadata_tunnel_vni148 = hdr.genv.vni;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w4;
         transition select(hdr.genv.ver, hdr.genv.optLen, hdr.genv.protoType) {
             (2w0x0, 6w0x0, 16w0x6558): parse_inner_ethernet;
             (2w0x0, 6w0x0, 16w0x800): parse_inner_ipv4;
@@ -1048,16 +1041,16 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_gre_ipv4") state parse_gre_ipv4 {
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w2;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w2;
         transition parse_inner_ipv4;
     }
     @name(".parse_gre_ipv6") state parse_gre_ipv6 {
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w2;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w2;
         transition parse_inner_ipv6;
     }
     @name(".parse_icmp") state parse_icmp {
         packet.extract<icmp_t>(hdr.icmp);
-        meta._l3_metadata_lkp_outer_l4_sport102 = hdr.icmp.typeCode;
+        meta._l3_metadata_lkp_outer_l4_sport93 = hdr.icmp.typeCode;
         transition select(hdr.icmp.typeCode) {
             16w0x8200 &&& 16w0xfe00: parse_set_prio_med;
             16w0x8400 &&& 16w0xfc00: parse_set_prio_med;
@@ -1067,8 +1060,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_inner_ethernet") state parse_inner_ethernet {
         packet.extract<ethernet_t>(hdr.inner_ethernet);
-        meta._l2_metadata_lkp_mac_sa80 = hdr.inner_ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.inner_ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.inner_ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.inner_ethernet.dstAddr;
         transition select(hdr.inner_ethernet.etherType) {
             16w0x800: parse_inner_ipv4;
             16w0x86dd: parse_inner_ipv6;
@@ -1077,15 +1070,15 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_inner_icmp") state parse_inner_icmp {
         packet.extract<icmp_t>(hdr.inner_icmp);
-        meta._l3_metadata_lkp_l4_sport100 = hdr.inner_icmp.typeCode;
+        meta._l3_metadata_lkp_l4_sport91 = hdr.inner_icmp.typeCode;
         transition accept;
     }
     @name(".parse_inner_ipv4") state parse_inner_ipv4 {
         packet.extract<ipv4_t>(hdr.inner_ipv4);
-        meta._ipv4_metadata_lkp_ipv4_sa71 = hdr.inner_ipv4.srcAddr;
-        meta._ipv4_metadata_lkp_ipv4_da72 = hdr.inner_ipv4.dstAddr;
-        meta._l3_metadata_lkp_ip_proto97 = hdr.inner_ipv4.protocol;
-        meta._l3_metadata_lkp_ip_ttl99 = hdr.inner_ipv4.ttl;
+        meta._ipv4_metadata_lkp_ipv4_sa62 = hdr.inner_ipv4.srcAddr;
+        meta._ipv4_metadata_lkp_ipv4_da63 = hdr.inner_ipv4.dstAddr;
+        meta._l3_metadata_lkp_ip_proto88 = hdr.inner_ipv4.protocol;
+        meta._l3_metadata_lkp_ip_ttl90 = hdr.inner_ipv4.ttl;
         transition select(hdr.inner_ipv4.fragOffset, hdr.inner_ipv4.ihl, hdr.inner_ipv4.protocol) {
             (13w0x0, 4w0x5, 8w0x1): parse_inner_icmp;
             (13w0x0, 4w0x5, 8w0x6): parse_inner_tcp;
@@ -1095,10 +1088,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_inner_ipv6") state parse_inner_ipv6 {
         packet.extract<ipv6_t>(hdr.inner_ipv6);
-        meta._ipv6_metadata_lkp_ipv6_sa75 = hdr.inner_ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da76 = hdr.inner_ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_proto97 = hdr.inner_ipv6.nextHdr;
-        meta._l3_metadata_lkp_ip_ttl99 = hdr.inner_ipv6.hopLimit;
+        meta._ipv6_metadata_lkp_ipv6_sa66 = hdr.inner_ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da67 = hdr.inner_ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_proto88 = hdr.inner_ipv6.nextHdr;
+        meta._l3_metadata_lkp_ip_ttl90 = hdr.inner_ipv6.hopLimit;
         transition select(hdr.inner_ipv6.nextHdr) {
             8w58: parse_inner_icmp;
             8w6: parse_inner_tcp;
@@ -1108,14 +1101,14 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_inner_tcp") state parse_inner_tcp {
         packet.extract<tcp_t>(hdr.inner_tcp);
-        meta._l3_metadata_lkp_l4_sport100 = hdr.inner_tcp.srcPort;
-        meta._l3_metadata_lkp_l4_dport101 = hdr.inner_tcp.dstPort;
+        meta._l3_metadata_lkp_l4_sport91 = hdr.inner_tcp.srcPort;
+        meta._l3_metadata_lkp_l4_dport92 = hdr.inner_tcp.dstPort;
         transition accept;
     }
     @name(".parse_inner_udp") state parse_inner_udp {
         packet.extract<udp_t>(hdr.inner_udp);
-        meta._l3_metadata_lkp_l4_sport100 = hdr.inner_udp.srcPort;
-        meta._l3_metadata_lkp_l4_dport101 = hdr.inner_udp.dstPort;
+        meta._l3_metadata_lkp_l4_sport91 = hdr.inner_udp.srcPort;
+        meta._l3_metadata_lkp_l4_dport92 = hdr.inner_udp.dstPort;
         transition accept;
     }
     @name(".parse_int_header") state parse_int_header {
@@ -1153,7 +1146,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_ipv4_in_ip") state parse_ipv4_in_ip {
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w3;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w3;
         transition parse_inner_ipv4;
     }
     @name(".parse_ipv6") state parse_ipv6 {
@@ -1173,7 +1166,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_ipv6_in_ip") state parse_ipv6_in_ip {
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w3;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w3;
         transition parse_inner_ipv6;
     }
     @name(".parse_llc_header") state parse_llc_header {
@@ -1201,17 +1194,17 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_mpls_inner_ipv4") state parse_mpls_inner_ipv4 {
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w9;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w9;
         transition parse_inner_ipv4;
     }
     @name(".parse_mpls_inner_ipv6") state parse_mpls_inner_ipv6 {
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w9;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w9;
         transition parse_inner_ipv6;
     }
     @name(".parse_nvgre") state parse_nvgre {
         packet.extract<nvgre_t>(hdr.nvgre);
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w5;
-        meta._tunnel_metadata_tunnel_vni153 = hdr.nvgre.tni;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w5;
+        meta._tunnel_metadata_tunnel_vni148 = hdr.nvgre.tni;
         transition parse_inner_ethernet;
     }
     @name(".parse_qinq") state parse_qinq {
@@ -1234,11 +1227,11 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".parse_set_prio_high") state parse_set_prio_high {
-        meta._intrinsic_metadata_priority70 = 3w5;
+        meta._intrinsic_metadata_priority61 = 3w5;
         transition accept;
     }
     @name(".parse_set_prio_med") state parse_set_prio_med {
-        meta._intrinsic_metadata_priority70 = 3w3;
+        meta._intrinsic_metadata_priority61 = 3w3;
         transition accept;
     }
     @name(".parse_sflow") state parse_sflow {
@@ -1261,8 +1254,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_tcp") state parse_tcp {
         packet.extract<tcp_t>(hdr.tcp);
-        meta._l3_metadata_lkp_outer_l4_sport102 = hdr.tcp.srcPort;
-        meta._l3_metadata_lkp_outer_l4_dport103 = hdr.tcp.dstPort;
+        meta._l3_metadata_lkp_outer_l4_sport93 = hdr.tcp.srcPort;
+        meta._l3_metadata_lkp_outer_l4_dport94 = hdr.tcp.dstPort;
         transition select(hdr.tcp.dstPort) {
             16w179: parse_set_prio_med;
             16w639: parse_set_prio_med;
@@ -1271,8 +1264,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_udp") state parse_udp {
         packet.extract<udp_t>(hdr.udp);
-        meta._l3_metadata_lkp_outer_l4_sport102 = hdr.udp.srcPort;
-        meta._l3_metadata_lkp_outer_l4_dport103 = hdr.udp.dstPort;
+        meta._l3_metadata_lkp_outer_l4_sport93 = hdr.udp.srcPort;
+        meta._l3_metadata_lkp_outer_l4_dport94 = hdr.udp.dstPort;
         transition select(hdr.udp.dstPort) {
             16w4789: parse_vxlan;
             16w6081: parse_geneve;
@@ -1302,14 +1295,14 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @name(".parse_vxlan") state parse_vxlan {
         packet.extract<vxlan_t>(hdr.vxlan);
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w1;
-        meta._tunnel_metadata_tunnel_vni153 = hdr.vxlan.vni;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w1;
+        meta._tunnel_metadata_tunnel_vni148 = hdr.vxlan.vni;
         transition parse_inner_ethernet;
     }
     @name(".parse_vxlan_gpe") state parse_vxlan_gpe {
         packet.extract<vxlan_gpe_t>(hdr.vxlan_gpe);
-        meta._tunnel_metadata_ingress_tunnel_type152 = 5w12;
-        meta._tunnel_metadata_tunnel_vni153 = hdr.vxlan_gpe.vni;
+        meta._tunnel_metadata_ingress_tunnel_type147 = 5w12;
+        meta._tunnel_metadata_tunnel_vni148 = hdr.vxlan_gpe.vni;
         transition select(hdr.vxlan_gpe.flags, hdr.vxlan_gpe.next_proto) {
             (8w0x8 &&& 8w0x8, 8w0x5 &&& 8w0xff): parse_gpe_int_header;
             default: parse_inner_ethernet;
@@ -1421,25 +1414,25 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".egress_port_type_fabric") action egress_port_type_fabric(bit<16> ifindex) {
         meta._egress_metadata_port_type16 = 2w1;
-        meta._tunnel_metadata_egress_tunnel_type158 = 5w15;
+        meta._tunnel_metadata_egress_tunnel_type153 = 5w15;
         meta._egress_metadata_ifindex25 = ifindex;
     }
     @name(".egress_port_type_cpu") action egress_port_type_cpu(bit<16> ifindex) {
         meta._egress_metadata_port_type16 = 2w2;
-        meta._tunnel_metadata_egress_tunnel_type158 = 5w16;
+        meta._tunnel_metadata_egress_tunnel_type153 = 5w16;
         meta._egress_metadata_ifindex25 = ifindex;
     }
     @name(".nop") action nop() {
     }
     @name(".set_mirror_nhop") action set_mirror_nhop(bit<16> nhop_idx) {
-        meta._l3_metadata_nexthop_index115 = nhop_idx;
+        meta._l3_metadata_nexthop_index106 = nhop_idx;
     }
     @name(".set_mirror_bd") action set_mirror_bd(bit<16> bd) {
         meta._egress_metadata_bd19 = bd;
     }
     @name(".sflow_pkt_to_cpu") action sflow_pkt_to_cpu() {
         hdr.fabric_header_sflow.setValid();
-        hdr.fabric_header_sflow.sflow_session_id = meta._sflow_metadata_sflow_session_id151;
+        hdr.fabric_header_sflow.sflow_session_id = meta._sflow_metadata_sflow_session_id146;
     }
     @name(".egress_port_mapping") table egress_port_mapping_0 {
         actions = {
@@ -1477,23 +1470,23 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".outer_replica_from_rid") action _outer_replica_from_rid_0(bit<16> bd, bit<14> tunnel_index, bit<5> tunnel_type, bit<4> header_count) {
         meta._egress_metadata_bd19 = bd;
-        meta._multicast_metadata_replica141 = 1w1;
-        meta._multicast_metadata_inner_replica140 = 1w0;
-        meta._egress_metadata_routed22 = meta._l3_metadata_outer_routed117;
+        meta._multicast_metadata_replica132 = 1w1;
+        meta._multicast_metadata_inner_replica131 = 1w0;
+        meta._egress_metadata_routed22 = meta._l3_metadata_outer_routed108;
         meta._egress_metadata_same_bd_check23 = bd ^ meta._ingress_metadata_outer_bd41;
-        meta._tunnel_metadata_tunnel_index159 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type158 = tunnel_type;
-        meta._tunnel_metadata_egress_header_count167 = header_count;
+        meta._tunnel_metadata_tunnel_index154 = tunnel_index;
+        meta._tunnel_metadata_egress_tunnel_type153 = tunnel_type;
+        meta._tunnel_metadata_egress_header_count162 = header_count;
     }
     @name(".inner_replica_from_rid") action _inner_replica_from_rid_0(bit<16> bd, bit<14> tunnel_index, bit<5> tunnel_type, bit<4> header_count) {
         meta._egress_metadata_bd19 = bd;
-        meta._multicast_metadata_replica141 = 1w1;
-        meta._multicast_metadata_inner_replica140 = 1w1;
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed116;
+        meta._multicast_metadata_replica132 = 1w1;
+        meta._multicast_metadata_inner_replica131 = 1w1;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed107;
         meta._egress_metadata_same_bd_check23 = bd ^ meta._ingress_metadata_bd42;
-        meta._tunnel_metadata_tunnel_index159 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type158 = tunnel_type;
-        meta._tunnel_metadata_egress_header_count167 = header_count;
+        meta._tunnel_metadata_tunnel_index154 = tunnel_index;
+        meta._tunnel_metadata_egress_tunnel_type153 = tunnel_type;
+        meta._tunnel_metadata_egress_header_count162 = header_count;
     }
     @name(".replica_type") table _replica_type {
         actions = {
@@ -1502,7 +1495,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_115();
         }
         key = {
-            meta._multicast_metadata_replica141  : exact @name("multicast_metadata.replica") ;
+            meta._multicast_metadata_replica132  : exact @name("multicast_metadata.replica") ;
             meta._egress_metadata_same_bd_check23: ternary @name("egress_metadata.same_bd_check") ;
         }
         size = 512;
@@ -1516,7 +1509,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_116();
         }
         key = {
-            meta._intrinsic_metadata_egress_rid68: exact @name("intrinsic_metadata.egress_rid") ;
+            meta._intrinsic_metadata_egress_rid59: exact @name("intrinsic_metadata.egress_rid") ;
         }
         size = 1024;
         default_action = NoAction_116();
@@ -1822,7 +1815,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_119();
         }
         key = {
-            meta._tunnel_metadata_ingress_tunnel_type152: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._tunnel_metadata_ingress_tunnel_type147: exact @name("tunnel_metadata.ingress_tunnel_type") ;
             hdr.inner_ipv4.isValid()                    : exact @name("inner_ipv4.$valid$") ;
             hdr.inner_ipv6.isValid()                    : exact @name("inner_ipv6.$valid$") ;
         }
@@ -1842,55 +1835,55 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_metadata_routed22 = 1w0;
         meta._egress_metadata_bd19 = meta._ingress_metadata_bd42;
         meta._egress_metadata_outer_bd20 = meta._ingress_metadata_bd42;
-        meta._tunnel_metadata_tunnel_index159 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type158 = tunnel_type;
+        meta._tunnel_metadata_tunnel_index154 = tunnel_index;
+        meta._tunnel_metadata_egress_tunnel_type153 = tunnel_type;
     }
     @name(".set_l3_rewrite") action _set_l3_rewrite_0(bit<16> bd, bit<8> mtu_index, bit<48> dmac) {
         meta._egress_metadata_routed22 = 1w1;
         meta._egress_metadata_mac_da21 = dmac;
         meta._egress_metadata_bd19 = bd;
         meta._egress_metadata_outer_bd20 = bd;
-        meta._l3_metadata_mtu_index118 = mtu_index;
+        meta._l3_metadata_mtu_index109 = mtu_index;
     }
     @name(".set_l3_rewrite_with_tunnel") action _set_l3_rewrite_with_tunnel_0(bit<16> bd, bit<48> dmac, bit<14> tunnel_index, bit<5> tunnel_type) {
         meta._egress_metadata_routed22 = 1w1;
         meta._egress_metadata_mac_da21 = dmac;
         meta._egress_metadata_bd19 = bd;
         meta._egress_metadata_outer_bd20 = bd;
-        meta._tunnel_metadata_tunnel_index159 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type158 = tunnel_type;
+        meta._tunnel_metadata_tunnel_index154 = tunnel_index;
+        meta._tunnel_metadata_egress_tunnel_type153 = tunnel_type;
     }
     @name(".set_mpls_swap_push_rewrite_l2") action _set_mpls_swap_push_rewrite_l2_0(bit<20> label, bit<14> tunnel_index, bit<4> header_count) {
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed116;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed107;
         meta._egress_metadata_bd19 = meta._ingress_metadata_bd42;
         hdr.mpls[0].label = label;
-        meta._tunnel_metadata_tunnel_index159 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count167 = header_count;
-        meta._tunnel_metadata_egress_tunnel_type158 = 5w13;
+        meta._tunnel_metadata_tunnel_index154 = tunnel_index;
+        meta._tunnel_metadata_egress_header_count162 = header_count;
+        meta._tunnel_metadata_egress_tunnel_type153 = 5w13;
     }
     @name(".set_mpls_push_rewrite_l2") action _set_mpls_push_rewrite_l2_0(bit<14> tunnel_index, bit<4> header_count) {
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed116;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed107;
         meta._egress_metadata_bd19 = meta._ingress_metadata_bd42;
-        meta._tunnel_metadata_tunnel_index159 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count167 = header_count;
-        meta._tunnel_metadata_egress_tunnel_type158 = 5w13;
+        meta._tunnel_metadata_tunnel_index154 = tunnel_index;
+        meta._tunnel_metadata_egress_header_count162 = header_count;
+        meta._tunnel_metadata_egress_tunnel_type153 = 5w13;
     }
     @name(".set_mpls_swap_push_rewrite_l3") action _set_mpls_swap_push_rewrite_l3_0(bit<16> bd, bit<48> dmac, bit<20> label, bit<14> tunnel_index, bit<4> header_count) {
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed116;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed107;
         meta._egress_metadata_bd19 = bd;
         hdr.mpls[0].label = label;
         meta._egress_metadata_mac_da21 = dmac;
-        meta._tunnel_metadata_tunnel_index159 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count167 = header_count;
-        meta._tunnel_metadata_egress_tunnel_type158 = 5w14;
+        meta._tunnel_metadata_tunnel_index154 = tunnel_index;
+        meta._tunnel_metadata_egress_header_count162 = header_count;
+        meta._tunnel_metadata_egress_tunnel_type153 = 5w14;
     }
     @name(".set_mpls_push_rewrite_l3") action _set_mpls_push_rewrite_l3_0(bit<16> bd, bit<48> dmac, bit<14> tunnel_index, bit<4> header_count) {
-        meta._egress_metadata_routed22 = meta._l3_metadata_routed116;
+        meta._egress_metadata_routed22 = meta._l3_metadata_routed107;
         meta._egress_metadata_bd19 = bd;
         meta._egress_metadata_mac_da21 = dmac;
-        meta._tunnel_metadata_tunnel_index159 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count167 = header_count;
-        meta._tunnel_metadata_egress_tunnel_type158 = 5w14;
+        meta._tunnel_metadata_tunnel_index154 = tunnel_index;
+        meta._tunnel_metadata_egress_header_count162 = header_count;
+        meta._tunnel_metadata_egress_tunnel_type153 = 5w14;
     }
     @name(".rewrite_ipv4_multicast") action _rewrite_ipv4_multicast_0() {
         hdr.ethernet.dstAddr[22:0] = ((bit<48>)hdr.ipv4.dstAddr)[22:0];
@@ -1911,7 +1904,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_120();
         }
         key = {
-            meta._l3_metadata_nexthop_index115: exact @name("l3_metadata.nexthop_index") ;
+            meta._l3_metadata_nexthop_index106: exact @name("l3_metadata.nexthop_index") ;
         }
         size = 1024;
         default_action = NoAction_120();
@@ -2004,13 +1997,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         default_action = NoAction_124();
     }
     @name(".mtu_miss") action _mtu_miss_0() {
-        meta._l3_metadata_l3_mtu_check120 = 16w0xffff;
+        meta._l3_metadata_l3_mtu_check111 = 16w0xffff;
     }
     @name(".ipv4_mtu_check") action _ipv4_mtu_check_0(bit<16> l3_mtu) {
-        meta._l3_metadata_l3_mtu_check120 = l3_mtu |-| hdr.ipv4.totalLen;
+        meta._l3_metadata_l3_mtu_check111 = l3_mtu |-| hdr.ipv4.totalLen;
     }
     @name(".ipv6_mtu_check") action _ipv6_mtu_check_0(bit<16> l3_mtu) {
-        meta._l3_metadata_l3_mtu_check120 = l3_mtu |-| hdr.ipv6.payloadLen;
+        meta._l3_metadata_l3_mtu_check111 = l3_mtu |-| hdr.ipv6.payloadLen;
     }
     @name(".mtu") table _mtu {
         actions = {
@@ -2020,7 +2013,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_125();
         }
         key = {
-            meta._l3_metadata_mtu_index118: exact @name("l3_metadata.mtu_index") ;
+            meta._l3_metadata_mtu_index109: exact @name("l3_metadata.mtu_index") ;
             hdr.ipv4.isValid()            : exact @name("ipv4.$valid$") ;
             hdr.ipv6.isValid()            : exact @name("ipv6.$valid$") ;
         }
@@ -2098,18 +2091,18 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i1") action _int_set_header_0003_i1_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._intrinsic_metadata_enq_qdepth61;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._queueing_metadata_enq_qdepth140;
     }
     @name(".int_set_header_0003_i2") action _int_set_header_0003_i2_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta66;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta141;
     }
     @name(".int_set_header_0003_i3") action _int_set_header_0003_i3_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._intrinsic_metadata_enq_qdepth61;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._queueing_metadata_enq_qdepth140;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta66;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta141;
     }
     @name(".int_set_header_0003_i4") action _int_set_header_0003_i4_0() {
         hdr.int_ingress_port_id_header.setValid();
@@ -2119,14 +2112,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i5") action _int_set_header_0003_i5_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._intrinsic_metadata_enq_qdepth61;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._queueing_metadata_enq_qdepth140;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta._ingress_metadata_ifindex38;
     }
     @name(".int_set_header_0003_i6") action _int_set_header_0003_i6_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta66;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta141;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta._ingress_metadata_ifindex38;
@@ -2134,9 +2127,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i7") action _int_set_header_0003_i7_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._intrinsic_metadata_enq_qdepth61;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._queueing_metadata_enq_qdepth140;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta66;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta141;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta._ingress_metadata_ifindex38;
@@ -2148,22 +2141,22 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i9") action _int_set_header_0003_i9_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._intrinsic_metadata_enq_qdepth61;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._queueing_metadata_enq_qdepth140;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta._int_metadata_switch_id48;
     }
     @name(".int_set_header_0003_i10") action _int_set_header_0003_i10_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta66;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta141;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta._int_metadata_switch_id48;
     }
     @name(".int_set_header_0003_i11") action _int_set_header_0003_i11_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._intrinsic_metadata_enq_qdepth61;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._queueing_metadata_enq_qdepth140;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta66;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta141;
         hdr.int_switch_id_header.setValid();
         hdr.int_switch_id_header.switch_id = (bit<31>)meta._int_metadata_switch_id48;
     }
@@ -2177,7 +2170,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i13") action _int_set_header_0003_i13_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._intrinsic_metadata_enq_qdepth61;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._queueing_metadata_enq_qdepth140;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta._ingress_metadata_ifindex38;
@@ -2186,7 +2179,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".int_set_header_0003_i14") action _int_set_header_0003_i14_0() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta66;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta141;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta._ingress_metadata_ifindex38;
@@ -2196,9 +2189,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".int_set_header_0003_i15") action _int_set_header_0003_i15_0() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._intrinsic_metadata_enq_qdepth61;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta._queueing_metadata_enq_qdepth140;
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._intrinsic_metadata_deq_timedelta66;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta._queueing_metadata_deq_timedelta141;
         hdr.int_ingress_port_id_header.setValid();
         hdr.int_ingress_port_id_header.ingress_port_id_1 = 15w0;
         hdr.int_ingress_port_id_header.ingress_port_id_0 = meta._ingress_metadata_ifindex38;
@@ -2443,7 +2436,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         }
         key = {
             meta._egress_metadata_bd19      : exact @name("egress_metadata.bd") ;
-            meta._l2_metadata_lkp_pkt_type82: exact @name("l2_metadata.lkp_pkt_type") ;
+            meta._l2_metadata_lkp_pkt_type73: exact @name("l2_metadata.lkp_pkt_type") ;
         }
         size = 1024;
         counters = _egress_bd_stats;
@@ -2464,7 +2457,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".nop") action _nop_55() {
     }
     @name(".set_egress_tunnel_vni") action _set_egress_tunnel_vni_0(bit<24> vnid) {
-        meta._tunnel_metadata_vnid164 = vnid;
+        meta._tunnel_metadata_vnid159 = vnid;
     }
     @name(".rewrite_tunnel_dmac") action _rewrite_tunnel_dmac_0(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
@@ -2481,7 +2474,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_metadata_payload_length17 = hdr.ipv4.totalLen;
         hdr.udp.setInvalid();
         hdr.ipv4.setInvalid();
-        meta._tunnel_metadata_inner_ip_proto168 = 8w4;
+        meta._tunnel_metadata_inner_ip_proto163 = 8w4;
     }
     @name(".inner_ipv4_tcp_rewrite") action _inner_ipv4_tcp_rewrite_0() {
         hdr.inner_ipv4 = hdr.ipv4;
@@ -2489,7 +2482,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_metadata_payload_length17 = hdr.ipv4.totalLen;
         hdr.tcp.setInvalid();
         hdr.ipv4.setInvalid();
-        meta._tunnel_metadata_inner_ip_proto168 = 8w4;
+        meta._tunnel_metadata_inner_ip_proto163 = 8w4;
     }
     @name(".inner_ipv4_icmp_rewrite") action _inner_ipv4_icmp_rewrite_0() {
         hdr.inner_ipv4 = hdr.ipv4;
@@ -2497,20 +2490,20 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_metadata_payload_length17 = hdr.ipv4.totalLen;
         hdr.icmp.setInvalid();
         hdr.ipv4.setInvalid();
-        meta._tunnel_metadata_inner_ip_proto168 = 8w4;
+        meta._tunnel_metadata_inner_ip_proto163 = 8w4;
     }
     @name(".inner_ipv4_unknown_rewrite") action _inner_ipv4_unknown_rewrite_0() {
         hdr.inner_ipv4 = hdr.ipv4;
         meta._egress_metadata_payload_length17 = hdr.ipv4.totalLen;
         hdr.ipv4.setInvalid();
-        meta._tunnel_metadata_inner_ip_proto168 = 8w4;
+        meta._tunnel_metadata_inner_ip_proto163 = 8w4;
     }
     @name(".inner_ipv6_udp_rewrite") action _inner_ipv6_udp_rewrite_0() {
         hdr.inner_ipv6 = hdr.ipv6;
         hdr.inner_udp = hdr.udp;
         meta._egress_metadata_payload_length17 = hdr.ipv6.payloadLen + 16w40;
         hdr.ipv6.setInvalid();
-        meta._tunnel_metadata_inner_ip_proto168 = 8w41;
+        meta._tunnel_metadata_inner_ip_proto163 = 8w41;
     }
     @name(".inner_ipv6_tcp_rewrite") action _inner_ipv6_tcp_rewrite_0() {
         hdr.inner_ipv6 = hdr.ipv6;
@@ -2518,7 +2511,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_metadata_payload_length17 = hdr.ipv6.payloadLen + 16w40;
         hdr.tcp.setInvalid();
         hdr.ipv6.setInvalid();
-        meta._tunnel_metadata_inner_ip_proto168 = 8w41;
+        meta._tunnel_metadata_inner_ip_proto163 = 8w41;
     }
     @name(".inner_ipv6_icmp_rewrite") action _inner_ipv6_icmp_rewrite_0() {
         hdr.inner_ipv6 = hdr.ipv6;
@@ -2526,13 +2519,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_metadata_payload_length17 = hdr.ipv6.payloadLen + 16w40;
         hdr.icmp.setInvalid();
         hdr.ipv6.setInvalid();
-        meta._tunnel_metadata_inner_ip_proto168 = 8w41;
+        meta._tunnel_metadata_inner_ip_proto163 = 8w41;
     }
     @name(".inner_ipv6_unknown_rewrite") action _inner_ipv6_unknown_rewrite_0() {
         hdr.inner_ipv6 = hdr.ipv6;
         meta._egress_metadata_payload_length17 = hdr.ipv6.payloadLen + 16w40;
         hdr.ipv6.setInvalid();
-        meta._tunnel_metadata_inner_ip_proto168 = 8w41;
+        meta._tunnel_metadata_inner_ip_proto163 = 8w41;
     }
     @name(".inner_non_ip_rewrite") action _inner_non_ip_rewrite_0() {
         meta._egress_metadata_payload_length17 = (bit<16>)standard_metadata.packet_length + 16w65522;
@@ -2547,7 +2540,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.udp.length_ = meta._egress_metadata_payload_length17 + 16w30;
         hdr.vxlan.flags = 8w0x8;
         hdr.vxlan.reserved = 24w0;
-        hdr.vxlan.vni = meta._tunnel_metadata_vnid164;
+        hdr.vxlan.vni = meta._tunnel_metadata_vnid159;
         hdr.vxlan.reserved2 = 8w0;
         hdr.ipv4.setValid();
         hdr.ipv4.protocol = 8w17;
@@ -2571,7 +2564,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.genv.critical = 1w0;
         hdr.genv.optLen = 6w0;
         hdr.genv.protoType = 16w0x6558;
-        hdr.genv.vni = meta._tunnel_metadata_vnid164;
+        hdr.genv.vni = meta._tunnel_metadata_vnid159;
         hdr.genv.reserved = 6w0;
         hdr.genv.reserved2 = 8w0;
         hdr.ipv4.setValid();
@@ -2596,7 +2589,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.gre.C = 1w0;
         hdr.gre.S = 1w0;
         hdr.gre.s = 1w0;
-        hdr.nvgre.tni = meta._tunnel_metadata_vnid164;
+        hdr.nvgre.tni = meta._tunnel_metadata_vnid159;
         hdr.nvgre.flow_id[7:0] = ((bit<8>)meta._hash_metadata_entropy_hash34)[7:0];
         hdr.ipv4.setValid();
         hdr.ipv4.protocol = 8w47;
@@ -2621,7 +2614,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".ipv4_ip_rewrite") action _ipv4_ip_rewrite_0() {
         hdr.ipv4.setValid();
-        hdr.ipv4.protocol = meta._tunnel_metadata_inner_ip_proto168;
+        hdr.ipv4.protocol = meta._tunnel_metadata_inner_ip_proto163;
         hdr.ipv4.ttl = 8w64;
         hdr.ipv4.version = 4w0x4;
         hdr.ipv4.ihl = 4w0x5;
@@ -2669,7 +2662,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".ipv6_ip_rewrite") action _ipv6_ip_rewrite_0() {
         hdr.ipv6.setValid();
         hdr.ipv6.version = 4w0x6;
-        hdr.ipv6.nextHdr = meta._tunnel_metadata_inner_ip_proto168;
+        hdr.ipv6.nextHdr = meta._tunnel_metadata_inner_ip_proto163;
         hdr.ipv6.hopLimit = 8w64;
         hdr.ipv6.trafficClass = 8w0;
         hdr.ipv6.flowLabel = 20w0;
@@ -2689,7 +2682,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.gre.C = 1w0;
         hdr.gre.S = 1w0;
         hdr.gre.s = 1w0;
-        hdr.nvgre.tni = meta._tunnel_metadata_vnid164;
+        hdr.nvgre.tni = meta._tunnel_metadata_vnid159;
         hdr.nvgre.flow_id[7:0] = ((bit<8>)meta._hash_metadata_entropy_hash34)[7:0];
         hdr.ipv6.setValid();
         hdr.ipv6.version = 4w0x6;
@@ -2710,7 +2703,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.udp.length_ = meta._egress_metadata_payload_length17 + 16w30;
         hdr.vxlan.flags = 8w0x8;
         hdr.vxlan.reserved = 24w0;
-        hdr.vxlan.vni = meta._tunnel_metadata_vnid164;
+        hdr.vxlan.vni = meta._tunnel_metadata_vnid159;
         hdr.vxlan.reserved2 = 8w0;
         hdr.ipv6.setValid();
         hdr.ipv6.version = 4w0x6;
@@ -2734,7 +2727,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.genv.critical = 1w0;
         hdr.genv.optLen = 6w0;
         hdr.genv.protoType = 16w0x6558;
-        hdr.genv.vni = meta._tunnel_metadata_vnid164;
+        hdr.genv.vni = meta._tunnel_metadata_vnid159;
         hdr.genv.reserved = 6w0;
         hdr.genv.reserved2 = 8w0;
         hdr.ipv6.setValid();
@@ -2811,28 +2804,28 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.etherType = 16w0x8847;
     }
     @name(".fabric_rewrite") action _fabric_rewrite_0(bit<14> tunnel_index) {
-        meta._tunnel_metadata_tunnel_index159 = tunnel_index;
+        meta._tunnel_metadata_tunnel_index154 = tunnel_index;
     }
     @name(".tunnel_mtu_check") action _tunnel_mtu_check_0(bit<16> l3_mtu) {
-        meta._l3_metadata_l3_mtu_check120 = l3_mtu |-| meta._egress_metadata_payload_length17;
+        meta._l3_metadata_l3_mtu_check111 = l3_mtu |-| meta._egress_metadata_payload_length17;
     }
     @name(".tunnel_mtu_miss") action _tunnel_mtu_miss_0() {
-        meta._l3_metadata_l3_mtu_check120 = 16w0xffff;
+        meta._l3_metadata_l3_mtu_check111 = 16w0xffff;
     }
     @name(".set_tunnel_rewrite_details") action _set_tunnel_rewrite_details_0(bit<16> outer_bd, bit<9> smac_idx, bit<14> dmac_idx, bit<9> sip_index, bit<14> dip_index) {
         meta._egress_metadata_outer_bd20 = outer_bd;
-        meta._tunnel_metadata_tunnel_smac_index161 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index163 = dmac_idx;
-        meta._tunnel_metadata_tunnel_src_index160 = sip_index;
-        meta._tunnel_metadata_tunnel_dst_index162 = dip_index;
+        meta._tunnel_metadata_tunnel_smac_index156 = smac_idx;
+        meta._tunnel_metadata_tunnel_dmac_index158 = dmac_idx;
+        meta._tunnel_metadata_tunnel_src_index155 = sip_index;
+        meta._tunnel_metadata_tunnel_dst_index157 = dip_index;
     }
     @name(".set_mpls_rewrite_push1") action _set_mpls_rewrite_push1_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<9> smac_idx, bit<14> dmac_idx) {
         hdr.mpls[0].label = label1;
         hdr.mpls[0].exp = exp1;
         hdr.mpls[0].bos = 1w0x1;
         hdr.mpls[0].ttl = ttl1;
-        meta._tunnel_metadata_tunnel_smac_index161 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index163 = dmac_idx;
+        meta._tunnel_metadata_tunnel_smac_index156 = smac_idx;
+        meta._tunnel_metadata_tunnel_dmac_index158 = dmac_idx;
     }
     @name(".set_mpls_rewrite_push2") action _set_mpls_rewrite_push2_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<20> label2, bit<3> exp2, bit<8> ttl2, bit<9> smac_idx, bit<14> dmac_idx) {
         hdr.mpls[0].label = label1;
@@ -2843,8 +2836,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.mpls[1].exp = exp2;
         hdr.mpls[1].ttl = ttl2;
         hdr.mpls[1].bos = 1w0x1;
-        meta._tunnel_metadata_tunnel_smac_index161 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index163 = dmac_idx;
+        meta._tunnel_metadata_tunnel_smac_index156 = smac_idx;
+        meta._tunnel_metadata_tunnel_dmac_index158 = dmac_idx;
     }
     @name(".set_mpls_rewrite_push3") action _set_mpls_rewrite_push3_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<20> label2, bit<3> exp2, bit<8> ttl2, bit<20> label3, bit<3> exp3, bit<8> ttl3, bit<9> smac_idx, bit<14> dmac_idx) {
         hdr.mpls[0].label = label1;
@@ -2859,8 +2852,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.mpls[2].exp = exp3;
         hdr.mpls[2].ttl = ttl3;
         hdr.mpls[2].bos = 1w0x1;
-        meta._tunnel_metadata_tunnel_smac_index161 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index163 = dmac_idx;
+        meta._tunnel_metadata_tunnel_smac_index156 = smac_idx;
+        meta._tunnel_metadata_tunnel_dmac_index158 = dmac_idx;
     }
     @name(".cpu_rx_rewrite") action _cpu_rx_rewrite_0() {
         hdr.fabric_header.setValid();
@@ -2886,11 +2879,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.fabric_header.dstDevice = meta._fabric_metadata_dst_device29;
         hdr.fabric_header.dstPortOrGroup = meta._fabric_metadata_dst_port30;
         hdr.fabric_header_unicast.setValid();
-        hdr.fabric_header_unicast.tunnelTerminate = meta._tunnel_metadata_tunnel_terminate165;
-        hdr.fabric_header_unicast.routed = meta._l3_metadata_routed116;
-        hdr.fabric_header_unicast.outerRouted = meta._l3_metadata_outer_routed117;
-        hdr.fabric_header_unicast.ingressTunnelType = meta._tunnel_metadata_ingress_tunnel_type152;
-        hdr.fabric_header_unicast.nexthopIndex = meta._l3_metadata_nexthop_index115;
+        hdr.fabric_header_unicast.tunnelTerminate = meta._tunnel_metadata_tunnel_terminate160;
+        hdr.fabric_header_unicast.routed = meta._l3_metadata_routed107;
+        hdr.fabric_header_unicast.outerRouted = meta._l3_metadata_outer_routed108;
+        hdr.fabric_header_unicast.ingressTunnelType = meta._tunnel_metadata_ingress_tunnel_type147;
+        hdr.fabric_header_unicast.nexthopIndex = meta._l3_metadata_nexthop_index106;
         hdr.fabric_payload_header.setValid();
         hdr.fabric_payload_header.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = 16w0x9000;
@@ -2906,11 +2899,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.fabric_header_multicast.ingressIfindex = meta._ingress_metadata_ifindex38;
         hdr.fabric_header_multicast.ingressBd = meta._ingress_metadata_bd42;
         hdr.fabric_header_multicast.setValid();
-        hdr.fabric_header_multicast.tunnelTerminate = meta._tunnel_metadata_tunnel_terminate165;
-        hdr.fabric_header_multicast.routed = meta._l3_metadata_routed116;
-        hdr.fabric_header_multicast.outerRouted = meta._l3_metadata_outer_routed117;
-        hdr.fabric_header_multicast.ingressTunnelType = meta._tunnel_metadata_ingress_tunnel_type152;
-        hdr.fabric_header_multicast.mcastGrp = meta._multicast_metadata_mcast_grp142;
+        hdr.fabric_header_multicast.tunnelTerminate = meta._tunnel_metadata_tunnel_terminate160;
+        hdr.fabric_header_multicast.routed = meta._l3_metadata_routed107;
+        hdr.fabric_header_multicast.outerRouted = meta._l3_metadata_outer_routed108;
+        hdr.fabric_header_multicast.ingressTunnelType = meta._tunnel_metadata_ingress_tunnel_type147;
+        hdr.fabric_header_multicast.mcastGrp = meta._multicast_metadata_mcast_grp133;
         hdr.fabric_payload_header.setValid();
         hdr.fabric_payload_header.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = 16w0x9000;
@@ -2932,7 +2925,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         }
         key = {
             meta._egress_metadata_bd19                 : exact @name("egress_metadata.bd") ;
-            meta._tunnel_metadata_egress_tunnel_type158: exact @name("tunnel_metadata.egress_tunnel_type") ;
+            meta._tunnel_metadata_egress_tunnel_type153: exact @name("tunnel_metadata.egress_tunnel_type") ;
         }
         size = 1024;
         default_action = NoAction_134();
@@ -2944,7 +2937,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_135();
         }
         key = {
-            meta._tunnel_metadata_tunnel_dmac_index163: exact @name("tunnel_metadata.tunnel_dmac_index") ;
+            meta._tunnel_metadata_tunnel_dmac_index158: exact @name("tunnel_metadata.tunnel_dmac_index") ;
         }
         size = 1024;
         default_action = NoAction_135();
@@ -2957,7 +2950,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_136();
         }
         key = {
-            meta._tunnel_metadata_tunnel_dst_index162: exact @name("tunnel_metadata.tunnel_dst_index") ;
+            meta._tunnel_metadata_tunnel_dst_index157: exact @name("tunnel_metadata.tunnel_dst_index") ;
         }
         size = 1024;
         default_action = NoAction_136();
@@ -3010,9 +3003,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_138();
         }
         key = {
-            meta._tunnel_metadata_egress_tunnel_type158 : exact @name("tunnel_metadata.egress_tunnel_type") ;
-            meta._tunnel_metadata_egress_header_count167: exact @name("tunnel_metadata.egress_header_count") ;
-            meta._multicast_metadata_replica141         : exact @name("multicast_metadata.replica") ;
+            meta._tunnel_metadata_egress_tunnel_type153 : exact @name("tunnel_metadata.egress_tunnel_type") ;
+            meta._tunnel_metadata_egress_header_count162: exact @name("tunnel_metadata.egress_header_count") ;
+            meta._multicast_metadata_replica132         : exact @name("multicast_metadata.replica") ;
         }
         size = 1024;
         default_action = NoAction_138();
@@ -3024,7 +3017,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_139();
         }
         key = {
-            meta._tunnel_metadata_tunnel_index159: exact @name("tunnel_metadata.tunnel_index") ;
+            meta._tunnel_metadata_tunnel_index154: exact @name("tunnel_metadata.tunnel_index") ;
         }
         size = 1024;
         default_action = NoAction_139();
@@ -3042,7 +3035,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_140();
         }
         key = {
-            meta._tunnel_metadata_tunnel_index159: exact @name("tunnel_metadata.tunnel_index") ;
+            meta._tunnel_metadata_tunnel_index154: exact @name("tunnel_metadata.tunnel_index") ;
         }
         size = 1024;
         default_action = NoAction_140();
@@ -3054,7 +3047,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_141();
         }
         key = {
-            meta._tunnel_metadata_tunnel_smac_index161: exact @name("tunnel_metadata.tunnel_smac_index") ;
+            meta._tunnel_metadata_tunnel_smac_index156: exact @name("tunnel_metadata.tunnel_smac_index") ;
         }
         size = 1024;
         default_action = NoAction_141();
@@ -3067,7 +3060,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_142();
         }
         key = {
-            meta._tunnel_metadata_tunnel_src_index160: exact @name("tunnel_metadata.tunnel_src_index") ;
+            meta._tunnel_metadata_tunnel_src_index155: exact @name("tunnel_metadata.tunnel_src_index") ;
         }
         size = 1024;
         default_action = NoAction_142();
@@ -3099,7 +3092,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             hdr.ipv4.isValid()                         : exact @name("ipv4.$valid$") ;
             hdr.vxlan_gpe.isValid()                    : exact @name("vxlan_gpe.$valid$") ;
             meta._int_metadata_i2e_source55            : exact @name("int_metadata_i2e.source") ;
-            meta._tunnel_metadata_egress_tunnel_type158: ternary @name("tunnel_metadata.egress_tunnel_type") ;
+            meta._tunnel_metadata_egress_tunnel_type153: ternary @name("tunnel_metadata.egress_tunnel_type") ;
         }
         size = 8;
         default_action = NoAction_143();
@@ -3182,19 +3175,18 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             @defaultonly NoAction_147();
         }
         key = {
-            standard_metadata.egress_port             : ternary @name("standard_metadata.egress_port") ;
-            meta._intrinsic_metadata_deflection_flag59: ternary @name("intrinsic_metadata.deflection_flag") ;
-            meta._l3_metadata_l3_mtu_check120         : ternary @name("l3_metadata.l3_mtu_check") ;
+            standard_metadata.egress_port    : ternary @name("standard_metadata.egress_port") ;
+            meta._l3_metadata_l3_mtu_check111: ternary @name("l3_metadata.l3_mtu_check") ;
         }
         size = 512;
         default_action = NoAction_147();
     }
     apply {
-        if (meta._intrinsic_metadata_deflection_flag59 == 1w0 && meta._egress_metadata_bypass15 == 1w0) {
+        if (meta._egress_metadata_bypass15 == 1w0) {
             if (standard_metadata.instance_type != 32w0 && standard_metadata.instance_type != 32w5) 
                 mirror_0.apply();
             else 
-                if (meta._intrinsic_metadata_egress_rid68 != 16w0) {
+                if (meta._intrinsic_metadata_egress_rid59 != 16w0) {
                     _rid.apply();
                     _replica_type.apply();
                 }
@@ -3202,12 +3194,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
                 egress_port_type_normal: {
                     if (standard_metadata.instance_type == 32w0 || standard_metadata.instance_type == 32w5) 
                         _vlan_decap.apply();
-                    if (meta._tunnel_metadata_tunnel_terminate165 == 1w1) 
-                        if (meta._multicast_metadata_inner_replica140 == 1w1 || meta._multicast_metadata_replica141 == 1w0) {
+                    if (meta._tunnel_metadata_tunnel_terminate160 == 1w1) 
+                        if (meta._multicast_metadata_inner_replica131 == 1w1 || meta._multicast_metadata_replica132 == 1w0) {
                             _tunnel_decap_process_outer.apply();
                             _tunnel_decap_process_inner.apply();
                         }
-                    if (meta._egress_metadata_routed22 == 1w0 || meta._l3_metadata_nexthop_index115 != 16w0) 
+                    if (meta._egress_metadata_routed22 == 1w0 || meta._l3_metadata_nexthop_index106 != 16w0) 
                         _rewrite.apply();
                     else 
                         _rewrite_multicast.apply();
@@ -3234,9 +3226,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
                 }
             }
 
-            if (meta._fabric_metadata_fabric_header_present27 == 1w0 && meta._tunnel_metadata_egress_tunnel_type158 != 5w0) {
+            if (meta._fabric_metadata_fabric_header_present27 == 1w0 && meta._tunnel_metadata_egress_tunnel_type153 != 5w0) {
                 _egress_vni.apply();
-                if (meta._tunnel_metadata_egress_tunnel_type158 != 5w15 && meta._tunnel_metadata_egress_tunnel_type158 != 5w16) 
+                if (meta._tunnel_metadata_egress_tunnel_type153 != 5w15 && meta._tunnel_metadata_egress_tunnel_type153 != 5w16) 
                     _tunnel_encap_process_inner.apply();
                 _tunnel_encap_process_outer.apply();
                 _tunnel_rewrite.apply();
@@ -3251,8 +3243,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
             if (meta._egress_metadata_port_type16 == 2w0) 
                 _egress_vlan_xlate.apply();
             _egress_filter.apply();
-            if (meta._multicast_metadata_inner_replica140 == 1w1) 
-                if (meta._tunnel_metadata_ingress_tunnel_type152 == 5w0 && meta._tunnel_metadata_egress_tunnel_type158 == 5w0 && meta._egress_filter_metadata_bd13 == 16w0 && meta._egress_filter_metadata_ifindex_check12 == 16w0 || meta._tunnel_metadata_ingress_tunnel_type152 != 5w0 && meta._tunnel_metadata_egress_tunnel_type158 != 5w0 && meta._egress_filter_metadata_inner_bd14 == 16w0) 
+            if (meta._multicast_metadata_inner_replica131 == 1w1) 
+                if (meta._tunnel_metadata_ingress_tunnel_type147 == 5w0 && meta._tunnel_metadata_egress_tunnel_type153 == 5w0 && meta._egress_filter_metadata_bd13 == 16w0 && meta._egress_filter_metadata_ifindex_check12 == 16w0 || meta._tunnel_metadata_ingress_tunnel_type147 != 5w0 && meta._tunnel_metadata_egress_tunnel_type153 != 5w0 && meta._egress_filter_metadata_inner_bd14 == 16w0) 
                     _egress_filter_drop.apply();
         }
         if (meta._egress_metadata_bypass15 == 1w0) 
@@ -3483,10 +3475,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_225() {
     }
     @name(".rmac_hit") action rmac_hit_1() {
-        meta._l3_metadata_rmac_hit106 = 1w1;
+        meta._l3_metadata_rmac_hit97 = 1w1;
     }
     @name(".rmac_miss") action rmac_miss() {
-        meta._l3_metadata_rmac_hit106 = 1w0;
+        meta._l3_metadata_rmac_hit97 = 1w0;
     }
     @name(".rmac") table rmac_0 {
         actions = {
@@ -3495,8 +3487,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_148();
         }
         key = {
-            meta._l3_metadata_rmac_group105: exact @name("l3_metadata.rmac_group") ;
-            meta._l2_metadata_lkp_mac_da81 : exact @name("l2_metadata.lkp_mac_da") ;
+            meta._l3_metadata_rmac_group96: exact @name("l3_metadata.rmac_group") ;
+            meta._l2_metadata_lkp_mac_da72: exact @name("l2_metadata.lkp_mac_da") ;
         }
         size = 1024;
         default_action = NoAction_148();
@@ -3535,52 +3527,52 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._ingress_metadata_drop_reason44 = drop_reason;
     }
     @name(".set_valid_outer_unicast_packet_untagged") action _set_valid_outer_unicast_packet_untagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w1;
-        meta._l2_metadata_lkp_mac_type83 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w1;
+        meta._l2_metadata_lkp_mac_type74 = hdr.ethernet.etherType;
     }
     @name(".set_valid_outer_unicast_packet_single_tagged") action _set_valid_outer_unicast_packet_single_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w1;
-        meta._l2_metadata_lkp_mac_type83 = hdr.vlan_tag_[0].etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w1;
+        meta._l2_metadata_lkp_mac_type74 = hdr.vlan_tag_[0].etherType;
     }
     @name(".set_valid_outer_unicast_packet_double_tagged") action _set_valid_outer_unicast_packet_double_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w1;
-        meta._l2_metadata_lkp_mac_type83 = hdr.vlan_tag_[1].etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w1;
+        meta._l2_metadata_lkp_mac_type74 = hdr.vlan_tag_[1].etherType;
     }
     @name(".set_valid_outer_unicast_packet_qinq_tagged") action _set_valid_outer_unicast_packet_qinq_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w1;
-        meta._l2_metadata_lkp_mac_type83 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w1;
+        meta._l2_metadata_lkp_mac_type74 = hdr.ethernet.etherType;
     }
     @name(".set_valid_outer_multicast_packet_untagged") action _set_valid_outer_multicast_packet_untagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w2;
-        meta._l2_metadata_lkp_mac_type83 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w2;
+        meta._l2_metadata_lkp_mac_type74 = hdr.ethernet.etherType;
     }
     @name(".set_valid_outer_multicast_packet_single_tagged") action _set_valid_outer_multicast_packet_single_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w2;
-        meta._l2_metadata_lkp_mac_type83 = hdr.vlan_tag_[0].etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w2;
+        meta._l2_metadata_lkp_mac_type74 = hdr.vlan_tag_[0].etherType;
     }
     @name(".set_valid_outer_multicast_packet_double_tagged") action _set_valid_outer_multicast_packet_double_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w2;
-        meta._l2_metadata_lkp_mac_type83 = hdr.vlan_tag_[1].etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w2;
+        meta._l2_metadata_lkp_mac_type74 = hdr.vlan_tag_[1].etherType;
     }
     @name(".set_valid_outer_multicast_packet_qinq_tagged") action _set_valid_outer_multicast_packet_qinq_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w2;
-        meta._l2_metadata_lkp_mac_type83 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w2;
+        meta._l2_metadata_lkp_mac_type74 = hdr.ethernet.etherType;
     }
     @name(".set_valid_outer_broadcast_packet_untagged") action _set_valid_outer_broadcast_packet_untagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w4;
-        meta._l2_metadata_lkp_mac_type83 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w4;
+        meta._l2_metadata_lkp_mac_type74 = hdr.ethernet.etherType;
     }
     @name(".set_valid_outer_broadcast_packet_single_tagged") action _set_valid_outer_broadcast_packet_single_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w4;
-        meta._l2_metadata_lkp_mac_type83 = hdr.vlan_tag_[0].etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w4;
+        meta._l2_metadata_lkp_mac_type74 = hdr.vlan_tag_[0].etherType;
     }
     @name(".set_valid_outer_broadcast_packet_double_tagged") action _set_valid_outer_broadcast_packet_double_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w4;
-        meta._l2_metadata_lkp_mac_type83 = hdr.vlan_tag_[1].etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w4;
+        meta._l2_metadata_lkp_mac_type74 = hdr.vlan_tag_[1].etherType;
     }
     @name(".set_valid_outer_broadcast_packet_qinq_tagged") action _set_valid_outer_broadcast_packet_qinq_tagged_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w4;
-        meta._l2_metadata_lkp_mac_type83 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_pkt_type73 = 3w4;
+        meta._l2_metadata_lkp_mac_type74 = hdr.ethernet.etherType;
     }
     @name(".validate_outer_ethernet") table _validate_outer_ethernet {
         actions = {
@@ -3609,9 +3601,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_151();
     }
     @name(".set_valid_outer_ipv4_packet") action _set_valid_outer_ipv4_packet() {
-        meta._l3_metadata_lkp_ip_type95 = 2w1;
-        meta._l3_metadata_lkp_ip_tc98 = hdr.ipv4.diffserv;
-        meta._l3_metadata_lkp_ip_version96 = hdr.ipv4.version;
+        meta._l3_metadata_lkp_ip_type86 = 2w1;
+        meta._l3_metadata_lkp_ip_tc89 = hdr.ipv4.diffserv;
+        meta._l3_metadata_lkp_ip_version87 = hdr.ipv4.version;
     }
     @name(".set_malformed_outer_ipv4_packet") action _set_malformed_outer_ipv4_packet(bit<8> drop_reason) {
         meta._ingress_metadata_drop_flag43 = 1w1;
@@ -3632,9 +3624,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_152();
     }
     @name(".set_valid_outer_ipv6_packet") action _set_valid_outer_ipv6_packet() {
-        meta._l3_metadata_lkp_ip_type95 = 2w2;
-        meta._l3_metadata_lkp_ip_tc98 = hdr.ipv6.trafficClass;
-        meta._l3_metadata_lkp_ip_version96 = hdr.ipv6.version;
+        meta._l3_metadata_lkp_ip_type86 = 2w2;
+        meta._l3_metadata_lkp_ip_tc89 = hdr.ipv6.trafficClass;
+        meta._l3_metadata_lkp_ip_version87 = hdr.ipv6.version;
     }
     @name(".set_malformed_outer_ipv6_packet") action _set_malformed_outer_ipv6_packet(bit<8> drop_reason) {
         meta._ingress_metadata_drop_flag43 = 1w1;
@@ -3655,16 +3647,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_153();
     }
     @name(".set_valid_mpls_label1") action _set_valid_mpls_label1() {
-        meta._tunnel_metadata_mpls_label155 = hdr.mpls[0].label;
-        meta._tunnel_metadata_mpls_exp156 = hdr.mpls[0].exp;
+        meta._tunnel_metadata_mpls_label150 = hdr.mpls[0].label;
+        meta._tunnel_metadata_mpls_exp151 = hdr.mpls[0].exp;
     }
     @name(".set_valid_mpls_label2") action _set_valid_mpls_label2() {
-        meta._tunnel_metadata_mpls_label155 = hdr.mpls[1].label;
-        meta._tunnel_metadata_mpls_exp156 = hdr.mpls[1].exp;
+        meta._tunnel_metadata_mpls_label150 = hdr.mpls[1].label;
+        meta._tunnel_metadata_mpls_exp151 = hdr.mpls[1].exp;
     }
     @name(".set_valid_mpls_label3") action _set_valid_mpls_label3() {
-        meta._tunnel_metadata_mpls_label155 = hdr.mpls[2].label;
-        meta._tunnel_metadata_mpls_exp156 = hdr.mpls[2].exp;
+        meta._tunnel_metadata_mpls_label150 = hdr.mpls[2].label;
+        meta._tunnel_metadata_mpls_exp151 = hdr.mpls[2].exp;
     }
     @name(".validate_mpls_packet") table _validate_mpls_packet_0 {
         actions = {
@@ -3687,11 +3679,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 512;
         default_action = NoAction_154();
     }
-    @name(".set_config_parameters") action _set_config_parameters_0(bit<1> enable_dod) {
-        meta._intrinsic_metadata_deflect_on_drop60 = enable_dod;
-        meta._i2e_metadata_ingress_tstamp35 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp57;
+    @name(".set_config_parameters") action _set_config_parameters_0(bit<8> enable_dod) {
+        meta._i2e_metadata_ingress_tstamp35 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp57;
         meta._ingress_metadata_ingress_port37 = standard_metadata.ingress_port;
-        meta._l2_metadata_same_if_check94 = meta._ingress_metadata_ifindex38;
+        meta._l2_metadata_same_if_check85 = meta._ingress_metadata_ifindex38;
         standard_metadata.egress_spec = 9w511;
         random<bit<32>>(meta._ingress_metadata_sflow_take_sample47, 32w0, 32w0x7fffffff);
     }
@@ -3707,27 +3698,27 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._ingress_metadata_bd42 = bd;
         meta._ingress_metadata_outer_bd41 = bd;
         meta._acl_metadata_bd_label10 = bd_label;
-        meta._l2_metadata_stp_group89 = stp_group;
-        meta._l2_metadata_bd_stats_idx91 = stats_idx;
-        meta._l2_metadata_learning_enabled92 = learning_enabled;
-        meta._l3_metadata_vrf104 = vrf;
-        meta._ipv4_metadata_ipv4_unicast_enabled73 = ipv4_unicast_enabled;
-        meta._ipv6_metadata_ipv6_unicast_enabled77 = ipv6_unicast_enabled;
-        meta._ipv4_metadata_ipv4_urpf_mode74 = ipv4_urpf_mode;
-        meta._ipv6_metadata_ipv6_urpf_mode79 = ipv6_urpf_mode;
-        meta._l3_metadata_rmac_group105 = rmac_group;
-        meta._multicast_metadata_igmp_snooping_enabled133 = igmp_snooping_enabled;
-        meta._multicast_metadata_mld_snooping_enabled134 = mld_snooping_enabled;
-        meta._multicast_metadata_ipv4_multicast_enabled131 = ipv4_multicast_enabled;
-        meta._multicast_metadata_ipv6_multicast_enabled132 = ipv6_multicast_enabled;
-        meta._multicast_metadata_bd_mrpf_group135 = mrpf_group;
-        meta._multicast_metadata_ipv4_mcast_key_type123 = ipv4_mcast_key_type;
-        meta._multicast_metadata_ipv4_mcast_key124 = ipv4_mcast_key;
-        meta._multicast_metadata_ipv6_mcast_key_type125 = ipv6_mcast_key_type;
-        meta._multicast_metadata_ipv6_mcast_key126 = ipv6_mcast_key;
+        meta._l2_metadata_stp_group80 = stp_group;
+        meta._l2_metadata_bd_stats_idx82 = stats_idx;
+        meta._l2_metadata_learning_enabled83 = learning_enabled;
+        meta._l3_metadata_vrf95 = vrf;
+        meta._ipv4_metadata_ipv4_unicast_enabled64 = ipv4_unicast_enabled;
+        meta._ipv6_metadata_ipv6_unicast_enabled68 = ipv6_unicast_enabled;
+        meta._ipv4_metadata_ipv4_urpf_mode65 = ipv4_urpf_mode;
+        meta._ipv6_metadata_ipv6_urpf_mode70 = ipv6_urpf_mode;
+        meta._l3_metadata_rmac_group96 = rmac_group;
+        meta._multicast_metadata_igmp_snooping_enabled124 = igmp_snooping_enabled;
+        meta._multicast_metadata_mld_snooping_enabled125 = mld_snooping_enabled;
+        meta._multicast_metadata_ipv4_multicast_enabled122 = ipv4_multicast_enabled;
+        meta._multicast_metadata_ipv6_multicast_enabled123 = ipv6_multicast_enabled;
+        meta._multicast_metadata_bd_mrpf_group126 = mrpf_group;
+        meta._multicast_metadata_ipv4_mcast_key_type114 = ipv4_mcast_key_type;
+        meta._multicast_metadata_ipv4_mcast_key115 = ipv4_mcast_key;
+        meta._multicast_metadata_ipv6_mcast_key_type116 = ipv6_mcast_key_type;
+        meta._multicast_metadata_ipv6_mcast_key117 = ipv6_mcast_key;
     }
     @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss_0() {
-        meta._l2_metadata_port_vlan_mapping_miss93 = 1w1;
+        meta._l2_metadata_port_vlan_mapping_miss84 = 1w1;
     }
     @name(".port_vlan_mapping") table _port_vlan_mapping {
         actions = {
@@ -3747,7 +3738,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_156();
     }
     @name(".set_stp_state") action _set_stp_state_0(bit<3> stp_state) {
-        meta._l2_metadata_stp_state90 = stp_state;
+        meta._l2_metadata_stp_state81 = stp_state;
     }
     @name(".spanning_tree") table _spanning_tree {
         actions = {
@@ -3756,7 +3747,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_ifindex38: exact @name("ingress_metadata.ifindex") ;
-            meta._l2_metadata_stp_group89   : exact @name("l2_metadata.stp_group") ;
+            meta._l2_metadata_stp_group80   : exact @name("l2_metadata.stp_group") ;
         }
         size = 1024;
         default_action = NoAction_157();
@@ -3764,7 +3755,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss() {
     }
     @name(".ipsg_miss") action _ipsg_miss_0() {
-        meta._security_metadata_ipsg_check_fail150 = 1w1;
+        meta._security_metadata_ipsg_check_fail145 = 1w1;
     }
     @name(".ipsg") table _ipsg {
         actions = {
@@ -3774,8 +3765,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             meta._ingress_metadata_ifindex38 : exact @name("ingress_metadata.ifindex") ;
             meta._ingress_metadata_bd42      : exact @name("ingress_metadata.bd") ;
-            meta._l2_metadata_lkp_mac_sa80   : exact @name("l2_metadata.lkp_mac_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._l2_metadata_lkp_mac_sa71   : exact @name("l2_metadata.lkp_mac_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 1024;
         default_action = NoAction_158();
@@ -3786,9 +3777,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_159();
         }
         key = {
-            meta._l3_metadata_lkp_ip_proto97 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_l4_dport101: ternary @name("l3_metadata.lkp_l4_dport") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_lkp_ip_proto88 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_l4_dport92 : ternary @name("l3_metadata.lkp_l4_dport") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
         }
         size = 512;
         default_action = NoAction_159();
@@ -3864,8 +3855,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             hdr.int_header.isValid()         : exact @name("int_header.$valid$") ;
             hdr.ipv4.isValid()               : exact @name("ipv4.$valid$") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
             hdr.inner_ipv4.isValid()         : exact @name("inner_ipv4.$valid$") ;
             hdr.inner_ipv4.dstAddr           : ternary @name("inner_ipv4.dstAddr") ;
             hdr.inner_ipv4.srcAddr           : ternary @name("inner_ipv4.srcAddr") ;
@@ -3883,7 +3874,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             hdr.int_header.isValid()          : exact @name("int_header.$valid$") ;
             hdr.vxlan_gpe_int_header.isValid(): exact @name("vxlan_gpe_int_header.$valid$") ;
             hdr.ipv4.isValid()                : exact @name("ipv4.$valid$") ;
-            meta._ipv4_metadata_lkp_ipv4_da72 : ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._ipv4_metadata_lkp_ipv4_da63 : ternary @name("ipv4_metadata.lkp_ipv4_da") ;
             hdr.inner_ipv4.isValid()          : exact @name("inner_ipv4.$valid$") ;
             hdr.inner_ipv4.dstAddr            : ternary @name("inner_ipv4.dstAddr") ;
         }
@@ -3893,140 +3884,140 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_0() {
     }
     @name(".outer_rmac_hit") action _outer_rmac_hit_0() {
-        meta._l3_metadata_rmac_hit106 = 1w1;
+        meta._l3_metadata_rmac_hit97 = 1w1;
     }
     @name(".nop") action _nop_59() {
     }
     @name(".tunnel_lookup_miss") action _tunnel_lookup_miss_0() {
     }
     @name(".terminate_tunnel_inner_non_ip") action _terminate_tunnel_inner_non_ip_0(bit<16> bd, bit<16> bd_label, bit<16> stats_idx) {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
         meta._ingress_metadata_bd42 = bd;
         meta._acl_metadata_bd_label10 = bd_label;
-        meta._l2_metadata_bd_stats_idx91 = stats_idx;
-        meta._l3_metadata_lkp_ip_type95 = 2w0;
-        meta._l2_metadata_lkp_mac_type83 = hdr.inner_ethernet.etherType;
+        meta._l2_metadata_bd_stats_idx82 = stats_idx;
+        meta._l3_metadata_lkp_ip_type86 = 2w0;
+        meta._l2_metadata_lkp_mac_type74 = hdr.inner_ethernet.etherType;
     }
     @name(".terminate_tunnel_inner_ethernet_ipv4") action _terminate_tunnel_inner_ethernet_ipv4_0(bit<16> bd, bit<16> vrf, bit<10> rmac_group, bit<16> bd_label, bit<1> ipv4_unicast_enabled, bit<2> ipv4_urpf_mode, bit<1> igmp_snooping_enabled, bit<16> stats_idx, bit<1> ipv4_multicast_enabled, bit<16> mrpf_group) {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
         meta._ingress_metadata_bd42 = bd;
-        meta._l3_metadata_vrf104 = vrf;
-        meta._qos_metadata_outer_dscp144 = meta._l3_metadata_lkp_ip_tc98;
-        meta._ipv4_metadata_ipv4_unicast_enabled73 = ipv4_unicast_enabled;
-        meta._ipv4_metadata_ipv4_urpf_mode74 = ipv4_urpf_mode;
-        meta._l3_metadata_rmac_group105 = rmac_group;
+        meta._l3_metadata_vrf95 = vrf;
+        meta._qos_metadata_outer_dscp135 = meta._l3_metadata_lkp_ip_tc89;
+        meta._ipv4_metadata_ipv4_unicast_enabled64 = ipv4_unicast_enabled;
+        meta._ipv4_metadata_ipv4_urpf_mode65 = ipv4_urpf_mode;
+        meta._l3_metadata_rmac_group96 = rmac_group;
         meta._acl_metadata_bd_label10 = bd_label;
-        meta._l2_metadata_bd_stats_idx91 = stats_idx;
-        meta._l3_metadata_lkp_ip_type95 = 2w1;
-        meta._l2_metadata_lkp_mac_type83 = hdr.inner_ethernet.etherType;
-        meta._l3_metadata_lkp_ip_version96 = hdr.inner_ipv4.version;
-        meta._l3_metadata_lkp_ip_tc98 = hdr.inner_ipv4.diffserv;
-        meta._multicast_metadata_igmp_snooping_enabled133 = igmp_snooping_enabled;
-        meta._multicast_metadata_ipv4_multicast_enabled131 = ipv4_multicast_enabled;
-        meta._multicast_metadata_bd_mrpf_group135 = mrpf_group;
+        meta._l2_metadata_bd_stats_idx82 = stats_idx;
+        meta._l3_metadata_lkp_ip_type86 = 2w1;
+        meta._l2_metadata_lkp_mac_type74 = hdr.inner_ethernet.etherType;
+        meta._l3_metadata_lkp_ip_version87 = hdr.inner_ipv4.version;
+        meta._l3_metadata_lkp_ip_tc89 = hdr.inner_ipv4.diffserv;
+        meta._multicast_metadata_igmp_snooping_enabled124 = igmp_snooping_enabled;
+        meta._multicast_metadata_ipv4_multicast_enabled122 = ipv4_multicast_enabled;
+        meta._multicast_metadata_bd_mrpf_group126 = mrpf_group;
     }
     @name(".terminate_tunnel_inner_ipv4") action _terminate_tunnel_inner_ipv4_0(bit<16> vrf, bit<10> rmac_group, bit<2> ipv4_urpf_mode, bit<1> ipv4_unicast_enabled, bit<1> ipv4_multicast_enabled, bit<16> mrpf_group) {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
-        meta._l3_metadata_vrf104 = vrf;
-        meta._qos_metadata_outer_dscp144 = meta._l3_metadata_lkp_ip_tc98;
-        meta._ipv4_metadata_ipv4_unicast_enabled73 = ipv4_unicast_enabled;
-        meta._ipv4_metadata_ipv4_urpf_mode74 = ipv4_urpf_mode;
-        meta._l3_metadata_rmac_group105 = rmac_group;
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._l3_metadata_lkp_ip_type95 = 2w1;
-        meta._l3_metadata_lkp_ip_version96 = hdr.inner_ipv4.version;
-        meta._l3_metadata_lkp_ip_tc98 = hdr.inner_ipv4.diffserv;
-        meta._multicast_metadata_bd_mrpf_group135 = mrpf_group;
-        meta._multicast_metadata_ipv4_multicast_enabled131 = ipv4_multicast_enabled;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
+        meta._l3_metadata_vrf95 = vrf;
+        meta._qos_metadata_outer_dscp135 = meta._l3_metadata_lkp_ip_tc89;
+        meta._ipv4_metadata_ipv4_unicast_enabled64 = ipv4_unicast_enabled;
+        meta._ipv4_metadata_ipv4_urpf_mode65 = ipv4_urpf_mode;
+        meta._l3_metadata_rmac_group96 = rmac_group;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._l3_metadata_lkp_ip_type86 = 2w1;
+        meta._l3_metadata_lkp_ip_version87 = hdr.inner_ipv4.version;
+        meta._l3_metadata_lkp_ip_tc89 = hdr.inner_ipv4.diffserv;
+        meta._multicast_metadata_bd_mrpf_group126 = mrpf_group;
+        meta._multicast_metadata_ipv4_multicast_enabled122 = ipv4_multicast_enabled;
     }
     @name(".terminate_tunnel_inner_ethernet_ipv6") action _terminate_tunnel_inner_ethernet_ipv6_0(bit<16> bd, bit<16> vrf, bit<10> rmac_group, bit<16> bd_label, bit<1> ipv6_unicast_enabled, bit<2> ipv6_urpf_mode, bit<1> mld_snooping_enabled, bit<16> stats_idx, bit<1> ipv6_multicast_enabled, bit<16> mrpf_group) {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
         meta._ingress_metadata_bd42 = bd;
-        meta._l3_metadata_vrf104 = vrf;
-        meta._qos_metadata_outer_dscp144 = meta._l3_metadata_lkp_ip_tc98;
-        meta._ipv6_metadata_ipv6_unicast_enabled77 = ipv6_unicast_enabled;
-        meta._ipv6_metadata_ipv6_urpf_mode79 = ipv6_urpf_mode;
-        meta._l3_metadata_rmac_group105 = rmac_group;
+        meta._l3_metadata_vrf95 = vrf;
+        meta._qos_metadata_outer_dscp135 = meta._l3_metadata_lkp_ip_tc89;
+        meta._ipv6_metadata_ipv6_unicast_enabled68 = ipv6_unicast_enabled;
+        meta._ipv6_metadata_ipv6_urpf_mode70 = ipv6_urpf_mode;
+        meta._l3_metadata_rmac_group96 = rmac_group;
         meta._acl_metadata_bd_label10 = bd_label;
-        meta._l2_metadata_bd_stats_idx91 = stats_idx;
-        meta._l3_metadata_lkp_ip_type95 = 2w2;
-        meta._l2_metadata_lkp_mac_type83 = hdr.inner_ethernet.etherType;
-        meta._l3_metadata_lkp_ip_version96 = hdr.inner_ipv6.version;
-        meta._l3_metadata_lkp_ip_tc98 = hdr.inner_ipv6.trafficClass;
-        meta._multicast_metadata_bd_mrpf_group135 = mrpf_group;
-        meta._multicast_metadata_ipv6_multicast_enabled132 = ipv6_multicast_enabled;
-        meta._multicast_metadata_mld_snooping_enabled134 = mld_snooping_enabled;
+        meta._l2_metadata_bd_stats_idx82 = stats_idx;
+        meta._l3_metadata_lkp_ip_type86 = 2w2;
+        meta._l2_metadata_lkp_mac_type74 = hdr.inner_ethernet.etherType;
+        meta._l3_metadata_lkp_ip_version87 = hdr.inner_ipv6.version;
+        meta._l3_metadata_lkp_ip_tc89 = hdr.inner_ipv6.trafficClass;
+        meta._multicast_metadata_bd_mrpf_group126 = mrpf_group;
+        meta._multicast_metadata_ipv6_multicast_enabled123 = ipv6_multicast_enabled;
+        meta._multicast_metadata_mld_snooping_enabled125 = mld_snooping_enabled;
     }
     @name(".terminate_tunnel_inner_ipv6") action _terminate_tunnel_inner_ipv6_0(bit<16> vrf, bit<10> rmac_group, bit<1> ipv6_unicast_enabled, bit<2> ipv6_urpf_mode, bit<1> ipv6_multicast_enabled, bit<16> mrpf_group) {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
-        meta._l3_metadata_vrf104 = vrf;
-        meta._qos_metadata_outer_dscp144 = meta._l3_metadata_lkp_ip_tc98;
-        meta._ipv6_metadata_ipv6_unicast_enabled77 = ipv6_unicast_enabled;
-        meta._ipv6_metadata_ipv6_urpf_mode79 = ipv6_urpf_mode;
-        meta._l3_metadata_rmac_group105 = rmac_group;
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._l3_metadata_lkp_ip_type95 = 2w2;
-        meta._ipv6_metadata_lkp_ipv6_sa75 = hdr.inner_ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da76 = hdr.inner_ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_version96 = hdr.inner_ipv6.version;
-        meta._l3_metadata_lkp_ip_tc98 = hdr.inner_ipv6.trafficClass;
-        meta._multicast_metadata_bd_mrpf_group135 = mrpf_group;
-        meta._multicast_metadata_ipv6_multicast_enabled132 = ipv6_multicast_enabled;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
+        meta._l3_metadata_vrf95 = vrf;
+        meta._qos_metadata_outer_dscp135 = meta._l3_metadata_lkp_ip_tc89;
+        meta._ipv6_metadata_ipv6_unicast_enabled68 = ipv6_unicast_enabled;
+        meta._ipv6_metadata_ipv6_urpf_mode70 = ipv6_urpf_mode;
+        meta._l3_metadata_rmac_group96 = rmac_group;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._l3_metadata_lkp_ip_type86 = 2w2;
+        meta._ipv6_metadata_lkp_ipv6_sa66 = hdr.inner_ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da67 = hdr.inner_ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_version87 = hdr.inner_ipv6.version;
+        meta._l3_metadata_lkp_ip_tc89 = hdr.inner_ipv6.trafficClass;
+        meta._multicast_metadata_bd_mrpf_group126 = mrpf_group;
+        meta._multicast_metadata_ipv6_multicast_enabled123 = ipv6_multicast_enabled;
     }
     @name(".non_ip_tunnel_lookup_miss") action _non_ip_tunnel_lookup_miss_0() {
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
     }
     @name(".non_ip_tunnel_lookup_miss") action _non_ip_tunnel_lookup_miss_2() {
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
     }
     @name(".ipv4_tunnel_lookup_miss") action _ipv4_tunnel_lookup_miss_0() {
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._ipv4_metadata_lkp_ipv4_sa71 = hdr.ipv4.srcAddr;
-        meta._ipv4_metadata_lkp_ipv4_da72 = hdr.ipv4.dstAddr;
-        meta._l3_metadata_lkp_ip_proto97 = hdr.ipv4.protocol;
-        meta._l3_metadata_lkp_ip_ttl99 = hdr.ipv4.ttl;
-        meta._l3_metadata_lkp_l4_sport100 = meta._l3_metadata_lkp_outer_l4_sport102;
-        meta._l3_metadata_lkp_l4_dport101 = meta._l3_metadata_lkp_outer_l4_dport103;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._ipv4_metadata_lkp_ipv4_sa62 = hdr.ipv4.srcAddr;
+        meta._ipv4_metadata_lkp_ipv4_da63 = hdr.ipv4.dstAddr;
+        meta._l3_metadata_lkp_ip_proto88 = hdr.ipv4.protocol;
+        meta._l3_metadata_lkp_ip_ttl90 = hdr.ipv4.ttl;
+        meta._l3_metadata_lkp_l4_sport91 = meta._l3_metadata_lkp_outer_l4_sport93;
+        meta._l3_metadata_lkp_l4_dport92 = meta._l3_metadata_lkp_outer_l4_dport94;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
     }
     @name(".ipv4_tunnel_lookup_miss") action _ipv4_tunnel_lookup_miss_2() {
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._ipv4_metadata_lkp_ipv4_sa71 = hdr.ipv4.srcAddr;
-        meta._ipv4_metadata_lkp_ipv4_da72 = hdr.ipv4.dstAddr;
-        meta._l3_metadata_lkp_ip_proto97 = hdr.ipv4.protocol;
-        meta._l3_metadata_lkp_ip_ttl99 = hdr.ipv4.ttl;
-        meta._l3_metadata_lkp_l4_sport100 = meta._l3_metadata_lkp_outer_l4_sport102;
-        meta._l3_metadata_lkp_l4_dport101 = meta._l3_metadata_lkp_outer_l4_dport103;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._ipv4_metadata_lkp_ipv4_sa62 = hdr.ipv4.srcAddr;
+        meta._ipv4_metadata_lkp_ipv4_da63 = hdr.ipv4.dstAddr;
+        meta._l3_metadata_lkp_ip_proto88 = hdr.ipv4.protocol;
+        meta._l3_metadata_lkp_ip_ttl90 = hdr.ipv4.ttl;
+        meta._l3_metadata_lkp_l4_sport91 = meta._l3_metadata_lkp_outer_l4_sport93;
+        meta._l3_metadata_lkp_l4_dport92 = meta._l3_metadata_lkp_outer_l4_dport94;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
     }
     @name(".ipv6_tunnel_lookup_miss") action _ipv6_tunnel_lookup_miss_0() {
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._ipv6_metadata_lkp_ipv6_sa75 = hdr.ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da76 = hdr.ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_proto97 = hdr.ipv6.nextHdr;
-        meta._l3_metadata_lkp_ip_ttl99 = hdr.ipv6.hopLimit;
-        meta._l3_metadata_lkp_l4_sport100 = meta._l3_metadata_lkp_outer_l4_sport102;
-        meta._l3_metadata_lkp_l4_dport101 = meta._l3_metadata_lkp_outer_l4_dport103;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._ipv6_metadata_lkp_ipv6_sa66 = hdr.ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da67 = hdr.ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_proto88 = hdr.ipv6.nextHdr;
+        meta._l3_metadata_lkp_ip_ttl90 = hdr.ipv6.hopLimit;
+        meta._l3_metadata_lkp_l4_sport91 = meta._l3_metadata_lkp_outer_l4_sport93;
+        meta._l3_metadata_lkp_l4_dport92 = meta._l3_metadata_lkp_outer_l4_dport94;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
     }
     @name(".ipv6_tunnel_lookup_miss") action _ipv6_tunnel_lookup_miss_2() {
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._ipv6_metadata_lkp_ipv6_sa75 = hdr.ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da76 = hdr.ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_proto97 = hdr.ipv6.nextHdr;
-        meta._l3_metadata_lkp_ip_ttl99 = hdr.ipv6.hopLimit;
-        meta._l3_metadata_lkp_l4_sport100 = meta._l3_metadata_lkp_outer_l4_sport102;
-        meta._l3_metadata_lkp_l4_dport101 = meta._l3_metadata_lkp_outer_l4_dport103;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._ipv6_metadata_lkp_ipv6_sa66 = hdr.ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da67 = hdr.ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_proto88 = hdr.ipv6.nextHdr;
+        meta._l3_metadata_lkp_ip_ttl90 = hdr.ipv6.hopLimit;
+        meta._l3_metadata_lkp_l4_sport91 = meta._l3_metadata_lkp_outer_l4_sport93;
+        meta._l3_metadata_lkp_l4_dport92 = meta._l3_metadata_lkp_outer_l4_dport94;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
     }
     @name(".outer_rmac") table _outer_rmac {
@@ -4036,8 +4027,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_163();
         }
         key = {
-            meta._l3_metadata_rmac_group105: exact @name("l3_metadata.rmac_group") ;
-            hdr.ethernet.dstAddr           : exact @name("ethernet.dstAddr") ;
+            meta._l3_metadata_rmac_group96: exact @name("l3_metadata.rmac_group") ;
+            hdr.ethernet.dstAddr          : exact @name("ethernet.dstAddr") ;
         }
         size = 1024;
         default_action = NoAction_163();
@@ -4054,8 +4045,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_164();
         }
         key = {
-            meta._tunnel_metadata_tunnel_vni153         : exact @name("tunnel_metadata.tunnel_vni") ;
-            meta._tunnel_metadata_ingress_tunnel_type152: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._tunnel_metadata_tunnel_vni148         : exact @name("tunnel_metadata.tunnel_vni") ;
+            meta._tunnel_metadata_ingress_tunnel_type147: exact @name("tunnel_metadata.ingress_tunnel_type") ;
             hdr.inner_ipv4.isValid()                    : exact @name("inner_ipv4.$valid$") ;
             hdr.inner_ipv6.isValid()                    : exact @name("inner_ipv6.$valid$") ;
         }
@@ -4107,11 +4098,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".terminate_fabric_unicast_packet") action _terminate_fabric_unicast_packet() {
         standard_metadata.egress_spec = (bit<9>)hdr.fabric_header.dstPortOrGroup;
-        meta._tunnel_metadata_tunnel_terminate165 = hdr.fabric_header_unicast.tunnelTerminate;
-        meta._tunnel_metadata_ingress_tunnel_type152 = hdr.fabric_header_unicast.ingressTunnelType;
-        meta._l3_metadata_nexthop_index115 = hdr.fabric_header_unicast.nexthopIndex;
-        meta._l3_metadata_routed116 = hdr.fabric_header_unicast.routed;
-        meta._l3_metadata_outer_routed117 = hdr.fabric_header_unicast.outerRouted;
+        meta._tunnel_metadata_tunnel_terminate160 = hdr.fabric_header_unicast.tunnelTerminate;
+        meta._tunnel_metadata_ingress_tunnel_type147 = hdr.fabric_header_unicast.ingressTunnelType;
+        meta._l3_metadata_nexthop_index106 = hdr.fabric_header_unicast.nexthopIndex;
+        meta._l3_metadata_routed107 = hdr.fabric_header_unicast.routed;
+        meta._l3_metadata_outer_routed108 = hdr.fabric_header_unicast.outerRouted;
         hdr.ethernet.etherType = hdr.fabric_payload_header.etherType;
         hdr.fabric_header.setInvalid();
         hdr.fabric_header_unicast.setInvalid();
@@ -4122,11 +4113,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._intrinsic_metadata_mcast_grp58 = hdr.fabric_header.dstPortOrGroup;
     }
     @name(".terminate_fabric_multicast_packet") action _terminate_fabric_multicast_packet() {
-        meta._tunnel_metadata_tunnel_terminate165 = hdr.fabric_header_multicast.tunnelTerminate;
-        meta._tunnel_metadata_ingress_tunnel_type152 = hdr.fabric_header_multicast.ingressTunnelType;
-        meta._l3_metadata_nexthop_index115 = 16w0;
-        meta._l3_metadata_routed116 = hdr.fabric_header_multicast.routed;
-        meta._l3_metadata_outer_routed117 = hdr.fabric_header_multicast.outerRouted;
+        meta._tunnel_metadata_tunnel_terminate160 = hdr.fabric_header_multicast.tunnelTerminate;
+        meta._tunnel_metadata_ingress_tunnel_type147 = hdr.fabric_header_multicast.ingressTunnelType;
+        meta._l3_metadata_nexthop_index106 = 16w0;
+        meta._l3_metadata_routed107 = hdr.fabric_header_multicast.routed;
+        meta._l3_metadata_outer_routed108 = hdr.fabric_header_multicast.outerRouted;
         meta._intrinsic_metadata_mcast_grp58 = hdr.fabric_header_multicast.mcastGrp;
         hdr.ethernet.etherType = hdr.fabric_payload_header.etherType;
         hdr.fabric_header.setInvalid();
@@ -4136,27 +4127,27 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_ingress_ifindex_properties") action _set_ingress_ifindex_properties() {
     }
     @name(".non_ip_over_fabric") action _non_ip_over_fabric() {
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._l2_metadata_lkp_mac_type83 = hdr.ethernet.etherType;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_type74 = hdr.ethernet.etherType;
     }
     @name(".ipv4_over_fabric") action _ipv4_over_fabric() {
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._ipv4_metadata_lkp_ipv4_sa71 = hdr.ipv4.srcAddr;
-        meta._ipv4_metadata_lkp_ipv4_da72 = hdr.ipv4.dstAddr;
-        meta._l3_metadata_lkp_ip_proto97 = hdr.ipv4.protocol;
-        meta._l3_metadata_lkp_l4_sport100 = meta._l3_metadata_lkp_outer_l4_sport102;
-        meta._l3_metadata_lkp_l4_dport101 = meta._l3_metadata_lkp_outer_l4_dport103;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._ipv4_metadata_lkp_ipv4_sa62 = hdr.ipv4.srcAddr;
+        meta._ipv4_metadata_lkp_ipv4_da63 = hdr.ipv4.dstAddr;
+        meta._l3_metadata_lkp_ip_proto88 = hdr.ipv4.protocol;
+        meta._l3_metadata_lkp_l4_sport91 = meta._l3_metadata_lkp_outer_l4_sport93;
+        meta._l3_metadata_lkp_l4_dport92 = meta._l3_metadata_lkp_outer_l4_dport94;
     }
     @name(".ipv6_over_fabric") action _ipv6_over_fabric() {
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._ipv6_metadata_lkp_ipv6_sa75 = hdr.ipv6.srcAddr;
-        meta._ipv6_metadata_lkp_ipv6_da76 = hdr.ipv6.dstAddr;
-        meta._l3_metadata_lkp_ip_proto97 = hdr.ipv6.nextHdr;
-        meta._l3_metadata_lkp_l4_sport100 = meta._l3_metadata_lkp_outer_l4_sport102;
-        meta._l3_metadata_lkp_l4_dport101 = meta._l3_metadata_lkp_outer_l4_dport103;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._ipv6_metadata_lkp_ipv6_sa66 = hdr.ipv6.srcAddr;
+        meta._ipv6_metadata_lkp_ipv6_da67 = hdr.ipv6.dstAddr;
+        meta._l3_metadata_lkp_ip_proto88 = hdr.ipv6.nextHdr;
+        meta._l3_metadata_lkp_l4_sport91 = meta._l3_metadata_lkp_outer_l4_sport93;
+        meta._l3_metadata_lkp_l4_dport92 = meta._l3_metadata_lkp_outer_l4_dport94;
     }
     @name(".fabric_ingress_dst_lkp") table _fabric_ingress_dst_lkp_0 {
         actions = {
@@ -4207,32 +4198,32 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".outer_multicast_route_s_g_hit") action _outer_multicast_route_s_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
-        meta._multicast_metadata_outer_mcast_route_hit127 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_outer_mcast_route_hit118 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group126;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".outer_multicast_bridge_s_g_hit") action _outer_multicast_bridge_s_g_hit(bit<16> mc_index) {
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".outer_multicast_route_sm_star_g_hit") action _outer_multicast_route_sm_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
-        meta._multicast_metadata_outer_mcast_mode128 = 2w1;
+        meta._multicast_metadata_outer_mcast_mode119 = 2w1;
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
-        meta._multicast_metadata_outer_mcast_route_hit127 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_outer_mcast_route_hit118 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group126;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".outer_multicast_route_bidir_star_g_hit") action _outer_multicast_route_bidir_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
-        meta._multicast_metadata_outer_mcast_mode128 = 2w2;
+        meta._multicast_metadata_outer_mcast_mode119 = 2w2;
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
-        meta._multicast_metadata_outer_mcast_route_hit127 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_outer_mcast_route_hit118 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group126;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".outer_multicast_bridge_star_g_hit") action _outer_multicast_bridge_star_g_hit(bit<16> mc_index) {
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".outer_ipv4_multicast") table _outer_ipv4_multicast_0 {
@@ -4244,8 +4235,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_170();
         }
         key = {
-            meta._multicast_metadata_ipv4_mcast_key_type123: exact @name("multicast_metadata.ipv4_mcast_key_type") ;
-            meta._multicast_metadata_ipv4_mcast_key124     : exact @name("multicast_metadata.ipv4_mcast_key") ;
+            meta._multicast_metadata_ipv4_mcast_key_type114: exact @name("multicast_metadata.ipv4_mcast_key_type") ;
+            meta._multicast_metadata_ipv4_mcast_key115     : exact @name("multicast_metadata.ipv4_mcast_key") ;
             hdr.ipv4.srcAddr                               : exact @name("ipv4.srcAddr") ;
             hdr.ipv4.dstAddr                               : exact @name("ipv4.dstAddr") ;
         }
@@ -4261,8 +4252,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_171();
         }
         key = {
-            meta._multicast_metadata_ipv4_mcast_key_type123: exact @name("multicast_metadata.ipv4_mcast_key_type") ;
-            meta._multicast_metadata_ipv4_mcast_key124     : exact @name("multicast_metadata.ipv4_mcast_key") ;
+            meta._multicast_metadata_ipv4_mcast_key_type114: exact @name("multicast_metadata.ipv4_mcast_key_type") ;
+            meta._multicast_metadata_ipv4_mcast_key115     : exact @name("multicast_metadata.ipv4_mcast_key") ;
             hdr.ipv4.dstAddr                               : ternary @name("ipv4.dstAddr") ;
         }
         size = 512;
@@ -4276,32 +4267,32 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".outer_multicast_route_s_g_hit") action _outer_multicast_route_s_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
-        meta._multicast_metadata_outer_mcast_route_hit127 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_outer_mcast_route_hit118 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group126;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".outer_multicast_bridge_s_g_hit") action _outer_multicast_bridge_s_g_hit_0(bit<16> mc_index) {
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".outer_multicast_route_sm_star_g_hit") action _outer_multicast_route_sm_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
-        meta._multicast_metadata_outer_mcast_mode128 = 2w1;
+        meta._multicast_metadata_outer_mcast_mode119 = 2w1;
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
-        meta._multicast_metadata_outer_mcast_route_hit127 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_outer_mcast_route_hit118 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group126;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".outer_multicast_route_bidir_star_g_hit") action _outer_multicast_route_bidir_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
-        meta._multicast_metadata_outer_mcast_mode128 = 2w2;
+        meta._multicast_metadata_outer_mcast_mode119 = 2w2;
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
-        meta._multicast_metadata_outer_mcast_route_hit127 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_outer_mcast_route_hit118 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group126;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".outer_multicast_bridge_star_g_hit") action _outer_multicast_bridge_star_g_hit_0(bit<16> mc_index) {
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".outer_ipv6_multicast") table _outer_ipv6_multicast_0 {
@@ -4313,8 +4304,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_172();
         }
         key = {
-            meta._multicast_metadata_ipv6_mcast_key_type125: exact @name("multicast_metadata.ipv6_mcast_key_type") ;
-            meta._multicast_metadata_ipv6_mcast_key126     : exact @name("multicast_metadata.ipv6_mcast_key") ;
+            meta._multicast_metadata_ipv6_mcast_key_type116: exact @name("multicast_metadata.ipv6_mcast_key_type") ;
+            meta._multicast_metadata_ipv6_mcast_key117     : exact @name("multicast_metadata.ipv6_mcast_key") ;
             hdr.ipv6.srcAddr                               : exact @name("ipv6.srcAddr") ;
             hdr.ipv6.dstAddr                               : exact @name("ipv6.dstAddr") ;
         }
@@ -4330,8 +4321,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_173();
         }
         key = {
-            meta._multicast_metadata_ipv6_mcast_key_type125: exact @name("multicast_metadata.ipv6_mcast_key_type") ;
-            meta._multicast_metadata_ipv6_mcast_key126     : exact @name("multicast_metadata.ipv6_mcast_key") ;
+            meta._multicast_metadata_ipv6_mcast_key_type116: exact @name("multicast_metadata.ipv6_mcast_key_type") ;
+            meta._multicast_metadata_ipv6_mcast_key117     : exact @name("multicast_metadata.ipv6_mcast_key") ;
             hdr.ipv6.dstAddr                               : ternary @name("ipv6.dstAddr") ;
         }
         size = 512;
@@ -4340,11 +4331,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_66() {
     }
     @name(".set_tunnel_termination_flag") action _set_tunnel_termination_flag() {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
     }
     @name(".set_tunnel_vni_and_termination_flag") action _set_tunnel_vni_and_termination_flag(bit<24> tunnel_vni) {
-        meta._tunnel_metadata_tunnel_vni153 = tunnel_vni;
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_vni148 = tunnel_vni;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
     }
     @name(".on_miss") action _on_miss_3() {
     }
@@ -4359,9 +4350,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_174();
         }
         key = {
-            meta._l3_metadata_vrf104                    : exact @name("l3_metadata.vrf") ;
+            meta._l3_metadata_vrf95                     : exact @name("l3_metadata.vrf") ;
             hdr.ipv4.dstAddr                            : exact @name("ipv4.dstAddr") ;
-            meta._tunnel_metadata_ingress_tunnel_type152: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._tunnel_metadata_ingress_tunnel_type147: exact @name("tunnel_metadata.ingress_tunnel_type") ;
         }
         size = 1024;
         default_action = NoAction_174();
@@ -4373,9 +4364,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_175();
         }
         key = {
-            meta._l3_metadata_vrf104                    : exact @name("l3_metadata.vrf") ;
+            meta._l3_metadata_vrf95                     : exact @name("l3_metadata.vrf") ;
             hdr.ipv4.srcAddr                            : exact @name("ipv4.srcAddr") ;
-            meta._tunnel_metadata_ingress_tunnel_type152: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._tunnel_metadata_ingress_tunnel_type147: exact @name("tunnel_metadata.ingress_tunnel_type") ;
         }
         size = 1024;
         default_action = NoAction_175();
@@ -4383,11 +4374,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_67() {
     }
     @name(".set_tunnel_termination_flag") action _set_tunnel_termination_flag_0() {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
     }
     @name(".set_tunnel_vni_and_termination_flag") action _set_tunnel_vni_and_termination_flag_0(bit<24> tunnel_vni) {
-        meta._tunnel_metadata_tunnel_vni153 = tunnel_vni;
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
+        meta._tunnel_metadata_tunnel_vni148 = tunnel_vni;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
     }
     @name(".on_miss") action _on_miss_4() {
     }
@@ -4402,9 +4393,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_176();
         }
         key = {
-            meta._l3_metadata_vrf104                    : exact @name("l3_metadata.vrf") ;
+            meta._l3_metadata_vrf95                     : exact @name("l3_metadata.vrf") ;
             hdr.ipv6.dstAddr                            : exact @name("ipv6.dstAddr") ;
-            meta._tunnel_metadata_ingress_tunnel_type152: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._tunnel_metadata_ingress_tunnel_type147: exact @name("tunnel_metadata.ingress_tunnel_type") ;
         }
         size = 1024;
         default_action = NoAction_176();
@@ -4416,58 +4407,58 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_177();
         }
         key = {
-            meta._l3_metadata_vrf104                    : exact @name("l3_metadata.vrf") ;
+            meta._l3_metadata_vrf95                     : exact @name("l3_metadata.vrf") ;
             hdr.ipv6.srcAddr                            : exact @name("ipv6.srcAddr") ;
-            meta._tunnel_metadata_ingress_tunnel_type152: exact @name("tunnel_metadata.ingress_tunnel_type") ;
+            meta._tunnel_metadata_ingress_tunnel_type147: exact @name("tunnel_metadata.ingress_tunnel_type") ;
         }
         size = 1024;
         default_action = NoAction_177();
     }
     @name(".terminate_eompls") action _terminate_eompls(bit<16> bd, bit<5> tunnel_type) {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type152 = tunnel_type;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
+        meta._tunnel_metadata_ingress_tunnel_type147 = tunnel_type;
         meta._ingress_metadata_bd42 = bd;
-        meta._l2_metadata_lkp_mac_type83 = hdr.inner_ethernet.etherType;
+        meta._l2_metadata_lkp_mac_type74 = hdr.inner_ethernet.etherType;
     }
     @name(".terminate_vpls") action _terminate_vpls(bit<16> bd, bit<5> tunnel_type) {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type152 = tunnel_type;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
+        meta._tunnel_metadata_ingress_tunnel_type147 = tunnel_type;
         meta._ingress_metadata_bd42 = bd;
-        meta._l2_metadata_lkp_mac_type83 = hdr.inner_ethernet.etherType;
+        meta._l2_metadata_lkp_mac_type74 = hdr.inner_ethernet.etherType;
     }
     @name(".terminate_ipv4_over_mpls") action _terminate_ipv4_over_mpls(bit<16> vrf, bit<5> tunnel_type) {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type152 = tunnel_type;
-        meta._l3_metadata_vrf104 = vrf;
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._l3_metadata_lkp_ip_type95 = 2w1;
-        meta._l2_metadata_lkp_mac_type83 = hdr.inner_ethernet.etherType;
-        meta._l3_metadata_lkp_ip_version96 = hdr.inner_ipv4.version;
-        meta._l3_metadata_lkp_ip_tc98 = hdr.inner_ipv4.diffserv;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
+        meta._tunnel_metadata_ingress_tunnel_type147 = tunnel_type;
+        meta._l3_metadata_vrf95 = vrf;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._l3_metadata_lkp_ip_type86 = 2w1;
+        meta._l2_metadata_lkp_mac_type74 = hdr.inner_ethernet.etherType;
+        meta._l3_metadata_lkp_ip_version87 = hdr.inner_ipv4.version;
+        meta._l3_metadata_lkp_ip_tc89 = hdr.inner_ipv4.diffserv;
     }
     @name(".terminate_ipv6_over_mpls") action _terminate_ipv6_over_mpls(bit<16> vrf, bit<5> tunnel_type) {
-        meta._tunnel_metadata_tunnel_terminate165 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type152 = tunnel_type;
-        meta._l3_metadata_vrf104 = vrf;
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
-        meta._l3_metadata_lkp_ip_type95 = 2w2;
-        meta._l2_metadata_lkp_mac_type83 = hdr.inner_ethernet.etherType;
-        meta._l3_metadata_lkp_ip_version96 = hdr.inner_ipv6.version;
-        meta._l3_metadata_lkp_ip_tc98 = hdr.inner_ipv6.trafficClass;
+        meta._tunnel_metadata_tunnel_terminate160 = 1w1;
+        meta._tunnel_metadata_ingress_tunnel_type147 = tunnel_type;
+        meta._l3_metadata_vrf95 = vrf;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
+        meta._l3_metadata_lkp_ip_type86 = 2w2;
+        meta._l2_metadata_lkp_mac_type74 = hdr.inner_ethernet.etherType;
+        meta._l3_metadata_lkp_ip_version87 = hdr.inner_ipv6.version;
+        meta._l3_metadata_lkp_ip_tc89 = hdr.inner_ipv6.trafficClass;
     }
     @name(".terminate_pw") action _terminate_pw(bit<16> ifindex) {
         meta._ingress_metadata_egress_ifindex39 = ifindex;
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
     }
     @name(".forward_mpls") action _forward_mpls(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_nexthop112 = nexthop_index;
-        meta._l3_metadata_fib_nexthop_type113 = 1w0;
-        meta._l3_metadata_fib_hit111 = 1w1;
-        meta._l2_metadata_lkp_mac_sa80 = hdr.ethernet.srcAddr;
-        meta._l2_metadata_lkp_mac_da81 = hdr.ethernet.dstAddr;
+        meta._l3_metadata_fib_nexthop103 = nexthop_index;
+        meta._l3_metadata_fib_nexthop_type104 = 1w0;
+        meta._l3_metadata_fib_hit102 = 1w1;
+        meta._l2_metadata_lkp_mac_sa71 = hdr.ethernet.srcAddr;
+        meta._l2_metadata_lkp_mac_da72 = hdr.ethernet.dstAddr;
     }
     @name(".mpls") table _mpls_0 {
         actions = {
@@ -4480,7 +4471,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_178();
         }
         key = {
-            meta._tunnel_metadata_mpls_label155: exact @name("tunnel_metadata.mpls_label") ;
+            meta._tunnel_metadata_mpls_label150: exact @name("tunnel_metadata.mpls_label") ;
             hdr.inner_ipv4.isValid()           : exact @name("inner_ipv4.$valid$") ;
             hdr.inner_ipv6.isValid()           : exact @name("inner_ipv6.$valid$") ;
         }
@@ -4492,7 +4483,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".sflow_ing_session_enable") action _sflow_ing_session_enable_0(bit<32> rate_thr, bit<16> session_id) {
         meta._ingress_metadata_sflow_take_sample47 = rate_thr |+| meta._ingress_metadata_sflow_take_sample47;
-        meta._sflow_metadata_sflow_session_id151 = session_id;
+        meta._sflow_metadata_sflow_session_id146 = session_id;
     }
     @name(".nop") action _nop_69() {
         _sflow_ingress_session_pkt_counter.count();
@@ -4501,7 +4492,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         _sflow_ingress_session_pkt_counter.count();
         meta._fabric_metadata_reason_code28 = reason_code;
         meta._i2e_metadata_mirror_session_id36 = (bit<16>)sflow_i2e_mirror_id;
-        clone3<tuple_3>(CloneType.I2E, sflow_i2e_mirror_id, { { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code, meta._ingress_metadata_ingress_port37 }, meta._sflow_metadata_sflow_session_id151, (bit<16>)sflow_i2e_mirror_id });
+        clone3<tuple_3>(CloneType.I2E, sflow_i2e_mirror_id, { { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code, meta._ingress_metadata_ingress_port37 }, meta._sflow_metadata_sflow_session_id146, (bit<16>)sflow_i2e_mirror_id });
     }
     @name(".sflow_ing_take_sample") table _sflow_ing_take_sample {
         actions = {
@@ -4511,7 +4502,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_sflow_take_sample47: ternary @name("ingress_metadata.sflow_take_sample") ;
-            meta._sflow_metadata_sflow_session_id151  : exact @name("sflow_metadata.sflow_session_id") ;
+            meta._sflow_metadata_sflow_session_id146  : exact @name("sflow_metadata.sflow_session_id") ;
         }
         counters = _sflow_ingress_session_pkt_counter;
         default_action = NoAction_179();
@@ -4524,8 +4515,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_ifindex38 : ternary @name("ingress_metadata.ifindex") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
             hdr.sflow.isValid()              : exact @name("sflow.$valid$") ;
         }
         size = 512;
@@ -4535,8 +4526,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_70() {
     }
     @name(".set_storm_control_meter") action _set_storm_control_meter_0(bit<32> meter_idx) {
-        _storm_control_meter.execute_meter<bit<2>>(meter_idx, meta._meter_metadata_meter_color121);
-        meta._meter_metadata_meter_index122 = (bit<16>)meter_idx;
+        _storm_control_meter.execute_meter<bit<2>>(meter_idx, meta._meter_metadata_meter_color112);
+        meta._meter_metadata_meter_index113 = (bit<16>)meter_idx;
     }
     @name(".storm_control") table _storm_control {
         actions = {
@@ -4546,7 +4537,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             standard_metadata.ingress_port  : exact @name("standard_metadata.ingress_port") ;
-            meta._l2_metadata_lkp_pkt_type82: ternary @name("l2_metadata.lkp_pkt_type") ;
+            meta._l2_metadata_lkp_pkt_type73: ternary @name("l2_metadata.lkp_pkt_type") ;
         }
         size = 512;
         default_action = NoAction_181();
@@ -4554,24 +4545,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_71() {
     }
     @name(".set_unicast") action _set_unicast_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w1;
+        meta._l2_metadata_lkp_pkt_type73 = 3w1;
     }
     @name(".set_unicast_and_ipv6_src_is_link_local") action _set_unicast_and_ipv6_src_is_link_local_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w1;
-        meta._ipv6_metadata_ipv6_src_is_link_local78 = 1w1;
+        meta._l2_metadata_lkp_pkt_type73 = 3w1;
+        meta._ipv6_metadata_ipv6_src_is_link_local69 = 1w1;
     }
     @name(".set_multicast") action _set_multicast_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w2;
-        meta._l2_metadata_bd_stats_idx91 = meta._l2_metadata_bd_stats_idx91 + 16w1;
+        meta._l2_metadata_lkp_pkt_type73 = 3w2;
+        meta._l2_metadata_bd_stats_idx82 = meta._l2_metadata_bd_stats_idx82 + 16w1;
     }
     @name(".set_multicast_and_ipv6_src_is_link_local") action _set_multicast_and_ipv6_src_is_link_local_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w2;
-        meta._ipv6_metadata_ipv6_src_is_link_local78 = 1w1;
-        meta._l2_metadata_bd_stats_idx91 = meta._l2_metadata_bd_stats_idx91 + 16w1;
+        meta._l2_metadata_lkp_pkt_type73 = 3w2;
+        meta._ipv6_metadata_ipv6_src_is_link_local69 = 1w1;
+        meta._l2_metadata_bd_stats_idx82 = meta._l2_metadata_bd_stats_idx82 + 16w1;
     }
     @name(".set_broadcast") action _set_broadcast_0() {
-        meta._l2_metadata_lkp_pkt_type82 = 3w4;
-        meta._l2_metadata_bd_stats_idx91 = meta._l2_metadata_bd_stats_idx91 + 16w2;
+        meta._l2_metadata_lkp_pkt_type73 = 3w4;
+        meta._l2_metadata_bd_stats_idx82 = meta._l2_metadata_bd_stats_idx82 + 16w2;
     }
     @name(".set_malformed_packet") action _set_malformed_packet_0(bit<8> drop_reason) {
         meta._ingress_metadata_drop_flag43 = 1w1;
@@ -4589,13 +4580,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_182();
         }
         key = {
-            meta._l2_metadata_lkp_mac_sa80[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
-            meta._l2_metadata_lkp_mac_da81            : ternary @name("l2_metadata.lkp_mac_da") ;
-            meta._l3_metadata_lkp_ip_type95           : ternary @name("l3_metadata.lkp_ip_type") ;
-            meta._l3_metadata_lkp_ip_ttl99            : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta._l3_metadata_lkp_ip_version96        : ternary @name("l3_metadata.lkp_ip_version") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv6_metadata_lkp_ipv6_sa75[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._l2_metadata_lkp_mac_sa71[40:40]     : ternary @name("l2_metadata.lkp_mac_sa") ;
+            meta._l2_metadata_lkp_mac_da72            : ternary @name("l2_metadata.lkp_mac_da") ;
+            meta._l3_metadata_lkp_ip_type86           : ternary @name("l3_metadata.lkp_ip_type") ;
+            meta._l3_metadata_lkp_ip_ttl90            : ternary @name("l3_metadata.lkp_ip_ttl") ;
+            meta._l3_metadata_lkp_ip_version87        : ternary @name("l3_metadata.lkp_ip_version") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62[31:24]  : ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv6_metadata_lkp_ipv6_sa66[127:112]: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_182();
@@ -4606,7 +4597,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".dmac_hit") action _dmac_hit_0(bit<16> ifindex) {
         meta._ingress_metadata_egress_ifindex39 = ifindex;
-        meta._l2_metadata_same_if_check94 = meta._l2_metadata_same_if_check94 ^ ifindex;
+        meta._l2_metadata_same_if_check85 = meta._l2_metadata_same_if_check85 ^ ifindex;
     }
     @name(".dmac_multicast_hit") action _dmac_multicast_hit_0(bit<16> mc_index) {
         meta._intrinsic_metadata_mcast_grp58 = mc_index;
@@ -4617,23 +4608,23 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".dmac_redirect_nexthop") action _dmac_redirect_nexthop_0(bit<16> nexthop_index) {
-        meta._l2_metadata_l2_redirect86 = 1w1;
-        meta._l2_metadata_l2_nexthop84 = nexthop_index;
-        meta._l2_metadata_l2_nexthop_type85 = 1w0;
+        meta._l2_metadata_l2_redirect77 = 1w1;
+        meta._l2_metadata_l2_nexthop75 = nexthop_index;
+        meta._l2_metadata_l2_nexthop_type76 = 1w0;
     }
     @name(".dmac_redirect_ecmp") action _dmac_redirect_ecmp_0(bit<16> ecmp_index) {
-        meta._l2_metadata_l2_redirect86 = 1w1;
-        meta._l2_metadata_l2_nexthop84 = ecmp_index;
-        meta._l2_metadata_l2_nexthop_type85 = 1w1;
+        meta._l2_metadata_l2_redirect77 = 1w1;
+        meta._l2_metadata_l2_nexthop75 = ecmp_index;
+        meta._l2_metadata_l2_nexthop_type76 = 1w1;
     }
     @name(".dmac_drop") action _dmac_drop_0() {
         mark_to_drop();
     }
     @name(".smac_miss") action _smac_miss_0() {
-        meta._l2_metadata_l2_src_miss87 = 1w1;
+        meta._l2_metadata_l2_src_miss78 = 1w1;
     }
     @name(".smac_hit") action _smac_hit_0(bit<16> ifindex) {
-        meta._l2_metadata_l2_src_move88 = meta._ingress_metadata_ifindex38 ^ ifindex;
+        meta._l2_metadata_l2_src_move79 = meta._ingress_metadata_ifindex38 ^ ifindex;
     }
     @name(".dmac") table _dmac {
         support_timeout = true;
@@ -4649,7 +4640,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_bd42   : exact @name("ingress_metadata.bd") ;
-            meta._l2_metadata_lkp_mac_da81: exact @name("l2_metadata.lkp_mac_da") ;
+            meta._l2_metadata_lkp_mac_da72: exact @name("l2_metadata.lkp_mac_da") ;
         }
         size = 1024;
         default_action = NoAction_183();
@@ -4663,7 +4654,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_bd42   : exact @name("ingress_metadata.bd") ;
-            meta._l2_metadata_lkp_mac_sa80: exact @name("l2_metadata.lkp_mac_sa") ;
+            meta._l2_metadata_lkp_mac_sa71: exact @name("l2_metadata.lkp_mac_sa") ;
         }
         size = 1024;
         default_action = NoAction_184();
@@ -4673,29 +4664,29 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".acl_deny") action _acl_deny_1(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
         meta._acl_metadata_acl_deny0 = 1w1;
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
     @name(".acl_permit") action _acl_permit_1(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
     @name(".acl_mirror") action _acl_mirror_1(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id;
-        meta._i2e_metadata_ingress_tstamp35 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp57;
-        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp57, (bit<16>)session_id });
+        meta._i2e_metadata_ingress_tstamp35 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp57;
+        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp57, (bit<16>)session_id });
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
     }
     @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_1(bit<16> nexthop_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
         meta._acl_metadata_acl_redirect7 = 1w1;
         meta._acl_metadata_acl_nexthop3 = nexthop_index;
         meta._acl_metadata_acl_nexthop_type5 = 1w0;
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
@@ -4704,7 +4695,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._acl_metadata_acl_nexthop3 = ecmp_index;
         meta._acl_metadata_acl_nexthop_type5 = 1w1;
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
@@ -4721,9 +4712,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             meta._acl_metadata_if_label9    : ternary @name("acl_metadata.if_label") ;
             meta._acl_metadata_bd_label10   : ternary @name("acl_metadata.bd_label") ;
-            meta._l2_metadata_lkp_mac_sa80  : ternary @name("l2_metadata.lkp_mac_sa") ;
-            meta._l2_metadata_lkp_mac_da81  : ternary @name("l2_metadata.lkp_mac_da") ;
-            meta._l2_metadata_lkp_mac_type83: ternary @name("l2_metadata.lkp_mac_type") ;
+            meta._l2_metadata_lkp_mac_sa71  : ternary @name("l2_metadata.lkp_mac_sa") ;
+            meta._l2_metadata_lkp_mac_da72  : ternary @name("l2_metadata.lkp_mac_da") ;
+            meta._l2_metadata_lkp_mac_type74: ternary @name("l2_metadata.lkp_mac_type") ;
         }
         size = 512;
         default_action = NoAction_185();
@@ -4735,49 +4726,49 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".acl_deny") action _acl_deny_2(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
         meta._acl_metadata_acl_deny0 = 1w1;
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
     @name(".acl_deny") action _acl_deny_4(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
         meta._acl_metadata_acl_deny0 = 1w1;
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
     @name(".acl_permit") action _acl_permit_2(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
     @name(".acl_permit") action _acl_permit_4(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
     @name(".acl_mirror") action _acl_mirror_2(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id;
-        meta._i2e_metadata_ingress_tstamp35 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp57;
-        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp57, (bit<16>)session_id });
+        meta._i2e_metadata_ingress_tstamp35 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp57;
+        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp57, (bit<16>)session_id });
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
     }
     @name(".acl_mirror") action _acl_mirror_4(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id;
-        meta._i2e_metadata_ingress_tstamp35 = (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp57;
-        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_tstamp57, (bit<16>)session_id });
+        meta._i2e_metadata_ingress_tstamp35 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp57;
+        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp57, (bit<16>)session_id });
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
     }
     @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_2(bit<16> nexthop_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
         meta._acl_metadata_acl_redirect7 = 1w1;
         meta._acl_metadata_acl_nexthop3 = nexthop_index;
         meta._acl_metadata_acl_nexthop_type5 = 1w0;
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
@@ -4786,7 +4777,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._acl_metadata_acl_nexthop3 = nexthop_index;
         meta._acl_metadata_acl_nexthop_type5 = 1w0;
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
@@ -4795,7 +4786,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._acl_metadata_acl_nexthop3 = ecmp_index;
         meta._acl_metadata_acl_nexthop_type5 = 1w1;
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
@@ -4804,7 +4795,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._acl_metadata_acl_nexthop3 = ecmp_index;
         meta._acl_metadata_acl_nexthop_type5 = 1w1;
         meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index122 = acl_meter_index;
+        meta._meter_metadata_meter_index113 = acl_meter_index;
         meta._acl_metadata_acl_copy1 = acl_copy;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
@@ -4821,13 +4812,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             meta._acl_metadata_if_label9     : ternary @name("acl_metadata.if_label") ;
             meta._acl_metadata_bd_label10    : ternary @name("acl_metadata.bd_label") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
-            meta._l3_metadata_lkp_ip_proto97 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_l4_sport100: ternary @name("l3_metadata.lkp_l4_sport") ;
-            meta._l3_metadata_lkp_l4_dport101: ternary @name("l3_metadata.lkp_l4_dport") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_lkp_ip_proto88 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_l4_sport91 : ternary @name("l3_metadata.lkp_l4_sport") ;
+            meta._l3_metadata_lkp_l4_dport92 : ternary @name("l3_metadata.lkp_l4_dport") ;
             hdr.tcp.flags                    : ternary @name("tcp.flags") ;
-            meta._l3_metadata_lkp_ip_ttl99   : ternary @name("l3_metadata.lkp_ip_ttl") ;
+            meta._l3_metadata_lkp_ip_ttl90   : ternary @name("l3_metadata.lkp_ip_ttl") ;
         }
         size = 512;
         default_action = NoAction_186();
@@ -4845,13 +4836,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             meta._acl_metadata_if_label9     : ternary @name("acl_metadata.if_label") ;
             meta._acl_metadata_bd_label10    : ternary @name("acl_metadata.bd_label") ;
-            meta._ipv6_metadata_lkp_ipv6_sa75: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
-            meta._ipv6_metadata_lkp_ipv6_da76: ternary @name("ipv6_metadata.lkp_ipv6_da") ;
-            meta._l3_metadata_lkp_ip_proto97 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_l4_sport100: ternary @name("l3_metadata.lkp_l4_sport") ;
-            meta._l3_metadata_lkp_l4_dport101: ternary @name("l3_metadata.lkp_l4_dport") ;
+            meta._ipv6_metadata_lkp_ipv6_sa66: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._ipv6_metadata_lkp_ipv6_da67: ternary @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._l3_metadata_lkp_ip_proto88 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_l4_sport91 : ternary @name("l3_metadata.lkp_l4_sport") ;
+            meta._l3_metadata_lkp_l4_dport92 : ternary @name("l3_metadata.lkp_l4_dport") ;
             hdr.tcp.flags                    : ternary @name("tcp.flags") ;
-            meta._l3_metadata_lkp_ip_ttl99   : ternary @name("l3_metadata.lkp_ip_ttl") ;
+            meta._l3_metadata_lkp_ip_ttl90   : ternary @name("l3_metadata.lkp_ip_ttl") ;
         }
         size = 512;
         default_action = NoAction_187();
@@ -4859,13 +4850,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_94() {
     }
     @name(".apply_cos_marking") action _apply_cos_marking_0(bit<3> cos) {
-        meta._qos_metadata_marked_cos145 = cos;
+        meta._qos_metadata_marked_cos136 = cos;
     }
     @name(".apply_dscp_marking") action _apply_dscp_marking_0(bit<8> dscp) {
-        meta._qos_metadata_marked_dscp146 = dscp;
+        meta._qos_metadata_marked_dscp137 = dscp;
     }
     @name(".apply_tc_marking") action _apply_tc_marking_0(bit<3> tc) {
-        meta._qos_metadata_marked_exp147 = tc;
+        meta._qos_metadata_marked_exp138 = tc;
     }
     @name(".qos") table _qos {
         actions = {
@@ -4877,12 +4868,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._acl_metadata_if_label9     : ternary @name("acl_metadata.if_label") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
-            meta._l3_metadata_lkp_ip_proto97 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_ip_tc98    : ternary @name("l3_metadata.lkp_ip_tc") ;
-            meta._tunnel_metadata_mpls_exp156: ternary @name("tunnel_metadata.mpls_exp") ;
-            meta._qos_metadata_outer_dscp144 : ternary @name("qos_metadata.outer_dscp") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_lkp_ip_proto88 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_ip_tc89    : ternary @name("l3_metadata.lkp_ip_tc") ;
+            meta._tunnel_metadata_mpls_exp151: ternary @name("tunnel_metadata.mpls_exp") ;
+            meta._qos_metadata_outer_dscp135 : ternary @name("qos_metadata.outer_dscp") ;
         }
         size = 512;
         default_action = NoAction_188();
@@ -4892,14 +4883,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_5() {
     }
     @name(".multicast_bridge_s_g_hit") action _multicast_bridge_s_g_hit(bit<16> mc_index) {
-        meta._multicast_metadata_multicast_bridge_mc_index139 = mc_index;
-        meta._multicast_metadata_mcast_bridge_hit130 = 1w1;
+        meta._multicast_metadata_multicast_bridge_mc_index130 = mc_index;
+        meta._multicast_metadata_mcast_bridge_hit121 = 1w1;
     }
     @name(".nop") action _nop_95() {
     }
     @name(".multicast_bridge_star_g_hit") action _multicast_bridge_star_g_hit(bit<16> mc_index) {
-        meta._multicast_metadata_multicast_bridge_mc_index139 = mc_index;
-        meta._multicast_metadata_mcast_bridge_hit130 = 1w1;
+        meta._multicast_metadata_multicast_bridge_mc_index130 = mc_index;
+        meta._multicast_metadata_mcast_bridge_hit121 = 1w1;
     }
     @name(".ipv4_multicast_bridge") table _ipv4_multicast_bridge_0 {
         actions = {
@@ -4909,8 +4900,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_bd42      : exact @name("ingress_metadata.bd") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: exact @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: exact @name("ipv4_metadata.lkp_ipv4_da") ;
         }
         size = 1024;
         default_action = NoAction_189();
@@ -4923,7 +4914,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_bd42      : exact @name("ingress_metadata.bd") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: exact @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: exact @name("ipv4_metadata.lkp_ipv4_da") ;
         }
         size = 1024;
         default_action = NoAction_190();
@@ -4933,10 +4924,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".multicast_route_s_g_hit") action _multicast_route_s_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
         _ipv4_multicast_route_s_g_stats_0.count();
-        meta._multicast_metadata_multicast_route_mc_index138 = mc_index;
-        meta._multicast_metadata_mcast_mode137 = 2w1;
-        meta._multicast_metadata_mcast_route_hit129 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_multicast_route_mc_index129 = mc_index;
+        meta._multicast_metadata_mcast_mode128 = 2w1;
+        meta._multicast_metadata_mcast_route_hit120 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group126;
     }
     @name(".ipv4_multicast_route") table _ipv4_multicast_route_0 {
         actions = {
@@ -4945,9 +4936,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_191();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: exact @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: exact @name("ipv4_metadata.lkp_ipv4_da") ;
         }
         size = 1024;
         counters = _ipv4_multicast_route_s_g_stats_0;
@@ -4955,21 +4946,21 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".multicast_route_star_g_miss") action _multicast_route_star_g_miss() {
         _ipv4_multicast_route_star_g_stats_0.count();
-        meta._l3_metadata_l3_copy119 = 1w1;
+        meta._l3_metadata_l3_copy110 = 1w1;
     }
     @name(".multicast_route_sm_star_g_hit") action _multicast_route_sm_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
         _ipv4_multicast_route_star_g_stats_0.count();
-        meta._multicast_metadata_mcast_mode137 = 2w1;
-        meta._multicast_metadata_multicast_route_mc_index138 = mc_index;
-        meta._multicast_metadata_mcast_route_hit129 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_mcast_mode128 = 2w1;
+        meta._multicast_metadata_multicast_route_mc_index129 = mc_index;
+        meta._multicast_metadata_mcast_route_hit120 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group126;
     }
     @name(".multicast_route_bidir_star_g_hit") action _multicast_route_bidir_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
         _ipv4_multicast_route_star_g_stats_0.count();
-        meta._multicast_metadata_mcast_mode137 = 2w2;
-        meta._multicast_metadata_multicast_route_mc_index138 = mc_index;
-        meta._multicast_metadata_mcast_route_hit129 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_mcast_mode128 = 2w2;
+        meta._multicast_metadata_multicast_route_mc_index129 = mc_index;
+        meta._multicast_metadata_mcast_route_hit120 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group126;
     }
     @name(".ipv4_multicast_route_star_g") table _ipv4_multicast_route_star_g_0 {
         actions = {
@@ -4979,8 +4970,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_192();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: exact @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: exact @name("ipv4_metadata.lkp_ipv4_da") ;
         }
         size = 1024;
         counters = _ipv4_multicast_route_star_g_stats_0;
@@ -4991,14 +4982,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_7() {
     }
     @name(".multicast_bridge_s_g_hit") action _multicast_bridge_s_g_hit_0(bit<16> mc_index) {
-        meta._multicast_metadata_multicast_bridge_mc_index139 = mc_index;
-        meta._multicast_metadata_mcast_bridge_hit130 = 1w1;
+        meta._multicast_metadata_multicast_bridge_mc_index130 = mc_index;
+        meta._multicast_metadata_mcast_bridge_hit121 = 1w1;
     }
     @name(".nop") action _nop_96() {
     }
     @name(".multicast_bridge_star_g_hit") action _multicast_bridge_star_g_hit_0(bit<16> mc_index) {
-        meta._multicast_metadata_multicast_bridge_mc_index139 = mc_index;
-        meta._multicast_metadata_mcast_bridge_hit130 = 1w1;
+        meta._multicast_metadata_multicast_bridge_mc_index130 = mc_index;
+        meta._multicast_metadata_mcast_bridge_hit121 = 1w1;
     }
     @name(".ipv6_multicast_bridge") table _ipv6_multicast_bridge_0 {
         actions = {
@@ -5008,8 +4999,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_bd42      : exact @name("ingress_metadata.bd") ;
-            meta._ipv6_metadata_lkp_ipv6_sa75: exact @name("ipv6_metadata.lkp_ipv6_sa") ;
-            meta._ipv6_metadata_lkp_ipv6_da76: exact @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._ipv6_metadata_lkp_ipv6_sa66: exact @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._ipv6_metadata_lkp_ipv6_da67: exact @name("ipv6_metadata.lkp_ipv6_da") ;
         }
         size = 1024;
         default_action = NoAction_193();
@@ -5022,7 +5013,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_bd42      : exact @name("ingress_metadata.bd") ;
-            meta._ipv6_metadata_lkp_ipv6_da76: exact @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._ipv6_metadata_lkp_ipv6_da67: exact @name("ipv6_metadata.lkp_ipv6_da") ;
         }
         size = 1024;
         default_action = NoAction_194();
@@ -5032,10 +5023,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".multicast_route_s_g_hit") action _multicast_route_s_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
         _ipv6_multicast_route_s_g_stats_0.count();
-        meta._multicast_metadata_multicast_route_mc_index138 = mc_index;
-        meta._multicast_metadata_mcast_mode137 = 2w1;
-        meta._multicast_metadata_mcast_route_hit129 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_multicast_route_mc_index129 = mc_index;
+        meta._multicast_metadata_mcast_mode128 = 2w1;
+        meta._multicast_metadata_mcast_route_hit120 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group126;
     }
     @name(".ipv6_multicast_route") table _ipv6_multicast_route_0 {
         actions = {
@@ -5044,9 +5035,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_195();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_sa75: exact @name("ipv6_metadata.lkp_ipv6_sa") ;
-            meta._ipv6_metadata_lkp_ipv6_da76: exact @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_sa66: exact @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._ipv6_metadata_lkp_ipv6_da67: exact @name("ipv6_metadata.lkp_ipv6_da") ;
         }
         size = 1024;
         counters = _ipv6_multicast_route_s_g_stats_0;
@@ -5054,21 +5045,21 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".multicast_route_star_g_miss") action _multicast_route_star_g_miss_0() {
         _ipv6_multicast_route_star_g_stats_0.count();
-        meta._l3_metadata_l3_copy119 = 1w1;
+        meta._l3_metadata_l3_copy110 = 1w1;
     }
     @name(".multicast_route_sm_star_g_hit") action _multicast_route_sm_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
         _ipv6_multicast_route_star_g_stats_0.count();
-        meta._multicast_metadata_mcast_mode137 = 2w1;
-        meta._multicast_metadata_multicast_route_mc_index138 = mc_index;
-        meta._multicast_metadata_mcast_route_hit129 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_mcast_mode128 = 2w1;
+        meta._multicast_metadata_multicast_route_mc_index129 = mc_index;
+        meta._multicast_metadata_mcast_route_hit120 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group126;
     }
     @name(".multicast_route_bidir_star_g_hit") action _multicast_route_bidir_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
         _ipv6_multicast_route_star_g_stats_0.count();
-        meta._multicast_metadata_mcast_mode137 = 2w2;
-        meta._multicast_metadata_multicast_route_mc_index138 = mc_index;
-        meta._multicast_metadata_mcast_route_hit129 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group136 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group135;
+        meta._multicast_metadata_mcast_mode128 = 2w2;
+        meta._multicast_metadata_multicast_route_mc_index129 = mc_index;
+        meta._multicast_metadata_mcast_route_hit120 = 1w1;
+        meta._multicast_metadata_mcast_rpf_group127 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group126;
     }
     @name(".ipv6_multicast_route_star_g") table _ipv6_multicast_route_star_g_0 {
         actions = {
@@ -5078,8 +5069,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_196();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_da76: exact @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_da67: exact @name("ipv6_metadata.lkp_ipv6_da") ;
         }
         size = 1024;
         counters = _ipv6_multicast_route_star_g_stats_0;
@@ -5125,11 +5116,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._acl_metadata_bd_label10    : ternary @name("acl_metadata.bd_label") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
-            meta._l3_metadata_lkp_ip_proto97 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_l4_sport100: ternary @name("l3_metadata.lkp_l4_sport") ;
-            meta._l3_metadata_lkp_l4_dport101: ternary @name("l3_metadata.lkp_l4_dport") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62: ternary @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: ternary @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_lkp_ip_proto88 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_l4_sport91 : ternary @name("l3_metadata.lkp_l4_sport") ;
+            meta._l3_metadata_lkp_l4_dport92 : ternary @name("l3_metadata.lkp_l4_dport") ;
         }
         size = 512;
         default_action = NoAction_197();
@@ -5137,17 +5128,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_23() {
     }
     @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_0(bit<16> urpf_bd_group) {
-        meta._l3_metadata_urpf_hit108 = 1w1;
-        meta._l3_metadata_urpf_bd_group110 = urpf_bd_group;
-        meta._l3_metadata_urpf_mode107 = meta._ipv4_metadata_ipv4_urpf_mode74;
+        meta._l3_metadata_urpf_hit99 = 1w1;
+        meta._l3_metadata_urpf_bd_group101 = urpf_bd_group;
+        meta._l3_metadata_urpf_mode98 = meta._ipv4_metadata_ipv4_urpf_mode65;
     }
     @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_2(bit<16> urpf_bd_group) {
-        meta._l3_metadata_urpf_hit108 = 1w1;
-        meta._l3_metadata_urpf_bd_group110 = urpf_bd_group;
-        meta._l3_metadata_urpf_mode107 = meta._ipv4_metadata_ipv4_urpf_mode74;
+        meta._l3_metadata_urpf_hit99 = 1w1;
+        meta._l3_metadata_urpf_bd_group101 = urpf_bd_group;
+        meta._l3_metadata_urpf_mode98 = meta._ipv4_metadata_ipv4_urpf_mode65;
     }
     @name(".urpf_miss") action _urpf_miss_1() {
-        meta._l3_metadata_urpf_check_fail109 = 1w1;
+        meta._l3_metadata_urpf_check_fail100 = 1w1;
     }
     @name(".ipv4_urpf") table _ipv4_urpf {
         actions = {
@@ -5156,8 +5147,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_198();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62: exact @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 1024;
         default_action = NoAction_198();
@@ -5169,8 +5160,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_199();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_sa71: lpm @name("ipv4_metadata.lkp_ipv4_sa") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_sa62: lpm @name("ipv4_metadata.lkp_ipv4_sa") ;
         }
         size = 512;
         default_action = NoAction_199();
@@ -5180,24 +5171,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_25() {
     }
     @name(".fib_hit_nexthop") action _fib_hit_nexthop_1(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_hit111 = 1w1;
-        meta._l3_metadata_fib_nexthop112 = nexthop_index;
-        meta._l3_metadata_fib_nexthop_type113 = 1w0;
+        meta._l3_metadata_fib_hit102 = 1w1;
+        meta._l3_metadata_fib_nexthop103 = nexthop_index;
+        meta._l3_metadata_fib_nexthop_type104 = 1w0;
     }
     @name(".fib_hit_nexthop") action _fib_hit_nexthop_2(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_hit111 = 1w1;
-        meta._l3_metadata_fib_nexthop112 = nexthop_index;
-        meta._l3_metadata_fib_nexthop_type113 = 1w0;
+        meta._l3_metadata_fib_hit102 = 1w1;
+        meta._l3_metadata_fib_nexthop103 = nexthop_index;
+        meta._l3_metadata_fib_nexthop_type104 = 1w0;
     }
     @name(".fib_hit_ecmp") action _fib_hit_ecmp_1(bit<16> ecmp_index) {
-        meta._l3_metadata_fib_hit111 = 1w1;
-        meta._l3_metadata_fib_nexthop112 = ecmp_index;
-        meta._l3_metadata_fib_nexthop_type113 = 1w1;
+        meta._l3_metadata_fib_hit102 = 1w1;
+        meta._l3_metadata_fib_nexthop103 = ecmp_index;
+        meta._l3_metadata_fib_nexthop_type104 = 1w1;
     }
     @name(".fib_hit_ecmp") action _fib_hit_ecmp_2(bit<16> ecmp_index) {
-        meta._l3_metadata_fib_hit111 = 1w1;
-        meta._l3_metadata_fib_nexthop112 = ecmp_index;
-        meta._l3_metadata_fib_nexthop_type113 = 1w1;
+        meta._l3_metadata_fib_hit102 = 1w1;
+        meta._l3_metadata_fib_nexthop103 = ecmp_index;
+        meta._l3_metadata_fib_nexthop_type104 = 1w1;
     }
     @name(".ipv4_fib") table _ipv4_fib {
         actions = {
@@ -5207,8 +5198,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_200();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: exact @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: exact @name("ipv4_metadata.lkp_ipv4_da") ;
         }
         size = 1024;
         default_action = NoAction_200();
@@ -5221,8 +5212,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_201();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv4_metadata_lkp_ipv4_da72: lpm @name("ipv4_metadata.lkp_ipv4_da") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv4_metadata_lkp_ipv4_da63: lpm @name("ipv4_metadata.lkp_ipv4_da") ;
         }
         size = 512;
         default_action = NoAction_201();
@@ -5267,11 +5258,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._acl_metadata_bd_label10    : ternary @name("acl_metadata.bd_label") ;
-            meta._ipv6_metadata_lkp_ipv6_sa75: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
-            meta._ipv6_metadata_lkp_ipv6_da76: ternary @name("ipv6_metadata.lkp_ipv6_da") ;
-            meta._l3_metadata_lkp_ip_proto97 : ternary @name("l3_metadata.lkp_ip_proto") ;
-            meta._l3_metadata_lkp_l4_sport100: ternary @name("l3_metadata.lkp_l4_sport") ;
-            meta._l3_metadata_lkp_l4_dport101: ternary @name("l3_metadata.lkp_l4_dport") ;
+            meta._ipv6_metadata_lkp_ipv6_sa66: ternary @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._ipv6_metadata_lkp_ipv6_da67: ternary @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._l3_metadata_lkp_ip_proto88 : ternary @name("l3_metadata.lkp_ip_proto") ;
+            meta._l3_metadata_lkp_l4_sport91 : ternary @name("l3_metadata.lkp_l4_sport") ;
+            meta._l3_metadata_lkp_l4_dport92 : ternary @name("l3_metadata.lkp_l4_dport") ;
         }
         size = 512;
         default_action = NoAction_202();
@@ -5279,17 +5270,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_26() {
     }
     @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_0(bit<16> urpf_bd_group) {
-        meta._l3_metadata_urpf_hit108 = 1w1;
-        meta._l3_metadata_urpf_bd_group110 = urpf_bd_group;
-        meta._l3_metadata_urpf_mode107 = meta._ipv6_metadata_ipv6_urpf_mode79;
+        meta._l3_metadata_urpf_hit99 = 1w1;
+        meta._l3_metadata_urpf_bd_group101 = urpf_bd_group;
+        meta._l3_metadata_urpf_mode98 = meta._ipv6_metadata_ipv6_urpf_mode70;
     }
     @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_2(bit<16> urpf_bd_group) {
-        meta._l3_metadata_urpf_hit108 = 1w1;
-        meta._l3_metadata_urpf_bd_group110 = urpf_bd_group;
-        meta._l3_metadata_urpf_mode107 = meta._ipv6_metadata_ipv6_urpf_mode79;
+        meta._l3_metadata_urpf_hit99 = 1w1;
+        meta._l3_metadata_urpf_bd_group101 = urpf_bd_group;
+        meta._l3_metadata_urpf_mode98 = meta._ipv6_metadata_ipv6_urpf_mode70;
     }
     @name(".urpf_miss") action _urpf_miss_2() {
-        meta._l3_metadata_urpf_check_fail109 = 1w1;
+        meta._l3_metadata_urpf_check_fail100 = 1w1;
     }
     @name(".ipv6_urpf") table _ipv6_urpf {
         actions = {
@@ -5298,8 +5289,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_203();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_sa75: exact @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_sa66: exact @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 1024;
         default_action = NoAction_203();
@@ -5311,8 +5302,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_204();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_sa75: lpm @name("ipv6_metadata.lkp_ipv6_sa") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_sa66: lpm @name("ipv6_metadata.lkp_ipv6_sa") ;
         }
         size = 512;
         default_action = NoAction_204();
@@ -5322,24 +5313,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_30() {
     }
     @name(".fib_hit_nexthop") action _fib_hit_nexthop_5(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_hit111 = 1w1;
-        meta._l3_metadata_fib_nexthop112 = nexthop_index;
-        meta._l3_metadata_fib_nexthop_type113 = 1w0;
+        meta._l3_metadata_fib_hit102 = 1w1;
+        meta._l3_metadata_fib_nexthop103 = nexthop_index;
+        meta._l3_metadata_fib_nexthop_type104 = 1w0;
     }
     @name(".fib_hit_nexthop") action _fib_hit_nexthop_6(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_hit111 = 1w1;
-        meta._l3_metadata_fib_nexthop112 = nexthop_index;
-        meta._l3_metadata_fib_nexthop_type113 = 1w0;
+        meta._l3_metadata_fib_hit102 = 1w1;
+        meta._l3_metadata_fib_nexthop103 = nexthop_index;
+        meta._l3_metadata_fib_nexthop_type104 = 1w0;
     }
     @name(".fib_hit_ecmp") action _fib_hit_ecmp_5(bit<16> ecmp_index) {
-        meta._l3_metadata_fib_hit111 = 1w1;
-        meta._l3_metadata_fib_nexthop112 = ecmp_index;
-        meta._l3_metadata_fib_nexthop_type113 = 1w1;
+        meta._l3_metadata_fib_hit102 = 1w1;
+        meta._l3_metadata_fib_nexthop103 = ecmp_index;
+        meta._l3_metadata_fib_nexthop_type104 = 1w1;
     }
     @name(".fib_hit_ecmp") action _fib_hit_ecmp_6(bit<16> ecmp_index) {
-        meta._l3_metadata_fib_hit111 = 1w1;
-        meta._l3_metadata_fib_nexthop112 = ecmp_index;
-        meta._l3_metadata_fib_nexthop_type113 = 1w1;
+        meta._l3_metadata_fib_hit102 = 1w1;
+        meta._l3_metadata_fib_nexthop103 = ecmp_index;
+        meta._l3_metadata_fib_nexthop_type104 = 1w1;
     }
     @name(".ipv6_fib") table _ipv6_fib {
         actions = {
@@ -5349,8 +5340,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_205();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_da76: exact @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_da67: exact @name("ipv6_metadata.lkp_ipv6_da") ;
         }
         size = 1024;
         default_action = NoAction_205();
@@ -5363,8 +5354,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_206();
         }
         key = {
-            meta._l3_metadata_vrf104         : exact @name("l3_metadata.vrf") ;
-            meta._ipv6_metadata_lkp_ipv6_da76: lpm @name("ipv6_metadata.lkp_ipv6_da") ;
+            meta._l3_metadata_vrf95          : exact @name("l3_metadata.vrf") ;
+            meta._ipv6_metadata_lkp_ipv6_da67: lpm @name("ipv6_metadata.lkp_ipv6_da") ;
         }
         size = 512;
         default_action = NoAction_206();
@@ -5372,7 +5363,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_99() {
     }
     @name(".urpf_bd_miss") action _urpf_bd_miss_0() {
-        meta._l3_metadata_urpf_check_fail109 = 1w1;
+        meta._l3_metadata_urpf_check_fail100 = 1w1;
     }
     @name(".urpf_bd") table _urpf_bd {
         actions = {
@@ -5381,7 +5372,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_207();
         }
         key = {
-            meta._l3_metadata_urpf_bd_group110: exact @name("l3_metadata.urpf_bd_group") ;
+            meta._l3_metadata_urpf_bd_group101: exact @name("l3_metadata.urpf_bd_group") ;
             meta._ingress_metadata_bd42       : exact @name("ingress_metadata.bd") ;
         }
         size = 1024;
@@ -5389,7 +5380,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".meter_index") direct_meter<bit<2>>(MeterType.bytes) _meter_index;
     @name(".nop") action _nop_100() {
-        _meter_index.read(meta._meter_metadata_meter_color121);
+        _meter_index.read(meta._meter_metadata_meter_color112);
     }
     @name(".meter_index") table _meter_index_0 {
         actions = {
@@ -5397,30 +5388,28 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_208();
         }
         key = {
-            meta._meter_metadata_meter_index122: exact @name("meter_metadata.meter_index") ;
+            meta._meter_metadata_meter_index113: exact @name("meter_metadata.meter_index") ;
         }
         size = 1024;
         meters = _meter_index;
         default_action = NoAction_208();
     }
     @name(".compute_lkp_ipv4_hash") action _compute_lkp_ipv4_hash_0() {
-        hash<bit<16>, bit<16>, tuple_4, bit<32>>(meta._hash_metadata_hash132, HashAlgorithm.crc16, 16w0, { meta._ipv4_metadata_lkp_ipv4_sa71, meta._ipv4_metadata_lkp_ipv4_da72, meta._l3_metadata_lkp_ip_proto97, meta._l3_metadata_lkp_l4_sport100, meta._l3_metadata_lkp_l4_dport101 }, 32w65536);
-        hash<bit<16>, bit<16>, tuple_5, bit<32>>(meta._hash_metadata_hash233, HashAlgorithm.crc16, 16w0, { meta._l2_metadata_lkp_mac_sa80, meta._l2_metadata_lkp_mac_da81, meta._ipv4_metadata_lkp_ipv4_sa71, meta._ipv4_metadata_lkp_ipv4_da72, meta._l3_metadata_lkp_ip_proto97, meta._l3_metadata_lkp_l4_sport100, meta._l3_metadata_lkp_l4_dport101 }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_4, bit<32>>(meta._hash_metadata_hash132, HashAlgorithm.crc16, 16w0, { meta._ipv4_metadata_lkp_ipv4_sa62, meta._ipv4_metadata_lkp_ipv4_da63, meta._l3_metadata_lkp_ip_proto88, meta._l3_metadata_lkp_l4_sport91, meta._l3_metadata_lkp_l4_dport92 }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_5, bit<32>>(meta._hash_metadata_hash233, HashAlgorithm.crc16, 16w0, { meta._l2_metadata_lkp_mac_sa71, meta._l2_metadata_lkp_mac_da72, meta._ipv4_metadata_lkp_ipv4_sa62, meta._ipv4_metadata_lkp_ipv4_da63, meta._l3_metadata_lkp_ip_proto88, meta._l3_metadata_lkp_l4_sport91, meta._l3_metadata_lkp_l4_dport92 }, 32w65536);
     }
     @name(".compute_lkp_ipv6_hash") action _compute_lkp_ipv6_hash_0() {
-        hash<bit<16>, bit<16>, tuple_6, bit<32>>(meta._hash_metadata_hash132, HashAlgorithm.crc16, 16w0, { meta._ipv6_metadata_lkp_ipv6_sa75, meta._ipv6_metadata_lkp_ipv6_da76, meta._l3_metadata_lkp_ip_proto97, meta._l3_metadata_lkp_l4_sport100, meta._l3_metadata_lkp_l4_dport101 }, 32w65536);
-        hash<bit<16>, bit<16>, tuple_7, bit<32>>(meta._hash_metadata_hash233, HashAlgorithm.crc16, 16w0, { meta._l2_metadata_lkp_mac_sa80, meta._l2_metadata_lkp_mac_da81, meta._ipv6_metadata_lkp_ipv6_sa75, meta._ipv6_metadata_lkp_ipv6_da76, meta._l3_metadata_lkp_ip_proto97, meta._l3_metadata_lkp_l4_sport100, meta._l3_metadata_lkp_l4_dport101 }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_6, bit<32>>(meta._hash_metadata_hash132, HashAlgorithm.crc16, 16w0, { meta._ipv6_metadata_lkp_ipv6_sa66, meta._ipv6_metadata_lkp_ipv6_da67, meta._l3_metadata_lkp_ip_proto88, meta._l3_metadata_lkp_l4_sport91, meta._l3_metadata_lkp_l4_dport92 }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_7, bit<32>>(meta._hash_metadata_hash233, HashAlgorithm.crc16, 16w0, { meta._l2_metadata_lkp_mac_sa71, meta._l2_metadata_lkp_mac_da72, meta._ipv6_metadata_lkp_ipv6_sa66, meta._ipv6_metadata_lkp_ipv6_da67, meta._l3_metadata_lkp_ip_proto88, meta._l3_metadata_lkp_l4_sport91, meta._l3_metadata_lkp_l4_dport92 }, 32w65536);
     }
     @name(".compute_lkp_non_ip_hash") action _compute_lkp_non_ip_hash_0() {
-        hash<bit<16>, bit<16>, tuple_8, bit<32>>(meta._hash_metadata_hash233, HashAlgorithm.crc16, 16w0, { meta._ingress_metadata_ifindex38, meta._l2_metadata_lkp_mac_sa80, meta._l2_metadata_lkp_mac_da81, meta._l2_metadata_lkp_mac_type83 }, 32w65536);
+        hash<bit<16>, bit<16>, tuple_8, bit<32>>(meta._hash_metadata_hash233, HashAlgorithm.crc16, 16w0, { meta._ingress_metadata_ifindex38, meta._l2_metadata_lkp_mac_sa71, meta._l2_metadata_lkp_mac_da72, meta._l2_metadata_lkp_mac_type74 }, 32w65536);
     }
     @name(".computed_two_hashes") action _computed_two_hashes_0() {
-        meta._intrinsic_metadata_mcast_hash67 = (bit<13>)meta._hash_metadata_hash132;
         meta._hash_metadata_entropy_hash34 = meta._hash_metadata_hash233;
     }
     @name(".computed_one_hash") action _computed_one_hash_0() {
         meta._hash_metadata_hash132 = meta._hash_metadata_hash233;
-        meta._intrinsic_metadata_mcast_hash67 = (bit<13>)meta._hash_metadata_hash233;
         meta._hash_metadata_entropy_hash34 = meta._hash_metadata_hash233;
     }
     @name(".compute_ipv4_hashes") table _compute_ipv4_hashes {
@@ -5479,8 +5468,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_213();
         }
         key = {
-            meta._meter_metadata_meter_color121: exact @name("meter_metadata.meter_color") ;
-            meta._meter_metadata_meter_index122: exact @name("meter_metadata.meter_index") ;
+            meta._meter_metadata_meter_color112: exact @name("meter_metadata.meter_color") ;
+            meta._meter_metadata_meter_index113: exact @name("meter_metadata.meter_index") ;
         }
         size = 1024;
         counters = _meter_stats;
@@ -5488,7 +5477,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @min_width(32) @name(".ingress_bd_stats_count") counter(32w1024, CounterType.packets_and_bytes) _ingress_bd_stats_count;
     @name(".update_ingress_bd_stats") action _update_ingress_bd_stats_0() {
-        _ingress_bd_stats_count.count((bit<32>)meta._l2_metadata_bd_stats_idx91);
+        _ingress_bd_stats_count.count((bit<32>)meta._l2_metadata_bd_stats_idx82);
     }
     @name(".ingress_bd_stats") table _ingress_bd_stats {
         actions = {
@@ -5520,7 +5509,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_216();
         }
         key = {
-            meta._meter_metadata_meter_color121: exact @name("meter_metadata.meter_color") ;
+            meta._meter_metadata_meter_color112: exact @name("meter_metadata.meter_color") ;
             standard_metadata.ingress_port     : exact @name("standard_metadata.ingress_port") ;
         }
         size = 1024;
@@ -5530,38 +5519,38 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_102() {
     }
     @name(".set_l2_redirect_action") action _set_l2_redirect_action_0() {
-        meta._l3_metadata_nexthop_index115 = meta._l2_metadata_l2_nexthop84;
-        meta._nexthop_metadata_nexthop_type143 = meta._l2_metadata_l2_nexthop_type85;
+        meta._l3_metadata_nexthop_index106 = meta._l2_metadata_l2_nexthop75;
+        meta._nexthop_metadata_nexthop_type134 = meta._l2_metadata_l2_nexthop_type76;
         meta._ingress_metadata_egress_ifindex39 = 16w0;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
         meta._fabric_metadata_dst_device29 = 8w0;
     }
     @name(".set_fib_redirect_action") action _set_fib_redirect_action_0() {
-        meta._l3_metadata_nexthop_index115 = meta._l3_metadata_fib_nexthop112;
-        meta._nexthop_metadata_nexthop_type143 = meta._l3_metadata_fib_nexthop_type113;
-        meta._l3_metadata_routed116 = 1w1;
+        meta._l3_metadata_nexthop_index106 = meta._l3_metadata_fib_nexthop103;
+        meta._nexthop_metadata_nexthop_type134 = meta._l3_metadata_fib_nexthop_type104;
+        meta._l3_metadata_routed107 = 1w1;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
         meta._fabric_metadata_reason_code28 = 16w0x217;
         meta._fabric_metadata_dst_device29 = 8w0;
     }
     @name(".set_cpu_redirect_action") action _set_cpu_redirect_action_0() {
-        meta._l3_metadata_routed116 = 1w0;
+        meta._l3_metadata_routed107 = 1w0;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
         standard_metadata.egress_spec = 9w64;
         meta._ingress_metadata_egress_ifindex39 = 16w0;
         meta._fabric_metadata_dst_device29 = 8w0;
     }
     @name(".set_acl_redirect_action") action _set_acl_redirect_action_0() {
-        meta._l3_metadata_nexthop_index115 = meta._acl_metadata_acl_nexthop3;
-        meta._nexthop_metadata_nexthop_type143 = meta._acl_metadata_acl_nexthop_type5;
+        meta._l3_metadata_nexthop_index106 = meta._acl_metadata_acl_nexthop3;
+        meta._nexthop_metadata_nexthop_type134 = meta._acl_metadata_acl_nexthop_type5;
         meta._ingress_metadata_egress_ifindex39 = 16w0;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
         meta._fabric_metadata_dst_device29 = 8w0;
     }
     @name(".set_racl_redirect_action") action _set_racl_redirect_action_0() {
-        meta._l3_metadata_nexthop_index115 = meta._acl_metadata_racl_nexthop4;
-        meta._nexthop_metadata_nexthop_type143 = meta._acl_metadata_racl_nexthop_type6;
-        meta._l3_metadata_routed116 = 1w1;
+        meta._l3_metadata_nexthop_index106 = meta._acl_metadata_racl_nexthop4;
+        meta._nexthop_metadata_nexthop_type134 = meta._acl_metadata_racl_nexthop_type6;
+        meta._l3_metadata_routed107 = 1w1;
         meta._ingress_metadata_egress_ifindex39 = 16w0;
         meta._intrinsic_metadata_mcast_grp58 = 16w0;
         meta._fabric_metadata_dst_device29 = 8w0;
@@ -5569,14 +5558,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_multicast_route_action") action _set_multicast_route_action_0() {
         meta._fabric_metadata_dst_device29 = 8w127;
         meta._ingress_metadata_egress_ifindex39 = 16w0;
-        meta._intrinsic_metadata_mcast_grp58 = meta._multicast_metadata_multicast_route_mc_index138;
-        meta._l3_metadata_routed116 = 1w1;
-        meta._l3_metadata_same_bd_check114 = 16w0xffff;
+        meta._intrinsic_metadata_mcast_grp58 = meta._multicast_metadata_multicast_route_mc_index129;
+        meta._l3_metadata_routed107 = 1w1;
+        meta._l3_metadata_same_bd_check105 = 16w0xffff;
     }
     @name(".set_multicast_bridge_action") action _set_multicast_bridge_action_0() {
         meta._fabric_metadata_dst_device29 = 8w127;
         meta._ingress_metadata_egress_ifindex39 = 16w0;
-        meta._intrinsic_metadata_mcast_grp58 = meta._multicast_metadata_multicast_bridge_mc_index139;
+        meta._intrinsic_metadata_mcast_grp58 = meta._multicast_metadata_multicast_bridge_mc_index130;
     }
     @name(".set_multicast_flood") action _set_multicast_flood_0() {
         meta._fabric_metadata_dst_device29 = 8w127;
@@ -5601,19 +5590,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_217();
         }
         key = {
-            meta._l2_metadata_l2_redirect86                  : ternary @name("l2_metadata.l2_redirect") ;
+            meta._l2_metadata_l2_redirect77                  : ternary @name("l2_metadata.l2_redirect") ;
             meta._acl_metadata_acl_redirect7                 : ternary @name("acl_metadata.acl_redirect") ;
             meta._acl_metadata_racl_redirect8                : ternary @name("acl_metadata.racl_redirect") ;
-            meta._l3_metadata_rmac_hit106                    : ternary @name("l3_metadata.rmac_hit") ;
-            meta._l3_metadata_fib_hit111                     : ternary @name("l3_metadata.fib_hit") ;
-            meta._l2_metadata_lkp_pkt_type82                 : ternary @name("l2_metadata.lkp_pkt_type") ;
-            meta._l3_metadata_lkp_ip_type95                  : ternary @name("l3_metadata.lkp_ip_type") ;
-            meta._multicast_metadata_igmp_snooping_enabled133: ternary @name("multicast_metadata.igmp_snooping_enabled") ;
-            meta._multicast_metadata_mld_snooping_enabled134 : ternary @name("multicast_metadata.mld_snooping_enabled") ;
-            meta._multicast_metadata_mcast_route_hit129      : ternary @name("multicast_metadata.mcast_route_hit") ;
-            meta._multicast_metadata_mcast_bridge_hit130     : ternary @name("multicast_metadata.mcast_bridge_hit") ;
-            meta._multicast_metadata_mcast_rpf_group136      : ternary @name("multicast_metadata.mcast_rpf_group") ;
-            meta._multicast_metadata_mcast_mode137           : ternary @name("multicast_metadata.mcast_mode") ;
+            meta._l3_metadata_rmac_hit97                     : ternary @name("l3_metadata.rmac_hit") ;
+            meta._l3_metadata_fib_hit102                     : ternary @name("l3_metadata.fib_hit") ;
+            meta._l2_metadata_lkp_pkt_type73                 : ternary @name("l2_metadata.lkp_pkt_type") ;
+            meta._l3_metadata_lkp_ip_type86                  : ternary @name("l3_metadata.lkp_ip_type") ;
+            meta._multicast_metadata_igmp_snooping_enabled124: ternary @name("multicast_metadata.igmp_snooping_enabled") ;
+            meta._multicast_metadata_mld_snooping_enabled125 : ternary @name("multicast_metadata.mld_snooping_enabled") ;
+            meta._multicast_metadata_mcast_route_hit120      : ternary @name("multicast_metadata.mcast_route_hit") ;
+            meta._multicast_metadata_mcast_bridge_hit121     : ternary @name("multicast_metadata.mcast_bridge_hit") ;
+            meta._multicast_metadata_mcast_rpf_group127      : ternary @name("multicast_metadata.mcast_rpf_group") ;
+            meta._multicast_metadata_mcast_mode128           : ternary @name("multicast_metadata.mcast_mode") ;
         }
         size = 512;
         default_action = NoAction_217();
@@ -5624,28 +5613,28 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_ecmp_nexthop_details") action _set_ecmp_nexthop_details_0(bit<16> ifindex, bit<16> bd, bit<16> nhop_index, bit<1> tunnel) {
         meta._ingress_metadata_egress_ifindex39 = ifindex;
-        meta._l3_metadata_nexthop_index115 = nhop_index;
-        meta._l3_metadata_same_bd_check114 = meta._ingress_metadata_bd42 ^ bd;
-        meta._l2_metadata_same_if_check94 = meta._l2_metadata_same_if_check94 ^ ifindex;
-        meta._tunnel_metadata_tunnel_if_check166 = meta._tunnel_metadata_tunnel_terminate165 ^ tunnel;
+        meta._l3_metadata_nexthop_index106 = nhop_index;
+        meta._l3_metadata_same_bd_check105 = meta._ingress_metadata_bd42 ^ bd;
+        meta._l2_metadata_same_if_check85 = meta._l2_metadata_same_if_check85 ^ ifindex;
+        meta._tunnel_metadata_tunnel_if_check161 = meta._tunnel_metadata_tunnel_terminate160 ^ tunnel;
     }
     @name(".set_ecmp_nexthop_details_for_post_routed_flood") action _set_ecmp_nexthop_details_for_post_routed_flood_0(bit<16> bd, bit<16> uuc_mc_index, bit<16> nhop_index) {
         meta._intrinsic_metadata_mcast_grp58 = uuc_mc_index;
-        meta._l3_metadata_nexthop_index115 = nhop_index;
+        meta._l3_metadata_nexthop_index106 = nhop_index;
         meta._ingress_metadata_egress_ifindex39 = 16w0;
-        meta._l3_metadata_same_bd_check114 = meta._ingress_metadata_bd42 ^ bd;
+        meta._l3_metadata_same_bd_check105 = meta._ingress_metadata_bd42 ^ bd;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".set_nexthop_details") action _set_nexthop_details_0(bit<16> ifindex, bit<16> bd, bit<1> tunnel) {
         meta._ingress_metadata_egress_ifindex39 = ifindex;
-        meta._l3_metadata_same_bd_check114 = meta._ingress_metadata_bd42 ^ bd;
-        meta._l2_metadata_same_if_check94 = meta._l2_metadata_same_if_check94 ^ ifindex;
-        meta._tunnel_metadata_tunnel_if_check166 = meta._tunnel_metadata_tunnel_terminate165 ^ tunnel;
+        meta._l3_metadata_same_bd_check105 = meta._ingress_metadata_bd42 ^ bd;
+        meta._l2_metadata_same_if_check85 = meta._l2_metadata_same_if_check85 ^ ifindex;
+        meta._tunnel_metadata_tunnel_if_check161 = meta._tunnel_metadata_tunnel_terminate160 ^ tunnel;
     }
     @name(".set_nexthop_details_for_post_routed_flood") action _set_nexthop_details_for_post_routed_flood_0(bit<16> bd, bit<16> uuc_mc_index) {
         meta._intrinsic_metadata_mcast_grp58 = uuc_mc_index;
         meta._ingress_metadata_egress_ifindex39 = 16w0;
-        meta._l3_metadata_same_bd_check114 = meta._ingress_metadata_bd42 ^ bd;
+        meta._l3_metadata_same_bd_check105 = meta._ingress_metadata_bd42 ^ bd;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".ecmp_group") table _ecmp_group {
@@ -5656,7 +5645,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_218();
         }
         key = {
-            meta._l3_metadata_nexthop_index115: exact @name("l3_metadata.nexthop_index") ;
+            meta._l3_metadata_nexthop_index106: exact @name("l3_metadata.nexthop_index") ;
             meta._hash_metadata_hash132       : selector @name("hash_metadata.hash1") ;
         }
         size = 1024;
@@ -5671,7 +5660,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_219();
         }
         key = {
-            meta._l3_metadata_nexthop_index115: exact @name("l3_metadata.nexthop_index") ;
+            meta._l3_metadata_nexthop_index106: exact @name("l3_metadata.nexthop_index") ;
         }
         size = 1024;
         default_action = NoAction_219();
@@ -5689,7 +5678,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         key = {
             meta._ingress_metadata_bd42     : exact @name("ingress_metadata.bd") ;
-            meta._l2_metadata_lkp_pkt_type82: exact @name("l2_metadata.lkp_pkt_type") ;
+            meta._l2_metadata_lkp_pkt_type73: exact @name("l2_metadata.lkp_pkt_type") ;
         }
         size = 1024;
         default_action = NoAction_220();
@@ -5721,7 +5710,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_106() {
     }
     @name(".generate_learn_notify") action _generate_learn_notify_0() {
-        digest<mac_learn_digest>(32w1024, {meta._ingress_metadata_bd42,meta._l2_metadata_lkp_mac_sa80,meta._ingress_metadata_ifindex38});
+        digest<mac_learn_digest>(32w1024, {meta._ingress_metadata_bd42,meta._l2_metadata_lkp_mac_sa71,meta._ingress_metadata_ifindex38});
     }
     @name(".learn_notify") table _learn_notify {
         actions = {
@@ -5730,9 +5719,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_222();
         }
         key = {
-            meta._l2_metadata_l2_src_miss87: ternary @name("l2_metadata.l2_src_miss") ;
-            meta._l2_metadata_l2_src_move88: ternary @name("l2_metadata.l2_src_move") ;
-            meta._l2_metadata_stp_state90  : ternary @name("l2_metadata.stp_state") ;
+            meta._l2_metadata_l2_src_miss78: ternary @name("l2_metadata.l2_src_miss") ;
+            meta._l2_metadata_l2_src_move79: ternary @name("l2_metadata.l2_src_move") ;
+            meta._l2_metadata_stp_state81  : ternary @name("l2_metadata.stp_state") ;
         }
         size = 512;
         default_action = NoAction_222();
@@ -5743,7 +5732,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".set_fabric_multicast") action _set_fabric_multicast_0(bit<8> fabric_mgid) {
-        meta._multicast_metadata_mcast_grp142 = meta._intrinsic_metadata_mcast_grp58;
+        meta._multicast_metadata_mcast_grp133 = meta._intrinsic_metadata_mcast_grp58;
     }
     @name(".fabric_lag") table _fabric_lag {
         actions = {
@@ -5812,30 +5801,30 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         key = {
             meta._acl_metadata_if_label9                  : ternary @name("acl_metadata.if_label") ;
             meta._acl_metadata_bd_label10                 : ternary @name("acl_metadata.bd_label") ;
-            meta._l2_metadata_lkp_mac_sa80                : ternary @name("l2_metadata.lkp_mac_sa") ;
-            meta._l2_metadata_lkp_mac_da81                : ternary @name("l2_metadata.lkp_mac_da") ;
-            meta._l2_metadata_lkp_mac_type83              : ternary @name("l2_metadata.lkp_mac_type") ;
+            meta._l2_metadata_lkp_mac_sa71                : ternary @name("l2_metadata.lkp_mac_sa") ;
+            meta._l2_metadata_lkp_mac_da72                : ternary @name("l2_metadata.lkp_mac_da") ;
+            meta._l2_metadata_lkp_mac_type74              : ternary @name("l2_metadata.lkp_mac_type") ;
             meta._ingress_metadata_ifindex38              : ternary @name("ingress_metadata.ifindex") ;
-            meta._l2_metadata_port_vlan_mapping_miss93    : ternary @name("l2_metadata.port_vlan_mapping_miss") ;
-            meta._security_metadata_ipsg_check_fail150    : ternary @name("security_metadata.ipsg_check_fail") ;
-            meta._security_metadata_storm_control_color148: ternary @name("security_metadata.storm_control_color") ;
+            meta._l2_metadata_port_vlan_mapping_miss84    : ternary @name("l2_metadata.port_vlan_mapping_miss") ;
+            meta._security_metadata_ipsg_check_fail145    : ternary @name("security_metadata.ipsg_check_fail") ;
+            meta._security_metadata_storm_control_color143: ternary @name("security_metadata.storm_control_color") ;
             meta._acl_metadata_acl_deny0                  : ternary @name("acl_metadata.acl_deny") ;
             meta._acl_metadata_racl_deny2                 : ternary @name("acl_metadata.racl_deny") ;
-            meta._l3_metadata_urpf_check_fail109          : ternary @name("l3_metadata.urpf_check_fail") ;
+            meta._l3_metadata_urpf_check_fail100          : ternary @name("l3_metadata.urpf_check_fail") ;
             meta._ingress_metadata_drop_flag43            : ternary @name("ingress_metadata.drop_flag") ;
             meta._acl_metadata_acl_copy1                  : ternary @name("acl_metadata.acl_copy") ;
-            meta._l3_metadata_l3_copy119                  : ternary @name("l3_metadata.l3_copy") ;
-            meta._l3_metadata_rmac_hit106                 : ternary @name("l3_metadata.rmac_hit") ;
-            meta._l3_metadata_routed116                   : ternary @name("l3_metadata.routed") ;
-            meta._ipv6_metadata_ipv6_src_is_link_local78  : ternary @name("ipv6_metadata.ipv6_src_is_link_local") ;
-            meta._l2_metadata_same_if_check94             : ternary @name("l2_metadata.same_if_check") ;
-            meta._tunnel_metadata_tunnel_if_check166      : ternary @name("tunnel_metadata.tunnel_if_check") ;
-            meta._l3_metadata_same_bd_check114            : ternary @name("l3_metadata.same_bd_check") ;
-            meta._l3_metadata_lkp_ip_ttl99                : ternary @name("l3_metadata.lkp_ip_ttl") ;
-            meta._l2_metadata_stp_state90                 : ternary @name("l2_metadata.stp_state") ;
+            meta._l3_metadata_l3_copy110                  : ternary @name("l3_metadata.l3_copy") ;
+            meta._l3_metadata_rmac_hit97                  : ternary @name("l3_metadata.rmac_hit") ;
+            meta._l3_metadata_routed107                   : ternary @name("l3_metadata.routed") ;
+            meta._ipv6_metadata_ipv6_src_is_link_local69  : ternary @name("ipv6_metadata.ipv6_src_is_link_local") ;
+            meta._l2_metadata_same_if_check85             : ternary @name("l2_metadata.same_if_check") ;
+            meta._tunnel_metadata_tunnel_if_check161      : ternary @name("tunnel_metadata.tunnel_if_check") ;
+            meta._l3_metadata_same_bd_check105            : ternary @name("l3_metadata.same_bd_check") ;
+            meta._l3_metadata_lkp_ip_ttl90                : ternary @name("l3_metadata.lkp_ip_ttl") ;
+            meta._l2_metadata_stp_state81                 : ternary @name("l2_metadata.stp_state") ;
             meta._ingress_metadata_control_frame45        : ternary @name("ingress_metadata.control_frame") ;
-            meta._ipv4_metadata_ipv4_unicast_enabled73    : ternary @name("ipv4_metadata.ipv4_unicast_enabled") ;
-            meta._ipv6_metadata_ipv6_unicast_enabled77    : ternary @name("ipv6_metadata.ipv6_unicast_enabled") ;
+            meta._ipv4_metadata_ipv4_unicast_enabled64    : ternary @name("ipv4_metadata.ipv4_unicast_enabled") ;
+            meta._ipv6_metadata_ipv6_unicast_enabled68    : ternary @name("ipv6_metadata.ipv6_unicast_enabled") ;
             meta._ingress_metadata_egress_ifindex39       : ternary @name("ingress_metadata.egress_ifindex") ;
         }
         size = 512;
@@ -5861,9 +5850,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 
         _switch_config_params.apply();
         _port_vlan_mapping.apply();
-        if (meta._ingress_metadata_port_type40 == 2w0 && meta._l2_metadata_stp_group89 != 10w0) 
+        if (meta._ingress_metadata_port_type40 == 2w0 && meta._l2_metadata_stp_group80 != 10w0) 
             _spanning_tree.apply();
-        if (meta._ingress_metadata_port_type40 == 2w0 && meta._security_metadata_ipsg_enabled149 == 1w1) 
+        if (meta._ingress_metadata_port_type40 == 2w0 && meta._security_metadata_ipsg_enabled144 == 1w1) 
             switch (_ipsg.apply().action_run) {
                 _on_miss: {
                     _ipsg_permit_special.apply();
@@ -5881,11 +5870,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             if (meta._ingress_metadata_port_type40 == 2w1) {
                 if (hdr.fabric_header_multicast.isValid()) 
                     _fabric_ingress_src_lkp_0.apply();
-                if (meta._tunnel_metadata_tunnel_terminate165 == 1w0) 
+                if (meta._tunnel_metadata_tunnel_terminate160 == 1w0) 
                     _native_packet_over_fabric_0.apply();
             }
         }
-        if (meta._tunnel_metadata_ingress_tunnel_type152 != 5w0) 
+        if (meta._tunnel_metadata_ingress_tunnel_type147 != 5w0) 
             switch (_outer_rmac.apply().action_run) {
                 _on_miss_0: {
                     if (hdr.ipv4.isValid()) 
@@ -5926,7 +5915,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 }
             }
 
-        if (meta._tunnel_metadata_tunnel_terminate165 == 1w1 || meta._multicast_metadata_outer_mcast_route_hit127 == 1w1 && (meta._multicast_metadata_outer_mcast_mode128 == 2w1 && meta._multicast_metadata_mcast_rpf_group136 == 16w0 || meta._multicast_metadata_outer_mcast_mode128 == 2w2 && meta._multicast_metadata_mcast_rpf_group136 != 16w0)) 
+        if (meta._tunnel_metadata_tunnel_terminate160 == 1w1 || meta._multicast_metadata_outer_mcast_route_hit118 == 1w1 && (meta._multicast_metadata_outer_mcast_mode119 == 2w1 && meta._multicast_metadata_mcast_rpf_group127 == 16w0 || meta._multicast_metadata_outer_mcast_mode119 == 2w2 && meta._multicast_metadata_mcast_rpf_group127 != 16w0)) 
             switch (_tunnel.apply().action_run) {
                 _tunnel_lookup_miss_0: {
                     _tunnel_lookup_miss_1.apply();
@@ -5940,27 +5929,27 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         if (meta._ingress_metadata_port_type40 == 2w0) 
             _storm_control.apply();
         if (meta._ingress_metadata_port_type40 != 2w1) 
-            if (!(hdr.mpls[0].isValid() && meta._l3_metadata_fib_hit111 == 1w1)) {
+            if (!(hdr.mpls[0].isValid() && meta._l3_metadata_fib_hit102 == 1w1)) {
                 if (meta._ingress_metadata_drop_flag43 == 1w0) 
                     _validate_packet.apply();
                 if (meta._ingress_metadata_port_type40 == 2w0) 
                     _smac.apply();
                 if (meta._ingress_metadata_bypass_lookups46 & 16w0x1 == 16w0) 
                     _dmac.apply();
-                if (meta._l3_metadata_lkp_ip_type95 == 2w0) 
+                if (meta._l3_metadata_lkp_ip_type86 == 2w0) 
                     if (meta._ingress_metadata_bypass_lookups46 & 16w0x4 == 16w0) 
                         _mac_acl.apply();
                 else 
                     if (meta._ingress_metadata_bypass_lookups46 & 16w0x4 == 16w0) 
-                        if (meta._l3_metadata_lkp_ip_type95 == 2w1) 
+                        if (meta._l3_metadata_lkp_ip_type86 == 2w1) 
                             _ip_acl.apply();
                         else 
-                            if (meta._l3_metadata_lkp_ip_type95 == 2w2) 
+                            if (meta._l3_metadata_lkp_ip_type86 == 2w2) 
                                 _ipv6_acl.apply();
                 _qos.apply();
                 switch (rmac_0.apply().action_run) {
                     rmac_miss: {
-                        if (meta._l3_metadata_lkp_ip_type95 == 2w1) {
+                        if (meta._l3_metadata_lkp_ip_type86 == 2w1) {
                             if (meta._ingress_metadata_bypass_lookups46 & 16w0x1 == 16w0) 
                                 switch (_ipv4_multicast_bridge_0.apply().action_run) {
                                     _on_miss_5: {
@@ -5968,7 +5957,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     }
                                 }
 
-                            if (meta._ingress_metadata_bypass_lookups46 & 16w0x2 == 16w0 && meta._multicast_metadata_ipv4_multicast_enabled131 == 1w1) 
+                            if (meta._ingress_metadata_bypass_lookups46 & 16w0x2 == 16w0 && meta._multicast_metadata_ipv4_multicast_enabled122 == 1w1) 
                                 switch (_ipv4_multicast_route_0.apply().action_run) {
                                     _on_miss_6: {
                                         _ipv4_multicast_route_star_g_0.apply();
@@ -5977,7 +5966,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 
                         }
                         else 
-                            if (meta._l3_metadata_lkp_ip_type95 == 2w2) {
+                            if (meta._l3_metadata_lkp_ip_type86 == 2w2) {
                                 if (meta._ingress_metadata_bypass_lookups46 & 16w0x1 == 16w0) 
                                     switch (_ipv6_multicast_bridge_0.apply().action_run) {
                                         _on_miss_7: {
@@ -5985,7 +5974,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                         }
                                     }
 
-                                if (meta._ingress_metadata_bypass_lookups46 & 16w0x2 == 16w0 && meta._multicast_metadata_ipv6_multicast_enabled132 == 1w1) 
+                                if (meta._ingress_metadata_bypass_lookups46 & 16w0x2 == 16w0 && meta._multicast_metadata_ipv6_multicast_enabled123 == 1w1) 
                                     switch (_ipv6_multicast_route_0.apply().action_run) {
                                         _on_miss_8: {
                                             _ipv6_multicast_route_star_g_0.apply();
@@ -5996,9 +5985,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                     }
                     default: {
                         if (meta._ingress_metadata_bypass_lookups46 & 16w0x2 == 16w0) {
-                            if (meta._l3_metadata_lkp_ip_type95 == 2w1 && meta._ipv4_metadata_ipv4_unicast_enabled73 == 1w1) {
+                            if (meta._l3_metadata_lkp_ip_type86 == 2w1 && meta._ipv4_metadata_ipv4_unicast_enabled64 == 1w1) {
                                 _ipv4_racl.apply();
-                                if (meta._ipv4_metadata_ipv4_urpf_mode74 != 2w0) 
+                                if (meta._ipv4_metadata_ipv4_urpf_mode65 != 2w0) 
                                     switch (_ipv4_urpf.apply().action_run) {
                                         _on_miss_23: {
                                             _ipv4_urpf_lpm.apply();
@@ -6013,9 +6002,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 
                             }
                             else 
-                                if (meta._l3_metadata_lkp_ip_type95 == 2w2 && meta._ipv6_metadata_ipv6_unicast_enabled77 == 1w1) {
+                                if (meta._l3_metadata_lkp_ip_type86 == 2w2 && meta._ipv6_metadata_ipv6_unicast_enabled68 == 1w1) {
                                     _ipv6_racl.apply();
-                                    if (meta._ipv6_metadata_ipv6_urpf_mode79 != 2w0) 
+                                    if (meta._ipv6_metadata_ipv6_urpf_mode70 != 2w0) 
                                         switch (_ipv6_urpf.apply().action_run) {
                                             _on_miss_26: {
                                                 _ipv6_urpf_lpm.apply();
@@ -6029,7 +6018,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     }
 
                                 }
-                            if (meta._l3_metadata_urpf_mode107 == 2w2 && meta._l3_metadata_urpf_hit108 == 1w1) 
+                            if (meta._l3_metadata_urpf_mode98 == 2w2 && meta._l3_metadata_urpf_hit99 == 1w1) 
                                 _urpf_bd.apply();
                         }
                     }
@@ -6038,10 +6027,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             }
         if (meta._ingress_metadata_bypass_lookups46 & 16w0x10 == 16w0) 
             _meter_index_0.apply();
-        if (meta._tunnel_metadata_tunnel_terminate165 == 1w0 && hdr.ipv4.isValid() || meta._tunnel_metadata_tunnel_terminate165 == 1w1 && hdr.inner_ipv4.isValid()) 
+        if (meta._tunnel_metadata_tunnel_terminate160 == 1w0 && hdr.ipv4.isValid() || meta._tunnel_metadata_tunnel_terminate160 == 1w1 && hdr.inner_ipv4.isValid()) 
             _compute_ipv4_hashes.apply();
         else 
-            if (meta._tunnel_metadata_tunnel_terminate165 == 1w0 && hdr.ipv6.isValid() || meta._tunnel_metadata_tunnel_terminate165 == 1w1 && hdr.inner_ipv6.isValid()) 
+            if (meta._tunnel_metadata_tunnel_terminate160 == 1w0 && hdr.ipv6.isValid() || meta._tunnel_metadata_tunnel_terminate160 == 1w1 && hdr.inner_ipv6.isValid()) 
                 _compute_ipv6_hashes.apply();
             else 
                 _compute_non_ip_hashes.apply();
@@ -6054,7 +6043,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             _storm_control_stats_0.apply();
             if (meta._ingress_metadata_bypass_lookups46 != 16w0xffff) 
                 _fwd_result.apply();
-            if (meta._nexthop_metadata_nexthop_type143 == 1w1) 
+            if (meta._nexthop_metadata_nexthop_type134 == 1w1) 
                 _ecmp_group.apply();
             else 
                 _nexthop.apply();
@@ -6062,7 +6051,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 _bd_flood.apply();
             else 
                 _lag_group.apply();
-            if (meta._l2_metadata_learning_enabled92 == 1w1) 
+            if (meta._l2_metadata_learning_enabled83 == 1w1) 
                 _learn_notify.apply();
         }
         _fabric_lag.apply();

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -90,17 +90,8 @@ struct int_metadata_i2e_t {
 
 struct ingress_intrinsic_metadata_t {
     bit<1>  resubmit_flag;
-    bit<48> ingress_global_tstamp;
+    bit<48> ingress_global_timestamp;
     bit<16> mcast_grp;
-    bit<1>  deflection_flag;
-    bit<1>  deflect_on_drop;
-    bit<19> enq_qdepth;
-    bit<32> enq_tstamp;
-    bit<2>  enq_congest_stat;
-    bit<19> deq_qdepth;
-    bit<2>  deq_congest_stat;
-    bit<32> deq_timedelta;
-    bit<13> mcast_hash;
     bit<16> egress_rid;
     bit<32> lf_field_list;
     bit<3>  priority;
@@ -206,6 +197,13 @@ struct qos_metadata_t {
     bit<3> marked_cos;
     bit<8> marked_dscp;
     bit<3> marked_exp;
+}
+
+struct queueing_metadata_t {
+    bit<48> enq_timestamp;
+    bit<16> enq_qdepth;
+    bit<32> deq_timedelta;
+    bit<16> deq_qdepth;
 }
 
 struct security_metadata_t {
@@ -681,6 +679,8 @@ struct metadata {
     nexthop_metadata_t           nexthop_metadata;
     @name(".qos_metadata") 
     qos_metadata_t               qos_metadata;
+    @name(".queueing_metadata") 
+    queueing_metadata_t          queueing_metadata;
     @name(".security_metadata") 
     security_metadata_t          security_metadata;
     @name(".sflow_metadata") 
@@ -1951,14 +1951,14 @@ control process_int_insertion(inout headers hdr, inout metadata meta, inout stan
     @name(".int_set_header_3") action int_set_header_3() {
         hdr.int_q_occupancy_header.setValid();
         hdr.int_q_occupancy_header.q_occupancy1 = 7w0;
-        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.intrinsic_metadata.enq_qdepth;
+        hdr.int_q_occupancy_header.q_occupancy0 = (bit<24>)meta.queueing_metadata.enq_qdepth;
     }
     @name(".int_set_header_0003_i1") action int_set_header_0003_i1() {
         int_set_header_3();
     }
     @name(".int_set_header_2") action int_set_header_2() {
         hdr.int_hop_latency_header.setValid();
-        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.intrinsic_metadata.deq_timedelta;
+        hdr.int_hop_latency_header.hop_latency = (bit<31>)meta.queueing_metadata.deq_timedelta;
     }
     @name(".int_set_header_0003_i2") action int_set_header_0003_i2() {
         int_set_header_2();
@@ -2936,9 +2936,8 @@ control process_egress_acl(inout headers hdr, inout metadata meta, inout standar
             egress_redirect_to_cpu;
         }
         key = {
-            standard_metadata.egress_port          : ternary;
-            meta.intrinsic_metadata.deflection_flag: ternary;
-            meta.l3_metadata.l3_mtu_check          : ternary;
+            standard_metadata.egress_port: ternary;
+            meta.l3_metadata.l3_mtu_check: ternary;
         }
         size = 512;
     }
@@ -3016,7 +3015,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".process_egress_filter") process_egress_filter() process_egress_filter_0;
     @name(".process_egress_acl") process_egress_acl() process_egress_acl_0;
     apply {
-        if (meta.intrinsic_metadata.deflection_flag == 1w0 && meta.egress_metadata.bypass == 1w0) {
+        if (meta.egress_metadata.bypass == 1w0) {
             if (standard_metadata.instance_type != 32w0 && standard_metadata.instance_type != 32w5) {
                 mirror.apply();
             }
@@ -3277,12 +3276,11 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
 }
 
 control process_global_params(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".deflect_on_drop") action deflect_on_drop(bit<1> enable_dod) {
-        meta.intrinsic_metadata.deflect_on_drop = enable_dod;
+    @name(".deflect_on_drop") action deflect_on_drop(bit<8> enable_dod) {
     }
-    @name(".set_config_parameters") action set_config_parameters(bit<1> enable_dod) {
+    @name(".set_config_parameters") action set_config_parameters(bit<8> enable_dod) {
         deflect_on_drop(enable_dod);
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
         standard_metadata.egress_spec = 9w511;
@@ -4403,7 +4401,7 @@ control process_mac_acl(inout headers hdr, inout metadata meta, inout standard_m
     }
     @name(".acl_mirror") action acl_mirror(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
         meta.meter_metadata.meter_index = acl_meter_index;
@@ -4469,7 +4467,7 @@ control process_ip_acl(inout headers hdr, inout metadata meta, inout standard_me
     }
     @name(".acl_mirror") action acl_mirror(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_tstamp;
+        meta.i2e_metadata.ingress_tstamp = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
         clone3(CloneType.I2E, (bit<32>)session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         meta.acl_metadata.acl_stats_index = acl_stats_index;
         meta.meter_metadata.meter_index = acl_meter_index;
@@ -5224,12 +5222,10 @@ control process_hashes(inout headers hdr, inout metadata meta, inout standard_me
         hash(meta.hash_metadata.hash2, HashAlgorithm.crc16, (bit<16>)0, { meta.ingress_metadata.ifindex, meta.l2_metadata.lkp_mac_sa, meta.l2_metadata.lkp_mac_da, meta.l2_metadata.lkp_mac_type }, (bit<32>)65536);
     }
     @name(".computed_two_hashes") action computed_two_hashes() {
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash1;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".computed_one_hash") action computed_one_hash() {
         meta.hash_metadata.hash1 = meta.hash_metadata.hash2;
-        meta.intrinsic_metadata.mcast_hash = (bit<13>)meta.hash_metadata.hash2;
         meta.hash_metadata.entropy_hash = meta.hash_metadata.hash2;
     }
     @name(".compute_ipv4_hashes") table compute_ipv4_hashes {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4-stderr
@@ -1,6 +1,12 @@
 tunnel.p4(1002): [--Wwarn=mismatch] warning: -14: negative value with unsigned type
     add(egress_metadata.payload_length, standard_metadata.packet_length, -14);
                                                                           ^^
+intrinsic.p4(44): [--Wwarn=type-inference] warning: Could not infer type for enable_dod, using bit<8>
+action deflect_on_drop(enable_dod) {
+                       ^^^^^^^^^^
+switch_config.p4(21): [--Wwarn=type-inference] warning: Could not infer type for enable_dod, using bit<8>
+action set_config_parameters(enable_dod) {
+                             ^^^^^^^^^^
 fabric.p4(210): [--Wwarn=type-inference] warning: Could not infer type for fabric_mgid, using bit<8>
 action set_fabric_multicast(fabric_mgid) {
                             ^^^^^^^^^^^

--- a/testdata/p4_16_samples/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples/flowlet_switching-bmv2.p4
@@ -10,13 +10,6 @@ struct ingress_metadata_t {
     bit<32> nhop_ipv4;
 }
 
-struct intrinsic_metadata_t {
-    bit<48> ingress_global_timestamp;
-    bit<32> lf_field_list;
-    bit<16> mcast_grp;
-    bit<16> egress_rid;
-}
-
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;
@@ -55,8 +48,6 @@ header tcp_t {
 struct metadata {
     @name("ingress_metadata")
     ingress_metadata_t   ingress_metadata;
-    @name("intrinsic_metadata")
-    intrinsic_metadata_t intrinsic_metadata;
 }
 
 struct headers {
@@ -133,10 +124,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("lookup_flowlet_map") action lookup_flowlet_map() {
         hash(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, (bit<13>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<26>)13);
         flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
-        meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
+        meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
         flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_16_samples/multicast-bmv2.p4
+++ b/testdata/p4_16_samples/multicast-bmv2.p4
@@ -1,14 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<16> mcast_grp;
-    bit<16> egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-    bit<48> ingress_global_timestamp;
-}
-
 struct routing_metadata_t {
     bit<32> nhop_ipv4;
 }
@@ -35,8 +27,6 @@ header ipv4_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
     @name("routing_metadata") 
     routing_metadata_t   routing_metadata;
 }
@@ -89,7 +79,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".bcast") action bcast() {
-        meta.intrinsic_metadata.mcast_grp = 1;
+        standard_metadata.mcast_grp = 1;
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_16_samples/named_meter_1-bmv2.p4
+++ b/testdata/p4_16_samples/named_meter_1-bmv2.p4
@@ -17,13 +17,6 @@ limitations under the License.
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<4>  mcast_grp;
-    bit<4>  egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-}
-
 struct meta_t {
     bit<32> meter_tag;
 }
@@ -35,8 +28,6 @@ header ethernet_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata")
-    intrinsic_metadata_t intrinsic_metadata;
     @name("meta")
     meta_t               meta;
 }

--- a/testdata/p4_16_samples/named_meter_bmv2.p4
+++ b/testdata/p4_16_samples/named_meter_bmv2.p4
@@ -17,13 +17,6 @@ limitations under the License.
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<4>  mcast_grp;
-    bit<4>  egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-}
-
 struct meta_t {
     bit<32> meter_tag;
 }
@@ -35,8 +28,6 @@ header ethernet_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata")
-    intrinsic_metadata_t intrinsic_metadata;
     @name("meta")
     meta_t               meta;
 }

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
@@ -10,13 +10,6 @@ struct ingress_metadata_t {
     bit<32> nhop_ipv4;
 }
 
-struct intrinsic_metadata_t {
-    bit<48> ingress_global_timestamp;
-    bit<32> lf_field_list;
-    bit<16> mcast_grp;
-    bit<16> egress_rid;
-}
-
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;
@@ -54,9 +47,7 @@ header tcp_t {
 
 struct metadata {
     @name("ingress_metadata") 
-    ingress_metadata_t   ingress_metadata;
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
+    ingress_metadata_t ingress_metadata;
 }
 
 struct headers {
@@ -133,10 +124,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
         flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
-        meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
+        meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
         flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
@@ -10,13 +10,6 @@ struct ingress_metadata_t {
     bit<32> nhop_ipv4;
 }
 
-struct intrinsic_metadata_t {
-    bit<48> ingress_global_timestamp;
-    bit<32> lf_field_list;
-    bit<16> mcast_grp;
-    bit<16> egress_rid;
-}
-
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;
@@ -54,9 +47,7 @@ header tcp_t {
 
 struct metadata {
     @name("ingress_metadata") 
-    ingress_metadata_t   ingress_metadata;
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
+    ingress_metadata_t ingress_metadata;
 }
 
 struct headers {
@@ -151,10 +142,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress.lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
         flowlet_id_0.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
-        meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
+        meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
         flowlet_lasttime_0.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
+        flowlet_lasttime_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("ingress.set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -10,13 +10,6 @@ struct ingress_metadata_t {
     bit<32> nhop_ipv4;
 }
 
-struct intrinsic_metadata_t {
-    bit<48> ingress_global_timestamp;
-    bit<32> lf_field_list;
-    bit<16> mcast_grp;
-    bit<16> egress_rid;
-}
-
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;
@@ -59,10 +52,6 @@ struct metadata {
     bit<32> _ingress_metadata_flowlet_lasttime3;
     bit<14> _ingress_metadata_ecmp_offset4;
     bit<32> _ingress_metadata_nhop_ipv45;
-    bit<48> _intrinsic_metadata_ingress_global_timestamp6;
-    bit<32> _intrinsic_metadata_lf_field_list7;
-    bit<16> _intrinsic_metadata_mcast_grp8;
-    bit<16> _intrinsic_metadata_egress_rid9;
 }
 
 struct headers {
@@ -174,10 +163,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress.lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple_1, bit<26>>(meta._ingress_metadata_flowlet_map_index1, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
         flowlet_id_0.read(meta._ingress_metadata_flowlet_id2, (bit<32>)meta._ingress_metadata_flowlet_map_index1);
-        meta._ingress_metadata_flow_ipg0 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp6;
+        meta._ingress_metadata_flow_ipg0 = (bit<32>)standard_metadata.ingress_global_timestamp;
         flowlet_lasttime_0.read(meta._ingress_metadata_flowlet_lasttime3, (bit<32>)meta._ingress_metadata_flowlet_map_index1);
-        meta._ingress_metadata_flow_ipg0 = (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp6 - meta._ingress_metadata_flowlet_lasttime3;
-        flowlet_lasttime_0.write((bit<32>)meta._ingress_metadata_flowlet_map_index1, (bit<32>)meta._intrinsic_metadata_ingress_global_timestamp6);
+        meta._ingress_metadata_flow_ipg0 = (bit<32>)standard_metadata.ingress_global_timestamp - meta._ingress_metadata_flowlet_lasttime3;
+        flowlet_lasttime_0.write((bit<32>)meta._ingress_metadata_flowlet_map_index1, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("ingress.set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
@@ -10,13 +10,6 @@ struct ingress_metadata_t {
     bit<32> nhop_ipv4;
 }
 
-struct intrinsic_metadata_t {
-    bit<48> ingress_global_timestamp;
-    bit<32> lf_field_list;
-    bit<16> mcast_grp;
-    bit<16> egress_rid;
-}
-
 header ethernet_t {
     bit<48> dstAddr;
     bit<48> srcAddr;
@@ -54,9 +47,7 @@ header tcp_t {
 
 struct metadata {
     @name("ingress_metadata") 
-    ingress_metadata_t   ingress_metadata;
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
+    ingress_metadata_t ingress_metadata;
 }
 
 struct headers {
@@ -133,10 +124,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("lookup_flowlet_map") action lookup_flowlet_map() {
         hash(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, (bit<13>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<26>)13);
         flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
-        meta.ingress_metadata.flow_ipg = (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp;
+        meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
         flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)meta.intrinsic_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-first.p4
@@ -1,14 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<16> mcast_grp;
-    bit<16> egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-    bit<48> ingress_global_timestamp;
-}
-
 struct routing_metadata_t {
     bit<32> nhop_ipv4;
 }
@@ -35,10 +27,8 @@ header ipv4_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
     @name("routing_metadata") 
-    routing_metadata_t   routing_metadata;
+    routing_metadata_t routing_metadata;
 }
 
 struct headers {
@@ -91,7 +81,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".bcast") action bcast() {
-        meta.intrinsic_metadata.mcast_grp = 16w1;
+        standard_metadata.mcast_grp = 16w1;
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-frontend.p4
@@ -1,14 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<16> mcast_grp;
-    bit<16> egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-    bit<48> ingress_global_timestamp;
-}
-
 struct routing_metadata_t {
     bit<32> nhop_ipv4;
 }
@@ -35,10 +27,8 @@ header ipv4_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
     @name("routing_metadata") 
-    routing_metadata_t   routing_metadata;
+    routing_metadata_t routing_metadata;
 }
 
 struct headers {
@@ -99,7 +89,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_7() {
     }
     @name(".bcast") action bcast() {
-        meta.intrinsic_metadata.mcast_grp = 16w1;
+        standard_metadata.mcast_grp = 16w1;
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-midend.p4
@@ -1,14 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<16> mcast_grp;
-    bit<16> egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-    bit<48> ingress_global_timestamp;
-}
-
 struct routing_metadata_t {
     bit<32> nhop_ipv4;
 }
@@ -35,12 +27,7 @@ header ipv4_t {
 }
 
 struct metadata {
-    bit<16> _intrinsic_metadata_mcast_grp0;
-    bit<16> _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<48> _intrinsic_metadata_ingress_global_timestamp4;
-    bit<32> _routing_metadata_nhop_ipv45;
+    bit<32> _routing_metadata_nhop_ipv40;
 }
 
 struct headers {
@@ -101,7 +88,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_7() {
     }
     @name(".bcast") action bcast() {
-        meta._intrinsic_metadata_mcast_grp0 = 16w1;
+        standard_metadata.mcast_grp = 16w1;
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
@@ -113,7 +100,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop();
     }
     @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta._routing_metadata_nhop_ipv45 = nhop_ipv4;
+        meta._routing_metadata_nhop_ipv40 = nhop_ipv4;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
@@ -132,7 +119,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             @defaultonly NoAction_6();
         }
         key = {
-            meta._routing_metadata_nhop_ipv45: exact @name("meta.routing_metadata.nhop_ipv4") ;
+            meta._routing_metadata_nhop_ipv40: exact @name("meta.routing_metadata.nhop_ipv4") ;
         }
         size = 512;
         default_action = NoAction_6();

--- a/testdata/p4_16_samples_outputs/multicast-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2.p4
@@ -1,14 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<16> mcast_grp;
-    bit<16> egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-    bit<48> ingress_global_timestamp;
-}
-
 struct routing_metadata_t {
     bit<32> nhop_ipv4;
 }
@@ -35,10 +27,8 @@ header ipv4_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
     @name("routing_metadata") 
-    routing_metadata_t   routing_metadata;
+    routing_metadata_t routing_metadata;
 }
 
 struct headers {
@@ -89,7 +79,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".bcast") action bcast() {
-        meta.intrinsic_metadata.mcast_grp = 1;
+        standard_metadata.mcast_grp = 1;
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-first.p4
@@ -1,13 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<4>  mcast_grp;
-    bit<4>  egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-}
-
 struct meta_t {
     bit<32> meter_tag;
 }
@@ -19,10 +12,8 @@ header ethernet_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
     @name("meta") 
-    meta_t               meta;
+    meta_t meta;
 }
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-frontend.p4
@@ -1,13 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<4>  mcast_grp;
-    bit<4>  egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-}
-
 struct meta_t {
     bit<32> meter_tag;
 }
@@ -19,10 +12,8 @@ header ethernet_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
     @name("meta") 
-    meta_t               meta;
+    meta_t meta;
 }
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-midend.p4
@@ -1,13 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<4>  mcast_grp;
-    bit<4>  egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-}
-
 struct meta_t {
     bit<32> meter_tag;
 }
@@ -19,11 +12,7 @@ header ethernet_t {
 }
 
 struct metadata {
-    bit<4>  _intrinsic_metadata_mcast_grp0;
-    bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<32> _meta_meter_tag4;
+    bit<32> _meta_meter_tag0;
 }
 
 struct headers {
@@ -65,17 +54,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             NoAction_0();
         }
         key = {
-            meta._meta_meter_tag4: exact @name("meta.meta.meter_tag") ;
+            meta._meta_meter_tag0: exact @name("meta.meta.meter_tag") ;
         }
         size = 16;
         default_action = NoAction_0();
     }
     @name("ingress.m_action") action m_action_0(bit<9> meter_idx) {
         standard_metadata.egress_spec = meter_idx;
-        my_meter.read(meta._meta_meter_tag4);
+        my_meter.read(meta._meta_meter_tag0);
     }
     @name("ingress._nop") action _nop_0() {
-        my_meter.read(meta._meta_meter_tag4);
+        my_meter.read(meta._meta_meter_tag0);
     }
     @name("ingress.m_table") table m_table_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4
@@ -1,13 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<4>  mcast_grp;
-    bit<4>  egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-}
-
 struct meta_t {
     bit<32> meter_tag;
 }
@@ -19,10 +12,8 @@ header ethernet_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
     @name("meta") 
-    meta_t               meta;
+    meta_t meta;
 }
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-first.p4
@@ -1,13 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<4>  mcast_grp;
-    bit<4>  egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-}
-
 struct meta_t {
     bit<32> meter_tag;
 }
@@ -19,10 +12,8 @@ header ethernet_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
     @name("meta") 
-    meta_t               meta;
+    meta_t meta;
 }
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
@@ -1,13 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<4>  mcast_grp;
-    bit<4>  egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-}
-
 struct meta_t {
     bit<32> meter_tag;
 }
@@ -19,10 +12,8 @@ header ethernet_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
     @name("meta") 
-    meta_t               meta;
+    meta_t meta;
 }
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
@@ -1,13 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<4>  mcast_grp;
-    bit<4>  egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-}
-
 struct meta_t {
     bit<32> meter_tag;
 }
@@ -19,11 +12,7 @@ header ethernet_t {
 }
 
 struct metadata {
-    bit<4>  _intrinsic_metadata_mcast_grp0;
-    bit<4>  _intrinsic_metadata_egress_rid1;
-    bit<16> _intrinsic_metadata_mcast_hash2;
-    bit<32> _intrinsic_metadata_lf_field_list3;
-    bit<32> _meta_meter_tag4;
+    bit<32> _meta_meter_tag0;
 }
 
 struct headers {
@@ -64,17 +53,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             NoAction_0();
         }
         key = {
-            meta._meta_meter_tag4: exact @name("meta.meta.meter_tag") ;
+            meta._meta_meter_tag0: exact @name("meta.meta.meter_tag") ;
         }
         size = 16;
         default_action = NoAction_0();
     }
     @name("ingress.m_action") action m_action_0(bit<9> meter_idx) {
         standard_metadata.egress_spec = 9w1;
-        my_meter_0.read(meta._meta_meter_tag4);
+        my_meter_0.read(meta._meta_meter_tag0);
     }
     @name("ingress._nop") action _nop_0() {
-        my_meter_0.read(meta._meta_meter_tag4);
+        my_meter_0.read(meta._meta_meter_tag0);
     }
     @name("ingress.m_table") table m_table_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2.p4
@@ -1,13 +1,6 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct intrinsic_metadata_t {
-    bit<4>  mcast_grp;
-    bit<4>  egress_rid;
-    bit<16> mcast_hash;
-    bit<32> lf_field_list;
-}
-
 struct meta_t {
     bit<32> meter_tag;
 }
@@ -19,10 +12,8 @@ header ethernet_t {
 }
 
 struct metadata {
-    @name("intrinsic_metadata") 
-    intrinsic_metadata_t intrinsic_metadata;
     @name("meta") 
-    meta_t               meta;
+    meta_t meta;
 }
 
 struct headers {


### PR DESCRIPTION
Removed ucast_egress_port
Only occured in in this one test program: p4_14_samples/sai_p4.p4

Replaced occurrences of ingress_global_tstamp with current
intrinsic_metadata.ingress_global_timestamp

Replaced occurrences of enq_tstamp with current
queueing_metadata.enq_timestamp

Removed occurrences of enq_congest_stat and deq_congest_stat, which
were defined in the two old switch.p4 versions, but never used.

mcast_hash in the two old switch.p4 test programs.  There is nothing
in current v1model.p4 to replace them with, but seems best to not
simply delete their few occurrences from switch.p4 source programs.

Deleted occurences of mcast_hash from P4_14 programs that simply
defined it, but never used it.

Deleted all occurrences of intrinsic_metadata struct from P4_16 test
programs that include v1model.p4, since all of those fields are
defined in struct standard_metadata_t now.