### PR TITLE
Support serializable enums in const table entries

### DIFF
--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -412,6 +412,10 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
         }
         constraints->addEqualityConstraint(dstack->elementType, sstack->elementType);
         return true;
+    } else if (dest->is<IR::Type_SerEnum>() && src->is<IR::Type_Bits>()) {
+        auto denum = dest->to<IR::Type_SerEnum>();
+        // unify with enum's underlying type
+        return unify(errorPosition, denum->type, src, reportErrors);
     }
 
     if (reportErrors)

--- a/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
+++ b/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
@@ -1,0 +1,85 @@
+/*
+Copyright 2019-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+enum bit<8> MyEnum1B {
+    MBR1 = 0,
+    MBR2 = 0xff
+}
+
+enum bit<16> MyEnum2B {
+    MBR1 = 10,
+    MBR2 = 0xab00
+}
+
+header hdr {
+    MyEnum1B f1;
+    MyEnum2B f2;
+}
+
+struct Header_t {
+    hdr h;
+}
+struct Meta_t {}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+
+    action a() { standard_meta.egress_spec = 0; }
+    action a_with_control_params(bit<9> x) { standard_meta.egress_spec = x; }
+
+
+    table t_ternary {
+
+  	key = {
+            h.h.f1 : exact;
+            h.h.f2 : ternary;
+        }
+
+	actions = {
+            a;
+            a_with_control_params;
+        }
+
+	const default_action = a();
+
+        const entries = {
+            (MyEnum1B.MBR1, _)                                      : a_with_control_params(1);
+            (MyEnum1B.MBR2, ((bit<16>)MyEnum2B.MBR2) &&& 0xff00)    : a_with_control_params(2);
+            (MyEnum1B.MBR2, _)                                      : a_with_control_params(3);
+        }
+    }
+
+    apply {
+        t_ternary.apply();
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples/table-entries-ser-enum-bmv2.stf
+++ b/testdata/p4_16_samples/table-entries-ser-enum-bmv2.stf
@@ -1,0 +1,20 @@
+# enum bit<8> MyEnum1B { MBR1 = 0, MBR2 = 0xff }
+# enum bit<16> MyEnum2B { MBR1 = 10, MBR2 = 0xab00 }
+# header hdr { MyEnum1B f1; MyEnum2B f2; }
+
+expect 1 00 1111 $
+packet 0 00 1111
+
+expect 2 ff ab00 $
+packet 0 ff ab00
+
+expect 2 ff abcd $
+packet 0 ff abcd
+
+expect 3 ff afff $
+packet 0 ff afff
+
+# miss
+
+expect 0 ab 0000 $
+packet 0 ab 0000

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-first.p4
@@ -1,0 +1,87 @@
+#include <core.p4>
+#include <v1model.p4>
+
+enum bit<8> MyEnum1B {
+    MBR1 = 8w0,
+    MBR2 = 8w0xff
+}
+
+enum bit<16> MyEnum2B {
+    MBR1 = 16w10,
+    MBR2 = 16w0xab00
+}
+
+header hdr {
+    MyEnum1B f1;
+    MyEnum2B f2;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    table t_ternary {
+        key = {
+            h.h.f1: exact @name("h.h.f1") ;
+            h.h.f2: ternary @name("h.h.f2") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        const default_action = a();
+        const entries = {
+                        (MyEnum1B.MBR1, default) : a_with_control_params(9w1);
+
+                        (MyEnum1B.MBR2, (bit<16>)MyEnum2B.MBR2 &&& 16w0xff00) : a_with_control_params(9w2);
+
+                        (MyEnum1B.MBR2, default) : a_with_control_params(9w3);
+
+        }
+
+    }
+    apply {
+        t_ternary.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-frontend.p4
@@ -1,0 +1,87 @@
+#include <core.p4>
+#include <v1model.p4>
+
+enum bit<8> MyEnum1B {
+    MBR1 = 8w0,
+    MBR2 = 8w0xff
+}
+
+enum bit<16> MyEnum2B {
+    MBR1 = 16w10,
+    MBR2 = 16w0xab00
+}
+
+header hdr {
+    MyEnum1B f1;
+    MyEnum2B f2;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    @name("ingress.a") action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    @name("ingress.t_ternary") table t_ternary_0 {
+        key = {
+            h.h.f1: exact @name("h.h.f1") ;
+            h.h.f2: ternary @name("h.h.f2") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        const default_action = a();
+        const entries = {
+                        (MyEnum1B.MBR1, default) : a_with_control_params(9w1);
+
+                        (MyEnum1B.MBR2, (bit<16>)MyEnum2B.MBR2 &&& 16w0xff00) : a_with_control_params(9w2);
+
+                        (MyEnum1B.MBR2, default) : a_with_control_params(9w3);
+
+        }
+
+    }
+    apply {
+        t_ternary_0.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-midend.p4
@@ -1,0 +1,77 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  f1;
+    bit<16> f2;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    @name("ingress.a") action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    @name("ingress.t_ternary") table t_ternary_0 {
+        key = {
+            h.h.f1: exact @name("h.h.f1") ;
+            h.h.f2: ternary @name("h.h.f2") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        const default_action = a();
+        const entries = {
+                        (8w0, default) : a_with_control_params(9w1);
+
+                        (8w0xff, 16w0xab00 &&& 16w0xff00) : a_with_control_params(9w2);
+
+                        (8w0xff, default) : a_with_control_params(9w3);
+
+        }
+
+    }
+    apply {
+        t_ternary_0.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4
@@ -1,0 +1,87 @@
+#include <core.p4>
+#include <v1model.p4>
+
+enum bit<8> MyEnum1B {
+    MBR1 = 0,
+    MBR2 = 0xff
+}
+
+enum bit<16> MyEnum2B {
+    MBR1 = 10,
+    MBR2 = 0xab00
+}
+
+header hdr {
+    MyEnum1B f1;
+    MyEnum2B f2;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    action a() {
+        standard_meta.egress_spec = 0;
+    }
+    action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    table t_ternary {
+        key = {
+            h.h.f1: exact;
+            h.h.f2: ternary;
+        }
+        actions = {
+            a;
+            a_with_control_params;
+        }
+        const default_action = a();
+        const entries = {
+                        (MyEnum1B.MBR1, default) : a_with_control_params(1);
+
+                        (MyEnum1B.MBR2, (bit<16>)MyEnum2B.MBR2 &&& 0xff00) : a_with_control_params(2);
+
+                        (MyEnum1B.MBR2, default) : a_with_control_params(3);
+
+        }
+
+    }
+    apply {
+        t_ternary.apply();
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.entries.txt
@@ -1,0 +1,79 @@
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33556639
+      match {
+        field_id: 1
+        exact {
+          value: "\000"
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\001"
+          }
+        }
+      }
+      priority: 3
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33556639
+      match {
+        field_id: 1
+        exact {
+          value: "\377"
+        }
+      }
+      match {
+        field_id: 2
+        ternary {
+          value: "\253\000"
+          mask: "\377\000"
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\002"
+          }
+        }
+      }
+      priority: 2
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33556639
+      match {
+        field_id: 1
+        exact {
+          value: "\377"
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\003"
+          }
+        }
+      }
+      priority: 1
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.p4info.txt
@@ -1,0 +1,50 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 33556639
+    name: "ingress.t_ternary"
+    alias: "t_ternary"
+  }
+  match_fields {
+    id: 1
+    name: "h.h.f1"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "h.h.f2"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 16795253
+  }
+  action_refs {
+    id: 16837978
+  }
+  const_default_action_id: 16795253
+  size: 1024
+  is_const_table: true
+}
+actions {
+  preamble {
+    id: 16795253
+    name: "ingress.a"
+    alias: "a"
+  }
+}
+actions {
+  preamble {
+    id: 16837978
+    name: "ingress.a_with_control_params"
+    alias: "a_with_control_params"
+  }
+  params {
+    id: 1
+    name: "x"
+    bitwidth: 9
+  }
+}


### PR DESCRIPTION
Most of the changes are in the p4RuntimeSerializer. One change was
required in type unification to support:
`((bit<16>)MyEnum2B.MBR2) &&& 0xff00`

`MyEnum2B.MBR2 &&& 0xff00` gives a compiler error, but AFAIK that 
behavior conforms to the P4_16 spec.