### PR TITLE
Do unified and non-unified builds in separate Travis instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ cache:
 
 env:
   - CTEST_PARALLEL_LEVEL=4
+    UNIFIED=ON
+  - CTEST_PARALLEL_LEVEL=4
+    UNIFIED=OFF
 
 before_install:
   - tools/install_os_deps.sh
@@ -28,11 +31,9 @@ install:
   # To flush out issues with unified vs. non-unified builds, do a non-unified
   # build before continuing with the rest, which produces a unified build.
   # This is done here on MacOS; for Linux, this is done in Dockerfile.
-  - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=OFF . ; fi
-  - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=ON . ; fi
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_UNIFIED_COMPILATION=OFF && cd build && make -j2 && cd .. && git clean -xfd ; fi
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE && cd build && make -j 2 ; fi
+  - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=$UNIFIED . ; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_UNIFIED_COMPILATION=$UNIFIED && cd build && make -j2; fi
 
 script:
-  - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then docker run -w /p4c/build -e CTEST_PARALLEL_LEVEL p4c ctest --output-on-failure --schedule-random ; fi
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then ctest --output-on-failure -j 2 --schedule-random -LE "ebpf$" ; fi
+  - if [[ $TRAVIS_OS_NAME == 'linux' && $UNIFIED == ON ]] ; then docker run -w /p4c/build -e CTEST_PARALLEL_LEVEL p4c ctest --output-on-failure --schedule-random ; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' && $UNIFIED == ON ]] ; then ctest --output-on-failure -j 2 --schedule-random -LE "ebpf$" ; fi


### PR DESCRIPTION
- avoid Travis 50 minute timeout

There's probably a more efficient way to do this?