### PR TITLE
Allow extern methods to be marked @noSideEffects

### DIFF
--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -27,6 +27,7 @@ ParseAnnotations::HandlerMap ParseAnnotations::standardHandlers() {
             PARSE_EMPTY(IR::Annotation::hiddenAnnotation),
             PARSE_EMPTY(IR::Annotation::atomicAnnotation),
             PARSE_EMPTY(IR::Annotation::optionalAnnotation),
+            PARSE_EMPTY(IR::Annotation::noSideEffectsAnnotation),
 
             // @name and @deprecated have a string literal argument.
             PARSE(IR::Annotation::nameAnnotation, StringLiteral),

--- a/ir/base.def
+++ b/ir/base.def
@@ -252,7 +252,8 @@ class Annotation {
     static const cstring optionalAnnotation;  /// Optional parameter annotation
     static const cstring pkginfoAnnotation;  /// Package documentation annotation.
     static const cstring deprecatedAnnotation;  /// Deprecation annotation.
-    static const cstring synchronousAnnotation;  /// Synchronous annotation.
+    static const cstring synchronousAnnotation;  /// noSideEffects annotation.
+    static const cstring noSideEffectsAnnotation;  /// Synchronous annotation.
     static const cstring matchAnnotation;  /// Match annotation (for value sets).
     toString{ return cstring("@") + name; }
     validate{

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -45,6 +45,7 @@ const cstring IR::Annotation::optionalAnnotation = "optional";
 const cstring IR::Annotation::pkginfoAnnotation = "pkginfo";
 const cstring IR::Annotation::deprecatedAnnotation = "deprecated";
 const cstring IR::Annotation::synchronousAnnotation = "synchronous";
+const cstring IR::Annotation::noSideEffectsAnnotation = "noSideEffects";
 const cstring IR::Annotation::matchAnnotation = "match";
 
 int Type_Declaration::nextId = 0;

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -80,7 +80,7 @@ class DoLocalCopyPropagation::ElimDead : public Transform {
             if (auto var = ::getref(self.available, dest->path->name)) {
                 if (var->local && !var->live) {
                     LOG3("  removing dead assignment to " << dest->path->name);
-                    if (hasSideEffects(as->right))
+                    if (self.hasSideEffects(as->right))
                         return makeSideEffectStatement(as->right);
                     return nullptr;
                 } else if (var->local) {
@@ -93,7 +93,7 @@ class DoLocalCopyPropagation::ElimDead : public Transform {
             /* can't leave ifTrue == nullptr, as that will fail validation -- fold away
              * the if statement as needed */
             if (s->ifFalse == nullptr) {
-                if (!hasSideEffects(s->condition)) {
+                if (!self.hasSideEffects(s->condition)) {
                     return nullptr;
                 } else {
                     s->ifTrue = new IR::EmptyStatement();

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "ir/ir.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
+#include "has_side_effects.h"
 
 namespace P4 {
 
@@ -80,6 +81,8 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
     bool name_overlap(cstring, cstring);
     void forOverlapAvail(cstring, std::function<void(cstring, VarInfo *)>);
     void dropValuesUsing(cstring);
+    bool hasSideEffects(const IR::Expression *e) {
+        return bool(::hasSideEffects(refMap, typeMap, e)); }
 
     void visit_local_decl(const IR::Declaration_Variable *);
     const IR::Node *postorder(IR::Declaration_Variable *) override;


### PR DESCRIPTION
- allows transformations/optimizations to have more knowledge of
  architecture-specific externs so as to better optimize things.