### PR TITLE
Remove use of __WORDSIZE

### DIFF
--- a/ir/expression.def
+++ b/ir/expression.def
@@ -141,32 +141,45 @@ class Constant : Literal {
 #noconstructor
     /// if noWarning is true, no warning is emitted
     void handleOverflow(bool noWarning);
-    // We need to enumerate all the integer types because we need proper 64-bit handling on
-    // 32-bit systems (which ain't long!) and mpz_import is too big a hammer because and it loses
-    // the signess of the value.
+#emit
+    // One-one correspondence between these constructors and the ones in libgmp (gmpxx.h header).
+    Constant(char v, unsigned base = 10) :
+        Literal(new Type_InfInt()), value(v), base(base) {}
+    Constant(unsigned char v, unsigned base = 10) :
+        Literal(new Type_InfInt()), value(v), base(base) {}
+    Constant(short v, unsigned base = 10) :
+        Literal(new Type_InfInt()), value(v), base(base) {}
+    Constant(unsigned short v, unsigned base = 10) :
+        Literal(new Type_InfInt()), value(v), base(base) {}
     Constant(int v, unsigned base = 10) :
         Literal(new Type_InfInt()), value(v), base(base) {}
-    Constant(unsigned v, unsigned base = 10) :
+    Constant(unsigned int v, unsigned base = 10) :
         Literal(new Type_InfInt()), value(v), base(base) {}
-#emit
-#if __WORDSIZE == 64
-    Constant(intmax_t v, unsigned base = 10) :
-        Literal(new Type_InfInt()), value(v), base(base) {}
-#else
     Constant(long v, unsigned base = 10) :
         Literal(new Type_InfInt()), value(v), base(base) {}
     Constant(unsigned long v, unsigned base = 10) :
         Literal(new Type_InfInt()), value(v), base(base) {}
-    Constant(intmax_t v, unsigned base = 10) :
+    // For other integral types, we default to using mpz_import since there are no constructors
+    // available in gmpxx. Note that the constructors above will always take precedence (plain old
+    // functions over function template) if the type matches.
+    template<typename T,
+             typename std::enable_if<std::is_integral<T>::value &&
+                      std::is_signed<T>::value, int>::type = 0>
+        Constant(T v, unsigned base = 10) :
+        Literal(new Type_InfInt()), base(base) {
+        mpz_import(value.get_mpz_t(), /* word count */1, /* msb first */0,
+                   /* word size */sizeof(v), /* native endian */0, /* nails */0, &v);
+        // mpz_import does not preserve the sign, so we need to adjust the mpz value ourselves when
+        // needed.
+        if (v < 0) value *= -1; }
+    template<typename T,
+             typename std::enable_if<std::is_integral<T>::value &&
+                      !std::is_signed<T>::value, int>::type = 0>
+    Constant(T v, unsigned base = 10) :
         Literal(new Type_InfInt()), base(base) {
         mpz_import(value.get_mpz_t(), /* word count */1, /* msb first */0,
                    /* word size */sizeof(v), /* native endian */0, /* nails */0, &v); }
-#endif
 #end
-    Constant(uint64_t v, unsigned base = 10) :
-        Literal(new Type_InfInt()), base(base) {
-        mpz_import(value.get_mpz_t(), /* word count */1, /* msb first */0,
-                   /* word size */sizeof(v), /* native endian */0, /* nails */0, &v); }
     Constant(mpz_class v, unsigned base = 10) :
             Literal(new Type_InfInt()), value(v), base(base) {}
     Constant(Util::SourceInfo si, mpz_class v, unsigned base = 10) :

--- a/test/gtest/constant_expr_test.cpp
+++ b/test/gtest/constant_expr_test.cpp
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <limits>
+
 #include "gtest/gtest.h"
 #include "helpers.h"
 #include "ir/ir.h"
@@ -72,12 +74,7 @@ TEST_F(ConstantExpr, TestLong) {
     auto res = c.asLong();
     EXPECT_EQ(res, val);
 
-    /* long is inconsistent! */
-#if __WORDSIZE == 64
-    val = INT64_MAX;
-#else
-    val = INT32_MAX;
-#endif
+    val = std::numeric_limits<decltype(val)>::max();
     IR::Constant m(val);
     res = m.asLong();
     EXPECT_EQ(res, val);


### PR DESCRIPTION
__WORDSIZE is not well-documented and we should probably avoid using
it. I'm compiling p4c on a 64-bit system that apparently does not define
__WORDSIZE. This proposal sticks to standard C++ constructs. We define
an IR::Constant constructor manually for each constructor defined in
gmpxx, plus function template constructors for all other integral types
(signed and unsigned) which use mpz_import. On systems for which
"unsigned long long" and "long long" are different from "unsigned long"
and "long", the template constructors will be used.