### PR TITLE
Add function to set left value

### DIFF
--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -84,12 +84,7 @@ const IR::Node* LowerExpressions::postorder(IR::Cast* expression) {
 const IR::Node* LowerExpressions::postorder(IR::Expression* expression) {
     // Just update the typeMap incrementally.
     auto orig = getOriginal<IR::Expression>();
-    auto type = typeMap->getType(orig, true);
-    typeMap->setType(expression, type);
-    if (typeMap->isCompileTimeConstant(orig))
-        typeMap->setCompileTimeConstant(expression);
-    if (typeMap->isLeftValue(orig))
-        typeMap->setLeftValue(expression);
+    typeMap->setLeftValue(expression, orig, typeMap);
     return expression;
 }
 

--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -84,7 +84,7 @@ const IR::Node* LowerExpressions::postorder(IR::Cast* expression) {
 const IR::Node* LowerExpressions::postorder(IR::Expression* expression) {
     // Just update the typeMap incrementally.
     auto orig = getOriginal<IR::Expression>();
-    typeMap->setLeftValue(expression, orig);
+    typeMap->copyIfOrigLeftValue(expression, orig);
     return expression;
 }
 

--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -84,7 +84,7 @@ const IR::Node* LowerExpressions::postorder(IR::Cast* expression) {
 const IR::Node* LowerExpressions::postorder(IR::Expression* expression) {
     // Just update the typeMap incrementally.
     auto orig = getOriginal<IR::Expression>();
-    typeMap->setLeftValue(expression, orig, typeMap);
+    typeMap->setLeftValue(expression, orig);
     return expression;
 }
 

--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -84,7 +84,7 @@ const IR::Node* LowerExpressions::postorder(IR::Cast* expression) {
 const IR::Node* LowerExpressions::postorder(IR::Expression* expression) {
     // Just update the typeMap incrementally.
     auto orig = getOriginal<IR::Expression>();
-    typeMap->copyIfOrigLeftValue(expression, orig);
+    typeMap->cloneExpressionProperties(expression, orig);
     return expression;
 }
 

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -49,7 +49,7 @@ const IR::Expression* DoSimplifyExpressions::addAssignment(
 const IR::Node* DoSimplifyExpressions::postorder(IR::Expression* expression) {
     LOG3("Visiting " << dbp(expression));
     auto orig = getOriginal<IR::Expression>();
-    typeMap->copyIfOrigLeftValue(expression, orig);
+    typeMap->cloneExpressionProperties(expression, orig);
     return expression;
 }
 

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -49,7 +49,7 @@ const IR::Expression* DoSimplifyExpressions::addAssignment(
 const IR::Node* DoSimplifyExpressions::postorder(IR::Expression* expression) {
     LOG3("Visiting " << dbp(expression));
     auto orig = getOriginal<IR::Expression>();
-    typeMap->setLeftValue(expression, orig);
+    typeMap->copyIfOrigLeftValue(expression, orig);
     return expression;
 }
 

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -49,7 +49,7 @@ const IR::Expression* DoSimplifyExpressions::addAssignment(
 const IR::Node* DoSimplifyExpressions::postorder(IR::Expression* expression) {
     LOG3("Visiting " << dbp(expression));
     auto orig = getOriginal<IR::Expression>();
-    typeMap->setLeftValue(expression, orig, typeMap);
+    typeMap->setLeftValue(expression, orig);
     return expression;
 }
 

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -49,12 +49,7 @@ const IR::Expression* DoSimplifyExpressions::addAssignment(
 const IR::Node* DoSimplifyExpressions::postorder(IR::Expression* expression) {
     LOG3("Visiting " << dbp(expression));
     auto orig = getOriginal<IR::Expression>();
-    auto type = typeMap->getType(orig, true);
-    typeMap->setType(expression, type);
-    if (typeMap->isLeftValue(orig))
-        typeMap->setLeftValue(expression);
-    if (typeMap->isCompileTimeConstant(orig))
-        typeMap->setCompileTimeConstant(expression);
+    typeMap->setLeftValue(expression, orig, typeMap);
     return expression;
 }
 

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -50,8 +50,10 @@ bool TypeMap::isCompileTimeConstant(const IR::Expression* expression) const {
     return result;
 }
 
-void TypeMap::setLeftValue(const IR::Expression* expression,
-                           const IR::Expression* orig) {
+// Method sets left value of expression arg if orig arg
+// is a left value.
+void TypeMap::copyIfOrigLeftValue(const IR::Expression* expression,
+                                  const IR::Expression* orig) {
     auto type = getType(orig, true);
     setType(expression, type);
     if (isLeftValue(orig))

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -50,8 +50,7 @@ bool TypeMap::isCompileTimeConstant(const IR::Expression* expression) const {
     return result;
 }
 
-// Method sets left value of expression arg if orig arg
-// is a left value.
+// Method copies properties from expression to "to" expression.
 void TypeMap::cloneExpressionProperties(const IR::Expression* to,
                                         const IR::Expression* from) {
     auto type = getType(from, true);

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -50,6 +50,16 @@ bool TypeMap::isCompileTimeConstant(const IR::Expression* expression) const {
     return result;
 }
 
+void TypeMap::setLeftValue(const IR::Expression* expression,
+                           const IR::Expression* orig, TypeMap* tm) {
+    auto type = tm->getType(orig, true);
+    tm->setType(expression, type);
+    if (tm->isLeftValue(orig))
+        tm->setLeftValue(expression);
+    if (tm->isCompileTimeConstant(orig))
+        tm->setCompileTimeConstant(expression);
+}
+
 void TypeMap::clear() {
     LOG3("Clearing typeMap");
     typeMap.clear(); leftValues.clear(); constants.clear(); allTypeVariables.clear();

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -51,13 +51,13 @@ bool TypeMap::isCompileTimeConstant(const IR::Expression* expression) const {
 }
 
 void TypeMap::setLeftValue(const IR::Expression* expression,
-                           const IR::Expression* orig, TypeMap* tm) {
-    auto type = tm->getType(orig, true);
-    tm->setType(expression, type);
-    if (tm->isLeftValue(orig))
-        tm->setLeftValue(expression);
-    if (tm->isCompileTimeConstant(orig))
-        tm->setCompileTimeConstant(expression);
+                           const IR::Expression* orig) {
+    auto type = getType(orig, true);
+    setType(expression, type);
+    if (isLeftValue(orig))
+        setLeftValue(expression);
+    if (isCompileTimeConstant(orig))
+        setCompileTimeConstant(expression);
 }
 
 void TypeMap::clear() {

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -52,14 +52,14 @@ bool TypeMap::isCompileTimeConstant(const IR::Expression* expression) const {
 
 // Method sets left value of expression arg if orig arg
 // is a left value.
-void TypeMap::copyIfOrigLeftValue(const IR::Expression* expression,
-                                  const IR::Expression* orig) {
-    auto type = getType(orig, true);
-    setType(expression, type);
-    if (isLeftValue(orig))
-        setLeftValue(expression);
-    if (isCompileTimeConstant(orig))
-        setCompileTimeConstant(expression);
+void TypeMap::cloneExpressionProperties(const IR::Expression* to,
+                                        const IR::Expression* from) {
+    auto type = getType(from, true);
+    setType(to, type);
+    if (isLeftValue(from))
+        setLeftValue(to);
+    if (isCompileTimeConstant(from))
+        setCompileTimeConstant(to);
 }
 
 void TypeMap::clear() {

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -77,8 +77,8 @@ class TypeMap final : public ProgramMap {
     { return typeMap.size(); }
 
     void setLeftValue(const IR::Expression* expression);
-    void setLeftValue(const IR::Expression* expression,
-                      const IR::Expression* orig);
+    void copyIfOrigLeftValue(const IR::Expression* expression,
+                             const IR::Expression* orig);
     void setCompileTimeConstant(const IR::Expression* expression);
     void addSubstitutions(const TypeVariableSubstitution* tvs);
     const IR::Type* getSubstitution(const IR::Type_Var* var)

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -78,7 +78,7 @@ class TypeMap final : public ProgramMap {
 
     void setLeftValue(const IR::Expression* expression);
     void setLeftValue(const IR::Expression* expression,
-                      const IR::Expression* orig, TypeMap* tm);
+                      const IR::Expression* orig);
     void setCompileTimeConstant(const IR::Expression* expression);
     void addSubstitutions(const TypeVariableSubstitution* tvs);
     const IR::Type* getSubstitution(const IR::Type_Var* var)

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -77,8 +77,8 @@ class TypeMap final : public ProgramMap {
     { return typeMap.size(); }
 
     void setLeftValue(const IR::Expression* expression);
-    void copyIfOrigLeftValue(const IR::Expression* expression,
-                             const IR::Expression* orig);
+    void cloneExpressionProperties(const IR::Expression* to,
+                                   const IR::Expression* from);
     void setCompileTimeConstant(const IR::Expression* expression);
     void addSubstitutions(const TypeVariableSubstitution* tvs);
     const IR::Type* getSubstitution(const IR::Type_Var* var)

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -77,6 +77,8 @@ class TypeMap final : public ProgramMap {
     { return typeMap.size(); }
 
     void setLeftValue(const IR::Expression* expression);
+    void setLeftValue(const IR::Expression* expression,
+                      const IR::Expression* orig, TypeMap* tm);
     void setCompileTimeConstant(const IR::Expression* expression);
     void addSubstitutions(const TypeVariableSubstitution* tvs);
     const IR::Type* getSubstitution(const IR::Type_Var* var)


### PR DESCRIPTION
Production quality software does not duplicate code.  This PR defines a new function for use by two passes to set left value.