### PR TITLE
add a compiler option to disable specific annotations/pragmas

### DIFF
--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -19,6 +19,7 @@ limitations under the License.
 #ifndef FRONTENDS_COMMON_OPTIONS_H_
 #define FRONTENDS_COMMON_OPTIONS_H_
 
+#include <set>
 #include <unordered_map>
 #include "lib/compile_context.h"
 #include "lib/cstring.h"
@@ -38,6 +39,9 @@ extern const char* p4_14includePath;
 class CompilerOptions : public Util::Options {
     bool close_input = false;
     static const char* defaultMessage;
+
+    // annotation names that are to be ignored by the compiler
+    std::set<cstring> disabledAnnotations;
 
     // Checks if parsed options make sense with respect to each-other.
     void validateOptions() const;
@@ -138,6 +142,8 @@ class CompilerOptions : public Util::Options {
     // Get a debug hook function suitable for insertion
     // in the pass managers that are executed.
     DebugHook getDebugHook() const;
+
+    bool isAnnotationDisabled(const IR::Annotation *) const;
 
     virtual bool enable_intrinsic_metadata_fix();
 };

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -39,6 +39,7 @@ limitations under the License.
 #include <iostream>  // NOLINT(build/include_order)
 
 #include "frontends/common/constantParsing.h"
+#include "frontends/common/options.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 #include "lib/source_file.h"
@@ -440,8 +441,14 @@ optAnnotations
     ;
 
 annotations
-    : annotation  { $$ = new IR::Vector<IR::Annotation>(); $$->push_back($1); }
-    | annotations annotation { $$ = $1; $$->push_back($2); }
+    : annotation  {
+       $$ = new IR::Vector<IR::Annotation>();
+       if (! P4CContext::get().options().isAnnotationDisabled($1))
+         $$->push_back($1); }
+    | annotations annotation {
+       $$ = $1;
+       if (! P4CContext::get().options().isAnnotationDisabled($2))
+          $$->push_back($2); }
     ;
 
 annotation

--- a/frontends/parsers/parserDriver.cpp
+++ b/frontends/parsers/parserDriver.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "frontends/common/options.h"
 #include "frontends/common/constantFolding.h"
 #include "frontends/parsers/p4/p4lexer.hpp"
 #include "frontends/parsers/p4/p4AnnotationLexer.hpp"
@@ -374,7 +375,8 @@ void V1ParserDriver::clearPragmas() {
 }
 
 void V1ParserDriver::addPragma(IR::Annotation* pragma) {
-    currentPragmas.push_back(pragma);
+    if (!P4CContext::get().options().isAnnotationDisabled(pragma))
+        currentPragmas.push_back(pragma);
 }
 
 IR::Vector<IR::Annotation> V1ParserDriver::takePragmasAsVector() {

--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -158,6 +158,10 @@ class BackendDriver:
             self.add_command_option('compiler',
                                     "--p4runtime-files {}".format(opts.p4runtime_files))
 
+        # disable annotations
+        if opts.disabled_annos is not None:
+            self.add_command_option('compiler',
+                                    '--disable-annotations={}'.format(opts.disabled_annos))
         # set developer options
         if (os.environ['P4C_BUILD_TYPE'] == "DEVELOPER"):
             for option in opts.log_levels:

--- a/tools/driver/p4c_src/main.py
+++ b/tools/driver/p4c_src/main.py
@@ -98,7 +98,7 @@ def main():
     parser.add_argument("-a", "--arch", dest="arch",
                         help="specify target architecture",
                         action="store", default="v1model")
-    parser.add_argument("-c", dest="run_all",
+    parser.add_argument("-c", "--compile", dest="run_all",
                         help="Only run preprocess, compile, and assemble steps",
                         action="store_true", default=True)
     parser.add_argument("-D", dest="preprocessor_defines",
@@ -144,6 +144,9 @@ def main():
                         dest="show_target_help",
                         help="Display target specific command line options.",
                         action="store_true", default=False)
+    parser.add_argument("--disable-annotations", "--disable-pragmas",
+                        dest="disabled_annos", action="store",
+                        help="List of annotations (comma separated) that should be ignored by the compiler.")
     parser.add_argument("-S", dest="run_till_assembler",
                         help="Only run the preprocess and compilation steps",
                         action="store_true", default=False)


### PR DESCRIPTION
Add the --disable-annotations option to disable annotations by name.
It accepts a comma separated list of annotations that will not be
added in the IR tree. A warning will be printed that the annotation
was explicitly disabled. We do print the warning for every instance of
the annotation, which may be an overkill, however, it is intentional,
so that users can make sure that a particular annotation was not taken
into account.

The option only disable annotations present in the source
file. Compiler passes may continue to add annotations and process them
as before. Note that users may be able to disable annotations that may
cripple the code generation -- backend or control-plane. That's
another reason why it is important to print those warnings!