### PR TITLE
Structs, headers and tuples initialisation support (#762) (#2017)

### DIFF
--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -148,7 +148,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new ValidateMatchAnnotations(&typeMap),
         new DefaultArguments(&refMap, &typeMap),  // add default argument values to parameters
         new BindTypeVariables(&refMap, &typeMap),
-        new StructInitializers(&refMap, &typeMap),
+        new StructInitializers(&refMap, &typeMap, false),
         new TableKeyNames(&refMap, &typeMap),
         // Another round of constant folding, using type information.
         new ConstantFolding(&refMap, &typeMap),
@@ -162,6 +162,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new UniqueNames(&refMap),  // Give each local declaration a unique internal name
         new MoveDeclarations(),  // Move all local declarations to the beginning
         new MoveInitializers(),
+        new StructInitializers(&refMap, &typeMap, true),
         new SideEffectOrdering(&refMap, &typeMap, skipSideEffectOrdering),
         new SetHeaders(&refMap, &typeMap),
         new SimplifyControlFlow(&refMap, &typeMap),

--- a/testdata/p4_16_samples/zero_init.p4
+++ b/testdata/p4_16_samples/zero_init.p4
@@ -6,14 +6,30 @@ struct S {
     tuple<T, T> f1;
     T           f2;
     bit<1>      z;
+    tuple<int<8>, bool> tpl;
+}
+
+header H {
+    int<8> i;
+    bool b;
+    bit<7> l;
+    bit<7> l1;
+    bit<1> b1;
 }
 
 extern void f<D>(in D data);
 control c(inout bit<1> r) {
     S s_0;
+    H h_0;
     bit<1> tmp;
     apply {
-        s_0 = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
+    tuple<int<8>, bool> x = { };
+    s_0.tpl = x;
+        s_0 = {};
+    H h_1 = {};
+        h_0 = {};
+    h_0.b1 = h_1.b1;
+        s_0.z = h_0.b1;
         f<tuple<T, T>>(s_0.f1);
         tmp = s_0.f2.f & s_0.z;
         r = tmp;
@@ -23,4 +39,3 @@ control c(inout bit<1> r) {
 control simple(inout bit<1> r);
 package top(simple e);
 top(c()) main;
-

--- a/testdata/p4_16_samples_outputs/assign-first.p4
+++ b/testdata/p4_16_samples_outputs/assign-first.p4
@@ -5,7 +5,7 @@ header h {
 control c() {
     h hdr;
     apply {
-        hdr = h {field = 32w10};
+        hdr = { 32w10 };
     }
 }
 

--- a/testdata/p4_16_samples_outputs/copy-first.p4
+++ b/testdata/p4_16_samples_outputs/copy-first.p4
@@ -6,7 +6,7 @@ control c(inout bit<32> b) {
     action a() {
         S s1;
         S s2;
-        s2 = S {x = 32w0};
+        s2 = { 32w0 };
         s1 = s2;
         s2 = s1;
         b = s2.x;

--- a/testdata/p4_16_samples_outputs/issue1670-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1670-bmv2-first.p4
@@ -25,7 +25,7 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     apply {
         h.mirrored_md.setValid();
-        h.mirrored_md.meta = switch_metadata_t {port = 8w0};
+        h.mirrored_md.meta = { 8w0 };
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1863-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1863-first.p4
@@ -6,7 +6,7 @@ struct S {
 control c(out bit<1> b) {
     apply {
         S s = { 1w0, 1w1 };
-        s = S {a = s.b,b = s.a};
+        s = { s.b, s.a };
         b = s.a;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1863-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1863-frontend.p4
@@ -6,7 +6,7 @@ struct S {
 control c(out bit<1> b) {
     S s_0;
     apply {
-        s_0 = { 1w0, 1w1 };
+        s_0 = S {a = 1w0,b = 1w1};
         s_0 = S {a = s_0.b,b = s_0.a};
         b = s_0.a;
     }

--- a/testdata/p4_16_samples_outputs/issue232-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2-frontend.p4
@@ -34,10 +34,10 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
     bool done_0;
     bool ok_0;
     @name("Eg.test") action test() {
-        inKey_0 = { 32w1 };
-        defaultKey_0 = { 32w0 };
+        inKey_0 = Key {field1 = 32w1};
+        defaultKey_0 = Key {field1 = 32w0};
         same_0 = inKey_0 == defaultKey_0;
-        val = { 32w0 };
+        val = Value {field1 = 32w0};
         done_0 = false;
         ok_0 = !done_0 && same_0;
         if (ok_0) {

--- a/testdata/p4_16_samples_outputs/issue242-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-frontend.p4
@@ -64,7 +64,7 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
     @name("Eg.debug") register<bit<32>>(32w100) debug_0;
     @name("Eg.reg") register<bit<32>>(32w1) reg_0;
     @name("Eg.test") action test() {
-        val_0 = { 32w0 };
+        val_0 = Value {field1 = 32w0};
         _pred_0 = val_0.field1 != 32w0;
         if (_pred_0) {
             tmp = 32w1;

--- a/testdata/p4_16_samples_outputs/issue396-first.p4
+++ b/testdata/p4_16_samples_outputs/issue396-first.p4
@@ -20,13 +20,13 @@ control d(out bool b) {
         H h;
         H h1;
         H[2] h3;
-        h = H {x = 32w0};
+        h = { 32w0 };
         S s;
         S s1;
-        s = S {h = H {x = 32w0}};
-        s1.h = H {x = 32w0};
-        h3[0] = H {x = 32w0};
-        h3[1] = H {x = 32w1};
+        s = { { 32w0 } };
+        s1.h = { 32w0 };
+        h3[0] = { 32w0 };
+        h3[1] = { 32w1 };
         bool eout;
         einst.apply(H {x = 32w0}, eout);
         b = h.isValid() && eout && h3[1].isValid() && s1.h.isValid();

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-frontend.p4
@@ -66,7 +66,7 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
     bit<32> tmp;
     bit<32> tmp_0;
     @name("Eg.test") action test() {
-        val_0 = { 32w0 };
+        val_0 = Value {field1 = 32w0};
         _pred_0 = val_0.field1 != 32w0;
         if (_pred_0) {
             tmp = 32w1;

--- a/testdata/p4_16_samples_outputs/issue841-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue841-frontend.p4
@@ -47,7 +47,7 @@ control MyComputeChecksum(inout headers hdr, inout metadata meta) {
     @name("MyComputeChecksum.checksum") Checksum16() checksum_0;
     apply {
         h_0.setValid();
-        h_0 = { hdr.h.src, hdr.h.dst, 16w0 };
+        h_0 = h_t {src = hdr.h.src,dst = hdr.h.dst,csum = 16w0};
         tmp = checksum_0.get<h_t>(h_0);
         hdr.h.csum = tmp;
     }

--- a/testdata/p4_16_samples_outputs/issue907-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2-frontend.p4
@@ -21,7 +21,7 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
     S s_0;
     @name("Ing.r") register<S>(32w100) r_0;
     apply {
-        s_0 = { 32w0 };
+        s_0 = S {f = 32w0};
         r_0.write(32w0, s_0);
     }
 }

--- a/testdata/p4_16_samples_outputs/issue982-first.p4
+++ b/testdata/p4_16_samples_outputs/issue982-first.p4
@@ -397,7 +397,7 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
 control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd, out psa_ingress_deparser_output_metadata_t ostd) {
     apply {
         clone_metadata_t clone_md;
-        clone_md.data.h1 = clone_1_t {data = 32w0};
+        clone_md.data.h1 = { 32w0 };
         clone_md.type = 3w0;
         if (meta.custom_clone_id == 3w1) {
             ostd.clone_metadata = clone_md;

--- a/testdata/p4_16_samples_outputs/list-compare-frontend.p4
+++ b/testdata/p4_16_samples_outputs/list-compare-frontend.p4
@@ -10,7 +10,7 @@ control test(out bool zout) {
     S q_0;
     apply {
         p_0 = { 32w4, 32w5 };
-        q_0 = { 32w2, 32w3 };
+        q_0 = S {l = 32w2,r = 32w3};
         zout = p_0 == { 32w4, 32w5 };
         zout = zout && q_0 == S {l = 32w2,r = 32w3};
     }

--- a/testdata/p4_16_samples_outputs/nested-tuple-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-frontend.p4
@@ -17,7 +17,7 @@ extern void f<T>(in T data);
 control c(inout bit<1> r) {
     S s_0;
     apply {
-        s_0 = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
+        s_0 = S {f1 = { T {f = 1w0}, T {f = 1w1} },f2 = T {f = 1w0},z = 1w1};
         f<tuple<T, T>>(s_0.f1);
         f<tuple_0>(tuple_0 {field = T {f = 1w0},field_0 = T {f = 1w1}});
         r = s_0.f2.f & s_0.z;

--- a/testdata/p4_16_samples_outputs/precedence-first.p4
+++ b/testdata/p4_16_samples_outputs/precedence-first.p4
@@ -83,7 +83,7 @@ action ac() {
     a = b + c;
     a = f.z + b;
     a = fct(f.z + b, b + c);
-    f = s {z = a + b,w = c};
-    g = t {s1 = s {z = a + b,w = c},s2 = s {z = a + b,w = c}};
-    g = t {s1 = s {z = a + b + b,w = c},s2 = s {z = a + (b + c),w = c}};
+    f = { a + b, c };
+    g = { { a + b, c }, { a + b, c } };
+    g = { { a + b + b, c }, { a + (b + c), c } };
 }

--- a/testdata/p4_16_samples_outputs/select-struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/select-struct-frontend.p4
@@ -11,7 +11,7 @@ parser p() {
     tuple<bit<8>, bit<8>> t_0;
     state start {
         x_0 = 8w5;
-        s_0 = { 8w0, 8w0 };
+        s_0 = S {f0 = 8w0,f1 = 8w0};
         t_0 = { 8w0, 8w0 };
         transition select(x_0, x_0, { x_0, x_0 }, x_0) {
             (8w0, 8w0, { 8w0, 8w0 }, 8w0): accept;

--- a/testdata/p4_16_samples_outputs/zero_init-first.p4
+++ b/testdata/p4_16_samples_outputs/zero_init-first.p4
@@ -1,0 +1,41 @@
+struct T {
+    bit<1> f;
+}
+
+struct S {
+    tuple<T, T>         f1;
+    T                   f2;
+    bit<1>              z;
+    tuple<int<8>, bool> tpl;
+}
+
+header H {
+    int<8> i;
+    bool   b;
+    bit<7> l;
+    bit<7> l1;
+    bit<1> b1;
+}
+
+extern void f<D>(in D data);
+control c(inout bit<1> r) {
+    S s_0;
+    H h_0;
+    bit<1> tmp;
+    apply {
+        tuple<int<8>, bool> x = {  };
+        s_0.tpl = x;
+        s_0 = {  };
+        H h_1 = {  };
+        h_0 = {  };
+        h_0.b1 = h_1.b1;
+        s_0.z = h_0.b1;
+        f<tuple<T, T>>(s_0.f1);
+        tmp = s_0.f2.f & s_0.z;
+        r = tmp;
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/zero_init-frontend.p4
+++ b/testdata/p4_16_samples_outputs/zero_init-frontend.p4
@@ -1,0 +1,43 @@
+struct T {
+    bit<1> f;
+}
+
+struct S {
+    tuple<T, T>         f1;
+    T                   f2;
+    bit<1>              z;
+    tuple<int<8>, bool> tpl;
+}
+
+header H {
+    int<8> i;
+    bool   b;
+    bit<7> l;
+    bit<7> l1;
+    bit<1> b1;
+}
+
+extern void f<D>(in D data);
+control c(inout bit<1> r) {
+    S s;
+    H h;
+    bit<1> tmp_0;
+    tuple<int<8>, bool> x_0;
+    H h_2;
+    apply {
+        x_0 = { 8s0, false };
+        s = S {f1 = { T {f = 1w0}, T {f = 1w0} },f2 = T {f = 1w0},z = 1w0,tpl = { 8s0, false }};
+        h_2.setValid();
+        h_2 = H {i = 8s0,b = false,l = 7w0,l1 = 7w0,b1 = 1w0};
+        h.setValid();
+        h.b1 = h_2.b1;
+        s.z = h.b1;
+        f<tuple<T, T>>(s.f1);
+        tmp_0 = s.f2.f & s.z;
+        r = tmp_0;
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/zero_init-midend.p4
+++ b/testdata/p4_16_samples_outputs/zero_init-midend.p4
@@ -1,0 +1,63 @@
+struct T {
+    bit<1> f;
+}
+
+struct tuple_0 {
+    T field;
+    T field_0;
+}
+
+struct tuple_1 {
+    int<8> field_1;
+    bool   field_2;
+}
+
+struct S {
+    tuple_0 f1;
+    T       f2;
+    bit<1>  z;
+    tuple_1 tpl;
+}
+
+header H {
+    int<8> i;
+    bool   b;
+    bit<7> l;
+    bit<7> l1;
+    bit<1> b1;
+}
+
+extern void f<D>(in D data);
+control c(inout bit<1> r) {
+    T s_f1_field;
+    T s_f1_field_0;
+    H h;
+    H h_2;
+    @hidden action zero_init28() {
+        s_f1_field.f = 1w0;
+        s_f1_field_0.f = 1w0;
+        h_2.setValid();
+        h_2.i = 8s0;
+        h_2.b = false;
+        h_2.l = 7w0;
+        h_2.l1 = 7w0;
+        h_2.b1 = 1w0;
+        h.setValid();
+        h.b1 = 1w0;
+        f<tuple_0>({ s_f1_field, s_f1_field_0 });
+        r = 1w0;
+    }
+    @hidden table tbl_zero_init28 {
+        actions = {
+            zero_init28();
+        }
+        const default_action = zero_init28();
+    }
+    apply {
+        tbl_zero_init28.apply();
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/zero_init.p4
+++ b/testdata/p4_16_samples_outputs/zero_init.p4
@@ -1,0 +1,41 @@
+struct T {
+    bit<1> f;
+}
+
+struct S {
+    tuple<T, T>         f1;
+    T                   f2;
+    bit<1>              z;
+    tuple<int<8>, bool> tpl;
+}
+
+header H {
+    int<8> i;
+    bool   b;
+    bit<7> l;
+    bit<7> l1;
+    bit<1> b1;
+}
+
+extern void f<D>(in D data);
+control c(inout bit<1> r) {
+    S s_0;
+    H h_0;
+    bit<1> tmp;
+    apply {
+        tuple<int<8>, bool> x = {  };
+        s_0.tpl = x;
+        s_0 = {  };
+        H h_1 = {  };
+        h_0 = {  };
+        h_0.b1 = h_1.b1;
+        s_0.z = h_0.b1;
+        f<tuple<T, T>>(s_0.f1);
+        tmp = s_0.f2.f & s_0.z;
+        r = tmp;
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;


### PR DESCRIPTION
Added support for struct/header/tuple initialisation with empty tuple.

Types that are supported as leaf fields are int, bool and bit.
Int and bit type fields will be initialized to zero, bool to false.
If any other type is used as a lief field compiler will report error.

Frontnend reorganized, Struct initializer now processes declaration initializers
along with assignment statemants, which is the cause of changes in expected oputputs
of some tests.