### PR TITLE
Reject value sets with masks

### DIFF
--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -494,7 +494,7 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                 } else {
                     auto c = v.second->to<IR::Constant>();
                     CHECK_NULL(c);  // this is enforced elsewhere
-                    if (!c->fitsInt() || c->asInt() != 0) {
+                    if (!c->fitsInt() || c->asInt() != -1) {
                         ::error(ErrorType::ERR_INVALID,
                                 ": masks not supported for value sets", c);
                         continue;

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -493,12 +493,10 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                     cases.push_back(sc);
                 } else {
                     auto c = v.second->to<IR::Constant>();
-                    if (c == nullptr) {
-                        ::error(ErrorType::ERR_INVALID, ": mask", v.second);
-                        continue;
-                    }
+                    CHECK_NULL(c);  // this is enforced elsewhere
                     if (!c->fitsInt() || c->asInt() != 0) {
-                        ::error(ErrorType::ERR_INVALID, ": masks not supported for value sets", v.second);
+                        ::error(ErrorType::ERR_INVALID,
+                                ": masks not supported for value sets", c);
                         continue;
                     }
                     auto sc = new IR::SelectCase(c->srcInfo, v.first, deststate);

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -376,7 +376,7 @@ const IR::PathExpression* ProgramStructure::getState(IR::ID dest) {
 
 const IR::Expression*
 ProgramStructure::explodeLabel(const IR::Constant* value, const IR::Constant* mask,
-             const std::vector<const IR::Type::Bits *> &fieldTypes) {
+                               const std::vector<const IR::Type::Bits *> &fieldTypes) {
     if (mask->value == 0)
         return new IR::DefaultExpression(value->srcInfo);
     bool useMask = mask->value != -1;
@@ -492,6 +492,15 @@ const IR::ParserState* ProgramStructure::convertParser(const IR::V1Parser* parse
                     auto sc = new IR::SelectCase(c->srcInfo, expr, deststate);
                     cases.push_back(sc);
                 } else {
+                    auto c = v.second->to<IR::Constant>();
+                    if (c == nullptr) {
+                        ::error(ErrorType::ERR_INVALID, ": mask", v.second);
+                        continue;
+                    }
+                    if (!c->fitsInt() || c->asInt() != 0) {
+                        ::error(ErrorType::ERR_INVALID, ": masks not supported for value sets", v.second);
+                        continue;
+                    }
                     auto sc = new IR::SelectCase(c->srcInfo, v.first, deststate);
                     cases.push_back(sc);
                 }

--- a/testdata/p4_14_errors/issue2188.p4
+++ b/testdata/p4_14_errors/issue2188.p4
@@ -1,0 +1,25 @@
+header_type ethernet_t {
+    fields {
+        dst_addr        : 48; // width in bits
+        src_addr        : 48;
+        etherType       : 16;
+    }
+}
+header ethernet_t ethernet;
+
+parser_value_set pvs0;
+
+parser start {
+    return parse_ethernet;
+}
+
+parser parse_ethernet {
+    extract(ethernet);
+    return select(latest.etherType) {
+        pvs0 mask 0x0ff0 : ingress;       //  <--- this is the most significant line of the example
+        default : ingress;
+    }
+}
+
+control ingress {
+}

--- a/testdata/p4_14_errors_outputs/issue2188.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue2188.p4-stderr
@@ -1,0 +1,7 @@
+issue2188.p4(19): [--Wwarn=missing] warning: CaseEntry: parser_value_set has no @parser_value_set_size annotation.Using default size 4.
+        pvs0 mask 0x0ff0 : ingress; //  <--- this is the most significant line of the example
+        ^^^^^^^^^^^^^^^^
+issue2188.p4(19): [--Werror=invalid] error: 0xff0: Invalid : masks not supported for value sets
+        pvs0 mask 0x0ff0 : ingress; //  <--- this is the most significant line of the example
+                  ^^^^^^
+[--Werror=overlimit] error: 1 errors encountered, aborting compilation


### PR DESCRIPTION
This addresses #2188 somewhat: it will reject such programs instead of converting them silently into something incorrect. But #2188 also asks whether we want to support this idiom.

