### PR TITLE
Support for structure-valued expressions

### DIFF
--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -211,7 +211,7 @@ RemoveComplexExpressions::simplifyExpression(const IR::Expression* expression, b
         auto simpl = simplifyExpressions(&si->components);
         if (simpl != &si->components)
             return new IR::StructInitializerExpression(
-                si->srcInfo, si->name, *simpl, si->isHeader);
+                si->srcInfo, si->typeName, *simpl);
         return expression;
     } else {
         ComplexExpression ce;
@@ -316,7 +316,7 @@ RemoveComplexExpressions::postorder(IR::MethodCallExpression* expression) {
             } else if (auto si = arg1->to<IR::StructInitializerExpression>()) {
                 auto list = simplifyExpressions(&si->components);
                 arg1 = new IR::StructInitializerExpression(
-                    si->srcInfo, si->name, *list, si->isHeader);
+                    si->srcInfo, si->typeName, *list);
                 vec->push_back(new IR::Argument(arg1));
             } else {
                 auto tmp = new IR::Argument(

--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -211,7 +211,7 @@ RemoveComplexExpressions::simplifyExpression(const IR::Expression* expression, b
         auto simpl = simplifyExpressions(&si->components);
         if (simpl != &si->components)
             return new IR::StructInitializerExpression(
-                si->srcInfo, nullptr, si->typeName, *simpl);
+                si->srcInfo, si->typeName, si->typeName, *simpl);
         return expression;
     } else {
         ComplexExpression ce;
@@ -316,7 +316,7 @@ RemoveComplexExpressions::postorder(IR::MethodCallExpression* expression) {
             } else if (auto si = arg1->to<IR::StructInitializerExpression>()) {
                 auto list = simplifyExpressions(&si->components);
                 arg1 = new IR::StructInitializerExpression(
-                    si->srcInfo, nullptr, si->typeName, *list);
+                    si->srcInfo, si->typeName, si->typeName, *list);
                 vec->push_back(new IR::Argument(arg1));
             } else {
                 auto tmp = new IR::Argument(

--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -211,7 +211,7 @@ RemoveComplexExpressions::simplifyExpression(const IR::Expression* expression, b
         auto simpl = simplifyExpressions(&si->components);
         if (simpl != &si->components)
             return new IR::StructInitializerExpression(
-                si->srcInfo, si->typeName, *simpl);
+                si->srcInfo, nullptr, si->typeName, *simpl);
         return expression;
     } else {
         ComplexExpression ce;
@@ -316,7 +316,7 @@ RemoveComplexExpressions::postorder(IR::MethodCallExpression* expression) {
             } else if (auto si = arg1->to<IR::StructInitializerExpression>()) {
                 auto list = simplifyExpressions(&si->components);
                 arg1 = new IR::StructInitializerExpression(
-                    si->srcInfo, si->typeName, *list);
+                    si->srcInfo, nullptr, si->typeName, *list);
                 vec->push_back(new IR::Argument(arg1));
             } else {
                 auto tmp = new IR::Argument(

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -581,7 +581,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Member* e) {
                 BUG("Could not find field %1% in type %2%", e->member, type);
             result = CloneConstants::clone(list->components.at(index));
         } else if (auto si = expr->to<IR::StructInitializerExpression>()) {
-            if (si->isHeader && e->member.name == IR::Type_Header::isValid)
+            if (origtype->is<IR::Type_Header>() && e->member.name == IR::Type_Header::isValid)
                 return e;
             auto ne = si->components.getDeclaration<IR::NamedExpression>(e->member.name);
             BUG_CHECK(ne != nullptr, "Could not find field %1% in initializer %2%", e->member, si);

--- a/frontends/p4/structInitializers.cpp
+++ b/frontends/p4/structInitializers.cpp
@@ -36,7 +36,7 @@ convert(const IR::Expression* expression, const IR::Type* type) {
                 index++;
             }
             auto result = new IR::StructInitializerExpression(
-                expression->srcInfo, st->name, *si, st->is<IR::Type_Header>());
+                expression->srcInfo, st->getP4Type()->to<IR::Type_Name>(), *si);
             return result;
         } else if (auto sli = expression->to<IR::StructInitializerExpression>()) {
             for (auto f : st->fields) {
@@ -50,7 +50,7 @@ convert(const IR::Expression* expression, const IR::Type* type) {
             }
             if (modified) {
                 auto result = new IR::StructInitializerExpression(
-                    expression->srcInfo, st->name, *si, st->is<IR::Type_Header>());
+                    expression->srcInfo, st->getP4Type()->to<IR::Type_Name>(), *si);
                 return result;
             }
         }

--- a/frontends/p4/structInitializers.cpp
+++ b/frontends/p4/structInitializers.cpp
@@ -36,7 +36,7 @@ convert(const IR::Expression* expression, const IR::Type* type) {
                 index++;
             }
             auto result = new IR::StructInitializerExpression(
-                expression->srcInfo, st->getP4Type()->to<IR::Type_Name>(), *si);
+                expression->srcInfo, nullptr, st->getP4Type()->to<IR::Type_Name>(), *si);
             return result;
         } else if (auto sli = expression->to<IR::StructInitializerExpression>()) {
             for (auto f : st->fields) {
@@ -50,7 +50,7 @@ convert(const IR::Expression* expression, const IR::Type* type) {
             }
             if (modified) {
                 auto result = new IR::StructInitializerExpression(
-                    expression->srcInfo, st->getP4Type()->to<IR::Type_Name>(), *si);
+                    expression->srcInfo, nullptr, st->getP4Type()->to<IR::Type_Name>(), *si);
                 return result;
             }
         }

--- a/frontends/p4/structInitializers.cpp
+++ b/frontends/p4/structInitializers.cpp
@@ -35,8 +35,9 @@ convert(const IR::Expression* expression, const IR::Type* type) {
                 si->push_back(ne);
                 index++;
             }
