### PR TITLE
Set slice_width to int

### DIFF
--- a/frontends/p4/strengthReduction.cpp
+++ b/frontends/p4/strengthReduction.cpp
@@ -311,7 +311,7 @@ const IR::Node* DoStrengthReduction::postorder(IR::Slice* expr) {
         return new IR::Slice(e, hi, lo);
     }
 
-    auto slice_width = expr->getH() - expr->getL() + 1;
+    int slice_width = expr->getH() - expr->getL() + 1;
     if (slice_width == expr->e0->type->width_bits())
         return expr->e0;
 


### PR DESCRIPTION
Both `getH()` and `getL()` return a value of type unsigned, and `width_bits()` returns int.
This results in the following warning:

> p4c/frontends/p4/strengthReduction.cpp:315:21:
> warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
>      if (slice_width == expr->e0->type->width_bits())
>          ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

cc: @hanw