### PR TITLE
Remove tenjin Python package from Docker dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,7 @@ ENV P4C_DEPS bison \
              libgc-dev \
              libgmp-dev \
              pkg-config \
-             python-ipaddr \
              python-pip \
-             python-setuptools \
              tcpdump
 ENV P4C_EBPF_DEPS libpcap-dev \
              libelf-dev \
@@ -40,14 +38,15 @@ ENV P4C_RUNTIME_DEPS cpp \
                      libgmp10 \
                      libgmpxx4ldbl \
                      python
-ENV P4C_PIP_PACKAGES pyroute2 \
+ENV P4C_PIP_PACKAGES ipaddr \
+                     pyroute2 \
                      ply==3.8 \
                      scapy==2.4.0
 COPY . /p4c/
 WORKDIR /p4c/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $P4C_DEPS $P4C_EBPF_DEPS $P4C_RUNTIME_DEPS && \
-    pip install --upgrade pip && \
+    pip install --upgrade setuptools && \
     pip install $P4C_PIP_PACKAGES && \
     mkdir build && \
     cd build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ ENV P4C_RUNTIME_DEPS cpp \
                      libgmp10 \
                      libgmpxx4ldbl \
                      python
-ENV P4C_PIP_PACKAGES tenjin \
-                     pyroute2 \
+ENV P4C_PIP_PACKAGES pyroute2 \
                      ply==3.8 \
                      scapy==2.4.0
 COPY . /p4c/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ARG IMAGE_TYPE=build
 ENV P4C_DEPS bison \
              build-essential \
              cmake \
+             curl \
              flex \
              g++ \
              libboost-dev \
@@ -23,7 +24,6 @@ ENV P4C_DEPS bison \
              libgc-dev \
              libgmp-dev \
              pkg-config \
-             python-pip \
              tcpdump
 ENV P4C_EBPF_DEPS libpcap-dev \
              libelf-dev \
@@ -46,7 +46,7 @@ COPY . /p4c/
 WORKDIR /p4c/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $P4C_DEPS $P4C_EBPF_DEPS $P4C_RUNTIME_DEPS && \
-    pip install --upgrade setuptools && \
+    mkdir /tmp/pip && cd /tmp/pip && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && cd - && rm -rf /tmp/pip \
     pip install $P4C_PIP_PACKAGES && \
     mkdir build && \
     cd build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ COPY . /p4c/
 WORKDIR /p4c/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $P4C_DEPS $P4C_EBPF_DEPS $P4C_RUNTIME_DEPS && \
+    pip install --upgrade pip && \
     pip install $P4C_PIP_PACKAGES && \
     mkdir build && \
     cd build && \


### PR DESCRIPTION
tenjin installation seems to be creating issues in CI. It is unclear whether
this is because of tenjin or pip, but nothing in this repo uses tenjin anyway.