### PR TITLE
Add detection of p4-14 pvs

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -483,7 +483,8 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                     sizeConstant = new IR::Constant(4);
                 }
                 auto annos = addGlobalNameAnnotation(value_set->name, value_set->annotations);
-                auto decl = new IR::P4ValueSet(value_set->name, annos, type, sizeConstant, true);
+                auto decl = new IR::P4ValueSet(value_set->name, annos, type,
+                                               sizeConstant, true, v.second);
                 stateful->push_back(decl);
             }
             for (auto v : c->values) {

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -483,7 +483,7 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                     sizeConstant = new IR::Constant(4);
                 }
                 auto annos = addGlobalNameAnnotation(value_set->name, value_set->annotations);
-                auto decl = new IR::P4ValueSet(value_set->name, annos, type, sizeConstant);
+                auto decl = new IR::P4ValueSet(value_set->name, annos, type, sizeConstant, true);
                 stateful->push_back(decl);
             }
             for (auto v : c->values) {

--- a/frontends/p4/inlining.cpp
+++ b/frontends/p4/inlining.cpp
@@ -258,7 +258,7 @@ class Substitutions : public SubstituteParameters {
         LOG3("Renaming " << dbp(orig) << " to " << newName << "(" << extName << ")");
         auto annos = setNameAnnotation(extName, set->annotations);
         auto result = new IR::P4ValueSet(set->srcInfo, newName, annos,
-                                         set->elementType, set->size);
+                                         set->elementType, set->size, set->wasP414);
         return result;
     }
     const IR::Node* postorder(IR::P4Action* action) override {

--- a/frontends/p4/inlining.cpp
+++ b/frontends/p4/inlining.cpp
@@ -258,7 +258,8 @@ class Substitutions : public SubstituteParameters {
         LOG3("Renaming " << dbp(orig) << " to " << newName << "(" << extName << ")");
         auto annos = setNameAnnotation(extName, set->annotations);
         auto result = new IR::P4ValueSet(set->srcInfo, newName, annos,
-                                         set->elementType, set->size, set->wasP414);
+                                         set->elementType, set->size, set->wasV1,
+                                         set->maskV1);
         return result;
     }
     const IR::Node* postorder(IR::P4Action* action) override {

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -779,13 +779,13 @@ simpleKeysetExpression
 valueSetDeclaration
     : optAnnotations
         VALUESET "<" baseType r_angle "(" expression ")" name ";"
-        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7, false); }
+        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7, false, $7); }
     | optAnnotations
         VALUESET "<" tupleType r_angle "(" expression ")" name ";"
-        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7, false); }
+        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7, false, $7); }
     | optAnnotations
         VALUESET "<" typeName r_angle "(" expression ")" name ";"
-        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7, false); }
+        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7, false, $7); }
     ;
 
 /*************************** CONTROL ************************/

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -779,13 +779,13 @@ simpleKeysetExpression
 valueSetDeclaration
     : optAnnotations
         VALUESET "<" baseType r_angle "(" expression ")" name ";"
-        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
+        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7, false); }
     | optAnnotations
         VALUESET "<" tupleType r_angle "(" expression ")" name ";"
-        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
+        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7, false); }
     | optAnnotations
         VALUESET "<" typeName r_angle "(" expression ")" name ";"
-        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
+        { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7, false); }
     ;
 
 /*************************** CONTROL ************************/

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -344,7 +344,8 @@ class P4Table : Declaration, IAnnotated, IApply {
 class P4ValueSet : Declaration, IAnnotated {
     optional Annotations        annotations = Annotations::empty;
     Type                        elementType;
-    Expression                  size; // number of elements in set.
+    Expression                  size;
+    bool                        wasP414;
     Annotations getAnnotations() const override { return annotations; }
 }
 

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -344,7 +344,7 @@ class P4Table : Declaration, IAnnotated, IApply {
 class P4ValueSet : Declaration, IAnnotated {
     optional Annotations        annotations = Annotations::empty;
     Type                        elementType;
-    Expression                  size;
+    Expression                  size; // number of elements in set.
     bool                        wasP414;
     Annotations getAnnotations() const override { return annotations; }
 }

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -345,7 +345,8 @@ class P4ValueSet : Declaration, IAnnotated {
     optional Annotations        annotations = Annotations::empty;
     Type                        elementType;
     Expression                  size; // number of elements in set.
-    bool                        wasP414;
+    bool                        wasV1;
+    Expression                  maskV1;
     Annotations getAnnotations() const override { return annotations; }
 }
 

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -265,6 +265,9 @@ class ParserValueSet : IAnnotated {
 }
 
 class CaseEntry {
+    // With mask keyword, e.g. "pvs0 mask 0x0ff0", the Constant
+    // is the value after mask. Without mask keyword, the
+    // Constant is -1.
     safe_vector<std::pair<Expression, Constant>>    values = {};
     optional ID                                     action;
 }


### PR DESCRIPTION
See 

https://github.com/p4lang/p4c/pull/2183#discussion_r374828806

https://github.com/p4lang/behavioral-model/issues/854

and

https://github.com/p4lang/p4c/issues/2188

With this detection of p4-14, the json output is now different between p4-16 and p4-14.  Now, I am waiting for the discussion to resolve for how is p4-14 mask stored in IR so that the bmv2 backend can emit appropriate JSON.
