### PR TITLE
Fix right-shift operator precedence

### DIFF
--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -224,6 +224,7 @@ using Parser = P4::P4Parser;
 "{"            { BEGIN(driver.saveState); return makeToken(L_BRACE); }
 "}"            { BEGIN(driver.saveState); return makeToken(R_BRACE); }
 "<"            { BEGIN(driver.saveState); return makeToken(L_ANGLE); }
+">"/">"        { BEGIN(driver.saveState); return makeToken(R_ANGLE_SHIFT); }
 ">"            { BEGIN(driver.saveState); return makeToken(R_ANGLE); }
 
 "!"            { BEGIN(driver.saveState); return makeToken(NOT); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -193,6 +193,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %token<Token>      R_BRACE "}"
 %token<Token>      L_ANGLE "<"
 %token<Token>      R_ANGLE ">"
+%token<Token>      R_ANGLE_SHIFT   // > immediately followed by another >
 %token<Token>      L_PAREN "("
 %token<Token>      R_PAREN ")"
 %token<Token>      NOT "!"
@@ -305,7 +306,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %left BIT_OR
 %left BIT_XOR
 %left BIT_AND
-%left SHL
+%left SHL R_ANGLE_SHIFT
 %left PP PLUS MINUS PLUS_SAT MINUS_SAT
 %left MUL DIV MOD
 %right PREFIX
@@ -565,6 +566,7 @@ annotationToken
     | "}"              { $$ = $1; }
     | "<"              { $$ = $1; }
     | ">"              { $$ = $1; }
+    | R_ANGLE_SHIFT    { $$ = $1; }
 
     | "!"              { $$ = $1; }
     | ":"              { $$ = $1; }
@@ -776,13 +778,13 @@ simpleKeysetExpression
 
 valueSetDeclaration
     : optAnnotations
-        VALUESET "<" baseType ">" "(" expression ")" name ";"
+        VALUESET "<" baseType r_angle "(" expression ")" name ";"
         { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
     | optAnnotations
-        VALUESET "<" tupleType ">" "(" expression ")" name ";"
+        VALUESET "<" tupleType r_angle "(" expression ")" name ";"
         { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
     | optAnnotations
-        VALUESET "<" typeName ">" "(" expression ")" name ";"
+        VALUESET "<" typeName r_angle "(" expression ")" name ";"
         { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
     ;
 
@@ -888,7 +890,7 @@ typeName
     ;
 
 tupleType
-    : TUPLE "<" typeArgumentList ">"    { $$ = new IR::Type_Tuple(@1+@4, *$3); }
+    : TUPLE "<" typeArgumentList r_angle    { $$ = new IR::Type_Tuple(@1+@4, *$3); }
     ;
 
 headerStackType
@@ -896,7 +898,7 @@ headerStackType
     ;
 
 specializedType
-    : typeName "<" typeArgumentList ">" { $$ = new IR::Type_Specialized(@1 + @4, $1, $3); }
+    : typeName "<" typeArgumentList r_angle { $$ = new IR::Type_Specialized(@1 + @4, $1, $3); }
     ;
 
 baseType
@@ -905,18 +907,18 @@ baseType
     | BIT    { $$ = IR::Type::Bits::get(@1, 1); }
     | STRING { $$ = IR::Type::String::get(); }
     | INT    { $$ = new IR::Type_InfInt(); }
-    | BIT "<" INTEGER ">"
+    | BIT "<" INTEGER r_angle
       { $$ = IR::Type::Bits::get(@1+@4, parseConstantChecked(@3, $3), false); }
-    | INT "<" INTEGER ">"
+    | INT "<" INTEGER r_angle
       { $$ = IR::Type::Bits::get(@1+@4, parseConstantChecked(@3, $3), true); }
-    | VARBIT "<" INTEGER ">"
+    | VARBIT "<" INTEGER r_angle
       { $$ = IR::Type::Varbits::get(@1+@4, parseConstantChecked(@3, $3)); }
 
-    | BIT "<" "(" expression ")" ">"
+    | BIT "<" "(" expression ")" r_angle
       { $$ = new IR::Type_Bits(@1+@6, $4, false); }
-    | INT "<" "(" expression ")" ">"
+    | INT "<" "(" expression ")" r_angle
       { $$ = new IR::Type_Bits(@1+@6, $4, true); }
-    | VARBIT "<" "(" expression ")" ">"
+    | VARBIT "<" "(" expression ")" r_angle
       { $$ = new IR::Type_Varbits(@1+@6, $4); }
     ;
 
@@ -929,7 +931,7 @@ typeOrVoid
 
 optTypeParameters
     : /* empty */               { $$ = new IR::TypeParameters(); }
-    | "<" typeParameterList ">" { $$ = new IR::TypeParameters(@1+@3, *$2); }
+    | "<" typeParameterList r_angle { $$ = new IR::TypeParameters(@1+@3, *$2); }
     ;
 
 typeParameterList
@@ -1011,7 +1013,7 @@ enumDeclaration
     : optAnnotations
         ENUM name { driver.structure->declareType(*$3); }
         "{" identifierList "}" { $$ = new IR::Type_Enum(@3, *$3, *$6); }
-    | optAnnotations ENUM BIT "<" INTEGER ">" name { driver.structure->declareType(*$7); }
+    | optAnnotations ENUM BIT "<" INTEGER r_angle name { driver.structure->declareType(*$7); }
         "{" specifiedIdentifierList "}" {
             auto type = IR::Type::Bits::get(@3+@6, parseConstantChecked(@5, $5));
             $$ = new IR::Type_SerEnum(@7, *$7, type, *$10); }
@@ -1062,7 +1064,7 @@ assignmentOrMethodCallStatement
                                                  new IR::Vector<IR::Type>(), $3);
           $$ = new IR::MethodCallStatement(@1 + @4, mc); }
 
-    | lvalue "<" typeArgumentList ">" "(" argumentList ")" ";"
+    | lvalue "<" typeArgumentList r_angle "(" argumentList ")" ";"
         { auto mc = new IR::MethodCallExpression(@1 + @7,
                                                  $1, $3, $6);
           $$ = new IR::MethodCallStatement(@1 + @7, mc); }
@@ -1337,8 +1339,8 @@ expression
     | expression "|+|" expression        { $$ = new IR::AddSat(@1 + @3, $1, $3); }
     | expression "|-|" expression        { $$ = new IR::SubSat(@1 + @3, $1, $3); }
     | expression "<<" expression         { $$ = new IR::Shl(@1 + @3, $1, $3); }
-    | expression ">" ">" expression
-        { driver.checkShift(@2, @3); $$ = new IR::Shr(@1 + @4, $1, $4); }
+    | expression R_ANGLE_SHIFT ">" expression
+        { $$ = new IR::Shr(@1 + @4, $1, $4); }
     | expression "<=" expression         { $$ = new IR::Leq(@1 + @3, $1, $3); }
     | expression ">=" expression         { $$ = new IR::Geq(@1 + @3, $1, $3); }
     | expression "<" expression          { $$ = new IR::Lss(@1 + @3, $1, $3); }
@@ -1352,7 +1354,7 @@ expression
     | expression "&&" expression         { $$ = new IR::LAnd(@1 + @2 + @3, $1, $3); }
     | expression "||" expression         { $$ = new IR::LOr(@1 + @2 + @3, $1, $3); }
     | expression "?" expression ":" expression { $$ = new IR::Mux(@1 + @5, $1, $3, $5); }
-    | expression "<" realTypeArgumentList ">" "(" argumentList ")"
+    | expression "<" realTypeArgumentList r_angle "(" argumentList ")"
         { $$ = new IR::MethodCallExpression(@1 + @4, $1, $3, $6); }
     // FIXME: the previous rule has the wrong precedence, and parses with
     // precedence weaker than casts.  There is no easy way to fix this in bison.
@@ -1388,6 +1390,8 @@ strList
     | strList "," STRING_LITERAL { $$ = $1;
                                    $$->push_back(new IR::StringLiteral(@3, $3)); }
     ;
+
+r_angle : ">" | R_ANGLE_SHIFT ;
 
 /*****************************************************************************/
 

--- a/frontends/parsers/parserDriver.cpp
+++ b/frontends/parsers/parserDriver.cpp
@@ -298,17 +298,6 @@ P4ParserDriver::parseStringLiteralTriple(const Util::SourceInfo& srcInfo,
             P4AnnotationLexer::STRING_LITERAL_TRIPLE, srcInfo, body);
 }
 
-/* static */ void P4ParserDriver::checkShift(const Util::SourceInfo& l,
-                                             const Util::SourceInfo& r) {
-    if (!l.isValid() || !r.isValid())
-        BUG("Source position not available!");
-    const Util::SourcePosition& f = l.getStart();
-    const Util::SourcePosition& s = r.getStart();
-    if (f.getLineNumber() != s.getLineNumber() ||
-        f.getColumnNumber() != s.getColumnNumber() - 1)
-        ::error("Syntax error at shift operator: %1%", l);
-}
-
 void P4ParserDriver::onReadErrorDeclaration(IR::Type_Error* error) {
     if (allErrors == nullptr) {
         nodes->push_back(error);

--- a/frontends/parsers/parserDriver.h
+++ b/frontends/parsers/parserDriver.h
@@ -193,21 +193,6 @@ class P4ParserDriver final : public AbstractParserDriver {
     /// Notify that the parser parsed a P4 `error` declaration.
     void onReadErrorDeclaration(IR::Type_Error* error);
 
-    /**
-     * There's a lexical ambiguity in P4 between the right shift operator `>>`
-     * and nested template arguments. (e.g. `A<B<C>>`) We resolve this at the
-     * parser level; from the lexer's perspective, both cases are just a
-     * sequence of R_ANGLE tokens. Whitespace is allowed between the R_ANGLEs of
-     * nested template arguments, but in the right shift operator case that
-     * isn't permitted, and the parser calls this function to detect when that
-     * happens and report and error.
-     *
-     * @param l  The location of the first R_ANGLE token.
-     * @param r  The location of the second R_ANGLE token.
-     */
-    static void checkShift(const Util::SourceInfo& l, const Util::SourceInfo& r);
-
-
     ////////////////////////////////////////////////////////////////////////////
     // Shared state manipulated directly by the lexer and parser.
     ////////////////////////////////////////////////////////////////////////////

--- a/testdata/p4_16_errors_outputs/shift_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/shift_e.p4-stderr
@@ -1,4 +1,4 @@
-shift_e.p4(20): error: Syntax error at shift operator: 
-        int<32> b = a > > 1;
-                      ^
+shift_e.p4(20):syntax error, unexpected >
+        int<32> b = a > >
+                        ^
 [--Werror=overlimit] error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_samples/shift_precendence.p4
+++ b/testdata/p4_16_samples/shift_precendence.p4
@@ -1,0 +1,12 @@
+control i(out bit<4> a) {
+    bit<4> tmp_0;
+    apply {
+        tmp_0 = 4w0;
+        a = 4w1 & (4w2 + tmp_0) >> 4w2;
+    }
+}
+
+control c(out bit<4> a);
+package top(c _c);
+top(i()) main;
+

--- a/testdata/p4_16_samples_outputs/shift_precendence-first.p4
+++ b/testdata/p4_16_samples_outputs/shift_precendence-first.p4
@@ -1,0 +1,12 @@
+control i(out bit<4> a) {
+    bit<4> tmp_0;
+    apply {
+        tmp_0 = 4w0;
+        a = 4w1 & 4w2 + tmp_0 >> 4w2;
+    }
+}
+
+control c(out bit<4> a);
+package top(c _c);
+top(i()) main;
+

--- a/testdata/p4_16_samples_outputs/shift_precendence-frontend.p4
+++ b/testdata/p4_16_samples_outputs/shift_precendence-frontend.p4
@@ -1,0 +1,12 @@
+control i(out bit<4> a) {
+    bit<4> tmp;
+    apply {
+        tmp = 4w0;
+        a = 4w1 & 4w2 + tmp >> 4w2;
+    }
+}
+
+control c(out bit<4> a);
+package top(c _c);
+top(i()) main;
+

--- a/testdata/p4_16_samples_outputs/shift_precendence-midend.p4
+++ b/testdata/p4_16_samples_outputs/shift_precendence-midend.p4
@@ -1,0 +1,19 @@
+control i(out bit<4> a) {
+    @hidden action shift_precendence5() {
+        a = 4w0;
+    }
+    @hidden table tbl_shift_precendence5 {
+        actions = {
+            shift_precendence5();
+        }
+        const default_action = shift_precendence5();
+    }
+    apply {
+        tbl_shift_precendence5.apply();
+    }
+}
+
+control c(out bit<4> a);
+package top(c _c);
+top(i()) main;
+

--- a/testdata/p4_16_samples_outputs/shift_precendence.p4
+++ b/testdata/p4_16_samples_outputs/shift_precendence.p4
@@ -1,0 +1,12 @@
+control i(out bit<4> a) {
+    bit<4> tmp_0;
+    apply {
+        tmp_0 = 4w0;
+        a = 4w1 & 4w2 + tmp_0 >> 4w2;
+    }
+}
+
+control c(out bit<4> a);
+package top(c _c);
+top(i()) main;
+


### PR DESCRIPTION
Use a lookahead to identify > characters directly followed by another > as a separate token from other > characters -- either may be used to close angle brackets, but only the appropriate one as party of a right shift or a greater-than