### PR TITLE
Fix type_info generation

### DIFF
--- a/control-plane/typeSpecConverter.cpp
+++ b/control-plane/typeSpecConverter.cpp
@@ -70,6 +70,16 @@ bool hasTranslationAnnotation(const IR::Type* type, std::string* uri, int* sdnB)
     return true;
 }
 
+cstring getTypeName(const IR::Type* type, const TypeMap* typeMap) {
+    CHECK_NULL(type);
+
+    auto t = typeMap->getTypeType(type, true);
+    if (auto newt = t->to<IR::Type_Newtype>()) {
+        return newt->name;
+    }
+    return nullptr;
+}
+
 TypeSpecConverter::TypeSpecConverter(
     const P4::ReferenceMap* refMap, const P4::TypeMap* typeMap, P4TypeInfo* p4RtTypeInfo)
     : refMap(refMap), typeMap(typeMap), p4RtTypeInfo(p4RtTypeInfo) {

--- a/control-plane/typeSpecConverter.h
+++ b/control-plane/typeSpecConverter.h
@@ -86,10 +86,14 @@ class TypeSpecConverter : public Inspector {
         const IR::Type* type, ::p4::config::v1::P4TypeInfo* typeInfo);
 };
 
-// hasTranslationAnnotation returns true iff the type is annotated by a *valid*
-// p4runtime_translation annotation, in which case it also sets @uri and @sdnB based on the
-// annotation's two arguments.
+/// hasTranslationAnnotation returns true iff the type is annotated by a *valid*
+/// p4runtime_translation annotation, in which case it also sets @uri and @sdnB based on the
+/// annotation's two arguments.
 bool hasTranslationAnnotation(const IR::Type* type, std::string* uri, int* sdnB);
+
+/// getTypeName returns a cstring for use as type_name for a Type_Newtype. It
+/// returns nullptr if @type is not a Type_Newtype.
+cstring getTypeName(const IR::Type* type, const TypeMap* typeMap);
 
 }  // namespace ControlPlaneAPI
 

--- a/testdata/p4_16_errors_outputs/control-inline.p4-stderr
+++ b/testdata/p4_16_errors_outputs/control-inline.p4-stderr
@@ -1,3 +1,3 @@
-control-inline.p4(35): [--Werror=invalid] error: vc: Invalid declaration. Instantiations cannot be in a control 'apply' block.
+control-inline.p4(35): [--Werror=invalid] error: vc: invalid declaration. Instantiations cannot be in a control 'apply' block.
         VC() vc;
              ^^

--- a/testdata/p4_16_errors_outputs/local_instance.p4-stderr
+++ b/testdata/p4_16_errors_outputs/local_instance.p4-stderr
@@ -1,3 +1,3 @@
-local_instance.p4(33): [--Werror=invalid] error: vc: Invalid declaration. Instantiations cannot be in a control 'apply' block.
+local_instance.p4(33): [--Werror=invalid] error: vc: invalid declaration. Instantiations cannot be in a control 'apply' block.
         VC() vc; // illegal instance within an apply block
              ^^

