### PR TITLE
Support function-type arguments in IR generator

### DIFF
--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -79,7 +79,7 @@ static IrNamespace *current_namespace = LookupScope().resolve(0);
 %token<str>     BLOCK COMMENTBLOCK IDENTIFIER INTEGER NO STRING ZERO
 %token<emit>    EMITBLOCK
 
-%type<type>                     type nonRefType
+%type<type>                     type nonRefType type_arg
 %type<irClass>                  irclass partList
 %type<irElement>                part
 %type<irField>                  irField
@@ -88,7 +88,7 @@ static IrNamespace *current_namespace = LookupScope().resolve(0);
 %type<irNamespace>              scope
 %type<constFieldInit>           constFieldInit
 %type<kind>                     kind
-%type<types>                    parentList nonEmptyParentList type_args
+%type<types>                    parentList nonEmptyParentList type_args optTypeList typeList
 %type<str>                      name expression optInitializer fieldName methodName body
 %type<lookup>                   lookup_scope
 
@@ -356,9 +356,23 @@ type: nonRefType
     ;
 
 type_args
-    : type                              { $$ = new std::vector<const Type *>{$1}; }
-    | type_args ',' type                { ($$ = $1)->push_back($3); }
+    : type_arg                          { $$ = new std::vector<const Type *>{$1}; }
+    | type_args ',' type_arg            { ($$ = $1)->push_back($3); }
     ;
+
+type_arg
+    : type                              { $$ = $1; }
+    | type '(' optTypeList ')'          { $$ = new FunctionType($1, *$3); }
+    ;
+
+optTypeList
+    :                                   { $$ = new std::vector<const Type *>(); }
+    | typeList                          { $$ = $1; }
+    ;
+
+typeList
+    : type                              { $$ = new std::vector<const Type *>{$1}; }
+    | typeList ',' type                 { ($$ = $1)->push_back($3); }
 
 constFieldInit
     : modifiers IDENTIFIER '=' expression ';'

--- a/tools/ir-generator/type.cpp
+++ b/tools/ir-generator/type.cpp
@@ -152,3 +152,24 @@ cstring ArrayType::declSuffix() const {
     snprintf(buf, sizeof(buf), "[%d]", size);
     return buf;
 }
+
+const IrClass* FunctionType::resolve(const IrNamespace *ns) const {
+    ret->resolve(ns);
+    for (auto arg : args) arg->resolve(ns);
+    return nullptr;
+}
+
+cstring FunctionType::toString() const {
+    cstring result = ret->toString();
+    result += "(";
+    const char* sep = "";
+    for (auto arg : args) {
+        result += sep;
+        if (arg->isResolved()) result += "const ";
+        result += arg->toString().c_str();
+        if (arg->isResolved()) result += "*";
+        sep = ", ";
+    }
+    result += ")";
+    return result;
+}

--- a/tools/ir-generator/type.h
+++ b/tools/ir-generator/type.h
@@ -25,7 +25,7 @@ class IrClass;
 class IrNamespace;
 
 #define ALL_TYPES(M) M(NamedType) M(TemplateInstantiation) M(ReferenceType) \
-                     M(PointerType) M(ArrayType)
+                     M(PointerType) M(ArrayType) M(FunctionType)
 #define FORWARD_DECLARE(T) class T;
 ALL_TYPES(FORWARD_DECLARE)
 #undef FORWARD_DECLARE
@@ -174,6 +174,30 @@ class ArrayType : public Type {
     bool operator==(const Type &t) const override { return t == *this; }
     bool operator==(const ArrayType &t) const override {
         return size == t.size && *base == *t.base; }
+};
+
+class FunctionType : public Type {
+ public:
+    const Type                       *ret;
+    const std::vector<const Type *>   args;
+
+    FunctionType(const Type* ret, const std::vector<const Type*>& args) : ret(ret), args(args) { }
+
+    bool isResolved() const override { return false; }
+    const IrClass *resolve(const IrNamespace *ns) const override;
+    cstring toString() const override;
+    bool operator==(const Type &t) const override { return t == *this; }
+    bool operator==(const FunctionType &t) const override {
+        if (!(*ret == *t.ret)) return false;
+        if (args.size() != t.args.size()) return false;
+        for (auto i(args.begin()), j(t.args.begin());
+                i != args.end() && j != t.args.end();
+                ++i, ++j) {
+            if (!(**i == **j)) return false;
+        }
+
+        return true;
+    }
 };
 
 #endif /* _TOOLS_IR_GENERATOR_TYPE_H_ */


### PR DESCRIPTION
This adds support for template arguments of the form `T(T1, ..., Tn)`.