### PR TITLE
Add test program that tests catching of incorrect lpm const entries

### DIFF
--- a/testdata/p4_16_errors/table-entries-lpm-2.p4
+++ b/testdata/p4_16_errors/table-entries-lpm-2.p4
@@ -1,0 +1,92 @@
+/*
+Copyright 2020 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8> r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+struct Meta_t {}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+
+    action a() { standard_meta.egress_spec = 0; }
+    action a_with_control_params(bit<9> x) { standard_meta.egress_spec = x; }
+
+    table t_lpm {
+
+  	key = {
+            h.h.l : lpm;
+        }
+
+	actions = {
+            a;
+            a_with_control_params;
+        }
+
+	default_action = a;
+
+        const entries = {
+            // Test detection of bad values and/or masks for keys with
+            // match_kind lpm.
+
+            // value has 1s outside of field bit width
+            0x100 &&& 0xF0 : a_with_control_params(11);
+
+            // mask has 1s outside of field bit width
+            0x11 &&& 0x1F0 : a_with_control_params(12);
+
+            // mask that is not a prefix mask
+            0x11 &&& 0xE1 : a_with_control_params(13);
+
+            // another mask that is not a prefix mask, and has 1 bits
+            // outside of field bit width.
+            0x11 &&& 0x181 : a_with_control_params(14);
+
+            // exact match value with value having 1s outside of field
+            // bit width
+            0x100 : a_with_control_params(15);
+        }
+    }
+
+    apply {
+        t_lpm.apply();
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2-first.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2-first.p4
@@ -1,0 +1,83 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    table t_lpm {
+        key = {
+            h.h.l: lpm @name("h.h.l") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        default_action = a();
+        const entries = {
+                        8w0x0 &&& 8w0xf0 : a_with_control_params(9w11);
+
+                        8w0x11 &&& 8w0xf0 : a_with_control_params(9w12);
+
+                        8w0x11 &&& 8w0xe1 : a_with_control_params(9w13);
+
+                        8w0x11 &&& 8w0x81 : a_with_control_params(9w14);
+
+                        8w0x0 : a_with_control_params(9w15);
+
+        }
+
+    }
+    apply {
+        t_lpm.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2-frontend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2-frontend.p4
@@ -1,0 +1,83 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    @name("ingress.a") action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    @name("ingress.t_lpm") table t_lpm_0 {
+        key = {
+            h.h.l: lpm @name("h.h.l") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        default_action = a();
+        const entries = {
+                        8w0x0 &&& 8w0xf0 : a_with_control_params(9w11);
+
+                        8w0x11 &&& 8w0xf0 : a_with_control_params(9w12);
+
+                        8w0x11 &&& 8w0xe1 : a_with_control_params(9w13);
+
+                        8w0x11 &&& 8w0x81 : a_with_control_params(9w14);
+
+                        8w0x0 : a_with_control_params(9w15);
+
+        }
+
+    }
+    apply {
+        t_lpm_0.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2-midend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2-midend.p4
@@ -1,0 +1,83 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    @name("ingress.a") action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    @name("ingress.t_lpm") table t_lpm_0 {
+        key = {
+            h.h.l: lpm @name("h.h.l") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        default_action = a();
+        const entries = {
+                        8w0x0 &&& 8w0xf0 : a_with_control_params(9w11);
+
+                        8w0x11 &&& 8w0xf0 : a_with_control_params(9w12);
+
+                        8w0x11 &&& 8w0xe1 : a_with_control_params(9w13);
+
+                        8w0x11 &&& 8w0x81 : a_with_control_params(9w14);
+
+                        8w0x0 : a_with_control_params(9w15);
+
+        }
+
+    }
+    apply {
+        t_lpm_0.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4
@@ -1,0 +1,83 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    action a() {
+        standard_meta.egress_spec = 0;
+    }
+    action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    table t_lpm {
+        key = {
+            h.h.l: lpm;
+        }
+        actions = {
+            a;
+            a_with_control_params;
+        }
+        default_action = a;
+        const entries = {
+                        0x100 &&& 0xf0 : a_with_control_params(11);
+
+                        0x11 &&& 0x1f0 : a_with_control_params(12);
+
+                        0x11 &&& 0xe1 : a_with_control_params(13);
+
+                        0x11 &&& 0x181 : a_with_control_params(14);
+
+                        0x100 : a_with_control_params(15);
+
+        }
+
+    }
+    apply {
+        t_lpm.apply();
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4-stderr
@@ -1,0 +1,21 @@
+table-entries-lpm-2.p4(68): [--Wwarn=mismatch] warning: 0x100: value does not fit in 8 bits
+            0x100 &&& 0xF0 : a_with_control_params(11);
+            ^^^^^
+table-entries-lpm-2.p4(71): [--Wwarn=mismatch] warning: 0x1f0: value does not fit in 8 bits
+            0x11 &&& 0x1F0 : a_with_control_params(12);
+                     ^^^^^
+table-entries-lpm-2.p4(78): [--Wwarn=mismatch] warning: 0x181: value does not fit in 8 bits
+            0x11 &&& 0x181 : a_with_control_params(14);
+                     ^^^^^
+table-entries-lpm-2.p4(82): [--Wwarn=mismatch] warning: 0x100: value does not fit in 8 bits
+            0x100 : a_with_control_params(15);
+            ^^^^^
+table-entries-lpm-2.p4(71): [--Wwarn=mismatch] warning: P4Runtime requires that LPM matches have masked-off bits set to 0, updating value 0x11 to conform to the P4Runtime specification
+            0x11 &&& 0x1F0 : a_with_control_params(12);
+            ^^^^
+table-entries-lpm-2.p4(74): [--Werror=legacy] error: &&& invalid mask for LPM key
+            0x11 &&& 0xE1 : a_with_control_params(13);
+            ^^^^^^^^^^^^^
+table-entries-lpm-2.p4(78): [--Werror=legacy] error: &&& invalid mask for LPM key
+            0x11 &&& 0x181 : a_with_control_params(14);
+            ^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.entries.txt
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.entries.txt
@@ -1,0 +1,106 @@
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33555353
+      match {
+        field_id: 1
+        lpm {
+          value: "\000"
+          prefix_len: 4
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\013"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33555353
+      match {
+        field_id: 1
+        lpm {
+          value: "\020"
+          prefix_len: 4
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\014"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33555353
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\r"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33555353
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\016"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33555353
+      match {
+        field_id: 1
+        lpm {
+          value: "\000"
+          prefix_len: 8
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\017"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.p4info.txt
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.p4info.txt
@@ -1,0 +1,43 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 33555353
+    name: "ingress.t_lpm"
+    alias: "t_lpm"
+  }
+  match_fields {
+    id: 1
+    name: "h.h.l"
+    bitwidth: 8
+    match_type: LPM
+  }
+  action_refs {
+    id: 16795253
+  }
+  action_refs {
+    id: 16837978
+  }
+  size: 1024
+  is_const_table: true
+}
+actions {
+  preamble {
+    id: 16795253
+    name: "ingress.a"
+    alias: "a"
+  }
+}
+actions {
+  preamble {
+    id: 16837978
+    name: "ingress.a_with_control_params"
+    alias: "a_with_control_params"
+  }
+  params {
+    id: 1
+    name: "x"
+    bitwidth: 9
+  }
+}


### PR DESCRIPTION
From looking at the C++ code, I thought there might be some cases that
were not caught, but it seems that all of them get at least a warning,
if not an error, in some cases in the target-independent code, others
in the P4Runtime back end.