### PR TITLE
add support for printing help for pragmas

### DIFF
--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -123,6 +123,8 @@ class ParseAnnotations : public Modifier {
     static bool parseExpressionList(IR::Annotation* annotation);
     static bool parseKvList(IR::Annotation* annotation);
 
+    void addHandler(cstring name, Handler h) { handlers.insert({name, h}); }
+
  private:
     /// Whether to warn about unknown annotations.
     const bool warnUnknown;

--- a/tools/driver/p4c_src/main.py
+++ b/tools/driver/p4c_src/main.py
@@ -136,11 +136,11 @@ def main():
                         "description (default is binary). "
                         "[Deprecated; use '--p4runtime-files' instead]",
                         action="store", default="binary")
-    parser.add_argument("--pragmas-help", "--help-pragmas", "--help-pragma", "--help-annotations",
-                        "--annotations-help",
+    parser.add_argument("--help-pragmas", "--pragma-help", "--pragmas-help",
+                        "--help-annotations", "--annotation-help", "--annotations-help",
                         dest="help_pragmas", action="store_true", default=False,
                         help = "Print the documentation about supported annotations/pragmas and exit.")
-    parser.add_argument("--target-help", "--help-targets", "--help-traget",
+    parser.add_argument("--help-targets", "--target-help", "--targets-help",
                         dest="show_target_help",
                         help="Display target specific command line options.",
                         action="store_true", default=False)

--- a/tools/driver/p4c_src/main.py
+++ b/tools/driver/p4c_src/main.py
@@ -136,9 +136,10 @@ def main():
                         "description (default is binary). "
                         "[Deprecated; use '--p4runtime-files' instead]",
                         action="store", default="binary")
-    parser.add_argument("--pragmas-help", "--help-pragmas", "--help-pragma",
+    parser.add_argument("--pragmas-help", "--help-pragmas", "--help-pragma", "--help-annotations",
+                        "--annotations-help",
                         dest="help_pragmas", action="store_true", default=False,
-                        help = "Print the documentation about supported pragmas and exit.")
+                        help = "Print the documentation about supported annotations/pragmas and exit.")
     parser.add_argument("--target-help", "--help-targets", "--help-traget",
                         dest="show_target_help",
                         help="Display target specific command line options.",
@@ -198,7 +199,7 @@ def main():
     # so in that case, we set the input to dummy.p4 and expect that the backend itself
     # will do its printing and ignore the input file.
     # If not, the compiler will error out anyway.
-    checkInput = True if not opts.help_pragmas else False
+    checkInput = not opts.help_pragmas
 
     input_specified = False
     if opts.source_file:


### PR DESCRIPTION
Printing help is a backend specific option. It requires a bit more
flexible parsing of annotations (i.e., registering handlers outside
the constructor) and a bit of driver tweaking.