### PR TITLE
Add support for more kinds of annotation bodies

### DIFF
--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -81,6 +81,39 @@ bool ParseAnnotations::parseKvList(IR::Annotation* annotation) {
     return parsed != nullptr;
 }
 
+bool ParseAnnotations::parseConstantList(IR::Annotation* annotation) {
+    const IR::Vector<IR::Expression>* parsed =
+        P4::P4ParserDriver::parseConstantList(annotation->srcInfo,
+                                              annotation->body);
+    if (parsed != nullptr) {
+        annotation->expr.append(*parsed);
+    }
+
+    return parsed != nullptr;
+}
+
+bool ParseAnnotations::parseConstantOrStringLiteralList(IR::Annotation* annotation) {
+    const IR::Vector<IR::Expression>* parsed =
+        P4::P4ParserDriver::parseConstantOrStringLiteralList(annotation->srcInfo,
+                                                             annotation->body);
+    if (parsed != nullptr) {
+        annotation->expr.append(*parsed);
+    }
+
+    return parsed != nullptr;
+}
+
+bool ParseAnnotations::parseStringLiteralList(IR::Annotation* annotation) {
+    const IR::Vector<IR::Expression>* parsed =
+        P4::P4ParserDriver::parseStringLiteralList(annotation->srcInfo,
+                                                   annotation->body);
+    if (parsed != nullptr) {
+        annotation->expr.append(*parsed);
+    }
+
+    return parsed != nullptr;
+}
+
 void ParseAnnotations::postorder(IR::Annotation* annotation) {
     if (!annotation->needsParsing) {
         return;

--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -47,6 +47,19 @@ namespace P4 {
         }                                                               \
     }
 
+// Parses an annotation that is either an integer constant or a string literal.
+#define PARSE_CONSTANT_OR_STRING_LITERAL(aname)                                       \
+    { aname, [](IR::Annotation* annotation) {                                         \
+            const IR::Expression* parsed =                                            \
+                P4::P4ParserDriver::parseConstantOrStringLiteral(annotation->srcInfo, \
+                                                                 annotation->body);   \
+            if (parsed != nullptr) {                                                  \
+                annotation->expr.push_back(parsed);                                   \
+            }                                                                         \
+            return parsed != nullptr;                                                 \
+        }                                                                             \
+    }
+
 // Parses an annotation whose body is a pair.
 #define PARSE_PAIR(aname, tname)                                   \
     { aname, [](IR::Annotation* annotation) {                      \
@@ -74,11 +87,26 @@ namespace P4 {
         }                                                          \
     }
 
+// Parses an annotation whose body is a list of expressions.
 #define PARSE_EXPRESSION_LIST(aname) \
     { aname, &P4::ParseAnnotations::parseExpressionList }
 
+// Parses an annotation whose body is a list of key-value pairs.
 #define PARSE_KV_LIST(aname) \
     { aname, &P4::ParseAnnotations::parseKvList }
+
+// Parses an annotation whose body is a list of integer constants.
+#define PARSE_CONSTANT_LIST(aname) \
+    { aname, &P4::ParseAnnotations::parseConstantList }
+
+// Parses an annotation whose body is a list, where each element is an integer constant or a string
+// literal.
+#define PARSE_CONSTANT_OR_STRING_LITERAL_LIST(aname) \
+    { aname, &P4::ParseAnnotations::parseConstantOrStringLiteralList }
+
+// Parses an annotation whose body is a list of string literals.
+#define PARSE_STRING_LITERAL_LIST(aname) \
+    { aname, &P4::ParseAnnotations::parseStringLiteralList }
 
 class ParseAnnotations : public Modifier {
  public:
@@ -122,6 +150,9 @@ class ParseAnnotations : public Modifier {
     static bool parseEmpty(IR::Annotation* annotation);
     static bool parseExpressionList(IR::Annotation* annotation);
     static bool parseKvList(IR::Annotation* annotation);
+    static bool parseConstantList(IR::Annotation* annotation);
+    static bool parseConstantOrStringLiteralList(IR::Annotation* annotation);
+    static bool parseStringLiteralList(IR::Annotation* annotation);
 
     void addHandler(cstring name, Handler h) { handlers.insert({name, h}); }
 

--- a/frontends/parsers/p4/p4AnnotationLexer.hpp
+++ b/frontends/parsers/p4/p4AnnotationLexer.hpp
@@ -12,10 +12,15 @@ class P4AnnotationLexer : public AbstractP4Lexer {
         // Lists
         EXPRESSION_LIST = P4Parser::token_type::TOK_START_EXPRESSION_LIST,
         KV_LIST = P4Parser::token_type::TOK_START_KV_LIST,
+        INTEGER_LIST = P4Parser::token_type::TOK_START_INTEGER_LIST,
+        INTEGER_OR_STRING_LITERAL_LIST =
+            P4Parser::token_type::TOK_START_INTEGER_OR_STRING_LITERAL_LIST,
+        STRING_LITERAL_LIST = P4Parser::token_type::TOK_START_STRING_LITERAL_LIST,
 
         // Singletons
         EXPRESSION = P4Parser::token_type::TOK_START_EXPRESSION,
         INTEGER = P4Parser::token_type::TOK_START_INTEGER,
+        INTEGER_OR_STRING_LITERAL = P4Parser::token_type::TOK_START_INTEGER_OR_STRING_LITERAL,
         STRING_LITERAL = P4Parser::token_type::TOK_START_STRING_LITERAL,
 
         // Pairs

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -132,12 +132,30 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 
 %define api.token.prefix {TOK_}
 %token             START_PROGRAM
-                   START_EXPRESSION_LIST START_KV_LIST
-                   START_EXPRESSION START_INTEGER START_STRING_LITERAL
-                   START_EXPRESSION_PAIR START_INTEGER_PAIR
+
+                   // Lists
+                   START_EXPRESSION_LIST
+                   START_KV_LIST
+                   START_INTEGER_LIST
+                   START_INTEGER_OR_STRING_LITERAL_LIST
+                   START_STRING_LITERAL_LIST
+
+                   // Singletons
+                   START_EXPRESSION
+                   START_INTEGER
+                   START_INTEGER_OR_STRING_LITERAL
+                   START_STRING_LITERAL
+
+                   // Pairs
+                   START_EXPRESSION_PAIR
+                   START_INTEGER_PAIR
                    START_STRING_LITERAL_PAIR
-                   START_EXPRESSION_TRIPLE START_INTEGER_TRIPLE
+
+                   // Triples
+                   START_EXPRESSION_TRIPLE
+                   START_INTEGER_TRIPLE
                    START_STRING_LITERAL_TRIPLE
+
 %token             END END_ANNOTATION
 
 
@@ -272,6 +290,10 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %type<IR::MethodCallExpression*>  actionBinding
 %type<IR::IndexedVector<IR::NamedExpression>*> kvList
 %type<IR::NamedExpression*> kvPair
+%type<IR::Vector<IR::Expression>*> intList
+%type<IR::Vector<IR::Expression>*> intOrStrList
+%type<IR::Vector<IR::Expression>*> strList
+%type<IR::Expression*> intOrStr
 
 %left COMMA
 %nonassoc QUESTION
@@ -312,13 +334,17 @@ start
 
 fragment
       // Lists
-    : START_EXPRESSION_LIST expressionList { $$ = $2; }
-    | START_KV_LIST kvList                 { $$ = $2; }
+    : START_EXPRESSION_LIST expressionList              { $$ = $2; }
+    | START_KV_LIST kvList                              { $$ = $2; }
+    | START_INTEGER_LIST intList                        { $$ = $2; }
+    | START_INTEGER_OR_STRING_LITERAL_LIST intOrStrList { $$ = $2; }
+    | START_STRING_LITERAL_LIST strList                 { $$ = $2; }
 
       // Singletons
-    | START_EXPRESSION expression          { $$ = $2; }
-    | START_INTEGER INTEGER                { $$ = parseConstant(@2, $2, 0); }
-    | START_STRING_LITERAL STRING_LITERAL  { $$ = new IR::StringLiteral(@2, $2); }
+    | START_EXPRESSION expression                       { $$ = $2; }
+    | START_INTEGER INTEGER                             { $$ = parseConstant(@2, $2, 0); }
+    | START_INTEGER_OR_STRING_LITERAL intOrStr          { $$ = $2; }
+    | START_STRING_LITERAL STRING_LITERAL               { $$ = new IR::StringLiteral(@2, $2); }
 
       // Pairs
     | START_EXPRESSION_PAIR expression "," expression
@@ -1338,6 +1364,32 @@ expression
     | namedType "(" argumentList ")"
         { $$ = new IR::ConstructorCallExpression(@1 + @4, $1, $3); }
     | "(" typeRef ")" expression %prec PREFIX { $$ = new IR::Cast(@1 + @4, $2, $4); }
+    ;
+
+intOrStr
+    : INTEGER                { $$ = parseConstant(@1, $1, 0); }
+    | STRING_LITERAL         { $$ = new IR::StringLiteral(@1, $1); }
+    ;
+
+intList
+    : INTEGER                { $$ = new IR::Vector<IR::Expression>();
+                               $$->push_back(parseConstant(@1, $1, 0)); }
+    | intList INTEGER        { $$ = $1;
+                               $$->push_back(parseConstant(@2, $2, 0)); }
+    ;
+
+intOrStrList
+    : intOrStr               { $$ = new IR::Vector<IR::Expression>();
+                               $$->push_back($1); }
+    | intOrStrList intOrStr  { $$ = $1;
+                               $$->push_back($2); }
+    ;
+
+strList
+    : STRING_LITERAL         { $$ = new IR::Vector<IR::Expression>();
+                               $$->push_back(new IR::StringLiteral(@1, $1)); }
+    | strList STRING_LITERAL { $$ = $1;
+                               $$->push_back(new IR::StringLiteral(@2, $2)); }
     ;
 
 /*****************************************************************************/

--- a/frontends/parsers/parserDriver.cpp
+++ b/frontends/parsers/parserDriver.cpp
@@ -193,6 +193,30 @@ P4ParserDriver::parseKvList(const Util::SourceInfo& srcInfo,
             P4AnnotationLexer::KV_LIST, srcInfo, body);
 }
 
+/* static */ const IR::Vector<IR::Expression>*
+P4ParserDriver::parseConstantList(const Util::SourceInfo& srcInfo,
+                                  const IR::Vector<IR::AnnotationToken>& body) {
+    P4ParserDriver driver;
+    return driver.parse<IR::Vector<IR::Expression>>(
+            P4AnnotationLexer::INTEGER_LIST, srcInfo, body);
+}
+
+/* static */ const IR::Vector<IR::Expression>*
+P4ParserDriver::parseConstantOrStringLiteralList(const Util::SourceInfo& srcInfo,
+                                                 const IR::Vector<IR::AnnotationToken>& body) {
+    P4ParserDriver driver;
+    return driver.parse<IR::Vector<IR::Expression>>(
+            P4AnnotationLexer::INTEGER_OR_STRING_LITERAL_LIST, srcInfo, body);
+}
+
+/* static */ const IR::Vector<IR::Expression>*
+P4ParserDriver::parseStringLiteralList(const Util::SourceInfo& srcInfo,
+                                       const IR::Vector<IR::AnnotationToken>& body) {
+    P4ParserDriver driver;
+    return driver.parse<IR::Vector<IR::Expression>>(
+            P4AnnotationLexer::STRING_LITERAL_LIST, srcInfo, body);
+}
+
 /* static */ const IR::Expression*
 P4ParserDriver::parseExpression(const Util::SourceInfo& srcInfo,
                                 const IR::Vector<IR::AnnotationToken>& body) {
@@ -207,6 +231,14 @@ P4ParserDriver::parseConstant(const Util::SourceInfo& srcInfo,
     P4ParserDriver driver;
     return driver.parse<IR::Constant>(
             P4AnnotationLexer::INTEGER, srcInfo, body);
+}
+
+/* static */ const IR::Expression*
+P4ParserDriver::parseConstantOrStringLiteral(const Util::SourceInfo& srcInfo,
+                                             const IR::Vector<IR::AnnotationToken>& body) {
+    P4ParserDriver driver;
+    return driver.parse<IR::Expression>(
+            P4AnnotationLexer::INTEGER_OR_STRING_LITERAL, srcInfo, body);
 }
 
 /* static */ const IR::StringLiteral*

--- a/frontends/parsers/parserDriver.h
+++ b/frontends/parsers/parserDriver.h
@@ -131,12 +131,28 @@ class P4ParserDriver final : public AbstractParserDriver {
         const Util::SourceInfo& srcInfo,
         const IR::Vector<IR::AnnotationToken>& body);
 
+    static const IR::Vector<IR::Expression>* parseConstantList(
+        const Util::SourceInfo& srcInfo,
+        const IR::Vector<IR::AnnotationToken>& body);
+
+    static const IR::Vector<IR::Expression>* parseConstantOrStringLiteralList(
+        const Util::SourceInfo& srcInfo,
+        const IR::Vector<IR::AnnotationToken>& body);
+
+    static const IR::Vector<IR::Expression>* parseStringLiteralList(
+        const Util::SourceInfo& srcInfo,
+        const IR::Vector<IR::AnnotationToken>& body);
+
     // Singletons ////////////////////////////////////////////////////////////
     static const IR::Expression* parseExpression(
         const Util::SourceInfo& srcInfo,
         const IR::Vector<IR::AnnotationToken>& body);
 
     static const IR::Constant* parseConstant(
+        const Util::SourceInfo& srcInfo,
+        const IR::Vector<IR::AnnotationToken>& body);
+
+    static const IR::Expression* parseConstantOrStringLiteral(
         const Util::SourceInfo& srcInfo,
         const IR::Vector<IR::AnnotationToken>& body);
 


### PR DESCRIPTION
Add support for annotations whose bodies can be an integer constant or a string literal, an integer list, a string list, and a list of (integer constant or string literal).
