### PR TITLE
ordered_set::operator<

### DIFF
--- a/lib/log.h
+++ b/lib/log.h
@@ -61,7 +61,7 @@ class OutputLogPrefix {
 }  // namespace Detail
 
 inline std::ostream &endl(std::ostream &out) {
-    out << std::endl << indent_t::getindent(out);
+    out << std::endl;
     Detail::OutputLogPrefix::indent(out);
     return out; }
 


### PR DESCRIPTION
- allows sets of ordered_sets or ordered_sets as map keys in a sensible way.
  Compares the underlying sets independent of the order, so that it is
  possible to have ordered_sets where !(a < b) && !(b < a) && !(a == b).
  Such sets contain the same elements but in a different order.