### PR TITLE
ebpf: avoid global ebpf map pinning

### DIFF
--- a/backends/ebpf/runtime/ebpf_kernel.h
+++ b/backends/ebpf/runtime/ebpf_kernel.h
@@ -216,7 +216,7 @@ struct bpf_map_def SEC("maps") NAME = {          \
     .type       = TYPE,             \
     .key_size   = KEY_SIZE,         \
     .value_size = VALUE_SIZE,       \
-    .pinning = 2,                   \
+    .pinning = 1,                   \
     .max_entries = MAX_ENTRIES,     \
     .map_flags = 0,                 \
 };


### PR DESCRIPTION
Change to use PIN_OBJECT_NS(1) instead of PIN_GLOBAL_NS(2).
So when unloading the ebpf program, the map will be clean up.

Reported-at: https://github.com/vmware/p4c-xdp/issues/105