### PR TITLE
p4c-ubpf: Update links in installation scripts

### DIFF
--- a/backends/ubpf/tests/environment/setup-pktgen.sh
+++ b/backends/ubpf/tests/environment/setup-pktgen.sh
@@ -62,8 +62,7 @@ fi
 if [ ! -d "/home/vagrant/p4c" ]
 then
  cd /home/vagrant
- # TODO: it should be replaced with https://github.com/p4lang/p4c after merge
- git clone https://github.com/P4-Research/p4c.git
+ git clone https://github.com/p4lang/p4c.git
  cd p4c
 fi
 

--- a/backends/ubpf/tests/environment/setup-switch.sh
+++ b/backends/ubpf/tests/environment/setup-switch.sh
@@ -182,8 +182,7 @@ fi
 if [ ! -d "/home/vagrant/p4c" ]
 then
  cd /home/vagrant
- # TODO: it should be replaced with https://github.com/p4lang/p4c after merge
- git clone -b master https://github.com/P4-Research/p4c.git
+ git clone https://github.com/p4lang/p4c.git
  cd p4c
  git submodule update --init --recursive
  mkdir build


### PR DESCRIPTION
Once uBPF back-end is merged into master, the links in the installation scripts should be updated to point to the proper repo.