### PR TITLE
experimental feature: allowing constructor parameter to be non-constant

### DIFF
--- a/frontends/p4/evaluator/evaluator.cpp
+++ b/frontends/p4/evaluator/evaluator.cpp
@@ -129,7 +129,8 @@ Evaluator::evaluateArguments(
         CHECK_NULL(folded);
         visit(folded);  // recursive evaluation
         if (!hasValue(folded)) {
-            ::error("%1%: Cannot evaluate to a compile-time constant", arg->expression);
+            if (!typeMap->isCompileTimeConstantCheckDisabled())
+                error("%1%: Cannot evaluate to a compile-time constant", arg->expression);
             popBlock(context);
             return nullptr;
         } else {

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -114,7 +114,8 @@ class FrontEndDump : public PassManager {
 
 // TODO: remove skipSideEffectOrdering flag
 const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4Program* program,
-                                   bool skipSideEffectOrdering) {
+                                   bool skipSideEffectOrdering,
+                                   bool disableCompileTimeConstantCheck) {
     if (program == nullptr)
         return nullptr;
 
@@ -122,6 +123,10 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
     ReferenceMap  refMap;
     TypeMap       typeMap;
     refMap.setIsV1(isv1);
+    // XXX(hanw) experimental feature
+    // set true if constructor parameter does not have to be compile-time
+    // constant.
+    typeMap.disableCompileTimeConstantCheck(disableCompileTimeConstantCheck);
 
     auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
 

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -40,7 +40,8 @@ class FrontEnd {
     }
     void addDebugHook(DebugHook hook) { hooks.push_back(hook); }
     const IR::P4Program* run(const CompilerOptions& options, const IR::P4Program* program,
-                             bool skipSideEffectOrdering = false);
+                             bool skipSideEffectOrdering = false,
+                             bool disableCompileTimeConstantCheck = false);
 };
 
 }  // namespace P4

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -47,7 +47,11 @@ void TypeMap::setCompileTimeConstant(const IR::Expression* expression) {
 bool TypeMap::isCompileTimeConstant(const IR::Expression* expression) const {
     bool result = constants.find(expression) != constants.end();
     LOG3(dbp(expression) << (result ? " constant" : " not constant"));
-    return result;
+    return result || noCompileTimeConstantCheck;
+}
+
+void TypeMap::disableCompileTimeConstantCheck(bool noCheck) {
+    noCompileTimeConstantCheck = noCheck;
 }
 
 void TypeMap::clear() {

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -59,8 +59,13 @@ class TypeMap final : public ProgramMap {
     // checks some preconditions before setting the type
     void checkPrecondition(const IR::Node* element, const IR::Type* type) const;
 
+    // if `constructorParamMustBeConstant` is false, then
+    // the frontend will not enforce the rule that a constructor
+    // parameter must be compile time constant.
+    bool noCompileTimeConstantCheck;
+
  public:
-    TypeMap() : ProgramMap("TypeMap") {}
+    TypeMap() : ProgramMap("TypeMap"), noCompileTimeConstantCheck(true) {}
 
     bool contains(const IR::Node* element) { return typeMap.count(element) != 0; }
     void setType(const IR::Node* element, const IR::Type* type);
@@ -72,6 +77,9 @@ class TypeMap final : public ProgramMap {
     bool isLeftValue(const IR::Expression* expression) const
     { return leftValues.count(expression) > 0; }
     bool isCompileTimeConstant(const IR::Expression* expression) const;
+    void disableCompileTimeConstantCheck(bool disable);
+    bool isCompileTimeConstantCheckDisabled() const
+    { return noCompileTimeConstantCheck; }
     size_t size() const
     { return typeMap.size(); }
 


### PR DESCRIPTION
This feature is experimental, disabled by default and does not comply with the current P4-16 spec.

It violates the principle that there shall be no reference to field in P4-16. However, I hope we can allow this experimental feature to exist in the front-end to allow me to experiment with some non-spec-compliance way of writing P4-16. =)

One example that I have in mind:
```
/// extern requires two parameters.
/// partition_index: run-time value of a field.
/// number_partitions: compile-time constant.
extern ATCAM<T> {
   ATCAM(T partition_index, bit<32> number_partitions);
}

control ingress (header_t hdr, metadata_t md) {
  table {
    key = ...,
    actions = ...,
    implementation = ATCAM(md.meta.partition_index, 1024);
  }
}
```

I have thought about other way to implement this in P4-16.
```
/// use an extern function
extern void atcam(in T partition_index, bit<32> number_partitions);

control ingress (header_t hdr, metadata_t md) {
  table {
    key = ...,
    actions = ...,
    implementation = atcam(md.meta.partition_index, 1024); (this is a bit strange, because return value is void).
  }
}
```

We currently use annotation to solve the issue.
```
control ingress (header_t hdr, metadata_t md) {
  @atcam_partition_index(md.meta.partition_index)
  @atcam_number_partitions(1024)
  table {
    key = ...,
    actions = ...
  }
}
```