### PR TITLE
Remove XFAIL for two PSA test programs that should now pass

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -179,8 +179,6 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/issue1765-bmv2.p4
   testdata/p4_16_samples/issue1765-1-bmv2.p4
   # These tests require bmv2's psa_switch to support std metadata passing at minimum
-  testdata/p4_16_samples/psa-drop-all-bmv2.p4
-  testdata/p4_16_samples/psa-unicast-or-drop-bmv2.p4
   testdata/p4_16_samples/psa-ingress-input-meta-bmv2.p4
 )
 

--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -179,6 +179,7 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/issue1765-bmv2.p4
   testdata/p4_16_samples/issue1765-1-bmv2.p4
   # These tests require bmv2's psa_switch to support std metadata passing at minimum
+  testdata/p4_16_samples/psa-unicast-or-drop-bmv2.p4
   testdata/p4_16_samples/psa-ingress-input-meta-bmv2.p4
 )
 

--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -179,6 +179,7 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/issue1765-bmv2.p4
   testdata/p4_16_samples/issue1765-1-bmv2.p4
   # These tests require bmv2's psa_switch to support std metadata passing at minimum
+  testdata/p4_16_samples/psa-drop-all-bmv2.p4
   testdata/p4_16_samples/psa-unicast-or-drop-bmv2.p4
   testdata/p4_16_samples/psa-ingress-input-meta-bmv2.p4
 )

--- a/testdata/p4_16_samples/psa-drop-all-bmv2.stf
+++ b/testdata/p4_16_samples/psa-drop-all-bmv2.stf
@@ -1,2 +1,5 @@
-# This packet should be dropped
-packet 2 000000000000 000000000000 ffff
+# All input packets should be dropped
+packet 0 000000000000 000000000000 ffff
+packet 1 000000000000 000000000001 ffff
+packet 2 000000000000 000000000002 ffff
+packet 3 000000000000 000000000003 ffff

--- a/testdata/p4_16_samples/psa-unicast-or-drop-bmv2.stf
+++ b/testdata/p4_16_samples/psa-unicast-or-drop-bmv2.stf
@@ -1,15 +1,14 @@
 packet 4 000000000001 000000000000 ffff
-expect 1 000000000001 000000000000 ffff
+expect 1 000000000001 000000000000 ffff $
 
 packet 4 000000000002 000000000000 ffff
-expect 2 000000000002 000000000000 ffff
+expect 2 000000000002 000000000000 ffff $
 
 packet 4 000000000003 000000000000 ffff
-expect 3 000000000003 000000000000 ffff
+expect 3 000000000003 000000000000 ffff $
 
 # This packet should be dropped.  We send it into port 0, because if
 # there are no packets sent into nor expected on port 0, then the test
 # infrastructure does not check any of the packets that come out port
 # 0, or whether the right number come out port 0.
 packet 0 000000000000 000000000000 ffff
-


### PR DESCRIPTION
given recent changes in p4lang/behavioral-model code for PSA
implementation.