### PR TITLE
Added support for assert and assume statement in bmv2 backend (#1548)

### DIFF
--- a/backends/bmv2/common/extern.cpp
+++ b/backends/bmv2/common/extern.cpp
@@ -253,4 +253,39 @@ ExternConverter::convertHashAlgorithm(cstring algorithm) {
     return result;
 }
 
+ExternConverter_assert ExternConverter_assert::singleton;
+ExternConverter_assume ExternConverter_assume::singleton;
+
+Util::IJson*
+ExternConverter::convertAssertAssume(ConversionContext* ctxt,
+    const IR::MethodCallExpression* methodCall, const P4::ExternFunction* ef) {
+     if (methodCall->arguments->size() != 1) {
+        ::error("Expected 1 arguments for %1%", methodCall);
+        return nullptr;
+    }
+    auto primitive = mkPrimitive(ef->method->name.name);
+    auto parameters = mkParameters(primitive);
+    auto cond = methodCall->arguments->at(0);
+    // wrap expression in an additional JSON expression block
+    // cast the result of expression to b2d
+    auto jsonExpr = ctxt->conv->convert(cond->expression, true, true, true);
+    parameters->append(jsonExpr);
+    primitive->emplace_non_null("source_info", methodCall->sourceInfoJsonObj());
+    return primitive;
+}
+
+Util::IJson* ExternConverter_assert::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
+    return convertAssertAssume(ctxt, mc, ef);
+}
+
+Util::IJson* ExternConverter_assume::convertExternFunction(
+    UNUSED ConversionContext* ctxt, UNUSED const P4::ExternFunction* ef,
+    UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
+    UNUSED const bool emitExterns) {
+    return ExternConverter::convertAssertAssume(ctxt, mc, ef);
+}
+
 }  // namespace BMV2

--- a/backends/bmv2/common/extern.h
+++ b/backends/bmv2/common/extern.h
@@ -70,6 +70,9 @@ class ExternConverter {
     cstring createCalculation(ConversionContext* ctxt, cstring algo, const IR::Expression* fields,
                               Util::JsonArray* calculations, bool usePayload, const IR::Node* node);
     static cstring convertHashAlgorithm(cstring algorithm);
+    Util::IJson*
+    convertAssertAssume(ConversionContext* ctxt, const IR::MethodCallExpression* methodCall,
+                        const P4::ExternFunction* ef);
 };
 
 #define EXTERN_CONVERTER_W_FUNCTION_AND_MODEL(extern_name, model_type, model_name)  \
@@ -137,6 +140,9 @@ class ExternConverter {
         Util::IJson* convertExternObject(ConversionContext* ctxt,               \
             const P4::ExternMethod* em, const IR::MethodCallExpression* mc,     \
             const IR::StatOrDecl* s, const bool& emitExterns) override; };
+
+EXTERN_CONVERTER_W_FUNCTION(assert)
+EXTERN_CONVERTER_W_FUNCTION(assume)
 
 }  // namespace BMV2
 

--- a/backends/bmv2/psa_switch/midend.cpp
+++ b/backends/bmv2/psa_switch/midend.cpp
@@ -54,6 +54,7 @@ limitations under the License.
 #include "midend/tableHit.h"
 #include "midend/midEndLast.h"
 #include "midend/fillEnumMap.h"
