### PR TITLE
Fix #1881 - enhance BMv2 backend, support const entries range with 1 …

### DIFF
--- a/backends/bmv2/common/control.cpp
+++ b/backends/bmv2/common/control.cpp
@@ -89,6 +89,9 @@ void ControlConverter::convertTableEntries(const IR::P4Table *table,
                     auto kr = k->to<IR::Range>();
                     key->emplace("start", stringRepr(kr->left->to<IR::Constant>()->value, k8));
                     key->emplace("end", stringRepr(kr->right->to<IR::Constant>()->value, k8));
+                } else if (k->is<IR::Constant>()) {
+                    key->emplace("start", stringRepr(k->to<IR::Constant>()->value, k8));
+                    key->emplace("end", stringRepr(k->to<IR::Constant>()->value, k8));
                 } else if (k->is<IR::DefaultExpression>()) {
                     key->emplace("start", stringRepr(0, k8));
                     key->emplace("end", stringRepr((1 << keyWidth)-1, k8));  // 2^N -1

--- a/testdata/p4_16_samples/table-entries-exact-bmv2.stf
+++ b/testdata/p4_16_samples/table-entries-exact-bmv2.stf
@@ -2,15 +2,15 @@
 
 # t_exact tests: if packets come on port 0, we missed!
 
-expect 1 01 **** ** ** *
+expect 1 01 **** ** ** ** $
 packet 0 01 1111 00 00 b0
 
-expect 2 02 **** ** ** *
+expect 2 02 **** ** ** ** $
 packet 0 02 1181 00 00 b0
 
 # misses
-expect 0 03 **** ** ** *
+expect 0 03 **** ** ** ** $
 packet 0 03 1000 00 00 b0
 
-expect 0 04 **** ** ** *
+expect 0 04 **** ** ** ** $
 packet 0 04 1111 00 00 b0

--- a/testdata/p4_16_samples/table-entries-lpm-bmv2.stf
+++ b/testdata/p4_16_samples/table-entries-lpm-bmv2.stf
@@ -1,14 +1,14 @@
 # header hdr { bit<8>  e; bit<16> t; bit<8>  l; bit<8> r; bit<1>  v; }
 
 # t_lpm tests
-expect 11 0b **** 11 ** *
+expect 11 0b **** 11 ** ** $
 packet  0 0b 0000 11 00 b0
 
-expect 11 0b **** 10 ** *
+expect 11 0b **** 10 ** ** $
 packet  0 0b 0000 10 00 b0
 
-expect 12 0c **** 12 ** *
+expect 12 0c **** 12 ** ** $
 packet  0 0c 0000 12 00 b0
 
-expect 13 0d **** FF ** *
+expect 13 0d **** FF ** ** $
 packet  0 0d 0000 FF 00 b0

--- a/testdata/p4_16_samples/table-entries-range-bmv2.p4
+++ b/testdata/p4_16_samples/table-entries-range-bmv2.p4
@@ -63,6 +63,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         const entries = {
             1..8 : a_with_control_params(21);
             6..12: a_with_control_params(22);
+            15   : a_with_control_params(24);
             _    : a_with_control_params(23);
         }
     }

--- a/testdata/p4_16_samples/table-entries-range-bmv2.stf
+++ b/testdata/p4_16_samples/table-entries-range-bmv2.stf
@@ -1,15 +1,21 @@
 # header hdr { bit<8>  e; bit<16> t; bit<8>  l; bit<8> r; bit<1>  v; }
 
 #t_range
-expect 21 15 **** ** 01 *
+expect 21 15 **** ** 01 ** $
 packet  0 15 0000 00 01 b0
 
 # program order priority
-expect 21 15 **** ** 07 *
+expect 21 15 **** ** 07 ** $
 packet  0 15 0000 00 07 b0
 
-expect 22 16 **** ** 0a *
+expect 22 16 **** ** 0a ** $
 packet  0 16 0000 00 0a b0
 
-expect 23 17 **** ** f0 *
+expect 24 18 **** ** 0f ** $
+packet  0 18 0000 00 0f b0
+
+expect 23 17 **** ** 10 ** $
+packet  0 17 0000 00 10 b0
+
+expect 23 17 **** ** f0 ** $
 packet  0 17 0000 00 f0 b0

--- a/testdata/p4_16_samples/table-entries-ternary-bmv2.stf
+++ b/testdata/p4_16_samples/table-entries-ternary-bmv2.stf
@@ -2,18 +2,18 @@
 
 # t_ternary tests: if packets come on port 0, we missed!
 
-expect 1 01 **** ** ** *
+expect 1 01 **** ** ** ** $
 packet 0 01 1111 00 00 b0
 
 # check that the mask works
-expect 1 02 **** ** ** *
+expect 1 02 **** ** ** ** $
 packet 0 02 0001 00 00 b0
 
-expect 2 03 **** ** ** *
+expect 2 03 **** ** ** ** $
 packet 0 03 1187 00 00 b0
 
-expect 3 04 **** ** ** *
+expect 3 04 **** ** ** ** $
 packet 0 04 1000 00 00 b0
 
-expect 4 04 **** ** ** *
+expect 4 04 **** ** ** ** $
 packet 0 04 aaaa 00 00 b0

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-first.p4
@@ -65,6 +65,8 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
 
                         8w6 .. 8w12 : a_with_control_params(9w22);
 
+                        8w15 : a_with_control_params(9w24);
+
                         default : a_with_control_params(9w23);
 
         }

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-frontend.p4
@@ -65,6 +65,8 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
 
                         8w6 .. 8w12 : a_with_control_params(9w22);
 
+                        8w15 : a_with_control_params(9w24);
+
                         default : a_with_control_params(9w23);
 
         }

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-midend.p4
@@ -65,6 +65,8 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
 
                         8w6 .. 8w12 : a_with_control_params(9w22);
 
+                        8w15 : a_with_control_params(9w24);
+
                         default : a_with_control_params(9w23);
 
         }

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4
@@ -65,6 +65,8 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
 
                         6 .. 12 : a_with_control_params(22);
 
+                        15 : a_with_control_params(24);
+
                         default : a_with_control_params(23);
 
         }

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.entries.txt
@@ -19,7 +19,7 @@ updates {
           }
         }
       }
-      priority: 3
+      priority: 4
     }
   }
 }
@@ -41,6 +41,31 @@ updates {
           params {
             param_id: 1
             value: "\000\026"
+          }
+        }
+      }
+      priority: 3
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33595117
+      match {
+        field_id: 1
+        range {
+          low: "\017"
+          high: "\017"
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\030"
           }
         }
       }


### PR DESCRIPTION
…value