### PR TITLE
Warn in bmv2 backend about unsupported match types in value_sets

### DIFF
--- a/backends/bmv2/common/parser.h
+++ b/backends/bmv2/common/parser.h
@@ -44,6 +44,7 @@ class ParserConverter : public Inspector {
     Util::IJson* createDefaultTransition();
     cstring jsonAssignment(const IR::Type* type, bool inParser);
     std::vector<Util::IJson*> convertSelectExpression(const IR::SelectExpression* expr);
+    void addValueSets(const IR::P4Parser* parser);
 
  public:
     bool preorder(const IR::P4Parser* p) override;

--- a/testdata/p4_16_samples_outputs/select-struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/select-struct-frontend.p4
@@ -23,3 +23,4 @@ parser p() {
 parser s();
 package top(s _s);
 top(p()) main;
+

--- a/testdata/p4_16_samples_outputs/select-struct-midend.p4
+++ b/testdata/p4_16_samples_outputs/select-struct-midend.p4
@@ -14,3 +14,4 @@ parser p() {
 parser s();
 package top(s _s);
 top(p()) main;
+


### PR DESCRIPTION
bmv2 only supports exact matches, and a warning is better than silently
ignoring the @match annotation.