### PR TITLE
Order of src and dst template function arguments fix

### DIFF
--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 
 namespace P4 {
 
+
 /// Unifies a call with a prototype.
 bool TypeUnification::unifyCall(const IR::Node* errorPosition,
                                 const IR::Type_MethodBase* dest,
@@ -53,7 +54,10 @@ bool TypeUnification::unifyCall(const IR::Node* errorPosition,
         size_t i = 0;
         for (auto tv : dest->typeParameters->parameters) {
             auto type = src->typeArguments->at(i++);
-            constraints->addEqualityConstraint(tv, type);
+            // variable type represents type of formal method argument
+            // written beetween angle brackets, and tv should be replaced
+            // with type of an actual argument
+            constraints->addEqualityConstraint(type /*dst */, tv /* src */);
         }
     }
 
@@ -293,10 +297,6 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
                                      errorPosition, src->toString(), dest->toString());
         return false;
     } else if (auto td = dest->to<IR::Type_BaseList>()) {
-        if (src->is<IR::Type_Struct>() || src->is<IR::Type_Header>()) {
-            // swap and try again: handled below
-            return unify(errorPosition, src, dest, reportErrors);
-        }
         if (!src->is<IR::Type_BaseList>()) {
             if (reportErrors)
                 TypeInference::typeError("%1%: Cannot unify type %2% with %3%",

--- a/testdata/p4_16_samples/select-struct.p4
+++ b/testdata/p4_16_samples/select-struct.p4
@@ -25,13 +25,11 @@ parser p() {
     state start {
         bit<8> x = 5;
         S s = { 0, 0 };
-        tuple<bit<8>, bit<8>> t = { 0, 0 };
 
         transition select(x, x, {x, x}, x) {
             (0, 0, {0, 0}, 0): accept;
             (1, 1, default, 1): accept;
-            (1, 1, s, 2): accept;
-            (1, 1, t, 2): accept;
+            (1, 1, {s.f0, s.f1}, 2): accept;
             default: reject;
         }
     }

--- a/testdata/p4_16_samples_outputs/select-struct-first.p4
+++ b/testdata/p4_16_samples_outputs/select-struct-first.p4
@@ -9,12 +9,10 @@ parser p() {
     state start {
         bit<8> x = 8w5;
         S s = { 8w0, 8w0 };
-        tuple<bit<8>, bit<8>> t = { 8w0, 8w0 };
         transition select(x, x, { x, x }, x) {
             (8w0, 8w0, { 8w0, 8w0 }, 8w0): accept;
             (8w1, 8w1, default, 8w1): accept;
-            (8w1, 8w1, s, 8w2): accept;
-            (8w1, 8w1, t, 8w2): accept;
+            (8w1, 8w1, { s.f0, s.f1 }, 8w2): accept;
             default: reject;
         }
     }

--- a/testdata/p4_16_samples_outputs/select-struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/select-struct-frontend.p4
@@ -8,16 +8,13 @@ struct S {
 parser p() {
     bit<8> x_0;
     S s_0;
-    tuple<bit<8>, bit<8>> t_0;
     state start {
         x_0 = 8w5;
         s_0 = { 8w0, 8w0 };
-        t_0 = { 8w0, 8w0 };
         transition select(x_0, x_0, { x_0, x_0 }, x_0) {
             (8w0, 8w0, { 8w0, 8w0 }, 8w0): accept;
             (8w1, 8w1, default, 8w1): accept;
-            (8w1, 8w1, s_0, 8w2): accept;
-            (8w1, 8w1, t_0, 8w2): accept;
+            (8w1, 8w1, { s_0.f0, s_0.f1 }, 8w2): accept;
             default: reject;
         }
     }
@@ -26,4 +23,3 @@ parser p() {
 parser s();
 package top(s _s);
 top(p()) main;
-

--- a/testdata/p4_16_samples_outputs/select-struct-midend.p4
+++ b/testdata/p4_16_samples_outputs/select-struct-midend.p4
@@ -5,11 +5,6 @@ struct S {
     bit<8> f1;
 }
 
-struct tuple_0 {
-    bit<8> field;
-    bit<8> field_0;
-}
-
 parser p() {
     state start {
         transition reject;
@@ -19,4 +14,3 @@ parser p() {
 parser s();
 package top(s _s);
 top(p()) main;
-

--- a/testdata/p4_16_samples_outputs/select-struct.p4
+++ b/testdata/p4_16_samples_outputs/select-struct.p4
@@ -9,12 +9,10 @@ parser p() {
     state start {
         bit<8> x = 5;
         S s = { 0, 0 };
-        tuple<bit<8>, bit<8>> t = { 0, 0 };
         transition select(x, x, { x, x }, x) {
             (0, 0, { 0, 0 }, 0): accept;
             (1, 1, default, 1): accept;
-            (1, 1, s, 2): accept;
-            (1, 1, t, 2): accept;
+            (1, 1, { s.f0, s.f1 }, 2): accept;
             default: reject;
         }
     }


### PR DESCRIPTION
Fixing order of arguments allows removing of unnecessary
destination and source argument swapping if dst is base list
type and src is struct like type.

Select-struct.p4 test is changed to be in conformance with
specification.