### PR TITLE
do not remove extern method type parameter during type inference

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -293,7 +293,7 @@ const IR::Type* TypeInference::specialize(const IR::IMayBeGenericType* type,
 
     LOG2("Translation map\n" << bindings);
 
-    TypeVariableSubstitutionVisitor tsv(bindings);
+    TypeVariableSubstitutionVisitor tsv(bindings, true);
     const IR::Node* result = type->getNode()->apply(tsv);
     if (result == nullptr)
         return nullptr;


### PR DESCRIPTION
This is supposed to fix the issue in https://github.com/p4lang/p4c/issues/1856

Unfortunately, the fix does not work with extern defined as

```
extern Hash<W> {
   Hash(HashAlgorithm_t algo, CRCPolynomial<_> poly);
}
```

```
terminate called after throwing an instance of 'Util::CompilerBug'
  what():  In file: /home/hanwang/bf-p4c-release/p4c/frontends/p4/typeChecking/typeSubstitutionVisitor.cpp:43
Compiler Bug: /home/hanwang/bf-p4c-release/build/p4c/p4include/tofino.p4(470): cannot replace a type parameter T/39 with _:
```