### PR TITLE
Structs, headers and tuples initialization support (#762) (#2017)

### DIFF
--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -149,7 +149,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new ValidateMatchAnnotations(&typeMap),
         new DefaultArguments(&refMap, &typeMap),  // add default argument values to parameters
         new BindTypeVariables(&refMap, &typeMap),
-        new StructInitializers(&refMap, &typeMap),
+        new StructInitializers(&refMap, &typeMap, false),
         new TableKeyNames(&refMap, &typeMap),
         new PassRepeated({
             new ConstantFolding(&refMap, &typeMap),
@@ -165,6 +165,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new UniqueNames(&refMap),  // Give each local declaration a unique internal name
         new MoveDeclarations(),  // Move all local declarations to the beginning
         new MoveInitializers(),
+        new StructInitializers(&refMap, &typeMap, true),
         new SideEffectOrdering(&refMap, &typeMap, skipSideEffectOrdering),
         new SetHeaders(&refMap, &typeMap),
         new SimplifyControlFlow(&refMap, &typeMap),

--- a/frontends/p4/structInitializers.h
+++ b/frontends/p4/structInitializers.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "ir/ir.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
+#include "frontends/common/resolveReferences/resolveReferences.h"
 
 namespace P4 {
 
@@ -33,17 +34,36 @@ class CreateStructInitializers : public Transform {
         CHECK_NULL(refMap); CHECK_NULL(typeMap);
     }
 
-    const IR::Node* postorder(IR::AssignmentStatement* statement) override;
     const IR::Node* postorder(IR::MethodCallExpression* expression) override;
     const IR::Node* postorder(IR::Operation_Relation* expression) override;
 };
 
+class CreateStructAssignInitializers : public Transform {
+    ReferenceMap* refMap;
+    TypeMap* typeMap;
+ public:
+    CreateStructAssignInitializers(ReferenceMap* refMap, TypeMap* typeMap):
+            refMap(refMap), typeMap(typeMap) {
+        setName("CreateStructAssignInitializers");
+        CHECK_NULL(refMap); CHECK_NULL(typeMap);
+    }
+
+    const IR::Node* postorder(IR::AssignmentStatement* statement) override;
+};
+
 class StructInitializers : public PassManager {
  public:
-    StructInitializers(ReferenceMap* refMap, TypeMap* typeMap) {
+    StructInitializers(ReferenceMap* refMap, TypeMap* typeMap, bool doProcessAssignments) {
         setName("StructInitializers");
         passes.push_back(new TypeChecking(refMap, typeMap));
-        passes.push_back(new CreateStructInitializers(refMap, typeMap));
+        if (doProcessAssignments == false) {
+            passes.push_back(new CreateStructInitializers(refMap, typeMap));
+        } else {
+            passes.push_back(new CreateStructAssignInitializers(refMap, typeMap));
+            passes.push_back(new ResolveReferences(refMap));
+            // may insert new constants
+            passes.push_back(new TypeInference(refMap, typeMap, false));
+        }
         passes.push_back(new ClearTypeMap(typeMap));
     }
 };

--- a/frontends/p4/structInitializers.h
+++ b/frontends/p4/structInitializers.h
@@ -60,8 +60,9 @@ class StructInitializers : public PassManager {
             passes.push_back(new CreateStructInitializers(refMap, typeMap));
         } else {
             passes.push_back(new CreateStructAssignInitializers(refMap, typeMap));
+            // two passes below are needed only if a mix of explicit values and default values
+            // is used to initialize structs, headers or tuples
             passes.push_back(new ResolveReferences(refMap));
-            // may insert new constants
             passes.push_back(new TypeInference(refMap, typeMap, false));
         }
         passes.push_back(new ClearTypeMap(typeMap));

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -859,6 +859,13 @@ bool ToP4::preorder(const IR::ListExpression* e) {
     doneList();
     expressionPrecedence = prec;
     doneVec();
+    if (e->defaultInitializer) {
+        if (e->components.empty()) {
+            builder.append("...");
+        } else {
+            builder.append(", ...");
+        }
+    }
     builder.append(end);
     return false;
 }
@@ -886,6 +893,13 @@ bool ToP4::preorder(const IR::StructInitializerExpression* e) {
         builder.append(c->name.name);
         builder.append(" = ");
         visit(c->expression);
+    }
+    if (e->defaultInitializer) {
+        if (e->components.empty()) {
+            builder.append("...");
+        } else {
+            builder.append(", ... ");
+        }
     }
     expressionPrecedence = prec;
     builder.append("}");

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -384,7 +384,7 @@ const IR::Type* TypeInference::canonicalize(const IR::Type* type) {
         if (anySet)
             canon = new IR::Type_Tuple(type->srcInfo, *fields);
         else if (anyChange)
-            canon = new IR::Type_List(type->srcInfo, *fields);
+            canon = new IR::Type_List(type->srcInfo, *fields, list->fromDefaultInitializer);
         else
             canon = type;
         canon = typeMap->getCanonical(canon);
@@ -518,7 +518,8 @@ const IR::Type* TypeInference::canonicalize(const IR::Type* type) {
             });
     } else if (auto su = type->to<IR::Type_UnknownStruct>()) {
         return canonicalizeFields(su, [su](const IR::IndexedVector<IR::StructField>* fields) {
-                return new IR::Type_UnknownStruct(su->srcInfo, su->name, su->annotations, *fields);
+                return new IR::Type_UnknownStruct(su->srcInfo, su->name, su->annotations,
+                                                  *fields, su->fromDefaultInitializer);
             });
     } else if (auto st = type->to<IR::Type_Specialized>()) {
         auto baseCanon = canonicalize(st->baseType);
@@ -729,7 +730,6 @@ TypeInference::assignment(const IR::Node* errorPosition, const IR::Type* destTyp
 
     if (initType == destType)
         return sourceExpression;
-
     auto tvs = unify(errorPosition, destType, initType);
     if (tvs == nullptr)
         // error already signalled
@@ -750,7 +750,7 @@ TypeInference::assignment(const IR::Node* errorPosition, const IR::Type* destTyp
             bool cst = isCompileTimeConstant(sourceExpression);
             auto type = new IR::Type_Name(ts->name);
             sourceExpression = new IR::StructInitializerExpression(
-                type, type, si->components);
+                type, type, si->components, si->defaultInitializer);
             setType(sourceExpression, destType);
             if (cst)
                 setCompileTimeConstant(sourceExpression);
@@ -1799,7 +1799,8 @@ const IR::Node* TypeInference::postorder(IR::ListExpression* expression) {
         components->push_back(type);
     }
 
-    auto tupleType = new IR::Type_List(expression->srcInfo, *components);
+    auto tupleType = new IR::Type_List(expression->srcInfo, *components,
+                                       expression->defaultInitializer);
     auto type = canonicalize(tupleType);
     if (type == nullptr)
         return expression;
@@ -1826,7 +1827,7 @@ const IR::Node* TypeInference::postorder(IR::StructInitializerExpression* expres
     }
 
     const IR::Type* structType = new IR::Type_UnknownStruct(
-        expression->srcInfo, "unknown struct", *components);
+        expression->srcInfo, "unknown struct", *components, expression->defaultInitializer);
     structType = canonicalize(structType);
 
     const IR::Expression* result = expression;

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -384,7 +384,7 @@ const IR::Type* TypeInference::canonicalize(const IR::Type* type) {
         if (anySet)
             canon = new IR::Type_Tuple(type->srcInfo, *fields);
         else if (anyChange)
-            canon = new IR::Type_List(type->srcInfo, *fields, list->fromDefaultInitializer);
+            canon = new IR::Type_List(type->srcInfo, *fields, list->defaultInitializer);
         else
             canon = type;
         canon = typeMap->getCanonical(canon);
@@ -519,7 +519,7 @@ const IR::Type* TypeInference::canonicalize(const IR::Type* type) {
     } else if (auto su = type->to<IR::Type_UnknownStruct>()) {
         return canonicalizeFields(su, [su](const IR::IndexedVector<IR::StructField>* fields) {
                 return new IR::Type_UnknownStruct(su->srcInfo, su->name, su->annotations,
-                                                  *fields, su->fromDefaultInitializer);
+                                                  *fields, su->defaultInitializer);
             });
     } else if (auto st = type->to<IR::Type_Specialized>()) {
         auto baseCanon = canonicalize(st->baseType);

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 #include "typeUnification.h"
 #include "typeConstraints.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -303,24 +302,49 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
             return false;
         }
         auto ts = src->to<IR::Type_BaseList>();
-        if (td->components.size() != ts->components.size()) {
+        bool convenient;
+        if (auto lst = src->to<IR::Type_List>()) {
+            convenient = lst->fromDefaultInitializer;
+        }
+        if (td->components.size() != ts->components.size() && !convenient) {
             TypeInference::typeError("%1%: tuples with different sizes %2% vs %3%",
                                      errorPosition, td->components.size(), ts->components.size());
             return false;
         }
-
-        for (size_t i=0; i < td->components.size(); i++) {
-            auto si = ts->components.at(i);
-            auto di = td->components.at(i);
-            bool success = unify(errorPosition, di, si, reportErrors);
-            if (!success)
-                return false;
+        if (!convenient) {
+            for (size_t i=0; i < td->components.size(); i++) {
+                auto si = ts->components.at(i);
+                auto di = td->components.at(i);
+                bool success = unify(errorPosition, di, si, reportErrors);
+                if (!success)
+                    return false;
+            }
+        } else {
+            for (size_t i=0; i < td->components.size(); i++) {
+                auto di = td->components.at(i);
+                if (di->is<IR::Type_Varbits>() || di->is<IR::Type_Stack>()
+                    || di->is<IR::Type_HeaderUnion>()) {
+                    TypeInference::typeError("%1%: Structs, headers and tuples containing %2% data "
+                                             "type as a lief field cannot be zero initialized with "
+                                             "convenient initializer: %3% = {...}.",
+                                             errorPosition, td->components.at(i), td);
+                    return false;
+                } else if (di->is<IR::Type_Struct>() || di->is<IR::Type_Header>()
+                           || di->is<IR::Type_Tuple>()) {
+                    IR::Type_List* src_tmp =
+                                       new IR::Type_List(*(new IR::Vector<IR::Type>()), true);
+                    bool success = unify(errorPosition, di, src_tmp, reportErrors);
+                    if (!success)
+                        return false;
+                }
+            }
         }
         return true;
     } else if (dest->is<IR::Type_Struct>() || dest->is<IR::Type_Header>()) {
         auto strct = dest->to<IR::Type_StructLike>();
         if (auto tpl = src->to<IR::Type_List>()) {
-            if (strct->fields.size() != tpl->components.size()) {
+            if ((strct->fields.size() != tpl->components.size()) &&
+                (tpl->fromDefaultInitializer == false)) {
                 if (reportErrors)
                     TypeInference::typeError("%1%: Number of fields %2% in initializer different "
                                              "than number of fields in structure %3%: %4% to %5%",
@@ -328,22 +352,46 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
                                              strct->fields.size(), tpl, strct);
                 return false;
             }
+            if (tpl->fromDefaultInitializer  == false) {
+                int index = 0;
+                for (const IR::StructField* f : strct->fields) {
+                    const IR::Type* tplField = tpl->components.at(index);
+                    const IR::Type* destt = f->type;
 
-            int index = 0;
-            for (const IR::StructField* f : strct->fields) {
-                const IR::Type* tplField = tpl->components.at(index);
-                const IR::Type* destt = f->type;
-
-                bool success = unify(errorPosition, destt, tplField, reportErrors);
-                if (!success)
-                    return false;
-                index++;
+                    bool success = unify(errorPosition, destt, tplField, reportErrors);
+                    if (!success)
+                        return false;
+                    index++;
+                }
+            } else {
+                for (const IR::StructField* f : strct->fields) {
+                    if (f->type->is<IR::Type_Varbits>() || f->type->is<IR::Type_Stack>()
+                        || f->type->is<IR::Type_HeaderUnion>()) {
+                        TypeInference::typeError("%1%: Structs, headers and tuples "
+                                                 "containing %2% data type as a lief "
+                                                 "field cannot be zero initialized with "
+                                                 "convenient initializer: %3% = {...}.",
+                                                 errorPosition, f->type, strct);
+                        return false;
+                    } else if (f->type->is<IR::Type_Struct>() || f->type->is<IR::Type_Header>()
+                               || f->type->is<IR::Type_Tuple>()) {
+                        IR::Type_List* src_tmp =
+                                       new IR::Type_List(*(new IR::Vector<IR::Type>()), true);
+                        bool success = unify(errorPosition, f->type, src_tmp, reportErrors);
+                        if (!success)
+                            return false;
+                    }
+                }
             }
             return true;
         } else if (auto st = src->to<IR::Type_StructLike>()) {
             // There is another case, in which each field of the source is unifiable with the
             // corresponding field of the destination, e.g., a struct containing tuples.
-            if (strct->fields.size() != st->fields.size()) {
+            bool convenient = false;
+            if (auto unkn = src->to<IR::Type_UnknownStruct>()) {
+                convenient = unkn->fromDefaultInitializer;
+            }
+            if ((strct->fields.size() != st->fields.size()) && !convenient) {
                 if (reportErrors)
                     TypeInference::typeError("%1%: Number of fields %2% in initializer different "
                                              "than number of fields in structure %3%: %4% to %5%",
@@ -351,16 +399,45 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
                                              strct->fields.size(), st, strct);
                 return false;
             }
-
-            for (const IR::StructField* f : strct->fields) {
-                auto stField = st->getField(f->name);
-                if (stField == nullptr) {
-                    TypeInference::typeError("%1%: No initializer for field %2%", errorPosition, f);
-                    return false;
+            if (!convenient) {
+                for (const IR::StructField* f : strct->fields) {
+                    auto stField = st->getField(f->name);
+                    if (stField == nullptr) {
+                        TypeInference::typeError("%1%: No initializer for field %2%",
+                                                 errorPosition, f);
+                        return false;
+                    }
+                    bool success = unify(errorPosition, f->type, stField->type, reportErrors);
+                    if (!success)
+                        return false;
                 }
-                bool success = unify(errorPosition, f->type, stField->type, reportErrors);
-                if (!success)
-                    return false;
+            } else {
+                for (const IR::StructField* f : st->fields) {
+                    auto strctField = strct->getField(f->name);
+                    if (strctField == nullptr) {
+                        TypeInference::typeError("%1%: No field named %2% in structure %3%",
+                                                 errorPosition, f->name, strct);
+                        return false;
+                    }
+                }
+                for (const IR::StructField* f : strct->fields) {
+                    if (f->type->is<IR::Type_Varbits>() || f->type->is<IR::Type_Stack>()
+                        || f->type->is<IR::Type_HeaderUnion>()) {
+                        TypeInference::typeError("%1%: Structs, headers and tuples "
+                                                 "containing %2% data type as a lief "
+                                                 "field cannot be zero initialized with "
+                                                 "convenient initializer: %3% = {...}.",
+                                                 errorPosition, f->type, strct);
+                        return false;
+                    } else if (f->type->is<IR::Type_Struct>() || f->type->is<IR::Type_Header>()
+                               || f->type->is<IR::Type_Tuple>()) {
+                        IR::Type_List* src_tmp =
+                                       new IR::Type_List(*(new IR::Vector<IR::Type>()), true);
+                        bool success = unify(errorPosition, f->type, src_tmp, reportErrors);
+                        if (!success)
+                            return false;
+                    }
+                }
             }
             return true;
         }
@@ -381,7 +458,6 @@ bool TypeUnification::unify(const IR::Node* errorPosition,
                                          errorPosition, src->toString(), dest->toString());
             return false;
         }
-
         bool success = (*src) == (*dest);
         if (!success) {
             if (reportErrors)

--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -194,7 +194,7 @@ using Parser = P4::P4Parser;
                           return Parser::make_INTEGER(constant, driver.yylloc); }
 
 "&&&"           { BEGIN(driver.saveState); return makeToken(MASK); }
-"..."           { BEGIN(driver.saveState); return makeToken(CONVINIENT_INITIALIZER); }
+"..."           { BEGIN(driver.saveState); return makeToken(DOTS); }
 ".."            { BEGIN(driver.saveState); return makeToken(RANGE); }
 "<<"            { BEGIN(driver.saveState); return makeToken(SHL); }
 "&&"            { BEGIN(driver.saveState); return makeToken(AND); }

--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -194,6 +194,7 @@ using Parser = P4::P4Parser;
                           return Parser::make_INTEGER(constant, driver.yylloc); }
 
 "&&&"           { BEGIN(driver.saveState); return makeToken(MASK); }
+"..."           { BEGIN(driver.saveState); return makeToken(CONVINIENT_INITIALIZER); }
 ".."            { BEGIN(driver.saveState); return makeToken(RANGE); }
 "<<"            { BEGIN(driver.saveState); return makeToken(SHL); }
 "&&"            { BEGIN(driver.saveState); return makeToken(AND); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -207,7 +207,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %token<Token>      PP "++"
 %token<Token>      DONTCARE "_"
 %token<Token>      MASK "&&&"
-%token<Token>      CONVINIENT_INITIALIZER "..."
+%token<Token>      DOTS "..."
 %token<Token>      RANGE ".."
 %token<Token>      TRUE FALSE THIS
 %token<Token>      ABSTRACT ACTION ACTIONS APPLY BOOL BIT CONST CONTROL DEFAULT

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -207,6 +207,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %token<Token>      PP "++"
 %token<Token>      DONTCARE "_"
 %token<Token>      MASK "&&&"
+%token<Token>      CONVINIENT_INITIALIZER "..."
 %token<Token>      RANGE ".."
 %token<Token>      TRUE FALSE THIS
 %token<Token>      ABSTRACT ACTION ACTIONS APPLY BOOL BIT CONST CONTROL DEFAULT
@@ -1260,6 +1261,7 @@ optInitializer
 
 initializer
     : expression                          { $$ = $1; }
+    | "..."                               { $$ = new IR::ListExpression(@1, *(new IR::Vector<IR::Expression>()), true); }
     ;
 
 /**************** Expressions ****************/
@@ -1316,10 +1318,14 @@ expression
     | dotPrefix nonTypeName              { $$ = new IR::PathExpression(new IR::Path(*$2, true)); driver.structure->clearPath(); }
     | expression "[" expression "]"      { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | expression "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
+    | "{" expressionList "," "..." "}"   { $$ = new IR::ListExpression(@1 + @5, *$2, true); }
     | "{" expressionList "}"             { $$ = new IR::ListExpression(@1 + @3, *$2); }
-| typeName "{" kvList "}"                { $$ = new IR::StructInitializerExpression(@1 + @4, IR::Type::Unknown::get(), $1, *$3); }  // experimental
+    | "{" "..." "}"                      { $$ = new IR::ListExpression(@1 + @3, *(new IR::Vector<IR::Expression>()), true); }
+    | typeName "{" kvList "}"            { $$ = new IR::StructInitializerExpression(@1 + @4, IR::Type::Unknown::get(), $1, *$3); }  // experimental
     | "{" kvList "}"                     { $$ = new IR::StructInitializerExpression(
                                                   @1 + @3, IR::Type::Unknown::get(), (IR::Type_Name*)nullptr, *$2); }  // experimental
+    | "{" kvList "," "..." "}"                     { $$ = new IR::StructInitializerExpression(
+                                                  @1 + @5, IR::Type::Unknown::get(), (IR::Type_Name*)nullptr, *$2, true); }  // experimental
     | "(" expression ")"                 { $$ = $2; }
     | "!" expression %prec PREFIX        { $$ = new IR::LNot(@1 + @2, $2); }
     | "~" expression %prec PREFIX        { $$ = new IR::Cmpl(@1 + @2, $2); }

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -384,6 +384,18 @@ class ConstructorCallExpression : Expression {
 
 /// Represents a list of expressions separated by commas
 class ListExpression : Expression {
+    bool defaultInitializer = false;
+    ListExpression(Util::SourceInfo srcInfo, IR::Vector<IR::Expression>& components, bool convenientInit) : Expression(srcInfo), components(components){
+        defaultInitializer = convenientInit;
+        validate();
+        if (type->is<Type::Unknown>()) {
+            Vector<Type> tuple;
+            for (auto e : components)
+                tuple.push_back(e->type);
+            type = new Type_List(tuple, defaultInitializer);
+        }
+    }
+
     inline Vector<Expression> components;
     ListExpression {
         validate();
@@ -391,7 +403,9 @@ class ListExpression : Expression {
             Vector<Type> tuple;
             for (auto e : components)
                 tuple.push_back(e->type);
-            type = new Type_List(tuple); } }
+            type = new Type_List(tuple);
+        }
+    }
     validate { components.check_null(); }
     size_t size() const { return components.size(); }
     void push_back(Expression e) { components.push_back(e); }
@@ -400,6 +414,19 @@ class ListExpression : Expression {
 /// IR representation of an initializer for a struct.
 /// Currently it does not have a direct representation as P4 source.
 class StructInitializerExpression : Expression {
+    bool defaultInitializer = false;
+    StructInitializerExpression(Util::SourceInfo srcInfo, const IR::Type* type, const IR::Type_Name* typeName, IR::IndexedVector<IR::NamedExpression>& components, bool convenientInit)
+                                : StructInitializerExpression(srcInfo, type, typeName, components) {
+        defaultInitializer = convenientInit;
+
+    }
+
+    StructInitializerExpression(const IR::Type* type, const IR::Type_Name* typeName, const IR::IndexedVector<IR::NamedExpression>& components, bool convenientInit)
+                                : StructInitializerExpression(type, typeName, components) {
+        defaultInitializer = convenientInit;
+
+    }
+
     /// The struct or header type that is being intialized.
     /// May only be known after type checking; so it can be nullptr.
     NullOK optional Type_Name typeName;

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -385,9 +385,19 @@ class ConstructorCallExpression : Expression {
 /// Represents a list of expressions separated by commas
 class ListExpression : Expression {
     bool defaultInitializer = false;
-    ListExpression(Util::SourceInfo srcInfo, IR::Vector<IR::Expression>& components, bool convenientInit) : Expression(srcInfo), components(components){
-        defaultInitializer = convenientInit;
+    ListExpression(Util::SourceInfo srcInfo, IR::Vector<IR::Expression>& components, bool defaultInitializer)
+                   : Expression(srcInfo), defaultInitializer(defaultInitializer), components(components) {
         validate();
+        initUnknown();
+    }
+
+    inline Vector<Expression> components;
+    ListExpression {
+        validate();
+        initUnknown();
+    }
+
+    void initUnknown(){
         if (type->is<Type::Unknown>()) {
             Vector<Type> tuple;
             for (auto e : components)
@@ -396,16 +406,6 @@ class ListExpression : Expression {
         }
     }
 
-    inline Vector<Expression> components;
-    ListExpression {
-        validate();
-        if (type->is<Type::Unknown>()) {
-            Vector<Type> tuple;
-            for (auto e : components)
-                tuple.push_back(e->type);
-            type = new Type_List(tuple);
-        }
-    }
     validate { components.check_null(); }
     size_t size() const { return components.size(); }
     void push_back(Expression e) { components.push_back(e); }
@@ -415,16 +415,14 @@ class ListExpression : Expression {
 /// Currently it does not have a direct representation as P4 source.
 class StructInitializerExpression : Expression {
     bool defaultInitializer = false;
-    StructInitializerExpression(Util::SourceInfo srcInfo, const IR::Type* type, const IR::Type_Name* typeName, IR::IndexedVector<IR::NamedExpression>& components, bool convenientInit)
-                                : StructInitializerExpression(srcInfo, type, typeName, components) {
-        defaultInitializer = convenientInit;
-
+    StructInitializerExpression(Util::SourceInfo srcInfo, const IR::Type* type, const IR::Type_Name* typeName, IR::IndexedVector<IR::NamedExpression>& components, bool defaultInitializer)
+                                : Expression(srcInfo, type), defaultInitializer(defaultInitializer), typeName(typeName), components(components) {
+        validate();
     }
 
-    StructInitializerExpression(const IR::Type* type, const IR::Type_Name* typeName, const IR::IndexedVector<IR::NamedExpression>& components, bool convenientInit)
-                                : StructInitializerExpression(type, typeName, components) {
-        defaultInitializer = convenientInit;
-
+    StructInitializerExpression(const IR::Type* type, const IR::Type_Name* typeName, const IR::IndexedVector<IR::NamedExpression>& components, bool defaultInitializer)
+                                : Expression(type), defaultInitializer(defaultInitializer), typeName(typeName), components(components) {
+        validate();
     }
 
     /// The struct or header type that is being intialized.

--- a/ir/type.def
+++ b/ir/type.def
@@ -268,6 +268,16 @@ class Type_Struct : Type_StructLike {
 /// and some information about their types.
 class Type_UnknownStruct : Type_StructLike {
 #nodbprint
+    bool fromDefaultInitializer = false;
+    Type_UnknownStruct(Util::SourceInfo srcInfo, IR::ID name, IR::IndexedVector<IR::StructField>& fields, bool convenientInit)
+                       : Type_UnknownStruct(srcInfo, name, fields){
+        fromDefaultInitializer = convenientInit;
+    }
+
+    Type_UnknownStruct(Util::SourceInfo srcInfo, IR::ID name, const IR::Annotations* annotations, const IR::IndexedVector<IR::StructField>& fields, bool convenientInit)
+                       : Type_UnknownStruct(srcInfo, name, annotations, fields){
+        fromDefaultInitializer = convenientInit;
+    }
 }
 
 class Type_HeaderUnion : Type_StructLike {
@@ -316,6 +326,16 @@ abstract Type_BaseList : Type {
 
 /// The type of an expressionList; can be unified with both Type_Tuple and Type_Struct
 class Type_List : Type_BaseList {
+    bool fromDefaultInitializer = false;
+
+    Type_List(IR::Vector<IR::Type>& components, bool fromConvenientInitializer) : Type_List(components) {
+        fromDefaultInitializer = fromConvenientInitializer;
+    }
+
+    Type_List(Util::SourceInfo srcInfo, IR::Vector<IR::Type>& components, bool fromConvenientInitializer) : Type_List(srcInfo, components) {
+        fromDefaultInitializer = fromConvenientInitializer;
+    }
+
     // In error messages this is shown as if it is a Tuple
     toString{ return "Tuple(" + Util::toString(components.size()) + ")"; }
     const Type* getP4Type() const override;

--- a/ir/type.def
+++ b/ir/type.def
@@ -268,15 +268,15 @@ class Type_Struct : Type_StructLike {
 /// and some information about their types.
 class Type_UnknownStruct : Type_StructLike {
 #nodbprint
-    bool fromDefaultInitializer = false;
-    Type_UnknownStruct(Util::SourceInfo srcInfo, IR::ID name, IR::IndexedVector<IR::StructField>& fields, bool convenientInit)
-                       : Type_UnknownStruct(srcInfo, name, fields){
-        fromDefaultInitializer = convenientInit;
+    bool defaultInitializer = false;
+    Type_UnknownStruct(Util::SourceInfo srcInfo, IR::ID name, IR::IndexedVector<IR::StructField>& fields, bool defaultInitializer)
+                       : Type_StructLike(srcInfo, name, fields), defaultInitializer(defaultInitializer) {
+        validate();
     }
 
-    Type_UnknownStruct(Util::SourceInfo srcInfo, IR::ID name, const IR::Annotations* annotations, const IR::IndexedVector<IR::StructField>& fields, bool convenientInit)
-                       : Type_UnknownStruct(srcInfo, name, annotations, fields){
-        fromDefaultInitializer = convenientInit;
+    Type_UnknownStruct(Util::SourceInfo srcInfo, IR::ID name, const IR::Annotations* annotations, const IR::IndexedVector<IR::StructField>& fields, bool defaultInitializer)
+                       : Type_StructLike(srcInfo, name, annotations, fields), defaultInitializer(defaultInitializer) {
+        validate();
     }
 }
 
@@ -326,14 +326,14 @@ abstract Type_BaseList : Type {
 
 /// The type of an expressionList; can be unified with both Type_Tuple and Type_Struct
 class Type_List : Type_BaseList {
-    bool fromDefaultInitializer = false;
+    bool defaultInitializer = false;
 
-    Type_List(IR::Vector<IR::Type>& components, bool fromConvenientInitializer) : Type_List(components) {
-        fromDefaultInitializer = fromConvenientInitializer;
+    Type_List(IR::Vector<IR::Type>& components, bool defaultInitializer) : Type_BaseList(components), defaultInitializer(defaultInitializer) {
+        validate();
     }
 
-    Type_List(Util::SourceInfo srcInfo, IR::Vector<IR::Type>& components, bool fromConvenientInitializer) : Type_List(srcInfo, components) {
-        fromDefaultInitializer = fromConvenientInitializer;
+    Type_List(Util::SourceInfo srcInfo, IR::Vector<IR::Type>& components, bool defaultInitializer) : Type_BaseList(srcInfo, components), defaultInitializer(defaultInitializer) {
+        validate();
     }
 
     // In error messages this is shown as if it is a Tuple

--- a/testdata/p4_16_errors/default-initializer-err.p4
+++ b/testdata/p4_16_errors/default-initializer-err.p4
@@ -1,0 +1,49 @@
+#include <core.p4>
+
+enum bit<8> myEnum { One = 1, Two = 2, Three = 3 }
+
+enum myEnum1 {e1, e2, e3}
+
+
+header H {
+    int<8> i;
+    bool   b;
+    bit<14> l;
+    bit<1> b1;
+    varbit<8>   v;
+}
+
+
+struct S {
+    myEnum      val;
+    myEnum1     val1;
+    error       errorNoOne;
+    H           h;
+    bit<1>              z;
+    bool        b;
+    int<8>      i;
+
+}
+
+
+extern void f<D>(in D data);
+control c(inout bit<1> r) {
+    S sa;
+    bit<1> tmp;
+    apply {
+        S sb;
+        sb = { b = false, h={3, true, ...}, ...};
+        H hb = ...;
+        sb.h = hb;
+        sa = sb;
+        tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x = { 0, true, ... };
+        f<tuple<int<8>, bool, error, myEnum1, myEnum, H, S>>(x);
+        tmp = sa.z;
+        r = tmp;
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;
+

--- a/testdata/p4_16_errors_outputs/default-initializer-err.p4
+++ b/testdata/p4_16_errors_outputs/default-initializer-err.p4
@@ -1,9 +1,9 @@
 #include <core.p4>
 
 enum bit<8> myEnum {
-    One = 8w1,
-    Two = 8w2,
-    Three = 8w3
+    One = 1,
+    Two = 2,
+    Three = 3
 }
 
 enum myEnum1 {
@@ -12,37 +12,40 @@ enum myEnum1 {
     e3
 }
 
+
 header H {
-    int<8>  i;
-    bool    b;
+    int<8> i;
+    bool   b;
     bit<14> l;
-    bit<1>  b1;
+    bit<1> b1;
+    varbit<8>   v;
 }
 
+
 struct S {
-    myEnum  val;
-    myEnum1 val1;
-    error   errorNoOne;
-    H       h;
-    bit<1>  z;
-    bool    b;
-    int<8>  i;
+    myEnum      val;
+    myEnum1     val1;
+    error       errorNoOne;
+    H           h;
+    bit<1>              z;
+    bool        b;
+    int<8>      i;
 }
+
 
 extern void f<D>(in D data);
 control c(inout bit<1> r) {
-    S s_0;
-    H h_0;
+    S sa;
     bit<1> tmp;
     apply {
-        S s_1;
-        s_1 = S {b = false,h = { 3, true, ... }, ...};
-        H h = { ... };
-        s_1.h = h;
-        s_0 = s_1;
+        S sb;
+        sb = { b = false, h={3, true, ...}, ...};
+        H hb = { ... };
+        sb.h = hb;
+        sa = sb;
         tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x = { 0, true, ... };
         f<tuple<int<8>, bool, error, myEnum1, myEnum, H, S>>(x);
-        tmp = s_0.z;
+        tmp = sa.z;
         r = tmp;
     }
 }

--- a/testdata/p4_16_errors_outputs/default-initializer-err.p4-stderr
+++ b/testdata/p4_16_errors_outputs/default-initializer-err.p4-stderr
@@ -1,0 +1,28 @@
+default-initializer-err.p4(35): [--Werror=type-error] error: AssignmentStatement: Structs, headers and tuples containing varbit<8> fields cannot be initialized using ...: header H = {...}.
+        sb = { b = false, h={3, true, ...}, ...};
+           ^
+default-initializer-err.p4(13)
+    varbit<8> v;
+    ^^^^^^^^^
+default-initializer-err.p4(8)
+header H {
+       ^
+default-initializer-err.p4(36): [--Werror=type-error] error: hb: Structs, headers and tuples containing varbit<8> fields cannot be initialized using ...: header H = {...}.
+        H hb = ...;
+        ^^^^^^^^^^^
+default-initializer-err.p4(13)
+    varbit<8> v;
+    ^^^^^^^^^
+default-initializer-err.p4(8)
+header H {
+       ^
+default-initializer-err.p4(39): [--Werror=type-error] error: x: Structs, headers and tuples containing varbit<8> fields cannot be initialized using ...: header H = {...}.
+        tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x = { 0, true, ... };
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+default-initializer-err.p4(13)
+    varbit<8> v;
+    ^^^^^^^^^
+default-initializer-err.p4(8)
+header H {
+       ^
+

--- a/testdata/p4_16_samples/convenient_init.p4
+++ b/testdata/p4_16_samples/convenient_init.p4
@@ -1,0 +1,47 @@
+#include <core.p4>
+
+enum bit<8> myEnum { One = 1, Two = 2, Three = 3 }
+
+enum myEnum1 {e1, e2, e3}
+
+
+header H {
+    int<8> i;
+    bool   b;
+    bit<14> l;
+    bit<1> b1;
+}
+
+
+struct S {
+    myEnum      val;
+    myEnum1     val1;
+    error       errorNoOne;
+    H           h;
+    bit<1>              z;
+    bool        b;
+    int<8>      i;
+}
+
+
+extern void f<D>(in D data);
+control c(inout bit<1> r) {
+    S s_0;
+    H h_0;
+    bit<1> tmp;
+    apply {
+        S s_1;
+        s_1 = { b = false, h={3, true, ...}, ...};
+        H h = ...;
+        s_1.h = h;
+        s_0 = s_1;
+        tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x = { 0, true, ... };
+        f<tuple<int<8>, bool, error, myEnum1, myEnum, H, S>>(x);
+        tmp = s_0.z;
+        r = tmp;
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;

--- a/testdata/p4_16_samples/default-initializer.p4
+++ b/testdata/p4_16_samples/default-initializer.p4
@@ -26,18 +26,17 @@ struct S {
 
 extern void f<D>(in D data);
 control c(inout bit<1> r) {
-    S s_0;
-    H h_0;
+    S sa;
     bit<1> tmp;
     apply {
-        S s_1;
-        s_1 = { b = false, h={3, true, ...}, ...};
-        H h = ...;
-        s_1.h = h;
-        s_0 = s_1;
+        S sb;
+        sb = { b = false, h={3, true, ...}, ...};
+        H hb = ...;
+        sb.h = hb;
+        sa = sb;
         tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x = { 0, true, ... };
         f<tuple<int<8>, bool, error, myEnum1, myEnum, H, S>>(x);
-        tmp = s_0.z;
+        tmp = sa.z;
         r = tmp;
     }
 }

--- a/testdata/p4_16_samples/nested-struct-default-initializers.p4
+++ b/testdata/p4_16_samples/nested-struct-default-initializers.p4
@@ -1,0 +1,104 @@
+/*
+Copyright 2020 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct headers_t {
+    ethernet_t    ethernet;
+}
+
+struct mystruct1_t {
+    bit<16> f1;
+    bit<8>  f2;
+}
+
+struct mystruct2_t {
+    mystruct1_t s1;
+    bit<16> f3;
+    bit<32> f4;
+}
+
+struct metadata_t {
+    mystruct1_t s1;
+    mystruct2_t s2;
+}
+
+parser parserImpl(packet_in packet,
+                  out headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t stdmeta)
+{
+    state start {
+        packet.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control ingressImpl(inout headers_t hdr,
+                    inout metadata_t meta,
+                    inout standard_metadata_t stdmeta)
+{
+    apply {
+        meta.s1 = {...};
+        meta.s2.s1 = meta.s1;
+        meta.s2 = {s1={f1=2, ... }, ...};
+        stdmeta.egress_spec = (bit<9>) meta.s2.s1.f2;
+    }
+}
+
+control egressImpl(inout headers_t hdr,
+                   inout metadata_t meta,
+                   inout standard_metadata_t stdmeta)
+{
+    metadata_t meta_a = ...;
+    ethernet_t eth_a = {0, ...};
+    apply {
+	hdr.ethernet = eth_a;
+	meta = meta_a;
+     }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control deparserImpl(packet_out packet,
+                     in headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+V1Switch(parserImpl(),
+         verifyChecksum(),
+         ingressImpl(),
+         egressImpl(),
+         updateChecksum(),
+         deparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/assign-first.p4
+++ b/testdata/p4_16_samples_outputs/assign-first.p4
@@ -5,7 +5,7 @@ header h {
 control c() {
     h hdr;
     apply {
-        hdr = h {field = 32w10};
+        hdr = { 32w10 };
     }
 }
 

--- a/testdata/p4_16_samples_outputs/convenient_init-first.p4
+++ b/testdata/p4_16_samples_outputs/convenient_init-first.p4
@@ -1,0 +1,52 @@
+#include <core.p4>
+
+enum bit<8> myEnum {
+    One = 8w1,
+    Two = 8w2,
+    Three = 8w3
+}
+
+enum myEnum1 {
+    e1,
+    e2,
+    e3
+}
+
+header H {
+    int<8>  i;
+    bool    b;
+    bit<14> l;
+    bit<1>  b1;
+}
+
+struct S {
+    myEnum  val;
+    myEnum1 val1;
+    error   errorNoOne;
+    H       h;
+    bit<1>  z;
+    bool    b;
+    int<8>  i;
+}
+
+extern void f<D>(in D data);
+control c(inout bit<1> r) {
+    S s_0;
+    H h_0;
+    bit<1> tmp;
+    apply {
+        S s_1;
+        s_1 = S {b = false,h = { 3, true, ... }, ...};
+        H h = { ... };
+        s_1.h = h;
+        s_0 = s_1;
+        tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x = { 0, true, ... };
+        f<tuple<int<8>, bool, error, myEnum1, myEnum, H, S>>(x);
+        tmp = s_0.z;
+        r = tmp;
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/convenient_init-frontend.p4
+++ b/testdata/p4_16_samples_outputs/convenient_init-frontend.p4
@@ -1,0 +1,55 @@
+#include <core.p4>
+
+enum bit<8> myEnum {
+    One = 8w1,
+    Two = 8w2,
+    Three = 8w3
+}
+
+enum myEnum1 {
+    e1,
+    e2,
+    e3
+}
+
+header H {
+    int<8>  i;
+    bool    b;
+    bit<14> l;
+    bit<1>  b1;
+}
+
+struct S {
+    myEnum  val;
+    myEnum1 val1;
+    error   errorNoOne;
+    H       h;
+    bit<1>  z;
+    bool    b;
+    int<8>  i;
+}
+
+extern void f<D>(in D data);
+control c(inout bit<1> r) {
+    S s;
+    bit<1> tmp_0;
+    S s_2;
+    H h_0;
+    tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x_0;
+    apply {
+        s_2.h.setValid();
+        s_2 = S {val = 8w0,val1 = myEnum1.e1,errorNoOne = error.NoError,h = H {i = 8s3,b = true,l = 14w0,b1 = 1w0},z = 1w0,b = false,i = 8s0};
+        h_0.setValid();
+        h_0 = H {i = 8s0,b = false,l = 14w0,b1 = 1w0};
+        s_2.h = h_0;
+        s = s_2;
+        x_0 = { 8s0, true, error.NoError, myEnum1.e1, 8w0, H {i = 8s0,b = false,l = 14w0,b1 = 1w0}, S {val = 8w0,val1 = myEnum1.e1,errorNoOne = error.NoError,h = H {i = 8s0,b = false,l = 14w0,b1 = 1w0},z = 1w0,b = false,i = 8s0} };
+        f<tuple<int<8>, bool, error, myEnum1, myEnum, H, S>>(x_0);
+        tmp_0 = s.z;
+        r = tmp_0;
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/convenient_init-midend.p4
+++ b/testdata/p4_16_samples_outputs/convenient_init-midend.p4
@@ -1,0 +1,78 @@
+#include <core.p4>
+
+enum myEnum1 {
+    e1,
+    e2,
+    e3
+}
+
+header H {
+    int<8>  i;
+    bool    b;
+    bit<14> l;
+    bit<1>  b1;
+}
+
+struct S {
+    bit<8>  val;
+    myEnum1 val1;
+    error   errorNoOne;
+    H       h;
+    bit<1>  z;
+    bool    b;
+    int<8>  i;
+}
+
+extern void f<D>(in D data);
+struct tuple_0 {
+    int<8>  field;
+    bool    field_0;
+    error   field_1;
+    myEnum1 field_2;
+    bit<8>  field_3;
+    H       field_4;
+    S       field_5;
+}
+
+control c(inout bit<1> r) {
+    H s_2_h;
+    H h_0;
+    H x_0_field_4;
+    H x_0_field_5_h;
+    @hidden action convenient_init34() {
+        s_2_h.setValid();
+        s_2_h.i = 8s3;
+        s_2_h.b = true;
+        s_2_h.l = 14w0;
+        s_2_h.b1 = 1w0;
+        h_0.setValid();
+        h_0.i = 8s0;
+        h_0.b = false;
+        h_0.l = 14w0;
+        h_0.b1 = 1w0;
+        s_2_h = h_0;
+        x_0_field_4.i = 8s0;
+        x_0_field_4.b = false;
+        x_0_field_4.l = 14w0;
+        x_0_field_4.b1 = 1w0;
+        x_0_field_5_h.i = 8s0;
+        x_0_field_5_h.b = false;
+        x_0_field_5_h.l = 14w0;
+        x_0_field_5_h.b1 = 1w0;
+        f<tuple_0>({ 8s0, true, error.NoError, myEnum1.e1, 8w0, x_0_field_4, { 8w0, myEnum1.e1, error.NoError, x_0_field_5_h, 1w0, false, 8s0 } });
+        r = 1w0;
+    }
+    @hidden table tbl_convenient_init34 {
+        actions = {
+            convenient_init34();
+        }
+        const default_action = convenient_init34();
+    }
+    apply {
+        tbl_convenient_init34.apply();
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/convenient_init.p4
+++ b/testdata/p4_16_samples_outputs/convenient_init.p4
@@ -1,0 +1,55 @@
+#include <core.p4>
+
+enum bit<8> myEnum {
+    One = 1,
+    Two = 2,
+    Three = 3
+}
+
+enum myEnum1 {
+    e1,
+    e2,
+    e3
+}
+
+
+header H {
+    int<8> i;
+    bool   b;
+    bit<14> l;
+    bit<1> b1;
+}
+
+
+struct S {
+    myEnum      val;
+    myEnum1     val1;
+    error       errorNoOne;
+    H           h;
+    bit<1>      z;
+    bool        b;
+    int<8>      i;
+}
+
+
+extern void f<D>(in D data);
+control c(inout bit<1> r) {
+    S s_0;
+    H h_0;
+    bit<1> tmp;
+    apply {
+        S s_1;
+        s_1 = { b = false, h={3, true, ...}, ...};
+        H h = { ... };
+        s_1.h = h;
+        s_0 = s_1;
+        tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x = { 0, true, ... };
+        f<tuple<int<8>, bool, error, myEnum1, myEnum, H, S>>(x);
+        tmp = s_0.z;
+        r = tmp;
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/copy-first.p4
+++ b/testdata/p4_16_samples_outputs/copy-first.p4
@@ -6,7 +6,7 @@ control c(inout bit<32> b) {
     action a() {
         S s1;
         S s2;
-        s2 = S {x = 32w0};
+        s2 = { 32w0 };
         s1 = s2;
         s2 = s1;
         b = s2.x;

--- a/testdata/p4_16_samples_outputs/default-initializer-first.p4
+++ b/testdata/p4_16_samples_outputs/default-initializer-first.p4
@@ -1,9 +1,9 @@
 #include <core.p4>
 
 enum bit<8> myEnum {
-    One = 1,
-    Two = 2,
-    Three = 3
+    One = 8w1,
+    Two = 8w2,
+    Three = 8w3
 }
 
 enum myEnum1 {
@@ -12,40 +12,36 @@ enum myEnum1 {
     e3
 }
 
-
 header H {
-    int<8> i;
-    bool   b;
+    int<8>  i;
+    bool    b;
     bit<14> l;
-    bit<1> b1;
+    bit<1>  b1;
 }
-
 
 struct S {
-    myEnum      val;
-    myEnum1     val1;
-    error       errorNoOne;
-    H           h;
-    bit<1>      z;
-    bool        b;
-    int<8>      i;
+    myEnum  val;
+    myEnum1 val1;
+    error   errorNoOne;
+    H       h;
+    bit<1>  z;
+    bool    b;
+    int<8>  i;
 }
-
 
 extern void f<D>(in D data);
 control c(inout bit<1> r) {
-    S s_0;
-    H h_0;
+    S sa;
     bit<1> tmp;
     apply {
-        S s_1;
-        s_1 = { b = false, h={3, true, ...}, ...};
-        H h = { ... };
-        s_1.h = h;
-        s_0 = s_1;
+        S sb;
+        sb = S {b = false,h = { 3, true, ... }, ... };
+        H hb = { ... };
+        sb.h = hb;
+        sa = sb;
         tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x = { 0, true, ... };
         f<tuple<int<8>, bool, error, myEnum1, myEnum, H, S>>(x);
-        tmp = s_0.z;
+        tmp = sa.z;
         r = tmp;
     }
 }

--- a/testdata/p4_16_samples_outputs/default-initializer-frontend.p4
+++ b/testdata/p4_16_samples_outputs/default-initializer-frontend.p4
@@ -31,21 +31,21 @@ struct S {
 
 extern void f<D>(in D data);
 control c(inout bit<1> r) {
-    S s;
+    S sa_0;
     bit<1> tmp_0;
-    S s_2;
-    H h_0;
+    S sb_0;
+    H hb_0;
     tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x_0;
     apply {
-        s_2.h.setValid();
-        s_2 = S {val = 8w0,val1 = myEnum1.e1,errorNoOne = error.NoError,h = H {i = 8s3,b = true,l = 14w0,b1 = 1w0},z = 1w0,b = false,i = 8s0};
-        h_0.setValid();
-        h_0 = H {i = 8s0,b = false,l = 14w0,b1 = 1w0};
-        s_2.h = h_0;
-        s = s_2;
+        sb_0.h.setValid();
+        sb_0 = S {val = 8w0,val1 = myEnum1.e1,errorNoOne = error.NoError,h = H {i = 8s3,b = true,l = 14w0,b1 = 1w0},z = 1w0,b = false,i = 8s0};
+        hb_0.setValid();
+        hb_0 = H {i = 8s0,b = false,l = 14w0,b1 = 1w0};
+        sb_0.h = hb_0;
+        sa_0 = sb_0;
         x_0 = { 8s0, true, error.NoError, myEnum1.e1, 8w0, H {i = 8s0,b = false,l = 14w0,b1 = 1w0}, S {val = 8w0,val1 = myEnum1.e1,errorNoOne = error.NoError,h = H {i = 8s0,b = false,l = 14w0,b1 = 1w0},z = 1w0,b = false,i = 8s0} };
         f<tuple<int<8>, bool, error, myEnum1, myEnum, H, S>>(x_0);
-        tmp_0 = s.z;
+        tmp_0 = sa_0.z;
         r = tmp_0;
     }
 }

--- a/testdata/p4_16_samples_outputs/default-initializer-midend.p4
+++ b/testdata/p4_16_samples_outputs/default-initializer-midend.p4
@@ -35,22 +35,22 @@ struct tuple_0 {
 }
 
 control c(inout bit<1> r) {
-    H s_2_h;
-    H h_0;
+    H sb_0_h;
+    H hb_0;
     H x_0_field_4;
     H x_0_field_5_h;
-    @hidden action convenient_init34() {
-        s_2_h.setValid();
-        s_2_h.i = 8s3;
-        s_2_h.b = true;
-        s_2_h.l = 14w0;
-        s_2_h.b1 = 1w0;
-        h_0.setValid();
-        h_0.i = 8s0;
-        h_0.b = false;
-        h_0.l = 14w0;
-        h_0.b1 = 1w0;
-        s_2_h = h_0;
+    @hidden action defaultinitializer33() {
+        sb_0_h.setValid();
+        sb_0_h.i = 8s3;
+        sb_0_h.b = true;
+        sb_0_h.l = 14w0;
+        sb_0_h.b1 = 1w0;
+        hb_0.setValid();
+        hb_0.i = 8s0;
+        hb_0.b = false;
+        hb_0.l = 14w0;
+        hb_0.b1 = 1w0;
+        sb_0_h = hb_0;
         x_0_field_4.i = 8s0;
         x_0_field_4.b = false;
         x_0_field_4.l = 14w0;
@@ -62,14 +62,14 @@ control c(inout bit<1> r) {
         f<tuple_0>({ 8s0, true, error.NoError, myEnum1.e1, 8w0, x_0_field_4, { 8w0, myEnum1.e1, error.NoError, x_0_field_5_h, 1w0, false, 8s0 } });
         r = 1w0;
     }
-    @hidden table tbl_convenient_init34 {
+    @hidden table tbl_defaultinitializer33 {
         actions = {
-            convenient_init34();
+            defaultinitializer33();
         }
-        const default_action = convenient_init34();
+        const default_action = defaultinitializer33();
     }
     apply {
-        tbl_convenient_init34.apply();
+        tbl_defaultinitializer33.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/default-initializer.p4
+++ b/testdata/p4_16_samples_outputs/default-initializer.p4
@@ -1,0 +1,54 @@
+#include <core.p4>
+
+enum bit<8> myEnum {
+    One = 1,
+    Two = 2,
+    Three = 3
+}
+
+enum myEnum1 {
+    e1,
+    e2,
+    e3
+}
+
+
+header H {
+    int<8> i;
+    bool   b;
+    bit<14> l;
+    bit<1> b1;
+}
+
+
+struct S {
+    myEnum      val;
+    myEnum1     val1;
+    error       errorNoOne;
+    H           h;
+    bit<1>              z;
+    bool        b;
+    int<8>      i;
+}
+
+
+extern void f<D>(in D data);
+control c(inout bit<1> r) {
+    S sa;
+    bit<1> tmp;
+    apply {
+        S sb;
+        sb = { b = false, h={3, true, ...}, ...};
+        H hb = { ... };
+        sb.h = hb;
+        sa = sb;
+        tuple<int<8>, bool, error, myEnum1, myEnum, H, S> x = { 0, true, ... };
+        f<tuple<int<8>, bool, error, myEnum1, myEnum, H, S>>(x);
+        tmp = sa.z;
+        r = tmp;
+    }
+}
+
+control simple(inout bit<1> r);
+package top(simple e);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue1670-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1670-bmv2-first.p4
@@ -25,7 +25,7 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     apply {
         h.mirrored_md.setValid();
-        h.mirrored_md.meta = switch_metadata_t {port = 8w0};
+        h.mirrored_md.meta = { 8w0 };
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1863-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1863-first.p4
@@ -6,7 +6,7 @@ struct S {
 control c(out bit<1> b) {
     apply {
         S s = { 1w0, 1w1 };
-        s = S {a = s.b,b = s.a};
+        s = { s.b, s.a };
         b = s.a;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1863-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1863-frontend.p4
@@ -6,7 +6,7 @@ struct S {
 control c(out bit<1> b) {
     S s_0;
     apply {
-        s_0 = { 1w0, 1w1 };
+        s_0 = S {a = 1w0,b = 1w1};
         s_0 = S {a = s_0.b,b = s_0.a};
         b = s_0.a;
     }

--- a/testdata/p4_16_samples_outputs/issue2213-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2213-first.p4
@@ -13,7 +13,7 @@ struct metadata_t {
 
 control ingressImpl(inout metadata_t meta) {
     apply {
-        meta.s2 = mystruct2_t {s1 = mystruct1_t {f1 = 16w2}};
+        meta.s2 = mystruct2_t {s1 = {f1 = 16w2}};
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue232-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2-frontend.p4
@@ -34,10 +34,10 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
     bool done_0;
     bool ok_0;
     @name("Eg.test") action test() {
-        inKey_0 = { 32w1 };
-        defaultKey_0 = { 32w0 };
+        inKey_0 = Key {field1 = 32w1};
+        defaultKey_0 = Key {field1 = 32w0};
         same_0 = inKey_0 == defaultKey_0;
-        val = { 32w0 };
+        val = Value {field1 = 32w0};
         done_0 = false;
         ok_0 = !done_0 && same_0;
         if (ok_0) {

--- a/testdata/p4_16_samples_outputs/issue242-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-frontend.p4
@@ -64,7 +64,7 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
     @name("Eg.debug") register<bit<32>>(32w100) debug_0;
     @name("Eg.reg") register<bit<32>>(32w1) reg_0;
     @name("Eg.test") action test() {
-        val_0 = { 32w0 };
+        val_0 = Value {field1 = 32w0};
         _pred_0 = val_0.field1 != 32w0;
         if (_pred_0) {
             tmp = 32w1;

--- a/testdata/p4_16_samples_outputs/issue396-first.p4
+++ b/testdata/p4_16_samples_outputs/issue396-first.p4
@@ -20,13 +20,13 @@ control d(out bool b) {
         H h;
         H h1;
         H[2] h3;
-        h = H {x = 32w0};
+        h = { 32w0 };
         S s;
         S s1;
-        s = S {h = H {x = 32w0}};
-        s1.h = H {x = 32w0};
-        h3[0] = H {x = 32w0};
-        h3[1] = H {x = 32w1};
+        s = { { 32w0 } };
+        s1.h = { 32w0 };
+        h3[0] = { 32w0 };
+        h3[1] = { 32w1 };
         bool eout;
         einst.apply(H {x = 32w0}, eout);
         b = h.isValid() && eout && h3[1].isValid() && s1.h.isValid();

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-frontend.p4
@@ -66,7 +66,7 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
     bit<32> tmp;
     bit<32> tmp_0;
     @name("Eg.test") action test() {
-        val_0 = { 32w0 };
+        val_0 = Value {field1 = 32w0};
         _pred_0 = val_0.field1 != 32w0;
         if (_pred_0) {
             tmp = 32w1;

--- a/testdata/p4_16_samples_outputs/issue841-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue841-frontend.p4
@@ -46,7 +46,7 @@ control MyComputeChecksum(inout headers hdr, inout metadata meta) {
     @name("MyComputeChecksum.checksum") Checksum16() checksum_0;
     apply {
         h_0.setValid();
-        h_0 = { hdr.h.src, hdr.h.dst, 16w0 };
+        h_0 = h_t {src = hdr.h.src,dst = hdr.h.dst,csum = 16w0};
         hdr.h.csum = checksum_0.get<h_t>(h_0);
     }
 }

--- a/testdata/p4_16_samples_outputs/issue907-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2-frontend.p4
@@ -21,7 +21,7 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
     S s_0;
     @name("Ing.r") register<S>(32w100) r_0;
     apply {
-        s_0 = { 32w0 };
+        s_0 = S {f = 32w0};
         r_0.write(32w0, s_0);
     }
 }

--- a/testdata/p4_16_samples_outputs/issue982-first.p4
+++ b/testdata/p4_16_samples_outputs/issue982-first.p4
@@ -397,7 +397,7 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
 control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd, out psa_ingress_deparser_output_metadata_t ostd) {
     apply {
         clone_metadata_t clone_md;
-        clone_md.data.h1 = clone_1_t {data = 32w0};
+        clone_md.data.h1 = { 32w0 };
         clone_md.type = 3w0;
         if (meta.custom_clone_id == 3w1) {
             ostd.clone_metadata = clone_md;

--- a/testdata/p4_16_samples_outputs/list-compare-frontend.p4
+++ b/testdata/p4_16_samples_outputs/list-compare-frontend.p4
@@ -10,7 +10,7 @@ control test(out bool zout) {
     S q_0;
     apply {
         p_0 = { 32w4, 32w5 };
-        q_0 = { 32w2, 32w3 };
+        q_0 = S {l = 32w2,r = 32w3};
         zout = p_0 == { 32w4, 32w5 };
         zout = zout && q_0 == S {l = 32w2,r = 32w3};
     }

--- a/testdata/p4_16_samples_outputs/nested-struct-default-initializers-first.p4
+++ b/testdata/p4_16_samples_outputs/nested-struct-default-initializers-first.p4
@@ -42,16 +42,19 @@ control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
 
 control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
     apply {
-        meta.s1 = mystruct1_t {f1 = 16w2,f2 = 8w3};
+        meta.s1 = { ... };
         meta.s2.s1 = meta.s1;
-        meta.s2 = mystruct2_t {s1 = meta.s1,f3 = 16w5,f4 = 32w8};
-        meta.s2 = mystruct2_t {s1 = {f1 = 16w2,f2 = 8w3},f3 = 16w5,f4 = 32w8};
+        meta.s2 = mystruct2_t {s1 = {f1 = 2, ... }, ... };
         stdmeta.egress_spec = (bit<9>)meta.s2.s1.f2;
     }
 }
 
 control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    metadata_t meta_a = { ... };
+    ethernet_t eth_a = { 0, ... };
     apply {
+        hdr.ethernet = eth_a;
+        meta = meta_a;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/nested-struct-default-initializers-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested-struct-default-initializers-frontend.p4
@@ -42,16 +42,21 @@ control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
 
 control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
     apply {
-        meta.s1 = mystruct1_t {f1 = 16w2,f2 = 8w3};
-        meta.s2.s1 = meta.s1;
-        meta.s2 = mystruct2_t {s1 = meta.s1,f3 = 16w5,f4 = 32w8};
-        meta.s2 = mystruct2_t {s1 = {f1 = 16w2,f2 = 8w3},f3 = 16w5,f4 = 32w8};
+        meta.s1 = mystruct1_t {f1 = 16w0,f2 = 8w0};
+        meta.s2 = mystruct2_t {s1 = mystruct1_t {f1 = 16w2,f2 = 8w0},f3 = 16w0,f4 = 32w0};
         stdmeta.egress_spec = (bit<9>)meta.s2.s1.f2;
     }
 }
 
 control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    metadata_t meta_a_0;
+    ethernet_t eth_a_0;
     apply {
+        meta_a_0 = metadata_t {s1 = mystruct1_t {f1 = 16w0,f2 = 8w0},s2 = mystruct2_t {s1 = mystruct1_t {f1 = 16w0,f2 = 8w0},f3 = 16w0,f4 = 32w0}};
+        eth_a_0.setValid();
+        eth_a_0 = ethernet_t {dstAddr = 48w0,srcAddr = 48w0,etherType = 16w0};
+        hdr.ethernet = eth_a_0;
+        meta = meta_a_0;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/nested-struct-default-initializers-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested-struct-default-initializers-midend.p4
@@ -1,0 +1,106 @@
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+struct mystruct1_t {
+    bit<16> f1;
+    bit<8>  f2;
+}
+
+struct mystruct2_t {
+    mystruct1_t s1;
+    bit<16>     f3;
+    bit<32>     f4;
+}
+
+struct metadata_t {
+    bit<16> _s1_f10;
+    bit<8>  _s1_f21;
+    bit<16> _s2_s1_f12;
+    bit<8>  _s2_s1_f23;
+    bit<16> _s2_f34;
+    bit<32> _s2_f45;
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @hidden action nestedstructdefaultinitializers68() {
+        meta._s1_f10 = 16w0;
+        meta._s1_f21 = 8w0;
+        meta._s2_s1_f12 = 16w2;
+        meta._s2_s1_f23 = 8w0;
+        meta._s2_f34 = 16w0;
+        meta._s2_f45 = 32w0;
+        stdmeta.egress_spec = 9w0;
+    }
+    @hidden table tbl_nestedstructdefaultinitializers68 {
+        actions = {
+            nestedstructdefaultinitializers68();
+        }
+        const default_action = nestedstructdefaultinitializers68();
+    }
+    apply {
+        tbl_nestedstructdefaultinitializers68.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    ethernet_t eth_a_0;
+    @hidden action nestedstructdefaultinitializers80() {
+        eth_a_0.setValid();
+        eth_a_0.dstAddr = 48w0;
+        eth_a_0.srcAddr = 48w0;
+        eth_a_0.etherType = 16w0;
+        hdr.ethernet = eth_a_0;
+        meta._s1_f10 = 16w0;
+        meta._s1_f21 = 8w0;
+        meta._s2_s1_f12 = 16w0;
+        meta._s2_s1_f23 = 8w0;
+        meta._s2_f34 = 16w0;
+        meta._s2_f45 = 32w0;
+    }
+    @hidden table tbl_nestedstructdefaultinitializers80 {
+        actions = {
+            nestedstructdefaultinitializers80();
+        }
+        const default_action = nestedstructdefaultinitializers80();
+    }
+    apply {
+        tbl_nestedstructdefaultinitializers80.apply();
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/nested-struct-default-initializers.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/nested-struct-default-initializers.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "v1model"
+}

--- a/testdata/p4_16_samples_outputs/nested-tuple-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple-frontend.p4
@@ -17,7 +17,7 @@ extern void f<T>(in T data);
 control c(inout bit<1> r) {
     S s_0;
     apply {
-        s_0 = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
+        s_0 = S {f1 = { T {f = 1w0}, T {f = 1w1} },f2 = T {f = 1w0},z = 1w1};
         f<tuple<T, T>>(s_0.f1);
         f<tuple_0>(tuple_0 {field = T {f = 1w0},field_0 = T {f = 1w1}});
         r = s_0.f2.f & s_0.z;

--- a/testdata/p4_16_samples_outputs/nested-tuple1-first.p4
+++ b/testdata/p4_16_samples_outputs/nested-tuple1-first.p4
@@ -13,7 +13,7 @@ control c(inout bit<1> r) {
     S s_0;
     bit<1> tmp;
     apply {
-        s_0 = S {f1 = { T {f = 1w0}, T {f = 1w1} },f2 = T {f = 1w0},z = 1w1};
+        s_0 = { { { 1w0 }, { 1w1 } }, { 1w0 }, 1w1 };
         f<tuple<T, T>>(s_0.f1);
         tmp = s_0.f2.f & s_0.z;
         r = tmp;

--- a/testdata/p4_16_samples_outputs/precedence-first.p4
+++ b/testdata/p4_16_samples_outputs/precedence-first.p4
@@ -83,7 +83,7 @@ action ac() {
     a = b + c;
     a = f.z + b;
     a = fct(f.z + b, b + c);
-    f = s {z = a + b,w = c};
-    g = t {s1 = s {z = a + b,w = c},s2 = s {z = a + b,w = c}};
-    g = t {s1 = s {z = a + b + b,w = c},s2 = s {z = a + (b + c),w = c}};
+    f = { a + b, c };
+    g = { { a + b, c }, { a + b, c } };
+    g = { { a + b + b, c }, { a + (b + c), c } };
 }

--- a/testdata/p4_16_samples_outputs/select-struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/select-struct-frontend.p4
@@ -10,7 +10,7 @@ parser p() {
     S s_0;
     state start {
         x_0 = 8w5;
-        s_0 = { 8w0, 8w0 };
+        s_0 = S {f0 = 8w0,f1 = 8w0};
         transition select(x_0, x_0, { x_0, x_0 }, x_0) {
             (8w0, 8w0, { 8w0, 8w0 }, 8w0): accept;
             (8w1, 8w1, default, 8w1): accept;


### PR DESCRIPTION
Struct, header or tuple can be initialized automatically with a default value of
the suitable type using the syntax `...` or using a mix of explicit
values and default values by using the notation `...` in a list
expression initializer(and struct initializer expression for structs).

Mix of explicit values and default values can also be used for assignment.

For `struct`, `tuple` and `header` types the default values are `struct`,
`tuple` and `header` respectively, where each field has the default value
of the suitable field type -- if all such default values are defined.

Default value for `header` type could be easily changed to invalid, as proposed
in p4-spec pull request #797, when a new literal for initializing `header` to
invalid is introduced.

Header stacks and `header_union` are not supported as a leaf fields of structs
and tuples if using this kind of initialization, because in current version of
spec there are no constructs to initialize these types.
If they are used as a leaf fields compiler will report an error.

Frontnend reorganized, Struct initializer now processes declaration initializers
along with assignment statemants, which is the cause of changes in expected outputs
of some tests.