### PR TITLE
Compile-time MAX_LOGGING_LEVEL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ OPTION (ENABLE_PROTOBUF_STATIC "Link against Protobuf statically" ON)
 OPTION (ENABLE_GC "Use libgc" ON)
 OPTION (ENABLE_MULTITHREAD "Use multithreading" OFF)
 
+set(MAX_LOGGING_LEVEL 10 CACHE STRING "Control the maximum logging level for -T logs")
+set_property(CACHE MAX_LOGGING_LEVEL PROPERTY STRINGS 0 1 2 3 4 5 6 7 8 9 10)
+add_definitions(-DMAX_LOGGING_LEVEL=${MAX_LOGGING_LEVEL})
+
 if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE "RELEASE")
 endif()

--- a/lib/log.h
+++ b/lib/log.h
@@ -86,7 +86,12 @@ void increaseVerbosity();
 
 }  // namespace Log
 
-#define LOGGING(N) (::Log::fileLogLevelIsAtLeast(__FILE__, N))
+#ifndef MAX_LOGGING_LEVEL
+// can be set on build command line and disables higher logging levels at compile time
+#define MAX_LOGGING_LEVEL 10
+#endif
+
+#define LOGGING(N) ((N) <= MAX_LOGGING_LEVEL && ::Log::fileLogLevelIsAtLeast(__FILE__, N))
 #define LOGN(N, X) (LOGGING(N)                                                  \
                       ? ::Log::Detail::fileLogOutput(__FILE__)                  \
                           << ::Log::Detail::OutputLogPrefix(__FILE__, N)        \
@@ -114,7 +119,7 @@ void increaseVerbosity();
 #define LOG8_UNINDENT   LOGN_UNINDENT(8)
 #define LOG9_UNINDENT   LOGN_UNINDENT(9)
 
-#define LOG_FEATURE(TAG, N, X) (::Log::fileLogLevelIsAtLeast(TAG, N)            \
+#define LOG_FEATURE(TAG, N, X) ((N) <= MAX_LOGGING_LEVEL && ::Log::fileLogLevelIsAtLeast(TAG, N) \
                       ? ::Log::Detail::fileLogOutput(TAG)                       \
                           << ::Log::Detail::OutputLogPrefix(TAG, N)             \
                           << X << std::endl                                     \


### PR DESCRIPTION
This limits the logging level compiled into the program -- when combined with -O it should also completely dead-code eliminate the unwanted logging code, making the binary smaller.