### PR TITLE
Logging prettification

### DIFF
--- a/ir/dbprint-expression.cpp
+++ b/ir/dbprint-expression.cpp
@@ -89,7 +89,7 @@ void IR::NamedExpression::dbprint(std::ostream &out) const {
 void IR::StructInitializerExpression::dbprint(std::ostream& out) const {
     out << "{" << indent;
     for (auto &field : components)
-        out << endl << field << ';';
+        out << Log::endl << field << ';';
     out << " }" << unindent;
 }
 
@@ -110,7 +110,7 @@ void IR::If::dbprint(std::ostream &out) const {
         out << "if (" << setprec(Prec_Low) << pred << ") {" << indent << setprec(0) << ifTrue;
         if (ifFalse) {
             if (!ifFalse->empty())
-                out << unindent << endl << "} else {" << indent;
+                out << unindent << Log::endl << "} else {" << indent;
             out << ifFalse; }
         out << " }" << unindent;
     }
@@ -122,7 +122,7 @@ void IR::Apply::dbprint(std::ostream &out) const {
     if (!actions.empty()) {
         out << " {" << indent << setprec(0);
         for (auto act : actions)
-            out << endl << act.first << " {" << indent << act.second << unindent << " }";
+            out << Log::endl << act.first << " {" << indent << act.second << unindent << " }";
         out << setprec(prec) << " }" << unindent;
     } else if (prec == 0) {
         out << ';'; }
@@ -251,6 +251,6 @@ void IR::SelectExpression::dbprint(std::ostream &out) const {
     int prec = getprec(out);
     out << "select" << setprec(Prec_Low) << select << " {" << indent;
     for (auto c : selectCases)
-        out << endl << c;
+        out << Log::endl << c;
     out << " }" << unindent << setprec(prec);
 }

--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -32,9 +32,9 @@ void IR::HeaderStackItemRef::dbprint(std::ostream &out) const {
 void IR::FieldList::dbprint(std::ostream &out) const {
     out << "field_list " << name << " {" << indent;
     for (auto f : fields)
-        out << endl << f;
+        out << Log::endl << f;
     if (payload)
-        out << endl << "payload;";
+        out << Log::endl << "payload;";
     out << unindent << " }";
 }
 void IR::FieldListCalculation::dbprint(std::ostream &out) const {
@@ -49,7 +49,7 @@ void IR::CalculatedField::dbprint(std::ostream &out) const {
     }
     out << indent;
     for (auto &spec : specs) {
-        out << endl << (spec.update ? "update " : "verify ") << spec.name;
+        out << Log::endl << (spec.update ? "update " : "verify ") << spec.name;
         if (spec.cond) out << " if " << spec.cond; }
     out << unindent;
 }
@@ -74,35 +74,35 @@ void IR::CaseEntry::dbprint(std::ostream &out) const {
 void IR::V1Parser::dbprint(std::ostream &out) const {
     out << "parser " << name << " {" << indent;
     for (auto &stmt : stmts)
-        out << endl << *stmt;
+        out << Log::endl << *stmt;
     if (select) {
         int prec = getprec(out);
         const char *sep = "";
-        out << endl << "select (" << setprec(Prec_Low);
+        out << Log::endl << "select (" << setprec(Prec_Low);
         for (auto e : *select) {
             out << sep << *e;
             sep = ", "; }
         out << ") {" << indent << setprec(prec); }
     if (cases)
         for (auto c : *cases)
-            out << endl << *c;
+            out << Log::endl << *c;
     if (select)
         out << " }" << unindent;
     if (default_return)
-        out << endl << "return " << default_return << ";";
+        out << Log::endl << "return " << default_return << ";";
     if (parse_error)
-        out << endl << "error " << parse_error << ";";
+        out << Log::endl << "error " << parse_error << ";";
     if (drop)
-        out << endl << "drop;";
+        out << Log::endl << "drop;";
     out << " }" << unindent;
 }
 void IR::ParserException::dbprint(std::ostream &out) const { out << "IR::ParserException"; }
 void IR::ParserState::dbprint(std::ostream &out) const {
     out << "state " << name << " " << annotations << "{" << indent;
     for (auto s : components)
-        out << endl << s;
+        out << Log::endl << s;
     if (selectExpression)
-        out << endl << selectExpression;
+        out << Log::endl << selectExpression;
     out << " }" << unindent;
 }
 void IR::P4Parser::dbprint(std::ostream &out) const {
@@ -114,9 +114,9 @@ void IR::P4Parser::dbprint(std::ostream &out) const {
         out << '(' << constructorParams << ')';
     out << " " << type->annotations << "{" << indent;
     for (auto d : parserLocals)
-        out << endl << d;
+        out << Log::endl << d;
     for (auto s : states)
-        out << endl << s;
+        out << Log::endl << s;
     out << " }" << unindent;
 }
 
@@ -134,7 +134,7 @@ void IR::ActionFunction::dbprint(std::ostream &out) const {
         sep = ", "; }
     out << ") {" << indent;
     for (auto &p : action)
-        out << endl << p;
+        out << Log::endl << p;
     out << unindent << " }";
 }
 
@@ -147,7 +147,7 @@ void IR::P4Action::dbprint(std::ostream &out) const {
     out << ") {" << indent;
     if (body)
         for (auto p : body->components)
-            out << endl << p;
+            out << Log::endl << p;
     out << unindent << " }";
 }
 
@@ -159,7 +159,7 @@ void IR::BlockStatement::dbprint(std::ostream &out) const {
             out << ' ' << p;
             first = false;
         } else {
-            out << endl << p; } }
+            out << Log::endl << p; } }
     out << unindent << " }";
 }
 
