### PR TITLE
type checker fix for inferring type parameter of extern

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -295,7 +295,7 @@ const IR::Type* TypeInference::specialize(const IR::IMayBeGenericType* type,
 
     LOG2("Translation map\n" << bindings);
 
-    TypeVariableSubstitutionVisitor tsv(bindings);
+    TypeVariableSubstitutionVisitor tsv(bindings, true);
     const IR::Node* result = type->getNode()->apply(tsv);
     if (result == nullptr)
         return nullptr;


### PR DESCRIPTION
I tried to use ExternInstance::resolve() to collect information on an extern that looks like this:

```
DirectCounter<W> {
    DirectCounter();
}

DirectCounter<bit<32>>() dc;
```

But the ExternInstance struct does not contain any info about `bit<32>`. After some debugging, I tracked the issue to typeChecker, where it removes the generic parameter, but did not replace it with the specialized type. Hence the fix. I am not sure why typeChecker is implemented in this way initially.