### PR TITLE
visitDagOnce = false for control flow simplifications; fixes #2148

### DIFF
--- a/frontends/p4/simplify.cpp
+++ b/frontends/p4/simplify.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 namespace P4 {
 
 const IR::Node* DoSimplifyControlFlow::postorder(IR::BlockStatement* statement) {
-    LOG1("Visiting " << dbp(getOriginal()));
+    LOG3("Visiting " << dbp(getOriginal()));
     if (statement->annotations->size() > 0)
         return statement;
     auto parent = getContext()->node;
@@ -60,7 +60,7 @@ const IR::Node* DoSimplifyControlFlow::postorder(IR::BlockStatement* statement) 
 }
 
 const IR::Node* DoSimplifyControlFlow::postorder(IR::IfStatement* statement)  {
-    LOG1("Visiting " << dbp(getOriginal()));
+    LOG3("Visiting " << dbp(getOriginal()));
     if (SideEffects::check(statement->condition, refMap, typeMap))
         return statement;
     if (statement->ifTrue->is<IR::EmptyStatement>() &&
@@ -70,7 +70,7 @@ const IR::Node* DoSimplifyControlFlow::postorder(IR::IfStatement* statement)  {
 }
 
 const IR::Node* DoSimplifyControlFlow::postorder(IR::EmptyStatement* statement)  {
-    LOG1("Visiting " << dbp(getOriginal()));
+    LOG3("Visiting " << dbp(getOriginal()));
     auto parent = findContext<IR::Statement>();
     if (parent == nullptr ||  // in a ParserState or P4Action
         parent->is<IR::BlockStatement>())
@@ -80,7 +80,7 @@ const IR::Node* DoSimplifyControlFlow::postorder(IR::EmptyStatement* statement) 
 }
 
 const IR::Node* DoSimplifyControlFlow::postorder(IR::SwitchStatement* statement)  {
-    LOG1("Visiting " << dbp(getOriginal()));
+    LOG3("Visiting " << dbp(getOriginal()));
     if (statement->cases.empty()) {
         // The P4_16 spec prohibits expressions other than table application as
         // switch conditions.  The parser should have rejected programs for

--- a/frontends/p4/simplify.h
+++ b/frontends/p4/simplify.h
@@ -25,7 +25,7 @@ limitations under the License.
 namespace P4 {
 
 /** @brief Replace complex control flow nodes with simpler ones where possible.
- * 
+ *
  * Simplify the IR in the following ways:
  *
  * 1. Remove empty statements from within parser states, actions, and block
@@ -42,7 +42,7 @@ namespace P4 {
  * 5. If a block statement is within another block or a parser state, and (a)
  * is empty, then replace it with an empty statement, or (b) does not contain
  * declarations, then move its component statements to the enclosing block.
- * 
+ *
  * 6. If a block statement in an if statement branch only contains a single
  * statement, replace the block with the statement it contains.
  *
@@ -53,8 +53,13 @@ class DoSimplifyControlFlow : public Transform {
     TypeMap*      typeMap;
  public:
     DoSimplifyControlFlow(ReferenceMap* refMap, TypeMap* typeMap) :
-            refMap(refMap), typeMap(typeMap)
-    { CHECK_NULL(refMap); CHECK_NULL(typeMap); setName("DoSimplifyControlFlow"); }
+            refMap(refMap), typeMap(typeMap) {
+        CHECK_NULL(refMap); CHECK_NULL(typeMap);
+        setName("DoSimplifyControlFlow");
+        // We may want to replace the same statement with different things
+        // in different places.
+        visitDagOnce = false;
+    }
     const IR::Node* postorder(IR::BlockStatement* statement) override;
     const IR::Node* postorder(IR::IfStatement* statement) override;
     const IR::Node* postorder(IR::EmptyStatement* statement) override;

--- a/frontends/p4/strengthReduction.cpp
+++ b/frontends/p4/strengthReduction.cpp
@@ -312,7 +312,7 @@ const IR::Node* DoStrengthReduction::postorder(IR::Slice* expr) {
     }
 
     auto slice_width = expr->getH() - expr->getL() + 1;
-    if (slice_width == expr->e0->type->width_bits())
+    if (slice_width == (unsigned)expr->e0->type->width_bits())
         return expr->e0;
 
     return expr;

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -439,6 +439,7 @@ class IfStatement : Statement {
         clone.visit(ifFalse, "ifFalse");
         v.flow_merge(clone);
     }
+    validate{ CHECK_NULL(ifTrue); }
 }
 
 class BlockStatement : Statement, ISimpleNamespace, IAnnotated {

--- a/testdata/p4_16_samples/issue2148.p4
+++ b/testdata/p4_16_samples/issue2148.p4
@@ -1,0 +1,46 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header H {
+    bit<16> a;
+}
+
+
+struct Headers {
+    H h;
+}
+
+struct Meta {
+}
+
+bit<16> do_thing_function() {
+    H not_initialized;
+    bit<32> new_val = 32w1;
+    if (not_initialized.a < 6) {
+    } else {
+        new_val = 32w232;
+    }
+    return (bit<16>)new_val;
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action do_thing_action() {
+        do_thing_function();
+    }
+    apply {
+        h.h.a = do_thing_function();
+        do_thing_action();
+    }
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+state start {transition accept;}}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/issue2148-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2148-first.p4
@@ -1,0 +1,62 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header H {
+    bit<16> a;
+}
+
+struct Headers {
+    H h;
+}
+
+struct Meta {
+}
+
+bit<16> do_thing_function() {
+    H not_initialized;
+    bit<32> new_val = 32w1;
+    if (not_initialized.a < 16w6) {
+        ;
+    } else {
+        new_val = 32w232;
+    }
+    return (bit<16>)new_val;
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action do_thing_action() {
+        do_thing_function();
+    }
+    apply {
+        h.h.a = do_thing_function();
+        do_thing_action();
+    }
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2148-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2148-frontend.p4
@@ -1,0 +1,79 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header H {
+    bit<16> a;
+}
+
+struct Headers {
+    H h;
+}
+
+struct Meta {
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @name("ingress.do_thing_action") action do_thing_action() {
+        {
+            bool hasReturned = false;
+            bit<16> retval;
+            H not_initialized_0;
+            bit<32> new_val_0;
+            new_val_0 = 32w1;
+            if (not_initialized_0.a < 16w6) {
+                ;
+            } else {
+                new_val_0 = 32w232;
+            }
+            hasReturned = true;
+            retval = (bit<16>)new_val_0;
+        }
+    }
+    apply {
+        {
+            bool hasReturned_1 = false;
+            bit<16> retval_1;
+            H not_initialized_2;
+            bit<32> new_val_1;
+            new_val_1 = 32w1;
+            if (not_initialized_2.a < 16w6) {
+                ;
+            } else {
+                new_val_1 = 32w232;
+            }
+            hasReturned_1 = true;
+            retval_1 = (bit<16>)new_val_1;
+            h.h.a = retval_1;
+        }
+        do_thing_action();
+    }
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2148-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2148-midend.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header H {
+    bit<16> a;
+}
+
+struct Headers {
+    H h;
+}
+
+struct Meta {
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    H not_initialized_0;
+    H not_initialized_2;
+    bit<32> new_val_1;
+    @name("ingress.do_thing_action") action do_thing_action() {
+    }
+    @hidden action issue2148l21() {
+        new_val_1 = 32w232;
+    }
+    @hidden action issue2148l18() {
+        new_val_1 = 32w1;
+    }
+    @hidden action issue2148l30() {
+        h.h.a = (bit<16>)new_val_1;
+    }
+    @hidden table tbl_issue2148l18 {
+        actions = {
+            issue2148l18();
+        }
+        const default_action = issue2148l18();
+    }
+    @hidden table tbl_issue2148l21 {
+        actions = {
+            issue2148l21();
+        }
+        const default_action = issue2148l21();
+    }
+    @hidden table tbl_issue2148l30 {
+        actions = {
+            issue2148l30();
+        }
+        const default_action = issue2148l30();
+    }
+    @hidden table tbl_do_thing_action {
+        actions = {
+            do_thing_action();
+        }
+        const default_action = do_thing_action();
+    }
+    apply {
+        tbl_issue2148l18.apply();
+        if (not_initialized_2.a < 16w6) {
+            ;
+        } else {
+            tbl_issue2148l21.apply();
+        }
+        tbl_issue2148l30.apply();
+        tbl_do_thing_action.apply();
+    }
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2148.p4
+++ b/testdata/p4_16_samples_outputs/issue2148.p4
@@ -1,0 +1,61 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header H {
+    bit<16> a;
+}
+
+struct Headers {
+    H h;
+}
+
+struct Meta {
+}
+
+bit<16> do_thing_function() {
+    H not_initialized;
+    bit<32> new_val = 32w1;
+    if (not_initialized.a < 6) {
+    } else {
+        new_val = 32w232;
+    }
+    return (bit<16>)new_val;
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action do_thing_action() {
+        do_thing_function();
+    }
+    apply {
+        h.h.a = do_thing_function();
+        do_thing_action();
+    }
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2148.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2148.p4-stderr
@@ -1,0 +1,3 @@
+issue2148.p4(19): [--Wwarn=uninitialized_use] warning: not_initialized.a may be uninitialized
+    if (not_initialized.a < 6) {
+        ^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue2148.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2148.p4.p4info.txt
@@ -1,0 +1,10 @@
+pkg_info {
+  arch: "v1model"
+}
+actions {
+  preamble {
+    id: 16827060
+    name: "ingress.do_thing_action"
+    alias: "do_thing_action"
+  }
+}


### PR DESCRIPTION
This was happening because an EmptyStatement is replaced with nullptr in a block, but the same EmptyStatement was a child of an IfStatement. The solution is `visitDagOnce = false` for this pass.