### PR TITLE
Warn on unsupported use of recirculate/resubmit/clone

### DIFF
--- a/backends/bmv2/common/JsonObjects.cpp
+++ b/backends/bmv2/common/JsonObjects.cpp
@@ -51,6 +51,18 @@ JsonObjects::JsonObjects() {
     field_aliases = insert_array_field(toplevel, "field_aliases");
 }
 
+Util::JsonArray*
+JsonObjects::get_field_list_contents(unsigned id) const {
+    for (auto e : *field_lists) {
+        auto obj = e->to<Util::JsonObject>();
+        auto val = obj->get("id")->to<Util::JsonValue>();
+        if (val != nullptr && val->isNumber() && val->getInt() == (int)id) {
+            return obj->get("elements")->to<Util::JsonArray>();
+        }
+    }
+    return nullptr;
+}
+
 Util::JsonObject*
 JsonObjects::find_object_by_name(Util::JsonArray* array, const cstring& name) {
     for (auto e : *array) {

--- a/backends/bmv2/common/JsonObjects.cpp
+++ b/backends/bmv2/common/JsonObjects.cpp
@@ -56,7 +56,7 @@ JsonObjects::get_field_list_contents(unsigned id) const {
     for (auto e : *field_lists) {
         auto obj = e->to<Util::JsonObject>();
         auto val = obj->get("id")->to<Util::JsonValue>();
-        if (val != nullptr && val->isNumber() && val->getInt() == (int)id) {
+        if (val != nullptr && val->isNumber() && val->getInt() == static_cast<int>(id)) {
             return obj->get("elements")->to<Util::JsonArray>();
         }
     }

--- a/backends/bmv2/common/JsonObjects.h
+++ b/backends/bmv2/common/JsonObjects.h
@@ -60,6 +60,8 @@ class JsonObjects {
     Util::JsonArray* append_array(Util::JsonArray* parent);
     Util::JsonArray* create_parameters(Util::JsonObject* object);
     Util::JsonObject* create_primitive(Util::JsonArray* parent, cstring name);
+    // Given a field list id returns the array of values called "elements"
+    Util::JsonArray* get_field_list_contents(unsigned id) const;
 
     std::map<unsigned, Util::JsonObject*> map_parser;
     std::map<unsigned, Util::JsonObject*> map_parser_state;

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -176,6 +176,12 @@ Util::IJson* ExternConverter_clone3::convertExternFunction(
         ctxt->typeMap->setType(cst, IR::Type_Bits::get(32));
         auto jcst = ctxt->conv->convert(cst);
         parameters->append(jcst);
+
+        // clone with a non-empty field list is not correctly implemented; give a warning
+        auto arr = ctxt->json->get_field_list_contents(id);
+        if (arr != nullptr && !arr->empty())
+            ::warning(ErrorType::WARN_UNSUPPORTED,
+                      "%1%: clone with non-empty argument not supported", mc);
     }
     return primitive;
 }
@@ -287,6 +293,11 @@ Util::IJson* ExternConverter_resubmit::convertExternFunction(
     }
     int id = createFieldList(ctxt, mc->arguments->at(0)->expression, "field_lists",
                              listName, ctxt->json->field_lists);
+    // resubmit with a non-empty field list is not correctly implemented; give a warning
+    auto arr = ctxt->json->get_field_list_contents(id);
+    if (arr != nullptr && !arr->empty())
+        ::warning(ErrorType::WARN_UNSUPPORTED,
+                  "%1%: resubmit with non-empty argument not supported", mc);
     auto cst = new IR::Constant(id);
     ctxt->typeMap->setType(cst, IR::Type_Bits::get(32));
     auto jcst = ctxt->conv->convert(cst);
@@ -323,6 +334,12 @@ Util::IJson* ExternConverter_recirculate::convertExternFunction(
     }
     int id = createFieldList(ctxt, mc->arguments->at(0)->expression, "field_lists",
                              listName, ctxt->json->field_lists);
+    // recirculate with a non-empty field list is not correctly implemented; give a warning
+    auto arr = ctxt->json->get_field_list_contents(id);
+    if (arr != nullptr && !arr->empty())
+        ::warning(ErrorType::WARN_UNSUPPORTED,
+                  "%1%: recirculate with non-empty argument not supported", mc);
+
     auto cst = new IR::Constant(id);
     ctxt->typeMap->setType(cst, IR::Type_Bits::get(32));
     auto jcst = ctxt->conv->convert(cst);

--- a/backends/ebpf/targets/xdp_target.py
+++ b/backends/ebpf/targets/xdp_target.py
@@ -1,0 +1,1 @@
+../../../extensions/p4c-xdp/xdp_target.py

--- a/backends/ebpf/targets/xdp_target.py
+++ b/backends/ebpf/targets/xdp_target.py
@@ -1,1 +1,0 @@
-../../../extensions/p4c-xdp/xdp_target.py


### PR DESCRIPTION
As discussed in the last LDWG, the bmv2 back-end currently does not implement correctly recirculate, resubmit and clone3. So we give a warning to the users. This would be ideally a temporary solution until we provide a working implementation of these primitives. A solution, proposed in #1698, has not been adopted yet, and no one has proposed an implementation for an alternative solution.