### PR TITLE
Add match_kind optional to v1model.p4 and bmv2 back end

### DIFF
--- a/backends/bmv2/common/helpers.cpp
+++ b/backends/bmv2/common/helpers.cpp
@@ -23,6 +23,7 @@ const cstring TableImplementation::actionProfileName = "action_profile";
 const cstring TableImplementation::actionSelectorName = "action_selector";
 const cstring MatchImplementation::selectorMatchTypeName = "selector";
 const cstring MatchImplementation::rangeMatchTypeName = "range";
+const cstring MatchImplementation::optionalMatchTypeName = "optional";
 const unsigned TableAttributes::defaultTableSize = 1024;
 const cstring V1ModelProperties::jsonMetadataParameterName = "standard_metadata";
 const cstring V1ModelProperties::validField = "$valid$";

--- a/backends/bmv2/common/helpers.h
+++ b/backends/bmv2/common/helpers.h
@@ -48,6 +48,7 @@ class MatchImplementation {
  public:
     static const cstring selectorMatchTypeName;
     static const cstring rangeMatchTypeName;
+    static const cstring optionalMatchTypeName;
 };
 
 class TableAttributes {

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -255,7 +255,8 @@ class V1Model : public ::Model::Model {
             ingress("ingress", headersType, metadataType, standardMetadataType),
             sw(), counterOrMeter("$"), counter(), meter(), random(), action_profile(),
             action_selector(), clone(), resubmit("resubmit"),
-            tableAttributes(), rangeMatchType("range"), selectorMatchType("selector"),
+            tableAttributes(), rangeMatchType("range"),
+                optionalMatchType("optional"), selectorMatchType("selector"),
             verify("verifyChecksum", headersType), compute("computeChecksum", headersType),
             digest_receiver(), hash(), algorithm(),
             registers(), drop("mark_to_drop"),
@@ -291,6 +292,7 @@ class V1Model : public ::Model::Model {
     ::Model::Elem       resubmit;
     TableAttributes_Model tableAttributes;
     ::Model::Elem       rangeMatchType;
+    ::Model::Elem       optionalMatchType;
     ::Model::Elem       selectorMatchType;
     VerifyUpdate_Model  verify;
     VerifyUpdate_Model  compute;

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -53,6 +53,8 @@ limitations under the License.
 
 match_kind {
     range,
+    // Either an exact match, or a wildcard (matching any value).
+    optional,
     // Used for implementing dynamic_action_selection
     selector
 }

--- a/testdata/p4_16_errors/table-entries-optional-2-bmv2.p4
+++ b/testdata/p4_16_errors/table-entries-optional-2-bmv2.p4
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8> r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+struct Meta_t {}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+
+    action a() { standard_meta.egress_spec = 0; }
+    action a_with_control_params(bit<9> x) { standard_meta.egress_spec = x; }
+
+
+    table t_optional {
+
+  	key = {
+            h.h.e : optional;
+            h.h.t : optional;
+        }
+
+	actions = {
+            a;
+            a_with_control_params;
+        }
+
+	default_action = a;
+
+        const entries = {
+            // Test that p4c gives error if one attempts to use an
+            // explicit mask for an optional field at all.  Only
+            // support an exact value without a mask, or _ / default.
+            (0xaa &&& 0xff, 0x1111 &&& 0xffff) : a_with_control_params(1);
+            // value too large
+            (0x100, default): a_with_control_params(2);
+            // other value too large
+            (default, 0x10000): a_with_control_params(3);
+        }
+    }
+
+    apply {
+        t_optional.apply();
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_errors_outputs/issue1541.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1541.p4-stderr
@@ -1,7 +1,7 @@
 issue1541.p4(25): [--Wwarn=shadow] warning: hash shadows hash
     action hash() {
            ^^^^
-v1model.p4(399)
+v1model.p4(401)
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
             ^^^^
 issue1541.p4(26): [--Werror=type-error] error: hash: Recursive action call

--- a/testdata/p4_16_errors_outputs/issue1557-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1557-bmv2.p4-stderr
@@ -1,7 +1,7 @@
 issue1557-bmv2.p4(17): [--Werror=type-error] error: Field drop is not a member of structure struct standard_metadata
     action drop() { smeta.drop = 1; }
                           ^^^^
-v1model.p4(61)
+v1model.p4(63)
 struct standard_metadata_t {
        ^^^^^^^^^^^^^^^^^^^
 issue1557-bmv2.p4(19): [--Werror=type-error] error: idx: parameter should be assigned in call rewrite

--- a/testdata/p4_16_errors_outputs/issue513.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue513.p4-stderr
@@ -1,7 +1,7 @@
 issue513.p4(60): [--Wwarn=deprecated] warning: mark_to_drop: Using deprecated feature mark_to_drop. Please use mark_to_drop(standard_metadata) instead.
             mark_to_drop();
             ^^^^^^^^^^^^
-v1model.p4(363)
+v1model.p4(365)
 extern void mark_to_drop();
             ^^^^^^^^^^^^
 issue513.p4(60): [--Werror=target-error] error: MethodCallStatement: Unsupported on target Conditional execution in actions

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-first.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-first.p4
@@ -1,0 +1,80 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    table t_optional {
+        key = {
+            h.h.e: optional @name("h.h.e") ;
+            h.h.t: optional @name("h.h.t") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        default_action = a();
+        const entries = {
+                        (8w0xaa &&& 8w0xff, 16w0x1111 &&& 16w0xffff) : a_with_control_params(9w1);
+
+                        (8w0x0, default) : a_with_control_params(9w2);
+
+                        (default, 16w0x0) : a_with_control_params(9w3);
+
+        }
+
+    }
+    apply {
+        t_optional.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-frontend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-frontend.p4
@@ -1,0 +1,80 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    @name("ingress.a") action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    @name("ingress.t_optional") table t_optional_0 {
+        key = {
+            h.h.e: optional @name("h.h.e") ;
+            h.h.t: optional @name("h.h.t") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        default_action = a();
+        const entries = {
+                        (8w0xaa &&& 8w0xff, 16w0x1111 &&& 16w0xffff) : a_with_control_params(9w1);
+
+                        (8w0x0, default) : a_with_control_params(9w2);
+
+                        (default, 16w0x0) : a_with_control_params(9w3);
+
+        }
+
+    }
+    apply {
+        t_optional_0.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-midend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-midend.p4
@@ -1,0 +1,80 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    @name("ingress.a") action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    @name("ingress.t_optional") table t_optional_0 {
+        key = {
+            h.h.e: optional @name("h.h.e") ;
+            h.h.t: optional @name("h.h.t") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        default_action = a();
+        const entries = {
+                        (8w0xaa &&& 8w0xff, 16w0x1111 &&& 16w0xffff) : a_with_control_params(9w1);
+
+                        (8w0x0, default) : a_with_control_params(9w2);
+
+                        (default, 16w0x0) : a_with_control_params(9w3);
+
+        }
+
+    }
+    apply {
+        t_optional_0.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4
@@ -1,0 +1,80 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    action a() {
+        standard_meta.egress_spec = 0;
+    }
+    action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    table t_optional {
+        key = {
+            h.h.e: optional;
+            h.h.t: optional;
+        }
+        actions = {
+            a;
+            a_with_control_params;
+        }
+        default_action = a;
+        const entries = {
+                        (0xaa &&& 0xff, 0x1111 &&& 0xffff) : a_with_control_params(1);
+
+                        (0x100, default) : a_with_control_params(2);
+
+                        (default, 0x10000) : a_with_control_params(3);
+
+        }
+
+    }
+    apply {
+        t_optional.apply();
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4-stderr
@@ -1,0 +1,12 @@
+table-entries-optional-2-bmv2.p4(71): [--Wwarn=mismatch] warning: 0x100: value does not fit in 8 bits
+            (0x100, default): a_with_control_params(2);
+             ^^^^^
+table-entries-optional-2-bmv2.p4(73): [--Wwarn=mismatch] warning: 0x10000: value does not fit in 16 bits
+            (default, 0x10000): a_with_control_params(3);
+                      ^^^^^^^
+table-entries-optional-2-bmv2.p4(69): [--Werror=legacy] error: &&& invalid key expression
+            (0xaa &&& 0xff, 0x1111 &&& 0xffff) : a_with_control_params(1);
+             ^^^^^^^^^^^^^
+table-entries-optional-2-bmv2.p4(69): [--Werror=legacy] error: &&& invalid key expression
+            (0xaa &&& 0xff, 0x1111 &&& 0xffff) : a_with_control_params(1);
+                            ^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.entries.txt
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.entries.txt
@@ -1,0 +1,76 @@
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33609018
+      match {
+        field_id: 1
+        optional {
+        }
+      }
+      match {
+        field_id: 2
+        optional {
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\001"
+          }
+        }
+      }
+      priority: 3
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33609018
+      match {
+        field_id: 1
+        optional {
+          value: "\000"
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\002"
+          }
+        }
+      }
+      priority: 2
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33609018
+      match {
+        field_id: 2
+        optional {
+          value: "\000\000"
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\003"
+          }
+        }
+      }
+      priority: 1
+    }
+  }
+}

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.p4info.txt
@@ -1,0 +1,49 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 33609018
+    name: "ingress.t_optional"
+    alias: "t_optional"
+  }
+  match_fields {
+    id: 1
+    name: "h.h.e"
+    bitwidth: 8
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 2
+    name: "h.h.t"
+    bitwidth: 16
+    match_type: OPTIONAL
+  }
+  action_refs {
+    id: 16795253
+  }
+  action_refs {
+    id: 16837978
+  }
+  size: 1024
+  is_const_table: true
+}
+actions {
+  preamble {
+    id: 16795253
+    name: "ingress.a"
+    alias: "a"
+  }
+}
+actions {
+  preamble {
+    id: 16837978
+    name: "ingress.a_with_control_params"
+    alias: "a_with_control_params"
+  }
+  params {
+    id: 1
+    name: "x"
+    bitwidth: 9
+  }
+}

--- a/testdata/p4_16_samples/table-entries-optional-bmv2.p4
+++ b/testdata/p4_16_samples/table-entries-optional-bmv2.p4
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8> r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+struct Meta_t {}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) { apply {} }
+control update(inout Header_t h, inout Meta_t m) { apply {} }
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) { apply {} }
+control deparser(packet_out b, in Header_t h) { apply { b.emit(h.h); } }
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+
+    action a() { standard_meta.egress_spec = 0; }
+    action a_with_control_params(bit<9> x) { standard_meta.egress_spec = x; }
+
+
+    table t_optional {
+
+  	key = {
+            h.h.e : optional;
+            h.h.t : optional;
+        }
+
+	actions = {
+            a;
+            a_with_control_params;
+        }
+
+	default_action = a;
+
+        const entries = {
+            (0xaa, 0x1111) : a_with_control_params(1);
+            (   _, 0x1111) : a_with_control_params(2);
+            (0xaa,      _) : a_with_control_params(3);
+            // test default entries
+            (   _,      _) : a_with_control_params(4);
+        }
+    }
+
+    apply {
+        t_optional.apply();
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples/table-entries-optional-bmv2.stf
+++ b/testdata/p4_16_samples/table-entries-optional-bmv2.stf
@@ -1,0 +1,15 @@
+# header hdr { bit<8>  e; bit<16> t; bit<8>  l; bit<8> r; bit<1>  v; }
+
+# t_optional tests: if packets come on port 0, we missed!
+
+expect 1 aa **** ** ** ** $
+packet 0 aa 1111 00 00 b0
+
+expect 2 ab **** ** ** ** $
+packet 0 ab 1111 00 00 b0
+
+expect 3 aa **** ** ** ** $
+packet 0 aa 1112 00 00 b0
+
+expect 4 a9 **** ** ** ** $
+packet 0 a9 1110 00 00 b0

--- a/testdata/p4_16_samples_outputs/issue841.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue841.p4-stderr
@@ -1,6 +1,6 @@
 issue841.p4(39): [--Wwarn=deprecated] warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
     Checksum16() checksum;
     ^^^^^^^^^^
-v1model.p4(411)
+v1model.p4(413)
 extern Checksum16 {
        ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-first.p4
@@ -1,0 +1,82 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    table t_optional {
+        key = {
+            h.h.e: optional @name("h.h.e") ;
+            h.h.t: optional @name("h.h.t") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        default_action = a();
+        const entries = {
+                        (8w0xaa, 16w0x1111) : a_with_control_params(9w1);
+
+                        (default, 16w0x1111) : a_with_control_params(9w2);
+
+                        (8w0xaa, default) : a_with_control_params(9w3);
+
+                        (default, default) : a_with_control_params(9w4);
+
+        }
+
+    }
+    apply {
+        t_optional.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-frontend.p4
@@ -1,0 +1,82 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    @name("ingress.a") action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    @name("ingress.t_optional") table t_optional_0 {
+        key = {
+            h.h.e: optional @name("h.h.e") ;
+            h.h.t: optional @name("h.h.t") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        default_action = a();
+        const entries = {
+                        (8w0xaa, 16w0x1111) : a_with_control_params(9w1);
+
+                        (default, 16w0x1111) : a_with_control_params(9w2);
+
+                        (8w0xaa, default) : a_with_control_params(9w3);
+
+                        (default, default) : a_with_control_params(9w4);
+
+        }
+
+    }
+    apply {
+        t_optional_0.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-midend.p4
@@ -1,0 +1,82 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    @name("ingress.a") action a() {
+        standard_meta.egress_spec = 9w0;
+    }
+    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    @name("ingress.t_optional") table t_optional_0 {
+        key = {
+            h.h.e: optional @name("h.h.e") ;
+            h.h.t: optional @name("h.h.t") ;
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        default_action = a();
+        const entries = {
+                        (8w0xaa, 16w0x1111) : a_with_control_params(9w1);
+
+                        (default, 16w0x1111) : a_with_control_params(9w2);
+
+                        (8w0xaa, default) : a_with_control_params(9w3);
+
+                        (default, default) : a_with_control_params(9w4);
+
+        }
+
+    }
+    apply {
+        t_optional_0.apply();
+    }
+}
+
+V1Switch<Header_t, Meta_t>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4
@@ -1,0 +1,82 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control update(inout Header_t h, inout Meta_t m) {
+    apply {
+    }
+}
+
+control egress(inout Header_t h, inout Meta_t m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Header_t h) {
+    apply {
+        b.emit(h.h);
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
+    action a() {
+        standard_meta.egress_spec = 0;
+    }
+    action a_with_control_params(bit<9> x) {
+        standard_meta.egress_spec = x;
+    }
+    table t_optional {
+        key = {
+            h.h.e: optional;
+            h.h.t: optional;
+        }
+        actions = {
+            a;
+            a_with_control_params;
+        }
+        default_action = a;
+        const entries = {
+                        (0xaa, 0x1111) : a_with_control_params(1);
+
+                        (default, 0x1111) : a_with_control_params(2);
+
+                        (0xaa, default) : a_with_control_params(3);
+
+                        (default, default) : a_with_control_params(4);
+
+        }
+
+    }
+    apply {
+        t_optional.apply();
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.entries.txt
@@ -1,0 +1,96 @@
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33609018
+      match {
+        field_id: 1
+        optional {
+          value: "\252"
+        }
+      }
+      match {
+        field_id: 2
+        optional {
+          value: "\021\021"
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\001"
+          }
+        }
+      }
+      priority: 4
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33609018
+      match {
+        field_id: 2
+        optional {
+          value: "\021\021"
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\002"
+          }
+        }
+      }
+      priority: 3
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33609018
+      match {
+        field_id: 1
+        optional {
+          value: "\252"
+        }
+      }
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\003"
+          }
+        }
+      }
+      priority: 2
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33609018
+      action {
+        action {
+          action_id: 16837978
+          params {
+            param_id: 1
+            value: "\000\004"
+          }
+        }
+      }
+      priority: 1
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.p4info.txt
@@ -1,0 +1,49 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 33609018
+    name: "ingress.t_optional"
+    alias: "t_optional"
+  }
+  match_fields {
+    id: 1
+    name: "h.h.e"
+    bitwidth: 8
+    match_type: OPTIONAL
+  }
+  match_fields {
+    id: 2
+    name: "h.h.t"
+    bitwidth: 16
+    match_type: OPTIONAL
+  }
+  action_refs {
+    id: 16795253
+  }
+  action_refs {
+    id: 16837978
+  }
+  size: 1024
+  is_const_table: true
+}
+actions {
+  preamble {
+    id: 16795253
+    name: "ingress.a"
+    alias: "a"
+  }
+}
+actions {
+  preamble {
+    id: 16837978
+    name: "ingress.a_with_control_params"
+    alias: "a_with_control_params"
+  }
+  params {
+    id: 1
+    name: "x"
+    bitwidth: 9
+  }
+}


### PR DESCRIPTION
In consultation with Antonin Bas on how best to implement this in
behavioral-model code, we decided to implement optional in table keys
in the P4_16 source code, by representing them exactly the same in the
BMv2 JSON file as ternary keys are.

The P4Info file generated does use the new OPTIONAL key type, as it
should, so that software using that file knows the difference between
ternary and optional keys in the source code.