### PR TITLE
Add a Type_List for list expressions; fixes #2036

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1147,7 +1147,7 @@ class P4RuntimeAnalyzer {
                     [](cstring name) { return name == IR::Annotation::matchAnnotation; });
                 addDocumentation(match, f);
             }
-        } else if (et->is<IR::Type_Tuple>()) {
+        } else if (et->is<IR::Type_BaseList>()) {
             ::error(ErrorType::ERR_UNSUPPORTED,
                     "type parameter for Value Set; "
                     "this version of P4Runtime requires the type parameter of a Value Set "

--- a/control-plane/typeSpecConverter.cpp
+++ b/control-plane/typeSpecConverter.cpp
@@ -121,7 +121,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Name* type) {
 bool TypeSpecConverter::preorder(const IR::Type_Newtype* type) {
     if (p4RtTypeInfo) {
         bool orig_type = true;
-        const IR::StringLiteral* uri;
+        const IR::StringLiteral* uri = nullptr;
         const IR::Constant* sdnB;
         auto ann = type->getAnnotation("p4runtime_translation");
         if (ann != nullptr) {
@@ -170,7 +170,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Newtype* type) {
     return false;
 }
 
-bool TypeSpecConverter::preorder(const IR::Type_Tuple* type) {
+bool TypeSpecConverter::preorder(const IR::Type_BaseList* type) {
     auto typeSpec = new P4DataTypeSpec();
     auto tupleTypeSpec = typeSpec->mutable_tuple();
     for (auto cType : type->components) {

--- a/control-plane/typeSpecConverter.h
+++ b/control-plane/typeSpecConverter.h
@@ -61,7 +61,7 @@ class TypeSpecConverter : public Inspector {
     bool preorder(const IR::Type_Bits* type) override;
     bool preorder(const IR::Type_Varbits* type) override;
     bool preorder(const IR::Type_Boolean* type) override;
-    bool preorder(const IR::Type_Tuple* type) override;
+    bool preorder(const IR::Type_BaseList* type) override;
     bool preorder(const IR::Type_Stack* type) override;
 
     bool preorder(const IR::Type_Name* type) override;

--- a/frontends/p4/setHeaders.cpp
+++ b/frontends/p4/setHeaders.cpp
@@ -45,7 +45,7 @@ void DoSetHeaders::generateSetValid(
 
     // Recurse on fields of structType
     if (list != nullptr) {
-        auto tt = srcType->to<IR::Type_Tuple>();
+        auto tt = srcType->to<IR::Type_BaseList>();
         CHECK_NULL(tt);
         auto it = list->components.begin();
         for (auto f : structType->fields) {

--- a/frontends/p4/structInitializers.cpp
+++ b/frontends/p4/structInitializers.cpp
@@ -56,7 +56,7 @@ convert(const IR::Expression* expression, const IR::Type* type) {
                 return result;
             }
         }
-    } else if (auto tup = type->to<IR::Type_Tuple>()) {
+    } else if (auto tup = type->to<IR::Type_BaseList>()) {
         auto le = expression->to<IR::ListExpression>();
         if (le == nullptr)
             return expression;
@@ -117,9 +117,9 @@ const IR::Node* CreateStructInitializers::postorder(IR::MethodCallExpression* ex
 const IR::Node* CreateStructInitializers::postorder(IR::Operation_Relation* expression) {
     auto ltype = typeMap->getType(expression->left);
     auto rtype = typeMap->getType(expression->right);
-    if (ltype->is<IR::Type_StructLike>() && rtype->is<IR::Type_Tuple>())
+    if (ltype->is<IR::Type_StructLike>() && rtype->is<IR::Type_List>())
         expression->right = convert(expression->right, ltype);
-    if (rtype->is<IR::Type_StructLike>() && ltype->is<IR::Type_Tuple>())
+    if (rtype->is<IR::Type_StructLike>() && ltype->is<IR::Type_List>())
         expression->left = convert(expression->left, rtype);
     return expression;
 }

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -288,7 +288,7 @@ bool ToP4::preorder(const IR::Type_Newtype* t) {
     return false;
 }
 
-bool ToP4::preorder(const IR::Type_Tuple* t) {
+bool ToP4::preorder(const IR::Type_BaseList* t) {
     dump(3);
     builder.append("tuple<");
     bool first = true;

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -148,7 +148,7 @@ class ToP4 : public Inspector {
     bool preorder(const IR::Type_Newtype* t) override;
     bool preorder(const IR::Type_Extern* t) override;
     bool preorder(const IR::Type_Unknown* t) override;
-    bool preorder(const IR::Type_Tuple* t) override;
+    bool preorder(const IR::Type_BaseList* t) override;
 
     // declarations
     bool preorder(const IR::Declaration_Constant* cst) override;

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -106,7 +106,7 @@ class TypeInference : public Transform {
     const IR::Expression* assignment(const IR::Node* errorPosition, const IR::Type* destType,
                                      const IR::Expression* sourceExpression);
     const IR::SelectCase* matchCase(const IR::SelectExpression* select,
-                                    const IR::Type_Tuple* selectType,
+                                    const IR::Type_BaseList* selectType,
                                     const IR::SelectCase* selectCase,
                                     const IR::Type* caseType);
     bool canCastBetween(const IR::Type* dest, const IR::Type* src) const;
@@ -217,6 +217,7 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::Type_Specialized* type) override;
     const IR::Node* postorder(IR::Type_SpecializedCanonical* type) override;
     const IR::Node* postorder(IR::Type_Tuple* type) override;
+    const IR::Node* postorder(IR::Type_List* type) override;
     const IR::Node* postorder(IR::Type_Set* type) override;
     const IR::Node* postorder(IR::Type_ArchBlock* type) override;
     const IR::Node* postorder(IR::Type_Newtype* type) override;

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -292,21 +292,20 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
             TypeInference::typeError("%1%: Cannot unify non-function type %2% to function type %3%",
                                      errorPosition, src->toString(), dest->toString());
         return false;
-    } else if (dest->is<IR::Type_Tuple>()) {
+    } else if (auto td = dest->to<IR::Type_BaseList>()) {
         if (src->is<IR::Type_Struct>() || src->is<IR::Type_Header>()) {
             // swap and try again: handled below
             return unify(errorPosition, src, dest, reportErrors);
         }
-        if (!src->is<IR::Type_Tuple>()) {
+        if (!src->is<IR::Type_BaseList>()) {
             if (reportErrors)
-                TypeInference::typeError("%1%: Cannot unify tuple type %2% with non tuple-type %3%",
+                TypeInference::typeError("%1%: Cannot unify type %2% with %3%",
                                          errorPosition, dest->toString(), src->toString());
             return false;
         }
-        auto td = dest->to<IR::Type_Tuple>();
-        auto ts = src->to<IR::Type_Tuple>();
+        auto ts = src->to<IR::Type_BaseList>();
         if (td->components.size() != ts->components.size()) {
-            TypeInference::typeError("%1%: Cannot match tuples with different sizes %2% vs %3%",
+            TypeInference::typeError("%1%: tuples with different sizes %2% vs %3%",
                                      errorPosition, td->components.size(), ts->components.size());
             return false;
         }
@@ -321,7 +320,7 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
         return true;
     } else if (dest->is<IR::Type_Struct>() || dest->is<IR::Type_Header>()) {
         auto strct = dest->to<IR::Type_StructLike>();
-        if (auto tpl = src->to<IR::Type_Tuple>()) {
+        if (auto tpl = src->to<IR::Type_List>()) {
             if (strct->fields.size() != tpl->components.size()) {
                 if (reportErrors)
                     TypeInference::typeError("%1%: Number of fields %2% in initializer different "

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -40,9 +40,10 @@ Objects that have a type in the map:
 class TypeMap final : public ProgramMap {
  protected:
     // We want to have the same canonical type for two
-    // different tuples or stacks with the same signature.
+    // different tuples, lists, or stacks with the same signature.
     std::vector<const IR::Type*> canonicalTuples;
     std::vector<const IR::Type*> canonicalStacks;
+    std::vector<const IR::Type*> canonicalLists;
 
     // Map each node to its canonical type
     std::map<const IR::Node*, const IR::Type*> typeMap;

--- a/ir/dbprint-type.cpp
+++ b/ir/dbprint-type.cpp
@@ -106,6 +106,17 @@ void IR::Type_Tuple::dbprint(std::ostream& out) const {
     dbsetflags(out, flags);
 }
 
+void IR::Type_List::dbprint(std::ostream& out) const {
+    int flags = dbgetflags(out);
+    out << Brief << "list<";
+    const char *sep = "";
+    for (auto t : components) {
+        out << sep << t;
+        sep = ", "; }
+    out << ">";
+    dbsetflags(out, flags);
+}
+
 void IR::Type_Extern::dbprint(std::ostream& out) const {
     if (dbgetflags(out) & Brief) {
         out << name;

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -400,7 +400,7 @@ class ListExpression : Expression {
             Vector<Type> tuple;
             for (auto e : components)
                 tuple.push_back(e->type);
-            type = new Type_Tuple(tuple); } }
+            type = new Type_List(tuple); } }
     validate { components.check_null(); }
     size_t size() const { return components.size(); }
     void push_back(Expression e) { components.push_back(e); }

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -145,6 +145,16 @@ size_t Type_MethodBase::minParameterCount() const {
     return rv;
 }
 
+const Type* Type_List::getP4Type() const {
+    auto args = new IR::Vector<Type>();
+    for (auto a : components) {
+        auto at = a->getP4Type();
+        if (!at) return nullptr;
+        args->push_back(at);
+    }
+    return new IR::Type_List(srcInfo, *args);
+}
+
 const Type* Type_Tuple::getP4Type() const {
     auto args = new IR::Vector<Type>();
     for (auto a : components) {

--- a/ir/type.def
+++ b/ir/type.def
@@ -288,20 +288,31 @@ class Type_Set : Type {
         return elementType->width_bits(); }
 }
 
-/// The type of an expressionList
-class Type_Tuple : Type {
+/// Base class for Type_List and Type_Tuple
+abstract Type_BaseList : Type {
     optional inline Vector<Type> components;
-    toString{ return "Tuple(" + Util::toString(components.size()) + ")"; }
     validate{ components.check_null(); }
-    const Type* getP4Type() const override;
     size_t size() const { return components.size(); }
     int width_bits() const override {
-        /// returning sum of the width of the tuple elements
+        /// returning sum of the width of the elements
         int rv = 0;
         for (auto f : components) {
             rv += f->width_bits();
         }
         return rv; }
+}
+
+/// The type of an expressionList; can be unified with both Type_Tuple and Type_Struct
+class Type_List : Type_BaseList {
+    // In error messages this is shown as if it is a Tuple
+    toString{ return "Tuple(" + Util::toString(components.size()) + ")"; }
+    const Type* getP4Type() const override;
+}
+
+/// The type of a tuple.
+class Type_Tuple : Type_BaseList {
+    toString{ return "Tuple(" + Util::toString(components.size()) + ")"; }
+    const Type* getP4Type() const override;
 }
 
 /// The type of an architectural block.

--- a/midend/complexComparison.cpp
+++ b/midend/complexComparison.cpp
@@ -25,7 +25,7 @@ const IR::Expression* RemoveComplexComparisons::explode(
 
     // we allow several cases
     // header == header
-    // header == list (tuple)
+    // header == list
     // list == header
     // list == list
     // struct == struct
@@ -33,8 +33,8 @@ const IR::Expression* RemoveComplexComparisons::explode(
     // struct == list
     // list == struct
 
-    auto rightTuple = rightType->to<IR::Type_Tuple>();
-    auto leftTuple = leftType->to<IR::Type_Tuple>();
+    auto rightTuple = rightType->to<IR::Type_BaseList>();
+    auto leftTuple = leftType->to<IR::Type_BaseList>();
     if (leftTuple && !rightTuple)
         // put the tuple on the right if it is the only one,
         // so we handle fewer cases
@@ -155,7 +155,7 @@ const IR::Node* RemoveComplexComparisons::postorder(IR::Operation_Binary* expres
     auto ltype = typeMap->getType(expression->left, true);
     auto rtype = typeMap->getType(expression->right, true);
     if (!ltype->is<IR::Type_StructLike>() && !ltype->is<IR::Type_Stack>() &&
-        !ltype->is<IR::Type_Tuple>())
+        !ltype->is<IR::Type_BaseList>())
         return expression;
     auto result = explode(expression->srcInfo, ltype, expression->left, rtype, expression->right);
     if (expression->is<IR::Neq>())

--- a/midend/eliminateTuples.cpp
+++ b/midend/eliminateTuples.cpp
@@ -26,10 +26,10 @@ const IR::Type* ReplacementMap::convertType(const IR::Type* type) {
         } else {
             return type;
         }
-    } else if (type->is<IR::Type_Tuple>()) {
+    } else if (type->is<IR::Type_BaseList>()) {
         cstring name = ng->newName("tuple");
         IR::IndexedVector<IR::StructField> fields;
-        for (auto t : type->to<IR::Type_Tuple>()->components) {
+        for (auto t : type->to<IR::Type_BaseList>()->components) {
             auto ftype = convertType(t);
             auto fname = ng->newName("field");
             auto field = new IR::StructField(IR::ID(fname), ftype->getP4Type());
@@ -43,7 +43,7 @@ const IR::Type* ReplacementMap::convertType(const IR::Type* type) {
     return type;
 }
 
-const IR::Type_Struct* ReplacementMap::getReplacement(const IR::Type_Tuple* tt) {
+const IR::Type_Struct* ReplacementMap::getReplacement(const IR::Type_BaseList* tt) {
     auto st = convertType(tt)->to<IR::Type_Struct>();
     CHECK_NULL(st);
     replacement.emplace(tt, st);
@@ -63,9 +63,9 @@ IR::IndexedVector<IR::Node>* ReplacementMap::getNewReplacements() {
     return retval;
 }
 
-const IR::Node* DoReplaceTuples::postorder(IR::Type_Tuple*) {
-    auto type = getOriginal<IR::Type_Tuple>();
-    auto canon = repl->typeMap->getTypeType(type, true)->to<IR::Type_Tuple>();
+const IR::Node* DoReplaceTuples::postorder(IR::Type_BaseList*) {
+    auto type = getOriginal<IR::Type_BaseList>();
+    auto canon = repl->typeMap->getTypeType(type, true)->to<IR::Type_BaseList>();
     auto st = repl->getReplacement(canon)->getP4Type();
     return st;
 }

--- a/midend/eliminateTuples.h
+++ b/midend/eliminateTuples.h
@@ -24,7 +24,7 @@ limitations under the License.
 namespace P4 {
 
 /**
- * Maintains for each type that may contain a tuple (or be a tuple) the
+ * Maintains for each type that may contain a tuple (or is a tuple) the
  * corresponding struct replacement.
 */
 class ReplacementMap {
@@ -37,7 +37,7 @@ class ReplacementMap {
 
     ReplacementMap(NameGenerator* ng, TypeMap* typeMap) : ng(ng), typeMap(typeMap)
     { CHECK_NULL(ng); CHECK_NULL(typeMap); }
-    const IR::Type_Struct* getReplacement(const IR::Type_Tuple* tt);
+    const IR::Type_Struct* getReplacement(const IR::Type_BaseList* tt);
     IR::IndexedVector<IR::Node>* getNewReplacements();
 };
 
@@ -69,7 +69,7 @@ class DoReplaceTuples final : public Transform {
  public:
     explicit DoReplaceTuples(ReplacementMap* replMap) : repl(replMap)
     { CHECK_NULL(repl); setName("DoReplaceTuples"); }
-    const IR::Node* postorder(IR::Type_Tuple* type) override;
+    const IR::Node* postorder(IR::Type_BaseList* type) override;
     const IR::Node* insertReplacements(const IR::Node* before);
     const IR::Node* postorder(IR::Type_Struct* type) override
     { return insertReplacements(type); }

--- a/testdata/p4_16_errors/issue2036-1.p4
+++ b/testdata/p4_16_errors/issue2036-1.p4
@@ -1,0 +1,12 @@
+struct s {
+    bit<8> x;
+}
+
+extern void f(in s sarg);
+
+control c() {
+    apply {
+        tuple<bit<8>> b = { 0 };
+        f(b);
+    }
+}

--- a/testdata/p4_16_errors/issue2036-2.p4
+++ b/testdata/p4_16_errors/issue2036-2.p4
@@ -1,0 +1,12 @@
+struct s {
+    bit<8> x;
+}
+
+extern void f(out s sarg);
+
+control c() {
+    apply {
+        tuple<bit<8>> b = { 0 };
+        f(b);
+    }
+}

--- a/testdata/p4_16_errors/issue2036.p4
+++ b/testdata/p4_16_errors/issue2036.p4
@@ -1,0 +1,29 @@
+#include <core.p4>
+
+//Architecture
+parser C();
+package S(C p);
+
+//User Program
+struct s {
+  bit<8> x;
+}
+
+parser D(in s z) {
+  state start {
+    transition accept;
+  }
+}
+
+parser E() {
+  tuple<bit<8>> a = { 0 };
+  s b = { 1 };
+  D() d;
+  state start {
+    d.apply(a);
+    d.apply(b);
+    transition accept;
+  }
+}
+
+S(E()) main;

--- a/testdata/p4_16_errors_outputs/issue2036-1.p4
+++ b/testdata/p4_16_errors_outputs/issue2036-1.p4
@@ -1,0 +1,12 @@
+struct s {
+    bit<8> x;
+}
+
+extern void f(in s sarg);
+control c() {
+    apply {
+        tuple<bit<8>> b = { 0 };
+        f(b);
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/issue2036-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2036-1.p4-stderr
@@ -1,0 +1,3 @@
+issue2036-1.p4(10): [--Werror=type-error] error: f: Cannot unify Tuple(1) to struct s
+        f(b);
+        ^^^^

--- a/testdata/p4_16_errors_outputs/issue2036-2.p4
+++ b/testdata/p4_16_errors_outputs/issue2036-2.p4
@@ -1,0 +1,12 @@
+struct s {
+    bit<8> x;
+}
+
+extern void f(out s sarg);
+control c() {
+    apply {
+        tuple<bit<8>> b = { 0 };
+        f(b);
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/issue2036-2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2036-2.p4-stderr
@@ -1,0 +1,3 @@
+issue2036-2.p4(10): [--Werror=type-error] error: f: Cannot unify Tuple(1) to struct s
+        f(b);
+        ^^^^

--- a/testdata/p4_16_errors_outputs/issue2036.p4
+++ b/testdata/p4_16_errors_outputs/issue2036.p4
@@ -1,0 +1,27 @@
+#include <core.p4>
+
+parser C();
+package S(C p);
+struct s {
+    bit<8> x;
+}
+
+parser D(in s z) {
+    state start {
+        transition accept;
+    }
+}
+
+parser E() {
+    tuple<bit<8>> a = { 0 };
+    s b = { 1 };
+    D() d;
+    state start {
+        d.apply(a);
+        d.apply(b);
+        transition accept;
+    }
+}
+
+S(E()) main;
+

--- a/testdata/p4_16_errors_outputs/issue2036.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2036.p4-stderr
@@ -1,0 +1,3 @@
+issue2036.p4(23): [--Werror=type-error] error: d.apply: Cannot unify Tuple(1) to struct s
+    d.apply(a);
+    ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-exact.p4(72): [--Werror=type-error] error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-exact.p4(72): [--Werror=type-error] error: Entry: tuples with different sizes 1 vs 2
             (0x1111 &&& 0xF, 0x1 ) : a(); // invalid exact key
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-lpm.p4(72): [--Werror=type-error] error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-lpm.p4(72): [--Werror=type-error] error: Entry: tuples with different sizes 1 vs 2
             (0x1, 0x11 &&& 0xF0): a(); // invalid keyset
             ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-range.p4(71): [--Werror=type-error] error: Entry: Cannot match tuples with different sizes 1 vs 2
+table-entries-range.p4(71): [--Werror=type-error] error: Entry: tuples with different sizes 1 vs 2
             (0x18, 0xF) : a_with_control_params(24); // not a range
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/tuple-newtype.p4-stderr
+++ b/testdata/p4_16_errors_outputs/tuple-newtype.p4-stderr
@@ -1,3 +1,6 @@
 tuple-newtype.p4(5): error: T: `type' can only be applied to base types
 type tuple<bit> T;
                 ^
+tuple-newtype.p4(12): [--Werror=type-error] error: cast: Illegal cast from Tuple(1) to T
+        T tt2 = (T){1w0};
+                ^^^^^^^^

--- a/testdata/p4_16_errors_outputs/tuple-to-header.p4-stderr
+++ b/testdata/p4_16_errors_outputs/tuple-to-header.p4-stderr
@@ -1,9 +1,3 @@
-tuple-to-header.p4(23): [--Werror=type-error] error: AssignmentStatement: Cannot assign a Tuple(1) to a header H
+tuple-to-header.p4(23): [--Werror=type-error] error: AssignmentStatement: Cannot unify Tuple(1) to header H
         h = t; // illegal assignment between tuple and header
           ^
-tuple-to-header.p4(20)
-    tuple<bit<32>> t = { 0 };
-    ^^^^^^^^^^^^^^
-tuple-to-header.p4(17)
-header H { bit<32> x; }
-       ^

--- a/testdata/p4_16_samples/issue2036-3.p4
+++ b/testdata/p4_16_samples/issue2036-3.p4
@@ -1,0 +1,11 @@
+struct s {
+    bit<8> x;
+}
+
+extern void f(in tuple<bit<8>> a, in s sarg);
+
+control c() {
+    apply {
+        f({0}, {0});
+    }
+}

--- a/testdata/p4_16_samples_outputs/issue2036-3-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2036-3-first.p4
@@ -1,0 +1,11 @@
+struct s {
+    bit<8> x;
+}
+
+extern void f(in tuple<bit<8>> a, in s sarg);
+control c() {
+    apply {
+        f({ 8w0 }, s {x = 8w0});
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/issue2036-3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2036-3-frontend.p4
@@ -1,0 +1,4 @@
+struct s {
+    bit<8> x;
+}
+

--- a/testdata/p4_16_samples_outputs/issue2036-3.p4
+++ b/testdata/p4_16_samples_outputs/issue2036-3.p4
@@ -1,0 +1,11 @@
+struct s {
+    bit<8> x;
+}
+
+extern void f(in tuple<bit<8>> a, in s sarg);
+control c() {
+    apply {
+        f({ 0 }, { 0 });
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/issue2036-3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2036-3.p4-stderr
@@ -1,0 +1,1 @@
+warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/logging.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/logging.p4.p4info.txt
@@ -1,0 +1,35 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 33595561
+    name: "c.t"
+    alias: "t"
+  }
+  action_refs {
+    id: 16782098
+  }
+  action_refs {
+    id: 16800567
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16782098
+    name: "c.a"
+    alias: "a"
+  }
+}
+type_info {
+}


### PR DESCRIPTION
This generalizes the solution in #2070.
The solution is to assign to tuple Type_Tuple and to lists Type_List. Both extend Type_BaseList.
Type_List can be however unified with both Type_Tuple and Type_Struct, while Type_Tuple cannot be unified with Type_Struct.
There are quite a few changes because many passes which were looking at Type_Tuple now have to handle Type_List or Type_BaseList instead.