### PR TITLE
Avoid ambiguous overload when doing operations on a Match

### DIFF
--- a/ir/pattern.h
+++ b/ir/pattern.h
@@ -99,6 +99,11 @@ class Pattern {
         Pattern operator^(const Pattern &a) { return Pattern(*this) ^ a; }
         Pattern operator&&(const Pattern &a) { return Pattern(*this) && a; }
         Pattern operator||(const Pattern &a) { return Pattern(*this) || a; }
+        // avoid ambiguous overloads with operator const T * above
+        Pattern operator+(int a) { return Pattern(*this) + Pattern(a); }
+        Pattern operator-(int a) { return Pattern(*this) - Pattern(a); }
+        Pattern operator==(int a) { return Pattern(*this) == Pattern(a); }
+        Pattern operator!=(int a) { return Pattern(*this) != Pattern(a); }
     };
 
     template <class T> Pattern(const T*&m) : pattern(new MatchExt<T>(m)) {}


### PR DESCRIPTION
- because of the operator T * converter operations between a Match and
  an int that could be pointer arithmetic or comparisons generate an
  ambiguous overload message.  Avoid that by explicitly supplying these
  operator overloads that avoid user-defined conversions.