### PR TITLE
Add instructions to install Python 3 version of Scapy as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,14 @@ included with `p4c` are documented here:
 
 Most dependencies can be installed using `apt-get install`:
 
-`sudo apt-get install cmake g++ git automake libtool libgc-dev bison flex
+```bash
+$ sudo apt-get install cmake g++ git automake libtool libgc-dev bison flex
 libfl-dev libgmp-dev libboost-dev libboost-iostreams-dev
-libboost-graph-dev llvm pkg-config python python-scapy python-ipaddr python-ply
-tcpdump`
+libboost-graph-dev llvm pkg-config python python-scapy python-ipaddr python-ply python3-pip
+tcpdump
+
+$ pip3 install scapy
+```
 
 For documentation building:
 `sudo apt-get install -y doxygen graphviz texlive-full`


### PR DESCRIPTION
Without something like this, `cd p4c/build ; make check` fails on a
freshly installed Ubuntu Linux machine.