### PR TITLE
Quick scapy fix.

### DIFF
--- a/backends/ebpf/targets/target.py
+++ b/backends/ebpf/targets/target.py
@@ -26,8 +26,7 @@
 import os
 import sys
 from glob import glob
-from scapy.utils import rdpcap, RawPcapWriter
-from scapy.layers.all import *
+import scapy.utils as scapy_util
 from .ebpfstf import create_table_file, parse_stf_file
 # path to the tools folder of the compiler
 sys.path.insert(0, os.path.dirname(
@@ -120,7 +119,7 @@ class EBPFTarget(object):
             direction = "in"
             infile = self.filename(iface, direction)
             # Linktype 1 the Ethernet Link Type, see also 'man pcap-linktype'
-            fp = RawPcapWriter(infile, linktype=1)
+            fp = scapy_util.RawPcapWriter(infile, linktype=1)
             fp._write_header(None)
             for pkt_data in pkts:
                 try:
@@ -181,7 +180,7 @@ class EBPFTarget(object):
                 packets = []
             else:
                 try:
-                    packets = rdpcap(file)
+                    packets = scapy_util.rdpcap(file)
                 except Exception as e:
                     report_err(self.outputs["stderr"],
                                "Corrupt pcap file", file, e)

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -68,7 +68,7 @@ def hex_to_byte(hexStr):
 def compare_pkt(outputs, expected, received):
     """  Compare two given byte sequences and check if they are the same.
          Report errors if this is not the case. """
-    received = received.convert_to(Raw).load.hex().upper()
+    received = bytes(received).hex().upper()
     expected = ''.join(expected.split()).upper()
     if len(received) < len(expected):
         report_err(outputs["stderr"], "Received packet too short",


### PR DESCRIPTION
Maybe this fixes the byte casting issues with scapy. `received` is a scapy raw object and `bytes(received)` converts the object to its byte representation.