+            auto type = st->getP4Type()->to<IR::Type_Name>();
             auto result = new IR::StructInitializerExpression(
-                expression->srcInfo, nullptr, st->getP4Type()->to<IR::Type_Name>(), *si);
+                expression->srcInfo, type, type, *si);
             return result;
         } else if (auto sli = expression->to<IR::StructInitializerExpression>()) {
             for (auto f : st->fields) {
@@ -49,8 +50,9 @@ convert(const IR::Expression* expression, const IR::Type* type) {
                 si->push_back(ne);
             }
             if (modified) {
+                auto type = st->getP4Type()->to<IR::Type_Name>();
                 auto result = new IR::StructInitializerExpression(
-                    expression->srcInfo, nullptr, st->getP4Type()->to<IR::Type_Name>(), *si);
+                    expression->srcInfo, type, type, *si);
                 return result;
             }
         }

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -859,6 +859,10 @@ bool ToP4::preorder(const IR::NamedExpression* e) {
 }
 
 bool ToP4::preorder(const IR::StructInitializerExpression* e) {
+    if (e->typeName != nullptr) {
+        visit(e->typeName);
+        builder.append(" ");
+    }
     builder.append("{");
     int prec = expressionPrecedence;
     expressionPrecedence = DBPrint::Prec_Low;

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -859,10 +859,6 @@ bool ToP4::preorder(const IR::NamedExpression* e) {
 }
 
 bool ToP4::preorder(const IR::StructInitializerExpression* e) {
-    // Currently the P4 language does not have a syntax
-    // for struct initializers, so we use the same syntax as for list expressions.
-    // TODO: this is incorrect if the fields are not in the same order as
-    // in the type.
     builder.append("{");
     int prec = expressionPrecedence;
     expressionPrecedence = DBPrint::Prec_Low;
@@ -871,6 +867,8 @@ bool ToP4::preorder(const IR::StructInitializerExpression* e) {
         if (!first)
             builder.append(",");
         first = false;
+        builder.append(c->name.name);
+        builder.append(" = ");
         visit(c->expression);
     }
     expressionPrecedence = prec;

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -742,8 +742,9 @@ TypeInference::assignment(const IR::Node* errorPosition, const IR::Type* destTyp
             auto si = sourceExpression->to<IR::StructInitializerExpression>();
             CHECK_NULL(si);
             bool cst = isCompileTimeConstant(sourceExpression);
+            auto type = new IR::Type_Name(ts->name);
             sourceExpression = new IR::StructInitializerExpression(
-                nullptr, new IR::Type_Name(ts->name), si->components);
+                type, type, si->components);
             setType(sourceExpression, destType);
             if (cst)
                 setCompileTimeConstant(sourceExpression);
@@ -1546,10 +1547,9 @@ const IR::Node* TypeInference::postorder(IR::Operation_Relation* expression) {
                     CHECK_NULL(l);  // struct initializers are the only expressions that can
                                     // have StructUnknown types
                     BUG_CHECK(rtype->is<IR::Type_StructLike>(), "%1%: expected a struct", rtype);
+                    auto type = new IR::Type_Name(rtype->to<IR::Type_StructLike>()->name);
                     expression->left = new IR::StructInitializerExpression(
-                        expression->left->srcInfo, nullptr,
-                        new IR::Type_Name(rtype->to<IR::Type_StructLike>()->name),
-                        l->components);
+                        expression->left->srcInfo, type, type, l->components);
                     setType(expression->left, rtype);
                     if (lcst)
                         setCompileTimeConstant(expression->left);
@@ -1558,10 +1558,9 @@ const IR::Node* TypeInference::postorder(IR::Operation_Relation* expression) {
                     CHECK_NULL(r);  // struct initializers are the only expressions that can
                                     // have StructUnknown types
                     BUG_CHECK(ltype->is<IR::Type_StructLike>(), "%1%: expected a struct", ltype);
+                    auto type = new IR::Type_Name(ltype->to<IR::Type_StructLike>()->name);
                     expression->right = new IR::StructInitializerExpression(
-                        expression->right->srcInfo, nullptr,
-                        new IR::Type_Name(ltype->to<IR::Type_StructLike>()->name),
-                        r->components);
+                        expression->right->srcInfo, type, type, r->components);
                     setType(expression->right, rtype);
                     if (rcst)
                         setCompileTimeConstant(expression->right);

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -206,8 +206,10 @@ TypeVariableSubstitution* TypeInference::unify(const IR::Node* errorPosition,
     return tvs;
 }
 
-const IR::IndexedVector<IR::StructField>*
-TypeInference::canonicalizeFields(const IR::Type_StructLike* type) {
+const IR::Type*
+TypeInference::canonicalizeFields(
+    const IR::Type_StructLike* type,
+    std::function<const IR::Type*(const IR::IndexedVector<IR::StructField>*)> constructor) {
     bool changes = false;
     auto fields = new IR::IndexedVector<IR::StructField>();
     for (auto field : type->fields) {
@@ -221,9 +223,9 @@ TypeInference::canonicalizeFields(const IR::Type_StructLike* type) {
         fields->push_back(newField);
     }
     if (changes)
-        return fields;
+        return constructor(fields);
     else
-        return &type->fields;
+        return type;
 }
 
 const IR::ParameterList* TypeInference::canonicalizeParameters(const IR::ParameterList* params) {
@@ -492,39 +494,22 @@ const IR::Type* TypeInference::canonicalize(const IR::Type* type) {
         if (changes)
             resultType = new IR::Type_Method(mt->getSourceInfo(), tps, res, pl);
         return resultType;
-    } else if (type->is<IR::Type_Header>()) {
-        auto hdr = type->to<IR::Type_Header>();
-        auto fields = canonicalizeFields(hdr);
-        if (fields == nullptr)
-            return nullptr;
-        const IR::Type* canon;
-        if (fields != &hdr->fields)
-            canon = new IR::Type_Header(hdr->srcInfo, hdr->name, hdr->annotations, *fields);
-        else
-            canon = hdr;
-        return canon;
-    } else if (type->is<IR::Type_Struct>()) {
-        auto str = type->to<IR::Type_Struct>();
-        auto fields = canonicalizeFields(str);
-        if (fields == nullptr)
-            return nullptr;
-        const IR::Type* canon;
-        if (fields != &str->fields)
-            canon = new IR::Type_Struct(str->srcInfo, str->name, str->annotations, *fields);
-        else
-            canon = str;
-        return canon;
-    } else if (type->is<IR::Type_HeaderUnion>()) {
-        auto str = type->to<IR::Type_HeaderUnion>();
-        auto fields = canonicalizeFields(str);
-        if (fields == nullptr)
-            return nullptr;
-        const IR::Type* canon;
-        if (fields != &str->fields)
-            canon = new IR::Type_HeaderUnion(str->srcInfo, str->name, str->annotations, *fields);
-        else
-            canon = str;
-        return canon;
+    } else if (auto hdr = type->to<IR::Type_Header>()) {
+        return canonicalizeFields(hdr, [hdr](const IR::IndexedVector<IR::StructField>* fields) {
+                return new IR::Type_Header(hdr->srcInfo, hdr->name, hdr->annotations, *fields);
+            });
+    } else if (auto str = type->to<IR::Type_Struct>()) {
+        return canonicalizeFields(str, [str](const IR::IndexedVector<IR::StructField>* fields) {
+                return new IR::Type_Struct(str->srcInfo, str->name, str->annotations, *fields);
+            });
+    } else if (auto hu = type->to<IR::Type_HeaderUnion>()) {
+        return canonicalizeFields(hu, [hu](const IR::IndexedVector<IR::StructField>* fields) {
+                return new IR::Type_HeaderUnion(hu->srcInfo, hu->name, hu->annotations, *fields);
+            });
+    } else if (auto su = type->to<IR::Type_UnknownStruct>()) {
+        return canonicalizeFields(su, [su](const IR::IndexedVector<IR::StructField>* fields) {
+                return new IR::Type_UnknownStruct(su->srcInfo, su->name, su->annotations, *fields);
+            });
     } else if (type->is<IR::Type_Specialized>()) {
         auto st = type->to<IR::Type_Specialized>();
         auto baseCanon = canonicalize(st->baseType);
@@ -752,6 +737,19 @@ TypeInference::assignment(const IR::Node* errorPosition, const IR::Type* destTyp
         setType(sourceExpression, destType);
         setCompileTimeConstant(sourceExpression);
     }
+    if (initType->is<IR::Type_UnknownStruct>()) {
+        if (auto ts = destType->to<IR::Type_StructLike>()) {
+            auto si = sourceExpression->to<IR::StructInitializerExpression>();
+            CHECK_NULL(si);
+            bool cst = isCompileTimeConstant(sourceExpression);
+            sourceExpression = new IR::StructInitializerExpression(
+                new IR::Type_Name(ts->name), si->components);
+            setType(sourceExpression, destType);
+            if (cst)
+                setCompileTimeConstant(sourceExpression);
+        }
+    }
+
     return sourceExpression;
 }
 
@@ -1522,6 +1520,53 @@ const IR::Node* TypeInference::postorder(IR::Operation_Relation* expression) {
             }
             defined = true;
         } else {
+            auto ls = ltype->to<IR::Type_UnknownStruct>();
+            auto rs = rtype->to<IR::Type_UnknownStruct>();
+            if (ls != nullptr || rs != nullptr) {
+                if (ls != nullptr && rs != nullptr) {
+                    typeError("%1%: cannot compare initializers with unknown types", expression);
+                    return expression;
+                }
+
+                bool lcst = isCompileTimeConstant(expression->left);
+                bool rcst = isCompileTimeConstant(expression->right);
+
+                auto tvs = unify(expression, ltype, rtype);
+                if (tvs == nullptr)
+                    // error already signalled
+                    return expression;
+                if (!tvs->isIdentity()) {
+                    ConstantTypeSubstitution cts(tvs, refMap, typeMap, this);
+                    expression->left = cts.convert(expression->left);
+                    expression->right = cts.convert(expression->right);
+                }
+
+                if (ls != nullptr) {
+                    auto l = expression->left->to<IR::StructInitializerExpression>();
+                    CHECK_NULL(l);  // struct initializers are the only expressions that can
+                                    // have StructUnknown types
+                    BUG_CHECK(rtype->is<IR::Type_StructLike>(), "%1%: expected a struct", rtype);
+                    expression->left = new IR::StructInitializerExpression(
+                        new IR::Type_Name(rtype->to<IR::Type_StructLike>()->name),
+                        l->components);
+                    setType(expression->left, rtype);
+                    if (lcst)
+                        setCompileTimeConstant(expression->left);
+                } else {
+                    auto r = expression->right->to<IR::StructInitializerExpression>();
+                    CHECK_NULL(r);  // struct initializers are the only expressions that can
+                                    // have StructUnknown types
+                    BUG_CHECK(ltype->is<IR::Type_StructLike>(), "%1%: expected a struct", ltype);
+                    expression->right = new IR::StructInitializerExpression(
+                        new IR::Type_Name(ltype->to<IR::Type_StructLike>()->name),
+                        r->components);
+                    setType(expression->right, rtype);
+                    if (rcst)
+                        setCompileTimeConstant(expression->right);
+                }
+                defined = true;
+            }
+
             // comparison between structs and list expressions is allowed only
             // if the expression with tuple type is a list expression
             if ((ltype->is<IR::Type_StructLike>() &&

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1770,12 +1770,13 @@ const IR::Node* TypeInference::postorder(IR::StructInitializerExpression* expres
     }
 
     const IR::Type* structType;
-    if (expression->isHeader)
-        structType = new IR::Type_Header(
-            expression->srcInfo, expression->name, *components);
-    else
+    if (expression->typeName != nullptr) {
+        structType = getType(expression->typeName);
+    } else {
+        // TODO: this could be a header type
         structType = new IR::Type_Struct(
-            expression->srcInfo, expression->name, *components);
+            expression->srcInfo, expression->typeName->path->name, *components);
+    }
     auto type = canonicalize(structType);
     if (type == nullptr)
         return expression;

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -743,7 +743,7 @@ TypeInference::assignment(const IR::Node* errorPosition, const IR::Type* destTyp
             CHECK_NULL(si);
             bool cst = isCompileTimeConstant(sourceExpression);
             sourceExpression = new IR::StructInitializerExpression(
-                new IR::Type_Name(ts->name), si->components);
+                nullptr, new IR::Type_Name(ts->name), si->components);
             setType(sourceExpression, destType);
             if (cst)
                 setCompileTimeConstant(sourceExpression);
@@ -1547,6 +1547,7 @@ const IR::Node* TypeInference::postorder(IR::Operation_Relation* expression) {
                                     // have StructUnknown types
                     BUG_CHECK(rtype->is<IR::Type_StructLike>(), "%1%: expected a struct", rtype);
                     expression->left = new IR::StructInitializerExpression(
+                        expression->left->srcInfo, nullptr,
                         new IR::Type_Name(rtype->to<IR::Type_StructLike>()->name),
                         l->components);
                     setType(expression->left, rtype);
@@ -1558,6 +1559,7 @@ const IR::Node* TypeInference::postorder(IR::Operation_Relation* expression) {
                                     // have StructUnknown types
                     BUG_CHECK(ltype->is<IR::Type_StructLike>(), "%1%: expected a struct", ltype);
                     expression->right = new IR::StructInitializerExpression(
+                        expression->right->srcInfo, nullptr,
                         new IR::Type_Name(ltype->to<IR::Type_StructLike>()->name),
                         r->components);
                     setType(expression->right, rtype);

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1773,9 +1773,8 @@ const IR::Node* TypeInference::postorder(IR::StructInitializerExpression* expres
     if (expression->typeName != nullptr) {
         structType = getType(expression->typeName);
     } else {
-        // TODO: this could be a header type
-        structType = new IR::Type_Struct(
-            expression->srcInfo, expression->typeName->path->name, *components);
+        structType = new IR::Type_UnknownStruct(
+            expression->srcInfo, "unknown", *components);
     }
     auto type = canonicalize(structType);
     if (type == nullptr)

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -90,11 +90,6 @@ class TypeInference : public Transform {
     bool isCompileTimeConstant(const IR::Expression* expression) const
     { return typeMap->isCompileTimeConstant(expression); }
 
-    template<typename... T>
-    void typeError(const char* format, T... args) const {
-        ::error(ErrorType::ERR_TYPE_ERROR, format, args...);
-    }
-
     // This is needed because sometimes we invoke visitors recursively on subtrees explicitly.
     // (visitDagOnce cannot take care of this).
     bool done() const;
@@ -174,6 +169,10 @@ class TypeInference : public Transform {
     using Transform::postorder;
     using Transform::preorder;
 
+    template<typename... T>
+    static void typeError(const char* format, T... args) {
+        ::error(ErrorType::ERR_TYPE_ERROR, format, args...);
+    }
     static const IR::Type* specialize(const IR::IMayBeGenericType* type,
                                       const IR::Vector<IR::Type>* arguments);
     const IR::Node* pruneIfDone(const IR::Node* node)

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -123,8 +123,9 @@ class TypeInference : public Transform {
      *  Made virtual to enable private midend passes to extend standard IR with custom IR classes.
      */
     virtual const IR::Type* canonicalize(const IR::Type* type);
-    virtual const IR::IndexedVector<IR::StructField>*
-        canonicalizeFields(const IR::Type_StructLike* type);
+    const IR::Type* canonicalizeFields(
+        const IR::Type_StructLike* type,
+        std::function<const IR::Type*(const IR::IndexedVector<IR::StructField>*)> constructor);
     virtual const IR::ParameterList* canonicalizeParameters(const IR::ParameterList* params);
 
     // various helpers

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -171,8 +171,9 @@ bool TypeUnification::unifyFunctions(const IR::Node* errorPosition,
             if (dit->defaultValue != nullptr)
                 continue;
             if (reportErrors)
-                TypeInference::typeError("%1%: Cannot unify functions with different number of arguments: "
-                                         "%2% to %3%", errorPosition, src, dest);
+                TypeInference::typeError(
+                    "%1%: Cannot unify functions with different number of arguments: "
+                    "%2% to %3%", errorPosition, src, dest);
             return false; }
         if ((*sit)->direction != dit->direction) {
             if (reportErrors)
@@ -403,8 +404,9 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
         auto sstack = src->to<IR::Type_Stack>();
         if (dstack->getSize() != sstack->getSize()) {
             if (reportErrors)
-                TypeInference::typeError("%1%: cannot unify stacks with different sized %2% and %3%",
-                                         errorPosition, dstack, sstack);
+                TypeInference::typeError(
+                    "%1%: cannot unify stacks with different sized %2% and %3%",
+                    errorPosition, dstack, sstack);
             return false;
         }
         constraints->addEqualityConstraint(dstack->elementType, sstack->elementType);

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1291,6 +1291,10 @@ expression
     | expression "[" expression "]"      { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | expression "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
     | "{" expressionList "}"             { $$ = new IR::ListExpression(@1 + @3, *$2); }
+    | typeName "{" kvList "}"                { $$ = new IR::StructInitializerExpression(
+                                                @1 + @4, $1, *$3); }  // experimental
+    | "{" kvList "}"                     { $$ = new IR::StructInitializerExpression(
+                                                @1 + @3, (IR::Type_Name*)nullptr, *$2); }  // experimental
     | "(" expression ")"                 { $$ = $2; }
     | "!" expression %prec PREFIX        { $$ = new IR::LNot(@1 + @2, $2); }
     | "~" expression %prec PREFIX        { $$ = new IR::Cmpl(@1 + @2, $2); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1291,10 +1291,9 @@ expression
     | expression "[" expression "]"      { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | expression "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
     | "{" expressionList "}"             { $$ = new IR::ListExpression(@1 + @3, *$2); }
-    | typeName "{" kvList "}"                { $$ = new IR::StructInitializerExpression(
-                                                @1 + @4, $1, *$3); }  // experimental
+    | typeName "{" kvList "}"                { $$ = new IR::StructInitializerExpression(@1 + @4, nullptr, $1, *$3); }  // experimental
     | "{" kvList "}"                     { $$ = new IR::StructInitializerExpression(
-                                                @1 + @3, (IR::Type_Name*)nullptr, *$2); }  // experimental
+                                             @1 + @3, nullptr, (IR::Type_Name*)nullptr, *$2); }  // experimental
     | "(" expression ")"                 { $$ = $2; }
     | "!" expression %prec PREFIX        { $$ = new IR::LNot(@1 + @2, $2); }
     | "~" expression %prec PREFIX        { $$ = new IR::Cmpl(@1 + @2, $2); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1291,9 +1291,9 @@ expression
     | expression "[" expression "]"      { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | expression "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
     | "{" expressionList "}"             { $$ = new IR::ListExpression(@1 + @3, *$2); }
-    | typeName "{" kvList "}"                { $$ = new IR::StructInitializerExpression(@1 + @4, nullptr, $1, *$3); }  // experimental
+| typeName "{" kvList "}"                { $$ = new IR::StructInitializerExpression(@1 + @4, IR::Type::Unknown::get(), $1, *$3); }  // experimental
     | "{" kvList "}"                     { $$ = new IR::StructInitializerExpression(
-                                             @1 + @3, nullptr, (IR::Type_Name*)nullptr, *$2); }  // experimental
+                                                  @1 + @3, IR::Type::Unknown::get(), (IR::Type_Name*)nullptr, *$2); }  // experimental
     | "(" expression ")"                 { $$ = $2; }
     | "!" expression %prec PREFIX        { $$ = new IR::LNot(@1 + @2, $2); }
     | "~" expression %prec PREFIX        { $$ = new IR::Cmpl(@1 + @2, $2); }

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -409,12 +409,10 @@ class ListExpression : Expression {
 /// IR representation of an initializer for a struct.
 /// Currently it does not have a direct representation as P4 source.
 class StructInitializerExpression : Expression {
-    /// Name of the struct type that is being intialized.
-    /// May only be known after type checking; so it can be empty.
-    ID name;
+    /// The struct or header type that is being intialized.
+    /// May only be known after type checking; so it can be nullptr.
+    NullOK optional Type_Name typeName;
     inline IndexedVector<NamedExpression> components;
-    /// If true this represents a header.
-    bool isHeader;
     validate { components.check_null(); }
     size_t size() const { return components.size(); }
 }

--- a/ir/type.def
+++ b/ir/type.def
@@ -251,6 +251,13 @@ class Type_Struct : Type_StructLike {
     toString{ return cstring("struct ") + externalName(); }
 }
 
+/// This is the type of a struct-valued expression whose
+/// exact struct type is yet unknown; we only know the field names
+/// and some information about their types.
+class Type_UnknownStruct : Type_StructLike {
+#nodbprint
+}
+
 class Type_HeaderUnion : Type_StructLike {
 #nodbprint
     toString{ return cstring("header_union ") + externalName(); }

--- a/midend/expandLookahead.cpp
+++ b/midend/expandLookahead.cpp
@@ -50,8 +50,9 @@ const IR::Expression* DoExpandLookahead::expand(
             auto e = expand(base, t, offset);
             vec->push_back(new IR::NamedExpression(f->srcInfo, f->name, e));
         }
+        auto type = st->getP4Type()->to<IR::Type_Name>();
         return new IR::StructInitializerExpression(
-            base->srcInfo, nullptr, st->getP4Type()->to<IR::Type_Name>(), *vec);
+            base->srcInfo, type, type, *vec);
     } else if (type->is<IR::Type_Bits>() || type->is<IR::Type_Boolean>()) {
         unsigned size = type->width_bits();
         BUG_CHECK(size > 0, "%1%: unexpected size %2%", type, size);

--- a/midend/expandLookahead.cpp
+++ b/midend/expandLookahead.cpp
@@ -51,7 +51,7 @@ const IR::Expression* DoExpandLookahead::expand(
             vec->push_back(new IR::NamedExpression(f->srcInfo, f->name, e));
         }
         return new IR::StructInitializerExpression(
-            base->srcInfo, st->getP4Type(), *vec);
+            base->srcInfo, nullptr, st->getP4Type()->to<IR::Type_Name>(), *vec);
     } else if (type->is<IR::Type_Bits>() || type->is<IR::Type_Boolean>()) {
         unsigned size = type->width_bits();
         BUG_CHECK(size > 0, "%1%: unexpected size %2%", type, size);

--- a/midend/expandLookahead.cpp
+++ b/midend/expandLookahead.cpp
@@ -51,7 +51,7 @@ const IR::Expression* DoExpandLookahead::expand(
             vec->push_back(new IR::NamedExpression(f->srcInfo, f->name, e));
         }
         return new IR::StructInitializerExpression(
-            base->srcInfo, st->name, *vec, type->is<IR::Type_Header>());
+            base->srcInfo, st->getP4Type(), *vec);
     } else if (type->is<IR::Type_Bits>() || type->is<IR::Type_Boolean>()) {
         unsigned size = type->width_bits();
         BUG_CHECK(size > 0, "%1%: unexpected size %2%", type, size);

--- a/midend/flattenInterfaceStructs.cpp
+++ b/midend/flattenInterfaceStructs.cpp
@@ -57,7 +57,8 @@ const IR::StructInitializerExpression* StructTypeReplacement::explode(
         }
         vec->push_back(new IR::NamedExpression(f->name, expr));
     }
-    return new IR::StructInitializerExpression(root->srcInfo, fieldType->name, *vec, false);
+    return new IR::StructInitializerExpression(
+        root->srcInfo, fieldType->getP4Type()->to<IR::Type_Name>(), *vec);
 }
 
 static const IR::Type_Struct* isNestedStruct(const P4::TypeMap* typeMap, const IR::Type* type) {

--- a/midend/flattenInterfaceStructs.cpp
+++ b/midend/flattenInterfaceStructs.cpp
@@ -58,7 +58,7 @@ const IR::StructInitializerExpression* StructTypeReplacement::explode(
         vec->push_back(new IR::NamedExpression(f->name, expr));
     }
     return new IR::StructInitializerExpression(
-        root->srcInfo, fieldType->getP4Type()->to<IR::Type_Name>(), *vec);
+        root->srcInfo, nullptr, fieldType->getP4Type()->to<IR::Type_Name>(), *vec);
 }
 
 static const IR::Type_Struct* isNestedStruct(const P4::TypeMap* typeMap, const IR::Type* type) {

--- a/midend/flattenInterfaceStructs.cpp
+++ b/midend/flattenInterfaceStructs.cpp
@@ -57,8 +57,9 @@ const IR::StructInitializerExpression* StructTypeReplacement::explode(
         }
         vec->push_back(new IR::NamedExpression(f->name, expr));
     }
+    auto type = fieldType->getP4Type()->to<IR::Type_Name>();
     return new IR::StructInitializerExpression(
-        root->srcInfo, nullptr, fieldType->getP4Type()->to<IR::Type_Name>(), *vec);
+        root->srcInfo, type, type, *vec);
 }
 
 static const IR::Type_Struct* isNestedStruct(const P4::TypeMap* typeMap, const IR::Type* type) {

--- a/testdata/p4_14_samples_outputs/issue1058-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1058-first.p4
@@ -43,7 +43,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".test_action") action test_action() {
-        digest<test1_digest>(32w0x666, {hdr.ethernet.dstAddr,standard_metadata});
+        digest<test1_digest>(32w0x666, test1_digest {dstAddr = hdr.ethernet.dstAddr,standard_metadata = standard_metadata});
     }
     @name(".tbl0") table tbl0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue1058-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1058-frontend.p4
@@ -45,7 +45,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name(".test_action") action test_action() {
-        digest<test1_digest>(32w0x666, {hdr.ethernet.dstAddr,standard_metadata});
+        digest<test1_digest>(32w0x666, test1_digest {dstAddr = hdr.ethernet.dstAddr,standard_metadata = standard_metadata});
     }
     @name(".tbl0") table tbl0_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue1058-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1058-midend.p4
@@ -44,7 +44,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".NoAction") action NoAction_0() {
     }
     @name(".test_action") action test_action() {
-        digest<test1_digest>(32w0x666, {hdr.ethernet.dstAddr,standard_metadata});
+        digest<test1_digest>(32w0x666, test1_digest {dstAddr = hdr.ethernet.dstAddr,standard_metadata = standard_metadata});
     }
     @name(".tbl0") table tbl0_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-midend.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-midend.p4
@@ -62,13 +62,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710633;
         meta._mymeta_f14 = meta._mymeta_f14 + 8w23;
         meta._mymeta_clone_e2e_count2 = meta._mymeta_clone_e2e_count2 + 8w1;
-        clone3<tuple_0>(CloneType.E2E, 32w1, { {meta._mymeta_resubmit_count0,meta._mymeta_recirculate_count1,meta._mymeta_clone_e2e_count2,meta._mymeta_last_ing_instance_type3,meta._mymeta_f14} });
+        clone3<tuple_0>(CloneType.E2E, 32w1, { mymeta_t {resubmit_count = meta._mymeta_resubmit_count0,recirculate_count = meta._mymeta_recirculate_count1,clone_e2e_count = meta._mymeta_clone_e2e_count2,last_ing_instance_type = meta._mymeta_last_ing_instance_type3,f1 = meta._mymeta_f14} });
     }
     @name(".do_recirculate") action do_recirculate() {
         hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710637;
         meta._mymeta_f14 = meta._mymeta_f14 + 8w19;
         meta._mymeta_recirculate_count1 = meta._mymeta_recirculate_count1 + 8w1;
-        recirculate<tuple_0>({ {meta._mymeta_resubmit_count0,meta._mymeta_recirculate_count1,meta._mymeta_clone_e2e_count2,meta._mymeta_last_ing_instance_type3,meta._mymeta_f14} });
+        recirculate<tuple_0>({ mymeta_t {resubmit_count = meta._mymeta_resubmit_count0,recirculate_count = meta._mymeta_recirculate_count1,clone_e2e_count = meta._mymeta_clone_e2e_count2,last_ing_instance_type = meta._mymeta_last_ing_instance_type3,f1 = meta._mymeta_f14} });
     }
     @name("._nop") action _nop() {
     }
@@ -260,7 +260,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ethernet.srcAddr = hdr.ethernet.srcAddr + 48w281474976710639;
         meta._mymeta_f14 = meta._mymeta_f14 + 8w17;
         meta._mymeta_resubmit_count0 = meta._mymeta_resubmit_count0 + 8w1;
-        resubmit<tuple_0>({ {meta._mymeta_resubmit_count0,meta._mymeta_recirculate_count1,meta._mymeta_clone_e2e_count2,meta._mymeta_last_ing_instance_type3,meta._mymeta_f14} });
+        resubmit<tuple_0>({ mymeta_t {resubmit_count = meta._mymeta_resubmit_count0,recirculate_count = meta._mymeta_recirculate_count1,clone_e2e_count = meta._mymeta_clone_e2e_count2,last_ing_instance_type = meta._mymeta_last_ing_instance_type3,f1 = meta._mymeta_f14} });
     }
     @name("._nop") action _nop_5() {
     }

--- a/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
@@ -55,10 +55,10 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name("._nop") action _nop() {
     }
     @name("._recirculate") action _recirculate() {
-        recirculate<tuple_0>({ standard_metadata, {meta._metaA_f10,meta._metaA_f21} });
+        recirculate<tuple_0>({ standard_metadata, metaA_t {f1 = meta._metaA_f10,f2 = meta._metaA_f21} });
     }
     @name("._clone_e2e") action _clone_e2e(bit<32> mirror_id) {
-        clone3<tuple_0>(CloneType.E2E, mirror_id, { standard_metadata, {meta._metaA_f10,meta._metaA_f21} });
+        clone3<tuple_0>(CloneType.E2E, mirror_id, { standard_metadata, metaA_t {f1 = meta._metaA_f10,f2 = meta._metaA_f21} });
     }
     @name(".t_egress") table t_egress_0 {
         actions = {
@@ -96,10 +96,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.mcast_grp = mgrp;
     }
     @name("._resubmit") action _resubmit() {
-        resubmit<tuple_0>({ standard_metadata, {meta._metaA_f10,meta._metaA_f21} });
+        resubmit<tuple_0>({ standard_metadata, metaA_t {f1 = meta._metaA_f10,f2 = meta._metaA_f21} });
     }
     @name("._clone_i2e") action _clone_i2e(bit<32> mirror_id) {
-        clone3<tuple_0>(CloneType.I2E, mirror_id, { standard_metadata, {meta._metaA_f10,meta._metaA_f21} });
+        clone3<tuple_0>(CloneType.I2E, mirror_id, { standard_metadata, metaA_t {f1 = meta._metaA_f10,f2 = meta._metaA_f21} });
     }
     @name(".t_ingress_1") table t_ingress {
         actions = {

--- a/testdata/p4_14_samples_outputs/resubmit-midend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-midend.p4
@@ -61,7 +61,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._resubmit") action _resubmit() {
         meta._mymeta_f10 = 8w1;
-        resubmit<tuple_0>({ standard_metadata, {8w1} });
+        resubmit<tuple_0>({ standard_metadata, mymeta_t {f1 = 8w1} });
     }
     @name(".t_ingress_1") table t_ingress {
         actions = {

--- a/testdata/p4_14_samples_outputs/sai_p4-first.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-first.p4
@@ -145,7 +145,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action nop() {
     }
     @name(".generate_learn_notify") action generate_learn_notify() {
-        digest<mac_learn_digest>(32w1024, {meta.ingress_metadata.vlan_id,hdr.eth.srcAddr,standard_metadata.ingress_port,meta.ingress_metadata.learning});
+        digest<mac_learn_digest>(32w1024, mac_learn_digest {vlan_id = meta.ingress_metadata.vlan_id,srcAddr = hdr.eth.srcAddr,ingress_port = standard_metadata.ingress_port,learning = meta.ingress_metadata.learning});
     }
     @name(".set_dmac") action set_dmac(bit<48> dst_mac_address, bit<9> port_id) {
         hdr.eth.dstAddr = dst_mac_address;

--- a/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
@@ -163,7 +163,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action nop() {
     }
     @name(".generate_learn_notify") action generate_learn_notify() {
-        digest<mac_learn_digest>(32w1024, {meta.ingress_metadata.vlan_id,hdr.eth.srcAddr,standard_metadata.ingress_port,meta.ingress_metadata.learning});
+        digest<mac_learn_digest>(32w1024, mac_learn_digest {vlan_id = meta.ingress_metadata.vlan_id,srcAddr = hdr.eth.srcAddr,ingress_port = standard_metadata.ingress_port,learning = meta.ingress_metadata.learning});
     }
     @name(".set_dmac") action set_dmac(bit<48> dst_mac_address, bit<9> port_id) {
         hdr.eth.dstAddr = dst_mac_address;

--- a/testdata/p4_14_samples_outputs/sai_p4-midend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-midend.p4
@@ -200,7 +200,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action nop() {
     }
     @name(".generate_learn_notify") action generate_learn_notify() {
-        digest<mac_learn_digest>(32w1024, {meta._ingress_metadata_vlan_id37,hdr.eth.srcAddr,standard_metadata.ingress_port,meta._ingress_metadata_learning33});
+        digest<mac_learn_digest>(32w1024, mac_learn_digest {vlan_id = meta._ingress_metadata_vlan_id37,srcAddr = hdr.eth.srcAddr,ingress_port = standard_metadata.ingress_port,learning = meta._ingress_metadata_learning33});
     }
     @name(".set_dmac") action set_dmac(bit<48> dst_mac_address, bit<9> port_id) {
         hdr.eth.dstAddr = dst_mac_address;

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -5727,7 +5727,7 @@ control process_mac_learning(inout headers hdr, inout metadata meta, inout stand
     @name(".nop") action nop() {
     }
     @name(".generate_learn_notify") action generate_learn_notify() {
-        digest<mac_learn_digest>(32w1024, {meta.ingress_metadata.bd,meta.l2_metadata.lkp_mac_sa,meta.ingress_metadata.ifindex});
+        digest<mac_learn_digest>(32w1024, mac_learn_digest {bd = meta.ingress_metadata.bd,lkp_mac_sa = meta.l2_metadata.lkp_mac_sa,ifindex = meta.ingress_metadata.ifindex});
     }
     @name(".learn_notify") table learn_notify {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -5531,7 +5531,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_106() {
     }
     @name(".generate_learn_notify") action _generate_learn_notify_0() {
-        digest<mac_learn_digest>(32w1024, {meta.ingress_metadata.bd,meta.l2_metadata.lkp_mac_sa,meta.ingress_metadata.ifindex});
+        digest<mac_learn_digest>(32w1024, mac_learn_digest {bd = meta.ingress_metadata.bd,lkp_mac_sa = meta.l2_metadata.lkp_mac_sa,ifindex = meta.ingress_metadata.ifindex});
     }
     @name(".learn_notify") table _learn_notify {
         actions = {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -5707,7 +5707,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_106() {
     }
     @name(".generate_learn_notify") action _generate_learn_notify_0() {
-        digest<mac_learn_digest>(32w1024, {meta._ingress_metadata_bd42,meta._l2_metadata_lkp_mac_sa65,meta._ingress_metadata_ifindex38});
+        digest<mac_learn_digest>(32w1024, mac_learn_digest {bd = meta._ingress_metadata_bd42,lkp_mac_sa = meta._l2_metadata_lkp_mac_sa65,ifindex = meta._ingress_metadata_ifindex38});
     }
     @name(".learn_notify") table _learn_notify {
         actions = {

--- a/testdata/p4_16_errors_outputs/constructor3_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor3_e.p4-stderr
@@ -1,3 +1,3 @@
-constructor3_e.p4(22): [--Werror=legacy] error: e: Cannot unify bool to bit<1>
+constructor3_e.p4(22): [--Werror=type-error] error: e: Cannot unify bool to bit<1>
     E(true) e;
             ^

--- a/testdata/p4_16_errors_outputs/factory-err2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/factory-err2.p4-stderr
@@ -1,4 +1,4 @@
-factory-err2.p4(31): error: : not a compile-time constant when binding to a
+factory-err2.p4(31): [--Werror=type-error] error: : not a compile-time constant when binding to a
     c1<bit<16>>(createWidget(hdr.f1, hdr.f2)) c; // factory args must be constants
                              ^^^^^^
 factory-err2.p4(20)

--- a/testdata/p4_16_errors_outputs/function1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function1_e.p4-stderr
@@ -1,4 +1,4 @@
-function1_e.p4(21): error: : Read-only value used for out/inout parameter x
+function1_e.p4(21): [--Werror=type-error] error: : Read-only value used for out/inout parameter x
         f(1w1 & 1w0); // non lvalue passed to out parameter
           ^^^^^^^^^
 function1_e.p4(16)

--- a/testdata/p4_16_errors_outputs/function_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function_e.p4-stderr
@@ -1,15 +1,15 @@
-function_e.p4(22): [--Werror=legacy] error: f: No argument for parameter x
+function_e.p4(22): [--Werror=type-error] error: f: No argument for parameter x
         f(); // not enough arguments
         ^^^
 function_e.p4(16)
 extern void f(in bit x);
                      ^
-function_e.p4(23): [--Werror=legacy] error: f: Passing 2 arguments when 1 expected
+function_e.p4(23): [--Werror=type-error] error: f: Passing 2 arguments when 1 expected
         f(1w1, 1w0); // too many arguments
         ^^^^^^^^^^^
-function_e.p4(24): [--Werror=legacy] error: f has 0 type parameters, but is invoked with 1 type arguments
+function_e.p4(24): [--Werror=type-error] error: f has 0 type parameters, but is invoked with 1 type arguments
         f<bit>(1w0); // too many type arguments
         ^^^^^^^^^^^
-function_e.p4(25): [--Werror=legacy] error: g has 1 type parameters, but is invoked with 2 type arguments
+function_e.p4(25): [--Werror=type-error] error: g has 1 type parameters, but is invoked with 2 type arguments
         g<bit, bit>(); // too many type arguments
         ^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/implicit.p4-stderr
+++ b/testdata/p4_16_errors_outputs/implicit.p4-stderr
@@ -1,3 +1,3 @@
-implicit.p4(19): [--Werror=legacy] error: b: Cannot unify int<32> to bit<32>
+implicit.p4(19): [--Werror=type-error] error: b: Cannot unify int<32> to bit<32>
     bit<32> b = 32s1;
     ^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue1006-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1006-1.p4-stderr
@@ -1,3 +1,3 @@
-issue1006-1.p4(14): [--Werror=legacy] error: reg2: Cannot unify bit<16> to bit<8>
+issue1006-1.p4(14): [--Werror=type-error] error: reg2: Cannot unify bit<16> to bit<8>
     R<bit<8>>(16w1) reg2;
                     ^^^^

--- a/testdata/p4_16_errors_outputs/issue401.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue401.p4-stderr
@@ -1,4 +1,4 @@
-issue401.p4(42): [--Werror=legacy] error: cast: Cannot unify Tuple(1) to bit<1>
+issue401.p4(42): [--Werror=type-error] error: cast: Cannot unify Tuple(1) to bit<1>
     bit<1> b = (bit<1>) { 0 };
                ^^^^^^^^^^^^^^
 issue401.p4(42): [--Werror=type-error] error: cast: Illegal cast from Tuple(1) to bit<1>

--- a/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
@@ -1,4 +1,4 @@
-issue561-1.p4(29): [--Werror=legacy] error: u: Cannot unify Tuple(2) to header_union U
+issue561-1.p4(29): [--Werror=type-error] error: u: Cannot unify Tuple(2) to header_union U
         U u = { { 10 }, { 20 } }; // illegal to initialize unions
         ^^^^^^^^^^^^^^^^^^^^^^^^^
 issue561-1.p4(29)

--- a/testdata/p4_16_errors_outputs/issue774-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue774-1.p4-stderr
@@ -1,3 +1,3 @@
-issue774-1.p4(7): error: : don't care argument only allowed for out parameters
+issue774-1.p4(7): [--Werror=type-error] error: : don't care argument only allowed for out parameters
         f(_);
           ^

--- a/testdata/p4_16_errors_outputs/issue803-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue803-1.p4-stderr
@@ -1,3 +1,3 @@
-issue803-1.p4(14): [--Werror=legacy] error: ig1: Passing 1 arguments when 0 expected
+issue803-1.p4(14): [--Werror=type-error] error: ig1: Passing 1 arguments when 0 expected
 Ingress<H>(ing_parse()) ig1;
                         ^^^

--- a/testdata/p4_16_errors_outputs/module_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/module_e.p4-stderr
@@ -1,4 +1,4 @@
-module_e.p4(25): [--Werror=legacy] error: main: Cannot unify parameter x with filter because they have different directions
+module_e.p4(25): [--Werror=type-error] error: main: Cannot unify parameter x with filter because they have different directions
 top(g()) main;
          ^^^^
 module_e.p4(20)

--- a/testdata/p4_16_errors_outputs/mux_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/mux_e.p4-stderr
@@ -1,4 +1,4 @@
 [--Werror=type-error] error: Selector of ?: must be bool, not bit<1>
-mux_e.p4(25): [--Werror=legacy] error: ?:: Cannot unify bool to bit<1>
+mux_e.p4(25): [--Werror=type-error] error: ?:: Cannot unify bool to bit<1>
         d = d ? a : d; // wrong types a <-> d
             ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/named-fail1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/named-fail1.p4-stderr
@@ -1,4 +1,4 @@
-named-fail1.p4(8): [--Werror=legacy] error: f: No parameter named z
+named-fail1.p4(8): [--Werror=type-error] error: f: No parameter named z
         f(z = b, y = b); // No such parameter
         ^^^^^^^^^^^^^^^
 named-fail1.p4(8)

--- a/testdata/p4_16_errors_outputs/newtype-err.p4-stderr
+++ b/testdata/p4_16_errors_outputs/newtype-err.p4-stderr
@@ -1,4 +1,4 @@
-newtype-err.p4(10): [--Werror=legacy] error: AssignmentStatement: Cannot unify bit<32> to N32
+newtype-err.p4(10): [--Werror=type-error] error: AssignmentStatement: Cannot unify bit<32> to N32
         n = b + b;
           ^
 newtype-err.p4(2)
@@ -7,6 +7,6 @@ type bit<32> N32;
 newtype-err.p4(11): [--Werror=type-error] error: +: cannot be applied to n of type N32
         n1 = n + 0;
              ^
-newtype-err.p4(12): [--Werror=legacy] error: AssignmentStatement: Cannot unify N32 to bit<32>
+newtype-err.p4(12): [--Werror=type-error] error: AssignmentStatement: Cannot unify N32 to bit<32>
         x = n;
           ^

--- a/testdata/p4_16_errors_outputs/psa-meter2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/psa-meter2.p4-stderr
@@ -1,4 +1,4 @@
-psa-meter2.p4(53): [--Werror=legacy] error: cast: Cannot unify PSA_MeterColor_t to bit<16>
+psa-meter2.p4(53): [--Werror=type-error] error: cast: Cannot unify PSA_MeterColor_t to bit<16>
         b.data = (bit<16>)meter0.execute(index, PSA_MeterColor_t.GREEN);
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 psa-meter2.p4(53): [--Werror=type-error] error: cast: Illegal cast from PSA_MeterColor_t to bit<16>

--- a/testdata/p4_16_errors_outputs/signs.p4-stderr
+++ b/testdata/p4_16_errors_outputs/signs.p4-stderr
@@ -4,7 +4,7 @@ signs.p4(17): [--Wwarn=shadow] warning: a shadows a
 signs.p4(16)
 action a() {
        ^
-signs.p4(18): [--Werror=legacy] error: b: Cannot unify bit<8> to int<8>
+signs.p4(18): [--Werror=type-error] error: b: Cannot unify bit<8> to int<8>
     int<8> b = 8w0;
     ^^^^^^^^^^^^^^^
 signs.p4(19): [--Werror=type-error] error: -: Cannot operate on values with different signs

--- a/testdata/p4_16_errors_outputs/stack2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack2.p4-stderr
@@ -1,4 +1,4 @@
-stack2.p4(24): [--Werror=legacy] error: AssignmentStatement: cannot unify stacks with different sized header h[] and header h[]
+stack2.p4(24): [--Werror=type-error] error: AssignmentStatement: cannot unify stacks with different sized header h[] and header h[]
         stack1 = stack2; // assignment between different stacks
                ^
 stack2.p4(21)

--- a/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-exact.p4(72): [--Werror=legacy] error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-exact.p4(72): [--Werror=type-error] error: Entry: Cannot match tuples with different sizes 1 vs 2
             (0x1111 &&& 0xF, 0x1 ) : a(); // invalid exact key
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-lpm.p4(72): [--Werror=legacy] error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-lpm.p4(72): [--Werror=type-error] error: Entry: Cannot match tuples with different sizes 1 vs 2
             (0x1, 0x11 &&& 0xF0): a(); // invalid keyset
             ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-range.p4(71): [--Werror=legacy] error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-range.p4(71): [--Werror=type-error] error: Entry: Cannot match tuples with different sizes 1 vs 2
             (0x18, 0xF) : a_with_control_params(24); // not a range
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/typecheck_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typecheck_e.p4-stderr
@@ -1,3 +1,3 @@
-typecheck_e.p4(21): [--Werror=legacy] error: f: Cannot unify T to int<32>
+typecheck_e.p4(21): [--Werror=type-error] error: f: Cannot unify T to int<32>
         f(x);
         ^^^^

--- a/testdata/p4_16_errors_outputs/virtual1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual1.p4-stderr
@@ -1,6 +1,6 @@
-virtual1.p4(23): [--Werror=legacy] error: return +: Cannot unify bit<16> to bool
+virtual1.p4(23): [--Werror=type-error] error: return +: Cannot unify bit<16> to bool
             return (ix + 1);
             ^^^^^^
-virtual1.p4(21): [--Werror=legacy] error: cntr: Cannot unify bool to bit<16>
+virtual1.p4(21): [--Werror=type-error] error: cntr: Cannot unify bool to bit<16>
     Virtual() cntr = {
               ^^^^

--- a/testdata/p4_16_errors_outputs/virtual2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual2.p4-stderr
@@ -1,6 +1,6 @@
 virtual2.p4(23): [--Werror=type-error] error: return +: return expression in function with void return
             return (ix + 1);
             ^^^^^^
-virtual2.p4(21): [--Werror=legacy] error: cntr: Cannot unify void to bit<16>
+virtual2.p4(21): [--Werror=type-error] error: cntr: Cannot unify void to bit<16>
     Virtual() cntr = {
               ^^^^

--- a/testdata/p4_16_samples/struct_init-1.p4
+++ b/testdata/p4_16_samples/struct_init-1.p4
@@ -1,0 +1,26 @@
+struct PortId_t { bit<9> _v; }
+header H { bit<32> b; }
+
+const PortId_t PSA_CPU_PORT = { _v = 9w192 };
+
+struct metadata_t {
+    PortId_t foo;
+}
+
+control I(inout metadata_t meta) {
+    apply {
+        PortId_t p = { _v = 0 };
+        H h = { b = 1 };
+        if (meta.foo == PSA_CPU_PORT) {
+            meta.foo._v = meta.foo._v + 1;
+            h = { b = 2 };
+            if (h == H { b = 1 })
+                h = { b = 2 };
+        }
+    }
+}
+
+control C<M>(inout M m);
+package top<M>(C<M> c);
+
+top(I()) main;

--- a/testdata/p4_16_samples_outputs/annotation-bug-first.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-first.p4
@@ -21,7 +21,7 @@ extern bit<16> get<T>(in T data);
 control cc() {
     headers hdr;
     apply {
-        get<headers>({hdr.ipv4_option_timestamp});
+        get<headers>(headers {ipv4_option_timestamp = hdr.ipv4_option_timestamp});
     }
 }
 

--- a/testdata/p4_16_samples_outputs/annotation-bug-frontend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-frontend.p4
@@ -22,7 +22,7 @@ control cc() {
     headers hdr_0;
     headers tmp;
     apply {
-        tmp = {hdr_0.ipv4_option_timestamp};
+        tmp = headers {ipv4_option_timestamp = hdr_0.ipv4_option_timestamp};
         get<headers>(tmp);
     }
 }

--- a/testdata/p4_16_samples_outputs/assign-first.p4
+++ b/testdata/p4_16_samples_outputs/assign-first.p4
@@ -5,7 +5,7 @@ header h {
 control c() {
     h hdr;
     apply {
-        hdr = {32w10};
+        hdr = h {field = 32w10};
     }
 }
 

--- a/testdata/p4_16_samples_outputs/copy-first.p4
+++ b/testdata/p4_16_samples_outputs/copy-first.p4
@@ -6,7 +6,7 @@ control c(inout bit<32> b) {
     action a() {
         S s1;
         S s2;
-        s2 = {32w0};
+        s2 = S {x = 32w0};
         s1 = s2;
         s2 = s1;
         b = s2.x;

--- a/testdata/p4_16_samples_outputs/copy-frontend.p4
+++ b/testdata/p4_16_samples_outputs/copy-frontend.p4
@@ -6,7 +6,7 @@ control c(inout bit<32> b) {
     S s1_0;
     S s2_0;
     @name("c.a") action a() {
-        s2_0 = {32w0};
+        s2_0 = S {x = 32w0};
         s1_0 = s2_0;
         s2_0 = s1_0;
         b = s2_0.x;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-midend.p4
@@ -104,7 +104,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @name("MyIngress.send_digest") action send_digest() {
         meta._test_digest_in_mac_srcAddr0 = hdr.ethernet.srcAddr;
-        digest<test_digest_t>(32w1, {hdr.ethernet.srcAddr});
+        digest<test_digest_t>(32w1, test_digest_t {in_mac_srcAddr = hdr.ethernet.srcAddr});
     }
     @hidden table tbl_send_digest {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1638-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1638-first.p4
@@ -37,7 +37,7 @@ control MyC2(in meta_t meta={ 0, 0, 0 }) {
 control MyC(inout hdr_t hdr, inout meta_t meta, in intrinsic_metadata_t intr_md) {
     MyC2() c2;
     apply {
-        c2.apply(meta = {8w0,8w0,8w0});
+        c2.apply(meta = meta_t {f0 = 8w0,f1 = 8w0,f2 = 8w0});
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1638-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1638-frontend.p4
@@ -24,7 +24,7 @@ control MyC(inout hdr_t hdr, inout meta_t meta, in intrinsic_metadata_t intr_md)
     }
     @name("MyC.c2.a") table c2_a {
         key = {
-            {8w0,8w0,8w0}.f0: exact @name("meta.f0") ;
+            meta_t {f0 = 8w0,f1 = 8w0,f2 = 8w0}.f0: exact @name("meta.f0") ;
         }
         actions = {
             NoAction_0();

--- a/testdata/p4_16_samples_outputs/issue1642-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1642-bmv2-midend.p4
@@ -40,7 +40,7 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata._row_alt0_port2 = local_metadata._row_alt1_port4;
         local_metadata._row_alt0_valid1 = 1w1;
         local_metadata._row_alt1_port4 = local_metadata._row_alt1_port4 + 7w1;
-        clone3<row_t>(CloneType.I2E, 32w0, {{1w1,local_metadata._row_alt0_port2},{local_metadata._row_alt1_valid3,local_metadata._row_alt1_port4}});
+        clone3<row_t>(CloneType.I2E, 32w0, row_t {alt0 = alt_t {valid = 1w1,port = local_metadata._row_alt0_port2},alt1 = alt_t {valid = local_metadata._row_alt1_valid3,port = local_metadata._row_alt1_port4}});
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-midend.p4
@@ -93,7 +93,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
     @hidden action act() {
         h.bvh0._row_alt1_type10 = 16w0x800;
         local_metadata._row0_alt0_useHash3 = true;
-        clone3<row_t>(CloneType.I2E, 32w0, {{local_metadata._row0_alt0_valid0,local_metadata._row0_alt0_port1,local_metadata._row0_alt0_hashRes2,true,local_metadata._row0_alt0_type4,local_metadata._row0_alt0_pad5},{local_metadata._row0_alt1_valid6,local_metadata._row0_alt1_port7,local_metadata._row0_alt1_hashRes8,local_metadata._row0_alt1_useHash9,local_metadata._row0_alt1_type10,local_metadata._row0_alt1_pad11}});
+        clone3<row_t>(CloneType.I2E, 32w0, row_t {alt0 = alt_t {valid = local_metadata._row0_alt0_valid0,port = local_metadata._row0_alt0_port1,hashRes = local_metadata._row0_alt0_hashRes2,useHash = true,type = local_metadata._row0_alt0_type4,pad = local_metadata._row0_alt0_pad5},alt1 = alt_t {valid = local_metadata._row0_alt1_valid6,port = local_metadata._row0_alt1_port7,hashRes = local_metadata._row0_alt1_hashRes8,useHash = local_metadata._row0_alt1_useHash9,type = local_metadata._row0_alt1_type10,pad = local_metadata._row0_alt1_pad11}});
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1670-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1670-bmv2-first.p4
@@ -25,7 +25,7 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     apply {
         h.mirrored_md.setValid();
-        h.mirrored_md.meta = {8w0};
+        h.mirrored_md.meta = switch_metadata_t {port = 8w0};
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1670-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1670-bmv2-frontend.p4
@@ -25,7 +25,7 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     apply {
         h.mirrored_md.setValid();
-        h.mirrored_md.meta = {8w0};
+        h.mirrored_md.meta = switch_metadata_t {port = 8w0};
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1863-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1863-first.p4
@@ -6,7 +6,7 @@ struct S {
 control c(out bit<1> b) {
     apply {
         S s = { 1w0, 1w1 };
-        s = {s.b,s.a};
+        s = S {a = s.b,b = s.a};
         b = s.a;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1863-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1863-frontend.p4
@@ -7,7 +7,7 @@ control c(out bit<1> b) {
     S s_0;
     apply {
         s_0 = { 1w0, 1w1 };
-        s_0 = {s_0.b,s_0.a};
+        s_0 = S {a = s_0.b,b = s_0.a};
         b = s_0.a;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2-first.p4
@@ -1,0 +1,85 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header addr_type_t {
+    bit<8> dstType;
+    bit<8> srcType;
+}
+
+header addr_ipv4_t {
+    bit<32> addr;
+}
+
+header addr_ipv6_t {
+    bit<128> addr;
+}
+
+header_union addr_t {
+    addr_ipv4_t ipv4;
+    addr_ipv6_t ipv6;
+}
+
+struct metadata {
+}
+
+struct headers {
+    addr_type_t addr_type;
+    addr_t      addr_dst;
+    addr_t      addr_src;
+}
+
+parser ProtAddrParser(packet_in packet, in bit<8> addrType, out addr_t addr) {
+    state start {
+        transition select(addrType) {
+            8w0x1: ipv4;
+            8w0x2: ipv6;
+        }
+    }
+    state ipv4 {
+        packet.extract<addr_ipv4_t>(addr.ipv4);
+        transition accept;
+    }
+    state ipv6 {
+        packet.extract<addr_ipv6_t>(addr.ipv6);
+        transition accept;
+    }
+}
+
+parser ProtParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    ProtAddrParser() addrParser;
+    state start {
+        packet.extract<addr_type_t>(hdr.addr_type);
+        addrParser.apply(packet, hdr.addr_type.dstType, hdr.addr_dst);
+        addrParser.apply(packet, hdr.addr_type.srcType, hdr.addr_src);
+        transition accept;
+    }
+}
+
+control ProtVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control ProtIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ProtEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ProtComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control ProtDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<headers>(hdr);
+    }
+}
+
+V1Switch<headers, metadata>(ProtParser(), ProtVerifyChecksum(), ProtIngress(), ProtEgress(), ProtComputeChecksum(), ProtDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2-frontend.p4
@@ -1,0 +1,109 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header addr_type_t {
+    bit<8> dstType;
+    bit<8> srcType;
+}
+
+header addr_ipv4_t {
+    bit<32> addr;
+}
+
+header addr_ipv6_t {
+    bit<128> addr;
+}
+
+header_union addr_t {
+    addr_ipv4_t ipv4;
+    addr_ipv6_t ipv6;
+}
+
+struct metadata {
+}
+
+struct headers {
+    addr_type_t addr_type;
+    addr_t      addr_dst;
+    addr_t      addr_src;
+}
+
+parser ProtParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<8> addrType_0;
+    addr_t addr_0;
+    state start {
+        packet.extract<addr_type_t>(hdr.addr_type);
+        addrType_0 = hdr.addr_type.dstType;
+        addr_0.ipv4.setInvalid();
+        addr_0.ipv6.setInvalid();
+        transition ProtAddrParser_start;
+    }
+    state ProtAddrParser_start {
+        transition select(addrType_0) {
+            8w0x1: ProtAddrParser_ipv4;
+            8w0x2: ProtAddrParser_ipv6;
+        }
+    }
+    state ProtAddrParser_ipv4 {
+        packet.extract<addr_ipv4_t>(addr_0.ipv4);
+        transition start_0;
+    }
+    state ProtAddrParser_ipv6 {
+        packet.extract<addr_ipv6_t>(addr_0.ipv6);
+        transition start_0;
+    }
+    state start_0 {
+        hdr.addr_dst = addr_0;
+        addrType_0 = hdr.addr_type.srcType;
+        addr_0.ipv4.setInvalid();
+        addr_0.ipv6.setInvalid();
+        transition ProtAddrParser_start_0;
+    }
+    state ProtAddrParser_start_0 {
+        transition select(addrType_0) {
+            8w0x1: ProtAddrParser_ipv4_0;
+            8w0x2: ProtAddrParser_ipv6_0;
+        }
+    }
+    state ProtAddrParser_ipv4_0 {
+        packet.extract<addr_ipv4_t>(addr_0.ipv4);
+        transition start_1;
+    }
+    state ProtAddrParser_ipv6_0 {
+        packet.extract<addr_ipv6_t>(addr_0.ipv6);
+        transition start_1;
+    }
+    state start_1 {
+        hdr.addr_src = addr_0;
+        transition accept;
+    }
+}
+
+control ProtVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control ProtIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ProtEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ProtComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control ProtDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<headers>(hdr);
+    }
+}
+
+V1Switch<headers, metadata>(ProtParser(), ProtVerifyChecksum(), ProtIngress(), ProtEgress(), ProtComputeChecksum(), ProtDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2-midend.p4
@@ -1,0 +1,112 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header addr_type_t {
+    bit<8> dstType;
+    bit<8> srcType;
+}
+
+header addr_ipv4_t {
+    bit<32> addr;
+}
+
+header addr_ipv6_t {
+    bit<128> addr;
+}
+
+header_union addr_t {
+    addr_ipv4_t ipv4;
+    addr_ipv6_t ipv6;
+}
+
+struct metadata {
+}
+
+struct headers {
+    addr_type_t addr_type;
+    addr_t      addr_dst;
+    addr_t      addr_src;
+}
+
+parser ProtParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    addr_t addr_0;
+    state start {
+        packet.extract<addr_type_t>(hdr.addr_type);
+        addr_0.ipv4.setInvalid();
+        addr_0.ipv6.setInvalid();
+        transition select(hdr.addr_type.dstType) {
+            8w0x1: ProtAddrParser_ipv4;
+            8w0x2: ProtAddrParser_ipv6;
+            default: noMatch;
+        }
+    }
+    state ProtAddrParser_ipv4 {
+        packet.extract<addr_ipv4_t>(addr_0.ipv4);
+        transition start_0;
+    }
+    state ProtAddrParser_ipv6 {
+        packet.extract<addr_ipv6_t>(addr_0.ipv6);
+        transition start_0;
+    }
+    state start_0 {
+        hdr.addr_dst.ipv4 = addr_0.ipv4;
+        hdr.addr_dst.ipv6 = addr_0.ipv6;
+        addr_0.ipv4.setInvalid();
+        addr_0.ipv6.setInvalid();
+        transition select(hdr.addr_type.srcType) {
+            8w0x1: ProtAddrParser_ipv4_0;
+            8w0x2: ProtAddrParser_ipv6_0;
+            default: noMatch;
+        }
+    }
+    state ProtAddrParser_ipv4_0 {
+        packet.extract<addr_ipv4_t>(addr_0.ipv4);
+        transition start_1;
+    }
+    state ProtAddrParser_ipv6_0 {
+        packet.extract<addr_ipv6_t>(addr_0.ipv6);
+        transition start_1;
+    }
+    state start_1 {
+        hdr.addr_src.ipv4 = addr_0.ipv4;
+        hdr.addr_src.ipv6 = addr_0.ipv6;
+        transition accept;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
+    }
+}
+
+control ProtVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control ProtIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ProtEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ProtComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control ProtDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<addr_type_t>(hdr.addr_type);
+        packet.emit<addr_ipv4_t>(hdr.addr_dst.ipv4);
+        packet.emit<addr_ipv6_t>(hdr.addr_dst.ipv6);
+        packet.emit<addr_ipv4_t>(hdr.addr_src.ipv4);
+        packet.emit<addr_ipv6_t>(hdr.addr_src.ipv6);
+    }
+}
+
+V1Switch<headers, metadata>(ProtParser(), ProtVerifyChecksum(), ProtIngress(), ProtEgress(), ProtComputeChecksum(), ProtDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2.p4
@@ -1,0 +1,85 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header addr_type_t {
+    bit<8> dstType;
+    bit<8> srcType;
+}
+
+header addr_ipv4_t {
+    bit<32> addr;
+}
+
+header addr_ipv6_t {
+    bit<128> addr;
+}
+
+header_union addr_t {
+    addr_ipv4_t ipv4;
+    addr_ipv6_t ipv6;
+}
+
+struct metadata {
+}
+
+struct headers {
+    addr_type_t addr_type;
+    addr_t      addr_dst;
+    addr_t      addr_src;
+}
+
+parser ProtAddrParser(packet_in packet, in bit<8> addrType, out addr_t addr) {
+    state start {
+        transition select(addrType) {
+            0x1: ipv4;
+            0x2: ipv6;
+        }
+    }
+    state ipv4 {
+        packet.extract(addr.ipv4);
+        transition accept;
+    }
+    state ipv6 {
+        packet.extract(addr.ipv6);
+        transition accept;
+    }
+}
+
+parser ProtParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    ProtAddrParser() addrParser;
+    state start {
+        packet.extract(hdr.addr_type);
+        addrParser.apply(packet, hdr.addr_type.dstType, hdr.addr_dst);
+        addrParser.apply(packet, hdr.addr_type.srcType, hdr.addr_src);
+        transition accept;
+    }
+}
+
+control ProtVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control ProtIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ProtEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ProtComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control ProtDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<headers>(hdr);
+    }
+}
+
+V1Switch(ProtParser(), ProtVerifyChecksum(), ProtIngress(), ProtEgress(), ProtComputeChecksum(), ProtDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
@@ -81,7 +81,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         local_metadata._row0_alt0_port1 = local_metadata._row1_alt1_port7;
         local_metadata._row1_alt0_valid4 = 1w1;
         local_metadata._row1_alt1_port7 = local_metadata._row0_alt1_port3 + 7w1;
-        clone3<row_t>(CloneType.I2E, 32w0, {{local_metadata._row1_alt1_valid6,local_metadata._row0_alt0_port1},{local_metadata._row0_alt1_valid2,local_metadata._row0_alt1_port3}});
+        clone3<row_t>(CloneType.I2E, 32w0, row_t {alt0 = alt_t {valid = local_metadata._row1_alt1_valid6,port = local_metadata._row0_alt0_port1},alt1 = alt_t {valid = local_metadata._row0_alt1_valid2,port = local_metadata._row0_alt1_port3}});
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue396-first.p4
+++ b/testdata/p4_16_samples_outputs/issue396-first.p4
@@ -20,15 +20,15 @@ control d(out bool b) {
         H h;
         H h1;
         H[2] h3;
-        h = {32w0};
+        h = H {x = 32w0};
         S s;
         S s1;
-        s = {{32w0}};
-        s1.h = {32w0};
-        h3[0] = {32w0};
-        h3[1] = {32w1};
+        s = S {h = H {x = 32w0}};
+        s1.h = H {x = 32w0};
+        h3[0] = H {x = 32w0};
+        h3[1] = H {x = 32w1};
         bool eout;
-        einst.apply({32w0}, eout);
+        einst.apply(H {x = 32w0}, eout);
         b = h.isValid() && eout && h3[1].isValid() && s1.h.isValid();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue396-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-frontend.p4
@@ -17,15 +17,15 @@ control d(out bool b) {
     H tmp;
     apply {
         h_0.setValid();
-        h_0 = {32w0};
+        h_0 = H {x = 32w0};
         s_0.h.setValid();
         s1_0.h.setValid();
-        s1_0.h = {32w0};
+        s1_0.h = H {x = 32w0};
         h3_0[0].setValid();
         h3_0[1].setValid();
-        h3_0[1] = {32w1};
+        h3_0[1] = H {x = 32w1};
         tmp.setValid();
-        tmp = {32w0};
+        tmp = H {x = 32w0};
         eout_0 = tmp.isValid();
         b = h_0.isValid() && eout_0 && h3_0[1].isValid() && s1_0.h.isValid();
     }

--- a/testdata/p4_16_samples_outputs/issue562-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue562-bmv2-midend.p4
@@ -33,7 +33,7 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata._row_alt0_port1 = local_metadata._row_alt1_port3;
         local_metadata._row_alt0_valid0 = 1w1;
         local_metadata._row_alt1_port3 = local_metadata._row_alt1_port3 + 7w1;
-        clone3<row_t>(CloneType.I2E, 32w0, {{1w1,local_metadata._row_alt0_port1},{local_metadata._row_alt1_valid2,local_metadata._row_alt1_port3}});
+        clone3<row_t>(CloneType.I2E, 32w0, row_t {alt0 = alt_t {valid = 1w1,port = local_metadata._row_alt0_port1},alt1 = alt_t {valid = local_metadata._row_alt1_valid2,port = local_metadata._row_alt1_port3}});
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue933-1-first.p4
+++ b/testdata/p4_16_samples_outputs/issue933-1-first.p4
@@ -8,7 +8,7 @@ extern void f(headers h);
 control c() {
     apply {
         headers h;
-        f({32w5});
+        f(headers {x = 32w5});
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue933-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue933-1-frontend.p4
@@ -7,7 +7,7 @@ struct headers {
 extern void f(headers h);
 control c() {
     apply {
-        f({32w5});
+        f(headers {x = 32w5});
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue933-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue933-1-midend.p4
@@ -7,7 +7,7 @@ struct headers {
 extern void f(headers h);
 control c() {
     @hidden action act() {
-        f({32w5});
+        f(headers {x = 32w5});
     }
     @hidden table tbl_act {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue933-first.p4
+++ b/testdata/p4_16_samples_outputs/issue933-first.p4
@@ -7,7 +7,7 @@ struct headers {
 
 control MyDeparser(packet_out packet, in headers hdr) {
     apply {
-        packet.emit<headers>({});
+        packet.emit<headers>(headers {});
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue933-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue933-frontend.p4
@@ -7,7 +7,7 @@ struct headers {
 
 control MyDeparser(packet_out packet, in headers hdr) {
     apply {
-        packet.emit<headers>({});
+        packet.emit<headers>(headers {});
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue982-first.p4
+++ b/testdata/p4_16_samples_outputs/issue982-first.p4
@@ -397,7 +397,7 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
 control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd, out psa_ingress_deparser_output_metadata_t ostd) {
     apply {
         clone_metadata_t clone_md;
-        clone_md.data.h1 = {32w0};
+        clone_md.data.h1 = clone_1_t {data = 32w0};
         clone_md.type = 3w0;
         if (meta.custom_clone_id == 3w1) 
             ostd.clone_metadata = clone_md;

--- a/testdata/p4_16_samples_outputs/issue982-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue982-frontend.p4
@@ -386,7 +386,7 @@ control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata me
     clone_metadata_t clone_md_0;
     apply {
         clone_md_0.data.h1.setValid();
-        clone_md_0.data.h1 = {32w0};
+        clone_md_0.data.h1 = clone_1_t {data = 32w0};
         clone_md_0.type = 3w0;
         if (meta.custom_clone_id == 3w1) 
             ostd.clone_metadata = clone_md_0;

--- a/testdata/p4_16_samples_outputs/list-compare-first.p4
+++ b/testdata/p4_16_samples_outputs/list-compare-first.p4
@@ -16,7 +16,7 @@ control test(out bool zout) {
         tuple<bit<32>, bit<32>> p = { 32w4, 32w5 };
         S q = { 32w2, 32w3 };
         zout = p == { 32w4, 32w5 };
-        zout = zout && q == {32w2,32w3};
+        zout = zout && q == S {l = 32w2,r = 32w3};
     }
 }
 

--- a/testdata/p4_16_samples_outputs/list-compare-frontend.p4
+++ b/testdata/p4_16_samples_outputs/list-compare-frontend.p4
@@ -12,7 +12,7 @@ control test(out bool zout) {
         p_0 = { 32w4, 32w5 };
         q_0 = { 32w2, 32w3 };
         zout = p_0 == { 32w4, 32w5 };
-        zout = zout && q_0 == {32w2,32w3};
+        zout = zout && q_0 == S {l = 32w2,r = 32w3};
     }
 }
 

--- a/testdata/p4_16_samples_outputs/nested-tuple-first.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-first.p4
@@ -18,7 +18,7 @@ control c(inout bit<1> r) {
     apply {
         S s = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
         f<tuple<T, T>>(s.f1);
-        f<tuple_0>({{1w0},{1w1}});
+        f<tuple_0>(tuple_0 {field = T {f = 1w0},field_0 = T {f = 1w1}});
         r = s.f2.f & s.z;
     }
 }

--- a/testdata/p4_16_samples_outputs/nested-tuple-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-frontend.p4
@@ -19,7 +19,7 @@ control c(inout bit<1> r) {
     apply {
         s_0 = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
         f<tuple<T, T>>(s_0.f1);
-        f<tuple_0>({{1w0},{1w1}});
+        f<tuple_0>(tuple_0 {field = T {f = 1w0},field_0 = T {f = 1w1}});
         r = s_0.f2.f & s_0.z;
     }
 }

--- a/testdata/p4_16_samples_outputs/nested-tuple-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-midend.p4
@@ -26,7 +26,7 @@ control c(inout bit<1> r) {
         s_0_f1_field.f = 1w0;
         s_0_f1_field_0.f = 1w1;
         f<tuple_1>({ s_0_f1_field, s_0_f1_field_0 });
-        f<tuple_0>({{1w0},{1w1}});
+        f<tuple_0>(tuple_0 {field = T {f = 1w0},field_0 = T {f = 1w1}});
         r = 1w0;
     }
     @hidden table tbl_act {

--- a/testdata/p4_16_samples_outputs/nested-tuple1-first.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple1-first.p4
@@ -13,7 +13,7 @@ control c(inout bit<1> r) {
     S s_0;
     bit<1> tmp;
     apply {
-        s_0 = {{ {1w0}, {1w1} },{1w0},1w1};
+        s_0 = S {f1 = { T {f = 1w0}, T {f = 1w1} },f2 = T {f = 1w0},z = 1w1};
         f<tuple<T, T>>(s_0.f1);
         tmp = s_0.f2.f & s_0.z;
         r = tmp;

--- a/testdata/p4_16_samples_outputs/nested-tuple1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple1-frontend.p4
@@ -13,7 +13,7 @@ control c(inout bit<1> r) {
     S s;
     bit<1> tmp_0;
     apply {
-        s = {{ {1w0}, {1w1} },{1w0},1w1};
+        s = S {f1 = { T {f = 1w0}, T {f = 1w1} },f2 = T {f = 1w0},z = 1w1};
         f<tuple<T, T>>(s.f1);
         tmp_0 = s.f2.f & s.z;
         r = tmp_0;

--- a/testdata/p4_16_samples_outputs/p4rt_digest_complex-first.p4
+++ b/testdata/p4_16_samples_outputs/p4rt_digest_complex-first.p4
@@ -50,7 +50,7 @@ struct digest_t {
 control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     Digest<digest_t>() digest;
     apply {
-        digest.pack({hdr.h,f.egress_port});
+        digest.pack(digest_t {h = hdr.h,port = f.egress_port});
     }
 }
 

--- a/testdata/p4_16_samples_outputs/p4rt_digest_complex-frontend.p4
+++ b/testdata/p4_16_samples_outputs/p4rt_digest_complex-frontend.p4
@@ -51,7 +51,7 @@ control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout hea
     digest_t tmp;
     @name("MyID.digest") Digest<digest_t>() digest_0;
     apply {
-        tmp = {hdr.h,f.egress_port};
+        tmp = digest_t {h = hdr.h,port = f.egress_port};
         digest_0.pack(tmp);
     }
 }

--- a/testdata/p4_16_samples_outputs/precedence-first.p4
+++ b/testdata/p4_16_samples_outputs/precedence-first.p4
@@ -83,7 +83,7 @@ action ac() {
     a = b + c;
     a = f.z + b;
     a = fct(f.z + b, b + c);
-    f = {a + b,c};
-    g = {{a + b,c},{a + b,c}};
-    g = {{a + b + b,c},{a + (b + c),c}};
+    f = s {z = a + b,w = c};
+    g = t {s1 = s {z = a + b,w = c},s2 = s {z = a + b,w = c}};
+    g = t {s1 = s {z = a + b + b,w = c},s2 = s {z = a + (b + c),w = c}};
 }

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-first.p4
@@ -1,0 +1,82 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter;
+    action execute() {
+        counter.count(12w256);
+    }
+    table tbl {
+        actions = {
+            execute();
+        }
+        default_action = execute();
+    }
+    apply {
+        send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[1:0]);
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-frontend.p4
@@ -1,0 +1,79 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_1, in PortId_t egress_port_1) {
+        meta_1.drop = false;
+        meta_1.multicast_group = (MulticastGroup_t)32w0;
+        meta_1.egress_port = egress_port_1;
+    }
+    @name("cIngress.counter") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter_0;
+    @name("cIngress.execute") action execute_1() {
+        counter_0.count(12w256);
+    }
+    @name("cIngress.tbl") table tbl_0 {
+        actions = {
+            execute_1();
+        }
+        default_action = execute_1();
+    }
+    apply {
+        send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[1:0]);
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-midend.p4
@@ -1,0 +1,103 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".send_to_port") action send_to_port() {
+        ostd.drop = false;
+        ostd.multicast_group = 32w0;
+        ostd.egress_port = (PortIdUint_t)hdr.ethernet.dstAddr[1:0];
+    }
+    @name("cIngress.counter") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter_0;
+    @name("cIngress.execute") action execute_1() {
+        counter_0.count(12w256);
+    }
+    @name("cIngress.tbl") table tbl_0 {
+        actions = {
+            execute_1();
+        }
+        default_action = execute_1();
+    }
+    @hidden table tbl_send_to_port {
+        actions = {
+            send_to_port();
+        }
+        const default_action = send_to_port();
+    }
+    apply {
+        tbl_send_to_port.apply();
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action act() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action act_0() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    apply {
+        tbl_act_0.apply();
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4
@@ -1,0 +1,82 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter;
+    action execute() {
+        counter.count(256);
+    }
+    table tbl {
+        actions = {
+            execute;
+        }
+        default_action = execute;
+    }
+    apply {
+        send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[1:0]);
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.p4info.txt
@@ -1,0 +1,42 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 33578158
+    name: "cIngress.tbl"
+    alias: "tbl"
+  }
+  action_refs {
+    id: 16801940
+  }
+  size: 1024
+  idle_timeout_behavior: NOTIFY_CONTROL
+}
+actions {
+  preamble {
+    id: 16833049
+    name: "send_to_port"
+    alias: "send_to_port"
+  }
+}
+actions {
+  preamble {
+    id: 16801940
+    name: "cIngress.execute"
+    alias: "execute"
+  }
+}
+counters {
+  preamble {
+    id: 301992253
+    name: "cIngress.counter"
+    alias: "counter"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2-first.p4
@@ -1,0 +1,102 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+}
+
+struct metadata_t {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control ingress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control egress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2-frontend.p4
@@ -1,0 +1,92 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+}
+
+struct metadata_t {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control ingress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control egress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2-midend.p4
@@ -1,0 +1,109 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control ingress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control egress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action act() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action act_0() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    apply {
+        tbl_act_0.apply();
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4
@@ -1,0 +1,102 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+}
+
+struct metadata_t {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control ingress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t parsed_hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        buffer.extract(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control egress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "psa"
+}

--- a/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-midend.p4
@@ -158,7 +158,7 @@ control egress(inout headers hdr, inout metadata meta, in psa_egress_input_metad
 control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
     @name("IngressDeparserImpl.mac_learn_digest") Digest<mac_learn_digest_t>() mac_learn_digest_0;
     @hidden action act_0() {
-        mac_learn_digest_0.pack({meta._mac_learn_msg_srcAddr1,meta._mac_learn_msg_ingress_port2});
+        mac_learn_digest_0.pack(mac_learn_digest_t {srcAddr = meta._mac_learn_msg_srcAddr1,ingress_port = meta._mac_learn_msg_ingress_port2});
     }
     @hidden action act_1() {
         packet.emit<ethernet_t>(hdr.ethernet);

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-first.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+        multicast(ostd, (MulticastGroup_t)hdr.ethernet.dstAddr[31:0]);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-frontend.p4
@@ -1,0 +1,67 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".multicast") action multicast(inout psa_ingress_output_metadata_t meta_1, in MulticastGroup_t multicast_group_1) {
+        meta_1.drop = false;
+        meta_1.multicast_group = multicast_group_1;
+    }
+    apply {
+        multicast(ostd, (MulticastGroup_t)hdr.ethernet.dstAddr[31:0]);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-midend.p4
@@ -1,0 +1,91 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".multicast") action multicast() {
+        ostd.drop = false;
+        ostd.multicast_group = hdr.ethernet.dstAddr[31:0];
+    }
+    @hidden table tbl_multicast {
+        actions = {
+            multicast();
+        }
+        const default_action = multicast();
+    }
+    apply {
+        tbl_multicast.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action act() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action act_0() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    apply {
+        tbl_act_0.apply();
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+        multicast(ostd, (MulticastGroup_t)hdr.ethernet.dstAddr[31:0]);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.p4info.txt
@@ -1,0 +1,10 @@
+pkg_info {
+  arch: "psa"
+}
+actions {
+  preamble {
+    id: 16807491
+    name: "multicast"
+    alias: "multicast"
+  }
+}

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-first.p4
@@ -1,0 +1,73 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+        send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[1:0]);
+        if (hdr.ethernet.dstAddr[1:0] == 2w0) 
+            ingress_drop(ostd);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-frontend.p4
@@ -1,0 +1,73 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_2, in PortId_t egress_port_1) {
+        meta_2.drop = false;
+        meta_2.multicast_group = (MulticastGroup_t)32w0;
+        meta_2.egress_port = egress_port_1;
+    }
+    @name(".ingress_drop") action ingress_drop(inout psa_ingress_output_metadata_t meta_3) {
+        meta_3.drop = true;
+    }
+    apply {
+        send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[1:0]);
+        if (hdr.ethernet.dstAddr[1:0] == 2w0) 
+            ingress_drop(ostd);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-midend.p4
@@ -1,0 +1,103 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name(".send_to_port") action send_to_port() {
+        ostd.drop = false;
+        ostd.multicast_group = 32w0;
+        ostd.egress_port = (PortIdUint_t)hdr.ethernet.dstAddr[1:0];
+    }
+    @name(".ingress_drop") action ingress_drop() {
+        ostd.drop = true;
+    }
+    @hidden table tbl_send_to_port {
+        actions = {
+            send_to_port();
+        }
+        const default_action = send_to_port();
+    }
+    @hidden table tbl_ingress_drop {
+        actions = {
+            ingress_drop();
+        }
+        const default_action = ingress_drop();
+    }
+    apply {
+        tbl_send_to_port.apply();
+        if (hdr.ethernet.dstAddr[1:0] == 2w0) 
+            tbl_ingress_drop.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action act() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action act_0() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    apply {
+        tbl_act_0.apply();
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+        send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr[1:0]);
+        if (hdr.ethernet.dstAddr[1:0] == 0) {
+            ingress_drop(ostd);
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.p4info.txt
@@ -1,0 +1,17 @@
+pkg_info {
+  arch: "psa"
+}
+actions {
+  preamble {
+    id: 16833049
+    name: "send_to_port"
+    alias: "send_to_port"
+  }
+}
+actions {
+  preamble {
+    id: 16829615
+    name: "ingress_drop"
+    alias: "ingress_drop"
+  }
+}

--- a/testdata/p4_16_samples_outputs/specialization-first.p4
+++ b/testdata/p4_16_samples_outputs/specialization-first.p4
@@ -11,8 +11,8 @@ struct S1 {
 action a() {
     S x;
     S1 y;
-    f<S>({32w0});
+    f<S>(S {f = 32w0});
     f<S>(x);
     f<S1>(y);
-    f<S1>({32w0,32w1});
+    f<S1>(S1 {f = 32w0,g = 32w1});
 }

--- a/testdata/p4_16_samples_outputs/struct_init-1-first.p4
+++ b/testdata/p4_16_samples_outputs/struct_init-1-first.p4
@@ -1,0 +1,30 @@
+struct PortId_t {
+    bit<9> _v;
+}
+
+header H {
+    bit<32> b;
+}
+
+const PortId_t PSA_CPU_PORT = PortId_t {_v = 9w192};
+struct metadata_t {
+    PortId_t foo;
+}
+
+control I(inout metadata_t meta) {
+    apply {
+        PortId_t p = PortId_t {_v = 9w0};
+        H h = H {b = 32w1};
+        if (meta.foo == PortId_t {_v = 9w192}) {
+            meta.foo._v = meta.foo._v + 9w1;
+            h = H {b = 32w2};
+            if (h == H {b = 32w1}) 
+                h = H {b = 32w2};
+        }
+    }
+}
+
+control C<M>(inout M m);
+package top<M>(C<M> c);
+top<metadata_t>(I()) main;
+

--- a/testdata/p4_16_samples_outputs/struct_init-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/struct_init-1-frontend.p4
@@ -1,0 +1,30 @@
+struct PortId_t {
+    bit<9> _v;
+}
+
+header H {
+    bit<32> b;
+}
+
+struct metadata_t {
+    PortId_t foo;
+}
+
+control I(inout metadata_t meta) {
+    H h_0;
+    apply {
+        h_0.setValid();
+        if (meta.foo == PortId_t {_v = 9w192}) {
+            meta.foo._v = meta.foo._v + 9w1;
+            h_0.setValid();
+            h_0 = H {b = 32w2};
+            if (h_0 == H {b = 32w1}) 
+                h_0.setValid();
+        }
+    }
+}
+
+control C<M>(inout M m);
+package top<M>(C<M> c);
+top<metadata_t>(I()) main;
+

--- a/testdata/p4_16_samples_outputs/struct_init-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/struct_init-1-midend.p4
@@ -1,0 +1,57 @@
+struct PortId_t {
+    bit<9> _v;
+}
+
+header H {
+    bit<32> b;
+}
+
+struct metadata_t {
+    bit<9> _foo__v0;
+}
+
+control I(inout metadata_t meta) {
+    H h_0;
+    @hidden action act() {
+        h_0.setValid();
+    }
+    @hidden action act_0() {
+        meta._foo__v0 = meta._foo__v0 + 9w1;
+        h_0.setValid();
+        h_0.b = 32w2;
+    }
+    @hidden action act_1() {
+        h_0.setValid();
+    }
+    @hidden table tbl_act {
+        actions = {
+            act_1();
+        }
+        const default_action = act_1();
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    @hidden table tbl_act_1 {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    apply {
+        tbl_act.apply();
+        if (meta._foo__v0 == 9w192) {
+            tbl_act_0.apply();
+            if (!h_0.isValid() && false || h_0.isValid() && true && false) 
+                tbl_act_1.apply();
+        }
+    }
+}
+
+control C<M>(inout M m);
+package top<M>(C<M> c);
+top<metadata_t>(I()) main;
+

--- a/testdata/p4_16_samples_outputs/struct_init-1.p4
+++ b/testdata/p4_16_samples_outputs/struct_init-1.p4
@@ -1,0 +1,30 @@
+struct PortId_t {
+    bit<9> _v;
+}
+
+header H {
+    bit<32> b;
+}
+
+const PortId_t PSA_CPU_PORT = {_v = 9w192};
+struct metadata_t {
+    PortId_t foo;
+}
+
+control I(inout metadata_t meta) {
+    apply {
+        PortId_t p = {_v = 0};
+        H h = {b = 1};
+        if (meta.foo == PSA_CPU_PORT) {
+            meta.foo._v = meta.foo._v + 1;
+            h = {b = 2};
+            if (h == H {b = 1}) 
+                h = {b = 2};
+        }
+    }
+}
+
+control C<M>(inout M m);
+package top<M>(C<M> c);
+top(I()) main;
+

--- a/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-midend.p4
@@ -125,12 +125,12 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         meta._test_digest_in_mac_srcAddr0 = hdr.ethernet.srcAddr;
         meta._test_digest_my_parser_error1 = error.PacketTooShort;
         meta._test_digest_pkt_type2 = MyPacketTypes.IPv4;
-        digest<test_digest_t>(32w1, {hdr.ethernet.srcAddr,error.PacketTooShort,MyPacketTypes.IPv4});
+        digest<test_digest_t>(32w1, test_digest_t {in_mac_srcAddr = hdr.ethernet.srcAddr,my_parser_error = error.PacketTooShort,pkt_type = MyPacketTypes.IPv4});
         meta._test_digest2_in_mac_dstAddr3 = hdr.ethernet.dstAddr;
         meta._test_digest2_my_thing4 = 8w42;
-        digest<test_digest2_t>(32w2, {hdr.ethernet.dstAddr,8w42});
+        digest<test_digest2_t>(32w2, test_digest2_t {in_mac_dstAddr = hdr.ethernet.dstAddr,my_thing = 8w42});
         meta._test_digest3_in_mac_etherType5 = hdr.ethernet.etherType;
-        digest<test_digest3_t>(32w3, {hdr.ethernet.etherType});
+        digest<test_digest3_t>(32w3, test_digest3_t {in_mac_etherType = hdr.ethernet.etherType});
     }
     @hidden table tbl_send_digest {
         actions = {


### PR DESCRIPTION
Unfortunately we cannot implement just structure-valued initializers first, we need support for structure-valued expressions because constant folding will fold structure-valued initializers converting them into structure-valued expressions.

This adds full support for structure-valued expressions, including type inference. An structure-valued expression that has no type name specified will have its type inferred from the context.