### PR TITLE
Remove unused function declaration in bmv2 backend

### DIFF
--- a/backends/bmv2/common/JsonObjects.h
+++ b/backends/bmv2/common/JsonObjects.h
@@ -51,7 +51,6 @@ class JsonObjects {
     void add_parser_transition_key(const unsigned id, Util::IJson* key);
     void add_parse_vset(const cstring& name, const unsigned size);
     unsigned add_action(const cstring& name, Util::JsonArray*& params, Util::JsonArray*& body);
-    void add_pipeline();
     void add_extern_attribute(const cstring& name, const cstring& type,
                               const cstring& value, Util::JsonArray* attributes);
     void add_extern(const cstring& name, const cstring& type, Util::JsonArray* attributes);


### PR DESCRIPTION
A very minor change but I noticed while reviewing code that there was a
declaration for a function that was neither defined nor called.