### PR TITLE
Make eBPF CMAKE robust against llvm check failures

### DIFF
--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -105,19 +105,24 @@ endif()
 
 # Check if we have the right llvm version
 set (MIN_LLVM 3.7.1)
-
-# If you get an error here see
-# https://stackoverflow.com/questions/38171543/error-when-using-cmake-with-llvm
-find_package(LLVM QUIET)
-if (LLVM_PACKAGE_VERSION)
+# Grab the LLVM version, do not use find_package because it is unstable
+# https://github.com/p4lang/p4c/issues/1376
+set(LLVM_CMD "llvm-config --version")
+message(STATUS "Check LLVM version with '${LLVM_CMD}'")
+exec_program(${LLVM_CMD}
+	 RETURN_VALUE LLVM_RET
+	 OUTPUT_VARIABLE LLVM_PACKAGE_VERSION)
+if (NOT LLVM_RET)
   message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
   if (${LLVM_PACKAGE_VERSION} VERSION_LESS ${MIN_LLVM})
-    MESSAGE(WARNING "LLVM version ${LLVM_PACKAGE_VERSION} too small, expected ${MIN_LLVM}.
+    message(WARNING "LLVM version ${LLVM_PACKAGE_VERSION} too small, expected ${MIN_LLVM}.
     Ignoring ebpf tests...")
     set (SUPPORTS_KERNEL False)
   endif()
 else()
-  message(STATUS "LLVM missing, disabling kernel tests...")
+  message(WARNING
+	 "Problem with LLVM, disabling kernel tests...\n"
+	 "Return Value: " ${LLVM_RET} " Reason: " ${LLVM_PACKAGE_VERSION})
   set (SUPPORTS_KERNEL False)
 endif()
 

--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -110,8 +110,8 @@ set (MIN_LLVM 3.7.1)
 set(LLVM_CMD "llvm-config --version")
 message(STATUS "Check LLVM version with '${LLVM_CMD}'")
 exec_program(${LLVM_CMD}
-	 RETURN_VALUE LLVM_RET
-	 OUTPUT_VARIABLE LLVM_PACKAGE_VERSION)
+    RETURN_VALUE LLVM_RET
+    OUTPUT_VARIABLE LLVM_PACKAGE_VERSION)
 if (NOT LLVM_RET)
   message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
   if (${LLVM_PACKAGE_VERSION} VERSION_LESS ${MIN_LLVM})
@@ -121,8 +121,9 @@ if (NOT LLVM_RET)
   endif()
 else()
   message(WARNING
-	 "Problem with LLVM, disabling kernel tests...\n"
-	 "Return Value: " ${LLVM_RET} " Reason: " ${LLVM_PACKAGE_VERSION})
+    "Did not find an LLVM version that can compile the eBPF kernel tests...\n"
+    "'llvm-config' reason: ${LLVM_PACKAGE_VERSION}\n"
+    "'llvm-config' return value: ${LLVM_RET}" )
   set (SUPPORTS_KERNEL False)
 endif()
 


### PR DESCRIPTION
This pull request is intended to introduce a workaround for #1376.
Instead of using CMAKE's `find_package` we manually check the LLVM version and compare. This prevents crashes with specific versions of LLVM and Ubuntu. 
The downside of this method is that it does not catch versions of LLVM that were installed (via ` apt install llvm-3.8` for example) and disables the eBPF backend despite an LLVM version that exists. 
However, because the eBPF framework uses `llc` anyway instead of, say, `llc-3.8` it is probably for the better that this discrepancy is caught.

Let me know what you think.
