### PR TITLE
Enable Slice test with runtime index

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1623,9 +1623,8 @@ class P4RuntimeEntriesConverter {
             // earlier.
             // For e.g. 16 bit key has a max value of 65535, Range of (1..65536)
             // will be converted to (1..0) and will fail below check.
-	    if (*start > *end)
-                ::error(ErrorType::ERR_INVALID, "%2% Invalid range for table entry",
-                        k, kr->srcInfo);
+            if (*start > *end)
+                ::error("%s Invalid range for table entry", kr->srcInfo);
             if (*start == 0 && *end == maxValue)  // don't care
                 return;
             startStr = stringReprConstant(*start, keyWidth);

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1623,8 +1623,9 @@ class P4RuntimeEntriesConverter {
             // earlier.
             // For e.g. 16 bit key has a max value of 65535, Range of (1..65536)
             // will be converted to (1..0) and will fail below check.
-            if (*start > *end)
-                ::error("%s Invalid range for table entry", kr->srcInfo);
+	    if (*start > *end)
+                ::error(ErrorType::ERR_INVALID, "%2% Invalid range for table entry",
+                        k, kr->srcInfo);
             if (*start == 0 && *end == maxValue)  // don't care
                 return;
             startStr = stringReprConstant(*start, keyWidth);

--- a/testdata/p4_16_samples/runtime-index-2-bmv2.p4
+++ b/testdata/p4_16_samples/runtime-index-2-bmv2.p4
@@ -71,14 +71,11 @@ control ingress(inout headers hdr, inout metadata_t meta,
         // similar, but with runtime index as R-value.
         hdr.ethernet.etherType[7:0] = hdr.vector[(hdr.ml.idx2 ^ 8w0x07) & 8w0x7].e;
 
-        // TODO: The line of code below is commented out
-        // because p4c compilation fails.  Another PR will
-        // fix the failure.
-	// Test runtime index with arithmetic expression as index,
+        // Test runtime index with arithmetic expression as index,
         // where that arithmetic expression includes another header
         // stack index with a runtime variable value.
-        // hdr.vector[hdr.vector[hdr.ethernet.dstAddr[39:32] & 0x7].e & 0x7].e =
-        //    hdr.ethernet.dstAddr[47:40];
+        hdr.vector[hdr.vector[hdr.ethernet.dstAddr[39:32] & 0x7].e & 0x7].e =
+            hdr.ethernet.dstAddr[47:40];
     }
 }
 

--- a/testdata/p4_16_samples/runtime-index-2-bmv2.stf
+++ b/testdata/p4_16_samples/runtime-index-2-bmv2.stf
@@ -29,7 +29,7 @@ packet 0 ca0107fc001c111111111111f00d 0805 01234567 89abcdef
 #                                        changed VV
 #        ca0107fc001c111111111111f045 0805 012345ca 89abf7ef
 
-expect 0 ca0107fc001c111111111111f045 0805 01234567 89abf7ef $
+expect 0 ca0107fc001c111111111111f045 0805 012345ca 89abf7ef $
 
 ######################################################################
 
@@ -62,4 +62,4 @@ packet 0 cafa07fc001c111111111111cafe 61b8 01234567 89abcdef
 #                                             changed VV
 #        cafa07fc001c111111111111caef 61b8 01234567 89cacdef
 
-expect 0 cafa07fc001c111111111111caef 61b8 01234567 89d1cdef $
+expect 0 cafA07fc001c111111111111caef 61b8 01234567 89cacdef $

--- a/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-first.p4
@@ -46,6 +46,7 @@ control ingress(inout headers hdr, inout metadata_t meta, inout standard_metadat
     apply {
         hdr.vector[hdr.ml.idx1 - (hdr.ml.idx2 >> 8w1)].e = hdr.ethernet.etherType[15:8] + 8w7;
         hdr.ethernet.etherType[7:0] = hdr.vector[(hdr.ml.idx2 ^ 8w0x7) & 8w0x7].e;
+        hdr.vector[hdr.vector[hdr.ethernet.dstAddr[39:32] & 8w0x7].e & 8w0x7].e = hdr.ethernet.dstAddr[47:40];
     }
 }
 

--- a/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-frontend.p4
@@ -46,6 +46,7 @@ control ingress(inout headers hdr, inout metadata_t meta, inout standard_metadat
     apply {
         hdr.vector[hdr.ml.idx1 - (hdr.ml.idx2 >> 8w1)].e = hdr.ethernet.etherType[15:8] + 8w7;
         hdr.ethernet.etherType[7:0] = hdr.vector[(hdr.ml.idx2 ^ 8w0x7) & 8w0x7].e;
+        hdr.vector[hdr.vector[hdr.ethernet.dstAddr[39:32] & 8w0x7].e & 8w0x7].e = hdr.ethernet.dstAddr[47:40];
     }
 }
 

--- a/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-midend.p4
@@ -46,6 +46,7 @@ control ingress(inout headers hdr, inout metadata_t meta, inout standard_metadat
     @hidden action runtimeindex2bmv2l69() {
         hdr.vector[hdr.ml.idx1 - (hdr.ml.idx2 >> 8w1)].e = hdr.ethernet.etherType[15:8] + 8w7;
         hdr.ethernet.etherType[7:0] = hdr.vector[(hdr.ml.idx2 ^ 8w0x7) & 8w0x7].e;
+        hdr.vector[hdr.vector[hdr.ethernet.dstAddr[39:32] & 8w0x7].e & 8w0x7].e = hdr.ethernet.dstAddr[47:40];
     }
     @hidden table tbl_runtimeindex2bmv2l69 {
         actions = {

--- a/testdata/p4_16_samples_outputs/runtime-index-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-2-bmv2.p4
@@ -46,6 +46,7 @@ control ingress(inout headers hdr, inout metadata_t meta, inout standard_metadat
     apply {
         hdr.vector[hdr.ml.idx1 - (hdr.ml.idx2 >> 8w1)].e = hdr.ethernet.etherType[15:8] + 7;
         hdr.ethernet.etherType[7:0] = hdr.vector[(hdr.ml.idx2 ^ 8w0x7) & 8w0x7].e;
+        hdr.vector[hdr.vector[hdr.ethernet.dstAddr[39:32] & 0x7].e & 0x7].e = hdr.ethernet.dstAddr[47:40];
     }
 }
 


### PR DESCRIPTION
After checkin of https://github.com/p4lang/p4c/commit/b281cddc79de75f048a2f3c663ebce5b732d2c63, this PR enables Slice and runtime index test line of code.

This PR has also changed p4RuntimeSerializer.cpp to use ErrorType so that when the error occurs, the line number of P4 code causing the error is also printed. 

I will file a separate issue against p4RuntimeSerializer.cpp because many of its errors do not print the line of P4 code where the error occurs.  The code should change. 