### PR TITLE
Add new match kind `optional` to v1model

### DIFF
--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -52,6 +52,8 @@ limitations under the License.
 
 match_kind {
     range,
+    // Either an exact match, or a wildcard (matching any value).
+    optional,
     // Used for implementing dynamic_action_selection
     selector
 }


### PR DESCRIPTION
`optional` is a new match kind that matches either exactly, or is a wildcard.  Note that unlike `ternary`, there is no mask, it is either a full match on all bits, or a complete wildcard.  This was proposed to be added to the language, and in the LDWG meeting from Jan 6, 2020, we decided the newly proposed match kind  should be added to v1model and P4RT first, and possibly later consider promoting it to the `core.p4` standard library.  This PR is to add it to v1model, and a companion PR will add support to P4RT soon.

More details on the original discussion in the LDWG meeting notes and here: https://github.com/p4lang/p4-spec/issues/794.