### PR TITLE
fix type inference for IR::Neg and IR::Cmpl

### DIFF
--- a/frontends/p4-14/typecheck.cpp
+++ b/frontends/p4-14/typecheck.cpp
@@ -315,6 +315,10 @@ class TypeCheck::InferExpressionsBottomUp : public Modifier {
     void postorder(IR::LNot *op) override {
         logic_operand(op->expr);
         setType(op, IR::Type::Boolean::get()); }
+    void postorder(IR::Neg *op) override {
+        setType(op, op->expr->type); }
+    void postorder(IR::Cmpl *op) override {
+        setType(op, op->expr->type); }
     void postorder(IR::Operation_Relation *op) override {
         setType(op, IR::Type::Boolean::get()); }
 };


### PR DESCRIPTION
manually tested on one of our internal test case