### PR TITLE
One more strength reduction

### DIFF
--- a/frontends/p4/strengthReduction.cpp
+++ b/frontends/p4/strengthReduction.cpp
@@ -188,12 +188,22 @@ const IR::Node* DoStrengthReduction::postorder(IR::Add* expr) {
 const IR::Node* DoStrengthReduction::postorder(IR::Shl* expr) {
     if (isZero(expr->right) || isZero(expr->left))
         return expr->left;
+    if (auto sh2 = expr->left->to<IR::Shl>()) {
+        // (a << b) << c is a << (b + c)
+        return new IR::Shl(expr->srcInfo, sh2->left,
+                           new IR::Add(expr->srcInfo, sh2->right, expr->right));
+    }
     return expr;
 }
 
 const IR::Node* DoStrengthReduction::postorder(IR::Shr* expr) {
     if (isZero(expr->right) || isZero(expr->left))
         return expr->left;
+    if (auto sh2 = expr->left->to<IR::Shr>()) {
+        // (a >> b) >> c is a >> (b + c)
+        return new IR::Shr(expr->srcInfo, sh2->left,
+                           new IR::Add(expr->srcInfo, sh2->right, expr->right));
+    }
     return expr;
 }
 

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
@@ -39,7 +39,7 @@ header ipv4_t {
     bit<16>     hdrChecksum;
     bit<32>     srcAddr;
     bit<32>     dstAddr;
-    @length(((bit<32>)ihl << 2 << 3) + 32w4294967136) 
+    @length(((bit<32>)ihl << 5) + 32w4294967136) 
     varbit<352> options;
 }
 
@@ -90,7 +90,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         tmp_hdr_0.hdrChecksum = tmp[79:64];
         tmp_hdr_0.srcAddr = tmp[63:32];
         tmp_hdr_0.dstAddr = tmp[31:0];
-        packet.extract<ipv4_t>(hdr.ipv4, ((bit<32>)tmp[155:152] << 2 << 3) + 32w4294967136);
+        packet.extract<ipv4_t>(hdr.ipv4, ((bit<32>)tmp[155:152] << 5) + 32w4294967136);
         transition accept;
     }
     @name(".parse_vlan_tag") state parse_vlan_tag {

--- a/testdata/p4_14_samples_outputs/issue576-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue576-midend.p4
@@ -29,7 +29,7 @@ header ipv4_t {
     bit<16>     hdrChecksum;
     bit<32>     srcAddr;
     bit<32>     dstAddr;
-    @length(((bit<32>)ihl << 2 << 3) + 32w4294967136) 
+    @length(((bit<32>)ihl << 5) + 32w4294967136) 
     varbit<320> options_ipv4;
 }
 
@@ -80,7 +80,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         tmp_hdr_1.hdrChecksum = tmp[79:64];
         tmp_hdr_1.srcAddr = tmp[63:32];
         tmp_hdr_1.dstAddr = tmp[31:0];
-        packet.extract<ipv4_t>(hdr.h.next, ((bit<32>)tmp[155:152] << 2 << 3) + 32w4294967136);
+        packet.extract<ipv4_t>(hdr.h.next, ((bit<32>)tmp[155:152] << 5) + 32w4294967136);
         tmp_0 = packet.lookahead<bit<160>>();
         tmp_hdr_2.setValid();
         tmp_hdr_2.version = tmp_0[159:156];
@@ -95,7 +95,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         tmp_hdr_2.hdrChecksum = tmp_0[79:64];
         tmp_hdr_2.srcAddr = tmp_0[63:32];
         tmp_hdr_2.dstAddr = tmp_0[31:0];
-        packet.extract<ipv4_t>(hdr.h.next, ((bit<32>)tmp_0[155:152] << 2 << 3) + 32w4294967136);
+        packet.extract<ipv4_t>(hdr.h.next, ((bit<32>)tmp_0[155:152] << 5) + 32w4294967136);
         transition accept;
     }
 }

--- a/testdata/p4_14_samples_outputs/issue781-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue781-midend.p4
@@ -29,7 +29,7 @@ header ipv4_t {
     bit<16>     hdrChecksum;
     bit<32>     srcAddr;
     bit<32>     dstAddr;
-    @length(((bit<32>)ihl << 2 << 3) + 32w4294967136) 
+    @length(((bit<32>)ihl << 5) + 32w4294967136) 
     varbit<320> options_ipv4;
 }
 
@@ -59,7 +59,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         tmp_hdr_0.hdrChecksum = tmp[79:64];
         tmp_hdr_0.srcAddr = tmp[63:32];
         tmp_hdr_0.dstAddr = tmp[31:0];
-        packet.extract<ipv4_t>(hdr.h, ((bit<32>)tmp[155:152] << 2 << 3) + 32w4294967136);
+        packet.extract<ipv4_t>(hdr.h, ((bit<32>)tmp[155:152] << 5) + 32w4294967136);
         transition accept;
     }
 }

--- a/testdata/p4_16_samples/strength5.p4
+++ b/testdata/p4_16_samples/strength5.p4
@@ -1,0 +1,3 @@
+action a(inout bit<32> x) {
+    x = x >> 3 >> 8;
+}

--- a/testdata/p4_16_samples_outputs/precedence-first.p4
+++ b/testdata/p4_16_samples_outputs/precedence-first.p4
@@ -69,7 +69,7 @@ action ac() {
     e = a < b == e;
     e = e == a < b;
     e = a < b == e;
-    a = a << b << c;
+    a = a << b + c;
     a = a << (b << c);
     a = a << b >> c;
     a = a << (b >> c);

--- a/testdata/p4_16_samples_outputs/strength5-first.p4
+++ b/testdata/p4_16_samples_outputs/strength5-first.p4
@@ -1,0 +1,3 @@
+action a(inout bit<32> x) {
+    x = x >> 3 + 8;
+}

--- a/testdata/p4_16_samples_outputs/strength5.p4
+++ b/testdata/p4_16_samples_outputs/strength5.p4
@@ -1,0 +1,3 @@
+action a(inout bit<32> x) {
+    x = x >> 3 >> 8;
+}

--- a/testdata/p4_16_samples_outputs/strength5.p4-stderr
+++ b/testdata/p4_16_samples_outputs/strength5.p4-stderr
@@ -1,0 +1,1 @@
+warning: Program does not contain a `main' module


### PR DESCRIPTION
This is inspired by the recent bug of shr.
Perhaps we should do this only if both shift amounts are constants?