### PR TITLE
p4c_driver: add missing return in case of success

### DIFF
--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -288,3 +288,5 @@ class BackendDriver:
             # backends that override run can chose what to do on error
             if rc != 0:
                 return rc
+
+        return 0


### PR DESCRIPTION
Need to get a proper exit code rather than a None!