### PR TITLE
Add pvs size to bmv2 JSON

### DIFF
--- a/backends/bmv2/common/JsonObjects.cpp
+++ b/backends/bmv2/common/JsonObjects.cpp
@@ -386,7 +386,7 @@ JsonObjects::add_parser_transition_key(const unsigned state_id, Util::IJson* new
 
 void
 JsonObjects::add_parse_vset(const cstring& name, const unsigned bitwidth,
-                            const big_int size) {
+                            const big_int& size) {
     auto parse_vset = new Util::JsonObject();
     unsigned id = BMV2::nextId("parse_vsets");
     parse_vset->emplace("name", name);

--- a/backends/bmv2/common/JsonObjects.cpp
+++ b/backends/bmv2/common/JsonObjects.cpp
@@ -385,14 +385,14 @@ JsonObjects::add_parser_transition_key(const unsigned state_id, Util::IJson* new
 }
 
 void
-JsonObjects::add_parse_vset(const cstring& name, const unsigned& size,
-                            const big_int& n) {
+JsonObjects::add_parse_vset(const cstring& name, const unsigned bitwidth,
+                            const big_int size) {
     auto parse_vset = new Util::JsonObject();
     unsigned id = BMV2::nextId("parse_vsets");
     parse_vset->emplace("name", name);
     parse_vset->emplace("id", id);
-    parse_vset->emplace("compressed_bitwidth", size);
-    parse_vset->emplace("size", n);
+    parse_vset->emplace("compressed_bitwidth", bitwidth);
+    parse_vset->emplace("size", size);
     parse_vsets->append(parse_vset);
 }
 

--- a/backends/bmv2/common/JsonObjects.cpp
+++ b/backends/bmv2/common/JsonObjects.cpp
@@ -385,12 +385,14 @@ JsonObjects::add_parser_transition_key(const unsigned state_id, Util::IJson* new
 }
 
 void
-JsonObjects::add_parse_vset(const cstring& name, const unsigned size) {
+JsonObjects::add_parse_vset(const cstring& name, const unsigned& size,
+                            const big_int& n) {
     auto parse_vset = new Util::JsonObject();
     unsigned id = BMV2::nextId("parse_vsets");
     parse_vset->emplace("name", name);
     parse_vset->emplace("id", id);
     parse_vset->emplace("compressed_bitwidth", size);
+    parse_vset->emplace("size", n);
     parse_vsets->append(parse_vset);
 }
 

--- a/backends/bmv2/common/JsonObjects.h
+++ b/backends/bmv2/common/JsonObjects.h
@@ -50,7 +50,7 @@ class JsonObjects {
     void add_parser_op(const unsigned id, Util::IJson* op);
     void add_parser_transition_key(const unsigned id, Util::IJson* key);
     void add_parse_vset(const cstring& name, const unsigned bitwidth,
-                        const big_int size);
+                        const big_int& size);
     unsigned add_action(const cstring& name, Util::JsonArray*& params, Util::JsonArray*& body);
     void add_pipeline();
     void add_extern_attribute(const cstring& name, const cstring& type,

--- a/backends/bmv2/common/JsonObjects.h
+++ b/backends/bmv2/common/JsonObjects.h
@@ -49,7 +49,7 @@ class JsonObjects {
     void add_parser_transition(const unsigned id, Util::IJson* transition);
     void add_parser_op(const unsigned id, Util::IJson* op);
     void add_parser_transition_key(const unsigned id, Util::IJson* key);
-    void add_parse_vset(const cstring& name, const unsigned size);
+    void add_parse_vset(const cstring& name, const unsigned& size, const big_int& n);
     unsigned add_action(const cstring& name, Util::JsonArray*& params, Util::JsonArray*& body);
     void add_pipeline();
     void add_extern_attribute(const cstring& name, const cstring& type,

--- a/backends/bmv2/common/JsonObjects.h
+++ b/backends/bmv2/common/JsonObjects.h
@@ -49,7 +49,8 @@ class JsonObjects {
     void add_parser_transition(const unsigned id, Util::IJson* transition);
     void add_parser_op(const unsigned id, Util::IJson* op);
     void add_parser_transition_key(const unsigned id, Util::IJson* key);
-    void add_parse_vset(const cstring& name, const unsigned& size, const big_int& n);
+    void add_parse_vset(const cstring& name, const unsigned bitwidth,
+                        const big_int size);
     unsigned add_action(const cstring& name, Util::JsonArray*& params, Util::JsonArray*& body);
     void add_pipeline();
     void add_extern_attribute(const cstring& name, const cstring& type,

--- a/backends/bmv2/common/parser.cpp
+++ b/backends/bmv2/common/parser.cpp
@@ -445,7 +445,9 @@ bool ParserConverter::preorder(const IR::P4Parser* parser) {
         if (auto inst = s->to<IR::P4ValueSet>()) {
             auto bitwidth = inst->elementType->width_bits();
             auto name = inst->controlPlaneName();
-            ctxt->json->add_parse_vset(name, bitwidth);
+            auto size = inst->size;
+            auto n = size->to<IR::Constant>()->value;
+            ctxt->json->add_parse_vset(name, bitwidth, n);
         }
     }
 

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -344,7 +344,7 @@ class P4Table : Declaration, IAnnotated, IApply {
 class P4ValueSet : Declaration, IAnnotated {
     optional Annotations        annotations = Annotations::empty;
     Type                        elementType;
-    Expression                  size;
+    Expression                  size; // number of elements in set.
     Annotations getAnnotations() const override { return annotations; }
 }
 


### PR DESCRIPTION
Please see this issue against behavioral model where is it asked that p4c support pvs size in bvm2 JSON.

https://github.com/p4lang/behavioral-model/issues/856
