### PR TITLE
Use sourceInfo to generate action names in ActionSynthesis

### DIFF
--- a/testdata/p4_14_samples_outputs/exact_match_mask1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-midend.p4
@@ -45,17 +45,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action exact_match_mask1l41() {
         key_0 = hdr.data.f1 & 32w0xff00ff;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_exact_match_mask1l41 {
         actions = {
-            act();
+            exact_match_mask1l41();
         }
-        const default_action = act();
+        const default_action = exact_match_mask1l41();
     }
     apply {
-        tbl_act.apply();
+        tbl_exact_match_mask1l41.apply();
         test1_0.apply();
     }
 }

--- a/testdata/p4_14_samples_outputs/issue1237-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1237-midend.p4
@@ -53,17 +53,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue1237l37() {
         key_0 = 48w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1237l37 {
         actions = {
-            act();
+            issue1237l37();
         }
-        const default_action = act();
+        const default_action = issue1237l37();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1237l37.apply();
         conceptualization_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/action_call_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_call_ebpf-midend.p4
@@ -15,14 +15,14 @@ control pipe(inout Headers_t headers, out bool pass) {
     @name("pipe.Reject") action Reject() {
         pass = x_0;
     }
-    @hidden action act() {
+    @hidden action action_call_ebpf34() {
         x_0 = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_action_call_ebpf34 {
         actions = {
-            act();
+            action_call_ebpf34();
         }
-        const default_action = act();
+        const default_action = action_call_ebpf34();
     }
     @hidden table tbl_Reject {
         actions = {
@@ -31,7 +31,7 @@ control pipe(inout Headers_t headers, out bool pass) {
         const default_action = Reject();
     }
     apply {
-        tbl_act.apply();
+        tbl_action_call_ebpf34.apply();
         tbl_Reject.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/annotation-bug-midend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-midend.p4
@@ -20,17 +20,17 @@ struct tuple_0 {
 extern bit<16> get<T>(in T data);
 control cc() {
     ipv4_option_timestamp_t hdr_0_ipv4_option_timestamp;
-    @hidden action act() {
+    @hidden action annotationbug24() {
         get<headers>({ hdr_0_ipv4_option_timestamp });
     }
-    @hidden table tbl_act {
+    @hidden table tbl_annotationbug24 {
         actions = {
-            act();
+            annotationbug24();
         }
-        const default_action = act();
+        const default_action = annotationbug24();
     }
     apply {
-        tbl_act.apply();
+        tbl_annotationbug24.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2-midend.p4
@@ -52,18 +52,18 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         }
         const default_action = c_add_0();
     }
-    @hidden action act() {
+    @hidden action arithinlineskeleton51() {
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_arithinlineskeleton51 {
         actions = {
-            act();
+            arithinlineskeleton51();
         }
-        const default_action = act();
+        const default_action = arithinlineskeleton51();
     }
     apply {
         c_t.apply();
-        tbl_act.apply();
+        tbl_arithinlineskeleton51.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2-midend.p4
@@ -43,40 +43,40 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action arith2inlinebmv2l29() {
         h.h.c = 8w0;
     }
-    @hidden action act_0() {
+    @hidden action arith2inlinebmv2l31() {
         h.h.c = 8w1;
     }
-    @hidden action act_1() {
+    @hidden action arithinlineskeleton51() {
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_arith2inlinebmv2l29 {
         actions = {
-            act();
+            arith2inlinebmv2l29();
         }
-        const default_action = act();
+        const default_action = arith2inlinebmv2l29();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_arith2inlinebmv2l31 {
         actions = {
-            act_0();
+            arith2inlinebmv2l31();
         }
-        const default_action = act_0();
+        const default_action = arith2inlinebmv2l31();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_arithinlineskeleton51 {
         actions = {
-            act_1();
+            arithinlineskeleton51();
         }
-        const default_action = act_1();
+        const default_action = arithinlineskeleton51();
     }
     apply {
         if (h.h.a < h.h.b) {
-            tbl_act.apply();
+            tbl_arith2inlinebmv2l29.apply();
         } else {
-            tbl_act_0.apply();
+            tbl_arith2inlinebmv2l31.apply();
         }
-        tbl_act_1.apply();
+        tbl_arithinlineskeleton51.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/array-copy-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/array-copy-bmv2-midend.p4
@@ -47,17 +47,17 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action arraycopybmv2l34() {
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_arraycopybmv2l34 {
         actions = {
-            act();
+            arraycopybmv2l34();
         }
-        const default_action = act();
+        const default_action = arraycopybmv2l34();
     }
     apply {
-        tbl_act.apply();
+        tbl_arraycopybmv2l34.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/array_field-midend.p4
+++ b/testdata/p4_16_samples_outputs/array_field-midend.p4
@@ -7,20 +7,20 @@ control c(out H[2] h);
 package top(c _c);
 control my(out H[2] s) {
     bit<32> tmp;
-    @hidden action act() {
+    @hidden action array_field27() {
         s[32w0].z = 1w1;
         s[32w1].z = 1w0;
         tmp = f(s[32w0].z, 1w0);
         f(s[tmp].z, 1w1);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_array_field27 {
         actions = {
-            act();
+            array_field27();
         }
-        const default_action = act();
+        const default_action = array_field27();
     }
     apply {
-        tbl_act.apply();
+        tbl_array_field27.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/bool_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/bool_ebpf-midend.p4
@@ -11,17 +11,17 @@ parser prs(packet_in p, out Headers_t headers) {
 }
 
 control pipe(inout Headers_t headers, out bool pass) {
-    @hidden action act() {
+    @hidden action bool_ebpf31() {
         pass = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_bool_ebpf31 {
         actions = {
-            act();
+            bool_ebpf31();
         }
-        const default_action = act();
+        const default_action = bool_ebpf31();
     }
     apply {
-        tbl_act.apply();
+        tbl_bool_ebpf31.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/bvec_union-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/bvec_union-bmv2-midend.p4
@@ -86,18 +86,18 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action bvec_unionbmv2l88() {
         h.u.h2.setInvalid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_bvec_unionbmv2l88 {
         actions = {
-            act();
+            bvec_unionbmv2l88();
         }
-        const default_action = act();
+        const default_action = bvec_unionbmv2l88();
     }
     apply {
         if (h.u.h2.isValid()) {
-            tbl_act.apply();
+            tbl_bvec_unionbmv2l88.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/calc-ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/calc-ebpf-midend.p4
@@ -141,14 +141,14 @@ control Ingress(inout headers hdr, out bool xout) {
 
         implementation = hash_table(32w8);
     }
-    @hidden action act() {
+    @hidden action calcebpf152() {
         xout = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_calcebpf152 {
         actions = {
-            act();
+            calcebpf152();
         }
-        const default_action = act();
+        const default_action = calcebpf152();
     }
     @hidden table tbl_operation_drop {
         actions = {
@@ -157,7 +157,7 @@ control Ingress(inout headers hdr, out bool xout) {
         const default_action = operation_drop_2();
     }
     apply {
-        tbl_act.apply();
+        tbl_calcebpf152.apply();
         if (hdr.p4calc.isValid()) {
             calculate_0.apply();
         } else {

--- a/testdata/p4_16_samples_outputs/checksum2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/checksum2-bmv2-midend.p4
@@ -81,52 +81,52 @@ parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standa
 }
 
 control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
-    @hidden action act() {
+    @hidden action checksum2bmv2l130() {
         hdr.ethernet.srcAddr = 48w0xbad;
     }
-    @hidden action act_0() {
+    @hidden action checksum2bmv2l126() {
         stdmeta.egress_spec = 9w0;
     }
-    @hidden action act_1() {
+    @hidden action checksum2bmv2l134() {
         hdr.ethernet.dstAddr = 48w0xbad;
     }
-    @hidden action act_2() {
+    @hidden action checksum2bmv2l142() {
         hdr.ipv4.ttl = hdr.ipv4.ttl |-| 8w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_checksum2bmv2l126 {
         actions = {
-            act_0();
+            checksum2bmv2l126();
         }
-        const default_action = act_0();
+        const default_action = checksum2bmv2l126();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_checksum2bmv2l130 {
         actions = {
-            act();
+            checksum2bmv2l130();
         }
-        const default_action = act();
+        const default_action = checksum2bmv2l130();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_checksum2bmv2l134 {
         actions = {
-            act_1();
+            checksum2bmv2l134();
         }
-        const default_action = act_1();
+        const default_action = checksum2bmv2l134();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_checksum2bmv2l142 {
         actions = {
-            act_2();
+            checksum2bmv2l142();
         }
-        const default_action = act_2();
+        const default_action = checksum2bmv2l142();
     }
     apply {
-        tbl_act.apply();
+        tbl_checksum2bmv2l126.apply();
         if (stdmeta.checksum_error == 1w1) {
-            tbl_act_0.apply();
+            tbl_checksum2bmv2l130.apply();
         }
         if (stdmeta.parser_error != error.NoError) {
-            tbl_act_1.apply();
+            tbl_checksum2bmv2l134.apply();
         }
         if (hdr.ipv4.isValid()) {
-            tbl_act_2.apply();
+            tbl_checksum2bmv2l142.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/checksum3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/checksum3-bmv2-midend.p4
@@ -81,52 +81,52 @@ parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standa
 }
 
 control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
-    @hidden action act() {
+    @hidden action checksum3bmv2l130() {
         hdr.ethernet.srcAddr = 48w0xbad;
     }
-    @hidden action act_0() {
+    @hidden action checksum3bmv2l126() {
         stdmeta.egress_spec = 9w0;
     }
-    @hidden action act_1() {
+    @hidden action checksum3bmv2l134() {
         hdr.ethernet.dstAddr = 48w0xbad;
     }
-    @hidden action act_2() {
+    @hidden action checksum3bmv2l141() {
         hdr.ipv4.ttl = hdr.ipv4.ttl |-| 8w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_checksum3bmv2l126 {
         actions = {
-            act_0();
+            checksum3bmv2l126();
         }
-        const default_action = act_0();
+        const default_action = checksum3bmv2l126();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_checksum3bmv2l130 {
         actions = {
-            act();
+            checksum3bmv2l130();
         }
-        const default_action = act();
+        const default_action = checksum3bmv2l130();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_checksum3bmv2l134 {
         actions = {
-            act_1();
+            checksum3bmv2l134();
         }
-        const default_action = act_1();
+        const default_action = checksum3bmv2l134();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_checksum3bmv2l141 {
         actions = {
-            act_2();
+            checksum3bmv2l141();
         }
-        const default_action = act_2();
+        const default_action = checksum3bmv2l141();
     }
     apply {
-        tbl_act.apply();
+        tbl_checksum3bmv2l126.apply();
         if (stdmeta.checksum_error == 1w1) {
-            tbl_act_0.apply();
+            tbl_checksum3bmv2l130.apply();
         }
         if (stdmeta.parser_error != error.NoError) {
-            tbl_act_1.apply();
+            tbl_checksum3bmv2l134.apply();
         }
         if (hdr.ipv4.isValid()) {
-            tbl_act_2.apply();
+            tbl_checksum3bmv2l141.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/complex-midend.p4
+++ b/testdata/p4_16_samples_outputs/complex-midend.p4
@@ -2,19 +2,19 @@ extern bit<32> f(in bit<32> x);
 control c(inout bit<32> r) {
     bit<32> tmp;
     bit<32> tmp_1;
-    @hidden action act() {
+    @hidden action complex21() {
         tmp = f(32w5);
         tmp_1 = f(tmp);
         r = tmp_1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_complex21 {
         actions = {
-            act();
+            complex21();
         }
-        const default_action = act();
+        const default_action = complex21();
     }
     apply {
-        tbl_act.apply();
+        tbl_complex21.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/complex1-midend.p4
+++ b/testdata/p4_16_samples_outputs/complex1-midend.p4
@@ -4,21 +4,21 @@ control c(inout bit<32> r) {
     bit<32> tmp_1;
     bit<32> tmp_3;
     bit<32> tmp_5;
-    @hidden action act() {
+    @hidden action complex1l21() {
         tmp = f(32w5, 32w2);
         tmp_1 = f(32w2, 32w3);
         tmp_3 = f(32w6, tmp_1);
         tmp_5 = f(tmp, tmp_3);
         r = tmp_5;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_complex1l21 {
         actions = {
-            act();
+            complex1l21();
         }
-        const default_action = act();
+        const default_action = complex1l21();
     }
     apply {
-        tbl_act.apply();
+        tbl_complex1l21.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/complex10-midend.p4
+++ b/testdata/p4_16_samples_outputs/complex10-midend.p4
@@ -5,87 +5,87 @@ control c(inout bit<32> r) {
     bit<32> tmp_2;
     bool tmp_4;
     bit<32> tmp_5;
-    @hidden action act() {
+    @hidden action complex10l21() {
         tmp_1 = false;
     }
-    @hidden action act_0() {
+    @hidden action complex10l21_0() {
         tmp_2 = f(32w3);
         tmp_1 = tmp_2 < 32w0;
     }
-    @hidden action act_1() {
+    @hidden action act() {
         tmp = f(32w2);
     }
-    @hidden action act_2() {
+    @hidden action complex10l21_1() {
         tmp_4 = true;
     }
-    @hidden action act_3() {
+    @hidden action complex10l21_2() {
         tmp_5 = f(32w5);
         tmp_4 = tmp_5 == 32w2;
     }
-    @hidden action act_4() {
+    @hidden action complex10l22() {
         r = 32w1;
     }
-    @hidden action act_5() {
+    @hidden action complex10l24() {
         r = 32w2;
     }
     @hidden table tbl_act {
-        actions = {
-            act_1();
-        }
-        const default_action = act_1();
-    }
-    @hidden table tbl_act_0 {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_complex10l21 {
         actions = {
-            act_0();
+            complex10l21();
         }
-        const default_action = act_0();
+        const default_action = complex10l21();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_complex10l21_0 {
         actions = {
-            act_2();
+            complex10l21_0();
         }
-        const default_action = act_2();
+        const default_action = complex10l21_0();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_complex10l21_1 {
         actions = {
-            act_3();
+            complex10l21_1();
         }
-        const default_action = act_3();
+        const default_action = complex10l21_1();
     }
-    @hidden table tbl_act_4 {
+    @hidden table tbl_complex10l21_2 {
         actions = {
-            act_4();
+            complex10l21_2();
         }
-        const default_action = act_4();
+        const default_action = complex10l21_2();
     }
-    @hidden table tbl_act_5 {
+    @hidden table tbl_complex10l22 {
         actions = {
-            act_5();
+            complex10l22();
         }
-        const default_action = act_5();
+        const default_action = complex10l22();
+    }
+    @hidden table tbl_complex10l24 {
+        actions = {
+            complex10l24();
+        }
+        const default_action = complex10l24();
     }
     apply {
         tbl_act.apply();
         if (!(tmp > 32w0)) {
-            tbl_act_0.apply();
+            tbl_complex10l21.apply();
         } else {
-            tbl_act_1.apply();
+            tbl_complex10l21_0.apply();
         }
         if (tmp_1) {
-            tbl_act_2.apply();
+            tbl_complex10l21_1.apply();
         } else {
-            tbl_act_3.apply();
+            tbl_complex10l21_2.apply();
         }
         if (tmp_4) {
-            tbl_act_4.apply();
+            tbl_complex10l22.apply();
         } else {
-            tbl_act_5.apply();
+            tbl_complex10l24.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/complex2-midend.p4
+++ b/testdata/p4_16_samples_outputs/complex2-midend.p4
@@ -6,18 +6,18 @@ header H {
 control c(inout bit<32> r) {
     H[2] h_0;
     bit<32> tmp;
-    @hidden action act() {
+    @hidden action complex2l25() {
         tmp = f(32w2);
         h_0[tmp].setValid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_complex2l25 {
         actions = {
-            act();
+            complex2l25();
         }
-        const default_action = act();
+        const default_action = complex2l25();
     }
     apply {
-        tbl_act.apply();
+        tbl_complex2l25.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/complex3-midend.p4
+++ b/testdata/p4_16_samples_outputs/complex3-midend.p4
@@ -2,19 +2,19 @@ extern bit<32> f(in bit<32> x);
 control c(inout bit<32> r) {
     bit<32> tmp;
     bit<32> tmp_0;
-    @hidden action act() {
+    @hidden action complex3l21() {
         tmp = f(32w4);
         tmp_0 = f(32w5);
         r = tmp + tmp_0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_complex3l21 {
         actions = {
-            act();
+            complex3l21();
         }
-        const default_action = act();
+        const default_action = complex3l21();
     }
     apply {
-        tbl_act.apply();
+        tbl_complex3l21.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/complex4-midend.p4
+++ b/testdata/p4_16_samples_outputs/complex4-midend.p4
@@ -7,19 +7,19 @@ control c(inout bit<32> r) {
     bit<32> tmp;
     bit<32> tmp_0;
     @name("c.e") E() e_0;
-    @hidden action act() {
+    @hidden action complex4l25() {
         tmp = e_0.f(32w4);
         tmp_0 = e_0.f(32w5);
         r = tmp + tmp_0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_complex4l25 {
         actions = {
-            act();
+            complex4l25();
         }
-        const default_action = act();
+        const default_action = complex4l25();
     }
     apply {
-        tbl_act.apply();
+        tbl_complex4l25.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/complex5-midend.p4
+++ b/testdata/p4_16_samples_outputs/complex5-midend.p4
@@ -1,39 +1,39 @@
 extern bit<32> f(in bit<32> x);
 control c(inout bit<32> r) {
     bit<32> tmp;
-    @hidden action act() {
+    @hidden action complex5l22() {
         r = 32w1;
     }
-    @hidden action act_0() {
+    @hidden action complex5l24() {
         r = 32w2;
     }
-    @hidden action act_1() {
+    @hidden action act() {
         tmp = f(32w2);
     }
     @hidden table tbl_act {
-        actions = {
-            act_1();
-        }
-        const default_action = act_1();
-    }
-    @hidden table tbl_act_0 {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_complex5l22 {
         actions = {
-            act_0();
+            complex5l22();
         }
-        const default_action = act_0();
+        const default_action = complex5l22();
+    }
+    @hidden table tbl_complex5l24 {
+        actions = {
+            complex5l24();
+        }
+        const default_action = complex5l24();
     }
     apply {
         tbl_act.apply();
         if (tmp > 32w0) {
-            tbl_act_0.apply();
+            tbl_complex5l22.apply();
         } else {
-            tbl_act_1.apply();
+            tbl_complex5l24.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/complex6-midend.p4
+++ b/testdata/p4_16_samples_outputs/complex6-midend.p4
@@ -2,62 +2,62 @@ extern bit<32> f(in bit<32> x);
 control c(inout bit<32> r) {
     bit<32> tmp;
     bit<32> tmp_1;
-    @hidden action act() {
+    @hidden action complex6l23() {
         r = 32w1;
     }
-    @hidden action act_0() {
+    @hidden action complex6l25() {
         r = 32w3;
     }
-    @hidden action act_1() {
+    @hidden action act() {
         tmp = f(32w2);
     }
-    @hidden action act_2() {
+    @hidden action complex6l27() {
         r = 32w2;
     }
-    @hidden action act_3() {
+    @hidden action act_0() {
         tmp_1 = f(32w2);
     }
     @hidden table tbl_act {
-        actions = {
-            act_3();
-        }
-        const default_action = act_3();
-    }
-    @hidden table tbl_act_0 {
-        actions = {
-            act_1();
-        }
-        const default_action = act_1();
-    }
-    @hidden table tbl_act_1 {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
-    @hidden table tbl_act_2 {
         actions = {
             act_0();
         }
         const default_action = act_0();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_act_0 {
         actions = {
-            act_2();
+            act();
         }
-        const default_action = act_2();
+        const default_action = act();
+    }
+    @hidden table tbl_complex6l23 {
+        actions = {
+            complex6l23();
+        }
+        const default_action = complex6l23();
+    }
+    @hidden table tbl_complex6l25 {
+        actions = {
+            complex6l25();
+        }
+        const default_action = complex6l25();
+    }
+    @hidden table tbl_complex6l27 {
+        actions = {
+            complex6l27();
+        }
+        const default_action = complex6l27();
     }
     apply {
         tbl_act.apply();
         if (tmp_1 > 32w0) {
             tbl_act_0.apply();
             if (tmp < 32w2) {
-                tbl_act_1.apply();
+                tbl_complex6l23.apply();
             } else {
-                tbl_act_2.apply();
+                tbl_complex6l25.apply();
             }
         } else {
-            tbl_act_3.apply();
+            tbl_complex6l27.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/complex9-midend.p4
+++ b/testdata/p4_16_samples_outputs/complex9-midend.p4
@@ -3,63 +3,63 @@ control c(inout bit<32> r) {
     bit<32> tmp;
     bool tmp_1;
     bit<32> tmp_2;
-    @hidden action act() {
+    @hidden action complex9l21() {
         tmp_1 = false;
     }
-    @hidden action act_0() {
+    @hidden action complex9l21_0() {
         tmp_2 = f(32w3);
         tmp_1 = tmp_2 < 32w0;
     }
-    @hidden action act_1() {
+    @hidden action act() {
         tmp = f(32w2);
     }
-    @hidden action act_2() {
+    @hidden action complex9l22() {
         r = 32w1;
     }
-    @hidden action act_3() {
+    @hidden action complex9l24() {
         r = 32w2;
     }
     @hidden table tbl_act {
-        actions = {
-            act_1();
-        }
-        const default_action = act_1();
-    }
-    @hidden table tbl_act_0 {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_complex9l21 {
         actions = {
-            act_0();
+            complex9l21();
         }
-        const default_action = act_0();
+        const default_action = complex9l21();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_complex9l21_0 {
         actions = {
-            act_2();
+            complex9l21_0();
         }
-        const default_action = act_2();
+        const default_action = complex9l21_0();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_complex9l22 {
         actions = {
-            act_3();
+            complex9l22();
         }
-        const default_action = act_3();
+        const default_action = complex9l22();
+    }
+    @hidden table tbl_complex9l24 {
+        actions = {
+            complex9l24();
+        }
+        const default_action = complex9l24();
     }
     apply {
         tbl_act.apply();
         if (!(tmp > 32w0)) {
-            tbl_act_0.apply();
+            tbl_complex9l21.apply();
         } else {
-            tbl_act_1.apply();
+            tbl_complex9l21_0.apply();
         }
         if (tmp_1) {
-            tbl_act_2.apply();
+            tbl_complex9l22.apply();
         } else {
-            tbl_act_3.apply();
+            tbl_complex9l24.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/concat-midend.p4
+++ b/testdata/p4_16_samples_outputs/concat-midend.p4
@@ -1,17 +1,17 @@
 control proto(out bit<32> x);
 package top(proto _c);
 control c(out bit<32> x) {
-    @hidden action act() {
+    @hidden action concat24() {
         x = 32w0xf0f1e1e;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_concat24 {
         actions = {
-            act();
+            concat24();
         }
-        const default_action = act();
+        const default_action = concat24();
     }
     apply {
-        tbl_act.apply();
+        tbl_concat24.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-midend.p4
@@ -45,18 +45,18 @@ struct tuple_0 {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action constantincalculationbmv2l27() {
         hash<bit<16>, bit<10>, tuple_0, bit<10>>(h.h.a, HashAlgorithm.crc16, 10w0, { 16w1 }, 10w4);
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_constantincalculationbmv2l27 {
         actions = {
-            act();
+            constantincalculationbmv2l27();
         }
-        const default_action = act();
+        const default_action = constantincalculationbmv2l27();
     }
     apply {
-        tbl_act.apply();
+        tbl_constantincalculationbmv2l27.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/constant_folding-midend.p4
+++ b/testdata/p4_16_samples_outputs/constant_folding-midend.p4
@@ -1,17 +1,17 @@
 control proto(out bit<32> x);
 package top(proto _c);
 control c(out bit<32> x) {
-    @hidden action act() {
+    @hidden action constant_folding59() {
         x = 32w17;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_constant_folding59 {
         actions = {
-            act();
+            constant_folding59();
         }
-        const default_action = act();
+        const default_action = constant_folding59();
     }
     apply {
-        tbl_act.apply();
+        tbl_constant_folding59.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/control-as-param-midend.p4
+++ b/testdata/p4_16_samples_outputs/control-as-param-midend.p4
@@ -2,18 +2,18 @@
 
 control E(out bit<1> b);
 control Ingress(out bit<1> b) {
-    @hidden action act() {
+    @hidden action controlasparam7() {
         b = 1w1;
         b = 1w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_controlasparam7 {
         actions = {
-            act();
+            controlasparam7();
         }
-        const default_action = act();
+        const default_action = controlasparam7();
     }
     apply {
-        tbl_act.apply();
+        tbl_controlasparam7.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/count_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/count_ebpf-midend.p4
@@ -45,30 +45,30 @@ parser prs(packet_in p, out Headers_t headers) {
 
 control pipe(inout Headers_t headers, out bool pass) {
     @name("pipe.counters") CounterArray(32w10, true) counters_0;
-    @hidden action act() {
+    @hidden action count_ebpf54() {
         counters_0.increment(headers.ipv4.dstAddr);
         pass = true;
     }
-    @hidden action act_0() {
+    @hidden action count_ebpf58() {
         pass = false;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_count_ebpf54 {
         actions = {
-            act();
+            count_ebpf54();
         }
-        const default_action = act();
+        const default_action = count_ebpf54();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_count_ebpf58 {
         actions = {
-            act_0();
+            count_ebpf58();
         }
-        const default_action = act_0();
+        const default_action = count_ebpf58();
     }
     apply {
         if (headers.ipv4.isValid()) {
-            tbl_act.apply();
+            tbl_count_ebpf54.apply();
         } else {
-            tbl_act_0.apply();
+            tbl_count_ebpf58.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/decl2-midend.p4
+++ b/testdata/p4_16_samples_outputs/decl2-midend.p4
@@ -2,14 +2,14 @@ control p() {
     bit<1> x_3;
     @name("p.b") action b() {
     }
-    @hidden action act() {
+    @hidden action decl2l32() {
         x_3 = 1w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_decl2l32 {
         actions = {
-            act();
+            decl2l32();
         }
-        const default_action = act();
+        const default_action = decl2l32();
     }
     @hidden table tbl_b {
         actions = {
@@ -18,7 +18,7 @@ control p() {
         const default_action = b();
     }
     apply {
-        tbl_act.apply();
+        tbl_decl2l32.apply();
         tbl_b.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-midend.p4
@@ -51,18 +51,18 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         }
         const default_action = c_add_0(32w10);
     }
-    @hidden action act() {
+    @hidden action arithinlineskeleton51() {
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_arithinlineskeleton51 {
         actions = {
-            act();
+            arithinlineskeleton51();
         }
-        const default_action = act();
+        const default_action = arithinlineskeleton51();
     }
     apply {
         c_t.apply();
-        tbl_act.apply();
+        tbl_arithinlineskeleton51.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/direct-action-midend.p4
+++ b/testdata/p4_16_samples_outputs/direct-action-midend.p4
@@ -3,14 +3,14 @@ control c(inout bit<16> y) {
     @name("c.a") action a() {
         y = (bit<16>)x_0;
     }
-    @hidden action act() {
+    @hidden action directaction18() {
         x_0 = 32w2;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_directaction18 {
         actions = {
-            act();
+            directaction18();
         }
-        const default_action = act();
+        const default_action = directaction18();
     }
     @hidden table tbl_a {
         actions = {
@@ -19,7 +19,7 @@ control c(inout bit<16> y) {
         const default_action = a();
     }
     apply {
-        tbl_act.apply();
+        tbl_directaction18.apply();
         tbl_a.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/direct-action1-midend.p4
+++ b/testdata/p4_16_samples_outputs/direct-action1-midend.p4
@@ -3,14 +3,14 @@ control c(inout bit<16> y) {
     @name("c.a") action a() {
         y = (bit<16>)x_0;
     }
-    @hidden action act() {
+    @hidden action directaction1l18() {
         x_0 = 32w10;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_directaction1l18 {
         actions = {
-            act();
+            directaction1l18();
         }
-        const default_action = act();
+        const default_action = directaction1l18();
     }
     @hidden table tbl_a {
         actions = {
@@ -19,7 +19,7 @@ control c(inout bit<16> y) {
         const default_action = a();
     }
     apply {
-        tbl_act.apply();
+        tbl_directaction1l18.apply();
         tbl_a.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/emptyTuple-midend.p4
+++ b/testdata/p4_16_samples_outputs/emptyTuple-midend.p4
@@ -3,17 +3,17 @@ struct tuple_0 {
 
 typedef tuple_0 emptyTuple;
 control c(out bool b) {
-    @hidden action act() {
+    @hidden action emptyTuple7() {
         b = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_emptyTuple7 {
         actions = {
-            act();
+            emptyTuple7();
         }
-        const default_action = act();
+        const default_action = emptyTuple7();
     }
     apply {
-        tbl_act.apply();
+        tbl_emptyTuple7.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/enum-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv2-midend.p4
@@ -48,18 +48,18 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action enumbmv2l40() {
         h.h.c = h.h.b;
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_enumbmv2l40 {
         actions = {
-            act();
+            enumbmv2l40();
         }
-        const default_action = act();
+        const default_action = enumbmv2l40();
     }
     apply {
-        tbl_act.apply();
+        tbl_enumbmv2l40.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/equality-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/equality-bmv2-midend.p4
@@ -30,77 +30,77 @@ parser p(packet_in b, out headers hdr, inout metadata meta, inout standard_metad
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
     H[2] tmp_0;
-    @hidden action act() {
+    @hidden action equalitybmv2l42() {
         hdr.same.same = 8w1;
     }
-    @hidden action act_0() {
+    @hidden action equalitybmv2l37() {
         hdr.same.setValid();
         hdr.same.same = 8w0;
         stdmeta.egress_spec = 9w0;
     }
-    @hidden action act_1() {
+    @hidden action equalitybmv2l45() {
         hdr.same.same = hdr.same.same | 8w2;
     }
-    @hidden action act_2() {
+    @hidden action equalitybmv2l48() {
         hdr.same.same = hdr.same.same | 8w4;
     }
-    @hidden action act_3() {
+    @hidden action equalitybmv2l55() {
         hdr.same.same = hdr.same.same | 8w8;
     }
-    @hidden action act_4() {
+    @hidden action equalitybmv2l52() {
         tmp_0[0] = hdr.h;
         tmp_0[1] = hdr.a[0];
     }
-    @hidden table tbl_act {
+    @hidden table tbl_equalitybmv2l37 {
         actions = {
-            act_0();
+            equalitybmv2l37();
         }
-        const default_action = act_0();
+        const default_action = equalitybmv2l37();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_equalitybmv2l42 {
         actions = {
-            act();
+            equalitybmv2l42();
         }
-        const default_action = act();
+        const default_action = equalitybmv2l42();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_equalitybmv2l45 {
         actions = {
-            act_1();
+            equalitybmv2l45();
         }
-        const default_action = act_1();
+        const default_action = equalitybmv2l45();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_equalitybmv2l48 {
         actions = {
-            act_2();
+            equalitybmv2l48();
         }
-        const default_action = act_2();
+        const default_action = equalitybmv2l48();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_equalitybmv2l52 {
         actions = {
-            act_4();
+            equalitybmv2l52();
         }
-        const default_action = act_4();
+        const default_action = equalitybmv2l52();
     }
-    @hidden table tbl_act_4 {
+    @hidden table tbl_equalitybmv2l55 {
         actions = {
-            act_3();
+            equalitybmv2l55();
         }
-        const default_action = act_3();
+        const default_action = equalitybmv2l55();
     }
     apply {
-        tbl_act.apply();
+        tbl_equalitybmv2l37.apply();
         if (hdr.h.s == hdr.a[0].s) {
-            tbl_act_0.apply();
+            tbl_equalitybmv2l42.apply();
         }
         if (hdr.h.v == hdr.a[0].v) {
-            tbl_act_1.apply();
+            tbl_equalitybmv2l45.apply();
         }
         if (!hdr.h.isValid() && !hdr.a[0].isValid() || hdr.h.isValid() && hdr.a[0].isValid() && hdr.h.s == hdr.a[0].s && hdr.h.v == hdr.a[0].v) {
-            tbl_act_2.apply();
+            tbl_equalitybmv2l48.apply();
         }
-        tbl_act_3.apply();
+        tbl_equalitybmv2l52.apply();
         if ((!tmp_0[0].isValid() && !hdr.a[0].isValid() || tmp_0[0].isValid() && hdr.a[0].isValid() && tmp_0[0].s == hdr.a[0].s && tmp_0[0].v == hdr.a[0].v) && (!tmp_0[1].isValid() && !hdr.a[1].isValid() || tmp_0[1].isValid() && hdr.a[1].isValid() && tmp_0[1].s == hdr.a[1].s && tmp_0[1].v == hdr.a[1].v)) {
-            tbl_act_4.apply();
+            tbl_equalitybmv2l55.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/equality-midend.p4
+++ b/testdata/p4_16_samples_outputs/equality-midend.p4
@@ -19,62 +19,62 @@ control c(out bit<1> x) {
     H s2_0_h;
     H[2] a1_0;
     H[2] a2_0;
-    @hidden action act() {
+    @hidden action equality23() {
         x = 1w1;
     }
-    @hidden action act_0() {
+    @hidden action equality25() {
         x = 1w1;
     }
-    @hidden action act_1() {
+    @hidden action equality27() {
         x = 1w1;
     }
-    @hidden action act_2() {
+    @hidden action equality29() {
         x = 1w1;
     }
-    @hidden action act_3() {
+    @hidden action equality31() {
         x = 1w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_equality23 {
         actions = {
-            act();
+            equality23();
         }
-        const default_action = act();
+        const default_action = equality23();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_equality25 {
         actions = {
-            act_0();
+            equality25();
         }
-        const default_action = act_0();
+        const default_action = equality25();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_equality27 {
         actions = {
-            act_1();
+            equality27();
         }
-        const default_action = act_1();
+        const default_action = equality27();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_equality29 {
         actions = {
-            act_2();
+            equality29();
         }
-        const default_action = act_2();
+        const default_action = equality29();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_equality31 {
         actions = {
-            act_3();
+            equality31();
         }
-        const default_action = act_3();
+        const default_action = equality31();
     }
     apply {
         if (a_0 == b_0) {
-            tbl_act.apply();
+            tbl_equality23.apply();
         } else if (!h1_0.isValid() && !h2_0.isValid() || h1_0.isValid() && h2_0.isValid() && h1_0.a == h2_0.a && h1_0.b == h2_0.b) {
-            tbl_act_0.apply();
+            tbl_equality25.apply();
         } else if (s1_0_a == s2_0_a && (!s1_0_h.isValid() && !s2_0_h.isValid() || s1_0_h.isValid() && s2_0_h.isValid() && s1_0_h.a == s2_0_h.a && s1_0_h.b == s2_0_h.b)) {
-            tbl_act_1.apply();
+            tbl_equality27.apply();
         } else if ((!a1_0[0].isValid() && !a2_0[0].isValid() || a1_0[0].isValid() && a2_0[0].isValid() && a1_0[0].a == a2_0[0].a && a1_0[0].b == a2_0[0].b) && (!a1_0[1].isValid() && !a2_0[1].isValid() || a1_0[1].isValid() && a2_0[1].isValid() && a1_0[1].a == a2_0[1].a && a1_0[1].b == a2_0[1].b)) {
-            tbl_act_2.apply();
+            tbl_equality29.apply();
         } else {
-            tbl_act_3.apply();
+            tbl_equality31.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/equality-varbit-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/equality-varbit-bmv2-midend.p4
@@ -22,29 +22,29 @@ parser p(packet_in b, out headers hdr, inout metadata meta, inout standard_metad
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
     H h_0;
-    @hidden action act() {
+    @hidden action equalityvarbitbmv2l33() {
         stdmeta.egress_spec = 9w1;
     }
-    @hidden action act_0() {
+    @hidden action equalityvarbitbmv2l29() {
         stdmeta.egress_spec = 9w0;
         h_0 = hdr.h;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_equalityvarbitbmv2l29 {
         actions = {
-            act_0();
+            equalityvarbitbmv2l29();
         }
-        const default_action = act_0();
+        const default_action = equalityvarbitbmv2l29();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_equalityvarbitbmv2l33 {
         actions = {
-            act();
+            equalityvarbitbmv2l33();
         }
-        const default_action = act();
+        const default_action = equalityvarbitbmv2l33();
     }
     apply {
-        tbl_act.apply();
+        tbl_equalityvarbitbmv2l29.apply();
         if (hdr.h.v == h_0.v) {
-            tbl_act_0.apply();
+            tbl_equalityvarbitbmv2l33.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/exit2-midend.p4
+++ b/testdata/p4_16_samples_outputs/exit2-midend.p4
@@ -6,18 +6,18 @@ control ctrl(out bit<32> c) {
     @name("ctrl.e") action e_2() {
         hasExited = true;
     }
-    @hidden action act() {
+    @hidden action exit2l31() {
         hasExited = false;
         c = 32w2;
     }
-    @hidden action act_0() {
+    @hidden action exit2l41() {
         c = 32w5;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_exit2l31 {
         actions = {
-            act();
+            exit2l31();
         }
-        const default_action = act();
+        const default_action = exit2l31();
     }
     @hidden table tbl_e {
         actions = {
@@ -25,17 +25,17 @@ control ctrl(out bit<32> c) {
         }
         const default_action = e();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_exit2l41 {
         actions = {
-            act_0();
+            exit2l41();
         }
-        const default_action = act_0();
+        const default_action = exit2l41();
     }
     apply {
-        tbl_act.apply();
+        tbl_exit2l31.apply();
         tbl_e.apply();
         if (!hasExited) {
-            tbl_act_0.apply();
+            tbl_exit2l41.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/exit3-midend.p4
+++ b/testdata/p4_16_samples_outputs/exit3-midend.p4
@@ -9,30 +9,30 @@ control ctrl(out bit<32> c) {
         }
         default_action = e();
     }
-    @hidden action act() {
+    @hidden action exit3l33() {
         hasExited = false;
         c = 32w2;
     }
-    @hidden action act_0() {
+    @hidden action exit3l43() {
         c = 32w5;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_exit3l33 {
         actions = {
-            act();
+            exit3l33();
         }
-        const default_action = act();
+        const default_action = exit3l33();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_exit3l43 {
         actions = {
-            act_0();
+            exit3l43();
         }
-        const default_action = act_0();
+        const default_action = exit3l43();
     }
     apply {
-        tbl_act.apply();
+        tbl_exit3l33.apply();
         t_0.apply();
         if (!hasExited) {
-            tbl_act_0.apply();
+            tbl_exit3l43.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/extern-funcs-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/extern-funcs-bmv2-midend.p4
@@ -42,18 +42,18 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action externfuncsbmv2l29() {
         extern_func(h.h.a, 32w0xff);
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_externfuncsbmv2l29 {
         actions = {
-            act();
+            externfuncsbmv2l29();
         }
-        const default_action = act();
+        const default_action = externfuncsbmv2l29();
     }
     apply {
-        tbl_act.apply();
+        tbl_externfuncsbmv2l29.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
@@ -655,83 +655,131 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     }
     @name("FabricIngress.port_counters_control.egress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_egress_port_counter;
     @name("FabricIngress.port_counters_control.ingress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_ingress_port_counter;
-    @hidden action act() {
+    @hidden action spgw30() {
         spgw_normalizer_hasReturned = true;
     }
-    @hidden action act_0() {
+    @hidden action fabric78() {
         hasExited = false;
         hdr.gtpu_ipv4.setInvalid();
         hdr.gtpu_udp.setInvalid();
         spgw_normalizer_hasReturned = false;
     }
-    @hidden action act_1() {
+    @hidden action spgw35() {
         hdr.udp = hdr.inner_udp;
     }
-    @hidden action act_2() {
+    @hidden action spgw37() {
         hdr.udp.setInvalid();
     }
-    @hidden action act_3() {
+    @hidden action spgw31() {
         hdr.gtpu_ipv4 = hdr.ipv4;
         hdr.ipv4 = hdr.inner_ipv4;
         hdr.gtpu_udp = hdr.udp;
     }
-    @hidden action act_4() {
+    @hidden action packetio25() {
         standard_metadata.egress_spec = hdr.packet_out.egress_port;
         hdr.packet_out.setInvalid();
         fabric_metadata._is_controller_packet_out12 = true;
         hasExited = true;
     }
-    @hidden action act_5() {
+    @hidden action filtering105() {
         fabric_metadata._eth_type0 = hdr.vlan_tag.eth_type;
         fabric_metadata._vlan_id2 = hdr.vlan_tag.vlan_id;
         fabric_metadata._vlan_pri3 = hdr.vlan_tag.pri;
         fabric_metadata._vlan_cfi4 = hdr.vlan_tag.cfi;
     }
-    @hidden action act_6() {
+    @hidden action filtering115() {
         fabric_metadata._mpls_ttl6 = 8w65;
     }
-    @hidden action act_7() {
+    @hidden action act() {
         spgw_ingress_tmp = true;
     }
-    @hidden action act_8() {
+    @hidden action act_0() {
         spgw_ingress_tmp = false;
     }
-    @hidden action act_9() {
+    @hidden action spgw149() {
         mark_to_drop(standard_metadata);
     }
-    @hidden action act_10() {
+    @hidden action spgw151() {
         fabric_metadata._spgw_direction17 = 2w1;
     }
-    @hidden action act_11() {
+    @hidden action act_1() {
         spgw_ingress_tmp_0 = true;
     }
-    @hidden action act_12() {
+    @hidden action act_2() {
         spgw_ingress_tmp_0 = false;
     }
-    @hidden action act_13() {
+    @hidden action spgw154() {
         fabric_metadata._spgw_direction17 = 2w2;
     }
-    @hidden action act_14() {
+    @hidden action spgw156() {
         fabric_metadata._spgw_direction17 = 2w0;
         spgw_ingress_hasReturned = true;
     }
-    @hidden action act_15() {
+    @hidden action act_3() {
         spgw_ingress_hasReturned = false;
     }
-    @hidden action act_16() {
+    @hidden action spgw175() {
         fabric_metadata._spgw_ipv4_len18 = hdr.ipv4.total_len;
     }
-    @hidden action act_17() {
+    @hidden action port_counter31() {
         port_counters_control_egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
     }
-    @hidden action act_18() {
+    @hidden action port_counter34() {
         port_counters_control_ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
+    }
+    @hidden table tbl_fabric78 {
+        actions = {
+            fabric78();
+        }
+        const default_action = fabric78();
+    }
+    @hidden table tbl_spgw30 {
+        actions = {
+            spgw30();
+        }
+        const default_action = spgw30();
+    }
+    @hidden table tbl_spgw31 {
+        actions = {
+            spgw31();
+        }
+        const default_action = spgw31();
+    }
+    @hidden table tbl_spgw35 {
+        actions = {
+            spgw35();
+        }
+        const default_action = spgw35();
+    }
+    @hidden table tbl_spgw37 {
+        actions = {
+            spgw37();
+        }
+        const default_action = spgw37();
+    }
+    @hidden table tbl_packetio25 {
+        actions = {
+            packetio25();
+        }
+        const default_action = packetio25();
+    }
+    @hidden table tbl_filtering105 {
+        actions = {
+            filtering105();
+        }
+        const default_action = filtering105();
+    }
+    @hidden table tbl_filtering115 {
+        actions = {
+            filtering115();
+        }
+        const default_action = filtering115();
     }
     @hidden table tbl_act {
         actions = {
-            act_0();
+            act_3();
         }
-        const default_action = act_0();
+        const default_action = act_3();
     }
     @hidden table tbl_act_0 {
         actions = {
@@ -741,9 +789,27 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     }
     @hidden table tbl_act_1 {
         actions = {
-            act_3();
+            act_0();
         }
-        const default_action = act_3();
+        const default_action = act_0();
+    }
+    @hidden table tbl_spgw149 {
+        actions = {
+            spgw149();
+        }
+        const default_action = spgw149();
+    }
+    @hidden table tbl_spgw151 {
+        actions = {
+            spgw151();
+        }
+        const default_action = spgw151();
+    }
+    @hidden table tbl_spgw_ingress_gtpu_decap {
+        actions = {
+            spgw_ingress_gtpu_decap_0();
+        }
+        const default_action = spgw_ingress_gtpu_decap_0();
     }
     @hidden table tbl_act_2 {
         actions = {
@@ -757,153 +823,87 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         }
         const default_action = act_2();
     }
-    @hidden table tbl_act_4 {
+    @hidden table tbl_spgw154 {
         actions = {
-            act_4();
+            spgw154();
         }
-        const default_action = act_4();
+        const default_action = spgw154();
     }
-    @hidden table tbl_act_5 {
+    @hidden table tbl_spgw156 {
         actions = {
-            act_5();
+            spgw156();
         }
-        const default_action = act_5();
+        const default_action = spgw156();
     }
-    @hidden table tbl_act_6 {
+    @hidden table tbl_spgw175 {
         actions = {
-            act_6();
+            spgw175();
         }
-        const default_action = act_6();
+        const default_action = spgw175();
     }
-    @hidden table tbl_act_7 {
+    @hidden table tbl_port_counter31 {
         actions = {
-            act_15();
+            port_counter31();
         }
-        const default_action = act_15();
+        const default_action = port_counter31();
     }
-    @hidden table tbl_act_8 {
+    @hidden table tbl_port_counter34 {
         actions = {
-            act_7();
+            port_counter34();
         }
-        const default_action = act_7();
-    }
-    @hidden table tbl_act_9 {
-        actions = {
-            act_8();
-        }
-        const default_action = act_8();
-    }
-    @hidden table tbl_act_10 {
-        actions = {
-            act_9();
-        }
-        const default_action = act_9();
-    }
-    @hidden table tbl_act_11 {
-        actions = {
-            act_10();
-        }
-        const default_action = act_10();
-    }
-    @hidden table tbl_spgw_ingress_gtpu_decap {
-        actions = {
-            spgw_ingress_gtpu_decap_0();
-        }
-        const default_action = spgw_ingress_gtpu_decap_0();
-    }
-    @hidden table tbl_act_12 {
-        actions = {
-            act_11();
-        }
-        const default_action = act_11();
-    }
-    @hidden table tbl_act_13 {
-        actions = {
-            act_12();
-        }
-        const default_action = act_12();
-    }
-    @hidden table tbl_act_14 {
-        actions = {
-            act_13();
-        }
-        const default_action = act_13();
-    }
-    @hidden table tbl_act_15 {
-        actions = {
-            act_14();
-        }
-        const default_action = act_14();
-    }
-    @hidden table tbl_act_16 {
-        actions = {
-            act_16();
-        }
-        const default_action = act_16();
-    }
-    @hidden table tbl_act_17 {
-        actions = {
-            act_17();
-        }
-        const default_action = act_17();
-    }
-    @hidden table tbl_act_18 {
-        actions = {
-            act_18();
-        }
-        const default_action = act_18();
+        const default_action = port_counter34();
     }
     apply {
-        tbl_act.apply();
+        tbl_fabric78.apply();
         if (!hdr.gtpu.isValid()) {
-            tbl_act_0.apply();
+            tbl_spgw30.apply();
         }
         if (!spgw_normalizer_hasReturned) {
-            tbl_act_1.apply();
+            tbl_spgw31.apply();
             if (hdr.inner_udp.isValid()) {
-                tbl_act_2.apply();
+                tbl_spgw35.apply();
             } else {
-                tbl_act_3.apply();
+                tbl_spgw37.apply();
             }
         }
         if (hdr.packet_out.isValid()) {
-            tbl_act_4.apply();
+            tbl_packetio25.apply();
         }
         if (!hasExited) {
             if (hdr.vlan_tag.isValid()) {
-                tbl_act_5.apply();
+                tbl_filtering105.apply();
             }
             if (!hdr.mpls.isValid()) {
-                tbl_act_6.apply();
+                tbl_filtering115.apply();
             }
             filtering_ingress_port_vlan.apply();
             filtering_fwd_classifier.apply();
-            tbl_act_7.apply();
+            tbl_act.apply();
             if (hdr.gtpu.isValid()) {
                 if (spgw_ingress_s1u_filter_table.apply().hit) {
-                    tbl_act_8.apply();
+                    tbl_act_0.apply();
                 } else {
-                    tbl_act_9.apply();
+                    tbl_act_1.apply();
                 }
                 if (!spgw_ingress_tmp) {
-                    tbl_act_10.apply();
+                    tbl_spgw149.apply();
                 }
-                tbl_act_11.apply();
+                tbl_spgw151.apply();
                 tbl_spgw_ingress_gtpu_decap.apply();
             } else {
                 if (spgw_ingress_dl_sess_lookup.apply().hit) {
-                    tbl_act_12.apply();
+                    tbl_act_2.apply();
                 } else {
-                    tbl_act_13.apply();
+                    tbl_act_3.apply();
                 }
                 if (spgw_ingress_tmp_0) {
-                    tbl_act_14.apply();
+                    tbl_spgw154.apply();
                 } else {
-                    tbl_act_15.apply();
+                    tbl_spgw156.apply();
                 }
             }
             if (!spgw_ingress_hasReturned) {
-                tbl_act_16.apply();
+                tbl_spgw175.apply();
             }
             if (fabric_metadata._skip_forwarding7 == false) {
                 if (fabric_metadata._fwd_type9 == 3w0) {
@@ -921,10 +921,10 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
                 next_multicast.apply();
                 next_next_vlan.apply();
                 if (standard_metadata.egress_spec < 9w511) {
-                    tbl_act_17.apply();
+                    tbl_port_counter31.apply();
                 }
                 if (standard_metadata.ingress_port < 9w511) {
-                    tbl_act_18.apply();
+                    tbl_port_counter34.apply();
                 }
             }
         }
@@ -1006,70 +1006,70 @@ control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_
         counters = egress_next_egress_vlan_counter;
         size = 1024;
     }
-    @hidden action act_19() {
+    @hidden action packetio41() {
         hasExited_0 = true;
     }
-    @hidden action act_20() {
+    @hidden action act_4() {
         hasExited_0 = false;
     }
-    @hidden action act_21() {
+    @hidden action packetio47() {
         mark_to_drop(standard_metadata);
     }
-    @hidden action act_22() {
+    @hidden action packetio49() {
         hdr.packet_in.setValid();
         hdr.packet_in.ingress_port = standard_metadata.ingress_port;
         hasExited_0 = true;
     }
-    @hidden action act_23() {
+    @hidden action next308() {
         mark_to_drop(standard_metadata);
     }
-    @hidden action act_24() {
+    @hidden action act_5() {
         egress_next_tmp = true;
     }
-    @hidden action act_25() {
+    @hidden action act_6() {
         egress_next_tmp = false;
     }
-    @hidden action act_26() {
+    @hidden action next327() {
         mark_to_drop(standard_metadata);
     }
-    @hidden action act_27() {
+    @hidden action next326() {
         hdr.mpls.ttl = hdr.mpls.ttl + 8w255;
     }
-    @hidden action act_28() {
+    @hidden action next331() {
         mark_to_drop(standard_metadata);
     }
-    @hidden action act_29() {
+    @hidden action next330() {
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @hidden table tbl_act_19 {
+    @hidden table tbl_act_4 {
         actions = {
-            act_20();
+            act_4();
         }
-        const default_action = act_20();
+        const default_action = act_4();
     }
-    @hidden table tbl_act_20 {
+    @hidden table tbl_packetio41 {
         actions = {
-            act_19();
+            packetio41();
         }
-        const default_action = act_19();
+        const default_action = packetio41();
     }
-    @hidden table tbl_act_21 {
+    @hidden table tbl_packetio47 {
         actions = {
-            act_21();
+            packetio47();
         }
-        const default_action = act_21();
+        const default_action = packetio47();
     }
-    @hidden table tbl_act_22 {
+    @hidden table tbl_packetio49 {
         actions = {
-            act_22();
+            packetio49();
         }
-        const default_action = act_22();
+        const default_action = packetio49();
     }
-    @hidden table tbl_act_23 {
+    @hidden table tbl_next308 {
         actions = {
-            act_23();
+            next308();
         }
-        const default_action = act_23();
+        const default_action = next308();
     }
     @hidden table tbl_egress_next_pop_mpls_if_present {
         actions = {
@@ -1083,17 +1083,17 @@ control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_
         }
         const default_action = egress_next_set_mpls_0();
     }
-    @hidden table tbl_act_24 {
+    @hidden table tbl_act_5 {
         actions = {
-            act_24();
+            act_5();
         }
-        const default_action = act_24();
+        const default_action = act_5();
     }
-    @hidden table tbl_act_25 {
+    @hidden table tbl_act_6 {
         actions = {
-            act_25();
+            act_6();
         }
-        const default_action = act_25();
+        const default_action = act_6();
     }
     @hidden table tbl_egress_next_push_vlan {
         actions = {
@@ -1101,29 +1101,29 @@ control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_
         }
         const default_action = egress_next_push_vlan_0();
     }
-    @hidden table tbl_act_26 {
+    @hidden table tbl_next326 {
         actions = {
-            act_27();
+            next326();
         }
-        const default_action = act_27();
+        const default_action = next326();
     }
-    @hidden table tbl_act_27 {
+    @hidden table tbl_next327 {
         actions = {
-            act_26();
+            next327();
         }
-        const default_action = act_26();
+        const default_action = next327();
     }
-    @hidden table tbl_act_28 {
+    @hidden table tbl_next330 {
         actions = {
-            act_29();
+            next330();
         }
-        const default_action = act_29();
+        const default_action = next330();
     }
-    @hidden table tbl_act_29 {
+    @hidden table tbl_next331 {
         actions = {
-            act_28();
+            next331();
         }
-        const default_action = act_28();
+        const default_action = next331();
     }
     @hidden table tbl_spgw_egress_gtpu_encap {
         actions = {
@@ -1132,21 +1132,21 @@ control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_
         const default_action = spgw_egress_gtpu_encap_0();
     }
     apply {
-        tbl_act_19.apply();
+        tbl_act_4.apply();
         if (fabric_metadata._is_controller_packet_out12 == true) {
-            tbl_act_20.apply();
+            tbl_packetio41.apply();
         }
         if (!hasExited_0) {
             if (standard_metadata.egress_port == 9w255) {
                 if (fabric_metadata._is_multicast11 == true && fabric_metadata._clone_to_cpu13 == false) {
-                    tbl_act_21.apply();
+                    tbl_packetio47.apply();
                 }
-                tbl_act_22.apply();
+                tbl_packetio49.apply();
             }
         }
         if (!hasExited_0) {
             if (fabric_metadata._is_multicast11 == true && standard_metadata.ingress_port == standard_metadata.egress_port) {
-                tbl_act_23.apply();
+                tbl_next308.apply();
             }
             if (fabric_metadata._mpls_label5 == 20w0) {
                 if (hdr.mpls.isValid()) {
@@ -1156,9 +1156,9 @@ control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_
                 tbl_egress_next_set_mpls.apply();
             }
             if (egress_next_egress_vlan.apply().hit) {
-                tbl_act_24.apply();
+                tbl_act_5.apply();
             } else {
-                tbl_act_25.apply();
+                tbl_act_6.apply();
             }
             if (!egress_next_tmp) {
                 if (fabric_metadata._vlan_id2 != 12w4094) {
@@ -1166,14 +1166,14 @@ control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_
                 }
             }
             if (hdr.mpls.isValid()) {
-                tbl_act_26.apply();
+                tbl_next326.apply();
                 if (hdr.mpls.ttl == 8w0) {
-                    tbl_act_27.apply();
+                    tbl_next327.apply();
                 }
             } else if (hdr.ipv4.isValid()) {
-                tbl_act_28.apply();
+                tbl_next330.apply();
                 if (hdr.ipv4.ttl == 8w0) {
-                    tbl_act_29.apply();
+                    tbl_next331.apply();
                 }
             }
             if (fabric_metadata._spgw_direction17 == 2w2) {

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-midend.p4
@@ -77,14 +77,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1024;
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action flag_lostbmv2l86() {
         meta.test_bool = false;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_flag_lostbmv2l86 {
         actions = {
-            act();
+            flag_lostbmv2l86();
         }
-        const default_action = act();
+        const default_action = flag_lostbmv2l86();
     }
     @hidden table tbl_drop {
         actions = {
@@ -93,7 +93,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         const default_action = drop_2();
     }
     apply {
-        tbl_act.apply();
+        tbl_flag_lostbmv2l86.apply();
         if (hdr.ipv4.isValid()) {
             ipv4_lpm_0.apply();
         }

--- a/testdata/p4_16_samples_outputs/function-midend.p4
+++ b/testdata/p4_16_samples_outputs/function-midend.p4
@@ -1,40 +1,40 @@
 control c(out bit<16> b) {
     bool hasReturned;
     bit<16> retval;
-    @hidden action act() {
+    @hidden action function4() {
         hasReturned = true;
         retval = 16w12;
     }
-    @hidden action act_0() {
+    @hidden action act() {
         hasReturned = false;
     }
-    @hidden action act_1() {
+    @hidden action function9() {
         b = retval;
     }
     @hidden table tbl_act {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
-    @hidden table tbl_act_0 {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_function4 {
         actions = {
-            act_1();
+            function4();
         }
-        const default_action = act_1();
+        const default_action = function4();
+    }
+    @hidden table tbl_function9 {
+        actions = {
+            function9();
+        }
+        const default_action = function9();
     }
     apply {
         tbl_act.apply();
         if (!hasReturned) {
-            tbl_act_0.apply();
+            tbl_function4.apply();
         }
-        tbl_act_1.apply();
+        tbl_function9.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/generic1-midend.p4
+++ b/testdata/p4_16_samples_outputs/generic1-midend.p4
@@ -8,19 +8,19 @@ extern void f<T>(in T arg);
 control caller() {
     bit<5> cinst_tmp_0;
     @name("caller.cinst.x") Generic<bit<8>>(8w9) cinst_x;
-    @hidden action act() {
+    @hidden action generic1l28() {
         cinst_x.get<bit<32>>();
         cinst_tmp_0 = cinst_x.get1<bit<5>, bit<10>>(10w0, 5w0);
         f<bit<5>>(cinst_tmp_0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_generic1l28 {
         actions = {
-            act();
+            generic1l28();
         }
-        const default_action = act();
+        const default_action = generic1l28();
     }
     apply {
-        tbl_act.apply();
+        tbl_generic1l28.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/header-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2-midend.p4
@@ -41,18 +41,18 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action headerbmv2l28() {
         h.h.f = h.h.f + 32w1;
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_headerbmv2l28 {
         actions = {
-            act();
+            headerbmv2l28();
         }
-        const default_action = act();
+        const default_action = headerbmv2l28();
     }
     apply {
-        tbl_act.apply();
+        tbl_headerbmv2l28.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/header-bool-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/header-bool-bmv2-midend.p4
@@ -52,17 +52,17 @@ control update(inout Headers h, inout Meta m) {
 }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action headerboolbmv2l67() {
         h.u.h1.x = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_headerboolbmv2l67 {
         actions = {
-            act();
+            headerboolbmv2l67();
         }
-        const default_action = act();
+        const default_action = headerboolbmv2l67();
     }
     apply {
-        tbl_act.apply();
+        tbl_headerboolbmv2l67.apply();
     }
 }
 
@@ -75,18 +75,18 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act_0() {
+    @hidden action headerboolbmv2l81() {
         h.u.h2.setInvalid();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_headerboolbmv2l81 {
         actions = {
-            act_0();
+            headerboolbmv2l81();
         }
-        const default_action = act_0();
+        const default_action = headerboolbmv2l81();
     }
     apply {
         if (h.u.h2.isValid()) {
-            tbl_act_0.apply();
+            tbl_headerboolbmv2l81.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/header-stack-ops-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/header-stack-ops-bmv2-midend.p4
@@ -62,741 +62,741 @@ parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standa
 
 control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
     h2_t[5] hdr_0_h2;
-    @hidden action act() {
+    @hidden action headerstackopsbmv2l94() {
         hdr_0_h2.push_front(1);
     }
-    @hidden action act_0() {
+    @hidden action headerstackopsbmv2l96() {
         hdr_0_h2.push_front(2);
     }
-    @hidden action act_1() {
+    @hidden action headerstackopsbmv2l98() {
         hdr_0_h2.push_front(3);
     }
-    @hidden action act_2() {
+    @hidden action headerstackopsbmv2l100() {
         hdr_0_h2.push_front(4);
     }
-    @hidden action act_3() {
+    @hidden action headerstackopsbmv2l102() {
         hdr_0_h2.push_front(5);
     }
-    @hidden action act_4() {
+    @hidden action headerstackopsbmv2l104() {
         hdr_0_h2.push_front(6);
     }
-    @hidden action act_5() {
+    @hidden action headerstackopsbmv2l109() {
         hdr_0_h2.pop_front(1);
     }
-    @hidden action act_6() {
+    @hidden action headerstackopsbmv2l111() {
         hdr_0_h2.pop_front(2);
     }
-    @hidden action act_7() {
+    @hidden action headerstackopsbmv2l113() {
         hdr_0_h2.pop_front(3);
     }
-    @hidden action act_8() {
+    @hidden action headerstackopsbmv2l115() {
         hdr_0_h2.pop_front(4);
     }
-    @hidden action act_9() {
+    @hidden action headerstackopsbmv2l117() {
         hdr_0_h2.pop_front(5);
     }
-    @hidden action act_10() {
+    @hidden action headerstackopsbmv2l119() {
         hdr_0_h2.pop_front(6);
     }
-    @hidden action act_11() {
+    @hidden action headerstackopsbmv2l124() {
         hdr_0_h2[0].setValid();
         hdr_0_h2[0].hdr_type = 8w2;
         hdr_0_h2[0].f1 = 8w0xa0;
         hdr_0_h2[0].f2 = 8w0xa;
         hdr_0_h2[0].next_hdr_type = 8w9;
     }
-    @hidden action act_12() {
+    @hidden action headerstackopsbmv2l130() {
         hdr_0_h2[1].setValid();
         hdr_0_h2[1].hdr_type = 8w2;
         hdr_0_h2[1].f1 = 8w0xa1;
         hdr_0_h2[1].f2 = 8w0x1a;
         hdr_0_h2[1].next_hdr_type = 8w9;
     }
-    @hidden action act_13() {
+    @hidden action headerstackopsbmv2l136() {
         hdr_0_h2[2].setValid();
         hdr_0_h2[2].hdr_type = 8w2;
         hdr_0_h2[2].f1 = 8w0xa2;
         hdr_0_h2[2].f2 = 8w0x2a;
         hdr_0_h2[2].next_hdr_type = 8w9;
     }
-    @hidden action act_14() {
+    @hidden action headerstackopsbmv2l142() {
         hdr_0_h2[3].setValid();
         hdr_0_h2[3].hdr_type = 8w2;
         hdr_0_h2[3].f1 = 8w0xa3;
         hdr_0_h2[3].f2 = 8w0x3a;
         hdr_0_h2[3].next_hdr_type = 8w9;
     }
-    @hidden action act_15() {
+    @hidden action headerstackopsbmv2l148() {
         hdr_0_h2[4].setValid();
         hdr_0_h2[4].hdr_type = 8w2;
         hdr_0_h2[4].f1 = 8w0xa4;
         hdr_0_h2[4].f2 = 8w0x4a;
         hdr_0_h2[4].next_hdr_type = 8w9;
     }
-    @hidden action act_16() {
+    @hidden action headerstackopsbmv2l157() {
         hdr_0_h2[0].setInvalid();
     }
-    @hidden action act_17() {
+    @hidden action headerstackopsbmv2l159() {
         hdr_0_h2[1].setInvalid();
     }
-    @hidden action act_18() {
+    @hidden action headerstackopsbmv2l161() {
         hdr_0_h2[2].setInvalid();
     }
-    @hidden action act_19() {
+    @hidden action headerstackopsbmv2l163() {
         hdr_0_h2[3].setInvalid();
     }
-    @hidden action act_20() {
+    @hidden action headerstackopsbmv2l165() {
         hdr_0_h2[4].setInvalid();
     }
-    @hidden action act_21() {
+    @hidden action act() {
         hdr_0_h2 = hdr.h2;
     }
-    @hidden action act_22() {
+    @hidden action headerstackopsbmv2l94_0() {
         hdr_0_h2.push_front(1);
     }
-    @hidden action act_23() {
+    @hidden action headerstackopsbmv2l96_0() {
         hdr_0_h2.push_front(2);
     }
-    @hidden action act_24() {
+    @hidden action headerstackopsbmv2l98_0() {
         hdr_0_h2.push_front(3);
     }
-    @hidden action act_25() {
+    @hidden action headerstackopsbmv2l100_0() {
         hdr_0_h2.push_front(4);
     }
-    @hidden action act_26() {
+    @hidden action headerstackopsbmv2l102_0() {
         hdr_0_h2.push_front(5);
     }
-    @hidden action act_27() {
+    @hidden action headerstackopsbmv2l104_0() {
         hdr_0_h2.push_front(6);
     }
-    @hidden action act_28() {
+    @hidden action headerstackopsbmv2l109_0() {
         hdr_0_h2.pop_front(1);
     }
-    @hidden action act_29() {
+    @hidden action headerstackopsbmv2l111_0() {
         hdr_0_h2.pop_front(2);
     }
-    @hidden action act_30() {
+    @hidden action headerstackopsbmv2l113_0() {
         hdr_0_h2.pop_front(3);
     }
-    @hidden action act_31() {
+    @hidden action headerstackopsbmv2l115_0() {
         hdr_0_h2.pop_front(4);
     }
-    @hidden action act_32() {
+    @hidden action headerstackopsbmv2l117_0() {
         hdr_0_h2.pop_front(5);
     }
-    @hidden action act_33() {
+    @hidden action headerstackopsbmv2l119_0() {
         hdr_0_h2.pop_front(6);
     }
-    @hidden action act_34() {
+    @hidden action headerstackopsbmv2l124_0() {
         hdr_0_h2[0].setValid();
         hdr_0_h2[0].hdr_type = 8w2;
         hdr_0_h2[0].f1 = 8w0xa0;
         hdr_0_h2[0].f2 = 8w0xa;
         hdr_0_h2[0].next_hdr_type = 8w9;
     }
-    @hidden action act_35() {
+    @hidden action headerstackopsbmv2l130_0() {
         hdr_0_h2[1].setValid();
         hdr_0_h2[1].hdr_type = 8w2;
         hdr_0_h2[1].f1 = 8w0xa1;
         hdr_0_h2[1].f2 = 8w0x1a;
         hdr_0_h2[1].next_hdr_type = 8w9;
     }
-    @hidden action act_36() {
+    @hidden action headerstackopsbmv2l136_0() {
         hdr_0_h2[2].setValid();
         hdr_0_h2[2].hdr_type = 8w2;
         hdr_0_h2[2].f1 = 8w0xa2;
         hdr_0_h2[2].f2 = 8w0x2a;
         hdr_0_h2[2].next_hdr_type = 8w9;
     }
-    @hidden action act_37() {
+    @hidden action headerstackopsbmv2l142_0() {
         hdr_0_h2[3].setValid();
         hdr_0_h2[3].hdr_type = 8w2;
         hdr_0_h2[3].f1 = 8w0xa3;
         hdr_0_h2[3].f2 = 8w0x3a;
         hdr_0_h2[3].next_hdr_type = 8w9;
     }
-    @hidden action act_38() {
+    @hidden action headerstackopsbmv2l148_0() {
         hdr_0_h2[4].setValid();
         hdr_0_h2[4].hdr_type = 8w2;
         hdr_0_h2[4].f1 = 8w0xa4;
         hdr_0_h2[4].f2 = 8w0x4a;
         hdr_0_h2[4].next_hdr_type = 8w9;
     }
-    @hidden action act_39() {
+    @hidden action headerstackopsbmv2l157_0() {
         hdr_0_h2[0].setInvalid();
     }
-    @hidden action act_40() {
+    @hidden action headerstackopsbmv2l159_0() {
         hdr_0_h2[1].setInvalid();
     }
-    @hidden action act_41() {
+    @hidden action headerstackopsbmv2l161_0() {
         hdr_0_h2[2].setInvalid();
     }
-    @hidden action act_42() {
+    @hidden action headerstackopsbmv2l163_0() {
         hdr_0_h2[3].setInvalid();
     }
-    @hidden action act_43() {
+    @hidden action headerstackopsbmv2l165_0() {
         hdr_0_h2[4].setInvalid();
     }
-    @hidden action act_44() {
+    @hidden action act_0() {
         hdr.h2 = hdr_0_h2;
     }
-    @hidden action act_45() {
+    @hidden action headerstackopsbmv2l94_1() {
         hdr_0_h2.push_front(1);
     }
-    @hidden action act_46() {
+    @hidden action headerstackopsbmv2l96_1() {
         hdr_0_h2.push_front(2);
     }
-    @hidden action act_47() {
+    @hidden action headerstackopsbmv2l98_1() {
         hdr_0_h2.push_front(3);
     }
-    @hidden action act_48() {
+    @hidden action headerstackopsbmv2l100_1() {
         hdr_0_h2.push_front(4);
     }
-    @hidden action act_49() {
+    @hidden action headerstackopsbmv2l102_1() {
         hdr_0_h2.push_front(5);
     }
-    @hidden action act_50() {
+    @hidden action headerstackopsbmv2l104_1() {
         hdr_0_h2.push_front(6);
     }
-    @hidden action act_51() {
+    @hidden action headerstackopsbmv2l109_1() {
         hdr_0_h2.pop_front(1);
     }
-    @hidden action act_52() {
+    @hidden action headerstackopsbmv2l111_1() {
         hdr_0_h2.pop_front(2);
     }
-    @hidden action act_53() {
+    @hidden action headerstackopsbmv2l113_1() {
         hdr_0_h2.pop_front(3);
     }
-    @hidden action act_54() {
+    @hidden action headerstackopsbmv2l115_1() {
         hdr_0_h2.pop_front(4);
     }
-    @hidden action act_55() {
+    @hidden action headerstackopsbmv2l117_1() {
         hdr_0_h2.pop_front(5);
     }
-    @hidden action act_56() {
+    @hidden action headerstackopsbmv2l119_1() {
         hdr_0_h2.pop_front(6);
     }
-    @hidden action act_57() {
+    @hidden action headerstackopsbmv2l124_1() {
         hdr_0_h2[0].setValid();
         hdr_0_h2[0].hdr_type = 8w2;
         hdr_0_h2[0].f1 = 8w0xa0;
         hdr_0_h2[0].f2 = 8w0xa;
         hdr_0_h2[0].next_hdr_type = 8w9;
     }
-    @hidden action act_58() {
+    @hidden action headerstackopsbmv2l130_1() {
         hdr_0_h2[1].setValid();
         hdr_0_h2[1].hdr_type = 8w2;
         hdr_0_h2[1].f1 = 8w0xa1;
         hdr_0_h2[1].f2 = 8w0x1a;
         hdr_0_h2[1].next_hdr_type = 8w9;
     }
-    @hidden action act_59() {
+    @hidden action headerstackopsbmv2l136_1() {
         hdr_0_h2[2].setValid();
         hdr_0_h2[2].hdr_type = 8w2;
         hdr_0_h2[2].f1 = 8w0xa2;
         hdr_0_h2[2].f2 = 8w0x2a;
         hdr_0_h2[2].next_hdr_type = 8w9;
     }
-    @hidden action act_60() {
+    @hidden action headerstackopsbmv2l142_1() {
         hdr_0_h2[3].setValid();
         hdr_0_h2[3].hdr_type = 8w2;
         hdr_0_h2[3].f1 = 8w0xa3;
         hdr_0_h2[3].f2 = 8w0x3a;
         hdr_0_h2[3].next_hdr_type = 8w9;
     }
-    @hidden action act_61() {
+    @hidden action headerstackopsbmv2l148_1() {
         hdr_0_h2[4].setValid();
         hdr_0_h2[4].hdr_type = 8w2;
         hdr_0_h2[4].f1 = 8w0xa4;
         hdr_0_h2[4].f2 = 8w0x4a;
         hdr_0_h2[4].next_hdr_type = 8w9;
     }
-    @hidden action act_62() {
+    @hidden action headerstackopsbmv2l157_1() {
         hdr_0_h2[0].setInvalid();
     }
-    @hidden action act_63() {
+    @hidden action headerstackopsbmv2l159_1() {
         hdr_0_h2[1].setInvalid();
     }
-    @hidden action act_64() {
+    @hidden action headerstackopsbmv2l161_1() {
         hdr_0_h2[2].setInvalid();
     }
-    @hidden action act_65() {
+    @hidden action headerstackopsbmv2l163_1() {
         hdr_0_h2[3].setInvalid();
     }
-    @hidden action act_66() {
+    @hidden action headerstackopsbmv2l165_1() {
         hdr_0_h2[4].setInvalid();
     }
-    @hidden action act_67() {
+    @hidden action act_1() {
         hdr.h2 = hdr_0_h2;
     }
-    @hidden action act_68() {
+    @hidden action headerstackopsbmv2l186() {
         hdr.h1.h2_valid_bits[0:0] = 1w1;
     }
-    @hidden action act_69() {
+    @hidden action headerstackopsbmv2l184() {
         hdr.h2 = hdr_0_h2;
         hdr.h1.h2_valid_bits = 8w0;
     }
-    @hidden action act_70() {
+    @hidden action headerstackopsbmv2l189() {
         hdr.h1.h2_valid_bits[1:1] = 1w1;
     }
-    @hidden action act_71() {
+    @hidden action headerstackopsbmv2l192() {
         hdr.h1.h2_valid_bits[2:2] = 1w1;
     }
-    @hidden action act_72() {
+    @hidden action headerstackopsbmv2l195() {
         hdr.h1.h2_valid_bits[3:3] = 1w1;
     }
-    @hidden action act_73() {
+    @hidden action headerstackopsbmv2l198() {
         hdr.h1.h2_valid_bits[4:4] = 1w1;
     }
     @hidden table tbl_act {
-        actions = {
-            act_21();
-        }
-        const default_action = act_21();
-    }
-    @hidden table tbl_act_0 {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_headerstackopsbmv2l94 {
+        actions = {
+            headerstackopsbmv2l94();
+        }
+        const default_action = headerstackopsbmv2l94();
+    }
+    @hidden table tbl_headerstackopsbmv2l96 {
+        actions = {
+            headerstackopsbmv2l96();
+        }
+        const default_action = headerstackopsbmv2l96();
+    }
+    @hidden table tbl_headerstackopsbmv2l98 {
+        actions = {
+            headerstackopsbmv2l98();
+        }
+        const default_action = headerstackopsbmv2l98();
+    }
+    @hidden table tbl_headerstackopsbmv2l100 {
+        actions = {
+            headerstackopsbmv2l100();
+        }
+        const default_action = headerstackopsbmv2l100();
+    }
+    @hidden table tbl_headerstackopsbmv2l102 {
+        actions = {
+            headerstackopsbmv2l102();
+        }
+        const default_action = headerstackopsbmv2l102();
+    }
+    @hidden table tbl_headerstackopsbmv2l104 {
+        actions = {
+            headerstackopsbmv2l104();
+        }
+        const default_action = headerstackopsbmv2l104();
+    }
+    @hidden table tbl_headerstackopsbmv2l109 {
+        actions = {
+            headerstackopsbmv2l109();
+        }
+        const default_action = headerstackopsbmv2l109();
+    }
+    @hidden table tbl_headerstackopsbmv2l111 {
+        actions = {
+            headerstackopsbmv2l111();
+        }
+        const default_action = headerstackopsbmv2l111();
+    }
+    @hidden table tbl_headerstackopsbmv2l113 {
+        actions = {
+            headerstackopsbmv2l113();
+        }
+        const default_action = headerstackopsbmv2l113();
+    }
+    @hidden table tbl_headerstackopsbmv2l115 {
+        actions = {
+            headerstackopsbmv2l115();
+        }
+        const default_action = headerstackopsbmv2l115();
+    }
+    @hidden table tbl_headerstackopsbmv2l117 {
+        actions = {
+            headerstackopsbmv2l117();
+        }
+        const default_action = headerstackopsbmv2l117();
+    }
+    @hidden table tbl_headerstackopsbmv2l119 {
+        actions = {
+            headerstackopsbmv2l119();
+        }
+        const default_action = headerstackopsbmv2l119();
+    }
+    @hidden table tbl_headerstackopsbmv2l124 {
+        actions = {
+            headerstackopsbmv2l124();
+        }
+        const default_action = headerstackopsbmv2l124();
+    }
+    @hidden table tbl_headerstackopsbmv2l130 {
+        actions = {
+            headerstackopsbmv2l130();
+        }
+        const default_action = headerstackopsbmv2l130();
+    }
+    @hidden table tbl_headerstackopsbmv2l136 {
+        actions = {
+            headerstackopsbmv2l136();
+        }
+        const default_action = headerstackopsbmv2l136();
+    }
+    @hidden table tbl_headerstackopsbmv2l142 {
+        actions = {
+            headerstackopsbmv2l142();
+        }
+        const default_action = headerstackopsbmv2l142();
+    }
+    @hidden table tbl_headerstackopsbmv2l148 {
+        actions = {
+            headerstackopsbmv2l148();
+        }
+        const default_action = headerstackopsbmv2l148();
+    }
+    @hidden table tbl_headerstackopsbmv2l157 {
+        actions = {
+            headerstackopsbmv2l157();
+        }
+        const default_action = headerstackopsbmv2l157();
+    }
+    @hidden table tbl_headerstackopsbmv2l159 {
+        actions = {
+            headerstackopsbmv2l159();
+        }
+        const default_action = headerstackopsbmv2l159();
+    }
+    @hidden table tbl_headerstackopsbmv2l161 {
+        actions = {
+            headerstackopsbmv2l161();
+        }
+        const default_action = headerstackopsbmv2l161();
+    }
+    @hidden table tbl_headerstackopsbmv2l163 {
+        actions = {
+            headerstackopsbmv2l163();
+        }
+        const default_action = headerstackopsbmv2l163();
+    }
+    @hidden table tbl_headerstackopsbmv2l165 {
+        actions = {
+            headerstackopsbmv2l165();
+        }
+        const default_action = headerstackopsbmv2l165();
+    }
+    @hidden table tbl_act_0 {
         actions = {
             act_0();
         }
         const default_action = act_0();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_headerstackopsbmv2l94_0 {
+        actions = {
+            headerstackopsbmv2l94_0();
+        }
+        const default_action = headerstackopsbmv2l94_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l96_0 {
+        actions = {
+            headerstackopsbmv2l96_0();
+        }
+        const default_action = headerstackopsbmv2l96_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l98_0 {
+        actions = {
+            headerstackopsbmv2l98_0();
+        }
+        const default_action = headerstackopsbmv2l98_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l100_0 {
+        actions = {
+            headerstackopsbmv2l100_0();
+        }
+        const default_action = headerstackopsbmv2l100_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l102_0 {
+        actions = {
+            headerstackopsbmv2l102_0();
+        }
+        const default_action = headerstackopsbmv2l102_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l104_0 {
+        actions = {
+            headerstackopsbmv2l104_0();
+        }
+        const default_action = headerstackopsbmv2l104_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l109_0 {
+        actions = {
+            headerstackopsbmv2l109_0();
+        }
+        const default_action = headerstackopsbmv2l109_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l111_0 {
+        actions = {
+            headerstackopsbmv2l111_0();
+        }
+        const default_action = headerstackopsbmv2l111_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l113_0 {
+        actions = {
+            headerstackopsbmv2l113_0();
+        }
+        const default_action = headerstackopsbmv2l113_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l115_0 {
+        actions = {
+            headerstackopsbmv2l115_0();
+        }
+        const default_action = headerstackopsbmv2l115_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l117_0 {
+        actions = {
+            headerstackopsbmv2l117_0();
+        }
+        const default_action = headerstackopsbmv2l117_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l119_0 {
+        actions = {
+            headerstackopsbmv2l119_0();
+        }
+        const default_action = headerstackopsbmv2l119_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l124_0 {
+        actions = {
+            headerstackopsbmv2l124_0();
+        }
+        const default_action = headerstackopsbmv2l124_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l130_0 {
+        actions = {
+            headerstackopsbmv2l130_0();
+        }
+        const default_action = headerstackopsbmv2l130_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l136_0 {
+        actions = {
+            headerstackopsbmv2l136_0();
+        }
+        const default_action = headerstackopsbmv2l136_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l142_0 {
+        actions = {
+            headerstackopsbmv2l142_0();
+        }
+        const default_action = headerstackopsbmv2l142_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l148_0 {
+        actions = {
+            headerstackopsbmv2l148_0();
+        }
+        const default_action = headerstackopsbmv2l148_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l157_0 {
+        actions = {
+            headerstackopsbmv2l157_0();
+        }
+        const default_action = headerstackopsbmv2l157_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l159_0 {
+        actions = {
+            headerstackopsbmv2l159_0();
+        }
+        const default_action = headerstackopsbmv2l159_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l161_0 {
+        actions = {
+            headerstackopsbmv2l161_0();
+        }
+        const default_action = headerstackopsbmv2l161_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l163_0 {
+        actions = {
+            headerstackopsbmv2l163_0();
+        }
+        const default_action = headerstackopsbmv2l163_0();
+    }
+    @hidden table tbl_headerstackopsbmv2l165_0 {
+        actions = {
+            headerstackopsbmv2l165_0();
+        }
+        const default_action = headerstackopsbmv2l165_0();
+    }
+    @hidden table tbl_act_1 {
         actions = {
             act_1();
         }
         const default_action = act_1();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_headerstackopsbmv2l94_1 {
         actions = {
-            act_2();
+            headerstackopsbmv2l94_1();
         }
-        const default_action = act_2();
+        const default_action = headerstackopsbmv2l94_1();
     }
-    @hidden table tbl_act_4 {
+    @hidden table tbl_headerstackopsbmv2l96_1 {
         actions = {
-            act_3();
+            headerstackopsbmv2l96_1();
         }
-        const default_action = act_3();
+        const default_action = headerstackopsbmv2l96_1();
     }
-    @hidden table tbl_act_5 {
+    @hidden table tbl_headerstackopsbmv2l98_1 {
         actions = {
-            act_4();
+            headerstackopsbmv2l98_1();
         }
-        const default_action = act_4();
+        const default_action = headerstackopsbmv2l98_1();
     }
-    @hidden table tbl_act_6 {
+    @hidden table tbl_headerstackopsbmv2l100_1 {
         actions = {
-            act_5();
+            headerstackopsbmv2l100_1();
         }
-        const default_action = act_5();
+        const default_action = headerstackopsbmv2l100_1();
     }
-    @hidden table tbl_act_7 {
+    @hidden table tbl_headerstackopsbmv2l102_1 {
         actions = {
-            act_6();
+            headerstackopsbmv2l102_1();
         }
-        const default_action = act_6();
+        const default_action = headerstackopsbmv2l102_1();
     }
-    @hidden table tbl_act_8 {
+    @hidden table tbl_headerstackopsbmv2l104_1 {
         actions = {
-            act_7();
+            headerstackopsbmv2l104_1();
         }
-        const default_action = act_7();
+        const default_action = headerstackopsbmv2l104_1();
     }
-    @hidden table tbl_act_9 {
+    @hidden table tbl_headerstackopsbmv2l109_1 {
         actions = {
-            act_8();
+            headerstackopsbmv2l109_1();
         }
-        const default_action = act_8();
+        const default_action = headerstackopsbmv2l109_1();
     }
-    @hidden table tbl_act_10 {
+    @hidden table tbl_headerstackopsbmv2l111_1 {
         actions = {
-            act_9();
+            headerstackopsbmv2l111_1();
         }
-        const default_action = act_9();
+        const default_action = headerstackopsbmv2l111_1();
     }
-    @hidden table tbl_act_11 {
+    @hidden table tbl_headerstackopsbmv2l113_1 {
         actions = {
-            act_10();
+            headerstackopsbmv2l113_1();
         }
-        const default_action = act_10();
+        const default_action = headerstackopsbmv2l113_1();
     }
-    @hidden table tbl_act_12 {
+    @hidden table tbl_headerstackopsbmv2l115_1 {
         actions = {
-            act_11();
+            headerstackopsbmv2l115_1();
         }
-        const default_action = act_11();
+        const default_action = headerstackopsbmv2l115_1();
     }
-    @hidden table tbl_act_13 {
+    @hidden table tbl_headerstackopsbmv2l117_1 {
         actions = {
-            act_12();
+            headerstackopsbmv2l117_1();
         }
-        const default_action = act_12();
+        const default_action = headerstackopsbmv2l117_1();
     }
-    @hidden table tbl_act_14 {
+    @hidden table tbl_headerstackopsbmv2l119_1 {
         actions = {
-            act_13();
+            headerstackopsbmv2l119_1();
         }
-        const default_action = act_13();
+        const default_action = headerstackopsbmv2l119_1();
     }
-    @hidden table tbl_act_15 {
+    @hidden table tbl_headerstackopsbmv2l124_1 {
         actions = {
-            act_14();
+            headerstackopsbmv2l124_1();
         }
-        const default_action = act_14();
+        const default_action = headerstackopsbmv2l124_1();
     }
-    @hidden table tbl_act_16 {
+    @hidden table tbl_headerstackopsbmv2l130_1 {
         actions = {
-            act_15();
+            headerstackopsbmv2l130_1();
         }
-        const default_action = act_15();
+        const default_action = headerstackopsbmv2l130_1();
     }
-    @hidden table tbl_act_17 {
+    @hidden table tbl_headerstackopsbmv2l136_1 {
         actions = {
-            act_16();
+            headerstackopsbmv2l136_1();
         }
-        const default_action = act_16();
+        const default_action = headerstackopsbmv2l136_1();
     }
-    @hidden table tbl_act_18 {
+    @hidden table tbl_headerstackopsbmv2l142_1 {
         actions = {
-            act_17();
+            headerstackopsbmv2l142_1();
         }
-        const default_action = act_17();
+        const default_action = headerstackopsbmv2l142_1();
     }
-    @hidden table tbl_act_19 {
+    @hidden table tbl_headerstackopsbmv2l148_1 {
         actions = {
-            act_18();
+            headerstackopsbmv2l148_1();
         }
-        const default_action = act_18();
+        const default_action = headerstackopsbmv2l148_1();
     }
-    @hidden table tbl_act_20 {
+    @hidden table tbl_headerstackopsbmv2l157_1 {
         actions = {
-            act_19();
+            headerstackopsbmv2l157_1();
         }
-        const default_action = act_19();
+        const default_action = headerstackopsbmv2l157_1();
     }
-    @hidden table tbl_act_21 {
+    @hidden table tbl_headerstackopsbmv2l159_1 {
         actions = {
-            act_20();
+            headerstackopsbmv2l159_1();
         }
-        const default_action = act_20();
+        const default_action = headerstackopsbmv2l159_1();
     }
-    @hidden table tbl_act_22 {
+    @hidden table tbl_headerstackopsbmv2l161_1 {
         actions = {
-            act_44();
+            headerstackopsbmv2l161_1();
         }
-        const default_action = act_44();
+        const default_action = headerstackopsbmv2l161_1();
     }
-    @hidden table tbl_act_23 {
+    @hidden table tbl_headerstackopsbmv2l163_1 {
         actions = {
-            act_22();
+            headerstackopsbmv2l163_1();
         }
-        const default_action = act_22();
+        const default_action = headerstackopsbmv2l163_1();
     }
-    @hidden table tbl_act_24 {
+    @hidden table tbl_headerstackopsbmv2l165_1 {
         actions = {
-            act_23();
+            headerstackopsbmv2l165_1();
         }
-        const default_action = act_23();
+        const default_action = headerstackopsbmv2l165_1();
     }
-    @hidden table tbl_act_25 {
+    @hidden table tbl_headerstackopsbmv2l184 {
         actions = {
-            act_24();
+            headerstackopsbmv2l184();
         }
-        const default_action = act_24();
+        const default_action = headerstackopsbmv2l184();
     }
-    @hidden table tbl_act_26 {
+    @hidden table tbl_headerstackopsbmv2l186 {
         actions = {
-            act_25();
+            headerstackopsbmv2l186();
         }
-        const default_action = act_25();
+        const default_action = headerstackopsbmv2l186();
     }
-    @hidden table tbl_act_27 {
+    @hidden table tbl_headerstackopsbmv2l189 {
         actions = {
-            act_26();
+            headerstackopsbmv2l189();
         }
-        const default_action = act_26();
+        const default_action = headerstackopsbmv2l189();
     }
-    @hidden table tbl_act_28 {
+    @hidden table tbl_headerstackopsbmv2l192 {
         actions = {
-            act_27();
+            headerstackopsbmv2l192();
         }
-        const default_action = act_27();
+        const default_action = headerstackopsbmv2l192();
     }
-    @hidden table tbl_act_29 {
+    @hidden table tbl_headerstackopsbmv2l195 {
         actions = {
-            act_28();
+            headerstackopsbmv2l195();
         }
-        const default_action = act_28();
+        const default_action = headerstackopsbmv2l195();
     }
-    @hidden table tbl_act_30 {
+    @hidden table tbl_headerstackopsbmv2l198 {
         actions = {
-            act_29();
+            headerstackopsbmv2l198();
         }
-        const default_action = act_29();
-    }
-    @hidden table tbl_act_31 {
-        actions = {
-            act_30();
-        }
-        const default_action = act_30();
-    }
-    @hidden table tbl_act_32 {
-        actions = {
-            act_31();
-        }
-        const default_action = act_31();
-    }
-    @hidden table tbl_act_33 {
-        actions = {
-            act_32();
-        }
-        const default_action = act_32();
-    }
-    @hidden table tbl_act_34 {
-        actions = {
-            act_33();
-        }
-        const default_action = act_33();
-    }
-    @hidden table tbl_act_35 {
-        actions = {
-            act_34();
-        }
-        const default_action = act_34();
-    }
-    @hidden table tbl_act_36 {
-        actions = {
-            act_35();
-        }
-        const default_action = act_35();
-    }
-    @hidden table tbl_act_37 {
-        actions = {
-            act_36();
-        }
-        const default_action = act_36();
-    }
-    @hidden table tbl_act_38 {
-        actions = {
-            act_37();
-        }
-        const default_action = act_37();
-    }
-    @hidden table tbl_act_39 {
-        actions = {
-            act_38();
-        }
-        const default_action = act_38();
-    }
-    @hidden table tbl_act_40 {
-        actions = {
-            act_39();
-        }
-        const default_action = act_39();
-    }
-    @hidden table tbl_act_41 {
-        actions = {
-            act_40();
-        }
-        const default_action = act_40();
-    }
-    @hidden table tbl_act_42 {
-        actions = {
-            act_41();
-        }
-        const default_action = act_41();
-    }
-    @hidden table tbl_act_43 {
-        actions = {
-            act_42();
-        }
-        const default_action = act_42();
-    }
-    @hidden table tbl_act_44 {
-        actions = {
-            act_43();
-        }
-        const default_action = act_43();
-    }
-    @hidden table tbl_act_45 {
-        actions = {
-            act_67();
-        }
-        const default_action = act_67();
-    }
-    @hidden table tbl_act_46 {
-        actions = {
-            act_45();
-        }
-        const default_action = act_45();
-    }
-    @hidden table tbl_act_47 {
-        actions = {
-            act_46();
-        }
-        const default_action = act_46();
-    }
-    @hidden table tbl_act_48 {
-        actions = {
-            act_47();
-        }
-        const default_action = act_47();
-    }
-    @hidden table tbl_act_49 {
-        actions = {
-            act_48();
-        }
-        const default_action = act_48();
-    }
-    @hidden table tbl_act_50 {
-        actions = {
-            act_49();
-        }
-        const default_action = act_49();
-    }
-    @hidden table tbl_act_51 {
-        actions = {
-            act_50();
-        }
-        const default_action = act_50();
-    }
-    @hidden table tbl_act_52 {
-        actions = {
-            act_51();
-        }
-        const default_action = act_51();
-    }
-    @hidden table tbl_act_53 {
-        actions = {
-            act_52();
-        }
-        const default_action = act_52();
-    }
-    @hidden table tbl_act_54 {
-        actions = {
-            act_53();
-        }
-        const default_action = act_53();
-    }
-    @hidden table tbl_act_55 {
-        actions = {
-            act_54();
-        }
-        const default_action = act_54();
-    }
-    @hidden table tbl_act_56 {
-        actions = {
-            act_55();
-        }
-        const default_action = act_55();
-    }
-    @hidden table tbl_act_57 {
-        actions = {
-            act_56();
-        }
-        const default_action = act_56();
-    }
-    @hidden table tbl_act_58 {
-        actions = {
-            act_57();
-        }
-        const default_action = act_57();
-    }
-    @hidden table tbl_act_59 {
-        actions = {
-            act_58();
-        }
-        const default_action = act_58();
-    }
-    @hidden table tbl_act_60 {
-        actions = {
-            act_59();
-        }
-        const default_action = act_59();
-    }
-    @hidden table tbl_act_61 {
-        actions = {
-            act_60();
-        }
-        const default_action = act_60();
-    }
-    @hidden table tbl_act_62 {
-        actions = {
-            act_61();
-        }
-        const default_action = act_61();
-    }
-    @hidden table tbl_act_63 {
-        actions = {
-            act_62();
-        }
-        const default_action = act_62();
-    }
-    @hidden table tbl_act_64 {
-        actions = {
-            act_63();
-        }
-        const default_action = act_63();
-    }
-    @hidden table tbl_act_65 {
-        actions = {
-            act_64();
-        }
-        const default_action = act_64();
-    }
-    @hidden table tbl_act_66 {
-        actions = {
-            act_65();
-        }
-        const default_action = act_65();
-    }
-    @hidden table tbl_act_67 {
-        actions = {
-            act_66();
-        }
-        const default_action = act_66();
-    }
-    @hidden table tbl_act_68 {
-        actions = {
-            act_69();
-        }
-        const default_action = act_69();
-    }
-    @hidden table tbl_act_69 {
-        actions = {
-            act_68();
-        }
-        const default_action = act_68();
-    }
-    @hidden table tbl_act_70 {
-        actions = {
-            act_70();
-        }
-        const default_action = act_70();
-    }
-    @hidden table tbl_act_71 {
-        actions = {
-            act_71();
-        }
-        const default_action = act_71();
-    }
-    @hidden table tbl_act_72 {
-        actions = {
-            act_72();
-        }
-        const default_action = act_72();
-    }
-    @hidden table tbl_act_73 {
-        actions = {
-            act_73();
-        }
-        const default_action = act_73();
+        const default_action = headerstackopsbmv2l198();
     }
     apply {
         tbl_act.apply();
@@ -804,184 +804,184 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
             ;
         } else if (hdr.h1.op1[7:4] == 4w1) {
             if (hdr.h1.op1[3:0] == 4w1) {
-                tbl_act_0.apply();
+                tbl_headerstackopsbmv2l94.apply();
             } else if (hdr.h1.op1[3:0] == 4w2) {
-                tbl_act_1.apply();
+                tbl_headerstackopsbmv2l96.apply();
             } else if (hdr.h1.op1[3:0] == 4w3) {
-                tbl_act_2.apply();
+                tbl_headerstackopsbmv2l98.apply();
             } else if (hdr.h1.op1[3:0] == 4w4) {
-                tbl_act_3.apply();
+                tbl_headerstackopsbmv2l100.apply();
             } else if (hdr.h1.op1[3:0] == 4w5) {
-                tbl_act_4.apply();
+                tbl_headerstackopsbmv2l102.apply();
             } else if (hdr.h1.op1[3:0] == 4w6) {
-                tbl_act_5.apply();
+                tbl_headerstackopsbmv2l104.apply();
             }
         } else if (hdr.h1.op1[7:4] == 4w2) {
             if (hdr.h1.op1[3:0] == 4w1) {
-                tbl_act_6.apply();
+                tbl_headerstackopsbmv2l109.apply();
             } else if (hdr.h1.op1[3:0] == 4w2) {
-                tbl_act_7.apply();
+                tbl_headerstackopsbmv2l111.apply();
             } else if (hdr.h1.op1[3:0] == 4w3) {
-                tbl_act_8.apply();
+                tbl_headerstackopsbmv2l113.apply();
             } else if (hdr.h1.op1[3:0] == 4w4) {
-                tbl_act_9.apply();
+                tbl_headerstackopsbmv2l115.apply();
             } else if (hdr.h1.op1[3:0] == 4w5) {
-                tbl_act_10.apply();
+                tbl_headerstackopsbmv2l117.apply();
             } else if (hdr.h1.op1[3:0] == 4w6) {
-                tbl_act_11.apply();
+                tbl_headerstackopsbmv2l119.apply();
             }
         } else if (hdr.h1.op1[7:4] == 4w3) {
             if (hdr.h1.op1[3:0] == 4w0) {
-                tbl_act_12.apply();
+                tbl_headerstackopsbmv2l124.apply();
             } else if (hdr.h1.op1[3:0] == 4w1) {
-                tbl_act_13.apply();
+                tbl_headerstackopsbmv2l130.apply();
             } else if (hdr.h1.op1[3:0] == 4w2) {
-                tbl_act_14.apply();
+                tbl_headerstackopsbmv2l136.apply();
             } else if (hdr.h1.op1[3:0] == 4w3) {
-                tbl_act_15.apply();
+                tbl_headerstackopsbmv2l142.apply();
             } else if (hdr.h1.op1[3:0] == 4w4) {
-                tbl_act_16.apply();
+                tbl_headerstackopsbmv2l148.apply();
             }
         } else if (hdr.h1.op1[7:4] == 4w4) {
             if (hdr.h1.op1[3:0] == 4w0) {
-                tbl_act_17.apply();
+                tbl_headerstackopsbmv2l157.apply();
             } else if (hdr.h1.op1[3:0] == 4w1) {
-                tbl_act_18.apply();
+                tbl_headerstackopsbmv2l159.apply();
             } else if (hdr.h1.op1[3:0] == 4w2) {
-                tbl_act_19.apply();
+                tbl_headerstackopsbmv2l161.apply();
             } else if (hdr.h1.op1[3:0] == 4w3) {
-                tbl_act_20.apply();
+                tbl_headerstackopsbmv2l163.apply();
             } else if (hdr.h1.op1[3:0] == 4w4) {
-                tbl_act_21.apply();
+                tbl_headerstackopsbmv2l165.apply();
             }
         }
-        tbl_act_22.apply();
+        tbl_act_0.apply();
         if (hdr.h1.op2 == 8w0x0) {
             ;
         } else if (hdr.h1.op2[7:4] == 4w1) {
             if (hdr.h1.op2[3:0] == 4w1) {
-                tbl_act_23.apply();
+                tbl_headerstackopsbmv2l94_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w2) {
-                tbl_act_24.apply();
+                tbl_headerstackopsbmv2l96_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w3) {
-                tbl_act_25.apply();
+                tbl_headerstackopsbmv2l98_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w4) {
-                tbl_act_26.apply();
+                tbl_headerstackopsbmv2l100_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w5) {
-                tbl_act_27.apply();
+                tbl_headerstackopsbmv2l102_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w6) {
-                tbl_act_28.apply();
+                tbl_headerstackopsbmv2l104_0.apply();
             }
         } else if (hdr.h1.op2[7:4] == 4w2) {
             if (hdr.h1.op2[3:0] == 4w1) {
-                tbl_act_29.apply();
+                tbl_headerstackopsbmv2l109_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w2) {
-                tbl_act_30.apply();
+                tbl_headerstackopsbmv2l111_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w3) {
-                tbl_act_31.apply();
+                tbl_headerstackopsbmv2l113_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w4) {
-                tbl_act_32.apply();
+                tbl_headerstackopsbmv2l115_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w5) {
-                tbl_act_33.apply();
+                tbl_headerstackopsbmv2l117_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w6) {
-                tbl_act_34.apply();
+                tbl_headerstackopsbmv2l119_0.apply();
             }
         } else if (hdr.h1.op2[7:4] == 4w3) {
             if (hdr.h1.op2[3:0] == 4w0) {
-                tbl_act_35.apply();
+                tbl_headerstackopsbmv2l124_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w1) {
-                tbl_act_36.apply();
+                tbl_headerstackopsbmv2l130_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w2) {
-                tbl_act_37.apply();
+                tbl_headerstackopsbmv2l136_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w3) {
-                tbl_act_38.apply();
+                tbl_headerstackopsbmv2l142_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w4) {
-                tbl_act_39.apply();
+                tbl_headerstackopsbmv2l148_0.apply();
             }
         } else if (hdr.h1.op2[7:4] == 4w4) {
             if (hdr.h1.op2[3:0] == 4w0) {
-                tbl_act_40.apply();
+                tbl_headerstackopsbmv2l157_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w1) {
-                tbl_act_41.apply();
+                tbl_headerstackopsbmv2l159_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w2) {
-                tbl_act_42.apply();
+                tbl_headerstackopsbmv2l161_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w3) {
-                tbl_act_43.apply();
+                tbl_headerstackopsbmv2l163_0.apply();
             } else if (hdr.h1.op2[3:0] == 4w4) {
-                tbl_act_44.apply();
+                tbl_headerstackopsbmv2l165_0.apply();
             }
         }
-        tbl_act_45.apply();
+        tbl_act_1.apply();
         if (hdr.h1.op3 == 8w0x0) {
             ;
         } else if (hdr.h1.op3[7:4] == 4w1) {
             if (hdr.h1.op3[3:0] == 4w1) {
-                tbl_act_46.apply();
+                tbl_headerstackopsbmv2l94_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w2) {
-                tbl_act_47.apply();
+                tbl_headerstackopsbmv2l96_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w3) {
-                tbl_act_48.apply();
+                tbl_headerstackopsbmv2l98_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w4) {
-                tbl_act_49.apply();
+                tbl_headerstackopsbmv2l100_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w5) {
-                tbl_act_50.apply();
+                tbl_headerstackopsbmv2l102_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w6) {
-                tbl_act_51.apply();
+                tbl_headerstackopsbmv2l104_1.apply();
             }
         } else if (hdr.h1.op3[7:4] == 4w2) {
             if (hdr.h1.op3[3:0] == 4w1) {
-                tbl_act_52.apply();
+                tbl_headerstackopsbmv2l109_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w2) {
-                tbl_act_53.apply();
+                tbl_headerstackopsbmv2l111_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w3) {
-                tbl_act_54.apply();
+                tbl_headerstackopsbmv2l113_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w4) {
-                tbl_act_55.apply();
+                tbl_headerstackopsbmv2l115_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w5) {
-                tbl_act_56.apply();
+                tbl_headerstackopsbmv2l117_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w6) {
-                tbl_act_57.apply();
+                tbl_headerstackopsbmv2l119_1.apply();
             }
         } else if (hdr.h1.op3[7:4] == 4w3) {
             if (hdr.h1.op3[3:0] == 4w0) {
-                tbl_act_58.apply();
+                tbl_headerstackopsbmv2l124_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w1) {
-                tbl_act_59.apply();
+                tbl_headerstackopsbmv2l130_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w2) {
-                tbl_act_60.apply();
+                tbl_headerstackopsbmv2l136_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w3) {
-                tbl_act_61.apply();
+                tbl_headerstackopsbmv2l142_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w4) {
-                tbl_act_62.apply();
+                tbl_headerstackopsbmv2l148_1.apply();
             }
         } else if (hdr.h1.op3[7:4] == 4w4) {
             if (hdr.h1.op3[3:0] == 4w0) {
-                tbl_act_63.apply();
+                tbl_headerstackopsbmv2l157_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w1) {
-                tbl_act_64.apply();
+                tbl_headerstackopsbmv2l159_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w2) {
-                tbl_act_65.apply();
+                tbl_headerstackopsbmv2l161_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w3) {
-                tbl_act_66.apply();
+                tbl_headerstackopsbmv2l163_1.apply();
             } else if (hdr.h1.op3[3:0] == 4w4) {
-                tbl_act_67.apply();
+                tbl_headerstackopsbmv2l165_1.apply();
             }
         }
-        tbl_act_68.apply();
+        tbl_headerstackopsbmv2l184.apply();
         if (hdr.h2[0].isValid()) {
-            tbl_act_69.apply();
+            tbl_headerstackopsbmv2l186.apply();
         }
         if (hdr.h2[1].isValid()) {
-            tbl_act_70.apply();
+            tbl_headerstackopsbmv2l189.apply();
         }
         if (hdr.h2[2].isValid()) {
-            tbl_act_71.apply();
+            tbl_headerstackopsbmv2l192.apply();
         }
         if (hdr.h2[3].isValid()) {
-            tbl_act_72.apply();
+            tbl_headerstackopsbmv2l195.apply();
         }
         if (hdr.h2[4].isValid()) {
-            tbl_act_73.apply();
+            tbl_headerstackopsbmv2l198.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/hit_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/hit_ebpf-midend.p4
@@ -63,54 +63,54 @@ control pipe(inout Headers_t headers, out bool pass) {
         implementation = hash_table(32w1024);
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action hit_ebpf63() {
         pass = false;
         hasReturned = true;
     }
-    @hidden action act_0() {
+    @hidden action hit_ebpf60() {
         hasReturned = false;
         pass = true;
     }
-    @hidden action act_1() {
+    @hidden action act() {
         tmp = true;
     }
-    @hidden action act_2() {
+    @hidden action act_0() {
         tmp = false;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_hit_ebpf60 {
         actions = {
-            act_0();
+            hit_ebpf60();
         }
-        const default_action = act_0();
+        const default_action = hit_ebpf60();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_hit_ebpf63 {
+        actions = {
+            hit_ebpf63();
+        }
+        const default_action = hit_ebpf63();
+    }
+    @hidden table tbl_act {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_act_0 {
         actions = {
-            act_1();
+            act_0();
         }
-        const default_action = act_1();
-    }
-    @hidden table tbl_act_2 {
-        actions = {
-            act_2();
-        }
-        const default_action = act_2();
+        const default_action = act_0();
     }
     apply {
-        tbl_act.apply();
+        tbl_hit_ebpf60.apply();
         if (!headers.ipv4.isValid()) {
-            tbl_act_0.apply();
+            tbl_hit_ebpf63.apply();
         }
         if (!hasReturned) {
             if (Check_src_ip_0.apply().hit) {
-                tbl_act_1.apply();
+                tbl_act.apply();
             } else {
-                tbl_act_2.apply();
+                tbl_act_0.apply();
             }
         }
     }

--- a/testdata/p4_16_samples_outputs/init_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/init_ebpf-midend.p4
@@ -42,17 +42,17 @@ control pipe(inout Headers_t headers, out bool pass) {
         implementation = hash_table(32w64);
         default_action = NoAction_0();
     }
-    @hidden action act_0() {
+    @hidden action init_ebpf58() {
         pass = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_init_ebpf58 {
         actions = {
-            act_0();
+            init_ebpf58();
         }
-        const default_action = act_0();
+        const default_action = init_ebpf58();
     }
     apply {
-        tbl_act.apply();
+        tbl_init_ebpf58.apply();
         tbl_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/initializers-midend.p4
+++ b/testdata/p4_16_samples_outputs/initializers-midend.p4
@@ -15,17 +15,17 @@ parser P() {
 
 control C() {
     @name("C.fake") Fake() fake_1;
-    @hidden action act() {
+    @hidden action initializers38() {
         fake_1.call(32w1);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_initializers38 {
         actions = {
-            act();
+            initializers38();
         }
-        const default_action = act();
+        const default_action = initializers38();
     }
     apply {
-        tbl_act.apply();
+        tbl_initializers38.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/inline-control-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-control-midend.p4
@@ -6,18 +6,18 @@ extern Y {
 control d(out bit<32> x) {
     bit<32> cinst_tmp;
     @name("d.cinst.y") Y(32w16) cinst_y;
-    @hidden action act() {
+    @hidden action inlinecontrol24() {
         cinst_tmp = cinst_y.get();
         x = cinst_tmp;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_inlinecontrol24 {
         actions = {
-            act();
+            inlinecontrol24();
         }
-        const default_action = act();
+        const default_action = inlinecontrol24();
     }
     apply {
-        tbl_act.apply();
+        tbl_inlinecontrol24.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/inline-function-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-function-midend.p4
@@ -1,39 +1,39 @@
 control c(inout bit<32> x) {
     bit<32> tmp_2;
-    @hidden action act() {
+    @hidden action inlinefunction2() {
         tmp_2 = x;
     }
-    @hidden action act_0() {
+    @hidden action inlinefunction2_0() {
         tmp_2 = x;
     }
-    @hidden action act_1() {
+    @hidden action inlinefunction11() {
         x = x + tmp_2;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_inlinefunction2 {
         actions = {
-            act();
+            inlinefunction2();
         }
-        const default_action = act();
+        const default_action = inlinefunction2();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_inlinefunction2_0 {
         actions = {
-            act_0();
+            inlinefunction2_0();
         }
-        const default_action = act_0();
+        const default_action = inlinefunction2_0();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_inlinefunction11 {
         actions = {
-            act_1();
+            inlinefunction11();
         }
-        const default_action = act_1();
+        const default_action = inlinefunction11();
     }
     apply {
         if (x > x) {
-            tbl_act.apply();
+            tbl_inlinefunction2.apply();
         } else {
-            tbl_act_0.apply();
+            tbl_inlinefunction2_0.apply();
         }
-        tbl_act_1.apply();
+        tbl_inlinefunction11.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/inline-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-midend.p4
@@ -3,14 +3,14 @@ control p(out bit<1> y) {
     @name("p.b") action b() {
         y = x_1 & x_1 & (x_1 & x_1) & (x_1 & x_1 & (x_1 & x_1));
     }
-    @hidden action act() {
+    @hidden action inline33() {
         x_1 = 1w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_inline33 {
         actions = {
-            act();
+            inline33();
         }
-        const default_action = act();
+        const default_action = inline33();
     }
     @hidden table tbl_b {
         actions = {
@@ -19,7 +19,7 @@ control p(out bit<1> y) {
         const default_action = b();
     }
     apply {
-        tbl_act.apply();
+        tbl_inline33.apply();
         tbl_b.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-midend.p4
@@ -272,18 +272,18 @@ control ingress(inout headers hdr, inout metadata_t meta, inout standard_metadat
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action ipv6switchmlbmv2l66() {
         key_0 = hdr.ipv6.dstAddr[127:120] == 8w0xff;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_ipv6switchmlbmv2l66 {
         actions = {
-            act();
+            ipv6switchmlbmv2l66();
         }
-        const default_action = act();
+        const default_action = ipv6switchmlbmv2l66();
     }
     apply {
         if (hdr.ipv6.isValid()) {
-            tbl_act.apply();
+            tbl_ipv6switchmlbmv2l66.apply();
             ipv6_tbl_0.apply();
         }
     }

--- a/testdata/p4_16_samples_outputs/issue1000-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1000-bmv2-midend.p4
@@ -69,17 +69,17 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue1000bmv2l88() {
         hdr.ethernet.etherType = meta.transition_taken;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1000bmv2l88 {
         actions = {
-            act();
+            issue1000bmv2l88();
         }
-        const default_action = act();
+        const default_action = issue1000bmv2l88();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1000bmv2l88.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1001-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1001-bmv2-midend.p4
@@ -17,17 +17,17 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     Meta x_0;
-    @hidden action act() {
+    @hidden action issue1001bmv2l20() {
         clone3<Meta>(CloneType.I2E, 32w64, x_0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1001bmv2l20 {
         actions = {
-            act();
+            issue1001bmv2l20();
         }
-        const default_action = act();
+        const default_action = issue1001bmv2l20();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1001bmv2l20.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1025-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1025-bmv2-midend.p4
@@ -88,20 +88,20 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
     bit<1> eth_valid_0;
     bit<1> ipv4_valid_0;
     bit<1> tcp_valid_0;
-    @hidden action act() {
+    @hidden action issue1025bmv2l132() {
         eth_valid_0 = (bit<1>)hdr.ethernet.isValid();
         ipv4_valid_0 = (bit<1>)hdr.ipv4.isValid();
         tcp_valid_0 = (bit<1>)hdr.tcp.isValid();
         hdr.ethernet.dstAddr = 31w0 ++ eth_valid_0 ++ 7w0 ++ ipv4_valid_0 ++ 7w0 ++ tcp_valid_0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1025bmv2l132 {
         actions = {
-            act();
+            issue1025bmv2l132();
         }
-        const default_action = act();
+        const default_action = issue1025bmv2l132();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1025bmv2l132.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1043-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1043-bmv2-midend.p4
@@ -42,18 +42,18 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action issue1043bmv2l33() {
         resubmit<Meta>(m);
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1043bmv2l33 {
         actions = {
-            act();
+            issue1043bmv2l33();
         }
-        const default_action = act();
+        const default_action = issue1043bmv2l33();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1043bmv2l33.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1049-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1049-bmv2-midend.p4
@@ -84,32 +84,32 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue1049bmv2l109() {
         hdr.ethernet.dstAddr = meta._mystruct1_hash10 ++ 7w0 ++ (bit<1>)meta._mystruct1_hash_drop1 ++ 8w0 ++ 16w0xdead;
     }
-    @hidden action act_0() {
+    @hidden action issue1049bmv2l111() {
         hdr.ethernet.dstAddr = meta._mystruct1_hash10 ++ 7w0 ++ (bit<1>)meta._mystruct1_hash_drop1 ++ 8w0 ++ 16w0xc001;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1049bmv2l109 {
         actions = {
-            act();
+            issue1049bmv2l109();
         }
-        const default_action = act();
+        const default_action = issue1049bmv2l109();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue1049bmv2l111 {
         actions = {
-            act_0();
+            issue1049bmv2l111();
         }
-        const default_action = act_0();
+        const default_action = issue1049bmv2l111();
     }
     apply {
         if (hdr.ipv4.isValid()) {
             guh_0.apply();
             debug_table_0.apply();
             if (meta._mystruct1_hash_drop1) {
-                tbl_act.apply();
+                tbl_issue1049bmv2l109.apply();
             } else {
-                tbl_act_0.apply();
+                tbl_issue1049bmv2l111.apply();
             }
         }
     }

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2-midend.p4
@@ -39,17 +39,17 @@ control EmptyIngress(inout headers_t headers, inout metadata_t meta, inout stand
 }
 
 control EmptyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue1079bmv2l47() {
         mark_to_drop(standard_metadata);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1079bmv2l47 {
         actions = {
-            act();
+            issue1079bmv2l47();
         }
-        const default_action = act();
+        const default_action = issue1079bmv2l47();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1079bmv2l47.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1097-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-2-bmv2-midend.p4
@@ -25,37 +25,37 @@ register<bit<8>>(32w256) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> x_0;
-    @hidden action act() {
+    @hidden action issue10972bmv2l51() {
         r.read(x_0, (bit<32>)h.myhdr.reg_idx_to_update);
         r.write((bit<32>)h.myhdr.reg_idx_to_update, 8w0x2a);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue10972bmv2l51 {
         actions = {
-            act();
+            issue10972bmv2l51();
         }
-        const default_action = act();
+        const default_action = issue10972bmv2l51();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue10972bmv2l51.apply();
     }
 }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> tmp_0;
-    @hidden action act_0() {
+    @hidden action issue10972bmv2l62() {
         r.read(tmp_0, (bit<32>)h.myhdr.reg_idx_to_update);
         tmp_0 = tmp_0 + h.myhdr.value_to_add;
         r.write((bit<32>)h.myhdr.reg_idx_to_update, tmp_0);
         h.myhdr.debug_last_reg_value_written = tmp_0;
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue10972bmv2l62 {
         actions = {
-            act_0();
+            issue10972bmv2l62();
         }
-        const default_action = act_0();
+        const default_action = issue10972bmv2l62();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_issue10972bmv2l62.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1097-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-bmv2-midend.p4
@@ -17,17 +17,17 @@ register<bit<8>>(32w2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> x_0;
-    @hidden action act() {
+    @hidden action issue1097bmv2l19() {
         r.read(x_0, 32w0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1097bmv2l19 {
         actions = {
-            act();
+            issue1097bmv2l19();
         }
-        const default_action = act();
+        const default_action = issue1097bmv2l19();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1097bmv2l19.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1127-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1127-bmv2-midend.p4
@@ -23,65 +23,65 @@ parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standa
 
 control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
     h1_t hdr_0_h1;
+    @hidden action issue1127bmv2l53() {
+        hdr_0_h1.out1 = 8w4;
+    }
     @hidden action act() {
+        hdr_0_h1 = hdr.h1;
+    }
+    @hidden action issue1127bmv2l53_0() {
         hdr_0_h1.out1 = 8w4;
     }
     @hidden action act_0() {
-        hdr_0_h1 = hdr.h1;
-    }
-    @hidden action act_1() {
-        hdr_0_h1.out1 = 8w4;
-    }
-    @hidden action act_2() {
         hdr.h1 = hdr_0_h1;
     }
-    @hidden action act_3() {
+    @hidden action act_1() {
         hdr.h1 = hdr_0_h1;
     }
     @hidden table tbl_act {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
-    @hidden table tbl_act_0 {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue1127bmv2l53 {
         actions = {
-            act_2();
+            issue1127bmv2l53();
         }
-        const default_action = act_2();
+        const default_action = issue1127bmv2l53();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    @hidden table tbl_issue1127bmv2l53_0 {
+        actions = {
+            issue1127bmv2l53_0();
+        }
+        const default_action = issue1127bmv2l53_0();
+    }
+    @hidden table tbl_act_1 {
         actions = {
             act_1();
         }
         const default_action = act_1();
-    }
-    @hidden table tbl_act_3 {
-        actions = {
-            act_3();
-        }
-        const default_action = act_3();
     }
     apply {
         tbl_act.apply();
         if (hdr.h1.op1 == 8w0x0) {
             ;
         } else if (hdr.h1.op1[7:4] == 4w1) {
-            tbl_act_0.apply();
+            tbl_issue1127bmv2l53.apply();
         }
-        tbl_act_1.apply();
+        tbl_act_0.apply();
         if (hdr.h1.op2 == 8w0x0) {
             ;
         } else if (hdr.h1.op2[7:4] == 4w1) {
-            tbl_act_2.apply();
+            tbl_issue1127bmv2l53_0.apply();
         }
-        tbl_act_3.apply();
+        tbl_act_1.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1210-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1210-midend.p4
@@ -20,30 +20,30 @@ parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout metadata_t m
 }
 
 control IngressImpl(inout parsed_headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue1210l50() {
         meta._foo__v0 = meta._foo__v0 + 9w1;
     }
-    @hidden action act_0() {
+    @hidden action issue1210l59() {
         meta._foo__v0 = meta._foo__v0 + 9w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1210l50 {
         actions = {
-            act();
+            issue1210l50();
         }
-        const default_action = act();
+        const default_action = issue1210l50();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue1210l59 {
         actions = {
-            act_0();
+            issue1210l59();
         }
-        const default_action = act_0();
+        const default_action = issue1210l59();
     }
     apply {
         if (meta._foo__v0 == meta._bar__v1) {
-            tbl_act.apply();
+            tbl_issue1210l50.apply();
         }
         if (meta._foo__v0 == 9w192) {
-            tbl_act_0.apply();
+            tbl_issue1210l59.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-midend.p4
@@ -22,18 +22,18 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 }
 
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue1325bmv2l31() {
         mark_to_drop(standard_metadata);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1325bmv2l31 {
         actions = {
-            act();
+            issue1325bmv2l31();
         }
-        const default_action = act();
+        const default_action = issue1325bmv2l31();
     }
     apply {
         if (local_metadata._test_test_error0 == error.Unused) {
-            tbl_act.apply();
+            tbl_issue1325bmv2l31.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1333-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1333-midend.p4
@@ -10,18 +10,18 @@ control ctrl();
 package top(ctrl _c);
 control c_0() {
     @name("c_0.e") E(x = 32w0) e_0;
-    @hidden action act() {
+    @hidden action issue1333l12() {
         f(a = 32w0, b = 32w4);
         e_0.f(z = 16w2);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1333l12 {
         actions = {
-            act();
+            issue1333l12();
         }
-        const default_action = act();
+        const default_action = issue1333l12();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1333l12.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1334-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1334-midend.p4
@@ -12,7 +12,7 @@ extern Overloaded {
 
 control c() {
     @name("c.o") Overloaded() o_0;
-    @hidden action act() {
+    @hidden action issue1334l31() {
         f();
         f(a = 32w2);
         f(b = 16w1);
@@ -24,14 +24,14 @@ control c() {
         o_0.f(a = 32w1, b = 16w2);
         o_0.f(b = 16w2, a = 32w1);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1334l31 {
         actions = {
-            act();
+            issue1334l31();
         }
-        const default_action = act();
+        const default_action = issue1334l31();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1334l31.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1386-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1386-midend.p4
@@ -42,39 +42,39 @@ control deparser(packet_out b, in Headers h) {
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bool c_hasReturned;
-    @hidden action act() {
+    @hidden action issue1386l12() {
         c_hasReturned = true;
     }
-    @hidden action act_0() {
+    @hidden action act() {
         c_hasReturned = false;
     }
-    @hidden action act_1() {
+    @hidden action arithinlineskeleton51() {
         sm.egress_spec = 9w0;
     }
     @hidden table tbl_act {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
-    @hidden table tbl_act_0 {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue1386l12 {
         actions = {
-            act_1();
+            issue1386l12();
         }
-        const default_action = act_1();
+        const default_action = issue1386l12();
+    }
+    @hidden table tbl_arithinlineskeleton51 {
+        actions = {
+            arithinlineskeleton51();
+        }
+        const default_action = arithinlineskeleton51();
     }
     apply {
         tbl_act.apply();
         if (!h.h.isValid()) {
-            tbl_act_0.apply();
+            tbl_issue1386l12.apply();
         }
-        tbl_act_1.apply();
+        tbl_arithinlineskeleton51.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1466-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1466-midend.p4
@@ -3,18 +3,18 @@ header hdr {
 }
 
 control A(inout hdr _hdr) {
-    @hidden action act() {
+    @hidden action issue1466l7() {
         _hdr.g = 1w1;
         _hdr.g = 1w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1466l7 {
         actions = {
-            act();
+            issue1466l7();
         }
-        const default_action = act();
+        const default_action = issue1466l7();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1466l7.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2-midend.p4
@@ -23,28 +23,28 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     bit<16> rand_int_0;
-    @hidden action act() {
+    @hidden action issue1517bmv2l62() {
         mark_to_drop(standard_metadata);
     }
-    @hidden action act_0() {
+    @hidden action issue1517bmv2l56() {
         random<bit<16>>(rand_int_0, 16w0, 16w49151);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1517bmv2l56 {
         actions = {
-            act_0();
+            issue1517bmv2l56();
         }
-        const default_action = act_0();
+        const default_action = issue1517bmv2l56();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue1517bmv2l62 {
         actions = {
-            act();
+            issue1517bmv2l62();
         }
-        const default_action = act();
+        const default_action = issue1517bmv2l62();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1517bmv2l56.apply();
         if (rand_int_0 < 16w32768) {
-            tbl_act_0.apply();
+            tbl_issue1517bmv2l62.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2-midend.p4
@@ -27,18 +27,18 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("MyIngress.h.c1.r") register<bit<16>>(32w8) h_c1_r;
     @name("MyIngress.h.c2.r") register<bit<16>>(32w8) h_c2_r;
-    @hidden action act() {
+    @hidden action issue1520bmv2l33() {
         h_c1_r.read(hdr.h.x, 32w0);
         h_c2_r.read(hdr.h.x, 32w0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1520bmv2l33 {
         actions = {
-            act();
+            issue1520bmv2l33();
         }
-        const default_action = act();
+        const default_action = issue1520bmv2l33();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1520bmv2l33.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1538-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-midend.p4
@@ -74,20 +74,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = my_drop();
     }
-    @hidden action act() {
+    @hidden action issue1538l90() {
         hdr.ethernet.srcAddr[15:0] = hdr.ethernet.srcAddr[15:0] + (hdr.ethernet.srcAddr[15:0] + 16w1);
         hdr.ethernet.srcAddr[15:0] = hdr.ethernet.srcAddr[15:0] + 16w1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1538l90 {
         actions = {
-            act();
+            issue1538l90();
         }
-        const default_action = act();
+        const default_action = issue1538l90();
     }
     apply {
         mac_da_0.apply();
-        tbl_act.apply();
+        tbl_issue1538l90.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-midend.p4
@@ -72,41 +72,41 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = my_drop();
     }
-    @hidden action act() {
+    @hidden action issue15441bmv2l25() {
         tmp_0 = hdr.ethernet.srcAddr[15:0] + 16w65535;
     }
-    @hidden action act_0() {
+    @hidden action issue15441bmv2l27() {
         tmp_0 = hdr.ethernet.srcAddr[15:0];
     }
-    @hidden action act_1() {
+    @hidden action issue15441bmv2l83() {
         hdr.ethernet.srcAddr[15:0] = tmp_0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue15441bmv2l25 {
         actions = {
-            act();
+            issue15441bmv2l25();
         }
-        const default_action = act();
+        const default_action = issue15441bmv2l25();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue15441bmv2l27 {
         actions = {
-            act_0();
+            issue15441bmv2l27();
         }
-        const default_action = act_0();
+        const default_action = issue15441bmv2l27();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue15441bmv2l83 {
         actions = {
-            act_1();
+            issue15441bmv2l83();
         }
-        const default_action = act_1();
+        const default_action = issue15441bmv2l83();
     }
     apply {
         mac_da_0.apply();
         if (hdr.ethernet.srcAddr[15:0] > 16w5) {
-            tbl_act.apply();
+            tbl_issue15441bmv2l25.apply();
         } else {
-            tbl_act_0.apply();
+            tbl_issue15441bmv2l27.apply();
         }
-        tbl_act_1.apply();
+        tbl_issue15441bmv2l83.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-midend.p4
@@ -72,40 +72,40 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = my_drop();
     }
-    @hidden action act() {
+    @hidden action issue15442bmv2l25() {
         tmp_0 = hdr.ethernet.srcAddr[15:0] + 16w65535;
     }
-    @hidden action act_0() {
+    @hidden action issue15442bmv2l23() {
         tmp_0 = hdr.ethernet.srcAddr[15:0];
     }
-    @hidden action act_1() {
+    @hidden action issue15442bmv2l81() {
         hdr.ethernet.srcAddr[15:0] = tmp_0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue15442bmv2l23 {
         actions = {
-            act_0();
+            issue15442bmv2l23();
         }
-        const default_action = act_0();
+        const default_action = issue15442bmv2l23();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue15442bmv2l25 {
         actions = {
-            act();
+            issue15442bmv2l25();
         }
-        const default_action = act();
+        const default_action = issue15442bmv2l25();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue15442bmv2l81 {
         actions = {
-            act_1();
+            issue15442bmv2l81();
         }
-        const default_action = act_1();
+        const default_action = issue15442bmv2l81();
     }
     apply {
         mac_da_0.apply();
-        tbl_act.apply();
+        tbl_issue15442bmv2l23.apply();
         if (hdr.ethernet.srcAddr[15:0] > 16w5) {
-            tbl_act_0.apply();
+            tbl_issue15442bmv2l25.apply();
         }
-        tbl_act_1.apply();
+        tbl_issue15442bmv2l81.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1544-2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-midend.p4
@@ -2,86 +2,86 @@ control c(inout bit<32> x) {
     bit<32> tmp_4;
     bit<32> tmp_11;
     bit<32> tmp_12;
-    @hidden action act() {
+    @hidden action issue15442l2() {
         tmp_4 = x + 32w1;
     }
-    @hidden action act_0() {
+    @hidden action issue15442l2_0() {
         tmp_4 = x;
     }
-    @hidden action act_1() {
+    @hidden action issue15442l2_1() {
         tmp_11 = x + 32w4294967295;
     }
-    @hidden action act_2() {
+    @hidden action issue15442l2_2() {
         tmp_11 = x;
     }
-    @hidden action act_3() {
+    @hidden action issue15442l2_3() {
         tmp_12 = tmp_11;
     }
-    @hidden action act_4() {
+    @hidden action issue15442l2_4() {
         tmp_12 = tmp_4;
     }
-    @hidden action act_5() {
+    @hidden action issue15442l7() {
         x = tmp_12;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue15442l2 {
         actions = {
-            act();
+            issue15442l2();
         }
-        const default_action = act();
+        const default_action = issue15442l2();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue15442l2_0 {
         actions = {
-            act_0();
+            issue15442l2_0();
         }
-        const default_action = act_0();
+        const default_action = issue15442l2_0();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue15442l2_1 {
         actions = {
-            act_1();
+            issue15442l2_1();
         }
-        const default_action = act_1();
+        const default_action = issue15442l2_1();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_issue15442l2_2 {
         actions = {
-            act_2();
+            issue15442l2_2();
         }
-        const default_action = act_2();
+        const default_action = issue15442l2_2();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_issue15442l2_3 {
         actions = {
-            act_3();
+            issue15442l2_3();
         }
-        const default_action = act_3();
+        const default_action = issue15442l2_3();
     }
-    @hidden table tbl_act_4 {
+    @hidden table tbl_issue15442l2_4 {
         actions = {
-            act_4();
+            issue15442l2_4();
         }
-        const default_action = act_4();
+        const default_action = issue15442l2_4();
     }
-    @hidden table tbl_act_5 {
+    @hidden table tbl_issue15442l7 {
         actions = {
-            act_5();
+            issue15442l7();
         }
-        const default_action = act_5();
+        const default_action = issue15442l7();
     }
     apply {
         if (x > x + 32w1) {
-            tbl_act.apply();
+            tbl_issue15442l2.apply();
         } else {
-            tbl_act_0.apply();
+            tbl_issue15442l2_0.apply();
         }
         if (x > x + 32w4294967295) {
-            tbl_act_1.apply();
+            tbl_issue15442l2_1.apply();
         } else {
-            tbl_act_2.apply();
+            tbl_issue15442l2_2.apply();
         }
         if (tmp_4 > tmp_11) {
-            tbl_act_3.apply();
+            tbl_issue15442l2_3.apply();
         } else {
-            tbl_act_4.apply();
+            tbl_issue15442l2_4.apply();
         }
-        tbl_act_5.apply();
+        tbl_issue15442l7.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-midend.p4
@@ -72,41 +72,41 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = my_drop();
     }
-    @hidden action act() {
+    @hidden action issue1544bmv2l24() {
         retval = hdr.ethernet.srcAddr[15:0] + 16w65535;
     }
-    @hidden action act_0() {
+    @hidden action issue1544bmv2l26() {
         retval = hdr.ethernet.srcAddr[15:0];
     }
-    @hidden action act_1() {
+    @hidden action issue1544bmv2l81() {
         hdr.ethernet.srcAddr[15:0] = retval;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1544bmv2l24 {
         actions = {
-            act();
+            issue1544bmv2l24();
         }
-        const default_action = act();
+        const default_action = issue1544bmv2l24();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue1544bmv2l26 {
         actions = {
-            act_0();
+            issue1544bmv2l26();
         }
-        const default_action = act_0();
+        const default_action = issue1544bmv2l26();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue1544bmv2l81 {
         actions = {
-            act_1();
+            issue1544bmv2l81();
         }
-        const default_action = act_1();
+        const default_action = issue1544bmv2l81();
     }
     apply {
         mac_da_0.apply();
         if (hdr.ethernet.srcAddr[15:0] > 16w5) {
-            tbl_act.apply();
+            tbl_issue1544bmv2l24.apply();
         } else {
-            tbl_act_0.apply();
+            tbl_issue1544bmv2l26.apply();
         }
-        tbl_act_1.apply();
+        tbl_issue1544bmv2l81.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2-midend.p4
@@ -156,19 +156,19 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
         size = 16;
         default_action = NoAction_5();
     }
-    @hidden action act() {
+    @hidden action issue1560bmv2l175() {
         meta._hash12 = hdr.ipv4.dstAddr[15:0];
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1560bmv2l175 {
         actions = {
-            act();
+            issue1560bmv2l175();
         }
-        const default_action = act();
+        const default_action = issue1560bmv2l175();
     }
     apply {
         t0_0.apply();
         t1_0.apply();
-        tbl_act.apply();
+        tbl_issue1560bmv2l175.apply();
         t2_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2-midend.p4
@@ -26,7 +26,7 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
     @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
-    @hidden action act() {
+    @hidden action issue1566bmv2l44() {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
         E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
@@ -34,14 +34,14 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
         E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1566bmv2l44 {
         actions = {
-            act();
+            issue1566bmv2l44();
         }
-        const default_action = act();
+        const default_action = issue1566bmv2l44();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1566bmv2l44.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-midend.p4
@@ -26,7 +26,7 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
     @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
-    @hidden action act() {
+    @hidden action issue1566l44() {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
         E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
@@ -34,14 +34,14 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
         E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1566l44 {
         actions = {
-            act();
+            issue1566l44();
         }
-        const default_action = act();
+        const default_action = issue1566l44();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1566l44.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1595-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-1-midend.p4
@@ -8,19 +8,19 @@ control c(inout bit<32> b) {
         }
         default_action = a();
     }
-    @hidden action act() {
+    @hidden action issue15951l12() {
         b[6:3] = 4w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue15951l12 {
         actions = {
-            act();
+            issue15951l12();
         }
-        const default_action = act();
+        const default_action = issue15951l12();
     }
     apply {
         switch (t_0.apply().action_run) {
             a: {
-                tbl_act.apply();
+                tbl_issue15951l12.apply();
             }
         }
 

--- a/testdata/p4_16_samples_outputs/issue1595-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-midend.p4
@@ -58,57 +58,57 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue1595l76() {
         hdr.ethernet.srcAddr[39:32] = 8w2;
     }
-    @hidden action act_0() {
+    @hidden action issue1595l77() {
         hdr.ethernet.srcAddr[39:32] = 8w3;
     }
-    @hidden action act_1() {
+    @hidden action issue1595l78() {
         hdr.ethernet.srcAddr[39:32] = 8w4;
     }
-    @hidden action act_2() {
+    @hidden action issue1595l79() {
         hdr.ethernet.srcAddr[39:32] = 8w5;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1595l76 {
         actions = {
-            act();
+            issue1595l76();
         }
-        const default_action = act();
+        const default_action = issue1595l76();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue1595l77 {
         actions = {
-            act_0();
+            issue1595l77();
         }
-        const default_action = act_0();
+        const default_action = issue1595l77();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue1595l78 {
         actions = {
-            act_1();
+            issue1595l78();
         }
-        const default_action = act_1();
+        const default_action = issue1595l78();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_issue1595l79 {
         actions = {
-            act_2();
+            issue1595l79();
         }
-        const default_action = act_2();
+        const default_action = issue1595l79();
     }
     apply {
         switch (t1_0.apply().action_run) {
             a1: {
             }
             a2: {
-                tbl_act.apply();
+                tbl_issue1595l76.apply();
             }
             a3: {
-                tbl_act_0.apply();
+                tbl_issue1595l77.apply();
             }
             a4: {
-                tbl_act_1.apply();
+                tbl_issue1595l78.apply();
             }
             NoAction_0: {
-                tbl_act_2.apply();
+                tbl_issue1595l79.apply();
             }
         }
 

--- a/testdata/p4_16_samples_outputs/issue1638-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1638-midend.p4
@@ -32,17 +32,17 @@ control MyC(inout hdr_t hdr, inout meta_t meta, in intrinsic_metadata_t intr_md)
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue1638l23() {
         key_0 = 8w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1638l23 {
         actions = {
-            act();
+            issue1638l23();
         }
-        const default_action = act();
+        const default_action = issue1638l23();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1638l23.apply();
         c2_a.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1642-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1642-bmv2-midend.p4
@@ -33,7 +33,7 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 }
 
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue1642bmv2l36() {
         local_metadata._s0.setValid();
         local_metadata._s0.f = 32w0;
         local_metadata._row_alt0_valid1 = local_metadata._row_alt1_valid3;
@@ -42,14 +42,14 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata._row_alt1_port4 = local_metadata._row_alt1_port4 + 7w1;
         clone3<row_t>(CloneType.I2E, 32w0, row_t {alt0 = alt_t {valid = 1w1,port = local_metadata._row_alt0_port2},alt1 = alt_t {valid = local_metadata._row_alt1_valid3,port = local_metadata._row_alt1_port4}});
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1642bmv2l36 {
         actions = {
-            act();
+            issue1642bmv2l36();
         }
-        const default_action = act();
+        const default_action = issue1642bmv2l36();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1642bmv2l36.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2-midend.p4
@@ -22,17 +22,17 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 }
 
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue1653bmv2l49() {
         clone3<parsed_packet_t>(CloneType.I2E, 32w0, h);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1653bmv2l49 {
         actions = {
-            act();
+            issue1653bmv2l49();
         }
-        const default_action = act();
+        const default_action = issue1653bmv2l49();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1653bmv2l49.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-midend.p4
@@ -90,20 +90,20 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue1653complexbmv2l95() {
         h.bvh0._row_alt1_type10 = 16w0x800;
         local_metadata._row0_alt0_useHash3 = true;
         clone3<row_t>(CloneType.I2E, 32w0, row_t {alt0 = alt_t {valid = local_metadata._row0_alt0_valid0,port = local_metadata._row0_alt0_port1,hashRes = local_metadata._row0_alt0_hashRes2,useHash = true,type = local_metadata._row0_alt0_type4,pad = local_metadata._row0_alt0_pad5},alt1 = alt_t {valid = local_metadata._row0_alt1_valid6,port = local_metadata._row0_alt1_port7,hashRes = local_metadata._row0_alt1_hashRes8,useHash = local_metadata._row0_alt1_useHash9,type = local_metadata._row0_alt1_type10,pad = local_metadata._row0_alt1_pad11}});
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1653complexbmv2l95 {
         actions = {
-            act();
+            issue1653complexbmv2l95();
         }
-        const default_action = act();
+        const default_action = issue1653complexbmv2l95();
     }
     apply {
         tns_0.apply();
-        tbl_act.apply();
+        tbl_issue1653complexbmv2l95.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2-midend.p4
@@ -19,18 +19,18 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     HasBool b_0;
-    @hidden action act() {
+    @hidden action issue1660bmv2l21() {
         b_0.x = true;
         clone3<HasBool>(CloneType.I2E, 32w0, b_0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1660bmv2l21 {
         actions = {
-            act();
+            issue1660bmv2l21();
         }
-        const default_action = act();
+        const default_action = issue1660bmv2l21();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1660bmv2l21.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1670-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1670-bmv2-midend.p4
@@ -23,18 +23,18 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 }
 
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue1670bmv2l29() {
         h.mirrored_md.setValid();
         h.mirrored_md._meta_port0 = 8w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1670bmv2l29 {
         actions = {
-            act();
+            issue1670bmv2l29();
         }
-        const default_action = act();
+        const default_action = issue1670bmv2l29();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1670bmv2l29.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2-midend.p4
@@ -277,22 +277,22 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
 }
 
 control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue17651bmv2l343() {
         hdr.cpu.setValid();
         hdr.cpu.task = meta.task;
         hdr.cpu.ethertype = hdr.ethernet.ethertype;
         hdr.cpu.ingress_port = (bit<16>)meta.ingress_port;
         hdr.ethernet.ethertype = 16w0x4242;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue17651bmv2l343 {
         actions = {
-            act();
+            issue17651bmv2l343();
         }
-        const default_action = act();
+        const default_action = issue17651bmv2l343();
     }
     apply {
         if (standard_metadata.instance_type == 32w1) {
-            tbl_act.apply();
+            tbl_issue17651bmv2l343.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2-midend.p4
@@ -24,18 +24,18 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue1768bmv2l32() {
         mark_to_drop(standard_metadata);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1768bmv2l32 {
         actions = {
-            act();
+            issue1768bmv2l32();
         }
-        const default_action = act();
+        const default_action = issue1768bmv2l32();
     }
     apply {
         if (standard_metadata.parser_error != error.NoError) {
-            tbl_act.apply();
+            tbl_issue1768bmv2l32.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2-midend.p4
@@ -36,18 +36,18 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue18141bmv2l42() {
         testRegister_0.read(registerData_0, 32w0);
         meta.test = (bool)registerData_0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue18141bmv2l42 {
         actions = {
-            act();
+            issue18141bmv2l42();
         }
-        const default_action = act();
+        const default_action = issue18141bmv2l42();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue18141bmv2l42.apply();
         debug_table_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2-midend.p4
@@ -28,18 +28,18 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue1814bmv2l33() {
         testRegister_0.read(registerData_0, 32w0);
         meta.test = (bool)registerData_0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1814bmv2l33 {
         actions = {
-            act();
+            issue1814bmv2l33();
         }
-        const default_action = act();
+        const default_action = issue1814bmv2l33();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1814bmv2l33.apply();
         debug_table_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1824-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1824-bmv2-midend.p4
@@ -36,18 +36,18 @@ parser MyParser(packet_in pkt, out headers hdr, inout metadata meta, inout stand
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
-    @hidden action act() {
+    @hidden action issue1824bmv2l52() {
         hdr.h1.dstAddr = 48w0xbad;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1824bmv2l52 {
         actions = {
-            act();
+            issue1824bmv2l52();
         }
-        const default_action = act();
+        const default_action = issue1824bmv2l52();
     }
     apply {
         if (stdmeta.parser_error != error.NoError) {
-            tbl_act.apply();
+            tbl_issue1824bmv2l52.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1829-4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1829-4-bmv2-midend.p4
@@ -40,17 +40,17 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
         }
         const default_action = do_meter();
     }
-    @hidden action act() {
+    @hidden action issue18294bmv2l74() {
         stdmeta.egress_spec = 9w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue18294bmv2l74 {
         actions = {
-            act();
+            issue18294bmv2l74();
         }
-        const default_action = act();
+        const default_action = issue18294bmv2l74();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue18294bmv2l74.apply();
         mac_da_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1863-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1863-midend.p4
@@ -4,17 +4,17 @@ struct S {
 }
 
 control c(out bit<1> b) {
-    @hidden action act() {
+    @hidden action issue1863l10() {
         b = 1w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1863l10 {
         actions = {
-            act();
+            issue1863l10();
         }
-        const default_action = act();
+        const default_action = issue1863l10();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1863l10.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2-midend.p4
@@ -144,18 +144,18 @@ control PROTVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control PROTIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue1879bmv2l206() {
         mark_to_drop(standard_metadata);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1879bmv2l206 {
         actions = {
-            act();
+            issue1879bmv2l206();
         }
-        const default_action = act();
+        const default_action = issue1879bmv2l206();
     }
     apply {
         if (meta._currenti_upDirection4 == 1w0) {
-            tbl_act.apply();
+            tbl_issue1879bmv2l206.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1882-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1882-1-bmv2-midend.p4
@@ -43,17 +43,17 @@ extern ExternCounter {
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.extr") ExternCounter(5) extr_0;
-    @hidden action act() {
+    @hidden action issue18821bmv2l33() {
         extr_0.increment();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue18821bmv2l33 {
         actions = {
-            act();
+            issue18821bmv2l33();
         }
-        const default_action = act();
+        const default_action = issue18821bmv2l33();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue18821bmv2l33.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1882-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1882-bmv2-midend.p4
@@ -43,17 +43,17 @@ extern ExternCounter {
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.extr") ExternCounter() extr_0;
-    @hidden action act() {
+    @hidden action issue1882bmv2l33() {
         extr_0.increment();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue1882bmv2l33 {
         actions = {
-            act();
+            issue1882bmv2l33();
         }
-        const default_action = act();
+        const default_action = issue1882bmv2l33();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue1882bmv2l33.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1937-3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-3-bmv2-midend.p4
@@ -14,18 +14,18 @@ struct metadata_t {
 }
 
 control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @hidden action act() {
+    @hidden action issue19373bmv2l26() {
         hdr.h1.f1 = hdr.h1.f1 >> 2;
         hdr.h1.f2 = 8w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue19373bmv2l26 {
         actions = {
-            act();
+            issue19373bmv2l26();
         }
-        const default_action = act();
+        const default_action = issue19373bmv2l26();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue19373bmv2l26.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue210-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue210-midend.p4
@@ -6,14 +6,14 @@ control Ing(out bit<32> a) {
         a = (b_0 ? 32w5 : a);
         a = (!b_0 ? 32w10 : a);
     }
-    @hidden action act() {
+    @hidden action issue210l30() {
         b_0 = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue210l30 {
         actions = {
-            act();
+            issue210l30();
         }
-        const default_action = act();
+        const default_action = issue210l30();
     }
     @hidden table tbl_cond {
         actions = {
@@ -22,7 +22,7 @@ control Ing(out bit<32> a) {
         const default_action = cond();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue210l30.apply();
         tbl_cond.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue242-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-midend.p4
@@ -55,17 +55,17 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    @hidden action act() {
+    @hidden action issue242l73() {
         standard_meta.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue242l73 {
         actions = {
-            act();
+            issue242l73();
         }
-        const default_action = act();
+        const default_action = issue242l73();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue242l73.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue272-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue272-1-bmv2-midend.p4
@@ -35,17 +35,17 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 }
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
-    @hidden action act() {
+    @hidden action issue2721bmv2l46() {
         meta._some_meta_flag0 = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue2721bmv2l46 {
         actions = {
-            act();
+            issue2721bmv2l46();
         }
-        const default_action = act();
+        const default_action = issue2721bmv2l46();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue2721bmv2l46.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue272-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue272-2-bmv2-midend.p4
@@ -31,17 +31,17 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 }
 
 control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
-    @hidden action act() {
+    @hidden action issue2722bmv2l44() {
         meta.flag = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue2722bmv2l44 {
         actions = {
-            act();
+            issue2722bmv2l44();
         }
-        const default_action = act();
+        const default_action = issue2722bmv2l44();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue2722bmv2l44.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue304-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue304-1-midend.p4
@@ -19,18 +19,18 @@ control t(inout bit<32> b) {
             arg = arg + c2_tmp;
         }
     };
-    @hidden action act() {
+    @hidden action issue3041l28() {
         c1_x.a(b);
         c2_x.a(b);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue3041l28 {
         actions = {
-            act();
+            issue3041l28();
         }
-        const default_action = act();
+        const default_action = issue3041l28();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue3041l28.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue304-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue304-midend.p4
@@ -1,16 +1,16 @@
 control t(inout bit<32> b) {
-    @hidden action act() {
+    @hidden action issue304l19() {
         b = b + 32w1;
         b = b + 32w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue304l19 {
         actions = {
-            act();
+            issue304l19();
         }
-        const default_action = act();
+        const default_action = issue304l19();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue304l19.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue313_1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue313_1-midend.p4
@@ -14,7 +14,7 @@ control ctrl(inout struct_t input, out header_h output) {
         input.stack.pop_front(1);
         tmp1_0 = tmp0_0;
     }
-    @hidden action act_0() {
+    @hidden action issue313_1l35() {
         output = tmp1_0;
     }
     @hidden table tbl_act {
@@ -23,15 +23,15 @@ control ctrl(inout struct_t input, out header_h output) {
         }
         const default_action = act();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue313_1l35 {
         actions = {
-            act_0();
+            issue313_1l35();
         }
-        const default_action = act_0();
+        const default_action = issue313_1l35();
     }
     apply {
         tbl_act.apply();
-        tbl_act_0.apply();
+        tbl_issue313_1l35.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue313_2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue313_2-midend.p4
@@ -14,7 +14,7 @@ control ctrl(inout struct_t input, out bit<8> output) {
         input.stack.pop_front(1);
         tmp1_0 = tmp0_0;
     }
-    @hidden action act_0() {
+    @hidden action issue313_2l35() {
         output = tmp1_0;
     }
     @hidden table tbl_act {
@@ -23,15 +23,15 @@ control ctrl(inout struct_t input, out bit<8> output) {
         }
         const default_action = act();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue313_2l35 {
         actions = {
-            act_0();
+            issue313_2l35();
         }
-        const default_action = act_0();
+        const default_action = issue313_2l35();
     }
     apply {
         tbl_act.apply();
-        tbl_act_0.apply();
+        tbl_issue313_2l35.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue313_3-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue313_3-midend.p4
@@ -19,7 +19,7 @@ control ctrl(inout struct_t input, out bit<8> out1, out header_h out2) {
         input.hdr.setInvalid();
         tmp3_0 = tmp2_0;
     }
-    @hidden action act_0() {
+    @hidden action issue313_3l41() {
         out1 = tmp1_0;
         out2 = tmp3_0;
     }
@@ -29,15 +29,15 @@ control ctrl(inout struct_t input, out bit<8> out1, out header_h out2) {
         }
         const default_action = act();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue313_3l41 {
         actions = {
-            act_0();
+            issue313_3l41();
         }
-        const default_action = act_0();
+        const default_action = issue313_3l41();
     }
     apply {
         tbl_act.apply();
-        tbl_act_0.apply();
+        tbl_issue313_3l41.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
@@ -75,7 +75,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue383bmv2l104() {
         local_metadata._col_bvh8._row_alt0_valid0 = 1w0;
         local_metadata._row0_alt0_valid0 = local_metadata._row1_alt1_valid6;
         local_metadata._row0_alt0_port1 = local_metadata._row1_alt1_port7;
@@ -83,15 +83,15 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         local_metadata._row1_alt1_port7 = local_metadata._row0_alt1_port3 + 7w1;
         clone3<row_t>(CloneType.I2E, 32w0, row_t {alt0 = alt_t {valid = local_metadata._row1_alt1_valid6,port = local_metadata._row0_alt0_port1},alt1 = alt_t {valid = local_metadata._row0_alt1_valid2,port = local_metadata._row0_alt1_port3}});
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue383bmv2l104 {
         actions = {
-            act();
+            issue383bmv2l104();
         }
-        const default_action = act();
+        const default_action = issue383bmv2l104();
     }
     apply {
         tns_0.apply();
-        tbl_act.apply();
+        tbl_issue383bmv2l104.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue396-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-midend.p4
@@ -15,7 +15,7 @@ control d(out bool b) {
     H s1_0_h;
     bool eout_0;
     H tmp;
-    @hidden action act() {
+    @hidden action issue396l28() {
         h_0.setValid();
         h_0.x = 32w0;
         s_0_h.setValid();
@@ -29,14 +29,14 @@ control d(out bool b) {
         eout_0 = tmp.isValid();
         b = h_0.isValid() && eout_0 && h3_0[1].isValid() && s1_0_h.isValid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue396l28 {
         actions = {
-            act();
+            issue396l28();
         }
-        const default_action = act();
+        const default_action = issue396l28();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue396l28.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2-midend.p4
@@ -31,18 +31,18 @@ struct tuple_0 {
 }
 
 control cIngress(inout Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
-    @hidden action act() {
+    @hidden action issue4301bmv2l44() {
         digest<tuple_0>(32w5, { hdr.ethernet.srcAddr });
         hdr.ethernet.srcAddr = 48w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue4301bmv2l44 {
         actions = {
-            act();
+            issue4301bmv2l44();
         }
-        const default_action = act();
+        const default_action = issue4301bmv2l44();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue4301bmv2l44.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue430-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue430-bmv2-midend.p4
@@ -29,17 +29,17 @@ struct tuple_0 {
 
 control MyIngress(inout my_packet p, inout my_metadata m, inout standard_metadata_t s) {
     bit<32> x_0;
-    @hidden action act() {
+    @hidden action issue430bmv2l40() {
         hash<bit<32>, bit<32>, tuple_0, bit<32>>(x_0, HashAlgorithm.crc32, 32w0, { p.h.f ^ 32w0xffff }, 32w65536);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue430bmv2l40 {
         actions = {
-            act();
+            issue430bmv2l40();
         }
-        const default_action = act();
+        const default_action = issue430bmv2l40();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue430bmv2l40.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-midend.p4
@@ -36,19 +36,19 @@ control DeparserI(packet_out packet, in Parsed_packet hdr) {
 
 control ingress(inout Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
     varbit<32> s_0;
-    @hidden action act() {
+    @hidden action issue4475bmv2l41() {
         s_0 = hdr.h1.var;
         hdr.h1.var = hdr.h2.var;
         hdr.h2.var = s_0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue4475bmv2l41 {
         actions = {
-            act();
+            issue4475bmv2l41();
         }
-        const default_action = act();
+        const default_action = issue4475bmv2l41();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue4475bmv2l41.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue486-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue486-bmv2-midend.p4
@@ -46,17 +46,17 @@ control cIngress(inout Parsed_packet hdr, inout metadata m, inout standard_metad
         }
         default_action = foo();
     }
-    @hidden action act() {
+    @hidden action issue486bmv2l58() {
         z_0 = 32w5;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue486bmv2l58 {
         actions = {
-            act();
+            issue486bmv2l58();
         }
-        const default_action = act();
+        const default_action = issue486bmv2l58();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue486bmv2l58.apply();
         t_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue510-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue510-bmv2-midend.p4
@@ -27,18 +27,18 @@ control MyVerifyChecksum(inout my_headers_t hdr, inout my_metadata_t meta) {
 }
 
 control MyIngress(inout my_headers_t hdr, inout my_metadata_t meta, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue510bmv2l59() {
         hdr.s.setInvalid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue510bmv2l59 {
         actions = {
-            act();
+            issue510bmv2l59();
         }
-        const default_action = act();
+        const default_action = issue510bmv2l59();
     }
     apply {
         if (meta.parser_error == error.NoMatch) {
-            tbl_act.apply();
+            tbl_issue510bmv2l59.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-1-bmv2-midend.p4
@@ -59,30 +59,30 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue5611bmv2l65() {
         hdr.u.short.data = 16w0xffff;
     }
-    @hidden action act_0() {
+    @hidden action issue5611bmv2l68() {
         hdr.u.byte.data = 8w0xff;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue5611bmv2l65 {
         actions = {
-            act();
+            issue5611bmv2l65();
         }
-        const default_action = act();
+        const default_action = issue5611bmv2l65();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue5611bmv2l68 {
         actions = {
-            act_0();
+            issue5611bmv2l68();
         }
-        const default_action = act_0();
+        const default_action = issue5611bmv2l68();
     }
     apply {
         debug_hdr_0.apply();
         if (hdr.u.short.isValid()) {
-            tbl_act.apply();
+            tbl_issue5611bmv2l65.apply();
         } else if (hdr.u.byte.isValid()) {
-            tbl_act_0.apply();
+            tbl_issue5611bmv2l68.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-2-bmv2-midend.p4
@@ -62,30 +62,30 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue5612bmv2l70() {
         hdr.u.short.setInvalid();
     }
-    @hidden action act_0() {
+    @hidden action issue5612bmv2l74() {
         hdr.u.byte.setInvalid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue5612bmv2l70 {
         actions = {
-            act();
+            issue5612bmv2l70();
         }
-        const default_action = act();
+        const default_action = issue5612bmv2l70();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue5612bmv2l74 {
         actions = {
-            act_0();
+            issue5612bmv2l74();
         }
-        const default_action = act_0();
+        const default_action = issue5612bmv2l74();
     }
     apply {
         debug_hdr_0.apply();
         if (hdr.u.short.isValid()) {
-            tbl_act.apply();
+            tbl_issue5612bmv2l70.apply();
         } else if (hdr.u.byte.isValid()) {
-            tbl_act_0.apply();
+            tbl_issue5612bmv2l74.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-3-bmv2-midend.p4
@@ -62,34 +62,34 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue5613bmv2l69() {
         hdr.u.short.data = 16w0xaaaa;
         hdr.u.byte.setValid();
         hdr.u.byte.data = 8w0xff;
     }
-    @hidden action act_0() {
+    @hidden action issue5613bmv2l74() {
         hdr.u.byte.data = 8w0xaa;
         hdr.u.short.setValid();
         hdr.u.short.data = 16w0xffff;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue5613bmv2l69 {
         actions = {
-            act();
+            issue5613bmv2l69();
         }
-        const default_action = act();
+        const default_action = issue5613bmv2l69();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue5613bmv2l74 {
         actions = {
-            act_0();
+            issue5613bmv2l74();
         }
-        const default_action = act_0();
+        const default_action = issue5613bmv2l74();
     }
     apply {
         debug_hdr_0.apply();
         if (hdr.u.short.isValid()) {
-            tbl_act.apply();
+            tbl_issue5613bmv2l69.apply();
         } else if (hdr.u.byte.isValid()) {
-            tbl_act_0.apply();
+            tbl_issue5613bmv2l74.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-4-bmv2-midend.p4
@@ -75,55 +75,55 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue5614bmv2l81() {
         hdr.u[0].short.data = 16w0xffff;
     }
-    @hidden action act_0() {
+    @hidden action issue5614bmv2l84() {
         hdr.u[0].byte.data = 8w0xaa;
     }
-    @hidden action act_1() {
+    @hidden action issue5614bmv2l87() {
         hdr.u[1].short.data = 16w0xffff;
     }
-    @hidden action act_2() {
+    @hidden action issue5614bmv2l90() {
         hdr.u[1].byte.data = 8w0xaa;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue5614bmv2l81 {
         actions = {
-            act();
+            issue5614bmv2l81();
         }
-        const default_action = act();
+        const default_action = issue5614bmv2l81();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue5614bmv2l84 {
         actions = {
-            act_0();
+            issue5614bmv2l84();
         }
-        const default_action = act_0();
+        const default_action = issue5614bmv2l84();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue5614bmv2l87 {
         actions = {
-            act_1();
+            issue5614bmv2l87();
         }
-        const default_action = act_1();
+        const default_action = issue5614bmv2l87();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_issue5614bmv2l90 {
         actions = {
-            act_2();
+            issue5614bmv2l90();
         }
-        const default_action = act_2();
+        const default_action = issue5614bmv2l90();
     }
     apply {
         debug_hdr_0.apply();
         if (hdr.u[0].short.isValid()) {
-            tbl_act.apply();
+            tbl_issue5614bmv2l81.apply();
         }
         if (hdr.u[0].byte.isValid()) {
-            tbl_act_0.apply();
+            tbl_issue5614bmv2l84.apply();
         }
         if (hdr.u[1].short.isValid()) {
-            tbl_act_1.apply();
+            tbl_issue5614bmv2l87.apply();
         }
         if (hdr.u[1].byte.isValid()) {
-            tbl_act_2.apply();
+            tbl_issue5614bmv2l90.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-5-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-5-bmv2-midend.p4
@@ -59,31 +59,31 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue5615bmv2l65() {
         hdr.u[0].short.data = 16w0xffff;
     }
-    @hidden action act_0() {
+    @hidden action issue5615bmv2l68() {
         hdr.u[0].byte.data = 8w0xff;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue5615bmv2l65 {
         actions = {
-            act();
+            issue5615bmv2l65();
         }
-        const default_action = act();
+        const default_action = issue5615bmv2l65();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue5615bmv2l68 {
         actions = {
-            act_0();
+            issue5615bmv2l68();
         }
-        const default_action = act_0();
+        const default_action = issue5615bmv2l68();
     }
     apply {
         debug_hdr_0.apply();
         if (hdr.u[0].short.isValid()) {
-            tbl_act.apply();
+            tbl_issue5615bmv2l65.apply();
         }
         if (hdr.u[0].byte.isValid()) {
-            tbl_act_0.apply();
+            tbl_issue5615bmv2l68.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-6-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-6-bmv2-midend.p4
@@ -75,55 +75,55 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue5616bmv2l81() {
         hdr.u[0].short.data = 16w0xffff;
     }
-    @hidden action act_0() {
+    @hidden action issue5616bmv2l84() {
         hdr.u[0].byte.data = 8w0xaa;
     }
-    @hidden action act_1() {
+    @hidden action issue5616bmv2l87() {
         hdr.u[1].short.data = 16w0xffff;
     }
-    @hidden action act_2() {
+    @hidden action issue5616bmv2l90() {
         hdr.u[1].byte.data = 8w0xaa;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue5616bmv2l81 {
         actions = {
-            act();
+            issue5616bmv2l81();
         }
-        const default_action = act();
+        const default_action = issue5616bmv2l81();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue5616bmv2l84 {
         actions = {
-            act_0();
+            issue5616bmv2l84();
         }
-        const default_action = act_0();
+        const default_action = issue5616bmv2l84();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue5616bmv2l87 {
         actions = {
-            act_1();
+            issue5616bmv2l87();
         }
-        const default_action = act_1();
+        const default_action = issue5616bmv2l87();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_issue5616bmv2l90 {
         actions = {
-            act_2();
+            issue5616bmv2l90();
         }
-        const default_action = act_2();
+        const default_action = issue5616bmv2l90();
     }
     apply {
         debug_hdr_0.apply();
         if (hdr.u[0].short.isValid()) {
-            tbl_act.apply();
+            tbl_issue5616bmv2l81.apply();
         }
         if (hdr.u[0].byte.isValid()) {
-            tbl_act_0.apply();
+            tbl_issue5616bmv2l84.apply();
         }
         if (hdr.u[1].short.isValid()) {
-            tbl_act_1.apply();
+            tbl_issue5616bmv2l87.apply();
         }
         if (hdr.u[1].byte.isValid()) {
-            tbl_act_2.apply();
+            tbl_issue5616bmv2l90.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-7-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-7-bmv2-midend.p4
@@ -59,30 +59,30 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue5617bmv2l66() {
         hdr.u[0].short.setInvalid();
     }
-    @hidden action act_0() {
+    @hidden action issue5617bmv2l70() {
         hdr.u[0].byte.setInvalid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue5617bmv2l66 {
         actions = {
-            act();
+            issue5617bmv2l66();
         }
-        const default_action = act();
+        const default_action = issue5617bmv2l66();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue5617bmv2l70 {
         actions = {
-            act_0();
+            issue5617bmv2l70();
         }
-        const default_action = act_0();
+        const default_action = issue5617bmv2l70();
     }
     apply {
         debug_hdr_0.apply();
         if (hdr.u[0].short.isValid()) {
-            tbl_act.apply();
+            tbl_issue5617bmv2l66.apply();
         } else if (hdr.u[0].byte.isValid()) {
-            tbl_act_0.apply();
+            tbl_issue5617bmv2l70.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-midend.p4
@@ -16,7 +16,7 @@ package top(ct _ct);
 control c(out bit<32> x) {
     U u_0;
     U[2] u2_0;
-    @hidden action act() {
+    @hidden action issue561l32() {
         u_0.isValid();
         u_0.h1.isValid();
         x = u_0.h1.f + u_0.h2.g;
@@ -29,14 +29,14 @@ control c(out bit<32> x) {
         u2_0[0].h1.f = 32w2;
         x = x + u2_0[1].h2.g + 32w2;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue561l32 {
         actions = {
-            act();
+            issue561l32();
         }
-        const default_action = act();
+        const default_action = issue561l32();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue561l32.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue562-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue562-bmv2-midend.p4
@@ -28,21 +28,21 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 }
 
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue562bmv2l31() {
         local_metadata._row_alt0_valid0 = local_metadata._row_alt1_valid2;
         local_metadata._row_alt0_port1 = local_metadata._row_alt1_port3;
         local_metadata._row_alt0_valid0 = 1w1;
         local_metadata._row_alt1_port3 = local_metadata._row_alt1_port3 + 7w1;
         clone3<row_t>(CloneType.I2E, 32w0, row_t {alt0 = alt_t {valid = 1w1,port = local_metadata._row_alt0_port1},alt1 = alt_t {valid = local_metadata._row_alt1_valid2,port = local_metadata._row_alt1_port3}});
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue562bmv2l31 {
         actions = {
-            act();
+            issue562bmv2l31();
         }
-        const default_action = act();
+        const default_action = issue562bmv2l31();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue562bmv2l31.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue584-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue584-1-midend.p4
@@ -5,17 +5,17 @@ control p();
 package top(p _p);
 control c() {
     bit<16> var_0;
-    @hidden action act() {
+    @hidden action issue5841l28() {
         hash<bit<16>, bit<16>, bit<32>, bit<16>>(var_0, HashAlgorithm.crc16, 16w0, 32w0, 16w0xffff);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue5841l28 {
         actions = {
-            act();
+            issue5841l28();
         }
-        const default_action = act();
+        const default_action = issue5841l28();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue5841l28.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue648-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue648-midend.p4
@@ -7,18 +7,18 @@ header hdr {
 }
 
 control ingress(inout hdr h) {
-    @hidden action act() {
+    @hidden action issue648l11() {
         h.a[7:0] = ((bit<32>)h.c)[7:0];
         h.a[15:8] = (h.c + h.c)[7:0];
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue648l11 {
         actions = {
-            act();
+            issue648l11();
         }
-        const default_action = act();
+        const default_action = issue648l11();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue648l11.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-midend.p4
@@ -27,17 +27,17 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout 
 }
 
 control cIngress(inout Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
-    @hidden action act() {
+    @hidden action issue655bmv2l32() {
         hdr.h.d = hdr.h.d + 16w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue655bmv2l32 {
         actions = {
-            act();
+            issue655bmv2l32();
         }
-        const default_action = act();
+        const default_action = issue655bmv2l32();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue655bmv2l32.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue655-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-midend.p4
@@ -27,17 +27,17 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout 
 }
 
 control cIngress(inout Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
-    @hidden action act() {
+    @hidden action issue655l32() {
         hdr.h.d = hdr.h.d + 16w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue655l32 {
         actions = {
-            act();
+            issue655l32();
         }
-        const default_action = act();
+        const default_action = issue655l32();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue655l32.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue677-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue677-bmv2-midend.p4
@@ -15,17 +15,17 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout SM smeta) {
 }
 
 control IngressI(inout H hdr, inout M meta, inout SM smeta) {
-    @hidden action act() {
+    @hidden action issue677bmv2l19() {
         smeta.egress_spec = 9w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue677bmv2l19 {
         actions = {
-            act();
+            issue677bmv2l19();
         }
-        const default_action = act();
+        const default_action = issue677bmv2l19();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue677bmv2l19.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-midend.p4
@@ -59,17 +59,17 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    @hidden action act() {
+    @hidden action issue696bmv2l76() {
         standard_meta.egress_spec = 9w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue696bmv2l76 {
         actions = {
-            act();
+            issue696bmv2l76();
         }
-        const default_action = act();
+        const default_action = issue696bmv2l76();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue696bmv2l76.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue737-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue737-bmv2-midend.p4
@@ -26,42 +26,42 @@ control VeryChecksum(inout Parsed_packet hdr, inout Meta meta) {
 }
 
 control IngressP(inout Parsed_packet hdr, inout Meta m, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue737bmv2l35() {
         hdr.h.field = 64w3;
     }
-    @hidden action act_0() {
+    @hidden action issue737bmv2l38() {
         hdr.h.field = 64w5;
     }
-    @hidden action act_1() {
+    @hidden action issue737bmv2l41() {
         hdr.h.field = 64w4;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue737bmv2l35 {
         actions = {
-            act();
+            issue737bmv2l35();
         }
-        const default_action = act();
+        const default_action = issue737bmv2l35();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue737bmv2l38 {
         actions = {
-            act_0();
+            issue737bmv2l38();
         }
-        const default_action = act_0();
+        const default_action = issue737bmv2l38();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue737bmv2l41 {
         actions = {
-            act_1();
+            issue737bmv2l41();
         }
-        const default_action = act_1();
+        const default_action = issue737bmv2l41();
     }
     apply {
         if (m.metafield) {
-            tbl_act.apply();
+            tbl_issue737bmv2l35.apply();
         }
         if (m.metafield == false) {
-            tbl_act_0.apply();
+            tbl_issue737bmv2l38.apply();
         }
         if (!m.metafield) {
-            tbl_act_1.apply();
+            tbl_issue737bmv2l41.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue754-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue754-midend.p4
@@ -1,17 +1,17 @@
 control ctrl(out bit<3> _x);
 package top(ctrl c);
 control c_0(out bit<3> x) {
-    @hidden action act() {
+    @hidden action issue754l1() {
         x = 3w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue754l1 {
         actions = {
-            act();
+            issue754l1();
         }
-        const default_action = act();
+        const default_action = issue754l1();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue754l1.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue794-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue794-midend.p4
@@ -18,17 +18,17 @@ parser caller() {
 
 control ingress() {
     @name("ingress.rand1") Random2() rand1_1;
-    @hidden action act() {
+    @hidden action issue794l47() {
         rand1_1.read();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue794l47 {
         actions = {
-            act();
+            issue794l47();
         }
-        const default_action = act();
+        const default_action = issue794l47();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue794l47.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue803-2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue803-2-midend.p4
@@ -55,34 +55,34 @@ parser ing_parse(packet_in buffer, out ing_in_headers parsed_hdr) {
 }
 
 control ingress(in ing_in_headers ihdr, in InControl inCtrl, out ing_out_headers ohdr, out ing_to_egr toEgress, out OutControl outCtrl) {
-    @hidden action act() {
+    @hidden action issue8032l95() {
         ohdr.ethernet = ihdr.ethernet;
         toEgress.x = inCtrl.inputPort;
         outCtrl.outputPort = inCtrl.inputPort;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue8032l95 {
         actions = {
-            act();
+            issue8032l95();
         }
-        const default_action = act();
+        const default_action = issue8032l95();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue8032l95.apply();
     }
 }
 
 control ing_deparse(in ing_out_headers ohdr, packet_out b) {
-    @hidden action act_0() {
+    @hidden action issue8032l104() {
         b.emit<ethernet_t>(ohdr.ethernet);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue8032l104 {
         actions = {
-            act_0();
+            issue8032l104();
         }
-        const default_action = act_0();
+        const default_action = issue8032l104();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_issue8032l104.apply();
     }
 }
 
@@ -94,33 +94,33 @@ parser egr_parse(packet_in buffer, out egr_in_headers parsed_hdr) {
 }
 
 control egress(in egr_in_headers ihdr, in InControl inCtrl, in ing_to_egr fromIngress, out egr_out_headers ohdr, out OutControl outCtrl) {
-    @hidden action act_1() {
+    @hidden action issue8032l123() {
         ohdr.ethernet = ihdr.ethernet;
         outCtrl.outputPort = fromIngress.x;
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue8032l123 {
         actions = {
-            act_1();
+            issue8032l123();
         }
-        const default_action = act_1();
+        const default_action = issue8032l123();
     }
     apply {
-        tbl_act_1.apply();
+        tbl_issue8032l123.apply();
     }
 }
 
 control egr_deparse(in egr_out_headers ohdr, packet_out b) {
-    @hidden action act_2() {
+    @hidden action issue8032l131() {
         b.emit<ethernet_t>(ohdr.ethernet);
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_issue8032l131 {
         actions = {
-            act_2();
+            issue8032l131();
         }
-        const default_action = act_2();
+        const default_action = issue8032l131();
     }
     apply {
-        tbl_act_2.apply();
+        tbl_issue8032l131.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue870_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue870_ebpf-midend.p4
@@ -62,30 +62,30 @@ control pipe(inout Headers_t headers, out bool pass) {
         implementation = hash_table(32w1024);
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue870_ebpf72() {
         pass = false;
         hasReturned = true;
     }
-    @hidden action act_0() {
+    @hidden action issue870_ebpf68() {
         hasReturned = false;
         pass = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue870_ebpf68 {
         actions = {
-            act_0();
+            issue870_ebpf68();
         }
-        const default_action = act_0();
+        const default_action = issue870_ebpf68();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue870_ebpf72 {
         actions = {
-            act();
+            issue870_ebpf72();
         }
-        const default_action = act();
+        const default_action = issue870_ebpf72();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue870_ebpf68.apply();
         if (!headers.ipv4.isValid()) {
-            tbl_act_0.apply();
+            tbl_issue870_ebpf72.apply();
         }
         if (!hasReturned) {
             Check_src_ip_0.apply();

--- a/testdata/p4_16_samples_outputs/issue871-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue871-midend.p4
@@ -5,17 +5,17 @@ extern lpf<I> {
 
 control c() {
     @name("c.lpf_0") lpf<bit<32>>(32w32) lpf_1;
-    @hidden action act() {
+    @hidden action issue871l11() {
         lpf_1.execute<bit<8>>(8w0, 32w0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue871l11 {
         actions = {
-            act();
+            issue871l11();
         }
-        const default_action = act();
+        const default_action = issue871l11();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue871l11.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue907-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2-midend.p4
@@ -20,18 +20,18 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     S s_0;
     @name("Ing.r") register<S>(32w100) r_0;
-    @hidden action act() {
+    @hidden action issue907bmv2l22() {
         s_0.f = 32w0;
         r_0.write(32w0, s_0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue907bmv2l22 {
         actions = {
-            act();
+            issue907bmv2l22();
         }
-        const default_action = act();
+        const default_action = issue907bmv2l22();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue907bmv2l22.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue933-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue933-1-midend.p4
@@ -6,17 +6,17 @@ struct headers {
 
 extern void f(headers h);
 control c() {
-    @hidden action act() {
+    @hidden action issue9331l13() {
         f(headers {x = 32w5});
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue9331l13 {
         actions = {
-            act();
+            issue9331l13();
         }
-        const default_action = act();
+        const default_action = issue9331l13();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue9331l13.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue955-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue955-midend.p4
@@ -20,17 +20,17 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
-    @hidden action act() {
+    @hidden action issue955l33() {
         hdr.h.isValid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue955l33 {
         actions = {
-            act();
+            issue955l33();
         }
-        const default_action = act();
+        const default_action = issue955l33();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue955l33.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue982-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue982-midend.p4
@@ -380,59 +380,59 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
 
 control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd, out psa_ingress_deparser_output_metadata_t ostd) {
     clone_union_t clone_md_0_data;
-    @hidden action act() {
+    @hidden action issue982l420() {
         ostd.clone_metadata.type = 3w0;
         ostd.clone_metadata.data.h0 = clone_md_0_data.h0;
         ostd.clone_metadata.data.h1 = clone_md_0_data.h1;
     }
-    @hidden action act_0() {
+    @hidden action issue982l417() {
         clone_md_0_data.h1.setValid();
         clone_md_0_data.h1.data = 32w0;
     }
-    @hidden action act_1() {
+    @hidden action issue982l422() {
         packet.emit<ethernet_t>(hdr.ethernet);
         packet.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue982l417 {
         actions = {
-            act_0();
+            issue982l417();
         }
-        const default_action = act_0();
+        const default_action = issue982l417();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue982l420 {
         actions = {
-            act();
+            issue982l420();
         }
-        const default_action = act();
+        const default_action = issue982l420();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue982l422 {
         actions = {
-            act_1();
+            issue982l422();
         }
-        const default_action = act_1();
+        const default_action = issue982l422();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue982l417.apply();
         if (meta._custom_clone_id1 == 3w1) {
-            tbl_act_0.apply();
+            tbl_issue982l420.apply();
         }
-        tbl_act_1.apply();
+        tbl_issue982l422.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, out psa_egress_deparser_output_metadata_t ostd) {
-    @hidden action act_2() {
+    @hidden action issue982l429() {
         packet.emit<ethernet_t>(hdr.ethernet);
         packet.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_issue982l429 {
         actions = {
-            act_2();
+            issue982l429();
         }
-        const default_action = act_2();
+        const default_action = issue982l429();
     }
     apply {
-        tbl_act_2.apply();
+        tbl_issue982l429.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue983-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue983-bmv2-midend.p4
@@ -69,10 +69,10 @@ control ingress(inout headers hdr, inout metadata user_meta, inout standard_meta
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue983bmv2l108() {
         hdr.ethernet.dstAddr[47:40] = 8w1;
     }
-    @hidden action act_0() {
+    @hidden action issue983bmv2l92() {
         user_meta._fwd_meta_tmp0 = ~hdr.ethernet.etherType;
         user_meta._fwd_meta_x11 = (bit<32>)~hdr.ethernet.etherType;
         user_meta._fwd_meta_x22 = ((bit<32>)~hdr.ethernet.etherType)[31:16] + ((bit<32>)~hdr.ethernet.etherType)[15:0];
@@ -85,70 +85,70 @@ control ingress(inout headers hdr, inout metadata user_meta, inout standard_meta
         user_meta._fwd_meta_exp_x49 = 32w0xfffff7ff;
         hdr.ethernet.dstAddr = 48w0;
     }
-    @hidden action act_1() {
+    @hidden action issue983bmv2l111() {
         hdr.ethernet.dstAddr[39:32] = 8w1;
     }
-    @hidden action act_2() {
+    @hidden action issue983bmv2l114() {
         hdr.ethernet.dstAddr[31:24] = 8w1;
     }
-    @hidden action act_3() {
+    @hidden action issue983bmv2l117() {
         hdr.ethernet.dstAddr[23:16] = 8w1;
     }
-    @hidden action act_4() {
+    @hidden action issue983bmv2l120() {
         hdr.ethernet.dstAddr[15:8] = 8w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue983bmv2l92 {
         actions = {
-            act_0();
+            issue983bmv2l92();
         }
-        const default_action = act_0();
+        const default_action = issue983bmv2l92();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue983bmv2l108 {
         actions = {
-            act();
+            issue983bmv2l108();
         }
-        const default_action = act();
+        const default_action = issue983bmv2l108();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_issue983bmv2l111 {
         actions = {
-            act_1();
+            issue983bmv2l111();
         }
-        const default_action = act_1();
+        const default_action = issue983bmv2l111();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_issue983bmv2l114 {
         actions = {
-            act_2();
+            issue983bmv2l114();
         }
-        const default_action = act_2();
+        const default_action = issue983bmv2l114();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_issue983bmv2l117 {
         actions = {
-            act_3();
+            issue983bmv2l117();
         }
-        const default_action = act_3();
+        const default_action = issue983bmv2l117();
     }
-    @hidden table tbl_act_4 {
+    @hidden table tbl_issue983bmv2l120 {
         actions = {
-            act_4();
+            issue983bmv2l120();
         }
-        const default_action = act_4();
+        const default_action = issue983bmv2l120();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue983bmv2l92.apply();
         if (hdr.ethernet.etherType != 16w0x800) {
-            tbl_act_0.apply();
+            tbl_issue983bmv2l108.apply();
         }
         if ((bit<32>)~hdr.ethernet.etherType != 32w0xf7ff) {
-            tbl_act_1.apply();
+            tbl_issue983bmv2l111.apply();
         }
         if (((bit<32>)~hdr.ethernet.etherType)[31:16] + ((bit<32>)~hdr.ethernet.etherType)[15:0] != 16w0xf7ff) {
-            tbl_act_2.apply();
+            tbl_issue983bmv2l114.apply();
         }
         if ((bit<32>)~hdr.ethernet.etherType != 32w0xf7ff) {
-            tbl_act_3.apply();
+            tbl_issue983bmv2l117.apply();
         }
         if (~(bit<32>)hdr.ethernet.etherType != 32w0xfffff7ff) {
-            tbl_act_4.apply();
+            tbl_issue983bmv2l120.apply();
         }
         debug_table_cksum1_0.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue986-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue986-bmv2-midend.p4
@@ -43,31 +43,31 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action issue986bmv2l42() {
         sm.egress_spec = 9w1;
     }
-    @hidden action act_0() {
+    @hidden action issue986bmv2l45() {
         sm.egress_spec = 9w2;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue986bmv2l42 {
         actions = {
-            act();
+            issue986bmv2l42();
         }
-        const default_action = act();
+        const default_action = issue986bmv2l42();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_issue986bmv2l45 {
         actions = {
-            act_0();
+            issue986bmv2l45();
         }
-        const default_action = act_0();
+        const default_action = issue986bmv2l45();
     }
     apply {
         if (m.b == 1w0) {
             t1_0.apply();
-            tbl_act.apply();
+            tbl_issue986bmv2l42.apply();
         } else {
             t1_0.apply();
-            tbl_act_0.apply();
+            tbl_issue986bmv2l45.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue995-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue995-bmv2-midend.p4
@@ -54,17 +54,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action issue995bmv2l76() {
         hdr.ethernet.etherType = meta.transition_taken;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_issue995bmv2l76 {
         actions = {
-            act();
+            issue995bmv2l76();
         }
-        const default_action = act();
+        const default_action = issue995bmv2l76();
     }
     apply {
-        tbl_act.apply();
+        tbl_issue995bmv2l76.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/key-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2-midend.p4
@@ -58,28 +58,28 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action keybmv2l28() {
         key_0 = h.h.a + h.h.a;
     }
-    @hidden action act_0() {
+    @hidden action arithinlineskeleton51() {
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_keybmv2l28 {
         actions = {
-            act();
+            keybmv2l28();
         }
-        const default_action = act();
+        const default_action = keybmv2l28();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_arithinlineskeleton51 {
         actions = {
-            act_0();
+            arithinlineskeleton51();
         }
-        const default_action = act_0();
+        const default_action = arithinlineskeleton51();
     }
     apply {
-        tbl_act.apply();
+        tbl_keybmv2l28.apply();
         c_t.apply();
-        tbl_act_0.apply();
+        tbl_arithinlineskeleton51.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/key-issue-1020_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/key-issue-1020_ebpf-midend.p4
@@ -68,18 +68,18 @@ control pipe(inout Headers_t headers, out bool pass) {
         implementation = hash_table(32w10);
         default_action = drop();
     }
-    @hidden action act() {
+    @hidden action keyissue1020_ebpf37() {
         key_0 = headers.ipv4.srcAddr + 32w1;
         key_1 = headers.ipv4.dstAddr + 32w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_keyissue1020_ebpf37 {
         actions = {
-            act();
+            keyissue1020_ebpf37();
         }
-        const default_action = act();
+        const default_action = keyissue1020_ebpf37();
     }
     apply {
-        tbl_act.apply();
+        tbl_keyissue1020_ebpf37.apply();
         t_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/key1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/key1-bmv2-midend.p4
@@ -58,28 +58,28 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action key1bmv2l28() {
         key_0 = h.h.a + 32w1;
     }
-    @hidden action act_0() {
+    @hidden action arithinlineskeleton51() {
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_key1bmv2l28 {
         actions = {
-            act();
+            key1bmv2l28();
         }
-        const default_action = act();
+        const default_action = key1bmv2l28();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_arithinlineskeleton51 {
         actions = {
-            act_0();
+            arithinlineskeleton51();
         }
-        const default_action = act_0();
+        const default_action = arithinlineskeleton51();
     }
     apply {
-        tbl_act.apply();
+        tbl_key1bmv2l28.apply();
         c_t.apply();
-        tbl_act_0.apply();
+        tbl_arithinlineskeleton51.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/list-compare-midend.p4
+++ b/testdata/p4_16_samples_outputs/list-compare-midend.p4
@@ -11,18 +11,18 @@ struct tuple_0 {
 }
 
 control test(out bool zout) {
-    @hidden action act() {
+    @hidden action listcompare22() {
         zout = true;
         zout = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_listcompare22 {
         actions = {
-            act();
+            listcompare22();
         }
-        const default_action = act();
+        const default_action = listcompare22();
     }
     apply {
-        tbl_act.apply();
+        tbl_listcompare22.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/lj_example-midend.p4
+++ b/testdata/p4_16_samples_outputs/lj_example-midend.p4
@@ -58,17 +58,17 @@ control LjPipe(inout Parsed_rep p, in error parseError, in InControl inCtrl, out
         }
         default_action = Drop_0();
     }
-    @hidden action act() {
+    @hidden action lj_example70() {
         outCtrl.outputPort = 4w0xf;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_lj_example70 {
         actions = {
-            act();
+            lj_example70();
         }
-        const default_action = act();
+        const default_action = lj_example70();
     }
     apply {
-        tbl_act.apply();
+        tbl_lj_example70.apply();
         if (p.arpa_pak.isValid()) {
             Enet_lkup_0.apply();
         }
@@ -76,17 +76,17 @@ control LjPipe(inout Parsed_rep p, in error parseError, in InControl inCtrl, out
 }
 
 control LJdeparse(inout Parsed_rep p, packet_out b) {
-    @hidden action act_0() {
+    @hidden action lj_example79() {
         b.emit<ARPA_hdr>(p.arpa_pak);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_lj_example79 {
         actions = {
-            act_0();
+            lj_example79();
         }
-        const default_action = act_0();
+        const default_action = lj_example79();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_lj_example79.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/lpm_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/lpm_ebpf-midend.p4
@@ -62,30 +62,30 @@ control pipe(inout Headers_t headers, out bool pass) {
         implementation = hash_table(32w1024);
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action lpm_ebpf72() {
         pass = false;
         hasReturned = true;
     }
-    @hidden action act_0() {
+    @hidden action lpm_ebpf68() {
         hasReturned = false;
         pass = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_lpm_ebpf68 {
         actions = {
-            act_0();
+            lpm_ebpf68();
         }
-        const default_action = act_0();
+        const default_action = lpm_ebpf68();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_lpm_ebpf72 {
         actions = {
-            act();
+            lpm_ebpf72();
         }
-        const default_action = act();
+        const default_action = lpm_ebpf72();
     }
     apply {
-        tbl_act.apply();
+        tbl_lpm_ebpf68.apply();
         if (!headers.ipv4.isValid()) {
-            tbl_act_0.apply();
+            tbl_lpm_ebpf72.apply();
         }
         if (!hasReturned) {
             Check_src_ip_0.apply();

--- a/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-midend.p4
@@ -52,18 +52,18 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
         }
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action matchonexprsbmv2l64() {
         key_1 = hdr.ethernet.dstAddr & 48w0x10101010101;
         key_2 = hdr.ethernet.etherType + 16w65526;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_matchonexprsbmv2l64 {
         actions = {
-            act();
+            matchonexprsbmv2l64();
         }
-        const default_action = act();
+        const default_action = matchonexprsbmv2l64();
     }
     apply {
-        tbl_act.apply();
+        tbl_matchonexprsbmv2l64.apply();
         t1_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-midend.p4
@@ -52,18 +52,18 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
         }
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action matchonexprs2bmv2l64() {
         key_1 = hdr.ethernet.dstAddr & 48w0x10101010101;
         key_2 = hdr.ethernet.etherType + 16w65526;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_matchonexprs2bmv2l64 {
         actions = {
-            act();
+            matchonexprs2bmv2l64();
         }
-        const default_action = act();
+        const default_action = matchonexprs2bmv2l64();
     }
     apply {
-        tbl_act.apply();
+        tbl_matchonexprs2bmv2l64.apply();
         t1_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/methodArgCast-midend.p4
+++ b/testdata/p4_16_samples_outputs/methodArgCast-midend.p4
@@ -5,17 +5,17 @@ extern E {
 
 control c() {
     @name("c.e") E() e_0;
-    @hidden action act() {
+    @hidden action methodArgCast24() {
         e_0.setValue(32w10);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_methodArgCast24 {
         actions = {
-            act();
+            methodArgCast24();
         }
-        const default_action = act();
+        const default_action = methodArgCast24();
     }
     apply {
-        tbl_act.apply();
+        tbl_methodArgCast24.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/mux-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2-midend.p4
@@ -29,14 +29,14 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         val[31:0] = tmp;
         res_0 = val;
     }
-    @hidden action act() {
+    @hidden action muxbmv2l58() {
         res_0 = 64w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_muxbmv2l58 {
         actions = {
-            act();
+            muxbmv2l58();
         }
-        const default_action = act();
+        const default_action = muxbmv2l58();
     }
     @hidden table tbl_update {
         actions = {
@@ -45,7 +45,7 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         const default_action = update();
     }
     apply {
-        tbl_act.apply();
+        tbl_muxbmv2l58.apply();
         tbl_update.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/named-arg-midend.p4
+++ b/testdata/p4_16_samples_outputs/named-arg-midend.p4
@@ -1,16 +1,16 @@
 extern void f(in bit<16> x, in bool y);
 control c() {
-    @hidden action act() {
+    @hidden action namedarg8() {
         f(y = true, x = 16w0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_namedarg8 {
         actions = {
-            act();
+            namedarg8();
         }
-        const default_action = act();
+        const default_action = namedarg8();
     }
     apply {
-        tbl_act.apply();
+        tbl_namedarg8.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/named-arg1-midend.p4
+++ b/testdata/p4_16_samples_outputs/named-arg1-midend.p4
@@ -16,7 +16,7 @@ control c(out bool b) {
     @name("c.a") action a_2() {
         xv_0 = 16w0;
     }
-    @hidden action act() {
+    @hidden action namedarg1l22() {
         b = xv_0 == 16w0;
         b_1 = xv_0 == 16w1;
         b = b_1;
@@ -39,16 +39,16 @@ control c(out bool b) {
         }
         const default_action = a_2();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_namedarg1l22 {
         actions = {
-            act();
+            namedarg1l22();
         }
-        const default_action = act();
+        const default_action = namedarg1l22();
     }
     apply {
         tbl_a.apply();
         tbl_a_0.apply();
-        tbl_act.apply();
+        tbl_namedarg1l22.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/nested-tuple-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-midend.p4
@@ -22,21 +22,21 @@ extern void f<T>(in T data);
 control c(inout bit<1> r) {
     T s_0_f1_field;
     T s_0_f1_field_0;
-    @hidden action act() {
+    @hidden action nestedtuple34() {
         s_0_f1_field.f = 1w0;
         s_0_f1_field_0.f = 1w1;
         f<tuple_1>({ s_0_f1_field, s_0_f1_field_0 });
         f<tuple_0>(tuple_0 {field = T {f = 1w0},field_0 = T {f = 1w1}});
         r = 1w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_nestedtuple34 {
         actions = {
-            act();
+            nestedtuple34();
         }
-        const default_action = act();
+        const default_action = nestedtuple34();
     }
     apply {
-        tbl_act.apply();
+        tbl_nestedtuple34.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/nested-tuple1-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple1-midend.p4
@@ -17,20 +17,20 @@ extern void f<D>(in D data);
 control c(inout bit<1> r) {
     T s_f1_field;
     T s_f1_field_0;
-    @hidden action act() {
+    @hidden action nestedtuple1l32() {
         s_f1_field.f = 1w0;
         s_f1_field_0.f = 1w1;
         f<tuple_0>({ s_f1_field, s_f1_field_0 });
         r = 1w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_nestedtuple1l32 {
         actions = {
-            act();
+            nestedtuple1l32();
         }
-        const default_action = act();
+        const default_action = nestedtuple1l32();
     }
     apply {
-        tbl_act.apply();
+        tbl_nestedtuple1l32.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/newtype-midend.p4
+++ b/testdata/p4_16_samples_outputs/newtype-midend.p4
@@ -24,29 +24,29 @@ control c(out B32 x) {
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action newtype34() {
         k_0 = 32w0;
         x = 32w0;
     }
-    @hidden action act_0() {
+    @hidden action newtype43() {
         x = 32w3;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_newtype34 {
         actions = {
-            act();
+            newtype34();
         }
-        const default_action = act();
+        const default_action = newtype34();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_newtype43 {
         actions = {
-            act_0();
+            newtype43();
         }
-        const default_action = act_0();
+        const default_action = newtype43();
     }
     apply {
-        tbl_act.apply();
+        tbl_newtype34.apply();
         t_0.apply();
-        tbl_act_0.apply();
+        tbl_newtype43.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/newtype1-midend.p4
+++ b/testdata/p4_16_samples_outputs/newtype1-midend.p4
@@ -3,17 +3,17 @@ typedef Narrow_t Narrow;
 typedef bit<32> Wide_t;
 typedef Wide_t Wide;
 control c(out bool b) {
-    @hidden action act() {
+    @hidden action newtype1l12() {
         b = false;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_newtype1l12 {
         actions = {
-            act();
+            newtype1l12();
         }
-        const default_action = act();
+        const default_action = newtype1l12();
     }
     apply {
-        tbl_act.apply();
+        tbl_newtype1l12.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/newtype2-midend.p4
+++ b/testdata/p4_16_samples_outputs/newtype2-midend.p4
@@ -10,17 +10,17 @@ struct M {
 control Ingress(inout M sm);
 package V1Switch(Ingress ig);
 control FabricIngress(inout M sm) {
-    @hidden action act() {
+    @hidden action newtype2l16() {
         sm.es = (PortIdUInt_t)sm.e;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_newtype2l16 {
         actions = {
-            act();
+            newtype2l16();
         }
-        const default_action = act();
+        const default_action = newtype2l16();
     }
     apply {
-        tbl_act.apply();
+        tbl_newtype2l16.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/overwrite-midend.p4
+++ b/testdata/p4_16_samples_outputs/overwrite-midend.p4
@@ -1,17 +1,17 @@
 control c(out bit<32> x);
 package top(c _c);
 control my(out bit<32> x) {
-    @hidden action act() {
+    @hidden action overwrite24() {
         x = 32w2;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_overwrite24 {
         actions = {
-            act();
+            overwrite24();
         }
-        const default_action = act();
+        const default_action = overwrite24();
     }
     apply {
-        tbl_act.apply();
+        tbl_overwrite24.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/p4rt_digest_complex-midend.p4
+++ b/testdata/p4_16_samples_outputs/p4rt_digest_complex-midend.p4
@@ -33,17 +33,17 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 }
 
 control MyIC(inout headers hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
-    @hidden action act() {
+    @hidden action p4rt_digest_complex51() {
         d.egress_port = c.ingress_port;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_p4rt_digest_complex51 {
         actions = {
-            act();
+            p4rt_digest_complex51();
         }
-        const default_action = act();
+        const default_action = p4rt_digest_complex51();
     }
     apply {
-        tbl_act.apply();
+        tbl_p4rt_digest_complex51.apply();
     }
 }
 
@@ -59,17 +59,17 @@ struct digest_t {
 
 control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     @name("MyID.digest") Digest<digest_t>() digest_0;
-    @hidden action act_0() {
+    @hidden action p4rt_digest_complex78() {
         digest_0.pack({ hdr.h, f.egress_port });
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_p4rt_digest_complex78 {
         actions = {
-            act_0();
+            p4rt_digest_complex78();
         }
-        const default_action = act_0();
+        const default_action = p4rt_digest_complex78();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_p4rt_digest_complex78.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/package-midend.p4
+++ b/testdata/p4_16_samples_outputs/package-midend.p4
@@ -1,17 +1,17 @@
 control proto(out bit<32> o);
 package top(proto _c, bool parameter);
 control c(out bit<32> o) {
-    @hidden action act() {
+    @hidden action package21() {
         o = 32w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_package21 {
         actions = {
-            act();
+            package21();
         }
-        const default_action = act();
+        const default_action = package21();
     }
     apply {
-        tbl_act.apply();
+        tbl_package21.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/parser_error-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser_error-bmv2-midend.p4
@@ -22,21 +22,21 @@ parser parse(packet_in pk, out parsed_packet_t hdr, inout local_metadata_t local
 }
 
 control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action parser_errorbmv2l30() {
         hdr.eth.setValid();
         hdr.eth.type = 16w0;
         hdr.eth.src = 48w0;
         hdr.eth.dst = 48w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_parser_errorbmv2l30 {
         actions = {
-            act();
+            parser_errorbmv2l30();
         }
-        const default_action = act();
+        const default_action = parser_errorbmv2l30();
     }
     apply {
         if (standard_metadata.parser_error == error.PacketTooShort) {
-            tbl_act.apply();
+            tbl_parser_errorbmv2l30.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-first.p4
@@ -79,3 +79,4 @@ IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty
 EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-frontend.p4
@@ -76,3 +76,4 @@ IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty
 EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-midend.p4
@@ -66,32 +66,32 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act() {
+    @hidden action psabasiccounterbmv2l104() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psabasiccounterbmv2l104 {
         actions = {
-            act();
+            psabasiccounterbmv2l104();
         }
-        const default_action = act();
+        const default_action = psabasiccounterbmv2l104();
     }
     apply {
-        tbl_act.apply();
+        tbl_psabasiccounterbmv2l104.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_0() {
+    @hidden action psabasiccounterbmv2l104_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psabasiccounterbmv2l104_0 {
         actions = {
-            act_0();
+            psabasiccounterbmv2l104_0();
         }
-        const default_action = act_0();
+        const default_action = psabasiccounterbmv2l104_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psabasiccounterbmv2l104_0.apply();
     }
 }
 
@@ -100,3 +100,4 @@ IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty
 EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4
@@ -79,3 +79,4 @@ IngressPipeline(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
 EgressPipeline(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-counter3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter3-midend.p4
@@ -27,17 +27,17 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @name("MyIC.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter0_0;
     @name("MyIC.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
-    @hidden action act() {
+    @hidden action psacounter3l51() {
         counter0_0.count(12w1024);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psacounter3l51 {
         actions = {
-            act();
+            psacounter3l51();
         }
-        const default_action = act();
+        const default_action = psacounter3l51();
     }
     apply {
-        tbl_act.apply();
+        tbl_psacounter3l51.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-drop-all-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-bmv2-midend.p4
@@ -68,34 +68,34 @@ control egress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_in
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act() {
+    @hidden action psadropallbmv2l118() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psadropallbmv2l118 {
         actions = {
-            act();
+            psadropallbmv2l118();
         }
-        const default_action = act();
+        const default_action = psadropallbmv2l118();
     }
     apply {
-        tbl_act.apply();
+        tbl_psadropallbmv2l118.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_0() {
+    @hidden action psadropallbmv2l118_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psadropallbmv2l118_0 {
         actions = {
-            act_0();
+            psadropallbmv2l118_0();
         }
-        const default_action = act_0();
+        const default_action = psadropallbmv2l118_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psadropallbmv2l118_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2-midend.p4
@@ -70,34 +70,34 @@ control egress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_in
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act() {
+    @hidden action psadropallcorrectedbmv2l120() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psadropallcorrectedbmv2l120 {
         actions = {
-            act();
+            psadropallcorrectedbmv2l120();
         }
-        const default_action = act();
+        const default_action = psadropallcorrectedbmv2l120();
     }
     apply {
-        tbl_act.apply();
+        tbl_psadropallcorrectedbmv2l120.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_0() {
+    @hidden action psadropallcorrectedbmv2l120_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psadropallcorrectedbmv2l120_0 {
         actions = {
-            act_0();
+            psadropallcorrectedbmv2l120_0();
         }
-        const default_action = act_0();
+        const default_action = psadropallcorrectedbmv2l120_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psadropallcorrectedbmv2l120_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-example-counters-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-counters-bmv2-midend.p4
@@ -101,17 +101,17 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
         default_action = default_route_drop();
         psa_direct_counter = per_prefix_pkt_byte_count_0;
     }
-    @hidden action act() {
+    @hidden action psaexamplecountersbmv2l150() {
         port_bytes_in_0.count(istd.ingress_port);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psaexamplecountersbmv2l150 {
         actions = {
-            act();
+            psaexamplecountersbmv2l150();
         }
-        const default_action = act();
+        const default_action = psaexamplecountersbmv2l150();
     }
     apply {
-        tbl_act.apply();
+        tbl_psaexamplecountersbmv2l150.apply();
         if (hdr.ipv4.isValid()) {
             ipv4_da_lpm_0.apply();
         }
@@ -120,49 +120,49 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
 
 control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
     @name("egress.port_bytes_out") Counter<ByteCounter_t, PortId_t>(32w512, PSA_CounterType_t.BYTES) port_bytes_out_0;
-    @hidden action act_0() {
+    @hidden action psaexamplecountersbmv2l169() {
         port_bytes_out_0.count(istd.egress_port);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psaexamplecountersbmv2l169 {
         actions = {
-            act_0();
+            psaexamplecountersbmv2l169();
         }
-        const default_action = act_0();
+        const default_action = psaexamplecountersbmv2l169();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psaexamplecountersbmv2l169.apply();
     }
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act_1() {
+    @hidden action psaexamplecountersbmv2l178() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_psaexamplecountersbmv2l178 {
         actions = {
-            act_1();
+            psaexamplecountersbmv2l178();
         }
-        const default_action = act_1();
+        const default_action = psaexamplecountersbmv2l178();
     }
     apply {
-        tbl_act_1.apply();
+        tbl_psaexamplecountersbmv2l178.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_2() {
+    @hidden action psaexamplecountersbmv2l178_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_psaexamplecountersbmv2l178_0 {
         actions = {
-            act_2();
+            psaexamplecountersbmv2l178_0();
         }
-        const default_action = act_2();
+        const default_action = psaexamplecountersbmv2l178_0();
     }
     apply {
-        tbl_act_2.apply();
+        tbl_psaexamplecountersbmv2l178_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-midend.p4
@@ -133,17 +133,17 @@ control ingress(inout headers hdr, inout metadata meta, in psa_ingress_input_met
         }
         default_action = NoAction_5();
     }
-    @hidden action act() {
+    @hidden action psaexampledigestbmv2l197() {
         meta._send_mac_learn_msg0 = false;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psaexampledigestbmv2l197 {
         actions = {
-            act();
+            psaexampledigestbmv2l197();
         }
-        const default_action = act();
+        const default_action = psaexampledigestbmv2l197();
     }
     apply {
-        tbl_act.apply();
+        tbl_psaexampledigestbmv2l197.apply();
         learned_sources_0.apply();
         l2_tbl_0.apply();
         tst_tbl_0.apply();
@@ -157,46 +157,46 @@ control egress(inout headers hdr, inout metadata meta, in psa_egress_input_metad
 
 control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
     @name("IngressDeparserImpl.mac_learn_digest") Digest<mac_learn_digest_t>() mac_learn_digest_0;
-    @hidden action act_0() {
+    @hidden action psaexampledigestbmv2l236() {
         mac_learn_digest_0.pack(mac_learn_digest_t {srcAddr = meta._mac_learn_msg_srcAddr1,ingress_port = meta._mac_learn_msg_ingress_port2});
     }
-    @hidden action act_1() {
+    @hidden action psaexampledigestbmv2l218() {
         packet.emit<ethernet_t>(hdr.ethernet);
         packet.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psaexampledigestbmv2l236 {
         actions = {
-            act_0();
+            psaexampledigestbmv2l236();
         }
-        const default_action = act_0();
+        const default_action = psaexampledigestbmv2l236();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_psaexampledigestbmv2l218 {
         actions = {
-            act_1();
+            psaexampledigestbmv2l218();
         }
-        const default_action = act_1();
+        const default_action = psaexampledigestbmv2l218();
     }
     apply {
         if (meta._send_mac_learn_msg0) {
-            tbl_act_0.apply();
+            tbl_psaexampledigestbmv2l236.apply();
         }
-        tbl_act_1.apply();
+        tbl_psaexampledigestbmv2l218.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_2() {
+    @hidden action psaexampledigestbmv2l218_0() {
         packet.emit<ethernet_t>(hdr.ethernet);
         packet.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_psaexampledigestbmv2l218_0 {
         actions = {
-            act_2();
+            psaexampledigestbmv2l218_0();
         }
-        const default_action = act_2();
+        const default_action = psaexampledigestbmv2l218_0();
     }
     apply {
-        tbl_act_2.apply();
+        tbl_psaexampledigestbmv2l218_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum-midend.p4
@@ -138,17 +138,17 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
 
         psa_direct_counter = parser_error_counts_0;
     }
-    @hidden action act() {
+    @hidden action psaexampleparserchecksum184() {
         hasExited = true;
     }
-    @hidden action act_0() {
+    @hidden action act() {
         hasExited = false;
     }
     @hidden table tbl_act {
         actions = {
-            act_0();
+            act();
         }
-        const default_action = act_0();
+        const default_action = act();
     }
     @hidden table tbl_ingress_drop {
         actions = {
@@ -156,18 +156,18 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
         }
         const default_action = ingress_drop();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psaexampleparserchecksum184 {
         actions = {
-            act();
+            psaexampleparserchecksum184();
         }
-        const default_action = act();
+        const default_action = psaexampleparserchecksum184();
     }
     apply {
         tbl_act.apply();
         if (istd.parser_error != error.NoError) {
             parser_error_count_and_convert_0.apply();
             tbl_ingress_drop.apply();
-            tbl_act_0.apply();
+            tbl_psaexampleparserchecksum184.apply();
         }
     }
 }
@@ -184,26 +184,26 @@ control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_
 }
 
 control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act_1() {
+    @hidden action psaexampleparserchecksum221() {
         packet.emit<ethernet_t>(hdr.ethernet);
         packet.emit<ipv4_t>(hdr.ipv4);
         packet.emit<tcp_t>(hdr.tcp);
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_psaexampleparserchecksum221 {
         actions = {
-            act_1();
+            psaexampleparserchecksum221();
         }
-        const default_action = act_1();
+        const default_action = psaexampleparserchecksum221();
     }
     apply {
-        tbl_act_1.apply();
+        tbl_psaexampleparserchecksum221.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
     bit<16> tmp_2;
     @name("EgressDeparserImpl.ck") InternetChecksum() ck_1;
-    @hidden action act_2() {
+    @hidden action psaexampleparserchecksum238() {
         ck_1.clear();
         ck_1.add<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
         tmp_2 = ck_1.get();
@@ -212,14 +212,14 @@ control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_met
         packet.emit<ipv4_t>(hdr.ipv4);
         packet.emit<tcp_t>(hdr.tcp);
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_psaexampleparserchecksum238 {
         actions = {
-            act_2();
+            psaexampleparserchecksum238();
         }
-        const default_action = act_2();
+        const default_action = psaexampleparserchecksum238();
     }
     apply {
-        tbl_act_2.apply();
+        tbl_psaexampleparserchecksum238.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-midend.p4
@@ -63,27 +63,27 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
         tmp = s;
     }
     @name("ingress.port_pkt_ip_bytes_in") Register<PacketByteCountState_t, PortId_t>(32w512) port_pkt_ip_bytes_in_0;
-    @hidden action act() {
+    @hidden action psaexampleregister2bmv2l127() {
         tmp_0 = port_pkt_ip_bytes_in_0.read(istd.ingress_port);
         tmp = tmp_0;
     }
-    @hidden action act_0() {
+    @hidden action psaexampleregister2bmv2l129() {
         port_pkt_ip_bytes_in_0.write(istd.ingress_port, tmp);
     }
-    @hidden action act_1() {
+    @hidden action psaexampleregister2bmv2l123() {
         ostd.egress_port = 32w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psaexampleregister2bmv2l123 {
         actions = {
-            act_1();
+            psaexampleregister2bmv2l123();
         }
-        const default_action = act_1();
+        const default_action = psaexampleregister2bmv2l123();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psaexampleregister2bmv2l127 {
         actions = {
-            act();
+            psaexampleregister2bmv2l127();
         }
-        const default_action = act();
+        const default_action = psaexampleregister2bmv2l127();
     }
     @hidden table tbl_update_pkt_ip_byte_count {
         actions = {
@@ -91,18 +91,18 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
         }
         const default_action = update_pkt_ip_byte_count();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_psaexampleregister2bmv2l129 {
         actions = {
-            act_0();
+            psaexampleregister2bmv2l129();
         }
-        const default_action = act_0();
+        const default_action = psaexampleregister2bmv2l129();
     }
     apply {
-        tbl_act.apply();
+        tbl_psaexampleregister2bmv2l123.apply();
         if (hdr.ipv4.isValid()) @atomic {
-            tbl_act_0.apply();
+            tbl_psaexampleregister2bmv2l127.apply();
             tbl_update_pkt_ip_byte_count.apply();
-            tbl_act_1.apply();
+            tbl_psaexampleregister2bmv2l129.apply();
         }
     }
 }
@@ -119,34 +119,34 @@ control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act_2() {
+    @hidden action psaexampleregister2bmv2l161() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_psaexampleregister2bmv2l161 {
         actions = {
-            act_2();
+            psaexampleregister2bmv2l161();
         }
-        const default_action = act_2();
+        const default_action = psaexampleregister2bmv2l161();
     }
     apply {
-        tbl_act_2.apply();
+        tbl_psaexampleregister2bmv2l161.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_3() {
+    @hidden action psaexampleregister2bmv2l161_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_psaexampleregister2bmv2l161_0 {
         actions = {
-            act_3();
+            psaexampleregister2bmv2l161_0();
         }
-        const default_action = act_3();
+        const default_action = psaexampleregister2bmv2l161_0();
     }
     apply {
-        tbl_act_3.apply();
+        tbl_psaexampleregister2bmv2l161_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-fwd-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-fwd-bmv2-midend.p4
@@ -48,32 +48,32 @@ control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_t clone_i2e_meta, out empty_t resubmit_meta, out empty_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act() {
+    @hidden action psafwdbmv2l102() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psafwdbmv2l102 {
         actions = {
-            act();
+            psafwdbmv2l102();
         }
-        const default_action = act();
+        const default_action = psafwdbmv2l102();
     }
     apply {
-        tbl_act.apply();
+        tbl_psafwdbmv2l102.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_t clone_e2e_meta, out empty_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_0() {
+    @hidden action psafwdbmv2l102_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psafwdbmv2l102_0 {
         actions = {
-            act_0();
+            psafwdbmv2l102_0();
         }
-        const default_action = act_0();
+        const default_action = psafwdbmv2l102_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psafwdbmv2l102_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2-midend.p4
@@ -53,32 +53,32 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act() {
+    @hidden action psamulticastbasicbmv2l88() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psamulticastbasicbmv2l88 {
         actions = {
-            act();
+            psamulticastbasicbmv2l88();
         }
-        const default_action = act();
+        const default_action = psamulticastbasicbmv2l88();
     }
     apply {
-        tbl_act.apply();
+        tbl_psamulticastbasicbmv2l88.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_0() {
+    @hidden action psamulticastbasicbmv2l88_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psamulticastbasicbmv2l88_0 {
         actions = {
-            act_0();
+            psamulticastbasicbmv2l88_0();
         }
-        const default_action = act_0();
+        const default_action = psamulticastbasicbmv2l88_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psamulticastbasicbmv2l88_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-first.p4
@@ -68,3 +68,4 @@ IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty
 EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-frontend.p4
@@ -64,3 +64,4 @@ IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty
 EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-midend.p4
@@ -54,32 +54,32 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act() {
+    @hidden action psamulticastbasiccorrectedbmv2l89() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psamulticastbasiccorrectedbmv2l89 {
         actions = {
-            act();
+            psamulticastbasiccorrectedbmv2l89();
         }
-        const default_action = act();
+        const default_action = psamulticastbasiccorrectedbmv2l89();
     }
     apply {
-        tbl_act.apply();
+        tbl_psamulticastbasiccorrectedbmv2l89.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_0() {
+    @hidden action psamulticastbasiccorrectedbmv2l89_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psamulticastbasiccorrectedbmv2l89_0 {
         actions = {
-            act_0();
+            psamulticastbasiccorrectedbmv2l89_0();
         }
-        const default_action = act_0();
+        const default_action = psamulticastbasiccorrectedbmv2l89_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psamulticastbasiccorrectedbmv2l89_0.apply();
     }
 }
 
@@ -88,3 +88,4 @@ IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty
 EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4
@@ -68,3 +68,4 @@ IngressPipeline(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
 EgressPipeline(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-portid-using-newtype2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-portid-using-newtype2-midend.p4
@@ -193,63 +193,63 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         }
         default_action = NoAction_3();
     }
-    @hidden action act() {
+    @hidden action psaportidusingnewtype2l132() {
         standard_metadata.egress_spec = (PortIdUInt_t)(bit<32>)hdr.packet_out.egress_port;
         hdr.packet_out.setInvalid();
         hasExited = true;
     }
-    @hidden action act_0() {
+    @hidden action act() {
         hasExited = false;
     }
-    @hidden action act_1() {
+    @hidden action psaportidusingnewtype2l213() {
         standard_metadata.egress_spec = (PortIdUInt_t)standard_metadata.egress_spec + 9w1;
         standard_metadata.egress_spec = (PortIdUInt_t)standard_metadata.egress_spec & 9w0xf;
     }
     @hidden table tbl_act {
         actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
-    @hidden table tbl_act_0 {
-        actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_psaportidusingnewtype2l132 {
         actions = {
-            act_1();
+            psaportidusingnewtype2l132();
         }
-        const default_action = act_1();
+        const default_action = psaportidusingnewtype2l132();
+    }
+    @hidden table tbl_psaportidusingnewtype2l213 {
+        actions = {
+            psaportidusingnewtype2l213();
+        }
+        const default_action = psaportidusingnewtype2l213();
     }
     apply {
         tbl_act.apply();
         if (hdr.packet_out.isValid()) {
-            tbl_act_0.apply();
+            tbl_psaportidusingnewtype2l132.apply();
         }
         if (!hasExited) {
             filtering_t.apply();
             forwarding_t.apply();
-            tbl_act_1.apply();
+            tbl_psaportidusingnewtype2l213.apply();
         }
     }
 }
 
 control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_metadata, inout standard_metadata_t standard_metadata) {
-    @hidden action act_2() {
+    @hidden action psaportidusingnewtype2l147() {
         hdr.packet_in.setValid();
         hdr.packet_in.ingress_port = (bit<32>)(PortIdUInt_t)standard_metadata.ingress_port;
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_psaportidusingnewtype2l147 {
         actions = {
-            act_2();
+            psaportidusingnewtype2l147();
         }
-        const default_action = act_2();
+        const default_action = psaportidusingnewtype2l147();
     }
     apply {
         if (standard_metadata.egress_port == 9w192) {
-            tbl_act_2.apply();
+            tbl_psaportidusingnewtype2l147.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-midend.p4
@@ -80,32 +80,32 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act() {
+    @hidden action psarecirculatenometabmv2l101() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psarecirculatenometabmv2l101 {
         actions = {
-            act();
+            psarecirculatenometabmv2l101();
         }
-        const default_action = act();
+        const default_action = psarecirculatenometabmv2l101();
     }
     apply {
-        tbl_act.apply();
+        tbl_psarecirculatenometabmv2l101.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_0() {
+    @hidden action psarecirculatenometabmv2l101_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psarecirculatenometabmv2l101_0 {
         actions = {
-            act_0();
+            psarecirculatenometabmv2l101_0();
         }
-        const default_action = act_0();
+        const default_action = psarecirculatenometabmv2l101_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psarecirculatenometabmv2l101_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2-midend.p4
@@ -80,32 +80,32 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act() {
+    @hidden action psaresubmitbmv2l104() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psaresubmitbmv2l104 {
         actions = {
-            act();
+            psaresubmitbmv2l104();
         }
-        const default_action = act();
+        const default_action = psaresubmitbmv2l104();
     }
     apply {
-        tbl_act.apply();
+        tbl_psaresubmitbmv2l104.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_0() {
+    @hidden action psaresubmitbmv2l104_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psaresubmitbmv2l104_0 {
         actions = {
-            act_0();
+            psaresubmitbmv2l104_0();
         }
-        const default_action = act_0();
+        const default_action = psaresubmitbmv2l104_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psaresubmitbmv2l104_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-top-level-assignments-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-top-level-assignments-bmv2-midend.p4
@@ -26,18 +26,18 @@ parser ingressParserImpl(packet_in packet, out headers_t hdr, inout metadata_t m
 }
 
 control ingressImpl(inout headers_t hdr, inout metadata_t meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @hidden action act() {
+    @hidden action psatoplevelassignmentsbmv2l57() {
         ostd.drop = false;
         ostd.egress_port = 32w3;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psatoplevelassignmentsbmv2l57 {
         actions = {
-            act();
+            psatoplevelassignmentsbmv2l57();
         }
-        const default_action = act();
+        const default_action = psatoplevelassignmentsbmv2l57();
     }
     apply {
-        tbl_act.apply();
+        tbl_psatoplevelassignmentsbmv2l57.apply();
     }
 }
 
@@ -53,32 +53,32 @@ control egressImpl(inout headers_t hdr, inout metadata_t meta, in psa_egress_inp
 }
 
 control ingressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act_0() {
+    @hidden action psatoplevelassignmentsbmv2l87() {
         packet.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psatoplevelassignmentsbmv2l87 {
         actions = {
-            act_0();
+            psatoplevelassignmentsbmv2l87();
         }
-        const default_action = act_0();
+        const default_action = psatoplevelassignmentsbmv2l87();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psatoplevelassignmentsbmv2l87.apply();
     }
 }
 
 control egressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_1() {
+    @hidden action psatoplevelassignmentsbmv2l87_0() {
         packet.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_psatoplevelassignmentsbmv2l87_0 {
         actions = {
-            act_1();
+            psatoplevelassignmentsbmv2l87_0();
         }
-        const default_action = act_1();
+        const default_action = psatoplevelassignmentsbmv2l87_0();
     }
     apply {
-        tbl_act_1.apply();
+        tbl_psatoplevelassignmentsbmv2l87_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2-midend.p4
@@ -66,32 +66,32 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act() {
+    @hidden action psaunicastordropbmv2l99() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psaunicastordropbmv2l99 {
         actions = {
-            act();
+            psaunicastordropbmv2l99();
         }
-        const default_action = act();
+        const default_action = psaunicastordropbmv2l99();
     }
     apply {
-        tbl_act.apply();
+        tbl_psaunicastordropbmv2l99.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_0() {
+    @hidden action psaunicastordropbmv2l99_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psaunicastordropbmv2l99_0 {
         actions = {
-            act_0();
+            psaunicastordropbmv2l99_0();
         }
-        const default_action = act_0();
+        const default_action = psaunicastordropbmv2l99_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psaunicastordropbmv2l99_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-first.p4
@@ -71,3 +71,4 @@ IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty
 EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-frontend.p4
@@ -71,3 +71,4 @@ IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty
 EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-midend.p4
@@ -67,32 +67,32 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action act() {
+    @hidden action psaunicastordropcorrectedbmv2l100() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_psaunicastordropcorrectedbmv2l100 {
         actions = {
-            act();
+            psaunicastordropcorrectedbmv2l100();
         }
-        const default_action = act();
+        const default_action = psaunicastordropcorrectedbmv2l100();
     }
     apply {
-        tbl_act.apply();
+        tbl_psaunicastordropcorrectedbmv2l100.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action act_0() {
+    @hidden action psaunicastordropcorrectedbmv2l100_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_psaunicastordropcorrectedbmv2l100_0 {
         actions = {
-            act_0();
+            psaunicastordropcorrectedbmv2l100_0();
         }
-        const default_action = act_0();
+        const default_action = psaunicastordropcorrectedbmv2l100_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_psaunicastordropcorrectedbmv2l100_0.apply();
     }
 }
 
@@ -101,3 +101,4 @@ IngressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty
 EgressPipeline<headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4
@@ -71,3 +71,4 @@ IngressPipeline(IngressParserImpl(), cIngress(), IngressDeparserImpl()) ip;
 EgressPipeline(EgressParserImpl(), cEgress(), EgressDeparserImpl()) ep;
 
 PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/rcp-midend.p4
+++ b/testdata/p4_16_samples_outputs/rcp-midend.p4
@@ -23,7 +23,7 @@ control ingress(inout H pkt_hdr, in Metadata metadata) {
     @name("ingress.input_traffic_bytes") Register<bit<32>>(32w1) input_traffic_bytes_0;
     @name("ingress.sum_rtt_Tr") Register<bit<32>>(32w1) sum_rtt_Tr_0;
     @name("ingress.num_pkts_with_rtt") Register<bit<32>>(32w1) num_pkts_with_rtt_0;
-    @hidden action act() {
+    @hidden action rcp55() {
         sum_rtt_Tr_0.read(32w0, sum_rtt_Tr_tmp_0);
         sum_rtt_Tr_tmp_0 = sum_rtt_Tr_tmp_0 + pkt_hdr.rtt;
         sum_rtt_Tr_0.write(sum_rtt_Tr_tmp_0, 32w0);
@@ -31,28 +31,28 @@ control ingress(inout H pkt_hdr, in Metadata metadata) {
         num_pkts_with_rtt_tmp_0 = num_pkts_with_rtt_tmp_0 + 32w1;
         num_pkts_with_rtt_0.write(num_pkts_with_rtt_tmp_0, 32w0);
     }
-    @hidden action act_0() {
+    @hidden action rcp50() {
         input_traffic_bytes_0.read(32w0, input_traffic_bytes_tmp_0);
         input_traffic_bytes_tmp_0 = input_traffic_bytes_tmp_0 + metadata.pkt_len;
         input_traffic_bytes_0.write(input_traffic_bytes_tmp_0, 32w0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_rcp50 {
         actions = {
-            act_0();
+            rcp50();
         }
-        const default_action = act_0();
+        const default_action = rcp50();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_rcp55 {
         actions = {
-            act();
+            rcp55();
         }
-        const default_action = act();
+        const default_action = rcp55();
     }
     apply {
         @atomic {
-            tbl_act.apply();
+            tbl_rcp50.apply();
             if (pkt_hdr.rtt < 32w2500) {
-                tbl_act_0.apply();
+                tbl_rcp55.apply();
             }
         }
     }

--- a/testdata/p4_16_samples_outputs/rcp1-midend.p4
+++ b/testdata/p4_16_samples_outputs/rcp1-midend.p4
@@ -31,20 +31,20 @@ control ingress(inout H pkt_hdr, in Metadata metadata) {
     @name("ingress.input_traffic_bytes") Counter<bit<32>>(CounterType.packets_and_bytes) input_traffic_bytes_0;
     @name("ingress.sum_rtt_Tr") ConditionalAccumulator<bit<32>>(32w1) sum_rtt_Tr_0;
     @name("ingress.num_pkts_with_rtt") ConditionalAccumulator<bit<32>>(32w1) num_pkts_with_rtt_0;
-    @hidden action act() {
+    @hidden action rcp1l61() {
         input_traffic_bytes_0.count();
         sum_rtt_Tr_0.write(pkt_hdr.rtt, pkt_hdr.rtt < 32w2500);
         num_pkts_with_rtt_0.write(32w1, pkt_hdr.rtt < 32w2500);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_rcp1l61 {
         actions = {
-            act();
+            rcp1l61();
         }
-        const default_action = act();
+        const default_action = rcp1l61();
     }
     apply {
         @atomic {
-            tbl_act.apply();
+            tbl_rcp1l61.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/serenum-midend.p4
+++ b/testdata/p4_16_samples_outputs/serenum-midend.p4
@@ -24,52 +24,52 @@ parser prs(packet_in p, out Headers h) {
 
 control c(inout Headers h) {
     bool hasReturned;
-    @hidden action act() {
+    @hidden action serenum39() {
         hasReturned = true;
     }
-    @hidden action act_0() {
+    @hidden action act() {
         hasReturned = false;
     }
-    @hidden action act_1() {
+    @hidden action serenum41() {
         h.eth.setInvalid();
     }
-    @hidden action act_2() {
+    @hidden action serenum43() {
         h.eth.type = 16w0;
     }
     @hidden table tbl_act {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
-    @hidden table tbl_act_0 {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_serenum39 {
         actions = {
-            act_1();
+            serenum39();
         }
-        const default_action = act_1();
+        const default_action = serenum39();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_serenum41 {
         actions = {
-            act_2();
+            serenum41();
         }
-        const default_action = act_2();
+        const default_action = serenum41();
+    }
+    @hidden table tbl_serenum43 {
+        actions = {
+            serenum43();
+        }
+        const default_action = serenum43();
     }
     apply {
         tbl_act.apply();
         if (!h.eth.isValid()) {
-            tbl_act_0.apply();
+            tbl_serenum39.apply();
         }
         if (!hasReturned) {
             if (h.eth.type == 16w0x800) {
-                tbl_act_1.apply();
+                tbl_serenum41.apply();
             } else {
-                tbl_act_2.apply();
+                tbl_serenum43.apply();
             }
         }
     }

--- a/testdata/p4_16_samples_outputs/side_effects-midend.p4
+++ b/testdata/p4_16_samples_outputs/side_effects-midend.p4
@@ -18,7 +18,7 @@ control my() {
     bit<1> tmp_8;
     bit<1> tmp_9;
     bit<1> tmp_10;
-    @hidden action act() {
+    @hidden action side_effects27() {
         a_0 = 1w0;
         tmp = g(a_0);
         tmp_1 = f(a_0, tmp);
@@ -37,14 +37,14 @@ control my() {
         a_0[0:0] = tmp_10;
         g(a_0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_side_effects27 {
         actions = {
-            act();
+            side_effects27();
         }
-        const default_action = act();
+        const default_action = side_effects27();
     }
     apply {
-        tbl_act.apply();
+        tbl_side_effects27.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/simplify-midend.p4
+++ b/testdata/p4_16_samples_outputs/simplify-midend.p4
@@ -32,41 +32,53 @@ control c(out bool x) {
     @hidden action act_0() {
         tmp = false;
     }
-    @hidden action act_1() {
+    @hidden action simplify31() {
         x = true;
     }
-    @hidden action act_2() {
+    @hidden action simplify32() {
         tmp_0 = false;
     }
-    @hidden action act_3() {
+    @hidden action act_1() {
         tmp_1 = true;
     }
-    @hidden action act_4() {
+    @hidden action act_2() {
         tmp_1 = false;
     }
-    @hidden action act_5() {
+    @hidden action simplify32_0() {
         tmp_0 = tmp_1;
     }
-    @hidden action act_6() {
+    @hidden action simplify33() {
         x = false;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_simplify31 {
         actions = {
-            act_1();
+            simplify31();
         }
-        const default_action = act_1();
+        const default_action = simplify31();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_act {
         actions = {
             act();
         }
         const default_action = act();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_act_0 {
         actions = {
             act_0();
         }
         const default_action = act_0();
+    }
+    @hidden table tbl_simplify32 {
+        actions = {
+            simplify32();
+        }
+        const default_action = simplify32();
+    }
+    @hidden table tbl_act_1 {
+        actions = {
+            act_1();
+        }
+        const default_action = act_1();
     }
     @hidden table tbl_act_2 {
         actions = {
@@ -74,49 +86,37 @@ control c(out bool x) {
         }
         const default_action = act_2();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_simplify32_0 {
         actions = {
-            act_3();
+            simplify32_0();
         }
-        const default_action = act_3();
+        const default_action = simplify32_0();
     }
-    @hidden table tbl_act_4 {
+    @hidden table tbl_simplify33 {
         actions = {
-            act_4();
+            simplify33();
         }
-        const default_action = act_4();
-    }
-    @hidden table tbl_act_5 {
-        actions = {
-            act_5();
-        }
-        const default_action = act_5();
-    }
-    @hidden table tbl_act_6 {
-        actions = {
-            act_6();
-        }
-        const default_action = act_6();
+        const default_action = simplify33();
     }
     apply {
-        tbl_act.apply();
+        tbl_simplify31.apply();
         if (t1_0.apply().hit) {
-            tbl_act_0.apply();
+            tbl_act.apply();
         } else {
-            tbl_act_1.apply();
+            tbl_act_0.apply();
         }
         if (!tmp) {
-            tbl_act_2.apply();
+            tbl_simplify32.apply();
         } else {
             if (t2_0.apply().hit) {
-                tbl_act_3.apply();
+                tbl_act_1.apply();
             } else {
-                tbl_act_4.apply();
+                tbl_act_2.apply();
             }
-            tbl_act_5.apply();
+            tbl_simplify32_0.apply();
         }
         if (tmp_0) {
-            tbl_act_6.apply();
+            tbl_simplify33.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use-midend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use-midend.p4
@@ -41,20 +41,20 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
     @name("Ing.debug") register<bit<8>>(32w2) debug_0;
-    @hidden action act() {
+    @hidden action slicedefuse79() {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
         debug_0.write(32w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_slicedefuse79 {
         actions = {
-            act();
+            slicedefuse79();
         }
-        const default_action = act();
+        const default_action = slicedefuse79();
     }
     apply {
-        tbl_act.apply();
+        tbl_slicedefuse79.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2-midend.p4
@@ -41,18 +41,18 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action stackbmv2l28() {
         h.h.f = h.h.f + 32w1;
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_stackbmv2l28 {
         actions = {
-            act();
+            stackbmv2l28();
         }
-        const default_action = act();
+        const default_action = stackbmv2l28();
     }
     apply {
-        tbl_act.apply();
+        tbl_stackbmv2l28.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack-bvec-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bvec-bmv2-midend.p4
@@ -55,19 +55,19 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action stackbvecbmv2l40() {
         h.h._f0 = h.h._f0 + 32w1;
         h.h._row_alt1_valid3 = 1w1;
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_stackbvecbmv2l40 {
         actions = {
-            act();
+            stackbvecbmv2l40();
         }
-        const default_action = act();
+        const default_action = stackbvecbmv2l40();
     }
     apply {
-        tbl_act.apply();
+        tbl_stackbvecbmv2l40.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-midend.p4
@@ -18,20 +18,20 @@ parser p() {
 
 control c() {
     h[4] stack_1;
-    @hidden action act() {
+    @hidden action stack39() {
         stack_1[3].setValid();
         stack_1[2] = stack_1[3];
         stack_1.push_front(2);
         stack_1.pop_front(2);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_stack39 {
         actions = {
-            act();
+            stack39();
         }
-        const default_action = act();
+        const default_action = stack39();
     }
     apply {
-        tbl_act.apply();
+        tbl_stack39.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack2-midend.p4
@@ -4,17 +4,17 @@ header h {
 }
 
 control c(out bit<32> x) {
-    @hidden action act() {
+    @hidden action stack2l7() {
         x = 32w4;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_stack2l7 {
         actions = {
-            act();
+            stack2l7();
         }
-        const default_action = act();
+        const default_action = stack2l7();
     }
     apply {
-        tbl_act.apply();
+        tbl_stack2l7.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack_ebpf-midend.p4
@@ -62,29 +62,29 @@ control pipe(inout Headers_t headers, out bool pass) {
         implementation = hash_table(32w1024);
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action stack_ebpf73() {
         pass = false;
     }
-    @hidden action act_0() {
+    @hidden action stack_ebpf69() {
         pass = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_stack_ebpf69 {
         actions = {
-            act_0();
+            stack_ebpf69();
         }
-        const default_action = act_0();
+        const default_action = stack_ebpf69();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_stack_ebpf73 {
         actions = {
-            act();
+            stack_ebpf73();
         }
-        const default_action = act();
+        const default_action = stack_ebpf73();
     }
     apply {
-        tbl_act.apply();
+        tbl_stack_ebpf69.apply();
         switch (Check_src_ip_0.apply().action_run) {
             Reject: {
-                tbl_act_0.apply();
+                tbl_stack_ebpf73.apply();
             }
             NoAction_0: {
             }

--- a/testdata/p4_16_samples_outputs/strength4-midend.p4
+++ b/testdata/p4_16_samples_outputs/strength4-midend.p4
@@ -33,20 +33,20 @@ control ingress_impl(inout headers_t hdr, inout local_metadata_t local_metadata,
 }
 
 control egress_impl(inout headers_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @hidden action act() {
+    @hidden action strength4l44() {
         local_metadata.m16 = local_metadata.f16[14:0] ++ 1w0;
         local_metadata.d16 = 1w0 ++ local_metadata.f16[15:1];
         local_metadata.a16 = (int<16>)(16s0 ++ local_metadata.x16 << 1)[15:0];
         local_metadata.b16 = (int<16>)(16s0 ++ local_metadata.x16 >> 1)[15:0];
     }
-    @hidden table tbl_act {
+    @hidden table tbl_strength4l44 {
         actions = {
-            act();
+            strength4l44();
         }
-        const default_action = act();
+        const default_action = strength4l44();
     }
     apply {
-        tbl_act.apply();
+        tbl_strength4l44.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/string-midend.p4
+++ b/testdata/p4_16_samples_outputs/string-midend.p4
@@ -1,16 +1,16 @@
 extern void log(string s);
 control c() {
-    @hidden action act() {
+    @hidden action string5() {
         log("This is a message");
     }
-    @hidden table tbl_act {
+    @hidden table tbl_string5 {
         actions = {
-            act();
+            string5();
         }
-        const default_action = act();
+        const default_action = string5();
     }
     apply {
-        tbl_act.apply();
+        tbl_string5.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/struct_init-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/struct_init-1-midend.p4
@@ -12,41 +12,41 @@ struct metadata_t {
 
 control I(inout metadata_t meta) {
     H h_0;
-    @hidden action act() {
+    @hidden action struct_init1l18() {
         h_0.setValid();
     }
-    @hidden action act_0() {
+    @hidden action struct_init1l15() {
         meta._foo__v0 = meta._foo__v0 + 9w1;
         h_0.setValid();
         h_0.b = 32w2;
     }
-    @hidden action act_1() {
+    @hidden action struct_init1l13() {
         h_0.setValid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_struct_init1l13 {
         actions = {
-            act_1();
+            struct_init1l13();
         }
-        const default_action = act_1();
+        const default_action = struct_init1l13();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_struct_init1l15 {
         actions = {
-            act_0();
+            struct_init1l15();
         }
-        const default_action = act_0();
+        const default_action = struct_init1l15();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_struct_init1l18 {
         actions = {
-            act();
+            struct_init1l18();
         }
-        const default_action = act();
+        const default_action = struct_init1l18();
     }
     apply {
-        tbl_act.apply();
+        tbl_struct_init1l13.apply();
         if (meta._foo__v0 == 9w192) {
-            tbl_act_0.apply();
+            tbl_struct_init1l15.apply();
             if (!h_0.isValid() && false || h_0.isValid() && true && false) {
-                tbl_act_1.apply();
+                tbl_struct_init1l18.apply();
             }
         }
     }

--- a/testdata/p4_16_samples_outputs/struct_init-midend.p4
+++ b/testdata/p4_16_samples_outputs/struct_init-midend.p4
@@ -7,18 +7,18 @@ struct metadata_t {
 }
 
 control I(inout metadata_t meta) {
-    @hidden action act() {
+    @hidden action struct_init12() {
         meta._foo__v0 = meta._foo__v0 + 9w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_struct_init12 {
         actions = {
-            act();
+            struct_init12();
         }
-        const default_action = act();
+        const default_action = struct_init12();
     }
     apply {
         if (meta._foo__v0 == 9w192) {
-            tbl_act.apply();
+            tbl_struct_init12.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-midend.p4
@@ -70,76 +70,76 @@ parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standa
 }
 
 control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
-    @hidden action act() {
+    @hidden action subparserwithheaderstackbmv2l117() {
         hdr.h1.h2_valid_bits[0:0] = 1w1;
     }
-    @hidden action act_0() {
+    @hidden action subparserwithheaderstackbmv2l115() {
         hdr.h1.h2_valid_bits = 8w0;
     }
-    @hidden action act_1() {
+    @hidden action subparserwithheaderstackbmv2l120() {
         hdr.h1.h2_valid_bits[1:1] = 1w1;
     }
-    @hidden action act_2() {
+    @hidden action subparserwithheaderstackbmv2l123() {
         hdr.h1.h2_valid_bits[2:2] = 1w1;
     }
-    @hidden action act_3() {
+    @hidden action subparserwithheaderstackbmv2l126() {
         hdr.h1.h2_valid_bits[3:3] = 1w1;
     }
-    @hidden action act_4() {
+    @hidden action subparserwithheaderstackbmv2l129() {
         hdr.h1.h2_valid_bits[4:4] = 1w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_subparserwithheaderstackbmv2l115 {
         actions = {
-            act_0();
+            subparserwithheaderstackbmv2l115();
         }
-        const default_action = act_0();
+        const default_action = subparserwithheaderstackbmv2l115();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_subparserwithheaderstackbmv2l117 {
         actions = {
-            act();
+            subparserwithheaderstackbmv2l117();
         }
-        const default_action = act();
+        const default_action = subparserwithheaderstackbmv2l117();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_subparserwithheaderstackbmv2l120 {
         actions = {
-            act_1();
+            subparserwithheaderstackbmv2l120();
         }
-        const default_action = act_1();
+        const default_action = subparserwithheaderstackbmv2l120();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_subparserwithheaderstackbmv2l123 {
         actions = {
-            act_2();
+            subparserwithheaderstackbmv2l123();
         }
-        const default_action = act_2();
+        const default_action = subparserwithheaderstackbmv2l123();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_subparserwithheaderstackbmv2l126 {
         actions = {
-            act_3();
+            subparserwithheaderstackbmv2l126();
         }
-        const default_action = act_3();
+        const default_action = subparserwithheaderstackbmv2l126();
     }
-    @hidden table tbl_act_4 {
+    @hidden table tbl_subparserwithheaderstackbmv2l129 {
         actions = {
-            act_4();
+            subparserwithheaderstackbmv2l129();
         }
-        const default_action = act_4();
+        const default_action = subparserwithheaderstackbmv2l129();
     }
     apply {
-        tbl_act.apply();
+        tbl_subparserwithheaderstackbmv2l115.apply();
         if (hdr.h2[0].isValid()) {
-            tbl_act_0.apply();
+            tbl_subparserwithheaderstackbmv2l117.apply();
         }
         if (hdr.h2[1].isValid()) {
-            tbl_act_1.apply();
+            tbl_subparserwithheaderstackbmv2l120.apply();
         }
         if (hdr.h2[2].isValid()) {
-            tbl_act_2.apply();
+            tbl_subparserwithheaderstackbmv2l123.apply();
         }
         if (hdr.h2[3].isValid()) {
-            tbl_act_3.apply();
+            tbl_subparserwithheaderstackbmv2l126.apply();
         }
         if (hdr.h2[4].isValid()) {
-            tbl_act_4.apply();
+            tbl_subparserwithheaderstackbmv2l129.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/switch_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/switch_ebpf-midend.p4
@@ -61,29 +61,29 @@ control pipe(inout Headers_t headers, out bool pass) {
         implementation = hash_table(32w1024);
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action switch_ebpf72() {
         pass = false;
     }
-    @hidden action act_0() {
+    @hidden action switch_ebpf68() {
         pass = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_switch_ebpf68 {
         actions = {
-            act_0();
+            switch_ebpf68();
         }
-        const default_action = act_0();
+        const default_action = switch_ebpf68();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_switch_ebpf72 {
         actions = {
-            act();
+            switch_ebpf72();
         }
-        const default_action = act();
+        const default_action = switch_ebpf72();
     }
     apply {
-        tbl_act.apply();
+        tbl_switch_ebpf68.apply();
         switch (Check_src_ip_0.apply().action_run) {
             Reject: {
-                tbl_act_0.apply();
+                tbl_switch_ebpf72.apply();
             }
             NoAction_0: {
             }

--- a/testdata/p4_16_samples_outputs/synth-action-midend.p4
+++ b/testdata/p4_16_samples_outputs/synth-action-midend.p4
@@ -1,17 +1,17 @@
 control c(inout bit<32> x) {
-    @hidden action act() {
+    @hidden action synthaction19() {
         x = 32w10;
         x = 32w12;
         x = 32w6;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_synthaction19 {
         actions = {
-            act();
+            synthaction19();
         }
-        const default_action = act();
+        const default_action = synthaction19();
     }
     apply {
-        tbl_act.apply();
+        tbl_synthaction19.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/test-parserinvalidargument-error-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/test-parserinvalidargument-error-bmv2-midend.p4
@@ -35,116 +35,116 @@ control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
 
 control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
     bit<8> error_as_int_0;
-    @hidden action act() {
+    @hidden action testparserinvalidargumenterrorbmv2l68() {
         error_as_int_0 = 8w0;
     }
-    @hidden action act_0() {
+    @hidden action testparserinvalidargumenterrorbmv2l70() {
         error_as_int_0 = 8w1;
     }
-    @hidden action act_1() {
+    @hidden action testparserinvalidargumenterrorbmv2l72() {
         error_as_int_0 = 8w2;
     }
-    @hidden action act_2() {
+    @hidden action testparserinvalidargumenterrorbmv2l74() {
         error_as_int_0 = 8w3;
     }
-    @hidden action act_3() {
+    @hidden action testparserinvalidargumenterrorbmv2l76() {
         error_as_int_0 = 8w4;
     }
-    @hidden action act_4() {
+    @hidden action testparserinvalidargumenterrorbmv2l78() {
         error_as_int_0 = 8w5;
     }
-    @hidden action act_5() {
+    @hidden action testparserinvalidargumenterrorbmv2l80() {
         error_as_int_0 = 8w6;
     }
-    @hidden action act_6() {
+    @hidden action testparserinvalidargumenterrorbmv2l85() {
         error_as_int_0 = 8w7;
     }
-    @hidden action act_7() {
+    @hidden action testparserinvalidargumenterrorbmv2l66() {
         stdmeta.egress_spec = 9w1;
     }
-    @hidden action act_8() {
+    @hidden action testparserinvalidargumenterrorbmv2l87() {
         hdr.ethernet.dstAddr[7:0] = error_as_int_0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_testparserinvalidargumenterrorbmv2l66 {
         actions = {
-            act_7();
+            testparserinvalidargumenterrorbmv2l66();
         }
-        const default_action = act_7();
+        const default_action = testparserinvalidargumenterrorbmv2l66();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_testparserinvalidargumenterrorbmv2l68 {
         actions = {
-            act();
+            testparserinvalidargumenterrorbmv2l68();
         }
-        const default_action = act();
+        const default_action = testparserinvalidargumenterrorbmv2l68();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_testparserinvalidargumenterrorbmv2l70 {
         actions = {
-            act_0();
+            testparserinvalidargumenterrorbmv2l70();
         }
-        const default_action = act_0();
+        const default_action = testparserinvalidargumenterrorbmv2l70();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_testparserinvalidargumenterrorbmv2l72 {
         actions = {
-            act_1();
+            testparserinvalidargumenterrorbmv2l72();
         }
-        const default_action = act_1();
+        const default_action = testparserinvalidargumenterrorbmv2l72();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_testparserinvalidargumenterrorbmv2l74 {
         actions = {
-            act_2();
+            testparserinvalidargumenterrorbmv2l74();
         }
-        const default_action = act_2();
+        const default_action = testparserinvalidargumenterrorbmv2l74();
     }
-    @hidden table tbl_act_4 {
+    @hidden table tbl_testparserinvalidargumenterrorbmv2l76 {
         actions = {
-            act_3();
+            testparserinvalidargumenterrorbmv2l76();
         }
-        const default_action = act_3();
+        const default_action = testparserinvalidargumenterrorbmv2l76();
     }
-    @hidden table tbl_act_5 {
+    @hidden table tbl_testparserinvalidargumenterrorbmv2l78 {
         actions = {
-            act_4();
+            testparserinvalidargumenterrorbmv2l78();
         }
-        const default_action = act_4();
+        const default_action = testparserinvalidargumenterrorbmv2l78();
     }
-    @hidden table tbl_act_6 {
+    @hidden table tbl_testparserinvalidargumenterrorbmv2l80 {
         actions = {
-            act_5();
+            testparserinvalidargumenterrorbmv2l80();
         }
-        const default_action = act_5();
+        const default_action = testparserinvalidargumenterrorbmv2l80();
     }
-    @hidden table tbl_act_7 {
+    @hidden table tbl_testparserinvalidargumenterrorbmv2l85 {
         actions = {
-            act_6();
+            testparserinvalidargumenterrorbmv2l85();
         }
-        const default_action = act_6();
+        const default_action = testparserinvalidargumenterrorbmv2l85();
     }
-    @hidden table tbl_act_8 {
+    @hidden table tbl_testparserinvalidargumenterrorbmv2l87 {
         actions = {
-            act_8();
+            testparserinvalidargumenterrorbmv2l87();
         }
-        const default_action = act_8();
+        const default_action = testparserinvalidargumenterrorbmv2l87();
     }
     apply {
-        tbl_act.apply();
+        tbl_testparserinvalidargumenterrorbmv2l66.apply();
         if (stdmeta.parser_error == error.NoError) {
-            tbl_act_0.apply();
+            tbl_testparserinvalidargumenterrorbmv2l68.apply();
         } else if (stdmeta.parser_error == error.PacketTooShort) {
-            tbl_act_1.apply();
+            tbl_testparserinvalidargumenterrorbmv2l70.apply();
         } else if (stdmeta.parser_error == error.NoMatch) {
-            tbl_act_2.apply();
+            tbl_testparserinvalidargumenterrorbmv2l72.apply();
         } else if (stdmeta.parser_error == error.StackOutOfBounds) {
-            tbl_act_3.apply();
+            tbl_testparserinvalidargumenterrorbmv2l74.apply();
         } else if (stdmeta.parser_error == error.HeaderTooShort) {
-            tbl_act_4.apply();
+            tbl_testparserinvalidargumenterrorbmv2l76.apply();
         } else if (stdmeta.parser_error == error.ParserTimeout) {
-            tbl_act_5.apply();
+            tbl_testparserinvalidargumenterrorbmv2l78.apply();
         } else if (stdmeta.parser_error == error.ParserInvalidArgument) {
-            tbl_act_6.apply();
+            tbl_testparserinvalidargumenterrorbmv2l80.apply();
         } else {
-            tbl_act_7.apply();
+            tbl_testparserinvalidargumenterrorbmv2l85.apply();
         }
-        tbl_act_8.apply();
+        tbl_testparserinvalidargumenterrorbmv2l87.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/test_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/test_ebpf-midend.p4
@@ -62,30 +62,30 @@ control pipe(inout Headers_t headers, out bool pass) {
         implementation = hash_table(32w1024);
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action test_ebpf72() {
         pass = false;
         hasReturned = true;
     }
-    @hidden action act_0() {
+    @hidden action test_ebpf68() {
         hasReturned = false;
         pass = true;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_test_ebpf68 {
         actions = {
-            act_0();
+            test_ebpf68();
         }
-        const default_action = act_0();
+        const default_action = test_ebpf68();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_test_ebpf72 {
         actions = {
-            act();
+            test_ebpf72();
         }
-        const default_action = act();
+        const default_action = test_ebpf72();
     }
     apply {
-        tbl_act.apply();
+        tbl_test_ebpf68.apply();
         if (!headers.ipv4.isValid()) {
-            tbl_act_0.apply();
+            tbl_test_ebpf72.apply();
         }
         if (!hasReturned) {
             Check_src_ip_0.apply();

--- a/testdata/p4_16_samples_outputs/tuple0-midend.p4
+++ b/testdata/p4_16_samples_outputs/tuple0-midend.p4
@@ -8,20 +8,20 @@ control proto();
 package top(proto _p);
 control c() {
     tuple_0 x_0;
-    @hidden action act() {
+    @hidden action tuple0l23() {
         x_0.field = 32w10;
         x_0.field_0 = false;
         f(x_0);
         f({ 32w20, true });
     }
-    @hidden table tbl_act {
+    @hidden table tbl_tuple0l23 {
         actions = {
-            act();
+            tuple0l23();
         }
-        const default_action = act();
+        const default_action = tuple0l23();
     }
     apply {
-        tbl_act.apply();
+        tbl_tuple0l23.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/tuple1-midend.p4
+++ b/testdata/p4_16_samples_outputs/tuple1-midend.p4
@@ -8,19 +8,19 @@ struct tuple_0 {
 
 control c() {
     tuple_0 x_0;
-    @hidden action act() {
+    @hidden action tuple1l23() {
         x_0.field = 32w10;
         x_0.field_0 = false;
         f<tuple_0>(x_0);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_tuple1l23 {
         actions = {
-            act();
+            tuple1l23();
         }
-        const default_action = act();
+        const default_action = tuple1l23();
     }
     apply {
-        tbl_act.apply();
+        tbl_tuple1l23.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/tuple2-midend.p4
+++ b/testdata/p4_16_samples_outputs/tuple2-midend.p4
@@ -8,19 +8,19 @@ struct tuple_0 {
 
 control c() {
     tuple_0 x;
-    @hidden action act() {
+    @hidden action tuple2l23() {
         x.field = 32w10;
         x.field_0 = false;
         f<tuple_0>(x);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_tuple2l23 {
         actions = {
-            act();
+            tuple2l23();
         }
-        const default_action = act();
+        const default_action = tuple2l23();
     }
     apply {
-        tbl_act.apply();
+        tbl_tuple2l23.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/two_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/two_ebpf-midend.p4
@@ -63,36 +63,48 @@ control pipe(inout Headers_t headers, out bool pass) {
         implementation = hash_table(32w1024);
         const default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action two_ebpf69() {
         pass = false;
         hasReturned = true;
     }
-    @hidden action act_0() {
+    @hidden action two_ebpf66() {
         hasReturned = false;
         pass = true;
     }
-    @hidden action act_1() {
+    @hidden action act() {
         address_0 = headers.ipv4.srcAddr;
         pass_0 = pass;
     }
-    @hidden action act_2() {
+    @hidden action act_0() {
         pass = pass_0;
         address_0 = headers.ipv4.dstAddr;
     }
-    @hidden action act_3() {
+    @hidden action act_1() {
         pass = pass_0;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_two_ebpf66 {
         actions = {
-            act_0();
+            two_ebpf66();
         }
-        const default_action = act_0();
+        const default_action = two_ebpf66();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_two_ebpf69 {
+        actions = {
+            two_ebpf69();
+        }
+        const default_action = two_ebpf69();
+    }
+    @hidden table tbl_act {
         actions = {
             act();
         }
         const default_action = act();
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
     }
     @hidden table tbl_act_1 {
         actions = {
@@ -100,29 +112,17 @@ control pipe(inout Headers_t headers, out bool pass) {
         }
         const default_action = act_1();
     }
-    @hidden table tbl_act_2 {
-        actions = {
-            act_2();
-        }
-        const default_action = act_2();
-    }
-    @hidden table tbl_act_3 {
-        actions = {
-            act_3();
-        }
-        const default_action = act_3();
-    }
     apply {
-        tbl_act.apply();
+        tbl_two_ebpf66.apply();
         if (!headers.ipv4.isValid()) {
-            tbl_act_0.apply();
+            tbl_two_ebpf69.apply();
         }
         if (!hasReturned) {
+            tbl_act.apply();
+            c1_Check_ip.apply();
+            tbl_act_0.apply();
+            c1_Check_ip.apply();
             tbl_act_1.apply();
-            c1_Check_ip.apply();
-            tbl_act_2.apply();
-            c1_Check_ip.apply();
-            tbl_act_3.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/uninit-midend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-midend.p4
@@ -57,23 +57,23 @@ control c(out bit<32> v) {
         }
         default_action = a1();
     }
-    @hidden action act() {
+    @hidden action uninit87() {
         e_0 = 32w1;
     }
-    @hidden action act_0() {
+    @hidden action uninit92() {
         e_0 = e_0 + 32w1;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_uninit87 {
         actions = {
-            act();
+            uninit87();
         }
-        const default_action = act();
+        const default_action = uninit87();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_uninit92 {
         actions = {
-            act_0();
+            uninit92();
         }
-        const default_action = act_0();
+        const default_action = uninit92();
     }
     @hidden table tbl_a1 {
         actions = {
@@ -83,11 +83,11 @@ control c(out bit<32> v) {
     }
     apply {
         if (e_0 > 32w0) {
-            tbl_act.apply();
+            tbl_uninit87.apply();
         } else {
             ;
         }
-        tbl_act_0.apply();
+        tbl_uninit92.apply();
         switch (t_0.apply().action_run) {
             a1: {
             }

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2-midend.p4
@@ -72,17 +72,17 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         }
         default_action = a_1();
     }
-    @hidden action act() {
+    @hidden action unionvalidbmv2l76() {
         key_0 = h.u.isValid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_unionvalidbmv2l76 {
         actions = {
-            act();
+            unionvalidbmv2l76();
         }
-        const default_action = act();
+        const default_action = unionvalidbmv2l76();
     }
     apply {
-        tbl_act.apply();
+        tbl_unionvalidbmv2l76.apply();
         t_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/union1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union1-bmv2-midend.p4
@@ -64,18 +64,18 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action union1bmv2l75() {
         h.u.h2.setInvalid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_union1bmv2l75 {
         actions = {
-            act();
+            union1bmv2l75();
         }
-        const default_action = act();
+        const default_action = union1bmv2l75();
     }
     apply {
         if (h.u.h2.isValid()) {
-            tbl_act.apply();
+            tbl_union1bmv2l75.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/union2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union2-bmv2-midend.p4
@@ -64,20 +64,20 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action union2bmv2l75() {
         h.u.h2.setInvalid();
         h.u.h1.setValid();
         h.u.h1.a = 8w0xff;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_union2bmv2l75 {
         actions = {
-            act();
+            union2bmv2l75();
         }
-        const default_action = act();
+        const default_action = union2bmv2l75();
     }
     apply {
         if (h.u.h2.isValid()) {
-            tbl_act.apply();
+            tbl_union2bmv2l75.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/union3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union3-bmv2-midend.p4
@@ -66,20 +66,20 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action union3bmv2l77() {
         h.h2.setValid();
         h.h2.b = h.u.h2.b;
         h.u.h2.setInvalid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_union3bmv2l77 {
         actions = {
-            act();
+            union3bmv2l77();
         }
-        const default_action = act();
+        const default_action = union3bmv2l77();
     }
     apply {
         if (h.u.h2.isValid()) {
-            tbl_act.apply();
+            tbl_union3bmv2l77.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/union4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union4-bmv2-midend.p4
@@ -66,22 +66,22 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action act() {
+    @hidden action union4bmv2l77() {
         h.h2.setValid();
         h.h2.b = h.u.h2.b;
         h.u.h1.setValid();
         h.u.h1.a = h.u.h2.b[7:0];
         h.u.h2.setInvalid();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_union4bmv2l77 {
         actions = {
-            act();
+            union4bmv2l77();
         }
-        const default_action = act();
+        const default_action = union4bmv2l77();
     }
     apply {
         if (h.u.h2.isValid()) {
-            tbl_act.apply();
+            tbl_union4bmv2l77.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/unreachable-accept-midend.p4
+++ b/testdata/p4_16_samples_outputs/unreachable-accept-midend.p4
@@ -18,17 +18,17 @@ parser Parser(packet_in pkt_in, out headers_t hdr) {
 }
 
 control Deparser(in headers_t hdr, packet_out pkt_out) {
-    @hidden action act() {
+    @hidden action unreachableaccept38() {
         pkt_out.emit<ethernet_h>(hdr.ethernet);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_unreachableaccept38 {
         actions = {
-            act();
+            unreachableaccept38();
         }
-        const default_action = act();
+        const default_action = unreachableaccept38();
     }
     apply {
-        tbl_act.apply();
+        tbl_unreachableaccept38.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/unused-midend.p4
+++ b/testdata/p4_16_samples_outputs/unused-midend.p4
@@ -18,31 +18,31 @@ extern E {
 control c(inout S s) {
     bit<32> tmp;
     @name("c.e") E() e_0;
-    @hidden action act() {
+    @hidden action unused38() {
         s.h.data3 = 32w0;
     }
-    @hidden action act_0() {
+    @hidden action unused40() {
         tmp = e_0.get<bit<32>>(s.h.data2);
         s.h.data1 = tmp;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_unused38 {
         actions = {
-            act();
+            unused38();
         }
-        const default_action = act();
+        const default_action = unused38();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_unused40 {
         actions = {
-            act_0();
+            unused40();
         }
-        const default_action = act_0();
+        const default_action = unused40();
     }
     apply {
         if (s.h.isValid()) {
-            tbl_act.apply();
+            tbl_unused38.apply();
         }
         if (s.h.data2 == 32w0) {
-            tbl_act_0.apply();
+            tbl_unused40.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
@@ -176,31 +176,31 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         }
         default_action = my_drop_0();
     }
-    @hidden action act() {
+    @hidden action v1modelspecialopsbmv2l312() {
         hdr.ipv4.srcAddr = 32w184320258;
         meta._fwd_l2ptr0 = 32w0xe50b;
     }
-    @hidden action act_0() {
+    @hidden action v1modelspecialopsbmv2l315() {
         hdr.ipv4.srcAddr = 32w180835939;
         meta._fwd_l2ptr0 = 32w0xec1c;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_v1modelspecialopsbmv2l312 {
         actions = {
-            act();
+            v1modelspecialopsbmv2l312();
         }
-        const default_action = act();
+        const default_action = v1modelspecialopsbmv2l312();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_v1modelspecialopsbmv2l315 {
         actions = {
-            act_0();
+            v1modelspecialopsbmv2l315();
         }
-        const default_action = act_0();
+        const default_action = v1modelspecialopsbmv2l315();
     }
     apply {
         if (standard_metadata.instance_type == 32w6) {
-            tbl_act.apply();
+            tbl_v1modelspecialopsbmv2l312.apply();
         } else if (standard_metadata.instance_type == 32w4) {
-            tbl_act_0.apply();
+            tbl_v1modelspecialopsbmv2l315.apply();
         } else {
             ipv4_da_lpm_0.apply();
         }
@@ -286,33 +286,33 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
         }
         default_action = my_drop_1();
     }
-    @hidden action act_1() {
+    @hidden action v1modelspecialopsbmv2l385() {
         hdr.switch_to_cpu.setValid();
         hdr.switch_to_cpu.word0 = 32w0x12e012e;
         hdr.switch_to_cpu.word1 = 32w0x5a5a5a5a;
     }
-    @hidden action act_2() {
+    @hidden action v1modelspecialopsbmv2l391() {
         hdr.switch_to_cpu.setValid();
         hdr.switch_to_cpu.word0 = 32w0xe2e0e2e;
         hdr.switch_to_cpu.word1 = 32w0x5a5a5a5a;
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_v1modelspecialopsbmv2l385 {
         actions = {
-            act_1();
+            v1modelspecialopsbmv2l385();
         }
-        const default_action = act_1();
+        const default_action = v1modelspecialopsbmv2l385();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_v1modelspecialopsbmv2l391 {
         actions = {
-            act_2();
+            v1modelspecialopsbmv2l391();
         }
-        const default_action = act_2();
+        const default_action = v1modelspecialopsbmv2l391();
     }
     apply {
         if (standard_metadata.instance_type == 32w1) {
-            tbl_act_1.apply();
+            tbl_v1modelspecialopsbmv2l385.apply();
         } else if (standard_metadata.instance_type == 32w2) {
-            tbl_act_2.apply();
+            tbl_v1modelspecialopsbmv2l391.apply();
         } else {
             if (standard_metadata.instance_type == 32w5) {
                 get_multicast_copy_out_bd_0.apply();

--- a/testdata/p4_16_samples_outputs/valid_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/valid_ebpf-midend.p4
@@ -59,31 +59,31 @@ control pipe(inout Headers_t headers, out bool pass) {
         implementation = array_table(32w1);
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action valid_ebpf49() {
         counters_0.increment(headers.ipv4.dstAddr);
         pass = true;
     }
-    @hidden action act_0() {
+    @hidden action valid_ebpf54() {
         pass = false;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_valid_ebpf49 {
         actions = {
-            act();
+            valid_ebpf49();
         }
-        const default_action = act();
+        const default_action = valid_ebpf49();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_valid_ebpf54 {
         actions = {
-            act_0();
+            valid_ebpf54();
         }
-        const default_action = act_0();
+        const default_action = valid_ebpf54();
     }
     apply {
         if (headers.ipv4.isValid()) {
-            tbl_act.apply();
+            tbl_valid_ebpf49.apply();
         } else {
             t_0.apply();
-            tbl_act_0.apply();
+            tbl_valid_ebpf54.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/virtual-midend.p4
+++ b/testdata/p4_16_samples_outputs/virtual-midend.p4
@@ -27,18 +27,18 @@ control c(inout bit<16> p) {
             }
         }
     };
-    @hidden action act() {
+    @hidden action virtual51() {
         tmp = cntr_0.f(16w6);
         p = tmp;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_virtual51 {
         actions = {
-            act();
+            virtual51();
         }
-        const default_action = act();
+        const default_action = virtual51();
     }
     apply {
-        tbl_act.apply();
+        tbl_virtual51.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/virtual2-midend.p4
+++ b/testdata/p4_16_samples_outputs/virtual2-midend.p4
@@ -18,17 +18,17 @@ control c(inout bit<16> p) {
             return tmp;
         }
     };
-    @hidden action act() {
+    @hidden action virtual2l38() {
         cntr_0.run(16w6);
     }
-    @hidden table tbl_act {
+    @hidden table tbl_virtual2l38 {
         actions = {
-            act();
+            virtual2l38();
         }
-        const default_action = act();
+        const default_action = virtual2l38();
     }
     apply {
-        tbl_act.apply();
+        tbl_virtual2l38.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/virtual3-midend.p4
+++ b/testdata/p4_16_samples_outputs/virtual3-midend.p4
@@ -35,17 +35,17 @@ control c(inout bit<16> p) {
         }
         default_action = NoAction_0();
     }
-    @hidden action act() {
+    @hidden action virtual3l47() {
         local_0 = 16w4;
     }
-    @hidden table tbl_act {
+    @hidden table tbl_virtual3l47 {
         actions = {
-            act();
+            virtual3l47();
         }
-        const default_action = act();
+        const default_action = virtual3l47();
     }
     apply {
-        tbl_act.apply();
+        tbl_virtual3l47.apply();
         run_ctr_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/vss-example-midend.p4
+++ b/testdata/p4_16_samples_outputs/vss-example-midend.p4
@@ -153,26 +153,26 @@ control TopPipe(inout Parsed_packet headers, in error parseError, in InControl i
         size = 16;
         default_action = Drop_action_5();
     }
-    @hidden action act() {
+    @hidden action vssexample191() {
         hasReturned = true;
     }
-    @hidden action act_0() {
+    @hidden action act() {
         hasReturned = false;
     }
-    @hidden action act_1() {
+    @hidden action vssexample195() {
         hasReturned = true;
     }
-    @hidden action act_2() {
+    @hidden action vssexample198() {
         hasReturned = true;
     }
-    @hidden action act_3() {
+    @hidden action vssexample201() {
         hasReturned = true;
     }
     @hidden table tbl_act {
         actions = {
-            act_0();
+            act();
         }
-        const default_action = act_0();
+        const default_action = act();
     }
     @hidden table tbl_Drop_action {
         actions = {
@@ -180,52 +180,52 @@ control TopPipe(inout Parsed_packet headers, in error parseError, in InControl i
         }
         const default_action = Drop_action_6();
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_vssexample191 {
         actions = {
-            act();
+            vssexample191();
         }
-        const default_action = act();
+        const default_action = vssexample191();
     }
-    @hidden table tbl_act_1 {
+    @hidden table tbl_vssexample195 {
         actions = {
-            act_1();
+            vssexample195();
         }
-        const default_action = act_1();
+        const default_action = vssexample195();
     }
-    @hidden table tbl_act_2 {
+    @hidden table tbl_vssexample198 {
         actions = {
-            act_2();
+            vssexample198();
         }
-        const default_action = act_2();
+        const default_action = vssexample198();
     }
-    @hidden table tbl_act_3 {
+    @hidden table tbl_vssexample201 {
         actions = {
-            act_3();
+            vssexample201();
         }
-        const default_action = act_3();
+        const default_action = vssexample201();
     }
     apply {
         tbl_act.apply();
         if (parseError != error.NoError) {
             tbl_Drop_action.apply();
-            tbl_act_0.apply();
+            tbl_vssexample191.apply();
         }
         if (!hasReturned) {
             ipv4_match_0.apply();
             if (outCtrl.outputPort == 4w0xf) {
-                tbl_act_1.apply();
+                tbl_vssexample195.apply();
             }
         }
         if (!hasReturned) {
             check_ttl_0.apply();
             if (outCtrl.outputPort == 4w0xe) {
-                tbl_act_2.apply();
+                tbl_vssexample198.apply();
             }
         }
         if (!hasReturned) {
             dmac_0.apply();
             if (outCtrl.outputPort == 4w0xf) {
-                tbl_act_3.apply();
+                tbl_vssexample201.apply();
             }
         }
         if (!hasReturned) {
@@ -237,43 +237,43 @@ control TopPipe(inout Parsed_packet headers, in error parseError, in InControl i
 control TopDeparser(inout Parsed_packet p, packet_out b) {
     bit<16> tmp_2;
     @name("TopDeparser.ck") Ck16() ck_1;
-    @hidden action act_4() {
+    @hidden action vssexample213() {
         ck_1.clear();
         p.ip.hdrChecksum = 16w0;
         ck_1.update<Ipv4_h>(p.ip);
         tmp_2 = ck_1.get();
         p.ip.hdrChecksum = tmp_2;
     }
-    @hidden action act_5() {
+    @hidden action vssexample211() {
         b.emit<Ethernet_h>(p.ethernet);
     }
-    @hidden action act_6() {
+    @hidden action vssexample218() {
         b.emit<Ipv4_h>(p.ip);
     }
-    @hidden table tbl_act_4 {
+    @hidden table tbl_vssexample211 {
         actions = {
-            act_5();
+            vssexample211();
         }
-        const default_action = act_5();
+        const default_action = vssexample211();
     }
-    @hidden table tbl_act_5 {
+    @hidden table tbl_vssexample213 {
         actions = {
-            act_4();
+            vssexample213();
         }
-        const default_action = act_4();
+        const default_action = vssexample213();
     }
-    @hidden table tbl_act_6 {
+    @hidden table tbl_vssexample218 {
         actions = {
-            act_6();
+            vssexample218();
         }
-        const default_action = act_6();
+        const default_action = vssexample218();
     }
     apply {
-        tbl_act_4.apply();
+        tbl_vssexample211.apply();
         if (p.ip.isValid()) {
-            tbl_act_5.apply();
+            tbl_vssexample213.apply();
         }
-        tbl_act_6.apply();
+        tbl_vssexample218.apply();
     }
 }
 


### PR DESCRIPTION
- make it easier in the backend to figure out where actions and tables
  came from when debugging by using a name that vaguely corresponds to
  the source file and line of the original statement.