### PR TITLE
Move updating of search_tail; fixes #1879

### DIFF
--- a/midend/expr_uses.h
+++ b/midend/expr_uses.h
@@ -28,16 +28,24 @@ class exprUses : public Inspector {
     cstring look_for;
     const char *search_tail = nullptr;  // pointer into look_for for partial match
     bool result = false;
-    bool preorder(const IR::Path *p) override {
-        if (look_for.startsWith(p->name)) {
-            search_tail = look_for.c_str() + p->name.name.size();
+
+    void set_search_tail(const IR::PathExpression *e) {
+        if (look_for.startsWith(e->path->name)) {
+            search_tail = look_for.c_str() + e->path->name.name.size();
             if (*search_tail == 0 || *search_tail == '.' || *search_tail == '[')
-                result = true; }
-        return !result; }
+                result = true; } }
+
+    bool preorder(const IR::Path *) override { return !result; }
     bool preorder(const IR::Primitive *p) override {
         if (p->name == look_for) result = true;
         return !result; }
     bool preorder(const IR::Expression *) override { return !result; }
+    bool preorder(const IR::PathExpression *e) override {
+        set_search_tail(e);
+        return !result; }
+
+    void revisit(const IR::PathExpression *e) override {
+        set_search_tail(e); }
 
     void postorder(const IR::Member *m) override {
         if (result && search_tail && *search_tail) {

--- a/test/gtest/expr_uses_test.cpp
+++ b/test/gtest/expr_uses_test.cpp
@@ -29,6 +29,7 @@ TEST(expr_uses, expr_uses) {
     auto obj2_f11 = new IR::Member(obj2, "f11");
     auto add = new IR::Add(obj1_f1, obj2_f11);
     auto sub = new IR::Sub(obj1_f11, obj2_f1);
+    auto add2 = new IR::Add(obj1_f1, obj1_f11);
 
     EXPECT_TRUE(exprUses(add, "obj1"));
     EXPECT_TRUE(exprUses(add, "obj2"));
@@ -40,4 +41,6 @@ TEST(expr_uses, expr_uses) {
     EXPECT_TRUE(exprUses(add, "obj2.f11"));
     EXPECT_TRUE(exprUses(sub, "obj1"));
     EXPECT_TRUE(exprUses(sub, "obj2"));
+    EXPECT_TRUE(exprUses(add2, "obj1.f1"));
+    EXPECT_TRUE(exprUses(add2, "obj1.f11"));
 }


### PR DESCRIPTION
Move updating of `search_tail` in `exprUses` to `preorder` and `revisit` of PathExpression instead of Path.

If Path is ever used outside of a PathExpression this might break, as then `search_tail` would not be updated, but I'm not sure this ever happens.