### PR TITLE
tools-driver: Move shebang on first line

### DIFF
--- a/tools/driver/p4c_src/main.py
+++ b/tools/driver/p4c_src/main.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env python3
 
 """
 p4c - P4 Compiler Driver


### PR DESCRIPTION
A script will be executed using the interpreter specified on the first line.