+#include "midend/removeAssertAssume.h"
 
 namespace BMV2 {
 
@@ -89,6 +90,7 @@ PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions& options) : MidEnd(options) {
     auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
     if (BMV2::BMV2Context::get().options().loadIRFromJson == false) {
         addPasses({
+            options.ndebug ? new P4::RemoveAssertAssume(&refMap, &typeMap) : nullptr,
             new P4::EliminateNewtype(&refMap, &typeMap),
             new P4::EliminateSerEnums(&refMap, &typeMap),
             new P4::RemoveActionParameters(&refMap, &typeMap),

--- a/backends/bmv2/simple_switch/midend.cpp
+++ b/backends/bmv2/simple_switch/midend.cpp
@@ -55,6 +55,7 @@ limitations under the License.
 #include "midend/tableHit.h"
 #include "midend/midEndLast.h"
 #include "midend/fillEnumMap.h"
+#include "midend/removeAssertAssume.h"
 
 namespace BMV2 {
 
@@ -63,6 +64,7 @@ SimpleSwitchMidEnd::SimpleSwitchMidEnd(CompilerOptions& options) : MidEnd(option
     if (BMV2::BMV2Context::get().options().loadIRFromJson == false) {
         auto convertEnums = new P4::ConvertEnums(&refMap, &typeMap, new EnumOn32Bits("v1model.p4"));
         addPasses({
+            options.ndebug ? new P4::RemoveAssertAssume(&refMap, &typeMap) : nullptr,
             new P4::CheckTableSize(),
             new P4::EliminateNewtype(&refMap, &typeMap),
             new P4::EliminateSerEnums(&refMap, &typeMap),
@@ -109,7 +111,6 @@ SimpleSwitchMidEnd::SimpleSwitchMidEnd(CompilerOptions& options) : MidEnd(option
             new P4::CompileTimeOperations(),
             new P4::TableHit(&refMap, &typeMap),
             new P4::RemoveLeftSlices(&refMap, &typeMap),
-
             // p4c-bm removed unused action parameters. To produce a compatible
             // control plane API, we remove them as well for P4-14 programs.
             isv1 ? new P4::RemoveUnusedActionParameters(&refMap) : nullptr,

--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -51,6 +51,7 @@ limitations under the License.
 #include "midend/simplifySelectCases.h"
 #include "midend/simplifySelectList.h"
 #include "midend/tableHit.h"
+#include "midend/removeAssertAssume.h"
 
 namespace P4Test {
 
@@ -78,6 +79,7 @@ MidEnd::MidEnd(CompilerOptions& options) {
     // TODO: lower errors to integers
     // TODO: handle bit-slices as out arguments
     addPasses({
+        options.ndebug ? new P4::RemoveAssertAssume(&refMap, &typeMap) : nullptr,
         new P4::EliminateNewtype(&refMap, &typeMap),
         new P4::EliminateSerEnums(&refMap, &typeMap),
         new P4::RemoveActionParameters(&refMap, &typeMap),

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -202,6 +202,9 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                   "  sourceFile:level,...,sourceFile:level\n"
                   "where 'sourceFile' is a compiler source file and\n"
                   "'level' is the verbosity level for LOG messages in that file");
+    registerOption("--ndebug", nullptr,
+                   [this](const char*) { ndebug = true; return true; },
+                  "Compile program in non-debug mode.\n");
 }
 
 void CompilerOptions::setInputFile() {

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -104,6 +104,9 @@ class CompilerOptions : public Util::Options {
     // substrings matched agains pass names
     std::vector<cstring> top4;
 
+    // if this flag is true, compile program in non-debug mode
+    bool ndebug = false;
+
     // Expect that the only remaining argument is the input file.
     void setInputFile();
 

--- a/frontends/p4/reservedWords.cpp
+++ b/frontends/p4/reservedWords.cpp
@@ -25,7 +25,7 @@ std::set<cstring> reservedWords = {
     "else", "enum", "error", "exit", "extern", "false", "header", "header_union",
     "if", "in", "inout", "int", "key", "match_kind", "out", "parser", "package",
     "return", "select", "set", "state", "struct", "switch", "table", "this",  // experimental
-    "transition", "true", "tuple", "typedef", "varbit", "verify", "void", "_",
+    "transition", "true", "tuple", "typedef", "varbit", "verify", "void", "_", "assert", "assume",
     "NoAction"  // core.p4
 };
 

--- a/frontends/p4/reservedWords.cpp
+++ b/frontends/p4/reservedWords.cpp
@@ -25,7 +25,7 @@ std::set<cstring> reservedWords = {
     "else", "enum", "error", "exit", "extern", "false", "header", "header_union",
     "if", "in", "inout", "int", "key", "match_kind", "out", "parser", "package",
     "return", "select", "set", "state", "struct", "switch", "table", "this",  // experimental
-    "transition", "true", "tuple", "typedef", "varbit", "verify", "void", "_", "assert", "assume",
+    "transition", "true", "tuple", "typedef", "varbit", "verify", "void", "_",
     "NoAction"  // core.p4
 };
 

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -44,6 +44,7 @@ set (MIDEND_SRCS
   tableHit.cpp
   validateProperties.cpp
   fillEnumMap.cpp
+  removeAssertAssume.cpp
   )
 
 set (MIDEND_HDRS
@@ -83,6 +84,7 @@ set (MIDEND_HDRS
   tableHit.h
   validateProperties.h
   fillEnumMap.h
+  removeAssertAssume.h
   )
 
 add_cpplint_files (${CMAKE_CURRENT_SOURCE_DIR} "${MIDEND_SRCS};${MIDEND_HDRS}")

--- a/midend/removeAssertAssume.cpp
+++ b/midend/removeAssertAssume.cpp
@@ -1,0 +1,21 @@
+#include "midend/removeAssertAssume.h"
+#include "frontends/p4/methodInstance.h"
+
+namespace P4 {
+
+const IR::Node* DoRemoveAssertAssume::preorder(IR::MethodCallStatement* statement) {
+    auto instance = P4::MethodInstance::resolve(statement->methodCall, refMap, typeMap);
+    if (instance->is<P4::ExternFunction>()) {
+        auto externFunc = instance->to<P4::ExternFunction>();
+        if (externFunc->method->name.name == "assert") {
+            LOG3("Eliminating assert call " << dbp(statement));
+            return nullptr;
+        } else if (externFunc->method->name.name == "assume") {
+            LOG3("Eliminating assume call " << dbp(statement));
+            return nullptr;
+        }
+    }
+    return statement;
+}
+
+}  // namespace P4

--- a/midend/removeAssertAssume.h
+++ b/midend/removeAssertAssume.h
@@ -1,0 +1,39 @@
+#ifndef _MIDEND_REMOVEASSERTASSUME_H_
+#define _MIDEND_REMOVEASSERTASSUME_H_
+
+#include "frontends/common/resolveReferences/resolveReferences.h"
+#include "frontends/p4/typeMap.h"
+#include "frontends/p4/typeChecking/typeChecker.h"
+#include "ir/ir.h"
+
+namespace P4 {
+// Removes assert and assume statements if it is not in debug mode
+class DoRemoveAssertAssume : public Transform {
+    P4::ReferenceMap* refMap;
+    P4::TypeMap* typeMap;
+ public:
+    explicit DoRemoveAssertAssume(P4::ReferenceMap* refMap, P4::TypeMap* typeMap)
+             : refMap(refMap), typeMap(typeMap) {
+        CHECK_NULL(refMap);
+        CHECK_NULL(typeMap);
+        setName("DoRemoveAssertAssume");
+    }
+
+    const IR::Node* preorder(IR::MethodCallStatement* statement);
+};
+
+class RemoveAssertAssume final : public PassManager {
+ public:
+    RemoveAssertAssume(ReferenceMap* refMap, TypeMap* typeMap,
+                     TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
+        passes.push_back(new DoRemoveAssertAssume(refMap, typeMap));
+        setName("RemoveAssertAssume");
+    }
+};
+
+}  // namespace P4
+
+#endif  /* _MIDEND_REMOVEASSERTASSUME_H_*/

--- a/p4include/psa.p4
+++ b/p4include/psa.p4
@@ -388,6 +388,9 @@ extern bool psa_recirculate(in psa_egress_output_metadata_t istd,
                             in psa_egress_deparser_input_metadata_t edstd);
 
 
+extern void assert(in bool check);
+extern void assume(in bool check);
+
 // BEGIN:Match_kinds
 match_kind {
     range,   /// Used to represent min..max intervals

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -398,6 +398,10 @@ extern void clone3<T>(in CloneType type, in bit<32> session, in T data);
 
 extern void truncate(in bit<32> length);
 
+
+extern void assert(in bool check);
+extern void assume(in bool check);
+
 // The name 'standard_metadata' is reserved
 
 // Architecture.

--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -174,6 +174,8 @@ class BackendDriver:
                 self.add_command_option('compiler', "--fromJSON {}".format(opts.json_source))
             if opts.pretty_print:
                 self.add_command_option('compiler', "--pp {}".format(opts.pretty_print))
+            if opts.ndebug_mode:
+                self.add_command_option('compiler', "--ndebug")
 
         if (os.environ['P4C_BUILD_TYPE'] == "DEVELOPER") and \
            'assembler' in self._commands and opts.debug:

--- a/tools/driver/p4c_src/main.py
+++ b/tools/driver/p4c_src/main.py
@@ -151,6 +151,9 @@ def main():
                         choices = ["p4-14", "p4_14", "p4-16", "p4_16"],
                         help="Treat subsequent input files as having type language.",
                         action="store", default="p4-16")
+    parser.add_argument("--ndebug", dest="ndebug_mode",
+                        help="Compile program in non-debug mode.\n",
+                        action="store_true", default=False)
 
     if (os.environ['P4C_BUILD_TYPE'] == "DEVELOPER"):
         add_developer_options(parser)


### PR DESCRIPTION
* Added removeAssertAssume pass in midend which will remove
 all assert and assume statements from program when --ndebug = true

* Not supported in ebpf backend yet

Signed-off-by: Enisa Hadzic <enisa.hadzic@rt-rk.com>