### PR TITLE
Ignore warnings if we've already emitted errors

### DIFF
--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -138,6 +138,10 @@ class ErrorReporter final {
 
         std::string prefix;
         if (action == DiagnosticAction::Warn) {
+            // Avoid burying errors in a pile of warnings: don't emit any more warnings if we've
+            // emitted errors.
+            if (errorCount > 0) return;
+
             warningCount++;
             if (diagnosticName != nullptr) {
                 prefix.append("[--Wwarn=");

--- a/testdata/p4_16_errors_outputs/nostart.p4-stderr
+++ b/testdata/p4_16_errors_outputs/nostart.p4-stderr
@@ -4,6 +4,3 @@ nostart.p4(18): [--Wwarn=parser-transition] warning: next: implicit transition t
 nostart.p4(17): error: parser p: parser does not have a `start' state
 parser p() {
        ^
-nostart.p4(17): [--Wwarn=parser-transition] warning: accept state in parser p is unreachable
-parser p() {
-       ^


### PR DESCRIPTION
This avoids burying errors in a pile of warnings by ignoring all warnings after the first error.