### PR TITLE
Abillity to disable passes in the frontend and midend (#830)

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -27,6 +27,7 @@ set (BMV2_SIMPLE_SWITCH_SRCS
     simple_switch/midend.h
     simple_switch/simpleSwitch.cpp
     simple_switch/simpleSwitch.h
+    simple_switch/options.h
     )
 add_cpplint_files (${CMAKE_CURRENT_SOURCE_DIR} "${BMV2_SIMPLE_SWITCH_SRCS}")
 
@@ -36,6 +37,7 @@ set (BMV2_PSA_SWITCH_SRCS
     psa_switch/midend.h
     psa_switch/psaSwitch.cpp
     psa_switch/psaSwitch.h
+    psa_switch/options.h
     )
 add_cpplint_files (${CMAKE_CURRENT_SOURCE_DIR} "${BMV2_PSA_SWITCH_SRCS}")
 

--- a/backends/bmv2/common/header.cpp
+++ b/backends/bmv2/common/header.cpp
@@ -294,7 +294,7 @@ void HeaderConverter::addHeaderType(const IR::Type_StructLike *st) {
             auto container = new Util::JsonArray();
             auto alias = new Util::JsonArray();
             auto target_name = "";
-            if (BMV2::BMV2Context::get().options().loadIRFromJson == false) {
+            if (BMV2Context::get().options().loadIRFromJson == false) {
                 target_name = aliasAnnotation->expr.front()->to<IR::StringLiteral>()->value;
             } else {
                 if (aliasAnnotation->body.size() != 0) {

--- a/backends/bmv2/psa_switch/main.cpp
+++ b/backends/bmv2/psa_switch/main.cpp
@@ -32,14 +32,15 @@ limitations under the License.
 #include "backends/bmv2/psa_switch/midend.h"
 #include "backends/bmv2/psa_switch/psaSwitch.h"
 #include "backends/bmv2/psa_switch/version.h"
+#include "backends/bmv2/psa_switch/options.h"
 #include "ir/json_loader.h"
 #include "fstream"
 
 int main(int argc, char *const argv[]) {
     setup_gc_logging();
 
-    AutoCompileContext autoBMV2Context(new BMV2::BMV2Context);
-    auto& options = BMV2::BMV2Context::get().options();
+    AutoCompileContext autoPsaSwitchContext(new BMV2::PsaSwitchContext);
+    auto& options = BMV2::PsaSwitchContext::get().options();
     options.langVersion = CompilerOptions::FrontendVersion::P4_16;
     options.compilerVersion = BMV2_PSA_VERSION_STRING;
 
@@ -116,6 +117,8 @@ int main(int argc, char *const argv[]) {
     auto backend = new BMV2::PsaSwitchBackend(options, &midEnd.refMap,
             &midEnd.typeMap, &midEnd.enumMap);
 
+    // Necessary because BMV2Context is expected at the top of stack in further processing
+    AutoCompileContext autoContext(new BMV2::BMV2Context(BMV2::PsaSwitchContext::get()));
     try {
         backend->convert(toplevel);
     } catch (const Util::P4CExceptionBase &bug) {

--- a/backends/bmv2/psa_switch/midend.cpp
+++ b/backends/bmv2/psa_switch/midend.cpp
@@ -55,6 +55,7 @@ limitations under the License.
 #include "midend/midEndLast.h"
 #include "midend/fillEnumMap.h"
 #include "midend/removeAssertAssume.h"
+#include "backends/bmv2/psa_switch/options.h"
 
 namespace BMV2 {
 
@@ -85,11 +86,12 @@ class PsaEnumOn32Bits : public P4::ChooseEnumRepresentation {
     explicit PsaEnumOn32Bits(cstring filename) : filename(filename) { }
 };
 
-PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions& options) : MidEnd(options) {
+PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions& options, std::ostream* outStream)
+                                : MidEnd(options) {
     auto convertEnums = new P4::ConvertEnums(&refMap, &typeMap, new PsaEnumOn32Bits("psa.p4"));
     auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
-    if (BMV2::BMV2Context::get().options().loadIRFromJson == false) {
-        addPasses({
+    if (BMV2::PsaSwitchContext::get().options().loadIRFromJson == false) {
+        std::initializer_list<Visitor *> midendPasses = {
             options.ndebug ? new P4::RemoveAssertAssume(&refMap, &typeMap) : nullptr,
             new P4::EliminateNewtype(&refMap, &typeMap),
             new P4::EliminateSerEnums(&refMap, &typeMap),
@@ -137,7 +139,19 @@ PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions& options) : MidEnd(options) {
             new P4::MidEndLast(),
             evaluator,
             new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
-        });
+        };
+        if (options.listMidendPasses) {
+            for (auto it : midendPasses) {
+                if (it != nullptr) {
+                    *outStream << it->name() <<'\n';
+                }
+            }
+            return;
+        }
+        addPasses(midendPasses);
+        if (options.excludeMidendPasses) {
+            removePasses(options.passesToExcludeMidend);
+        }
     } else {
         auto fillEnumMap = new P4::FillEnumMap(new PsaEnumOn32Bits("psa.p4"), &typeMap);
         addPasses({

--- a/backends/bmv2/psa_switch/midend.h
+++ b/backends/bmv2/psa_switch/midend.h
@@ -27,7 +27,8 @@ namespace BMV2 {
 
 class PsaSwitchMidEnd : public MidEnd {
  public:
-    explicit PsaSwitchMidEnd(CompilerOptions& options);
+    // If p4c is run with option '--listMidendPasses', outStream is used for printing passes names
+    explicit PsaSwitchMidEnd(CompilerOptions& options, std::ostream* outStream = nullptr);
 };
 
 }  // namespace BMV2

--- a/backends/bmv2/psa_switch/options.h
+++ b/backends/bmv2/psa_switch/options.h
@@ -1,0 +1,43 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef BACKENDS_BMV2_PSA_SWITCH_OPTIONS_H_
+#define BACKENDS_BMV2_PSA_SWITCH_OPTIONS_H_
+
+#include "backends/bmv2/common/options.h"
+#include "backends/bmv2/psa_switch/midend.h"
+
+namespace BMV2 {
+
+class PsaSwitchOptions : public BMV2Options {
+ public:
+    PsaSwitchOptions() {
+        registerOption("--listMidendPasses", nullptr,
+                [this](const char*) {
+                    listMidendPasses = true;
+                    loadIRFromJson = false;
+                    PsaSwitchMidEnd midEnd(*this, outStream);
+                    exit(0);
+                    return false; },
+                "[PsaSwitch back-end] Lists exact name of all midend passes.\n");
+    }
+};
+
+using PsaSwitchContext = P4CContextWithOptions<PsaSwitchOptions>;
+
+};  // namespace BMV2
+
+#endif /* BACKENDS_BMV2_PSA_SWITCH_OPTIONS_H_ */

--- a/backends/bmv2/simple_switch/main.cpp
+++ b/backends/bmv2/simple_switch/main.cpp
@@ -32,14 +32,15 @@ limitations under the License.
 #include "backends/bmv2/simple_switch/midend.h"
 #include "backends/bmv2/simple_switch/simpleSwitch.h"
 #include "backends/bmv2/simple_switch/version.h"
+#include "backends/bmv2/simple_switch/options.h"
 #include "ir/json_loader.h"
 #include "fstream"
 
 int main(int argc, char *const argv[]) {
     setup_gc_logging();
 
-    AutoCompileContext autoBMV2Context(new BMV2::BMV2Context);
-    auto& options = BMV2::BMV2Context::get().options();
+    AutoCompileContext autoBMV2Context(new BMV2::SimpleSwitchContext);
+    auto& options = BMV2::SimpleSwitchContext::get().options();
     options.langVersion = CompilerOptions::FrontendVersion::P4_16;
     options.compilerVersion = BMV2_SIMPLESWITCH_VERSION_STRING;
 
@@ -116,6 +117,8 @@ int main(int argc, char *const argv[]) {
     auto backend = new BMV2::SimpleSwitchBackend(options, &midEnd.refMap,
                                                  &midEnd.typeMap, &midEnd.enumMap);
 
+    // Necessary because BMV2Context is expected at the top of stack in further processing
+    AutoCompileContext autoContext(new BMV2::BMV2Context(BMV2::SimpleSwitchContext::get()));
     try {
         backend->convert(toplevel);
     } catch (const Util::P4CExceptionBase &bug) {

--- a/backends/bmv2/simple_switch/midend.h
+++ b/backends/bmv2/simple_switch/midend.h
@@ -27,7 +27,8 @@ namespace BMV2 {
 
 class SimpleSwitchMidEnd : public MidEnd {
  public:
-    explicit SimpleSwitchMidEnd(CompilerOptions& options);
+    // If p4c is run with option '--listMidendPasses', outStream is used for printing passes names
+    explicit SimpleSwitchMidEnd(CompilerOptions& options, std::ostream* outStream = nullptr);
 };
 
 }  // namespace BMV2

--- a/backends/bmv2/simple_switch/options.h
+++ b/backends/bmv2/simple_switch/options.h
@@ -1,0 +1,43 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef BACKENDS_BMV2_SIMPLE_SWITCH_OPTIONS_H_
+#define BACKENDS_BMV2_SIMPLE_SWITCH_OPTIONS_H_
+
+#include "backends/bmv2/common/options.h"
+#include "backends/bmv2/simple_switch/midend.h"
+
+namespace BMV2 {
+
+class SimpleSwitchOptions : public BMV2Options {
+ public:
+    SimpleSwitchOptions() {
+        registerOption("--listMidendPasses", nullptr,
+                [this](const char*) {
+                    listMidendPasses = true;
+                    loadIRFromJson = false;
+                    SimpleSwitchMidEnd midEnd(*this, outStream);
+                    exit(0);
+                    return false; },
+                "[SimpleSwitch back-end] Lists exact name of all midend passes.\n");
+    }
+};
+
+using SimpleSwitchContext = P4CContextWithOptions<SimpleSwitchOptions>;
+
+};  // namespace BMV2
+
+#endif /* BACKENDS_BMV2_SIMPLE_SWITCH_OPTIONS_H_ */

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include "backends/bmv2/common/annotations.h"
 #include "frontends/p4/fromv1.0/v1model.h"
 #include "simpleSwitch.h"
+#include "backends/bmv2/simple_switch/options.h"
 
 using BMV2::mkArrayField;
 using BMV2::mkParameters;

--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -25,6 +25,7 @@ set (P4C_EBPF_SRCS
   ebpfTable.cpp
   ebpfControl.cpp
   ebpfParser.cpp
+  ebpfOptions.cpp
   target.cpp
   ebpfType.cpp
   codeGen.cpp

--- a/backends/ebpf/ebpfOptions.cpp
+++ b/backends/ebpf/ebpfOptions.cpp
@@ -1,0 +1,24 @@
+#include "ebpfOptions.h"
+#include "midend.h"
+
+
+EbpfOptions::EbpfOptions() {
+        langVersion = CompilerOptions::FrontendVersion::P4_16;
+        registerOption("-o", "outfile",
+                [this](const char* arg) { outputFile = arg; return true; },
+                "Write output to outfile");
+        registerOption("--listMidendPasses", nullptr,
+                [this](const char*) {
+                    loadIRFromJson = false;
+                    listMidendPasses = true;
+                    EBPF::MidEnd midend;
+                    midend.run(*this, nullptr, outStream);
+                    exit(0);
+                    return false; },
+                "[ebpf back-end] Lists exact name of all midend passes.\n");
+        registerOption("--fromJSON", "file",
+                [this](const char* arg) { loadIRFromJson = true; file = arg; return true; },
+                "Use IR representation from JsonFile dumped previously,"
+                "the compilation starts with reduced midEnd.");
+}
+

--- a/backends/ebpf/ebpfOptions.h
+++ b/backends/ebpf/ebpfOptions.h
@@ -20,23 +20,14 @@ limitations under the License.
 #include <getopt.h>
 #include "frontends/common/options.h"
 
+
 class EbpfOptions : public CompilerOptions {
  public:
     // file to output to
     cstring outputFile = nullptr;
     // read from json
     bool loadIRFromJson = false;
-
-    EbpfOptions() {
-        langVersion = CompilerOptions::FrontendVersion::P4_16;
-        registerOption("-o", "outfile",
-                [this](const char* arg) { outputFile = arg; return true; },
-                "Write output to outfile");
-        registerOption("--fromJSON", "file",
-                [this](const char* arg) { loadIRFromJson = true; file = arg; return true; },
-                "Use IR representation from JsonFile dumped previously,"\
-                "the compilation starts with reduced midEnd.");
-    }
+    EbpfOptions();
 };
 
 using EbpfContext = P4CContextWithOptions<EbpfOptions>;

--- a/backends/ebpf/midend.h
+++ b/backends/ebpf/midend.h
@@ -31,7 +31,10 @@ class MidEnd {
     P4::TypeMap            typeMap;
 
     void addDebugHook(DebugHook hook) { hooks.push_back(hook); }
-    const IR::ToplevelBlock* run(EbpfOptions& options, const IR::P4Program* program);
+    // If p4c is run with option '--listMidendPasses', outStream is used for printing passes names
+    const IR::ToplevelBlock* run(EbpfOptions& options,
+                                 const IR::P4Program* program,
+                                 std::ostream* outStream = nullptr);
 };
 
 }  // namespace EBPF

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -73,6 +73,15 @@ class CompilerOptions : public Util::Options {
     cstring prettyPrintFile = nullptr;
     // Compiler version.
     cstring compilerVersion;
+    // if true skip frontend passes witch names are contained in passesToExcludeFrontend vector
+    bool excludeFrontendPasses = false;
+    bool listFrontendPasses = false;
+
+    // if true skip midend passes witch names are contained in passesToExcludeMidend vector
+    bool excludeMidendPasses = false;
+    bool listMidendPasses = false;
+    // if true skip backend passes witch names are contained in passesToExcludeBackend vector
+    bool excludeBackendPasses = false;
 
     // Dump a JSON representation of the IR in the file
     cstring dumpJsonFile = nullptr;
@@ -106,6 +115,15 @@ class CompilerOptions : public Util::Options {
 
     // if this flag is true, compile program in non-debug mode
     bool ndebug = false;
+
+    // strings matched against pass names that should be excluded from Frontend passes
+    std::vector<cstring> passesToExcludeFrontend;
+
+    // strings matched against pass names that should be excluded from Midend passes
+    std::vector<cstring> passesToExcludeMidend;
+
+    // strings matched against pass names that should be excluded from Backend passes
+    std::vector<cstring> passesToExcludeBackend;
 
     // Expect that the only remaining argument is the input file.
     void setInputFile();
@@ -176,6 +194,13 @@ class P4CContextWithOptions final : public P4CContext {
     /// P4CContextWithOptions<OptionsType>.
     static P4CContextWithOptions& get() {
         return CompileContextStack::top<P4CContextWithOptions>();
+    }
+
+    P4CContextWithOptions() {}
+
+    template <typename OptionsDerivedType>
+    P4CContextWithOptions(P4CContextWithOptions<OptionsDerivedType>& context) {
+        optionsInstance = context.options();
     }
 
     /// @return the compiler options for this compilation context.

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -39,8 +39,10 @@ class FrontEnd {
         hooks.push_back(hook);
     }
     void addDebugHook(DebugHook hook) { hooks.push_back(hook); }
+    // If p4c is run with option '--listFrontendPasses', outStream is used for printing passes names
     const IR::P4Program* run(const CompilerOptions& options, const IR::P4Program* program,
-                             bool skipSideEffectOrdering = false);
+                             bool skipSideEffectOrdering = false,
+                             std::ostream* outStream = nullptr);
 };
 
 }  // namespace P4

--- a/ir/pass_manager.cpp
+++ b/ir/pass_manager.cpp
@@ -18,6 +18,22 @@ limitations under the License.
 #include "lib/gc.h"
 #include "lib/n4.h"
 
+void PassManager::removePasses(const std::vector<cstring> &exclude) {
+    for (auto it : exclude) {
+        bool excluded = false;
+        for (std::vector<Visitor *>::iterator it1 = passes.begin(); it1 != passes.end(); ++it1) {
+            if ((*it1)!= nullptr && it == (*it1)->name()) {
+                delete (*it1);
+                passes.erase(it1--);
+                excluded = true;
+            }
+        }
+        if (!excluded) {
+            throw std::runtime_error("Trying to exclude unknown pass '" + it + "'");
+        }
+    }
+}
+
 const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *) {
     safe_vector<std::pair<safe_vector<Visitor *>::iterator, const IR::Node *>> backup;
     static indent_t log_indent(-1);

--- a/ir/pass_manager.h
+++ b/ir/pass_manager.h
@@ -45,6 +45,7 @@ class PassManager : virtual public Visitor, virtual public Backtrack {
     void addPasses(const std::initializer_list<Visitor *> &init) {
         never_backtracks_cache = -1;
         for (auto p : init) if (p) passes.emplace_back(p); }
+    void removePasses(const std::vector<cstring> &exclude);
     const IR::Node *apply_visitor(const IR::Node *, const char * = 0) override;
     bool backtrack(trigger &trig) override;
     bool never_backtracks() override;


### PR DESCRIPTION
Added four new compiler options :
--listFrontendPasses, prints names of all frontend passes
--listMidendPasses, prints names of all midend passes
--excludeFrontendPasses,  exclude one or more frontend passes,
			  which names are passed as arguments, from further processing
--excludeMidendPasses, exclude one or more midend passes,
                       which names are passed as arguments, from further processing

*Developers should be aware of possibility that skipping some passes may trigger bugs
 in other parts of compiler