### PR TITLE
Correctly parse action references in const table entries

### DIFF
--- a/frontends/p4/createBuiltins.cpp
+++ b/frontends/p4/createBuiltins.cpp
@@ -47,6 +47,13 @@ void CreateBuiltins::postorder(IR::ExpressionValue* expression) {
             new IR::Vector<IR::Type>(), new IR::Vector<IR::Argument>());
 }
 
+void CreateBuiltins::postorder(IR::Entry* entry) {
+  // convert a const table entry with action "a;" into "a();"
+  if(entry->action->is<IR::PathExpression>())
+    entry->action = new IR::MethodCallExpression(
+      entry->action->srcInfo, entry->action,
+      new IR::Vector<IR::Type>(), new IR::Vector<IR::Argument>());                                      }
+
 void CreateBuiltins::postorder(IR::ParserState* state) {
     if (state->selectExpression == nullptr) {
         warning(ErrorType::WARN_PARSER_TRANSITION, "%1%: implicit transition to `reject'", state);

--- a/frontends/p4/createBuiltins.cpp
+++ b/frontends/p4/createBuiltins.cpp
@@ -49,10 +49,11 @@ void CreateBuiltins::postorder(IR::ExpressionValue* expression) {
 
 void CreateBuiltins::postorder(IR::Entry* entry) {
   // convert a const table entry with action "a;" into "a();"
-  if(entry->action->is<IR::PathExpression>())
+  if (entry->action->is<IR::PathExpression>())
     entry->action = new IR::MethodCallExpression(
       entry->action->srcInfo, entry->action,
-      new IR::Vector<IR::Type>(), new IR::Vector<IR::Argument>());                                      }
+      new IR::Vector<IR::Type>(), new IR::Vector<IR::Argument>());
+}
 
 void CreateBuiltins::postorder(IR::ParserState* state) {
     if (state->selectExpression == nullptr) {

--- a/frontends/p4/createBuiltins.h
+++ b/frontends/p4/createBuiltins.h
@@ -35,6 +35,7 @@ class CreateBuiltins final : public Modifier {
     void postorder(IR::P4Parser* parser) override;
     void postorder(IR::ActionListElement* element) override;
     void postorder(IR::ExpressionValue* property) override;
+    void postorder(IR::Entry* property) override;
     bool preorder(IR::P4Table* table) override;
     void postorder(IR::ActionList* actions) override;
     void postorder(IR::TableProperties* properties) override;

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -288,7 +288,6 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %type<IR::IndexedVector<IR::ActionListElement>*>  actionList
 %type<IR::Entry*>           entry
 %type<IR::Vector<IR::Entry>*>  entriesList
-%type<IR::MethodCallExpression*>  actionBinding
 %type<IR::IndexedVector<IR::NamedExpression>*> kvList
 %type<IR::NamedExpression*> kvPair
 %type<IR::Vector<IR::Expression>*> intList
@@ -1196,42 +1195,29 @@ keyElement
 
 actionList
     : /* empty */                        { $$ = new IR::IndexedVector<IR::ActionListElement>(); }
-    | actionList optAnnotations actionRef ";" 
+    | actionList optAnnotations actionRef ";"
         { $$ = $1; $$->push_back(new IR::ActionListElement(@3, $2, $3)); }
     ;
 
 actionRef
-    : prefixedNonTypeName 
-        { $$ = new IR::PathExpression($1);}
+    : prefixedNonTypeName
+        { $$ = new IR::PathExpression($1); }
     | prefixedNonTypeName "(" argumentList ")"
         { $$ = new IR::MethodCallExpression(@1+@3, new IR::PathExpression($1), $3); }
     ;
 
 entry
-    : keysetExpression ":" actionBinding optAnnotations ";"
-                                         {
-                                           assert($3->is<IR::MethodCallExpression>());
-                                           if (auto l = $1->to<IR::ListExpression>())
-                                             $$ = new IR::Entry(@1+@4, $4, l, $3);
-                                           else {  // if not a tuple, make it a list of 1
-                                             IR::Vector<IR::Expression> le($1);
-                                             $$ = new IR::Entry(@1+@4, $4,
-                                                                new IR::ListExpression(@1, le),
-                                                                $3);
-                                           }
-                                         }
+    : keysetExpression ":" actionRef optAnnotations ";"
+        { if (auto l = $1->to<IR::ListExpression>())
+            $$ = new IR::Entry(@1+@4, $4, l, $3);
+          else {  // if not a tuple, make it a list of 1
+            IR::Vector<IR::Expression> le($1);
+            $$ = new IR::Entry(@1+@4, $4,
+                   new IR::ListExpression(@1, le),
+                   $3);
+          }
+        }
     ;
-
-actionBinding
-    : lvalue
-        { $$ = new IR::MethodCallExpression(@1, $1,
-                                            new IR::Vector<IR::Type>(),
-                                            new IR::Vector<IR::Argument>()); }
-    | lvalue "(" argumentList ")"
-        { $$ = new IR::MethodCallExpression(@1 + @4, $1,
-                                            new IR::Vector<IR::Type>(), $3); }
-    | lvalue "<" typeArgumentList ">" "(" argumentList ")"
-        { $$ = new IR::MethodCallExpression(@1 + @7, $1, $3, $6); }
 
 entriesList
     : entry                          { $$ = new IR::Vector<IR::Entry>(); $$->push_back($1); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1223,7 +1223,11 @@ entry
     ;
 
 actionBinding
-    : lvalue "(" argumentList ")"
+    : lvalue
+        { $$ = new IR::MethodCallExpression(@1, $1,
+                                            new IR::Vector<IR::Type>(),
+                                            new IR::Vector<IR::Argument>()); }
+    | lvalue "(" argumentList ")"
         { $$ = new IR::MethodCallExpression(@1 + @4, $1,
                                             new IR::Vector<IR::Type>(), $3); }
     | lvalue "<" typeArgumentList ">" "(" argumentList ")"

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -284,7 +284,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %type<IR::IndexedVector<IR::Property>*>  tablePropertyList
 %type<IR::KeyElement*>      keyElement
 %type<IR::Vector<IR::KeyElement>*>  keyElementList
-%type<IR::ActionListElement*>  actionRef
+%type<IR::Expression*>  actionRef
 %type<IR::IndexedVector<IR::ActionListElement>*>  actionList
 %type<IR::Entry*>           entry
 %type<IR::Vector<IR::Entry>*>  entriesList
@@ -1196,15 +1196,15 @@ keyElement
 
 actionList
     : /* empty */                        { $$ = new IR::IndexedVector<IR::ActionListElement>(); }
-    | actionList actionRef ";"           { $$ = $1; $$->push_back($2); }
+    | actionList optAnnotations actionRef ";" 
+        { $$ = $1; $$->push_back(new IR::ActionListElement(@3, $2, $3)); }
     ;
 
 actionRef
-    : optAnnotations prefixedNonTypeName { $$ = new IR::ActionListElement(@2, $1, new IR::PathExpression($2));}
-    | optAnnotations prefixedNonTypeName "(" argumentList ")"
-                                         { auto mce = new IR::MethodCallExpression(
-                                             @2+@4, new IR::PathExpression($2), $4);
-                                           $$ = new IR::ActionListElement(@2, $1, mce); }
+    : prefixedNonTypeName 
+        { $$ = new IR::PathExpression($1);}
+    | prefixedNonTypeName "(" argumentList ")"
+        { $$ = new IR::MethodCallExpression(@1+@3, new IR::PathExpression($1), $3); }
     ;
 
 entry

--- a/testdata/p4_16_samples/table-entries-no-arg-actions.p4
+++ b/testdata/p4_16_samples/table-entries-no-arg-actions.p4
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,16 +23,15 @@ control MyC(inout bit<2> x) {
     action a() { }
     action b() { }
     table t {
-	key = { x : exact; }
-	actions = {a; b;}
-	const entries = {
-	    { 0 } : a;
-	    { 1 } : b;
+        key = { x : exact; }
+        actions = {a; b;}
+        const entries = {
+            { 0 } : a;
+            { 1 } : b;
             { 2 } : a();
             { 3 } : b();
-	}
+        }
     }
-
     apply {
         t.apply();
     }

--- a/testdata/p4_16_samples/table-entries-no-arg-actions.p4
+++ b/testdata/p4_16_samples/table-entries-no-arg-actions.p4
@@ -1,0 +1,41 @@
+/*
+* Copyright 2019, Cornell University
+*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+
+control C(inout bit<2> x);
+package S(C c);
+
+control MyC(inout bit<2> x) {
+    action a() { }
+    action b() { }
+    table t {
+	key = { x : exact; }
+	actions = {a; b;}
+	const entries = {
+	    { 0 } : a;
+	    { 1 } : b;
+            { 2 } : a();
+            { 3 } : b();
+	}
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+S(MyC()) main;

--- a/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-first.p4
@@ -1,0 +1,38 @@
+#include <core.p4>
+
+control C(inout bit<2> x);
+package S(C c);
+control MyC(inout bit<2> x) {
+    action a() {
+    }
+    action b() {
+    }
+    table t {
+        key = {
+            x: exact @name("x") ;
+        }
+        actions = {
+            a();
+            b();
+            @defaultonly NoAction();
+        }
+        const entries = {
+                        2w0 : a();
+
+                        2w1 : b();
+
+                        2w2 : a();
+
+                        2w3 : b();
+
+        }
+
+        default_action = NoAction();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+S(MyC()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-frontend.p4
@@ -1,0 +1,40 @@
+#include <core.p4>
+
+control C(inout bit<2> x);
+package S(C c);
+control MyC(inout bit<2> x) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("MyC.a") action a() {
+    }
+    @name("MyC.b") action b() {
+    }
+    @name("MyC.t") table t_0 {
+        key = {
+            x: exact @name("x") ;
+        }
+        actions = {
+            a();
+            b();
+            @defaultonly NoAction_0();
+        }
+        const entries = {
+                        2w0 : a();
+
+                        2w1 : b();
+
+                        2w2 : a();
+
+                        2w3 : b();
+
+        }
+
+        default_action = NoAction_0();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+S(MyC()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-midend.p4
@@ -1,0 +1,40 @@
+#include <core.p4>
+
+control C(inout bit<2> x);
+package S(C c);
+control MyC(inout bit<2> x) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("MyC.a") action a() {
+    }
+    @name("MyC.b") action b() {
+    }
+    @name("MyC.t") table t_0 {
+        key = {
+            x: exact @name("x") ;
+        }
+        actions = {
+            a();
+            b();
+            @defaultonly NoAction_0();
+        }
+        const entries = {
+                        2w0 : a();
+
+                        2w1 : b();
+
+                        2w2 : a();
+
+                        2w3 : b();
+
+        }
+
+        default_action = NoAction_0();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+S(MyC()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-no-arg-actions.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-no-arg-actions.p4
@@ -16,9 +16,9 @@ control MyC(inout bit<2> x) {
             b;
         }
         const entries = {
-                        0 : a();
+                        0 : a;
 
-                        1 : b();
+                        1 : b;
 
                         2 : a();
 

--- a/testdata/p4_16_samples_outputs/table-entries-no-arg-actions.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-no-arg-actions.p4
@@ -1,0 +1,36 @@
+#include <core.p4>
+
+control C(inout bit<2> x);
+package S(C c);
+control MyC(inout bit<2> x) {
+    action a() {
+    }
+    action b() {
+    }
+    table t {
+        key = {
+            x: exact;
+        }
+        actions = {
+            a;
+            b;
+        }
+        const entries = {
+                        0 : a();
+
+                        1 : b();
+
+                        2 : a();
+
+                        3 : b();
+
+        }
+
+    }
+    apply {
+        t.apply();
+    }
+}
+
+S(MyC()) main;
+


### PR DESCRIPTION
This pull request fixes a discrepancy between the language specification and `p4c` with respect to the syntax for action references in `const` table entries.

The grammar in the language specification allows action references to be written with or without parentheses:
```
entry
    : keysetExpression ':' actionRef optAnnotations ';'
    ;

actionRef
    : optAnnotations prefixedNonTypeName
    | optAnnotations prefixedNonTypeName '(' argumentList ')'
    ;
```
However, the grammar in the `p4c` parser requires all action references to be given with parentheses, even for actions that do not take arguments:
```
entry
    : keysetExpression ":" actionBinding optAnnotations ";"
        { ... }
    ;

actionBinding
    : lvalue "(" argumentList ")"
        { ... }
    | lvalue "<" typeArgumentList ">" "(" argumentList ")"
        { ... }
    ;
```
This pull request adds a new clause to the `actionBinding` rule in the grammar for the `p4c` parser to handle actions without parentheses. It also includes a unit test (`p4_16_samples/table-entries-no-arg-actions.p4`) to check that such action references are parsed correctly.