### PR TITLE
Add Python 3 ply to install steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ libfl-dev libgmp-dev libboost-dev libboost-iostreams-dev
 libboost-graph-dev llvm pkg-config python python-scapy python-ipaddr python-ply python3-pip
 tcpdump
 
-$ pip3 install scapy
+$ pip3 install scapy ply
 ```
 
 For documentation building:


### PR DESCRIPTION
Without this, following the existing README instructions leads to an
installation that fails all ebpf tests run by 'cd p4c/build ; make
check'.  With this addition, I believe all tests pass.