### PR TITLE
Fix simplifyDefUse to deal with side effect in if condition

### DIFF
--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -249,6 +249,7 @@ class FindUninitialized : public Inspector {
         LOG3("FU Visiting " << statement);
         if (!unreachable) {
             visit(statement->condition);
+            currentPoint = ProgramPoint(context, statement->condition);
             auto saveCurrent = currentPoint;
             auto saveUnreachable = unreachable;
             visit(statement->ifTrue);


### PR DESCRIPTION
- fixes issue seen in #2026.  Allows table.hit/miss tests to remain in if conditions, where they need to be.