--- a/testdata/p4_16_errors_outputs/not_bound.p4-stderr
+++ b/testdata/p4_16_errors_outputs/not_bound.p4-stderr
@@ -4,4 +4,4 @@ not_bound.p4(36): [--Werror=legacy] error: action set_nhop: parameter port must 
 not_bound.p4(32)
     action set_nhop(bit<9> port) {
                            ^^^^
-[--Werror=unsupported] error: Cannot generate P4Info message: Unsupported P4 program (cannot apply necessary program transformations)
+[--Werror=unsupported] error: Cannot generate P4Info message: unsupported P4 program (cannot apply necessary program transformations)

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.p4info.txt
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.p4info.txt
@@ -41,3 +41,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4-stderr
@@ -1,3 +1,3 @@
-table-entries-non-const.p4(68): [--Werror=invalid] error: EntriesList: Invalid initializer. Table initializers must be constant.
+table-entries-non-const.p4(68): [--Werror=invalid] error: EntriesList: invalid initializer. Table initializers must be constant.
         entries = {
         ^^^^^^^

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.p4info.txt
@@ -47,3 +47,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_errors_outputs/width1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/width1_e.p4-stderr
@@ -1,9 +1,9 @@
 width1_e.p4(16): [--Wwarn=overflow] warning: 0xffffffff: signed value does not fit in 32 bits
 const int<32> c1 = 0xFFFFFFFF;
                    ^^^^^^^^^^
-width1_e.p4(17): [--Werror=invalid] error: int<-2>: Invalid type size
+width1_e.p4(17): [--Werror=invalid] error: int<-2>: invalid type size
 const int<(c1 + c1)> c2 = 0;
       ^^^^^^^^^^^^^^
-width1_e.p4(18): [--Werror=invalid] error: int<-3>: Invalid type size
+width1_e.p4(18): [--Werror=invalid] error: int<-3>: invalid type size
 const int<(-3)> c3 = 0;
       ^^^^^^^^^

--- a/testdata/p4_16_samples/custom-type-restricted-fields.p4
+++ b/testdata/p4_16_samples/custom-type-restricted-fields.p4
@@ -1,0 +1,186 @@
+// P4 program adapted from one submitted by Andy Fingerhut (@jafingerhut) in https://github.com/p4lang/p4c/issues/2239.
+/*
+Copyright 2020 Cisco Systems, Inc.
+Copyright 2020 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/EthernetAddr_t", 32)
+type bit<48>         EthernetAddr_t;
+
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/IPv4Addr_t", 32)
+type bit<32>         IPv4Addr_t;
+
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/CustomAddr_t", 32)
+type bit<32>         CustomAddr_t;
+
+header ethernet_t {
+    EthernetAddr_t  dstAddr;
+    EthernetAddr_t  srcAddr;
+    bit<16>         etherType;
+}
+
+@controller_header("packet_out")
+header packet_out_t {
+  bit<9> egress_port; /* suggested port where the packet
+                         should be sent */
+  bit<8> queue_id;    /* suggested queue ID */
+  EthernetAddr_t not_actually_useful;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    IPv4Addr_t srcAddr;
+    IPv4Addr_t dstAddr;
+}
+
+// @jafingerhut created this header, he claims it will revolutionize the
+// networking industry.
+header andycustom_t {
+    // @jafingerhut: No one is proposing this as any kind of standard.  I just
+    // made this up.  What else is P4 for?  :-)
+    bit<2>       version;
+    bit<6>       dscp;
+    bit<16>      totalLen;
+    bit<8>       ttl;
+
+    bit<8>       protocol;
+    bit<8>       l4Offset;
+    bit<8>       flags;
+    bit<8>       rsvd;
+
+    CustomAddr_t srcAddr;
+    CustomAddr_t dstAddr;
+}
+
+struct headers_t {
+    packet_out_t  cpu;
+    ethernet_t    ethernet;
+    ipv4_t        ipv4;
+    andycustom_t  andycustom;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet,
+                  out headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t stdmeta)
+{
+    const bit<16> ETHERTYPE_IPV4       = 16w0x0800;
+    const bit<16> ETHERTYPE_ANDYCUSTOM = 16w0xd00d;
+
+    const bit<8>  IP_PROTOCOLS_IPV4    = 4;
+    const bit<9>  CPU_PORT             = 111;
+
+    state start {
+        transition select(stdmeta.ingress_port) {
+            CPU_PORT: parse_cpu_hdr;
+            default: parse_ethernet;
+        }
+    }
+    state parse_cpu_hdr {
+        packet.extract(hdr.cpu);
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            ETHERTYPE_IPV4: parse_ipv4;
+            ETHERTYPE_ANDYCUSTOM: parse_andycustom;
+            default: accept;
+        }
+    }
+    state parse_andycustom {
+        packet.extract(hdr.andycustom);
+        transition select(hdr.andycustom.protocol) {
+            IP_PROTOCOLS_IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control ingressImpl(inout headers_t hdr,
+                    inout metadata_t meta,
+                    inout standard_metadata_t stdmeta)
+{
+    action my_drop() {
+        mark_to_drop(stdmeta);
+    }
+    action set_addr(IPv4Addr_t new_dstAddr) {
+        hdr.ipv4.dstAddr = new_dstAddr;
+        stdmeta.egress_spec = stdmeta.ingress_port;
+    }
+    table t1 {
+        key = {
+            hdr.andycustom.srcAddr: exact;
+        }
+        actions = {
+            set_addr;
+            my_drop;
+            NoAction;
+        }
+        const default_action = NoAction;
+    }
+    apply {
+        t1.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr,
+                   inout metadata_t meta,
+                   inout standard_metadata_t stdmeta)
+{
+    apply { }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control deparserImpl(packet_out packet,
+                     in headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+V1Switch(parserImpl(),
+         verifyChecksum(),
+         ingressImpl(),
+         egressImpl(),
+         updateChecksum(),
+         deparserImpl()) main;

--- a/testdata/p4_16_samples/psa-custom-type-counter-index.p4
+++ b/testdata/p4_16_samples/psa-custom-type-counter-index.p4
@@ -1,0 +1,109 @@
+#include <core.p4>
+#include <psa.p4>
+
+struct EMPTY { };
+
+header EMPTY_H {};
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+parser MyIP(
+    packet_in buffer,
+    out ethernet_t eth,
+    inout EMPTY b,
+    in psa_ingress_parser_input_metadata_t c,
+    in EMPTY_H d,
+    in EMPTY_H e) {
+
+    state start {
+        buffer.extract(eth);
+        transition accept;
+    }
+}
+
+parser MyEP(
+    packet_in buffer,
+    out EMPTY a,
+    inout EMPTY b,
+    in psa_egress_parser_input_metadata_t c,
+    in EMPTY d,
+    in EMPTY_H e,
+    in EMPTY_H f) {
+    state start {
+        transition accept;
+    }
+}
+
+type bit<12> CounterIndex_t;
+
+control MyIC(
+    inout ethernet_t a,
+    inout EMPTY b,
+    in psa_ingress_input_metadata_t c,
+    inout psa_ingress_output_metadata_t d) {
+
+    Counter<bit<10>,CounterIndex_t>(1024, PSA_CounterType_t.PACKETS) counter;
+
+    action execute() {
+        counter.count((CounterIndex_t)1024);
+    }
+
+    table tbl {
+        key = {
+            a.srcAddr : exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+
+    apply {
+        tbl.apply();
+    }
+}
+
+control MyEC(
+    inout EMPTY a,
+    inout EMPTY b,
+    in psa_egress_input_metadata_t c,
+    inout psa_egress_output_metadata_t d) {
+    apply { }
+}
+
+control MyID(
+    packet_out buffer,
+    out EMPTY_H a,
+    out EMPTY_H b,
+    out EMPTY c,
+    inout ethernet_t d,
+    in EMPTY e,
+    in psa_ingress_output_metadata_t f) {
+    apply { }
+}
+
+control MyED(
+    packet_out buffer,
+    out EMPTY_H a,
+    out EMPTY_H b,
+    inout EMPTY c,
+    in EMPTY d,
+    in psa_egress_output_metadata_t e,
+    in psa_egress_deparser_input_metadata_t f) {
+    apply { }
+}
+
+IngressPipeline(MyIP(), MyIC(), MyID()) ip;
+EgressPipeline(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch(
+    ip,
+    PacketReplicationEngine(),
+    ep,
+    BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/arith-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith-bmv2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "add"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "add"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/arith1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "compare"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/arith2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "compare"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/arith3-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "shift"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/arith4-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "shift"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/arith5-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "shift"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4.p4info.txt
@@ -41,3 +41,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/concat-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/concat-bmv2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "concat"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields-first.p4
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields-first.p4
@@ -1,0 +1,139 @@
+#include <core.p4>
+#include <v1model.p4>
+
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/EthernetAddr_t" , 32) type bit<48> EthernetAddr_t;
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/IPv4Addr_t" , 32) type bit<32> IPv4Addr_t;
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/CustomAddr_t" , 32) type bit<32> CustomAddr_t;
+header ethernet_t {
+    EthernetAddr_t dstAddr;
+    EthernetAddr_t srcAddr;
+    bit<16>        etherType;
+}
+
+@controller_header("packet_out") header packet_out_t {
+    bit<9>         egress_port;
+    bit<8>         queue_id;
+    EthernetAddr_t not_actually_useful;
+}
+
+header ipv4_t {
+    bit<4>     version;
+    bit<4>     ihl;
+    bit<8>     diffserv;
+    bit<16>    totalLen;
+    bit<16>    identification;
+    bit<3>     flags;
+    bit<13>    fragOffset;
+    bit<8>     ttl;
+    bit<8>     protocol;
+    bit<16>    hdrChecksum;
+    IPv4Addr_t srcAddr;
+    IPv4Addr_t dstAddr;
+}
+
+header andycustom_t {
+    bit<2>       version;
+    bit<6>       dscp;
+    bit<16>      totalLen;
+    bit<8>       ttl;
+    bit<8>       protocol;
+    bit<8>       l4Offset;
+    bit<8>       flags;
+    bit<8>       rsvd;
+    CustomAddr_t srcAddr;
+    CustomAddr_t dstAddr;
+}
+
+struct headers_t {
+    packet_out_t cpu;
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+    andycustom_t andycustom;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    const bit<16> ETHERTYPE_IPV4 = 16w0x800;
+    const bit<16> ETHERTYPE_ANDYCUSTOM = 16w0xd00d;
+    const bit<8> IP_PROTOCOLS_IPV4 = 8w4;
+    const bit<9> CPU_PORT = 9w111;
+    state start {
+        transition select(stdmeta.ingress_port) {
+            9w111: parse_cpu_hdr;
+            default: parse_ethernet;
+        }
+    }
+    state parse_cpu_hdr {
+        packet.extract<packet_out_t>(hdr.cpu);
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            16w0xd00d: parse_andycustom;
+            default: accept;
+        }
+    }
+    state parse_andycustom {
+        packet.extract<andycustom_t>(hdr.andycustom);
+        transition select(hdr.andycustom.protocol) {
+            8w4: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    action my_drop() {
+        mark_to_drop(stdmeta);
+    }
+    action set_addr(IPv4Addr_t new_dstAddr) {
+        hdr.ipv4.dstAddr = new_dstAddr;
+        stdmeta.egress_spec = stdmeta.ingress_port;
+    }
+    table t1 {
+        key = {
+            hdr.andycustom.srcAddr: exact @name("hdr.andycustom.srcAddr") ;
+        }
+        actions = {
+            set_addr();
+            my_drop();
+            NoAction();
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        t1.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields-frontend.p4
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields-frontend.p4
@@ -1,0 +1,137 @@
+#include <core.p4>
+#include <v1model.p4>
+
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/EthernetAddr_t" , 32) type bit<48> EthernetAddr_t;
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/IPv4Addr_t" , 32) type bit<32> IPv4Addr_t;
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/CustomAddr_t" , 32) type bit<32> CustomAddr_t;
+header ethernet_t {
+    EthernetAddr_t dstAddr;
+    EthernetAddr_t srcAddr;
+    bit<16>        etherType;
+}
+
+@controller_header("packet_out") header packet_out_t {
+    bit<9>         egress_port;
+    bit<8>         queue_id;
+    EthernetAddr_t not_actually_useful;
+}
+
+header ipv4_t {
+    bit<4>     version;
+    bit<4>     ihl;
+    bit<8>     diffserv;
+    bit<16>    totalLen;
+    bit<16>    identification;
+    bit<3>     flags;
+    bit<13>    fragOffset;
+    bit<8>     ttl;
+    bit<8>     protocol;
+    bit<16>    hdrChecksum;
+    IPv4Addr_t srcAddr;
+    IPv4Addr_t dstAddr;
+}
+
+header andycustom_t {
+    bit<2>       version;
+    bit<6>       dscp;
+    bit<16>      totalLen;
+    bit<8>       ttl;
+    bit<8>       protocol;
+    bit<8>       l4Offset;
+    bit<8>       flags;
+    bit<8>       rsvd;
+    CustomAddr_t srcAddr;
+    CustomAddr_t dstAddr;
+}
+
+struct headers_t {
+    packet_out_t cpu;
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+    andycustom_t andycustom;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        transition select(stdmeta.ingress_port) {
+            9w111: parse_cpu_hdr;
+            default: parse_ethernet;
+        }
+    }
+    state parse_cpu_hdr {
+        packet.extract<packet_out_t>(hdr.cpu);
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            16w0xd00d: parse_andycustom;
+            default: accept;
+        }
+    }
+    state parse_andycustom {
+        packet.extract<andycustom_t>(hdr.andycustom);
+        transition select(hdr.andycustom.protocol) {
+            8w4: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("ingressImpl.my_drop") action my_drop() {
+        mark_to_drop(stdmeta);
+    }
+    @name("ingressImpl.set_addr") action set_addr(IPv4Addr_t new_dstAddr) {
+        hdr.ipv4.dstAddr = new_dstAddr;
+        stdmeta.egress_spec = stdmeta.ingress_port;
+    }
+    @name("ingressImpl.t1") table t1_0 {
+        key = {
+            hdr.andycustom.srcAddr: exact @name("hdr.andycustom.srcAddr") ;
+        }
+        actions = {
+            set_addr();
+            my_drop();
+            NoAction_0();
+        }
+        const default_action = NoAction_0();
+    }
+    apply {
+        t1_0.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields-midend.p4
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields-midend.p4
@@ -1,0 +1,137 @@
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddr_t;
+typedef bit<32> IPv4Addr_t;
+typedef bit<32> CustomAddr_t;
+header ethernet_t {
+    EthernetAddr_t dstAddr;
+    EthernetAddr_t srcAddr;
+    bit<16>        etherType;
+}
+
+@controller_header("packet_out") header packet_out_t {
+    bit<9>         egress_port;
+    bit<8>         queue_id;
+    EthernetAddr_t not_actually_useful;
+}
+
+header ipv4_t {
+    bit<4>     version;
+    bit<4>     ihl;
+    bit<8>     diffserv;
+    bit<16>    totalLen;
+    bit<16>    identification;
+    bit<3>     flags;
+    bit<13>    fragOffset;
+    bit<8>     ttl;
+    bit<8>     protocol;
+    bit<16>    hdrChecksum;
+    IPv4Addr_t srcAddr;
+    IPv4Addr_t dstAddr;
+}
+
+header andycustom_t {
+    bit<2>       version;
+    bit<6>       dscp;
+    bit<16>      totalLen;
+    bit<8>       ttl;
+    bit<8>       protocol;
+    bit<8>       l4Offset;
+    bit<8>       flags;
+    bit<8>       rsvd;
+    CustomAddr_t srcAddr;
+    CustomAddr_t dstAddr;
+}
+
+struct headers_t {
+    packet_out_t cpu;
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+    andycustom_t andycustom;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        transition select(stdmeta.ingress_port) {
+            9w111: parse_cpu_hdr;
+            default: parse_ethernet;
+        }
+    }
+    state parse_cpu_hdr {
+        packet.extract<packet_out_t>(hdr.cpu);
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            16w0xd00d: parse_andycustom;
+            default: accept;
+        }
+    }
+    state parse_andycustom {
+        packet.extract<andycustom_t>(hdr.andycustom);
+        transition select(hdr.andycustom.protocol) {
+            8w4: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("ingressImpl.my_drop") action my_drop() {
+        mark_to_drop(stdmeta);
+    }
+    @name("ingressImpl.set_addr") action set_addr(IPv4Addr_t new_dstAddr) {
+        hdr.ipv4.dstAddr = new_dstAddr;
+        stdmeta.egress_spec = stdmeta.ingress_port;
+    }
+    @name("ingressImpl.t1") table t1_0 {
+        key = {
+            hdr.andycustom.srcAddr: exact @name("hdr.andycustom.srcAddr") ;
+        }
+        actions = {
+            set_addr();
+            my_drop();
+            NoAction_0();
+        }
+        const default_action = NoAction_0();
+    }
+    apply {
+        t1_0.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields.p4
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields.p4
@@ -1,0 +1,139 @@
+#include <core.p4>
+#include <v1model.p4>
+
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/EthernetAddr_t" , 32) type bit<48> EthernetAddr_t;
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/IPv4Addr_t" , 32) type bit<32> IPv4Addr_t;
+@p4runtime_translation("com.fingerhutpress/andysp4arch/v1/CustomAddr_t" , 32) type bit<32> CustomAddr_t;
+header ethernet_t {
+    EthernetAddr_t dstAddr;
+    EthernetAddr_t srcAddr;
+    bit<16>        etherType;
+}
+
+@controller_header("packet_out") header packet_out_t {
+    bit<9>         egress_port;
+    bit<8>         queue_id;
+    EthernetAddr_t not_actually_useful;
+}
+
+header ipv4_t {
+    bit<4>     version;
+    bit<4>     ihl;
+    bit<8>     diffserv;
+    bit<16>    totalLen;
+    bit<16>    identification;
+    bit<3>     flags;
+    bit<13>    fragOffset;
+    bit<8>     ttl;
+    bit<8>     protocol;
+    bit<16>    hdrChecksum;
+    IPv4Addr_t srcAddr;
+    IPv4Addr_t dstAddr;
+}
+
+header andycustom_t {
+    bit<2>       version;
+    bit<6>       dscp;
+    bit<16>      totalLen;
+    bit<8>       ttl;
+    bit<8>       protocol;
+    bit<8>       l4Offset;
+    bit<8>       flags;
+    bit<8>       rsvd;
+    CustomAddr_t srcAddr;
+    CustomAddr_t dstAddr;
+}
+
+struct headers_t {
+    packet_out_t cpu;
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+    andycustom_t andycustom;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    const bit<16> ETHERTYPE_IPV4 = 16w0x800;
+    const bit<16> ETHERTYPE_ANDYCUSTOM = 16w0xd00d;
+    const bit<8> IP_PROTOCOLS_IPV4 = 4;
+    const bit<9> CPU_PORT = 111;
+    state start {
+        transition select(stdmeta.ingress_port) {
+            CPU_PORT: parse_cpu_hdr;
+            default: parse_ethernet;
+        }
+    }
+    state parse_cpu_hdr {
+        packet.extract(hdr.cpu);
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            ETHERTYPE_IPV4: parse_ipv4;
+            ETHERTYPE_ANDYCUSTOM: parse_andycustom;
+            default: accept;
+        }
+    }
+    state parse_andycustom {
+        packet.extract(hdr.andycustom);
+        transition select(hdr.andycustom.protocol) {
+            IP_PROTOCOLS_IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    action my_drop() {
+        mark_to_drop(stdmeta);
+    }
+    action set_addr(IPv4Addr_t new_dstAddr) {
+        hdr.ipv4.dstAddr = new_dstAddr;
+        stdmeta.egress_spec = stdmeta.ingress_port;
+    }
+    table t1 {
+        key = {
+            hdr.andycustom.srcAddr: exact;
+        }
+        actions = {
+            set_addr;
+            my_drop;
+            NoAction;
+        }
+        const default_action = NoAction;
+    }
+    apply {
+        t1.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+V1Switch(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields.p4.p4info.txt
@@ -1,0 +1,114 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 33575637
+    name: "ingressImpl.t1"
+    alias: "t1"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.andycustom.srcAddr"
+    bitwidth: 32
+    match_type: EXACT
+    type_name {
+      name: "CustomAddr_t"
+    }
+  }
+  action_refs {
+    id: 16827880
+  }
+  action_refs {
+    id: 16788060
+  }
+  action_refs {
+    id: 16800567
+  }
+  const_default_action_id: 16800567
+  size: 1024
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16788060
+    name: "ingressImpl.my_drop"
+    alias: "my_drop"
+  }
+}
+actions {
+  preamble {
+    id: 16827880
+    name: "ingressImpl.set_addr"
+    alias: "set_addr"
+  }
+  params {
+    id: 1
+    name: "new_dstAddr"
+    bitwidth: 32
+    type_name {
+      name: "IPv4Addr_t"
+    }
+  }
+}
+controller_packet_metadata {
+  preamble {
+    id: 67135753
+    name: "packet_out"
+    alias: "packet_out"
+    annotations: "@controller_header(\"packet_out\")"
+  }
+  metadata {
+    id: 1
+    name: "egress_port"
+    bitwidth: 9
+  }
+  metadata {
+    id: 2
+    name: "queue_id"
+    bitwidth: 8
+  }
+  metadata {
+    id: 3
+    name: "not_actually_useful"
+    bitwidth: 32
+    type_name {
+      name: "EthernetAddr_t"
+    }
+  }
+}
+type_info {
+  new_types {
+    key: "CustomAddr_t"
+    value {
+      translated_type {
+        uri: "com.fingerhutpress/andysp4arch/v1/CustomAddr_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+  new_types {
+    key: "EthernetAddr_t"
+    value {
+      translated_type {
+        uri: "com.fingerhutpress/andysp4arch/v1/EthernetAddr_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+  new_types {
+    key: "IPv4Addr_t"
+    value {
+      translated_type {
+        uri: "com.fingerhutpress/andysp4arch/v1/IPv4Addr_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/def-use.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/def-use.p4.p4info.txt
@@ -19,3 +19,5 @@ actions {
     alias: "a"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/default_action-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2.p4.p4info.txt
@@ -25,3 +25,5 @@ actions {
     bitwidth: 32
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/hit-expr-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/hit-expr-bmv2.p4.p4info.txt
@@ -19,3 +19,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/inline-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/inline-bmv2.p4.p4info.txt
@@ -25,3 +25,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/inline1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2.p4.p4info.txt
@@ -25,3 +25,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1107.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1107.p4.p4info.txt
@@ -49,3 +49,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1412-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1412-bmv2.p4.p4info.txt
@@ -37,3 +37,5 @@ actions {
     alias: "set_true"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1478-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1478-bmv2.p4.p4info.txt
@@ -38,3 +38,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2.p4.p4info.txt
@@ -107,3 +107,5 @@ actions {
     bitwidth: 32
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1595.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1595.p4.p4info.txt
@@ -65,3 +65,5 @@ actions {
     alias: "a4"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1713-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1713-bmv2.p4.p4info.txt
@@ -50,3 +50,5 @@ actions {
     alias: "case3"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2.p4.p4info.txt
@@ -75,4 +75,28 @@ actions {
   }
 }
 type_info {
+  new_types {
+    key: "IPv4Address2_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 32
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "IPv4Address_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 32
+          }
+        }
+      }
+    }
+  }
 }

--- a/testdata/p4_16_samples_outputs/issue1806.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1806.p4.p4info.txt
@@ -37,3 +37,5 @@ actions {
     alias: "do_act"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1834-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1834-bmv2.p4.p4info.txt
@@ -43,3 +43,5 @@ actions {
     bitwidth: 8
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue1989-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1989-bmv2.p4.p4info.txt
@@ -37,3 +37,5 @@ actions {
     alias: "assign_non_const_array_index"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue2044-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2044-bmv2.p4.p4info.txt
@@ -25,3 +25,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2.p4.p4info.txt
@@ -35,3 +35,5 @@ actions {
     alias: "do_something"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue414-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2.p4.p4info.txt
@@ -25,3 +25,5 @@ actions {
     alias: "foo"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue420.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue420.p4.p4info.txt
@@ -34,3 +34,5 @@ actions {
     bitwidth: 16
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue422.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue422.p4.p4info.txt
@@ -29,3 +29,5 @@ actions {
     alias: "foo"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue486-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue486-bmv2.p4.p4info.txt
@@ -43,3 +43,5 @@ actions {
     alias: "foo"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue512.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue512.p4.p4info.txt
@@ -25,3 +25,5 @@ actions {
     alias: "foo"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue561-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-1-bmv2.p4.p4info.txt
@@ -38,3 +38,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue561-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-2-bmv2.p4.p4info.txt
@@ -38,3 +38,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue561-3-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-3-bmv2.p4.p4info.txt
@@ -38,3 +38,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue561-4-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-4-bmv2.p4.p4info.txt
@@ -50,3 +50,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue561-5-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-5-bmv2.p4.p4info.txt
@@ -38,3 +38,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue561-6-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-6-bmv2.p4.p4info.txt
@@ -50,3 +50,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue561-7-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-7-bmv2.p4.p4info.txt
@@ -38,3 +38,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue949.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue949.p4.p4info.txt
@@ -37,3 +37,5 @@ actions {
     alias: "setDest"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue983-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue983-bmv2.p4.p4info.txt
@@ -97,3 +97,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue986-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue986-1-bmv2.p4.p4info.txt
@@ -30,3 +30,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue986-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue986-bmv2.p4.p4info.txt
@@ -19,3 +19,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2.p4.p4info.txt
@@ -19,3 +19,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/key-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/key-bmv2.p4.p4info.txt
@@ -35,3 +35,5 @@ actions {
     alias: "a"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/key1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/key1-bmv2.p4.p4info.txt
@@ -35,3 +35,5 @@ actions {
     alias: "a"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/p416-type-use3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/p416-type-use3.p4.p4info.txt
@@ -258,4 +258,97 @@ actions {
   }
 }
 type_info {
+  new_types {
+    key: "CustomDDT_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "CustomDTT_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "CustomDT_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "CustomTDT_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "CustomTTT_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "CustomTT_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "CustomT_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "EthT_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/EthT_t"
+        sdn_bitwidth: 48
+      }
+    }
+  }
 }

--- a/testdata/p4_16_samples_outputs/parser-locals2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/parser-locals2.p4.p4info.txt
@@ -25,3 +25,5 @@ actions {
     alias: "foo"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/pred2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pred2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "cond"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4.p4info.txt
@@ -46,3 +46,5 @@ actions {
     alias: "a2"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-first.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <psa.p4>
+
+struct EMPTY {
+}
+
+header EMPTY_H {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+    state start {
+        buffer.extract<ethernet_t>(eth);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_input_metadata_t c, in EMPTY d, in EMPTY_H e, in EMPTY_H f) {
+    state start {
+        transition accept;
+    }
+}
+
+type bit<12> CounterIndex_t;
+control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    Counter<bit<10>, CounterIndex_t>(32w1024, PSA_CounterType_t.PACKETS) counter;
+    action execute() {
+        counter.count((CounterIndex_t)12w1024);
+    }
+    table tbl {
+        key = {
+            a.srcAddr: exact @name("a.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    apply {
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY_H a, out EMPTY_H b, inout EMPTY c, in EMPTY d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-frontend.p4
@@ -1,0 +1,73 @@
+#include <core.p4>
+#include <psa.p4>
+
+struct EMPTY {
+}
+
+header EMPTY_H {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+    state start {
+        buffer.extract<ethernet_t>(eth);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_input_metadata_t c, in EMPTY d, in EMPTY_H e, in EMPTY_H f) {
+    state start {
+        transition accept;
+    }
+}
+
+type bit<12> CounterIndex_t;
+control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("MyIC.counter") Counter<bit<10>, CounterIndex_t>(32w1024, PSA_CounterType_t.PACKETS) counter_0;
+    @name("MyIC.execute") action execute_1() {
+        counter_0.count((CounterIndex_t)12w1024);
+    }
+    @name("MyIC.tbl") table tbl_0 {
+        key = {
+            a.srcAddr: exact @name("a.srcAddr") ;
+        }
+        actions = {
+            NoAction_0();
+            execute_1();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    apply {
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY_H a, out EMPTY_H b, inout EMPTY c, in EMPTY d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-midend.p4
@@ -1,0 +1,73 @@
+#include <core.p4>
+#include <psa.p4>
+
+struct EMPTY {
+}
+
+header EMPTY_H {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+    state start {
+        buffer.extract<ethernet_t>(eth);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_input_metadata_t c, in EMPTY d, in EMPTY_H e, in EMPTY_H f) {
+    state start {
+        transition accept;
+    }
+}
+
+typedef bit<12> CounterIndex_t;
+control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    @name(".NoAction") action NoAction_0() {
+    }
+    @name("MyIC.counter") Counter<bit<10>, CounterIndex_t>(32w1024, PSA_CounterType_t.PACKETS) counter_0;
+    @name("MyIC.execute") action execute_1() {
+        counter_0.count(12w1024);
+    }
+    @name("MyIC.tbl") table tbl_0 {
+        key = {
+            a.srcAddr: exact @name("a.srcAddr") ;
+        }
+        actions = {
+            NoAction_0();
+            execute_1();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    apply {
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY_H a, out EMPTY_H b, inout EMPTY c, in EMPTY d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+#include <psa.p4>
+
+struct EMPTY {
+}
+
+header EMPTY_H {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+    state start {
+        buffer.extract(eth);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_input_metadata_t c, in EMPTY d, in EMPTY_H e, in EMPTY_H f) {
+    state start {
+        transition accept;
+    }
+}
+
+type bit<12> CounterIndex_t;
+control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    Counter<bit<10>, CounterIndex_t>(1024, PSA_CounterType_t.PACKETS) counter;
+    action execute() {
+        counter.count((CounterIndex_t)1024);
+    }
+    table tbl {
+        key = {
+            a.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    apply {
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY_H a, out EMPTY_H b, inout EMPTY c, in EMPTY d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.p4info.txt
@@ -1,0 +1,66 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 33610509
+    name: "MyIC.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "a.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 16800567
+  }
+  action_refs {
+    id: 16835440
+  }
+  size: 1024
+  idle_timeout_behavior: NOTIFY_CONTROL
+}
+actions {
+  preamble {
+    id: 16800567
+    name: "NoAction"
+    alias: "NoAction"
+  }
+}
+actions {
+  preamble {
+    id: 16835440
+    name: "MyIC.execute"
+    alias: "execute"
+  }
+}
+counters {
+  preamble {
+    id: 302014859
+    name: "MyIC.counter"
+    alias: "counter"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+  index_type_name {
+    name: "CounterIndex_t"
+  }
+}
+type_info {
+  new_types {
+    key: "CounterIndex_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 12
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/psa-example-counters-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-counters-bmv2.p4.p4info.txt
@@ -55,6 +55,9 @@ counters {
     unit: BYTES
   }
   size: 512
+  index_type_name {
+    name: "PortId_t"
+  }
 }
 counters {
   preamble {
@@ -66,6 +69,9 @@ counters {
     unit: BYTES
   }
   size: 512
+  index_type_name {
+    name: "PortId_t"
+  }
 }
 direct_counters {
   preamble {
@@ -79,4 +85,13 @@ direct_counters {
   direct_table_id: 33571396
 }
 type_info {
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
 }

--- a/testdata/p4_16_samples_outputs/psa-example-digest-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-digest-bmv2.p4.p4info.txt
@@ -152,6 +152,42 @@ type_info {
       }
     }
   }
+  serializable_enums {
+    key: "EthTypes"
+    value {
+      underlying_type {
+        bitwidth: 16
+      }
+      members {
+        name: "IPv4"
+        value: "\010\000"
+      }
+      members {
+        name: "ARP"
+        value: "\010\006"
+      }
+      members {
+        name: "RARP"
+        value: "\2005"
+      }
+      members {
+        name: "EtherTalk"
+        value: "\200\233"
+      }
+      members {
+        name: "VLAN"
+        value: "\201\000"
+      }
+      members {
+        name: "IPX"
+        value: "\2017"
+      }
+      members {
+        name: "IPv6"
+        value: "\206\335"
+      }
+    }
+  }
   new_types {
     key: "PortId_t"
     value {

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.p4info.txt
@@ -22,6 +22,18 @@ registers {
     }
   }
   size: 512
+  index_type_name {
+    name: "PortId_t"
+  }
 }
 type_info {
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
 }

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txt
@@ -27,3 +27,5 @@ actions {
     alias: "add"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2.p4.p4info.txt
@@ -50,3 +50,5 @@ value_sets {
   }
   size: 4
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2.p4.p4info.txt
@@ -51,3 +51,5 @@ value_sets {
   }
   size: 4
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2.p4.p4info.txt
@@ -57,3 +57,5 @@ value_sets {
   }
   size: 4
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2.p4.p4info.txt
@@ -69,3 +69,5 @@ value_sets {
   }
   size: 4
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2.p4.p4info.txt
@@ -20,3 +20,5 @@ actions {
     alias: "set_port"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/std_meta_inlining.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/std_meta_inlining.p4.p4info.txt
@@ -37,3 +37,5 @@ actions {
     alias: "NoAction"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/strength3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/strength3.p4.p4info.txt
@@ -90,3 +90,5 @@ actions {
     alias: "case7"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4.p4info.txt
@@ -41,3 +41,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4.p4info.txt
@@ -47,3 +47,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4.p4info.txt
@@ -41,3 +41,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.p4info.txt
@@ -47,3 +47,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4.p4info.txt
@@ -41,3 +41,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.p4info.txt
@@ -41,3 +41,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.p4info.txt
@@ -48,3 +48,37 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+  serializable_enums {
+    key: "MyEnum1B"
+    value {
+      underlying_type {
+        bitwidth: 8
+      }
+      members {
+        name: "MBR1"
+        value: "\000"
+      }
+      members {
+        name: "MBR2"
+        value: "\377"
+      }
+    }
+  }
+  serializable_enums {
+    key: "MyEnum2B"
+    value {
+      underlying_type {
+        bitwidth: 16
+      }
+      members {
+        name: "MBR1"
+        value: "\000\n"
+      }
+      members {
+        name: "MBR2"
+        value: "\253\000"
+      }
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4.p4info.txt
@@ -41,3 +41,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4.p4info.txt
@@ -47,3 +47,5 @@ actions {
     bitwidth: 9
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/table-key-serenum.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-key-serenum.p4.p4info.txt
@@ -43,3 +43,41 @@ actions {
     bitwidth: 32
   }
 }
+type_info {
+  serializable_enums {
+    key: "EthTypes"
+    value {
+      underlying_type {
+        bitwidth: 16
+      }
+      members {
+        name: "IPv4"
+        value: "\010\000"
+      }
+      members {
+        name: "ARP"
+        value: "\010\006"
+      }
+      members {
+        name: "RARP"
+        value: "\2005"
+      }
+      members {
+        name: "EtherTalk"
+        value: "\200\233"
+      }
+      members {
+        name: "VLAN"
+        value: "\201\000"
+      }
+      members {
+        name: "IPX"
+        value: "\2017"
+      }
+      members {
+        name: "IPv6"
+        value: "\206\335"
+      }
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2.p4.p4info.txt
@@ -182,3 +182,5 @@ actions {
     bitwidth: 8
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2.p4.p4info.txt
@@ -25,3 +25,5 @@ actions {
     alias: "a"
   }
 }
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/v1model-digest-custom-type.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/v1model-digest-custom-type.p4.p4info.txt
@@ -223,6 +223,15 @@ type_info {
     }
   }
   new_types {
+    key: "IPv4Addr_t"
+    value {
+      translated_type {
+        uri: "com.fingerhutpress/andysp4arch/v1/IPv4Addr_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+  new_types {
     key: "bar_t"
     value {
       original_type {

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1.p4.p4info.txt
@@ -485,11 +485,17 @@ controller_packet_metadata {
     id: 2
     name: "addr1"
     bitwidth: 48
+    type_name {
+      name: "Eth1_t"
+    }
   }
   metadata {
     id: 3
     name: "addr2"
     bitwidth: 49
+    type_name {
+      name: "Eth2_t"
+    }
   }
   metadata {
     id: 4
@@ -505,11 +511,17 @@ controller_packet_metadata {
     id: 6
     name: "e1"
     bitwidth: 8
+    type_name {
+      name: "Custom1_t"
+    }
   }
   metadata {
     id: 7
     name: "e2"
     bitwidth: 12
+    type_name {
+      name: "Custom2_t"
+    }
   }
   metadata {
     id: 8
@@ -520,86 +532,137 @@ controller_packet_metadata {
     id: 9
     name: "e01"
     bitwidth: 8
+    type_name {
+      name: "Custom01_t"
+    }
   }
   metadata {
     id: 10
     name: "e02"
     bitwidth: 13
+    type_name {
+      name: "Custom02_t"
+    }
   }
   metadata {
     id: 11
     name: "e10"
     bitwidth: 8
+    type_name {
+      name: "Custom1_t"
+    }
   }
   metadata {
     id: 12
     name: "e11"
     bitwidth: 8
+    type_name {
+      name: "Custom11_t"
+    }
   }
   metadata {
     id: 13
     name: "e12"
     bitwidth: 14
+    type_name {
+      name: "Custom12_t"
+    }
   }
   metadata {
     id: 14
     name: "e20"
     bitwidth: 12
+    type_name {
+      name: "Custom2_t"
+    }
   }
   metadata {
     id: 15
     name: "e21"
     bitwidth: 8
+    type_name {
+      name: "Custom21_t"
+    }
   }
   metadata {
     id: 16
     name: "e22"
     bitwidth: 15
+    type_name {
+      name: "Custom22_t"
+    }
   }
   metadata {
     id: 17
     name: "e001"
     bitwidth: 8
+    type_name {
+      name: "Custom001_t"
+    }
   }
   metadata {
     id: 18
     name: "e002"
     bitwidth: 16
+    type_name {
+      name: "Custom002_t"
+    }
   }
   metadata {
     id: 19
     name: "e101"
     bitwidth: 8
+    type_name {
+      name: "Custom101_t"
+    }
   }
   metadata {
     id: 20
     name: "e102"
     bitwidth: 17
+    type_name {
+      name: "Custom102_t"
+    }
   }
   metadata {
     id: 21
     name: "e201"
     bitwidth: 8
+    type_name {
+      name: "Custom201_t"
+    }
   }
   metadata {
     id: 22
     name: "e202"
     bitwidth: 18
+    type_name {
+      name: "Custom202_t"
+    }
   }
   metadata {
     id: 23
     name: "e220"
     bitwidth: 15
+    type_name {
+      name: "Custom22_t"
+    }
   }
   metadata {
     id: 24
     name: "e0020010"
     bitwidth: 8
+    type_name {
+      name: "Custom002001_t"
+    }
   }
   metadata {
     id: 25
     name: "e0020020"
     bitwidth: 19
+    type_name {
+      name: "Custom002002_t"
+    }
   }
 }
 value_sets {
@@ -635,4 +698,209 @@ value_sets {
   size: 4
 }
 type_info {
+  serializable_enums {
+    key: "serenum_t"
+    value {
+      underlying_type {
+        bitwidth: 8
+      }
+      members {
+        name: "A"
+        value: "\001"
+      }
+      members {
+        name: "B"
+        value: "\003"
+      }
+    }
+  }
+  new_types {
+    key: "Custom001_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "Custom002001_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "Custom002002_t"
+    value {
+      translated_type {
+        uri: "mycompany.com/My_Byte9"
+        sdn_bitwidth: 19
+      }
+    }
+  }
+  new_types {
+    key: "Custom002_t"
+    value {
+      translated_type {
+        uri: "mycompany.com/My_Byte6"
+        sdn_bitwidth: 16
+      }
+    }
+  }
+  new_types {
+    key: "Custom01_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "Custom02_t"
+    value {
+      translated_type {
+        uri: "mycompany.com/My_Byte3"
+        sdn_bitwidth: 13
+      }
+    }
+  }
+  new_types {
+    key: "Custom101_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "Custom102_t"
+    value {
+      translated_type {
+        uri: "mycompany.com/My_Byte7"
+        sdn_bitwidth: 17
+      }
+    }
+  }
+  new_types {
+    key: "Custom11_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "Custom12_t"
+    value {
+      translated_type {
+        uri: "mycompany.com/My_Byte4"
+        sdn_bitwidth: 14
+      }
+    }
+  }
+  new_types {
+    key: "Custom1_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "Custom201_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "Custom202_t"
+    value {
+      translated_type {
+        uri: "mycompany.com/My_Byte8"
+        sdn_bitwidth: 18
+      }
+    }
+  }
+  new_types {
+    key: "Custom21_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "Custom22_t"
+    value {
+      translated_type {
+        uri: "mycompany.com/My_Byte5"
+        sdn_bitwidth: 15
+      }
+    }
+  }
+  new_types {
+    key: "Custom2_t"
+    value {
+      translated_type {
+        uri: "mycompany.com/My_Byte2"
+        sdn_bitwidth: 12
+      }
+    }
+  }
+  new_types {
+    key: "Eth1_t"
+    value {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 48
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "Eth2_t"
+    value {
+      translated_type {
+        uri: "mycompany.com/EthernetAddress"
+        sdn_bitwidth: 49
+      }
+    }
+  }
 }


### PR DESCRIPTION
P4Runtime v1 resticts the type of some fields (match fields, action
parameters, controller metadata fields) to unsigned bitstrings. When a
user-defined type is used for one of these, P4Info will use the
underlying type, but will also populate a type_name field in the
Protobuf message so that P4Info consummers can be aware of the
user-defined type. The type_name can then be looked-up in the type_info
"database" of types. This commit fixes an issue which caused type_info
not to be populated correctly. It also makes sure that type_name is set
properly for counter / meter / register indices.

Fixes #2239