### PR TITLE
Disable kernel ebpf tests

### DIFF
--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -50,17 +50,20 @@ set (P4C_EBPF_HDRS
   lower.h
   )
 
-# determine the kernel version
-execute_process(COMMAND uname -r
-  OUTPUT_VARIABLE P4C_EBPF_KERNEL_VER
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  RESULT_VARIABLE rc)
-message(STATUS "Detected kernel version: ${P4C_EBPF_KERNEL_VER}")
-if (EXISTS /usr/src/linux-headers-${P4C_EBPF_KERNEL_VER}/include/uapi/linux)
-  set (SUPPORTS_KERNEL True)
-else()
-  set (SUPPORTS_KERNEL False)
-endif()
+# # determine the kernel version
+# execute_process(COMMAND uname -r
+#   OUTPUT_VARIABLE P4C_EBPF_KERNEL_VER
+#   OUTPUT_STRIP_TRAILING_WHITESPACE
+#   RESULT_VARIABLE rc)
+# message(STATUS "Detected kernel version: ${P4C_EBPF_KERNEL_VER}")
+# if (EXISTS /usr/src/linux-headers-${P4C_EBPF_KERNEL_VER}/include/uapi/linux)
+#   set (SUPPORTS_KERNEL True)
+# else()
+#   set (SUPPORTS_KERNEL False)
+# endif()
+# The kernel-based ebpf tests seem to be broken, so we disable them
+# The dependences on the kernel APIs are too brittle
+set (SUPPORTS_KERNEL False)
 
 add_cpplint_files(${CMAKE_CURRENT_SOURCE_DIR} "${P4C_EBPF_SRCS};${P4C_EBPF_HDRS}")
 

--- a/backends/ebpf/targets/kernel_target.py
+++ b/backends/ebpf/targets/kernel_target.py
@@ -42,9 +42,9 @@ class Target(EBPFTarget):
         # Input eBPF byte code
         args += self.template + ".o "
         # The bpf program to attach to the interface
-        args += "BPFOBJ=" + self.template + ".o "
+        args += "BPFOBJ=" + self.template + ".o"
         # add the folder local to the P4 file to the list of includes
-        args += "INCLUDES+=-I" + os.path.dirname(self.options.p4filename)
+        args += " INCLUDES+=-I" + os.path.dirname(self.options.p4filename)
         errmsg = "Failed to compile the eBPF byte code:"
         return run_timeout(self.options.verbose, args, TIMEOUT,
                            self.outputs, errmsg)


### PR DESCRIPTION
I don't know how to fix the building of the ebpf kernel-based tests so that they work on any kernel/distribution combination, so I am disabling them for now. @fruffy has actually created these tests. If anyone has time to work on them we can re-enable them.
We are still testing the p4c-ebpf compiler, but just with portable user-level tests.