### PR TITLE
Fix construction of bitref or bitranges object with a temp bitvec to not dangle

### DIFF
--- a/lib/bitrange.h
+++ b/lib/bitrange.h
@@ -43,6 +43,7 @@ class bitranges {
 
  public:
     explicit bitranges(const bitvec &b) : bits(b) {}
+    explicit bitranges(bitvec &&b) : tmp(b), bits(tmp) {}
     explicit bitranges(uintptr_t b) : tmp(b), bits(tmp) {}
     iter begin() const { return iter(bits.begin()); }
     iter end() const { return iter(bits.end()); }

--- a/test/gtest/bitvec_test.cpp
+++ b/test/gtest/bitvec_test.cpp
@@ -117,4 +117,17 @@ TEST(Bitvec, rotate) {
     EXPECT_EQ(bv, bv_verify3);
 }
 
+TEST(Bitvec, rvalue) {
+    bitvec a(0x1ffff);
+    bitvec b(0xfff0000);
+
+    for (auto it = (a & b).begin(); it != (a & b).end(); ++it) {
+        EXPECT_EQ(it.index(), 16);
+        EXPECT_TRUE(it);
+    }
+    for (auto it = (a | b).begin(); it != (a | b).end(); ++it) {
+        EXPECT_TRUE(it);
+    }
+}
+
 }  // namespace Test

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -3808,7 +3808,7 @@ def CheckRValueReference(filename, clean_lines, linenum, nesting_state, error):
   line = clean_lines.elided[linenum]
   match = Match(r'^(.*\S)&&', line)
   if not match:
-    match = Match(r'(.*)&&[^,\s]', line)
+    match = Match(r'(.*)&&[^,;\s]', line)
   if (not match) or '(&&)' in line or Search(r'\boperator\s*$', match.group(1)):
     return
 


### PR DESCRIPTION

- obscure corner case -- when a ctor is called with an rvalue ref to a
  temp, the lifetime of that temp is only until the end of the ctor --
  we need to have it persist until the dtor is called.