### PR TITLE
Fix const default action check

### DIFF
--- a/testdata/p4_14_samples/const_default_action.p4
+++ b/testdata/p4_14_samples/const_default_action.p4
@@ -53,10 +53,15 @@ action port_vlan_mapping_miss() {
     modify_field(ingress_metadata.drop_flag, 1);
 }
 
+action send(port) {
+    modify_field(ingress_metadata.ingress_port, port);
+}
+
 action_profile bd_action_profile {
     actions {
         set_bd_properties;
         port_vlan_mapping_miss;
+        send;
     }
     size : 1024;
 }
@@ -78,7 +83,7 @@ table vlan_to_bd_mapping {
         vlan_tag_[0].vid : exact;
     }
     action_profile: bd_action_profile;
-    const default_action: no_op();
+    const default_action: send(64);
     size : 1024;
 }
 

--- a/testdata/p4_14_samples_outputs/const_default_action-frontend.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action-frontend.p4
@@ -59,8 +59,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     bool _process_port_vlan_mapping_tmp;
     @name(".no_op") action _no_op_0() {
     }
-    @name(".no_op") action _no_op_2() {
-    }
     @name(".set_bd_properties") action _set_bd_properties_0(bit<14> bd, bit<14> ingress_rid) {
         meta.ingress_metadata.bd = bd;
         meta.ingress_metadata.rid = ingress_rid;
@@ -75,10 +73,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss_2() {
         meta.ingress_metadata.drop_flag = 1w1;
     }
+    @name(".send") action _send_0(bit<9> port) {
+        meta.ingress_metadata.ingress_port = port;
+    }
+    @name(".send") action _send_2(bit<9> port) {
+        meta.ingress_metadata.ingress_port = port;
+    }
     @name(".port_vlan_to_bd_mapping") table _port_vlan_to_bd_mapping {
         actions = {
             _set_bd_properties_0();
             _port_vlan_mapping_miss_0();
+            _send_0();
             @defaultonly _no_op_0();
         }
         key = {
@@ -93,13 +98,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         actions = {
             _set_bd_properties_2();
             _port_vlan_mapping_miss_2();
-            @defaultonly _no_op_2();
+            @defaultonly _send_2();
         }
         key = {
             hdr.vlan_tag_[0].vid: exact @name("vlan_tag_[0].vid") ;
         }
         size = 1024;
-        const default_action = _no_op_2();
+        const default_action = _send_2(9w64);
         implementation = bd_action_profile;
     }
     apply {

--- a/testdata/p4_14_samples_outputs/const_default_action-midend.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action-midend.p4
@@ -66,8 +66,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     bool _process_port_vlan_mapping_tmp;
     @name(".no_op") action _no_op_0() {
     }
-    @name(".no_op") action _no_op_2() {
-    }
     @name(".set_bd_properties") action _set_bd_properties_0(bit<14> bd, bit<14> ingress_rid) {
         meta._ingress_metadata_bd1 = bd;
         meta._ingress_metadata_rid2 = ingress_rid;
@@ -82,10 +80,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss_2() {
         meta._ingress_metadata_drop_flag3 = 1w1;
     }
+    @name(".send") action _send_0(bit<9> port) {
+        meta._ingress_metadata_ingress_port0 = port;
+    }
+    @name(".send") action _send_2(bit<9> port) {
+        meta._ingress_metadata_ingress_port0 = port;
+    }
     @name(".port_vlan_to_bd_mapping") table _port_vlan_to_bd_mapping {
         actions = {
             _set_bd_properties_0();
             _port_vlan_mapping_miss_0();
+            _send_0();
             @defaultonly _no_op_0();
         }
         key = {
@@ -100,13 +105,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         actions = {
             _set_bd_properties_2();
             _port_vlan_mapping_miss_2();
-            @defaultonly _no_op_2();
+            @defaultonly _send_2();
         }
         key = {
             hdr.vlan_tag_[0].vid: exact @name("vlan_tag_[0].vid") ;
         }
         size = 1024;
-        const default_action = _no_op_2();
+        const default_action = _send_2(9w64);
         implementation = bd_action_profile;
     }
     @hidden action act() {

--- a/testdata/p4_14_samples_outputs/const_default_action.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action.p4
@@ -65,10 +65,14 @@ control process_port_vlan_mapping(inout headers hdr, inout metadata meta, inout 
     @name(".port_vlan_mapping_miss") action port_vlan_mapping_miss() {
         meta.ingress_metadata.drop_flag = 1w1;
     }
+    @name(".send") action send(bit<9> port) {
+        meta.ingress_metadata.ingress_port = port;
+    }
     @name(".port_vlan_to_bd_mapping") table port_vlan_to_bd_mapping {
         actions = {
             set_bd_properties;
             port_vlan_mapping_miss;
+            send;
             @defaultonly no_op;
         }
         key = {
@@ -83,13 +87,13 @@ control process_port_vlan_mapping(inout headers hdr, inout metadata meta, inout 
         actions = {
             set_bd_properties;
             port_vlan_mapping_miss;
-            @defaultonly no_op;
+            @defaultonly send;
         }
         key = {
             hdr.vlan_tag_[0].vid: exact;
         }
         size = 1024;
-        const default_action = no_op();
+        const default_action = send(64);
         implementation = bd_action_profile;
     }
     apply {


### PR DESCRIPTION
Support for declaring a constant default action using a `const` keyword was added a while back by @hanw - #1523 . Fixing check to use this parsed info within `V1Table` into table property in generated `P4Table`.