### PR TITLE
Correct import statement in ebpf target.py test running file

### DIFF
--- a/backends/ebpf/targets/target.py
+++ b/backends/ebpf/targets/target.py
@@ -26,8 +26,8 @@
 import os
 import sys
 from glob import glob
-from scapy.utils import rdpcap
-from scapy.layers.all import RawPcapWriter
+from scapy.utils import rdpcap, RawPcapWriter
+from scapy.layers.all import *
 from ebpfstf import create_table_file, parse_stf_file
 # path to the tools folder of the compiler
 sys.path.insert(0, os.path.dirname(


### PR DESCRIPTION
Somehow this statement:
```
from scapy.layers.all import RawPcapWriter
```
does not raise an exception for older versions of Scapy like 2.2.0 and
2.3.2, even though the class RawPcapWriter is defined in the file for
scapy.utils.  With newer versions of Spapy like 2.4.2 and 2.4.3, this
import statement fails.

By importing it from the correct package scapy.utils, it works on all
versions of Scapy mentioned above.