### PR TITLE
Make changes to 3 PSA tests that are causing the build to fail

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -187,9 +187,6 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/psa-drop-all-bmv2.p4
   testdata/p4_16_samples/psa-unicast-or-drop-bmv2.p4
   testdata/p4_16_samples/psa-ingress-input-meta-bmv2.p4
-  testdata/p4_16_samples/psa-multicast-basic-bmv2.p4
-  # This test requires bmv2's psa_switch to support recirculating packets
-  testdata/p4_16_samples/psa-recirculate-no-meta-bmv2.p4
 )
 
 if (HAVE_SIMPLE_SWITCH)

--- a/testdata/p4_16_samples/psa-unicast-or-drop-bmv2.stf
+++ b/testdata/p4_16_samples/psa-unicast-or-drop-bmv2.stf
@@ -7,6 +7,9 @@ expect 2 000000000002 000000000000 ffff
 packet 4 000000000003 000000000000 ffff
 expect 3 000000000003 000000000000 ffff
 
-# This packet should be dropped
-packet 2 000000000000 000000000000 ffff
+# This packet should be dropped.  We send it into port 0, because if
+# there are no packets sent into nor expected on port 0, then the test
+# infrastructure does not check any of the packets that come out port
+# 0, or whether the right number come out port 0.
+packet 0 000000000000 000000000000 ffff
 


### PR DESCRIPTION
Two of them are passing now, and should be removed from the XFAIL list.

One of them was written in a way that it was passing, but it should
not have been.  Updated the STF test so it fails.  A separate PR on
behavioral-model code is required to make that test pass.