@@ -174,7 +174,7 @@ void IR::ActionList::dbprint(std::ostream &out) const {
         if (first)
             out << ' ' << el;
         else
-            out << endl << el;
+            out << Log::endl << el;
         first = false; }
     out << unindent << " }";
 }
@@ -190,7 +190,7 @@ void IR::Key::dbprint(std::ostream &out) const {
         if (first)
             out << ' ' << el;
         else
-            out << endl << el;
+            out << Log::endl << el;
         first = false; }
     out << unindent << " }";
 }
@@ -198,7 +198,7 @@ void IR::P4Table::dbprint(std::ostream &out) const {
     out << "table " << name;
     out << " " << annotations << "{" << indent;
     for (auto p : properties->properties)
-        out << endl << p;
+        out << Log::endl << p;
     out << " }" << unindent;
 }
 
@@ -220,20 +220,20 @@ void IR::P4Control::dbprint(std::ostream &out) const {
         out << '(' << constructorParams << ')';
     out << " " << type->annotations << "{" << indent;
     for (auto d : controlLocals)
-        out << endl << d;
+        out << Log::endl << d;
     for (auto s : body->components)
-        out << endl << s;
+        out << Log::endl << s;
     out << " }" << unindent;
 }
 
 void IR::V1Program::dbprint(std::ostream &out) const {
     for (auto &obj : Values(scope))
-        out << obj << endl;
+        out << obj << Log::endl;
 }
 
 void IR::P4Program::dbprint(std::ostream &out) const {
     for (auto obj : objects)
-        out << obj << endl;
+        out << obj << Log::endl;
 }
 
 void IR::Type_Error::dbprint(std::ostream &out) const {
@@ -267,6 +267,6 @@ void IR::Declaration_Instance::dbprint(std::ostream &out) const {
     if (!properties.empty()) {
         out << " {" << indent;
         for (auto &obj : properties)
-            out << endl << obj.second;
+            out << Log::endl << obj.second;
         out << " }" << unindent; }
 }

--- a/ir/dbprint-stmt.cpp
+++ b/ir/dbprint-stmt.cpp
@@ -37,9 +37,9 @@ void IR::AssignmentStatement::dbprint(std::ostream &out) const {
 
 void IR::IfStatement::dbprint(std::ostream &out) const {
     int prec = getprec(out);
-    out << Prec_Low << "if (" << condition << ") {" << indent << setprec(0) << endl << ifTrue;
+    out << Prec_Low << "if (" << condition << ") {" << indent << setprec(0) << Log::endl << ifTrue;
     if (ifFalse)
-        out << unindent << endl << "} else {" << indent << endl << ifFalse;
+        out << unindent << Log::endl << "} else {" << indent << Log::endl << ifFalse;
     out << " }" << unindent << setprec(prec);
 }
 
@@ -56,7 +56,7 @@ void IR::Function::dbprint(std::ostream &out) const {
         out << type->typeParameters;
     out << "(" << type->parameters << ") {" << indent;
     for (auto s : body->components)
-        out << endl << s;
+        out << Log::endl << s;
     out << unindent << " }";
 }
 
@@ -65,7 +65,7 @@ void IR::SwitchStatement::dbprint(std::ostream &out) const {
     out << Prec_Low << "switch (" << expression << ") {" << indent;
     bool fallthrough = false;
     for (auto c : cases) {
-        if (!fallthrough) out << endl;
+        if (!fallthrough) out << Log::endl;
         out << Prec_Low << c->label << ": " << setprec(0);
         if (c->statement) {
             out << c->statement;

--- a/ir/dbprint-type.cpp
+++ b/ir/dbprint-type.cpp
@@ -115,7 +115,7 @@ void IR::Type_Extern::dbprint(std::ostream& out) const {
         out << typeParameters;
     out << " {" << indent << clrflag(Brief);
     for (auto &method : methods)
-        out << endl << method << ';';
+        out << Log::endl << method << ';';
     out << " }" << unindent;
 }
 
@@ -142,7 +142,7 @@ void IR::Type_StructLike::dbprint(std::ostream &out) const {
         return; }
     out << toString() << " " << annotations << "{" << indent;
     for (auto &field : fields)
-        out << endl << field << ';';
+        out << Log::endl << field << ';';
     out << " }" << unindent;
 }
 

--- a/ir/dbprint.cpp
+++ b/ir/dbprint.cpp
@@ -64,12 +64,12 @@ void IR::Block::dbprint_recursive(std::ostream& out) const {
     out << indent;
     for (auto it : constantValue) {
         if (it.second == nullptr) {
-            out << endl << dbp(it.first) << " => null";
+            out << Log::endl << dbp(it.first) << " => null";
             continue;
         }
         if (it.second->is<IR::Block>() && it.first->is<IR::IDeclaration>()) {
             auto block = it.second->to<IR::Block>();
-            out << endl << dbp(it.first) << " => ";
+            out << Log::endl << dbp(it.first) << " => ";
             block->dbprint_recursive(out);
         }
     }
@@ -84,7 +84,7 @@ std::ostream &operator<<(std::ostream &out, const IR::Vector<IR::Expression> &v)
             return out; }
         out << "{"; }
     for (auto e : v)
-        out << endl << setprec(0) << e << setprec(prec);
+        out << Log::endl << setprec(0) << e << setprec(prec);
     if (prec)
         out << " }";
     return out;
@@ -99,6 +99,6 @@ void dbprint(const IR::Node &n) {
 void dbprint(const std::set<const IR::Expression *> s) {
     std::cout << indent << " {";
     int i = 0;
-    for (auto el : s) std::cout << endl << '[' << i++ << "] " << el;
-    std::cout << " }" << unindent << std::endl;
+    for (auto el : s) std::cout << Log::endl << '[' << i++ << "] " << el;
+    std::cout << " }" << unindent << Log::endl;
 }

--- a/lib/log.h
+++ b/lib/log.h
@@ -115,8 +115,9 @@ void increaseVerbosity();
 #define LOG9_UNINDENT   LOGN_UNINDENT(9)
 
 #define LOG_FEATURE(TAG, N, X) (::Log::fileLogLevelIsAtLeast(TAG, N)            \
-                      ? std::clog << ::Log::Detail::OutputLogPrefix(TAG, N)     \
-                                  << X << std::endl                             \
+                      ? ::Log::Detail::fileLogOutput(TAG)                       \
+                          << ::Log::Detail::OutputLogPrefix(TAG, N)             \
+                          << X << std::endl                                     \
                       : std::clog)
 
 #define ERROR(X) (std::clog << "ERROR: " << X << std::endl)


### PR DESCRIPTION
Fix dbprint routines to use the log prefixing/indenting support and allow redirecting LOG_FEATURE output.