### PR TITLE
Fix FindPythonModule to avoid warnings

### DIFF
--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -7,7 +7,7 @@ function(find_python_module module)
     # A module's location is usually a directory, but for binary modules
     # it's a .so file.
     execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-      "import re, ${module}; print re.compile('/__init__.py.*').sub('',${module}.__file__)"
+      "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
       RESULT_VARIABLE _${module}_status
       OUTPUT_VARIABLE _${module}_location
       ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Not sure what the purpose of all the find_python_module directives is,
since we only check for presence of standard library stuff. We also
use find_python_module to "find" the "re" module, and the
find_python_module implementation itself imports "re" :)

Fixes #2095