### PR TITLE
Throw error in case tuple type to struct like type conversion #2036

### DIFF
--- a/testdata/p4_16_errors/tuple-to-struct.p4
+++ b/testdata/p4_16_errors/tuple-to-struct.p4
@@ -1,0 +1,28 @@
+#include <core.p4>
+
+//Architecture
+parser C();
+package S(C p);
+
+//User Program
+struct s {
+  bit<8> x;
+}
+
+parser D(in s z) {
+  state start {
+    transition accept;
+  }
+}
+
+parser E() {
+  tuple<bit<8>> a = { 0 };
+  D() d;
+  state start {
+    d.apply(a);
+    transition accept;
+  }
+}
+
+S(E()) main;
+

--- a/testdata/p4_16_errors_outputs/tuple-to-struct.p4
+++ b/testdata/p4_16_errors_outputs/tuple-to-struct.p4
@@ -1,0 +1,25 @@
+#include <core.p4>
+
+parser C();
+package S(C p);
+struct s {
+    bit<8> x;
+}
+
+parser D(in s z) {
+    state start {
+        transition accept;
+    }
+}
+
+parser E() {
+    tuple<bit<8>> a = { 0 };
+    D() d;
+    state start {
+        d.apply(a);
+        transition accept;
+    }
+}
+
+S(E()) main;
+

--- a/testdata/p4_16_errors_outputs/tuple-to-struct.p4-stderr
+++ b/testdata/p4_16_errors_outputs/tuple-to-struct.p4-stderr
@@ -1,0 +1,9 @@
+tuple-to-struct.p4(22): [--Werror=type-error] error: d.apply: Cannot assign a Tuple(1) to a struct s
+    d.apply(a);
+    ^^^^^^^^^^
+tuple-to-struct.p4(19)
+  tuple<bit<8>> a = { 0 };
+  ^^^^^^^^^^^^^
+tuple-to-struct.p4(8)
+struct s {
+       ^


### PR DESCRIPTION
Corner case in which tuple type expressions, that are not list expression,
were unifiable with struct like types fixed.