### PR TITLE
fix stream output for default value of match_t

### DIFF
--- a/lib/match.cpp
+++ b/lib/match.cpp
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <assert.h>
 #include "match.h"
 
 static int chkmask(const match_t &m, int maskbits) {
@@ -29,6 +28,10 @@ static int chkmask(const match_t &m, int maskbits) {
 }
 
 std::ostream &operator<<(std::ostream &out, match_t m) {
+    if (!m) {
+        out << "*";
+        return out;
+    }
     int shift, bits;
     if ((shift = chkmask(m, (bits = 4))) >= 0)
         out << "0x";
@@ -49,7 +52,7 @@ std::ostream &operator<<(std::ostream &out, match_t m) {
 
 bool operator>>(const char *p, match_t &m) {
     if (!p) return false;
-    match_t rv(0, 0);
+    match_t rv;
     unsigned base = 10;
     if (*p == '0') {
         switch (p[1]) {

--- a/lib/match.h
+++ b/lib/match.h
@@ -46,6 +46,7 @@ struct match_t {
         word1 |= mask; }
     match_t(int size, uintmax_t val, uintmax_t mask) : word0(~val&mask), word1(val&mask)
         { setwidth(size); }
+    static match_t dont_care(int size) { return match_t(size, 0, 0); }
 };
 
 std::ostream &operator <<(std::ostream &, match_t);


### PR DESCRIPTION
As per out discussion in https://github.com/p4lang/p4c/issues/1953, it seems more correct to print the default value of `match_t` (which means "no match") as `*`.

The other idea is to print it as `-`. 