### PR TITLE
Ensure that ID prefixes are correct in P4Info when '@id' is used

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -457,8 +457,8 @@ class P4RuntimeSymbolTable : public P4RuntimeSymbolTableIface {
     void computeIdsForSymbols(P4RuntimeSymbolType type) {
         // The id for most resources follows a standard format:
         //
-        //   [resource type] [zero byte] [name hash value]
-        //    \____8_b____/   \__8_b__/   \_____16_b____/
+        //   [resource type] [name hash value]
+        //    \____8_b____/   \_____24_b____/
         auto& symbolTable = symbolTables.at(type);
         auto resourceType = static_cast<p4rt_id_t>(type);
 
@@ -483,7 +483,7 @@ class P4RuntimeSymbolTable : public P4RuntimeSymbolTableIface {
             // resolve hash collisions, the id that we select depends on the order in
             // which the names are hashed. This is why we sort the names above.
             boost::optional<p4rt_id_t> id = probeForId(nameId, [=](uint32_t nameId) {
-                return (resourceType << 24) | (nameId & 0xffff);
+                return (resourceType << 24) | (nameId & 0xffffff);
             });
 
             if (!id) {

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -201,10 +201,11 @@ struct ActionRef {
                                         // reference in the table declaration.
 };
 
-/// @return the value of any P4 '@id' annotation @declaration may have. The name
-/// 'externalId' is in analogy with externalName().
+/// @return the value of any P4 '@id' annotation @declaration may have, and
+/// ensure that the value is correct with respect to the P4Runtime
+/// specification. The name 'externalId' is in analogy with externalName().
 static boost::optional<p4rt_id_t>
-externalId(const IR::IDeclaration* declaration) {
+externalId(P4RuntimeSymbolType type, const IR::IDeclaration* declaration) {
     CHECK_NULL(declaration);
     if (!declaration->is<IR::IAnnotated>()) {
         return boost::none;  // Assign an id later; see below.
@@ -215,11 +216,22 @@ externalId(const IR::IDeclaration* declaration) {
         auto idConstant = idAnnotation->expr[0]->to<IR::Constant>();
         CHECK_NULL(idConstant);
         if (!idConstant->fitsInt()) {
-            ::error("@id should be an integer for declaration %1%", declaration);
+            ::error(ErrorType::ERR_INVALID, "%1%: @id should be an integer", declaration);
             return boost::none;
         }
 
-        const uint32_t id = static_cast<uint32_t>(idConstant->value);
+        auto id = static_cast<p4rt_id_t>(idConstant->value);
+
+        // If the id already has an 8-bit type prefix, make sure it is correct
+        // for the resource type; otherwise assign the correct prefix.
+        const auto typePrefix = static_cast<p4rt_id_t>(type) << 24;
+        const auto prefixMask = static_cast<p4rt_id_t>(0xff) << 24;
+        if ((id & prefixMask) != 0 && (id & prefixMask) != typePrefix) {
+            ::error(ErrorType::ERR_INVALID, "%1%: @id has the wrong 8-bit prefix", declaration);
+            return boost::none;
+        }
+        id |= typePrefix;
+
         return id;
     }
 
@@ -372,7 +384,7 @@ class P4RuntimeSymbolTable : public P4RuntimeSymbolTableIface {
     /// Add a @type symbol, extracting the name and id from @declaration.
     void add(P4RuntimeSymbolType type, const IR::IDeclaration* declaration) override {
         CHECK_NULL(declaration);
-        add(type, declaration->controlPlaneName(), externalId(declaration));
+        add(type, declaration->controlPlaneName(), externalId(type, declaration));
     }
 
     /// Add a @type symbol with @name and possibly an explicit P4 '@id'.
@@ -1280,7 +1292,7 @@ static void collectTableSymbols(P4RuntimeSymbolTable& symbols,
                                 const IR::TableBlock* tableBlock) {
     CHECK_NULL(tableBlock);
     auto name = archHandler->getControlPlaneName(tableBlock);
-    auto id = externalId(tableBlock->container);
+    auto id = externalId(P4RuntimeSymbolType::TABLE(), tableBlock->container);
     symbols.add(P4RuntimeSymbolType::TABLE(), name, id);
     archHandler->collectTableProperties(&symbols, tableBlock);
 }

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -189,6 +189,12 @@ TEST_F(P4Runtime, IdAssignment) {
                 default_action = noop;
             }
 
+            @id(0xffffff)
+            table igTableWithLargestId {
+                actions = { noop; }
+                default_action = noop;
+            }
+
             @id(0x02000133)
             table igTableWithPrefixedId {
                 actions = { noop; }
@@ -224,6 +230,7 @@ TEST_F(P4Runtime, IdAssignment) {
                 igTable.apply();
                 igTableWithoutName.apply();
                 igTableWithId.apply();
+                igTableWithLargestId.apply();
                 igTableWithPrefixedId.apply();
                 igTableWithoutNameAndId.apply();
                 conflictingTableA.apply();
@@ -254,7 +261,7 @@ TEST_F(P4Runtime, IdAssignment) {
         // Check that the rest of the id matches the hash value that we expect.
         // (If we were to ever change the hash algorithm we use when mapping P4
         // names to P4Runtime ids, we'd need to change this test.)
-        EXPECT_EQ(16119u, igTable->preamble().id() & 0x00ffffff);
+        EXPECT_EQ(14761719u, igTable->preamble().id() & 0x00ffffff);
     }
 
     {
@@ -268,7 +275,7 @@ TEST_F(P4Runtime, IdAssignment) {
         // Check that the id of 'igTableWithName' was computed based on its
         // @name annotation. (See above for caveat re: the hash algorithm.)
         EXPECT_EQ(unsigned(P4Ids::TABLE), igTableWithName->preamble().id() >> 24);
-        EXPECT_EQ(59806u, igTableWithName->preamble().id() & 0x00ffffff);
+        EXPECT_EQ(1108382u, igTableWithName->preamble().id() & 0x00ffffff);
     }
 
     {
@@ -279,6 +286,14 @@ TEST_F(P4Runtime, IdAssignment) {
         ASSERT_TRUE(igTableWithId != nullptr);
         auto expectedId = 1234u | (unsigned(P4Ids::TABLE) << 24);
         EXPECT_EQ(expectedId, igTableWithId->preamble().id());
+    }
+
+    {
+        // Same as above, but with the largest possible id (0xffffff).
+        auto* igTableWithLargestId = findTable(*test, "ingress.igTableWithLargestId");
+        ASSERT_TRUE(igTableWithLargestId != nullptr);
+        auto expectedId = 0xffffffu | (unsigned(P4Ids::TABLE) << 24);
+        EXPECT_EQ(expectedId, igTableWithLargestId->preamble().id());
     }
 
     {

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -189,6 +189,12 @@ TEST_F(P4Runtime, IdAssignment) {
                 default_action = noop;
             }
 
+            @id(0x02000133)
+            table igTableWithPrefixedId {
+                actions = { noop; }
+                default_action = noop;
+            }
+
             @id(5678)
             @name("igTableWithNameAndId")
             table igTableWithoutNameAndId {
@@ -196,14 +202,20 @@ TEST_F(P4Runtime, IdAssignment) {
                 default_action = noop;
             }
 
-            @id(4321)
+            @id(0x02000134)
             table conflictingTableA {
                 actions = { noop; }
                 default_action = noop;
             }
 
-            @id(4321)
+            @id(0x02000134)
             table conflictingTableB {
+                actions = { noop; }
+                default_action = noop;
+            }
+
+            @id(0x03000133)
+            table igTableWithIdInvalidPrefix {
                 actions = { noop; }
                 default_action = noop;
             }
@@ -212,9 +224,11 @@ TEST_F(P4Runtime, IdAssignment) {
                 igTable.apply();
                 igTableWithoutName.apply();
                 igTableWithId.apply();
+                igTableWithPrefixedId.apply();
                 igTableWithoutNameAndId.apply();
                 conflictingTableA.apply();
                 conflictingTableB.apply();
+                igTableWithIdInvalidPrefix.apply();
             }
         }
 
@@ -224,9 +238,10 @@ TEST_F(P4Runtime, IdAssignment) {
 
     ASSERT_TRUE(test);
 
-    // We expect exactly one error:
-    //   error: @id 4321 is assigned to multiple declarations
-    EXPECT_EQ(1u, ::diagnosticCount());
+    // We expect exactly two errors:
+    //   error: @id 33554740 is assigned to multiple declarations
+    //   error: ingress.igTableWithIdInvalidPrefix: @id has the wrong 8-bit prefix
+    EXPECT_EQ(2u, ::diagnosticCount());
 
     {
         // Check that 'igTable' ended up in the P4Info output.
@@ -258,10 +273,21 @@ TEST_F(P4Runtime, IdAssignment) {
 
     {
         // Check that 'igTableWithId' ended up in the P4Info output, and that
-        // its id matches the one set by its @id annotation.
+        // its id matches the one set by its @id annotation, with the required
+        // 8-bit type prefix (which is 0x2 for tables).
         auto* igTableWithId = findTable(*test, "ingress.igTableWithId");
         ASSERT_TRUE(igTableWithId != nullptr);
-        EXPECT_EQ(1234u, igTableWithId->preamble().id());
+        auto expectedId = 1234u | (unsigned(P4Ids::TABLE) << 24);
+        EXPECT_EQ(expectedId, igTableWithId->preamble().id());
+    }
+
+    {
+        // Check that 'igTableWithPrefixedId' ended up in the P4Info output, and
+        // that its id matches the one set by its @id annotation.
+        auto* igTableWithPrefixedId = findTable(*test, "ingress.igTableWithPrefixedId");
+        ASSERT_TRUE(igTableWithPrefixedId != nullptr);
+        auto expectedId = 0x02000133u;
+        EXPECT_EQ(expectedId, igTableWithPrefixedId->preamble().id());
     }
 
     {
@@ -271,7 +297,8 @@ TEST_F(P4Runtime, IdAssignment) {
         EXPECT_TRUE(findTable(*test, "ingress.igTableWithoutNameAndId") == nullptr);
         auto* igTableWithNameAndId = findTable(*test, "ingress.igTableWithNameAndId");
         ASSERT_TRUE(igTableWithNameAndId != nullptr);
-        EXPECT_EQ(5678u, igTableWithNameAndId->preamble().id());
+        auto expectedId = 5678u | (unsigned(P4Ids::TABLE) << 24);
+        EXPECT_EQ(expectedId, igTableWithNameAndId->preamble().id());
     }
 
     {
@@ -281,8 +308,8 @@ TEST_F(P4Runtime, IdAssignment) {
         ASSERT_TRUE(conflictingTableA != nullptr);
         auto* conflictingTableB = findTable(*test, "ingress.conflictingTableB");
         ASSERT_TRUE(conflictingTableB != nullptr);
-        EXPECT_TRUE(conflictingTableA->preamble().id() == 4321 ||
-                    conflictingTableB->preamble().id() == 4321);
+        EXPECT_TRUE(conflictingTableA->preamble().id() == 0x02000134 ||
+                    conflictingTableB->preamble().id() == 0x02000134);
         EXPECT_NE(conflictingTableA->preamble().id(),
                   conflictingTableB->preamble().id());
     }

--- a/testdata/p4_16_errors_outputs/issue1777-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_errors_outputs/issue1777-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 registers {
   preamble {
-    id: 369104710
+    id: 369563462
     name: "ingress.reg1"
     alias: "reg1"
   }
@@ -18,7 +18,7 @@ registers {
 }
 registers {
   preamble {
-    id: 369162436
+    id: 382138564
     name: "ingress.reg2"
     alias: "reg2"
   }

--- a/testdata/p4_16_errors_outputs/issue1803_same_table_name.p4.p4info.txt
+++ b/testdata/p4_16_errors_outputs/issue1803_same_table_name.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33580881
+    id: 33777489
     name: "t0"
     alias: "t0"
   }
@@ -14,17 +14,17 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16815162
+    id: 24155194
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 tables {
   preamble {
-    id: 33580881
+    id: 33777489
     name: "t0"
     alias: "t0"
   }
@@ -35,31 +35,31 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16790297
+    id: 29700889
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16815162
+    id: 24155194
     name: "IngressI.c1.drop"
     alias: "c1.drop"
   }
 }
 actions {
   preamble {
-    id: 16790297
+    id: 29700889
     name: "IngressI.c2.drop"
     alias: "c2.drop"
   }

--- a/testdata/p4_16_errors_outputs/issue513.p4.p4info.txt
+++ b/testdata/p4_16_errors_outputs/issue513.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33616793
+    id: 48165785
     name: "cIngress.guh"
     alias: "guh"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16808330
+    id: 25131402
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16808330
+    id: 25131402
     name: "cIngress.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_errors_outputs/issue532.p4.p4info.txt
+++ b/testdata/p4_16_errors_outputs/issue532.p4.p4info.txt
@@ -3,29 +3,29 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16842345
+    id: 31981161
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16842345
+    id: 31981161
     name: "ingress.select_entry"
     alias: "select_entry"
   }

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.entries.txt
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33555353
+      table_id: 42140569
       match {
         field_id: 1
         lpm {
@@ -12,7 +12,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\013"
@@ -26,7 +26,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33555353
+      table_id: 42140569
       match {
         field_id: 1
         lpm {
@@ -36,7 +36,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\014"
@@ -50,10 +50,10 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33555353
+      table_id: 42140569
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\r"
@@ -67,10 +67,10 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33555353
+      table_id: 42140569
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\016"
@@ -84,7 +84,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33555353
+      table_id: 42140569
       match {
         field_id: 1
         lpm {
@@ -94,7 +94,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\017"

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.p4info.txt
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33555353
+    id: 42140569
     name: "ingress.t_lpm"
     alias: "t_lpm"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.entries.txt
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33609018
+      table_id: 38131002
       match {
         field_id: 1
         optional {
@@ -15,7 +15,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\001"
@@ -30,7 +30,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33609018
+      table_id: 38131002
       match {
         field_id: 1
         optional {
@@ -39,7 +39,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\002"
@@ -54,7 +54,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33609018
+      table_id: 38131002
       match {
         field_id: 2
         optional {
@@ -63,7 +63,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\003"

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33609018
+    id: 38131002
     name: "ingress.t_optional"
     alias: "t_optional"
   }
@@ -20,24 +20,24 @@ tables {
     match_type: OPTIONAL
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/action-synth.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action-synth.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16805530
+    id: 27422362
     name: "IngressI.aux.a"
     alias: "a"
   }

--- a/testdata/p4_16_samples_outputs/action-two-params.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/action-two-params.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33567740
+      table_id: 46478332
       match {
         field_id: 1
         exact {
@@ -11,7 +11,7 @@ updates {
       }
       action {
         action {
-          action_id: 16780658
+          action_id: 23137650
           params {
             param_id: 1
             value: "\000\000*"

--- a/testdata/p4_16_samples_outputs/action-two-params.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action-two-params.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33567740
+    id: 46478332
     name: "MyIngress.ingress_tbl"
     alias: "ingress_tbl"
   }
@@ -14,25 +14,25 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16780658
+    id: 23137650
   }
   action_refs {
-    id: 16805608
+    id: 25652968
   }
-  const_default_action_id: 16805608
+  const_default_action_id: 25652968
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16805608
+    id: 25652968
     name: "MyIngress.drop"
     alias: "drop"
   }
 }
 actions {
   preamble {
-    id: 16780658
+    id: 23137650
     name: "MyIngress.actTbl"
     alias: "actTbl"
   }

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2.p4.p4info.txt
@@ -3,66 +3,66 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33568532
+    id: 46872340
     name: "IngressI.indirect"
     alias: "indirect"
   }
   action_refs {
-    id: 16836747
+    id: 23455883
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
-  implementation_id: 285227422
+  const_default_action_id: 21257015
+  implementation_id: 294074782
   size: 1024
 }
 tables {
   preamble {
-    id: 33594274
+    id: 38116258
     name: "IngressI.indirect_ws"
     alias: "indirect_ws"
   }
   action_refs {
-    id: 16836747
+    id: 23455883
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
-  implementation_id: 285251566
+  const_default_action_id: 21257015
+  implementation_id: 300324846
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16836747
+    id: 23455883
     name: "IngressI.drop"
     alias: "drop"
   }
 }
 action_profiles {
   preamble {
-    id: 285227422
+    id: 294074782
     name: "ap"
     alias: "ap"
   }
-  table_ids: 33568532
+  table_ids: 46872340
   size: 128
 }
 action_profiles {
   preamble {
-    id: 285251566
+    id: 300324846
     name: "ap_ws"
     alias: "ap_ws"
   }
-  table_ids: 33594274
+  table_ids: 38116258
   with_selector: true
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4.p4info.txt
@@ -3,66 +3,66 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33568532
+    id: 46872340
     name: "IngressI.indirect"
     alias: "indirect"
   }
   action_refs {
-    id: 16836747
+    id: 23455883
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
-  implementation_id: 285227422
+  const_default_action_id: 21257015
+  implementation_id: 294074782
   size: 1024
 }
 tables {
   preamble {
-    id: 33594274
+    id: 38116258
     name: "IngressI.indirect_ws"
     alias: "indirect_ws"
   }
   action_refs {
-    id: 16836747
+    id: 23455883
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
-  implementation_id: 285251566
+  const_default_action_id: 21257015
+  implementation_id: 300324846
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16836747
+    id: 23455883
     name: "IngressI.drop"
     alias: "drop"
   }
 }
 action_profiles {
   preamble {
-    id: 285227422
+    id: 294074782
     name: "ap"
     alias: "ap"
   }
-  table_ids: 33568532
+  table_ids: 46872340
   size: 128
 }
 action_profiles {
   preamble {
-    id: 285251566
+    id: 300324846
     name: "ap_ws"
     alias: "ap_ws"
   }
-  table_ids: 33594274
+  table_ids: 38116258
   with_selector: true
   size: 1024
   max_group_size: 200

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4.p4info.txt
@@ -3,58 +3,58 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33594274
+    id: 38116258
     name: "IngressI.indirect_ws"
     alias: "indirect_ws"
   }
   action_refs {
-    id: 16836747
+    id: 23455883
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
-  implementation_id: 285230093
+  const_default_action_id: 21257015
+  implementation_id: 291652621
   size: 1024
 }
 tables {
   preamble {
-    id: 33557881
+    id: 33951097
     name: "IngressI.indirect_ws_1"
     alias: "indirect_ws_1"
   }
   action_refs {
-    id: 16836747
+    id: 23455883
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
-  implementation_id: 285230093
+  const_default_action_id: 21257015
+  implementation_id: 291652621
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16836747
+    id: 23455883
     name: "IngressI.drop"
     alias: "drop"
   }
 }
 action_profiles {
   preamble {
-    id: 285230093
+    id: 291652621
     name: "IngressI.as"
     alias: "as"
   }
-  table_ids: 33594274
-  table_ids: 33557881
+  table_ids: 38116258
+  table_ids: 33951097
   with_selector: true
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 action_profiles {
   preamble {
-    id: 285230093
+    id: 291652621
     name: "IngressI.as"
     alias: "as"
   }

--- a/testdata/p4_16_samples_outputs/arith-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16796018
+    id: 20728178
   }
-  const_default_action_id: 16796018
+  const_default_action_id: 20728178
   size: 1024
 }
 actions {
   preamble {
-    id: 16796018
+    id: 20728178
     name: "ingress.add"
     alias: "add"
   }

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33615638
+    id: 43577110
     name: "ingress.c.t"
     alias: "t"
   }
   action_refs {
-    id: 16832348
+    id: 29022044
   }
-  const_default_action_id: 16832348
+  const_default_action_id: 29022044
   size: 1024
 }
 actions {
   preamble {
-    id: 16832348
+    id: 29022044
     name: "ingress.c.add"
     alias: "add"
   }

--- a/testdata/p4_16_samples_outputs/arith1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16815707
+    id: 25073243
   }
-  const_default_action_id: 16815707
+  const_default_action_id: 25073243
   size: 1024
 }
 actions {
   preamble {
-    id: 16815707
+    id: 25073243
     name: "ingress.compare"
     alias: "compare"
   }

--- a/testdata/p4_16_samples_outputs/arith2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16815707
+    id: 25073243
   }
-  const_default_action_id: 16815707
+  const_default_action_id: 25073243
   size: 1024
 }
 actions {
   preamble {
-    id: 16815707
+    id: 25073243
     name: "ingress.compare"
     alias: "compare"
   }

--- a/testdata/p4_16_samples_outputs/arith3-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16826359
+    id: 32554999
   }
-  const_default_action_id: 16826359
+  const_default_action_id: 32554999
   size: 1024
 }
 actions {
   preamble {
-    id: 16826359
+    id: 32554999
     name: "ingress.shift"
     alias: "shift"
   }

--- a/testdata/p4_16_samples_outputs/arith4-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16826359
+    id: 32554999
   }
-  const_default_action_id: 16826359
+  const_default_action_id: 32554999
   size: 1024
 }
 actions {
   preamble {
-    id: 16826359
+    id: 32554999
     name: "ingress.shift"
     alias: "shift"
   }

--- a/testdata/p4_16_samples_outputs/arith5-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16826359
+    id: 32554999
   }
-  const_default_action_id: 16826359
+  const_default_action_id: 32554999
   size: 1024
 }
 actions {
   preamble {
-    id: 16826359
+    id: 32554999
     name: "ingress.shift"
     alias: "shift"
   }

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33581415
+    id: 48392551
     name: "ingress.bd"
     alias: "bd"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16793910
+    id: 33505590
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,7 +25,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33613387
+    id: 41084491
     name: "ingress.ipv4_fib"
     alias: "ipv4_fib"
   }
@@ -42,13 +42,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16826976
+    id: 22594144
   }
   action_refs {
-    id: 16798108
+    id: 26104220
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -56,7 +56,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33569838
+    id: 42875950
     name: "ingress.ipv4_fib_lpm"
     alias: "ipv4_fib_lpm"
   }
@@ -73,13 +73,13 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16826976
+    id: 22594144
   }
   action_refs {
-    id: 16798108
+    id: 26104220
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -87,7 +87,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33619585
+    id: 43581057
     name: "ingress.nexthop"
     alias: "nexthop"
   }
@@ -98,13 +98,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16826976
+    id: 22594144
   }
   action_refs {
-    id: 16788993
+    id: 19738113
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -112,7 +112,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33616322
+    id: 39645634
     name: "ingress.port_mapping"
     alias: "port_mapping"
   }
@@ -123,10 +123,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16817852
+    id: 27500220
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -134,7 +134,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33558953
+    id: 40309161
     name: "egress.rewrite_mac"
     alias: "rewrite_mac"
   }
@@ -145,13 +145,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16805656
+    id: 28864280
   }
   action_refs {
-    id: 16842256
+    id: 28966416
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -159,14 +159,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16793910
+    id: 33505590
     name: "ingress.set_vrf"
     alias: "set_vrf"
   }
@@ -178,14 +178,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16826976
+    id: 22594144
     name: "ingress.on_miss"
     alias: "ingress.on_miss"
   }
 }
 actions {
   preamble {
-    id: 16798108
+    id: 26104220
     name: "ingress.fib_hit_nexthop"
     alias: "fib_hit_nexthop"
   }
@@ -197,7 +197,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16788993
+    id: 19738113
     name: "ingress.set_egress_details"
     alias: "set_egress_details"
   }
@@ -209,7 +209,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16817852
+    id: 27500220
     name: "ingress.set_bd"
     alias: "set_bd"
   }
@@ -221,14 +221,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16805656
+    id: 28864280
     name: "egress.on_miss"
     alias: "egress.on_miss"
   }
 }
 actions {
   preamble {
-    id: 16842256
+    id: 28966416
     name: "egress.rewrite_src_dst_mac"
     alias: "rewrite_src_dst_mac"
   }

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33562569
+      table_id: 40116169
       match {
         field_id: 1
         exact {
@@ -11,7 +11,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\001"
@@ -25,7 +25,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33562569
+      table_id: 40116169
       match {
         field_id: 1
         exact {
@@ -34,7 +34,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\002"

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33562569
+    id: 40116169
     name: "ingress.t_exact"
     alias: "t_exact"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/checksum1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/checksum1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33616793
+    id: 48165785
     name: "cIngress.guh"
     alias: "guh"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16808330
+    id: 25131402
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16808330
+    id: 25131402
     name: "cIngress.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/concat-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/concat-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16812993
+    id: 30378945
   }
-  const_default_action_id: 16812993
+  const_default_action_id: 30378945
   size: 1024
 }
 actions {
   preamble {
-    id: 16812993
+    id: 30378945
     name: "ingress.concat"
     alias: "concat"
   }

--- a/testdata/p4_16_samples_outputs/crc32-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33563863
+      table_id: 35792087
       match {
         field_id: 1
         exact {
@@ -11,7 +11,7 @@ updates {
       }
       action {
         action {
-          action_id: 16789700
+          action_id: 24785092
         }
       }
     }
@@ -21,7 +21,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33563863
+      table_id: 35792087
       match {
         field_id: 1
         exact {
@@ -30,7 +30,7 @@ updates {
       }
       action {
         action {
-          action_id: 16838158
+          action_id: 22867470
         }
       }
     }
@@ -40,7 +40,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33563863
+      table_id: 35792087
       match {
         field_id: 1
         exact {
@@ -49,7 +49,7 @@ updates {
       }
       action {
         action {
-          action_id: 16807127
+          action_id: 32601303
         }
       }
     }
@@ -59,7 +59,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33563863
+      table_id: 35792087
       match {
         field_id: 1
         exact {
@@ -68,7 +68,7 @@ updates {
       }
       action {
         action {
-          action_id: 16815851
+          action_id: 17405675
         }
       }
     }
@@ -78,7 +78,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33563863
+      table_id: 35792087
       match {
         field_id: 1
         exact {
@@ -87,7 +87,7 @@ updates {
       }
       action {
         action {
-          action_id: 16797152
+          action_id: 31935968
         }
       }
     }
@@ -97,7 +97,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33563863
+      table_id: 35792087
       match {
         field_id: 1
         exact {
@@ -106,7 +106,7 @@ updates {
       }
       action {
         action {
-          action_id: 16805060
+          action_id: 24997060
         }
       }
     }

--- a/testdata/p4_16_samples_outputs/crc32-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33563863
+    id: 35792087
     name: "MyIngress.calculate"
     alias: "calculate"
   }
@@ -14,75 +14,75 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16789700
+    id: 24785092
   }
   action_refs {
-    id: 16838158
+    id: 22867470
   }
   action_refs {
-    id: 16807127
+    id: 32601303
   }
   action_refs {
-    id: 16815851
+    id: 17405675
   }
   action_refs {
-    id: 16797152
+    id: 31935968
   }
   action_refs {
-    id: 16805060
+    id: 24997060
   }
   action_refs {
-    id: 16786411
+    id: 32121835
   }
-  const_default_action_id: 16786411
+  const_default_action_id: 32121835
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16789700
+    id: 24785092
     name: "MyIngress.operation_add"
     alias: "operation_add"
   }
 }
 actions {
   preamble {
-    id: 16838158
+    id: 22867470
     name: "MyIngress.operation_sub"
     alias: "operation_sub"
   }
 }
 actions {
   preamble {
-    id: 16807127
+    id: 32601303
     name: "MyIngress.operation_and"
     alias: "operation_and"
   }
 }
 actions {
   preamble {
-    id: 16815851
+    id: 17405675
     name: "MyIngress.operation_or"
     alias: "operation_or"
   }
 }
 actions {
   preamble {
-    id: 16797152
+    id: 31935968
     name: "MyIngress.operation_xor"
     alias: "operation_xor"
   }
 }
 actions {
   preamble {
-    id: 16805060
+    id: 24997060
     name: "MyIngress.operation_crc"
     alias: "operation_crc"
   }
 }
 actions {
   preamble {
-    id: 16786411
+    id: 32121835
     name: "MyIngress.operation_drop"
     alias: "operation_drop"
   }

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33575637
+    id: 49173205
     name: "ingressImpl.t1"
     alias: "t1"
   }
@@ -17,34 +17,34 @@ tables {
     }
   }
   action_refs {
-    id: 16827880
+    id: 23315944
   }
   action_refs {
-    id: 16788060
+    id: 32254556
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16788060
+    id: 32254556
     name: "ingressImpl.my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16827880
+    id: 23315944
     name: "ingressImpl.set_addr"
     alias: "set_addr"
   }
@@ -59,7 +59,7 @@ actions {
 }
 controller_packet_metadata {
   preamble {
-    id: 67135753
+    id: 75327753
     name: "packet_out"
     alias: "packet_out"
     annotations: "@controller_header(\"packet_out\")"

--- a/testdata/p4_16_samples_outputs/def-use.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/def-use.p4.p4info.txt
@@ -3,18 +3,18 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33618730
+    id: 45349674
     name: "EgressI.t"
     alias: "t"
   }
   action_refs {
-    id: 16801890
+    id: 21913698
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16801890
+    id: 21913698
     name: "EgressI.a"
     alias: "a"
   }

--- a/testdata/p4_16_samples_outputs/default_action-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33615638
+    id: 43577110
     name: "ingress.c.t"
     alias: "t"
   }
   action_refs {
-    id: 16832348
+    id: 29022044
   }
-  const_default_action_id: 16832348
+  const_default_action_id: 29022044
   size: 1024
 }
 actions {
   preamble {
-    id: 16832348
+    id: 29022044
     name: "ingress.c.add"
     alias: "add"
   }

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33603375
+    id: 47103791
     name: "IngressI.forward"
     alias: "forward"
   }
   action_refs {
-    id: 16793508
+    id: 18759588
   }
-  const_default_action_id: 16793508
+  const_default_action_id: 18759588
   size: 1024
 }
 actions {
   preamble {
-    id: 16793508
+    id: 18759588
     name: "drop"
     alias: "drop"
   }

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33582731
+    id: 49442443
     name: "FabricIngress.spgw_ingress.dl_sess_lookup"
     alias: "dl_sess_lookup"
   }
@@ -14,20 +14,20 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16804065
+    id: 31156449
   }
   action_refs {
-    id: 16819938
+    id: 28485346
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
-  const_default_action_id: 16819938
-  direct_resource_ids: 318781522
+  const_default_action_id: 28485346
+  direct_resource_ids: 334575698
   size: 1024
 }
 tables {
   preamble {
-    id: 33615906
+    id: 40038434
     name: "FabricIngress.spgw_ingress.s1u_filter_table"
     alias: "s1u_filter_table"
   }
@@ -38,14 +38,14 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16819938
+    id: 28485346
   }
-  const_default_action_id: 16819938
+  const_default_action_id: 28485346
   size: 1024
 }
 tables {
   preamble {
-    id: 33611649
+    id: 43310977
     name: "FabricIngress.filtering.ingress_port_vlan"
     alias: "ingress_port_vlan"
   }
@@ -68,21 +68,21 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16836487
+    id: 17164167
   }
   action_refs {
-    id: 16818236
+    id: 24158268
   }
   action_refs {
-    id: 16794911
+    id: 24266015
   }
-  const_default_action_id: 16836487
-  direct_resource_ids: 318815501
+  const_default_action_id: 17164167
+  direct_resource_ids: 326221069
   size: 1024
 }
 tables {
   preamble {
-    id: 33596298
+    id: 49718154
     name: "FabricIngress.filtering.fwd_classifier"
     alias: "fwd_classifier"
   }
@@ -105,15 +105,15 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16840921
+    id: 25032921
   }
-  const_default_action_id: 16840921
-  direct_resource_ids: 318827326
+  const_default_action_id: 25032921
+  direct_resource_ids: 335473470
   size: 1024
 }
 tables {
   preamble {
-    id: 33596749
+    id: 43623757
     name: "FabricIngress.forwarding.bridging"
     alias: "bridging"
   }
@@ -130,20 +130,20 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16811012
+    id: 21791748
   }
   action_refs {
-    id: 16819938
+    id: 28485346
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
-  const_default_action_id: 16819938
-  direct_resource_ids: 318770289
+  const_default_action_id: 28485346
+  direct_resource_ids: 330959985
   size: 1024
 }
 tables {
   preamble {
-    id: 33574274
+    id: 37768578
     name: "FabricIngress.forwarding.mpls"
     alias: "mpls"
   }
@@ -154,20 +154,20 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16827758
+    id: 30066030
   }
   action_refs {
-    id: 16819938
+    id: 28485346
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
-  const_default_action_id: 16819938
-  direct_resource_ids: 318830507
+  const_default_action_id: 28485346
+  direct_resource_ids: 318961579
   size: 1024
 }
 tables {
   preamble {
-    id: 33562650
+    id: 41754650
     name: "FabricIngress.forwarding.routing_v4"
     alias: "routing_v4"
   }
@@ -178,23 +178,23 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16777434
+    id: 19792090
   }
   action_refs {
-    id: 16804187
+    id: 29124955
   }
   action_refs {
-    id: 16819938
+    id: 28485346
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
-  const_default_action_id: 16819938
-  direct_resource_ids: 318811107
+  const_default_action_id: 28485346
+  direct_resource_ids: 333425635
   size: 1024
 }
 tables {
   preamble {
-    id: 33618978
+    id: 44104738
     name: "FabricIngress.acl.acl"
     alias: "acl"
   }
@@ -271,27 +271,27 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16807382
+    id: 23623126
   }
   action_refs {
-    id: 16829684
+    id: 23579892
   }
   action_refs {
-    id: 16790975
+    id: 29898175
   }
   action_refs {
-    id: 16820765
+    id: 23570973
   }
   action_refs {
-    id: 16827694
+    id: 29607214
   }
-  const_default_action_id: 16827694
-  direct_resource_ids: 318801025
+  const_default_action_id: 29607214
+  direct_resource_ids: 319194241
   size: 1024
 }
 tables {
   preamble {
-    id: 33599709
+    id: 35696861
     name: "FabricIngress.next.next_vlan"
     alias: "next_vlan"
   }
@@ -302,20 +302,20 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16790685
+    id: 22099101
   }
   action_refs {
-    id: 16819938
+    id: 28485346
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
-  const_default_action_id: 16819938
-  direct_resource_ids: 318768144
+  const_default_action_id: 28485346
+  direct_resource_ids: 326370320
   size: 1024
 }
 tables {
   preamble {
-    id: 33596977
+    id: 48735793
     name: "FabricIngress.next.xconnect"
     alias: "xconnect"
   }
@@ -332,23 +332,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16842190
+    id: 24640974
   }
   action_refs {
-    id: 16837052
+    id: 30599612
   }
   action_refs {
-    id: 16819938
+    id: 28485346
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
-  const_default_action_id: 16819938
-  direct_resource_ids: 318778156
+  const_default_action_id: 28485346
+  direct_resource_ids: 321989420
   size: 1024
 }
 tables {
   preamble {
-    id: 33608588
+    id: 47960972
     name: "FabricIngress.next.hashed"
     alias: "hashed"
   }
@@ -359,27 +359,27 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16815357
+    id: 27301117
   }
   action_refs {
-    id: 16791402
+    id: 20985706
   }
   action_refs {
-    id: 16779255
+    id: 27920375
   }
   action_refs {
-    id: 16819938
+    id: 28485346
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
-  const_default_action_id: 16819938
-  implementation_id: 285217164
-  direct_resource_ids: 318800532
+  const_default_action_id: 28485346
+  implementation_id: 291115404
+  direct_resource_ids: 322798228
   size: 1024
 }
 tables {
   preamble {
-    id: 33606828
+    id: 40619180
     name: "FabricIngress.next.multicast"
     alias: "multicast"
   }
@@ -390,20 +390,20 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16779917
+    id: 21629581
   }
   action_refs {
-    id: 16819938
+    id: 28485346
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
-  const_default_action_id: 16819938
-  direct_resource_ids: 318801752
+  const_default_action_id: 28485346
+  direct_resource_ids: 319194968
   size: 1024
 }
 tables {
   preamble {
-    id: 33599342
+    id: 49262446
     name: "FabricEgress.egress_next.egress_vlan"
     alias: "egress_vlan"
   }
@@ -420,27 +420,27 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16790030
+    id: 17183246
   }
   action_refs {
-    id: 16819938
+    id: 28485346
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
-  const_default_action_id: 16819938
-  direct_resource_ids: 318827144
+  const_default_action_id: 28485346
+  direct_resource_ids: 318892680
   size: 1024
 }
 actions {
   preamble {
-    id: 16819938
+    id: 28485346
     name: "nop"
     alias: "nop"
   }
 }
 actions {
   preamble {
-    id: 16804065
+    id: 31156449
     name: "FabricIngress.spgw_ingress.set_dl_sess_info"
     alias: "set_dl_sess_info"
   }
@@ -462,21 +462,21 @@ actions {
 }
 actions {
   preamble {
-    id: 16836487
+    id: 17164167
     name: "FabricIngress.filtering.deny"
     alias: "deny"
   }
 }
 actions {
   preamble {
-    id: 16818236
+    id: 24158268
     name: "FabricIngress.filtering.permit"
     alias: "permit"
   }
 }
 actions {
   preamble {
-    id: 16794911
+    id: 24266015
     name: "FabricIngress.filtering.permit_with_internal_vlan"
     alias: "permit_with_internal_vlan"
   }
@@ -488,7 +488,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16840921
+    id: 25032921
     name: "FabricIngress.filtering.set_forwarding_type"
     alias: "set_forwarding_type"
   }
@@ -500,7 +500,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16811012
+    id: 21791748
     name: "FabricIngress.forwarding.set_next_id_bridging"
     alias: "set_next_id_bridging"
   }
@@ -512,7 +512,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16827758
+    id: 30066030
     name: "FabricIngress.forwarding.pop_mpls_and_next"
     alias: "pop_mpls_and_next"
   }
@@ -524,7 +524,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16777434
+    id: 19792090
     name: "FabricIngress.forwarding.set_next_id_routing_v4"
     alias: "set_next_id_routing_v4"
   }
@@ -536,14 +536,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16804187
+    id: 29124955
     name: "FabricIngress.forwarding.nop_routing_v4"
     alias: "nop_routing_v4"
   }
 }
 actions {
   preamble {
-    id: 16807382
+    id: 23623126
     name: "FabricIngress.acl.set_next_id_acl"
     alias: "set_next_id_acl"
   }
@@ -555,35 +555,35 @@ actions {
 }
 actions {
   preamble {
-    id: 16829684
+    id: 23579892
     name: "FabricIngress.acl.punt_to_cpu"
     alias: "punt_to_cpu"
   }
 }
 actions {
   preamble {
-    id: 16790975
+    id: 29898175
     name: "FabricIngress.acl.clone_to_cpu"
     alias: "clone_to_cpu"
   }
 }
 actions {
   preamble {
-    id: 16820765
+    id: 23570973
     name: "FabricIngress.acl.drop"
     alias: "drop"
   }
 }
 actions {
   preamble {
-    id: 16827694
+    id: 29607214
     name: "FabricIngress.acl.nop_acl"
     alias: "nop_acl"
   }
 }
 actions {
   preamble {
-    id: 16790685
+    id: 22099101
     name: "FabricIngress.next.set_vlan"
     alias: "set_vlan"
   }
@@ -595,7 +595,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16842190
+    id: 24640974
     name: "FabricIngress.next.output_xconnect"
     alias: "output_xconnect"
   }
@@ -607,7 +607,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16837052
+    id: 30599612
     name: "FabricIngress.next.set_next_id_xconnect"
     alias: "set_next_id_xconnect"
   }
@@ -619,7 +619,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16815357
+    id: 27301117
     name: "FabricIngress.next.output_hashed"
     alias: "output_hashed"
   }
@@ -631,7 +631,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16791402
+    id: 20985706
     name: "FabricIngress.next.routing_hashed"
     alias: "routing_hashed"
   }
@@ -653,7 +653,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16779255
+    id: 27920375
     name: "FabricIngress.next.mpls_routing_hashed"
     alias: "mpls_routing_hashed"
   }
@@ -680,7 +680,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16779917
+    id: 21629581
     name: "FabricIngress.next.set_mcast_group_id"
     alias: "set_mcast_group_id"
   }
@@ -692,25 +692,25 @@ actions {
 }
 actions {
   preamble {
-    id: 16790030
+    id: 17183246
     name: "FabricEgress.egress_next.pop_vlan"
     alias: "pop_vlan"
   }
 }
 action_profiles {
   preamble {
-    id: 285217164
+    id: 291115404
     name: "FabricIngress.next.hashed_selector"
     alias: "hashed_selector"
   }
-  table_ids: 33608588
+  table_ids: 47960972
   with_selector: true
   size: 1024
   max_group_size: 16
 }
 counters {
   preamble {
-    id: 302011205
+    id: 314528581
     name: "FabricIngress.port_counters_control.egress_port_counter"
     alias: "egress_port_counter"
   }
@@ -721,7 +721,7 @@ counters {
 }
 counters {
   preamble {
-    id: 302002771
+    id: 312947283
     name: "FabricIngress.port_counters_control.ingress_port_counter"
     alias: "ingress_port_counter"
   }
@@ -732,139 +732,139 @@ counters {
 }
 direct_counters {
   preamble {
-    id: 318781522
+    id: 334575698
     name: "FabricIngress.spgw_ingress.ue_counter"
     alias: "ue_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33582731
+  direct_table_id: 49442443
 }
 direct_counters {
   preamble {
-    id: 318815501
+    id: 326221069
     name: "FabricIngress.filtering.ingress_port_vlan_counter"
     alias: "ingress_port_vlan_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33611649
+  direct_table_id: 43310977
 }
 direct_counters {
   preamble {
-    id: 318827326
+    id: 335473470
     name: "FabricIngress.filtering.fwd_classifier_counter"
     alias: "fwd_classifier_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33596298
+  direct_table_id: 49718154
 }
 direct_counters {
   preamble {
-    id: 318770289
+    id: 330959985
     name: "FabricIngress.forwarding.bridging_counter"
     alias: "bridging_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33596749
+  direct_table_id: 43623757
 }
 direct_counters {
   preamble {
-    id: 318830507
+    id: 318961579
     name: "FabricIngress.forwarding.mpls_counter"
     alias: "mpls_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33574274
+  direct_table_id: 37768578
 }
 direct_counters {
   preamble {
-    id: 318811107
+    id: 333425635
     name: "FabricIngress.forwarding.routing_v4_counter"
     alias: "routing_v4_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33562650
+  direct_table_id: 41754650
 }
 direct_counters {
   preamble {
-    id: 318801025
+    id: 319194241
     name: "FabricIngress.acl.acl_counter"
     alias: "acl_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33618978
+  direct_table_id: 44104738
 }
 direct_counters {
   preamble {
-    id: 318768144
+    id: 326370320
     name: "FabricIngress.next.next_vlan_counter"
     alias: "next_vlan_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33599709
+  direct_table_id: 35696861
 }
 direct_counters {
   preamble {
-    id: 318778156
+    id: 321989420
     name: "FabricIngress.next.xconnect_counter"
     alias: "xconnect_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33596977
+  direct_table_id: 48735793
 }
 direct_counters {
   preamble {
-    id: 318800532
+    id: 322798228
     name: "FabricIngress.next.hashed_counter"
     alias: "hashed_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33608588
+  direct_table_id: 47960972
 }
 direct_counters {
   preamble {
-    id: 318801752
+    id: 319194968
     name: "FabricIngress.next.multicast_counter"
     alias: "multicast_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33606828
+  direct_table_id: 40619180
 }
 direct_counters {
   preamble {
-    id: 318827144
+    id: 318892680
     name: "FabricEgress.egress_next.egress_vlan_counter"
     alias: "egress_vlan_counter"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33599342
+  direct_table_id: 49262446
 }
 controller_packet_metadata {
   preamble {
-    id: 67146229
+    id: 81826293
     name: "packet_in"
     alias: "packet_in"
     annotations: "@controller_header(\"packet_in\")"
@@ -882,7 +882,7 @@ controller_packet_metadata {
 }
 controller_packet_metadata {
   preamble {
-    id: 67121543
+    id: 76689799
     name: "packet_out"
     alias: "packet_out"
     annotations: "@controller_header(\"packet_out\")"

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33593274
+    id: 43030458
     name: "ingress.ipv4_lpm"
     alias: "ipv4_lpm"
   }
@@ -14,33 +14,33 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16785927
+    id: 30548487
   }
   action_refs {
-    id: 16832181
+    id: 33281717
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16832181
+    id: 33281717
     name: "ingress.drop"
     alias: "drop"
   }
 }
 actions {
   preamble {
-    id: 16785927
+    id: 30548487
     name: "ingress.ipv4_forward"
     alias: "ipv4_forward"
   }

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33596743
+    id: 38446407
     name: "ingress.ecmp_group"
     alias: "ecmp_group"
   }
@@ -14,19 +14,19 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16788328
+    id: 19344232
   }
   action_refs {
-    id: 16836056
+    id: 20375000
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33566903
+    id: 41627831
     name: "ingress.ecmp_nhop"
     alias: "ecmp_nhop"
   }
@@ -37,33 +37,33 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16788328
+    id: 19344232
   }
   action_refs {
-    id: 16787244
+    id: 29239084
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 16384
 }
 tables {
   preamble {
-    id: 33565359
+    id: 42150575
     name: "ingress.flowlet"
     alias: "flowlet"
   }
   action_refs {
-    id: 16813893
+    id: 27889477
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33590050
+    id: 43289378
     name: "ingress.forward"
     alias: "forward"
   }
@@ -74,33 +74,33 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16792359
+    id: 30489383
   }
   action_refs {
-    id: 16788328
+    id: 19344232
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 512
 }
 tables {
   preamble {
-    id: 33565493
+    id: 43789109
     name: "ingress.new_flowlet"
     alias: "new_flowlet"
   }
   action_refs {
-    id: 16807312
+    id: 17397136
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33573008
+    id: 49367184
     name: "egress.send_frame"
     alias: "send_frame"
   }
@@ -111,33 +111,33 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16781737
+    id: 23531945
   }
   action_refs {
-    id: 16806759
+    id: 25850727
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 256
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16788328
+    id: 19344232
     name: "ingress._drop"
     alias: "ingress._drop"
   }
 }
 actions {
   preamble {
-    id: 16836056
+    id: 20375000
     name: "ingress.set_ecmp_select"
     alias: "set_ecmp_select"
   }
@@ -154,7 +154,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16787244
+    id: 29239084
     name: "ingress.set_nhop"
     alias: "set_nhop"
   }
@@ -171,14 +171,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16813893
+    id: 27889477
     name: "ingress.lookup_flowlet_map"
     alias: "lookup_flowlet_map"
   }
 }
 actions {
   preamble {
-    id: 16792359
+    id: 30489383
     name: "ingress.set_dmac"
     alias: "set_dmac"
   }
@@ -190,14 +190,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16807312
+    id: 17397136
     name: "ingress.update_flowlet_id"
     alias: "update_flowlet_id"
   }
 }
 actions {
   preamble {
-    id: 16781737
+    id: 23531945
     name: "egress.rewrite_mac"
     alias: "rewrite_mac"
   }
@@ -209,14 +209,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16806759
+    id: 25850727
     name: "egress._drop"
     alias: "egress._drop"
   }
 }
 registers {
   preamble {
-    id: 369118452
+    id: 384519412
     name: "ingress.flowlet_id"
     alias: "flowlet_id"
   }
@@ -231,7 +231,7 @@ registers {
 }
 registers {
   preamble {
-    id: 369118221
+    id: 375147533
     name: "ingress.flowlet_lasttime"
     alias: "flowlet_lasttime"
   }

--- a/testdata/p4_16_samples_outputs/hash-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/hash-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16827160
+    id: 20366104
     name: "IngressI.a"
     alias: "a"
   }

--- a/testdata/p4_16_samples_outputs/hit-expr-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/hit-expr-bmv2.p4.p4info.txt
@@ -3,18 +3,18 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33557763
+    id: 36244739
     name: "IngressI.t"
     alias: "t"
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/inline-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/inline-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33605678
+    id: 40552494
     name: "IngressI.do_aux.adjust_lkp_fields"
     alias: "adjust_lkp_fields"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/inline1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33605678
+    id: 40552494
     name: "IngressI.do_aux.adjust_lkp_fields"
     alias: "adjust_lkp_fields"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33606302
+    id: 45337246
     name: "ingress.ipv6_tbl"
     alias: "ipv6_tbl"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16839149
+    id: 21164525
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,7 +25,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33603625
+    id: 34324521
     name: "egress.get_multicast_copy_out_bd"
     alias: "get_multicast_copy_out_bd"
   }
@@ -42,10 +42,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16826665
+    id: 22004009
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -53,7 +53,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33573008
+    id: 49367184
     name: "egress.send_frame"
     alias: "send_frame"
   }
@@ -64,23 +64,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16781737
+    id: 23531945
   }
   action_refs {
-    id: 16842696
+    id: 20119496
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16839149
+    id: 21164525
     name: "ingress.set_mcast_grp"
     alias: "set_mcast_grp"
   }
@@ -97,7 +97,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16826665
+    id: 22004009
     name: "egress.set_out_bd"
     alias: "set_out_bd"
   }
@@ -109,14 +109,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16842696
+    id: 20119496
     name: "egress.drop"
     alias: "drop"
   }
 }
 actions {
   preamble {
-    id: 16781737
+    id: 23531945
     name: "egress.rewrite_mac"
     alias: "rewrite_mac"
   }

--- a/testdata/p4_16_samples_outputs/issue-2123.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue-2123.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33581415
+    id: 48392551
     name: "ingress.bd"
     alias: "bd"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16793910
+    id: 33505590
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,7 +25,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33613387
+    id: 41084491
     name: "ingress.ipv4_fib"
     alias: "ipv4_fib"
   }
@@ -42,13 +42,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16826976
+    id: 22594144
   }
   action_refs {
-    id: 16798108
+    id: 26104220
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -56,7 +56,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33569838
+    id: 42875950
     name: "ingress.ipv4_fib_lpm"
     alias: "ipv4_fib_lpm"
   }
@@ -73,13 +73,13 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16826976
+    id: 22594144
   }
   action_refs {
-    id: 16798108
+    id: 26104220
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -87,7 +87,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33619585
+    id: 43581057
     name: "ingress.nexthop"
     alias: "nexthop"
   }
@@ -98,13 +98,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16826976
+    id: 22594144
   }
   action_refs {
-    id: 16788993
+    id: 19738113
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -112,7 +112,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33616322
+    id: 39645634
     name: "ingress.port_mapping"
     alias: "port_mapping"
   }
@@ -123,10 +123,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16817852
+    id: 27500220
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -134,7 +134,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33558953
+    id: 40309161
     name: "egress.rewrite_mac"
     alias: "rewrite_mac"
   }
@@ -145,13 +145,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16805656
+    id: 28864280
   }
   action_refs {
-    id: 16842256
+    id: 28966416
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -159,14 +159,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16793910
+    id: 33505590
     name: "ingress.set_vrf"
     alias: "set_vrf"
   }
@@ -178,14 +178,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16826976
+    id: 22594144
     name: "ingress.on_miss"
     alias: "ingress.on_miss"
   }
 }
 actions {
   preamble {
-    id: 16798108
+    id: 26104220
     name: "ingress.fib_hit_nexthop"
     alias: "fib_hit_nexthop"
   }
@@ -197,7 +197,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16788993
+    id: 19738113
     name: "ingress.set_egress_details"
     alias: "set_egress_details"
   }
@@ -209,7 +209,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16817852
+    id: 27500220
     name: "ingress.set_bd"
     alias: "set_bd"
   }
@@ -221,14 +221,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16805656
+    id: 28864280
     name: "egress.on_miss"
     alias: "egress.on_miss"
   }
 }
 actions {
   preamble {
-    id: 16842256
+    id: 28966416
     name: "egress.rewrite_src_dst_mac"
     alias: "rewrite_src_dst_mac"
   }

--- a/testdata/p4_16_samples_outputs/issue1049-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1049-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33616793
+    id: 48165785
     name: "cIngress.guh"
     alias: "guh"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16819683
+    id: 28550627
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33587833
+    id: 43025017
     name: "cIngress.debug_table"
     alias: "debug_table"
   }
@@ -37,20 +37,20 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16819683
+    id: 28550627
     name: "cIngress.hash_drop_decision"
     alias: "hash_drop_decision"
   }

--- a/testdata/p4_16_samples_outputs/issue1097-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1097-2-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 registers {
   preamble {
-    id: 369118178
+    id: 369183714
     name: "r"
     alias: "r"
   }

--- a/testdata/p4_16_samples_outputs/issue1097-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1097-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 registers {
   preamble {
-    id: 369118178
+    id: 369183714
     name: "r"
     alias: "r"
   }

--- a/testdata/p4_16_samples_outputs/issue1107.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/issue1107.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33604573
+      table_id: 48415709
       match {
         field_id: 1
         exact {
@@ -17,7 +17,7 @@ updates {
       }
       action {
         action {
-          action_id: 16791916
+          action_id: 16988524
           params {
             param_id: 1
             value: "\000\001"
@@ -31,7 +31,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33604573
+      table_id: 48415709
       match {
         field_id: 1
         exact {
@@ -46,7 +46,7 @@ updates {
       }
       action {
         action {
-          action_id: 16791916
+          action_id: 16988524
           params {
             param_id: 1
             value: "\000\002"

--- a/testdata/p4_16_samples_outputs/issue1107.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1107.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33604573
+    id: 48415709
     name: "IngressI.myc.myt"
     alias: "myt"
   }
@@ -20,10 +20,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16791916
+    id: 16988524
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -32,14 +32,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16791916
+    id: 16988524
     name: "IngressI.myc.set_eg"
     alias: "set_eg"
   }

--- a/testdata/p4_16_samples_outputs/issue1193-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1193-bmv2.p4.p4info.txt
@@ -3,15 +3,15 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33611905
+    id: 44621953
     name: "MyIngress.t"
     alias: "t"
   }
   action_refs {
-    id: 16812769
+    id: 17271521
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -19,14 +19,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16812769
+    id: 17271521
     name: "MyIngress.a"
     alias: "a"
   }

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33615889
+    id: 46460945
     name: "MyIngress.forward"
     alias: "forward"
   }
@@ -14,19 +14,19 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16837735
+    id: 33025127
   }
   action_refs {
-    id: 16805608
+    id: 25652968
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33574068
+    id: 37375156
     name: "MyIngress.ipv4_lpm"
     alias: "ipv4_lpm"
   }
@@ -37,19 +37,19 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16826124
+    id: 24952588
   }
   action_refs {
-    id: 16805608
+    id: 25652968
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33604441
+    id: 49202009
     name: "MyEgress.send_frame"
     alias: "send_frame"
   }
@@ -60,30 +60,30 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16828148
+    id: 22398708
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16805608
+    id: 25652968
     name: "MyIngress.drop"
     alias: "drop"
   }
 }
 actions {
   preamble {
-    id: 16837735
+    id: 33025127
     name: "MyIngress.set_dmac"
     alias: "set_dmac"
   }
@@ -95,7 +95,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16826124
+    id: 24952588
     name: "MyIngress.set_nhop"
     alias: "set_nhop"
   }
@@ -112,14 +112,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16842278
+    id: 23592486
     name: "MyIngress.send_digest"
     alias: "send_digest"
   }
 }
 actions {
   preamble {
-    id: 16828148
+    id: 22398708
     name: "MyEgress.rewrite_mac"
     alias: "rewrite_mac"
   }
@@ -131,7 +131,7 @@ actions {
 }
 digests {
   preamble {
-    id: 385901477
+    id: 387015589
     name: "test_digest_t"
     alias: "test_digest_t"
   }

--- a/testdata/p4_16_samples_outputs/issue1412-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1412-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33598117
+    id: 49261221
     name: "EgressImpl.change_cond"
     alias: "change_cond"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16804174
+    id: 28272974
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,14 +25,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16804174
+    id: 28272974
     name: "EgressImpl.set_true"
     alias: "set_true"
   }

--- a/testdata/p4_16_samples_outputs/issue1478-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/issue1478-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33618572
+      table_id: 42400396
       match {
         field_id: 1
         exact {
@@ -11,7 +11,7 @@ updates {
       }
       action {
         action {
-          action_id: 16800567
+          action_id: 21257015
         }
       }
     }

--- a/testdata/p4_16_samples_outputs/issue1478-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1478-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33594939
+    id: 39755323
     name: "ingress.t1"
     alias: "t1"
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 3
 }
 tables {
   preamble {
-    id: 33618572
+    id: 42400396
     name: "ingress.t2"
     alias: "t2"
   }
@@ -26,14 +26,14 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 10
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 registers {
   preamble {
-    id: 369136003
+    id: 385061251
     name: "MyIngress.h.c1.r"
     alias: "c1.r"
   }
@@ -18,7 +18,7 @@ registers {
 }
 registers {
   preamble {
-    id: 369141712
+    id: 369403856
     name: "MyIngress.h.c2.r"
     alias: "c2.r"
   }

--- a/testdata/p4_16_samples_outputs/issue1538.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1538.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33594010
+    id: 43424410
     name: "ingress.mac_da"
     alias: "mac_da"
   }
@@ -14,23 +14,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16821713
+    id: 29666769
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16815499
+    id: 32609675
     name: "my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16821713
+    id: 29666769
     name: "ingress.set_port"
     alias: "set_port"
   }

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33594010
+    id: 43424410
     name: "ingress.mac_da"
     alias: "mac_da"
   }
@@ -14,23 +14,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16821713
+    id: 29666769
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16815499
+    id: 32609675
     name: "my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16821713
+    id: 29666769
     name: "ingress.set_port"
     alias: "set_port"
   }

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33594010
+    id: 43424410
     name: "ingress.mac_da"
     alias: "mac_da"
   }
@@ -14,23 +14,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16821713
+    id: 29666769
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16815499
+    id: 32609675
     name: "my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16821713
+    id: 29666769
     name: "ingress.set_port"
     alias: "set_port"
   }

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33594010
+    id: 43424410
     name: "ingress.mac_da"
     alias: "mac_da"
   }
@@ -14,23 +14,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16821713
+    id: 29666769
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16815499
+    id: 32609675
     name: "my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16821713
+    id: 29666769
     name: "ingress.set_port"
     alias: "set_port"
   }

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33604812
+    id: 34391244
     name: "cIngress.t0"
     alias: "t0"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16810612
+    id: 32211572
   }
   action_refs {
-    id: 16787161
+    id: 18753241
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -28,7 +28,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33618272
+    id: 39254368
     name: "cIngress.t1"
     alias: "t1"
   }
@@ -39,13 +39,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16810612
+    id: 32211572
   }
   action_refs {
-    id: 16787161
+    id: 18753241
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -53,7 +53,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33574495
+    id: 47468127
     name: "cIngress.t2"
     alias: "t2"
   }
@@ -64,13 +64,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16810612
+    id: 32211572
   }
   action_refs {
-    id: 16787161
+    id: 18753241
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -78,14 +78,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16810612
+    id: 32211572
     name: "cIngress.foo1"
     alias: "foo1"
   }
@@ -97,7 +97,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16787161
+    id: 18753241
     name: "cIngress.foo2"
     alias: "foo2"
   }

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 counters {
   preamble {
-    id: 302019703
+    id: 314274935
     name: "cIngress.E.c1.stats"
     alias: "stats"
   }

--- a/testdata/p4_16_samples_outputs/issue1566.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1566.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 counters {
   preamble {
-    id: 302019703
+    id: 314274935
     name: "cIngress.E.c1.stats"
     alias: "stats"
   }

--- a/testdata/p4_16_samples_outputs/issue1595.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1595.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33618272
+    id: 39254368
     name: "cIngress.t1"
     alias: "t1"
   }
@@ -14,53 +14,53 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16820406
+    id: 21211318
   }
   action_refs {
-    id: 16824875
+    id: 17087019
   }
   action_refs {
-    id: 16785046
+    id: 20586134
   }
   action_refs {
-    id: 16799572
+    id: 26367828
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16820406
+    id: 21211318
     name: "cIngress.a1"
     alias: "a1"
   }
 }
 actions {
   preamble {
-    id: 16824875
+    id: 17087019
     name: "cIngress.a2"
     alias: "a2"
   }
 }
 actions {
   preamble {
-    id: 16785046
+    id: 20586134
     name: "cIngress.a3"
     alias: "a3"
   }
 }
 actions {
   preamble {
-    id: 16799572
+    id: 26367828
     name: "cIngress.a4"
     alias: "a4"
   }

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33574068
+    id: 37375156
     name: "MyIngress.ipv4_lpm"
     alias: "ipv4_lpm"
   }
@@ -14,33 +14,33 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16799317
+    id: 28792405
   }
   action_refs {
-    id: 16805608
+    id: 25652968
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16805608
+    id: 25652968
     name: "MyIngress.drop"
     alias: "drop"
   }
 }
 actions {
   preamble {
-    id: 16799317
+    id: 28792405
     name: "MyIngress.ipv4_forward"
     alias: "ipv4_forward"
   }

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33555551
+    id: 46138463
     name: "ingress.tns"
     alias: "tns"
   }
@@ -20,10 +20,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16810128
+    id: 22708368
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -31,14 +31,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16810128
+    id: 22708368
     name: "ingress.do_act"
     alias: "do_act"
   }

--- a/testdata/p4_16_samples_outputs/issue1713-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1713-bmv2.p4.p4info.txt
@@ -3,49 +3,49 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16800267
+    id: 25451019
   }
   action_refs {
-    id: 16807847
+    id: 22181799
   }
   action_refs {
-    id: 16782284
+    id: 23335884
   }
   action_refs {
-    id: 16797246
+    id: 27086398
   }
-  const_default_action_id: 16800267
+  const_default_action_id: 25451019
   size: 1024
 }
 actions {
   preamble {
-    id: 16800267
+    id: 25451019
     name: "ingress.case0"
     alias: "case0"
   }
 }
 actions {
   preamble {
-    id: 16807847
+    id: 22181799
     name: "ingress.case1"
     alias: "case1"
   }
 }
 actions {
   preamble {
-    id: 16782284
+    id: 23335884
     name: "ingress.case2"
     alias: "case2"
   }
 }
 actions {
   preamble {
-    id: 16797246
+    id: 27086398
     name: "ingress.case3"
     alias: "case3"
   }

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33571396
+    id: 35996228
     name: "ingress.ipv4_da_lpm"
     alias: "ipv4_da_lpm"
   }
@@ -17,16 +17,16 @@ tables {
     }
   }
   action_refs {
-    id: 16829338
+    id: 28429210
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33602240
+    id: 45595328
     name: "ingress.ipv4_sa_filter"
     alias: "ipv4_sa_filter"
   }
@@ -40,31 +40,31 @@ tables {
     }
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16815499
+    id: 32609675
     name: "my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16829338
+    id: 28429210
     name: "ingress.set_output"
     alias: "set_output"
   }

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33554432
+    id: 33947648
     name: "MyIngress.v6_addresses"
     alias: "v6_addresses"
   }
@@ -14,22 +14,22 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16789132
+    id: 23604876
   }
   action_refs {
-    id: 16807338
+    id: 32142762
   }
   action_refs {
-    id: 16795573
+    id: 24332213
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 64
 }
 tables {
   preamble {
-    id: 33567153
+    id: 38089137
     name: "MyIngress.v6_networks"
     alias: "v6_networks"
   }
@@ -40,22 +40,22 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16777697
+    id: 27787745
   }
   action_refs {
-    id: 16789132
+    id: 23604876
   }
   action_refs {
-    id: 16807338
+    id: 32142762
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 64
 }
 tables {
   preamble {
-    id: 33616067
+    id: 37875907
     name: "MyIngress.v4_networks"
     alias: "v4_networks"
   }
@@ -66,23 +66,23 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16777697
+    id: 27787745
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 64
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16777697
+    id: 27787745
     name: "MyIngress.set_egress_port"
     alias: "set_egress_port"
   }
@@ -94,14 +94,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16789132
+    id: 23604876
     name: "MyIngress.controller_debug"
     alias: "controller_debug"
   }
 }
 actions {
   preamble {
-    id: 16807338
+    id: 32142762
     name: "MyIngress.controller_reply"
     alias: "controller_reply"
   }
@@ -113,7 +113,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16795573
+    id: 24332213
     name: "MyIngress.icmp6_echo_reply"
     alias: "icmp6_echo_reply"
   }

--- a/testdata/p4_16_samples_outputs/issue1765-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1765-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33616793
+    id: 48165785
     name: "cIngress.guh"
     alias: "guh"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16808330
+    id: 25131402
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16808330
+    id: 25131402
     name: "cIngress.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/issue1781-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1781-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16805137
+    id: 25324817
     name: "IngressImpl.update_value"
     alias: "update_value"
   }

--- a/testdata/p4_16_samples_outputs/issue1806.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1806.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33555305
+    id: 48497513
     name: "c.tns"
     alias: "tns"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16828138
+    id: 22922986
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,14 +25,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16828138
+    id: 22922986
     name: "c.do_act"
     alias: "do_act"
   }

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33604775
+    id: 44942503
     name: "IngressImpl.debug_table"
     alias: "debug_table"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16824722
+    id: 17676690
   }
   action_refs {
-    id: 16795029
+    id: 33244565
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -28,28 +28,28 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16824722
+    id: 17676690
     name: "IngressImpl.drop"
     alias: "drop"
   }
 }
 actions {
   preamble {
-    id: 16795029
+    id: 33244565
     name: "IngressImpl.forward"
     alias: "forward"
   }
 }
 registers {
   preamble {
-    id: 369112648
+    id: 377042504
     name: "IngressImpl.testRegister"
     alias: "testRegister"
   }

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33604775
+    id: 44942503
     name: "IngressImpl.debug_table"
     alias: "debug_table"
   }
@@ -14,20 +14,20 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 registers {
   preamble {
-    id: 369112648
+    id: 377042504
     name: "IngressImpl.testRegister"
     alias: "testRegister"
   }

--- a/testdata/p4_16_samples_outputs/issue1829-4-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1829-4-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33578829
+    id: 43802445
     name: "ingressImpl.mac_da"
     alias: "mac_da"
   }
@@ -14,14 +14,14 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16788889
+    id: 23080345
   }
-  const_default_action_id: 16788889
+  const_default_action_id: 23080345
   size: 1024
 }
 actions {
   preamble {
-    id: 16788889
+    id: 23080345
     name: "ingressImpl.do_meter"
     alias: "do_meter"
   }

--- a/testdata/p4_16_samples_outputs/issue1834-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/issue1834-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33610813
+      table_id: 39967805
       match {
         field_id: 1
         exact {
@@ -11,7 +11,7 @@ updates {
       }
       action {
         action {
-          action_id: 16836940
+          action_id: 30009676
           params {
             param_id: 1
             value: "\001"

--- a/testdata/p4_16_samples_outputs/issue1834-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1834-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610813
+    id: 39967805
     name: "IngressImpl.test_table"
     alias: "test_table"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16836940
+    id: 30009676
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -26,14 +26,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16836940
+    id: 30009676
     name: "IngressImpl.act"
     alias: "act"
   }

--- a/testdata/p4_16_samples_outputs/issue1937-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1937-1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16808157
+    id: 25589981
     name: "foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/issue1955.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1955.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 value_sets {
   preamble {
-    id: 50343090
+    id: 59321522
     name: "parserImpl.p1.ipv4_ethertypes"
     alias: "p1.ipv4_ethertypes"
   }
@@ -16,7 +16,7 @@ value_sets {
 }
 value_sets {
   preamble {
-    id: 50350911
+    id: 55724863
     name: "parserImpl.p2.ipv4_ethertypes"
     alias: "p2.ipv4_ethertypes"
   }

--- a/testdata/p4_16_samples_outputs/issue1989-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1989-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33585498
+    id: 46102874
     name: "ingress.acl_table"
     alias: "acl_table"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16790071
+    id: 24130103
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,14 +25,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16790071
+    id: 24130103
     name: "ingress.assign_non_const_array_index"
     alias: "assign_non_const_array_index"
   }

--- a/testdata/p4_16_samples_outputs/issue2044-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2044-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue2104.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2104.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16819975
+    id: 24946439
     name: "c.v"
     alias: "v"
   }

--- a/testdata/p4_16_samples_outputs/issue2148.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2148.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16827060
+    id: 25346740
     name: "ingress.do_thing_action"
     alias: "do_thing_action"
   }

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33563505
+    id: 39789425
     name: "ingress.simple_table"
     alias: "simple_table"
   }
@@ -14,23 +14,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16830231
+    id: 30461719
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16830231
+    id: 30461719
     name: "ingress.do_something"
     alias: "do_something"
   }

--- a/testdata/p4_16_samples_outputs/issue2176-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2176-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16781964
+    id: 33493644
     name: "ingress.do_action_2"
     alias: "do_action_2"
   }

--- a/testdata/p4_16_samples_outputs/issue232-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16793215
+    id: 17055359
     name: "Eg.test"
     alias: "test"
   }

--- a/testdata/p4_16_samples_outputs/issue242.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue242.p4.p4info.txt
@@ -3,14 +3,14 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16793215
+    id: 17055359
     name: "Eg.test"
     alias: "test"
   }
 }
 registers {
   preamble {
-    id: 369101273
+    id: 373885401
     name: "Eg.debug"
     alias: "debug"
   }
@@ -25,7 +25,7 @@ registers {
 }
 registers {
   preamble {
-    id: 369099194
+    id: 383254970
     name: "Eg.reg"
     alias: "reg"
   }

--- a/testdata/p4_16_samples_outputs/issue297-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2.p4.p4info.txt
@@ -3,66 +3,66 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33568532
+    id: 46872340
     name: "IngressI.indirect"
     alias: "indirect"
   }
   action_refs {
-    id: 16836747
+    id: 23455883
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
-  implementation_id: 285267408
+  const_default_action_id: 21257015
+  implementation_id: 289199568
   size: 1024
 }
 tables {
   preamble {
-    id: 33594274
+    id: 38116258
     name: "IngressI.indirect_ws"
     alias: "indirect_ws"
   }
   action_refs {
-    id: 16836747
+    id: 23455883
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
-  implementation_id: 285251566
+  const_default_action_id: 21257015
+  implementation_id: 300324846
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16836747
+    id: 23455883
     name: "IngressI.drop"
     alias: "drop"
   }
 }
 action_profiles {
   preamble {
-    id: 285267408
+    id: 289199568
     name: "IngressI.ap"
     alias: "ap"
   }
-  table_ids: 33568532
+  table_ids: 46872340
   size: 128
 }
 action_profiles {
   preamble {
-    id: 285251566
+    id: 300324846
     name: "ap_ws"
     alias: "ap_ws"
   }
-  table_ids: 33594274
+  table_ids: 38116258
   with_selector: true
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2.p4.p4info.txt
@@ -3,18 +3,18 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33581551
+    id: 44788207
     name: "ingress.round_tbl"
     alias: "round_tbl"
   }
   action_refs {
-    id: 16780896
+    id: 28773984
   }
   size: 8
 }
 tables {
   preamble {
-    id: 33589471
+    id: 39880927
     name: "egress.drop_tbl"
     alias: "drop_tbl"
   }
@@ -25,37 +25,37 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16806759
+    id: 25850727
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 2
 }
 actions {
   preamble {
-    id: 16780896
+    id: 28773984
     name: "ingress.read_round"
     alias: "read_round"
   }
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16806759
+    id: 25850727
     name: "egress._drop"
     alias: "_drop"
   }
 }
 registers {
   preamble {
-    id: 369112422
+    id: 373634406
     name: "ingress.registerRound"
     alias: "registerRound"
   }

--- a/testdata/p4_16_samples_outputs/issue323.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue323.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16789621
+    id: 19804277
     name: "ingress.my_a"
     alias: "my_a"
   }

--- a/testdata/p4_16_samples_outputs/issue364-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2.p4.p4info.txt
@@ -3,20 +3,20 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16801679
+    id: 32530319
   }
-  const_default_action_id: 16801679
-  direct_resource_ids: 318771034
+  const_default_action_id: 32530319
+  direct_resource_ids: 330698586
   size: 1024
 }
 actions {
   preamble {
-    id: 16801679
+    id: 32530319
     name: "ingress.my_action"
     alias: "my_action"
   }
@@ -28,14 +28,14 @@ actions {
 }
 direct_counters {
   preamble {
-    id: 318771034
+    id: 330698586
     name: "ingress.c"
     alias: "c"
   }
   spec {
     unit: PACKETS
   }
-  direct_table_id: 33614349
+  direct_table_id: 34728461
 }
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/issue383-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33555551
+    id: 46138463
     name: "ingress.tns"
     alias: "tns"
   }
@@ -20,10 +20,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16810128
+    id: 22708368
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -31,14 +31,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16810128
+    id: 22708368
     name: "ingress.do_act"
     alias: "do_act"
   }

--- a/testdata/p4_16_samples_outputs/issue414-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33616793
+    id: 48165785
     name: "cIngress.guh"
     alias: "guh"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16808330
+    id: 25131402
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16808330
+    id: 25131402
     name: "cIngress.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/issue420.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue420.p4.p4info.txt
@@ -3,28 +3,28 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33584914
+    id: 46298898
     name: "cIngress.tbl1"
     alias: "tbl1"
   }
   action_refs {
-    id: 16808330
+    id: 25131402
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16808330
+    id: 25131402
     name: "cIngress.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/issue422.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue422.p4.p4info.txt
@@ -3,28 +3,28 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33584914
+    id: 46298898
     name: "cIngress.tbl1"
     alias: "tbl1"
   }
   action_refs {
-    id: 16808330
+    id: 25131402
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16808330
+    id: 25131402
     name: "cIngress.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 digests {
   preamble {
-    id: 385916781
+    id: 401776493
     name: "digest_0"
     alias: "digest_0"
   }

--- a/testdata/p4_16_samples_outputs/issue461-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33571396
+    id: 35996228
     name: "ingress.ipv4_da_lpm"
     alias: "ipv4_da_lpm"
   }
@@ -14,17 +14,17 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16798847
+    id: 26563711
   }
   action_refs {
-    id: 16806421
+    id: 20279829
   }
-  direct_resource_ids: 318821195
+  direct_resource_ids: 323801931
   size: 1024
 }
 tables {
   preamble {
-    id: 33594010
+    id: 43424410
     name: "ingress.mac_da"
     alias: "mac_da"
   }
@@ -35,16 +35,16 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16832597
+    id: 28039253
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33573008
+    id: 49367184
     name: "egress.send_frame"
     alias: "send_frame"
   }
@@ -55,23 +55,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16781737
+    id: 23531945
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16815499
+    id: 32609675
     name: "my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16798847
+    id: 26563711
     name: "ingress.set_l2ptr"
     alias: "set_l2ptr"
   }
@@ -83,14 +83,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16806421
+    id: 20279829
     name: "ingress.drop_with_count"
     alias: "drop_with_count"
   }
 }
 actions {
   preamble {
-    id: 16832597
+    id: 28039253
     name: "ingress.set_bd_dmac_intf"
     alias: "set_bd_dmac_intf"
   }
@@ -112,7 +112,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16781737
+    id: 23531945
     name: "egress.rewrite_mac"
     alias: "rewrite_mac"
   }
@@ -124,14 +124,14 @@ actions {
 }
 direct_counters {
   preamble {
-    id: 318821195
+    id: 323801931
     name: "ingress.ipv4_da_lpm_stats"
     alias: "ipv4_da_lpm_stats"
   }
   spec {
     unit: PACKETS
   }
-  direct_table_id: 33571396
+  direct_table_id: 35996228
 }
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/issue486-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue486-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33595553
+    id: 42311841
     name: "cIngress.t"
     alias: "t"
   }
@@ -32,13 +32,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16808330
+    id: 25131402
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16808330
+    id: 25131402
     name: "cIngress.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/issue512.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue512.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33616793
+    id: 48165785
     name: "cIngress.guh"
     alias: "guh"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16808330
+    id: 25131402
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16808330
+    id: 25131402
     name: "cIngress.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/issue561-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33593625
+    id: 47159577
     name: "ingress.debug_hdr"
     alias: "debug_hdr"
   }
@@ -26,14 +26,14 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue561-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-2-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33593625
+    id: 47159577
     name: "ingress.debug_hdr"
     alias: "debug_hdr"
   }
@@ -26,14 +26,14 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue561-3-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-3-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33593625
+    id: 47159577
     name: "ingress.debug_hdr"
     alias: "debug_hdr"
   }
@@ -26,14 +26,14 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue561-4-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-4-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33593625
+    id: 47159577
     name: "ingress.debug_hdr"
     alias: "debug_hdr"
   }
@@ -38,14 +38,14 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue561-5-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-5-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33593625
+    id: 47159577
     name: "ingress.debug_hdr"
     alias: "debug_hdr"
   }
@@ -26,14 +26,14 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue561-6-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-6-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33593625
+    id: 47159577
     name: "ingress.debug_hdr"
     alias: "debug_hdr"
   }
@@ -38,14 +38,14 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue561-7-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-7-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33593625
+    id: 47159577
     name: "ingress.debug_hdr"
     alias: "debug_hdr"
   }
@@ -26,14 +26,14 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue561-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33571396
+    id: 35996228
     name: "ingress.ipv4_da_lpm"
     alias: "ipv4_da_lpm"
   }
@@ -14,16 +14,16 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16798847
+    id: 26563711
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33594010
+    id: 43424410
     name: "ingress.mac_da"
     alias: "mac_da"
   }
@@ -34,16 +34,16 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16832597
+    id: 28039253
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33573008
+    id: 49367184
     name: "egress.send_frame"
     alias: "send_frame"
   }
@@ -54,23 +54,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16781737
+    id: 23531945
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16815499
+    id: 32609675
     name: "my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16798847
+    id: 26563711
     name: "ingress.set_l2ptr"
     alias: "set_l2ptr"
   }
@@ -82,7 +82,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16832597
+    id: 28039253
     name: "ingress.set_bd_dmac_intf"
     alias: "set_bd_dmac_intf"
   }
@@ -104,7 +104,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16781737
+    id: 23531945
     name: "egress.rewrite_mac"
     alias: "rewrite_mac"
   }

--- a/testdata/p4_16_samples_outputs/issue696-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2.p4.p4info.txt
@@ -3,14 +3,14 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16793215
+    id: 17055359
     name: "Eg.test"
     alias: "test"
   }
 }
 registers {
   preamble {
-    id: 369154380
+    id: 383637836
     name: "debug"
     alias: "debug"
   }
@@ -25,7 +25,7 @@ registers {
 }
 registers {
   preamble {
-    id: 369130682
+    id: 380140730
     name: "reg"
     alias: "reg"
   }

--- a/testdata/p4_16_samples_outputs/issue907-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 registers {
   preamble {
-    id: 369121423
+    id: 372201615
     name: "Ing.r"
     alias: "r"
   }

--- a/testdata/p4_16_samples_outputs/issue949.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue949.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33578994
+    id: 44851186
     name: "ingress.someTable"
     alias: "someTable"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16782834
+    id: 29955570
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,14 +25,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16782834
+    id: 29955570
     name: "ingress.setDest"
     alias: "setDest"
   }

--- a/testdata/p4_16_samples_outputs/issue983-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue983-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33564422
+    id: 48768774
     name: "ingress.debug_table_cksum1"
     alias: "debug_table_cksum1"
   }
@@ -86,13 +86,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue986-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue986-1-bmv2.p4.p4info.txt
@@ -3,29 +3,29 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33594939
+    id: 39755323
     name: "ingress.t1"
     alias: "t1"
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33618572
+    id: 42400396
     name: "ingress.t2"
     alias: "t2"
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/issue986-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue986-bmv2.p4.p4info.txt
@@ -3,18 +3,18 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33594939
+    id: 39755323
     name: "ingress.t1"
     alias: "t1"
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2.p4.p4info.txt
@@ -3,18 +3,18 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33557763
+    id: 36244739
     name: "IngressI.t"
     alias: "t"
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/key-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/key-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33615638
+    id: 43577110
     name: "ingress.c.t"
     alias: "t"
   }
@@ -14,23 +14,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16837667
+    id: 27847715
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16837667
+    id: 27847715
     name: "ingress.c.a"
     alias: "a"
   }

--- a/testdata/p4_16_samples_outputs/key1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/key1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33615638
+    id: 43577110
     name: "ingress.c.t"
     alias: "t"
   }
@@ -14,23 +14,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16837667
+    id: 27847715
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16837667
+    id: 27847715
     name: "ingress.c.a"
     alias: "a"
   }

--- a/testdata/p4_16_samples_outputs/logging.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/logging.p4.p4info.txt
@@ -3,15 +3,15 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33595561
+    id: 38772905
     name: "c.t"
     alias: "t"
   }
   action_refs {
-    id: 16782098
+    id: 23991058
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -19,14 +19,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16782098
+    id: 23991058
     name: "c.a"
     alias: "a"
   }

--- a/testdata/p4_16_samples_outputs/match-on-exprs-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/match-on-exprs-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33575637
+    id: 49173205
     name: "ingressImpl.t1"
     alias: "t1"
   }
@@ -26,34 +26,34 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16814741
+    id: 24416917
   }
   action_refs {
-    id: 16788060
+    id: 32254556
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16788060
+    id: 32254556
     name: "ingressImpl.my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16814741
+    id: 24416917
     name: "ingressImpl.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33575637
+    id: 49173205
     name: "ingressImpl.t1"
     alias: "t1"
   }
@@ -26,34 +26,34 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16814741
+    id: 24416917
   }
   action_refs {
-    id: 16788060
+    id: 32254556
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16788060
+    id: 32254556
     name: "ingressImpl.my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16814741
+    id: 24416917
     name: "ingressImpl.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/multicast-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2.p4.p4info.txt
@@ -3,15 +3,15 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33565772
+    id: 50277452
     name: "ingress.broadcast"
     alias: "broadcast"
   }
   action_refs {
-    id: 16792690
+    id: 18431090
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -19,7 +19,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33590050
+    id: 43289378
     name: "ingress.forward"
     alias: "forward"
   }
@@ -30,13 +30,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16780303
+    id: 25234447
   }
   action_refs {
-    id: 16784184
+    id: 19143480
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -44,7 +44,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33593274
+    id: 43030458
     name: "ingress.ipv4_lpm"
     alias: "ipv4_lpm"
   }
@@ -55,13 +55,13 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16812204
+    id: 23300268
   }
   action_refs {
-    id: 16784184
+    id: 19143480
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -69,7 +69,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33573008
+    id: 49367184
     name: "egress.send_frame"
     alias: "send_frame"
   }
@@ -80,13 +80,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16813016
+    id: 31165400
   }
   action_refs {
-    id: 16784184
+    id: 19143480
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -94,21 +94,21 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16792690
+    id: 18431090
     name: "bcast"
     alias: "bcast"
   }
 }
 actions {
   preamble {
-    id: 16780303
+    id: 25234447
     name: "set_dmac"
     alias: "set_dmac"
   }
@@ -120,14 +120,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16784184
+    id: 19143480
     name: "_drop"
     alias: "_drop"
   }
 }
 actions {
   preamble {
-    id: 16812204
+    id: 23300268
     name: "set_nhop"
     alias: "set_nhop"
   }
@@ -144,7 +144,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16813016
+    id: 31165400
     name: "rewrite_mac"
     alias: "rewrite_mac"
   }

--- a/testdata/p4_16_samples_outputs/mux-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/mux-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16779977
+    id: 32836297
     name: "Eg.update"
     alias: "update"
   }

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33559735
+    id: 40244407
     name: "ingress.m_filter"
     alias: "m_filter"
   }
@@ -14,19 +14,19 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16788328
+    id: 19344232
   }
   action_refs {
-    id: 16781360
+    id: 26939440
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 16
 }
 tables {
   preamble {
-    id: 33597405
+    id: 43296733
     name: "ingress.m_table"
     alias: "m_table"
   }
@@ -37,41 +37,41 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16779733
+    id: 24512981
   }
   action_refs {
-    id: 16781360
+    id: 26939440
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  direct_resource_ids: 352349353
+  direct_resource_ids: 368209065
   size: 16384
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16788328
+    id: 19344232
     name: "ingress._drop"
     alias: "_drop"
   }
 }
 actions {
   preamble {
-    id: 16781360
+    id: 26939440
     name: "ingress._nop"
     alias: "_nop"
   }
 }
 actions {
   preamble {
-    id: 16779733
+    id: 24512981
     name: "ingress.m_action"
     alias: "m_action"
   }
@@ -83,14 +83,14 @@ actions {
 }
 direct_meters {
   preamble {
-    id: 352349353
+    id: 368209065
     name: "namedmeter"
     alias: "namedmeter"
   }
   spec {
     unit: PACKETS
   }
-  direct_table_id: 33597405
+  direct_table_id: 43296733
 }
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33559735
+    id: 40244407
     name: "ingress.m_filter"
     alias: "m_filter"
   }
@@ -14,19 +14,19 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16788328
+    id: 19344232
   }
   action_refs {
-    id: 16781360
+    id: 26939440
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 16
 }
 tables {
   preamble {
-    id: 33597405
+    id: 43296733
     name: "ingress.m_table"
     alias: "m_table"
   }
@@ -37,41 +37,41 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16779733
+    id: 24512981
   }
   action_refs {
-    id: 16781360
+    id: 26939440
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  direct_resource_ids: 352370409
+  direct_resource_ids: 354402025
   size: 16384
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16788328
+    id: 19344232
     name: "ingress._drop"
     alias: "_drop"
   }
 }
 actions {
   preamble {
-    id: 16781360
+    id: 26939440
     name: "ingress._nop"
     alias: "_nop"
   }
 }
 actions {
   preamble {
-    id: 16779733
+    id: 24512981
     name: "ingress.m_action"
     alias: "m_action"
   }
@@ -83,14 +83,14 @@ actions {
 }
 direct_meters {
   preamble {
-    id: 352370409
+    id: 354402025
     name: "ingress.namedmeter"
     alias: "namedmeter"
   }
   spec {
     unit: PACKETS
   }
-  direct_table_id: 33597405
+  direct_table_id: 43296733
 }
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/p416-type-use3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/p416-type-use3.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33586815
+    id: 42499711
     name: "ingress.custom_table"
     alias: "custom_table"
   }
@@ -113,19 +113,19 @@ tables {
     }
   }
   action_refs {
-    id: 16829338
+    id: 28429210
   }
   action_refs {
-    id: 16797750
+    id: 21844022
   }
   action_refs {
-    id: 16796819
+    id: 21580947
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16829338
+    id: 28429210
     name: "ingress.set_output"
     alias: "set_output"
   }
@@ -137,7 +137,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16797750
+    id: 21844022
     name: "ingress.set_headers"
     alias: "set_headers"
   }
@@ -252,7 +252,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16796819
+    id: 21580947
     name: "ingress.my_drop"
     alias: "my_drop"
   }

--- a/testdata/p4_16_samples_outputs/p4rt_digest_complex.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/p4rt_digest_complex.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 digests {
   preamble {
-    id: 385929834
+    id: 387633770
     name: "MyID.digest"
     alias: "digest"
   }

--- a/testdata/p4_16_samples_outputs/parser-locals2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/parser-locals2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33616793
+    id: 48165785
     name: "cIngress.guh"
     alias: "guh"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16808330
+    id: 25131402
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16808330
+    id: 25131402
     name: "cIngress.foo"
     alias: "foo"
   }

--- a/testdata/p4_16_samples_outputs/pred.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pred.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16834953
+    id: 33546633
     name: "Ing.cond"
     alias: "cond"
   }

--- a/testdata/p4_16_samples_outputs/pred1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pred1.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16834953
+    id: 33546633
     name: "Ing.cond"
     alias: "cond"
   }

--- a/testdata/p4_16_samples_outputs/pred2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pred2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33605419
+    id: 41666347
     name: "Ing.tbl_cond"
     alias: "tbl_cond"
   }
   action_refs {
-    id: 16834953
+    id: 33546633
   }
-  const_default_action_id: 16834953
+  const_default_action_id: 33546633
   size: 1024
 }
 actions {
   preamble {
-    id: 16834953
+    id: 33546633
     name: "Ing.cond"
     alias: "cond"
   }

--- a/testdata/p4_16_samples_outputs/psa-action-profile1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,41 +14,41 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16786149
+    id: 21832421
   }
   action_refs {
-    id: 16781592
+    id: 23466264
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16786149
+    id: 21832421
     name: "MyIC.a1"
     alias: "a1"
   }
 }
 actions {
   preamble {
-    id: 16781592
+    id: 23466264
     name: "MyIC.a2"
     alias: "a2"
   }
 }
 action_profiles {
   preamble {
-    id: 285236196
+    id: 298015716
     name: "MyIC.ap"
     alias: "ap"
   }

--- a/testdata/p4_16_samples_outputs/psa-action-profile2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,41 +14,41 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16786149
+    id: 21832421
   }
   action_refs {
-    id: 16781592
+    id: 23466264
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16786149
+    id: 21832421
     name: "MyIC.a1"
     alias: "a1"
   }
 }
 actions {
   preamble {
-    id: 16781592
+    id: 23466264
     name: "MyIC.a2"
     alias: "a2"
   }
 }
 action_profiles {
   preamble {
-    id: 285236196
+    id: 298015716
     name: "MyIC.ap"
     alias: "ap"
   }
@@ -56,7 +56,7 @@ action_profiles {
 }
 action_profiles {
   preamble {
-    id: 285242821
+    id: 294024645
     name: "MyIC.ap1"
     alias: "ap1"
   }

--- a/testdata/p4_16_samples_outputs/psa-action-profile3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,20 +14,20 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16786149
+    id: 21832421
   }
   action_refs {
-    id: 16781592
+    id: 23466264
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 tables {
   preamble {
-    id: 33555510
+    id: 47318070
     name: "MyIC.tbl2"
     alias: "tbl2"
   }
@@ -38,41 +38,41 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16786149
+    id: 21832421
   }
   action_refs {
-    id: 16781592
+    id: 23466264
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16786149
+    id: 21832421
     name: "MyIC.a1"
     alias: "a1"
   }
 }
 actions {
   preamble {
-    id: 16781592
+    id: 23466264
     name: "MyIC.a2"
     alias: "a2"
   }
 }
 action_profiles {
   preamble {
-    id: 285236196
+    id: 298015716
     name: "MyIC.ap"
     alias: "ap"
   }

--- a/testdata/p4_16_samples_outputs/psa-action-profile4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,17 +14,17 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16781592
+    id: 23466264
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 tables {
   preamble {
-    id: 33555510
+    id: 47318070
     name: "MyIC.tbl2"
     alias: "tbl2"
   }
@@ -35,38 +35,38 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16786149
+    id: 21832421
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16786149
+    id: 21832421
     name: "MyIC.a1"
     alias: "a1"
   }
 }
 actions {
   preamble {
-    id: 16781592
+    id: 23466264
     name: "MyIC.a2"
     alias: "a2"
   }
 }
 action_profiles {
   preamble {
-    id: 285236196
+    id: 298015716
     name: "MyIC.ap"
     alias: "ap"
   }

--- a/testdata/p4_16_samples_outputs/psa-action-selector1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,41 +14,41 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16786149
+    id: 21832421
   }
   action_refs {
-    id: 16781592
+    id: 23466264
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16786149
+    id: 21832421
     name: "MyIC.a1"
     alias: "a1"
   }
 }
 actions {
   preamble {
-    id: 16781592
+    id: 23466264
     name: "MyIC.a2"
     alias: "a2"
   }
 }
 action_profiles {
   preamble {
-    id: 285272889
+    id: 294316857
     name: "MyIC.as"
     alias: "as"
   }

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,41 +14,41 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16786149
+    id: 21832421
   }
   action_refs {
-    id: 16781592
+    id: 23466264
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16786149
+    id: 21832421
     name: "MyIC.a1"
     alias: "a1"
   }
 }
 actions {
   preamble {
-    id: 16781592
+    id: 23466264
     name: "MyIC.a2"
     alias: "a2"
   }
 }
 action_profiles {
   preamble {
-    id: 285272889
+    id: 294316857
     name: "MyIC.as"
     alias: "as"
   }

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,34 +14,34 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16786149
+    id: 21832421
   }
   action_refs {
-    id: 16781592
+    id: 23466264
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16786149
+    id: 21832421
     name: "MyIC.a1"
     alias: "a1"
   }
 }
 actions {
   preamble {
-    id: 16781592
+    id: 23466264
     name: "MyIC.a2"
     alias: "a2"
   }

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.p4info.txt
@@ -3,33 +3,33 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33578158
+    id: 34888878
     name: "cIngress.tbl"
     alias: "tbl"
   }
   action_refs {
-    id: 16801940
+    id: 17064084
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16833049
+    id: 27646489
     name: "send_to_port"
     alias: "send_to_port"
   }
 }
 actions {
   preamble {
-    id: 16801940
+    id: 17064084
     name: "cIngress.execute"
     alias: "execute"
   }
 }
 counters {
   preamble {
-    id: 301992253
+    id: 304351549
     name: "cIngress.counter"
     alias: "counter"
   }

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,31 +14,31 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16835440
+    id: 22078320
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16835440
+    id: 22078320
     name: "MyIC.execute"
     alias: "execute"
   }
 }
 counters {
   preamble {
-    id: 302014859
+    id: 306209163
     name: "MyIC.counter"
     alias: "counter"
   }

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,31 +14,31 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16835440
+    id: 22078320
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16835440
+    id: 22078320
     name: "MyIC.execute"
     alias: "execute"
   }
 }
 counters {
   preamble {
-    id: 302023597
+    id: 303203245
     name: "MyIC.counter0"
     alias: "counter0"
   }
@@ -49,7 +49,7 @@ counters {
 }
 counters {
   preamble {
-    id: 302034433
+    id: 305966593
     name: "MyIC.counter1"
     alias: "counter1"
   }

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 counters {
   preamble {
-    id: 302023597
+    id: 303203245
     name: "MyIC.counter0"
     alias: "counter0"
   }
@@ -14,7 +14,7 @@ counters {
 }
 counters {
   preamble {
-    id: 302034433
+    id: 305966593
     name: "MyIC.counter1"
     alias: "counter1"
   }

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,29 +14,29 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  direct_resource_ids: 318800813
+  direct_resource_ids: 319980461
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 direct_counters {
   preamble {
-    id: 318800813
+    id: 319980461
     name: "MyIC.counter0"
     alias: "counter0"
   }
   spec {
     unit: PACKETS
   }
-  direct_table_id: 33610509
+  direct_table_id: 39967501
 }
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,31 +14,31 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16835440
+    id: 22078320
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16835440
+    id: 22078320
     name: "MyIC.execute"
     alias: "execute"
   }
 }
 counters {
   preamble {
-    id: 302014859
+    id: 306209163
     name: "MyIC.counter"
     alias: "counter"
   }

--- a/testdata/p4_16_samples_outputs/psa-example-counters-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-counters-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33571396
+    id: 35996228
     name: "ingress.ipv4_da_lpm"
     alias: "ipv4_da_lpm"
   }
@@ -14,18 +14,18 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16786796
+    id: 27207020
   }
   action_refs {
-    id: 16801000
+    id: 25648360
   }
-  direct_resource_ids: 318780894
+  direct_resource_ids: 332805598
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16786796
+    id: 27207020
     name: "ingress.next_hop"
     alias: "next_hop"
   }
@@ -40,14 +40,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16801000
+    id: 25648360
     name: "ingress.default_route_drop"
     alias: "default_route_drop"
   }
 }
 counters {
   preamble {
-    id: 302004348
+    id: 306657404
     name: "ingress.port_bytes_in"
     alias: "port_bytes_in"
   }
@@ -61,7 +61,7 @@ counters {
 }
 counters {
   preamble {
-    id: 302054690
+    id: 309984546
     name: "egress.port_bytes_out"
     alias: "port_bytes_out"
   }
@@ -75,14 +75,14 @@ counters {
 }
 direct_counters {
   preamble {
-    id: 318780894
+    id: 332805598
     name: "ingress.per_prefix_pkt_byte_count"
     alias: "per_prefix_pkt_byte_count"
   }
   spec {
     unit: BOTH
   }
-  direct_table_id: 33571396
+  direct_table_id: 35996228
 }
 type_info {
   new_types {

--- a/testdata/p4_16_samples_outputs/psa-example-digest-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-digest-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33564006
+    id: 47392102
     name: "ingress.learned_sources"
     alias: "learned_sources"
   }
@@ -14,17 +14,17 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16800063
+    id: 26564927
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 tables {
   preamble {
-    id: 33594478
+    id: 41262190
     name: "ingress.l2_tbl"
     alias: "l2_tbl"
   }
@@ -35,17 +35,17 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16830849
+    id: 31052161
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 tables {
   preamble {
-    id: 33601325
+    id: 36288301
     name: "ingress.tst_tbl"
     alias: "tst_tbl"
   }
@@ -59,31 +59,31 @@ tables {
     }
   }
   action_refs {
-    id: 16797276
+    id: 29249116
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16800063
+    id: 26564927
     name: "ingress.unknown_source"
     alias: "unknown_source"
   }
 }
 actions {
   preamble {
-    id: 16830849
+    id: 31052161
     name: "ingress.do_L2_forward"
     alias: "do_L2_forward"
   }
@@ -98,7 +98,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16797276
+    id: 29249116
     name: "ingress.do_tst"
     alias: "do_tst"
   }
@@ -118,7 +118,7 @@ actions {
 }
 digests {
   preamble {
-    id: 385907822
+    id: 401112174
     name: "IngressDeparserImpl.mac_learn_digest"
     alias: "mac_learn_digest"
   }

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.p4info.txt
@@ -3,14 +3,14 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16780617
+    id: 25103689
     name: "update_pkt_ip_byte_count"
     alias: "update_pkt_ip_byte_count"
   }
 }
 registers {
   preamble {
-    id: 369133592
+    id: 383813656
     name: "ingress.port_pkt_ip_bytes_in"
     alias: "port_pkt_ip_bytes_in"
   }

--- a/testdata/p4_16_samples_outputs/psa-hash.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-hash.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16786149
+    id: 21832421
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16786149
+    id: 21832421
     name: "MyIC.a1"
     alias: "a1"
   }

--- a/testdata/p4_16_samples_outputs/psa-meter3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter3.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,21 +14,21 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 meters {
   preamble {
-    id: 335562780
+    id: 351291420
     name: "MyIC.meter0"
     alias: "meter0"
   }

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,29 +14,29 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  direct_resource_ids: 352339996
+  direct_resource_ids: 368068636
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 direct_meters {
   preamble {
-    id: 352339996
+    id: 368068636
     name: "MyIC.meter0"
     alias: "meter0"
   }
   spec {
     unit: PACKETS
   }
-  direct_table_id: 33610509
+  direct_table_id: 39967501
 }
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,29 +14,29 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  direct_resource_ids: 352339996
+  direct_resource_ids: 368068636
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 direct_meters {
   preamble {
-    id: 352339996
+    id: 368068636
     name: "MyIC.meter0"
     alias: "meter0"
   }
   spec {
     unit: PACKETS
   }
-  direct_table_id: 33610509
+  direct_table_id: 39967501
 }
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/psa-meter6.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter6.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,15 +14,15 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  direct_resource_ids: 352339996
+  direct_resource_ids: 368068636
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 tables {
   preamble {
-    id: 33555510
+    id: 47318070
     name: "MyIC.tbl2"
     alias: "tbl2"
   }
@@ -33,38 +33,38 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16809586
+    id: 18579058
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16809586
+    id: 18579058
     name: "MyIC.execute_meter"
     alias: "execute_meter"
   }
 }
 direct_meters {
   preamble {
-    id: 352339996
+    id: 368068636
     name: "MyIC.meter0"
     alias: "meter0"
   }
   spec {
     unit: PACKETS
   }
-  direct_table_id: 33610509
+  direct_table_id: 39967501
 }
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16807491
+    id: 32077379
     name: "multicast"
     alias: "multicast"
   }

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16807491
+    id: 32077379
     name: "multicast"
     alias: "multicast"
   }

--- a/testdata/p4_16_samples_outputs/psa-random.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-random.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16789153
+    id: 18493089
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16789153
+    id: 18493089
     name: "MyIC.execute_random"
     alias: "execute_random"
   }

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txt
@@ -3,26 +3,26 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33603093
+    id: 43367957
     name: "cEgress.e"
     alias: "e"
   }
   action_refs {
-    id: 16829978
+    id: 25218586
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16833049
+    id: 27646489
     name: "send_to_port"
     alias: "send_to_port"
   }
 }
 actions {
   preamble {
-    id: 16829978
+    id: 25218586
     name: "cEgress.add"
     alias: "add"
   }

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16824071
+    id: 23115527
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16824071
+    id: 23115527
     name: "MyIC.execute_register"
     alias: "execute_register"
   }
@@ -43,7 +43,7 @@ actions {
 }
 registers {
   preamble {
-    id: 369130048
+    id: 369588800
     name: "MyIC.reg"
     alias: "reg"
   }

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16824071
+    id: 23115527
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16824071
+    id: 23115527
     name: "MyIC.execute_register"
     alias: "execute_register"
   }
@@ -43,7 +43,7 @@ actions {
 }
 registers {
   preamble {
-    id: 369130048
+    id: 369588800
     name: "MyIC.reg"
     alias: "reg"
   }

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33610509
+    id: 39967501
     name: "MyIC.tbl"
     alias: "tbl"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   action_refs {
-    id: 16824071
+    id: 23115527
   }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16824071
+    id: 23115527
     name: "MyIC.execute_register"
     alias: "execute_register"
   }
@@ -43,7 +43,7 @@ actions {
 }
 registers {
   preamble {
-    id: 369130048
+    id: 369588800
     name: "MyIC.reg"
     alias: "reg"
   }

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.p4info.txt
@@ -3,21 +3,21 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16833049
+    id: 27646489
     name: "send_to_port"
     alias: "send_to_port"
   }
 }
 actions {
   preamble {
-    id: 16783561
+    id: 27400393
     name: "cIngress.resubmit"
     alias: "resubmit"
   }
 }
 actions {
   preamble {
-    id: 16820544
+    id: 24095040
     name: "cIngress.pkt_write"
     alias: "pkt_write"
   }

--- a/testdata/p4_16_samples_outputs/psa-test.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-test.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 value_sets {
   preamble {
-    id: 50366883
+    id: 53184931
     name: "MyIP.pvs"
     alias: "pvs"
   }

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.p4info.txt
@@ -3,14 +3,14 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16833049
+    id: 27646489
     name: "send_to_port"
     alias: "send_to_port"
   }
 }
 actions {
   preamble {
-    id: 16829615
+    id: 30788783
     name: "ingress_drop"
     alias: "ingress_drop"
   }

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.p4info.txt
@@ -3,14 +3,14 @@ pkg_info {
 }
 actions {
   preamble {
-    id: 16833049
+    id: 27646489
     name: "send_to_port"
     alias: "send_to_port"
   }
 }
 actions {
   preamble {
-    id: 16829615
+    id: 30788783
     name: "ingress_drop"
     alias: "ingress_drop"
   }

--- a/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33611905
+    id: 44621953
     name: "MyIngress.t"
     alias: "t"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16777606
+    id: 29884806
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,21 +25,21 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16777606
+    id: 29884806
     name: "MyIngress.set_data"
     alias: "set_data"
   }
 }
 value_sets {
   preamble {
-    id: 50332118
+    id: 56033750
     name: "MyParser.pvs"
     alias: "pvs"
   }

--- a/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33611905
+    id: 44621953
     name: "MyIngress.t"
     alias: "t"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16777606
+    id: 29884806
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,21 +25,21 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16777606
+    id: 29884806
     name: "MyIngress.set_data"
     alias: "set_data"
   }
 }
 value_sets {
   preamble {
-    id: 50332118
+    id: 56033750
     name: "MyParser.pvs"
     alias: "pvs"
   }

--- a/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33611905
+    id: 44621953
     name: "MyIngress.t"
     alias: "t"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16777606
+    id: 29884806
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,21 +25,21 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16777606
+    id: 29884806
     name: "MyIngress.set_data"
     alias: "set_data"
   }
 }
 value_sets {
   preamble {
-    id: 50332118
+    id: 56033750
     name: "MyParser.pvs"
     alias: "pvs"
   }

--- a/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33611905
+    id: 44621953
     name: "MyIngress.t"
     alias: "t"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16777606
+    id: 29884806
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,21 +25,21 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16777606
+    id: 29884806
     name: "MyIngress.set_data"
     alias: "set_data"
   }
 }
 value_sets {
   preamble {
-    id: 50332118
+    id: 56033750
     name: "MyParser.pvs"
     alias: "pvs"
   }

--- a/testdata/p4_16_samples_outputs/register-serenum.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/register-serenum.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 registers {
   preamble {
-    id: 369133130
+    id: 384009802
     name: "c.reg"
     alias: "reg"
   }

--- a/testdata/p4_16_samples_outputs/same_name_for_table_and_action.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/same_name_for_table_and_action.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33608800
+    id: 46322784
     name: "IngressI.do_something"
     alias: "do_something"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16831584
+    id: 29545568
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
-  const_default_action_id: 16800567
+  const_default_action_id: 21257015
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16831584
+    id: 29545568
     name: "IngressI.do_something"
     alias: "do_something"
   }

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33614349
+      table_id: 34728461
       match {
         field_id: 1
         exact {
@@ -11,7 +11,7 @@ updates {
       }
       action {
         action {
-          action_id: 16832985
+          action_id: 20896217
         }
       }
     }
@@ -21,7 +21,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33614349
+      table_id: 34728461
       match {
         field_id: 1
         exact {
@@ -30,7 +30,7 @@ updates {
       }
       action {
         action {
-          action_id: 16813446
+          action_id: 28347782
         }
       }
     }
@@ -40,7 +40,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33614349
+      table_id: 34728461
       match {
         field_id: 1
         exact {
@@ -49,7 +49,7 @@ updates {
       }
       action {
         action {
-          action_id: 16838633
+          action_id: 30797801
         }
       }
     }
@@ -59,7 +59,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33614349
+      table_id: 34728461
       match {
         field_id: 1
         exact {
@@ -68,7 +68,7 @@ updates {
       }
       action {
         action {
-          action_id: 16783139
+          action_id: 18945827
         }
       }
     }

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
@@ -14,54 +14,54 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16832985
+    id: 20896217
   }
   action_refs {
-    id: 16813446
+    id: 28347782
   }
   action_refs {
-    id: 16838633
+    id: 30797801
   }
   action_refs {
-    id: 16783139
+    id: 18945827
   }
   action_refs {
-    id: 16832181
+    id: 33281717
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16832985
+    id: 20896217
     name: "ingress.usat_plus"
     alias: "usat_plus"
   }
 }
 actions {
   preamble {
-    id: 16813446
+    id: 28347782
     name: "ingress.usat_minus"
     alias: "usat_minus"
   }
 }
 actions {
   preamble {
-    id: 16838633
+    id: 30797801
     name: "ingress.sat_plus"
     alias: "sat_plus"
   }
 }
 actions {
   preamble {
-    id: 16783139
+    id: 18945827
     name: "ingress.sat_minus"
     alias: "sat_minus"
   }
 }
 actions {
   preamble {
-    id: 16832181
+    id: 33281717
     name: "ingress.drop"
     alias: "drop"
   }

--- a/testdata/p4_16_samples_outputs/simplify_slice.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/simplify_slice.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 registers {
   preamble {
-    id: 369100749
+    id: 376440781
     name: "Ing.debug"
     alias: "debug"
   }

--- a/testdata/p4_16_samples_outputs/slice-def-use.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/slice-def-use.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 registers {
   preamble {
-    id: 369100749
+    id: 376440781
     name: "Ing.debug"
     alias: "debug"
   }

--- a/testdata/p4_16_samples_outputs/slice-def-use1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/slice-def-use1.p4.p4info.txt
@@ -3,26 +3,26 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33558312
+    id: 35196712
     name: "Ing.tbl_act"
     alias: "tbl_act"
   }
   action_refs {
-    id: 16783513
+    id: 30218393
   }
-  const_default_action_id: 16783513
+  const_default_action_id: 30218393
   size: 1024
 }
 actions {
   preamble {
-    id: 16783513
+    id: 30218393
     name: "Ing.act"
     alias: "act"
   }
 }
 registers {
   preamble {
-    id: 369100749
+    id: 376440781
     name: "Ing.debug"
     alias: "debug"
   }

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2.p4.p4info.txt
@@ -3,19 +3,19 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16821713
+    id: 29666769
   }
-  const_default_action_id: 16821713
+  const_default_action_id: 29666769
   size: 1024
 }
 actions {
   preamble {
-    id: 16821713
+    id: 29666769
     name: "ingress.set_port"
     alias: "set_port"
   }

--- a/testdata/p4_16_samples_outputs/std_meta_inlining.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/std_meta_inlining.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33600455
+    id: 35959751
     name: "ingress.t0"
     alias: "t0"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16829080
+    id: 24562328
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -25,14 +25,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16829080
+    id: 24562328
     name: "send_to_cpu"
     alias: "send_to_cpu"
   }
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }

--- a/testdata/p4_16_samples_outputs/strength3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/strength3.p4.p4info.txt
@@ -3,89 +3,89 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16800267
+    id: 25451019
   }
   action_refs {
-    id: 16807847
+    id: 22181799
   }
   action_refs {
-    id: 16782284
+    id: 23335884
   }
   action_refs {
-    id: 16797246
+    id: 27086398
   }
   action_refs {
-    id: 16837873
+    id: 32959729
   }
   action_refs {
-    id: 16779157
+    id: 21235605
   }
   action_refs {
-    id: 16819678
+    id: 23635422
   }
   action_refs {
-    id: 16793963
+    id: 19874155
   }
-  const_default_action_id: 16800267
+  const_default_action_id: 25451019
   size: 1024
 }
 actions {
   preamble {
-    id: 16800267
+    id: 25451019
     name: "ingress.case0"
     alias: "case0"
   }
 }
 actions {
   preamble {
-    id: 16807847
+    id: 22181799
     name: "ingress.case1"
     alias: "case1"
   }
 }
 actions {
   preamble {
-    id: 16782284
+    id: 23335884
     name: "ingress.case2"
     alias: "case2"
   }
 }
 actions {
   preamble {
-    id: 16797246
+    id: 27086398
     name: "ingress.case3"
     alias: "case3"
   }
 }
 actions {
   preamble {
-    id: 16837873
+    id: 32959729
     name: "ingress.case4"
     alias: "case4"
   }
 }
 actions {
   preamble {
-    id: 16779157
+    id: 21235605
     name: "ingress.case5"
     alias: "case5"
   }
 }
 actions {
   preamble {
-    id: 16819678
+    id: 23635422
     name: "ingress.case6"
     alias: "case6"
   }
 }
 actions {
   preamble {
-    id: 16793963
+    id: 19874155
     name: "ingress.case7"
     alias: "case7"
   }

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33562569
+      table_id: 40116169
       match {
         field_id: 1
         exact {
@@ -11,7 +11,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\001"
@@ -25,7 +25,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33562569
+      table_id: 40116169
       match {
         field_id: 1
         exact {
@@ -34,7 +34,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\002"

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33562569
+    id: 40116169
     name: "ingress.t_exact"
     alias: "t_exact"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33616996
+      table_id: 44168292
       match {
         field_id: 1
         exact {
@@ -18,7 +18,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\001"
@@ -33,7 +33,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33616996
+      table_id: 44168292
       match {
         field_id: 1
         exact {
@@ -49,7 +49,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\002"
@@ -64,7 +64,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33616996
+      table_id: 44168292
       match {
         field_id: 1
         exact {
@@ -80,7 +80,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\003"
@@ -95,7 +95,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33616996
+      table_id: 44168292
       match {
         field_id: 1
         exact {
@@ -104,7 +104,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\004"

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33616996
+    id: 44168292
     name: "ingress.t_exact_ternary"
     alias: "t_exact_ternary"
   }
@@ -20,24 +20,24 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33555353
+      table_id: 42140569
       match {
         field_id: 1
         lpm {
@@ -12,7 +12,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\013"
@@ -26,7 +26,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33555353
+      table_id: 42140569
       match {
         field_id: 1
         lpm {
@@ -36,7 +36,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\014"
@@ -50,10 +50,10 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33555353
+      table_id: 42140569
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\r"

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33555353
+    id: 42140569
     name: "ingress.t_lpm"
     alias: "t_lpm"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33609018
+      table_id: 38131002
       match {
         field_id: 1
         optional {
@@ -17,7 +17,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\001"
@@ -32,7 +32,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33609018
+      table_id: 38131002
       match {
         field_id: 2
         optional {
@@ -41,7 +41,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\002"
@@ -56,7 +56,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33609018
+      table_id: 38131002
       match {
         field_id: 1
         optional {
@@ -65,7 +65,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\003"
@@ -80,10 +80,10 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33609018
+      table_id: 38131002
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\004"

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33609018
+    id: 38131002
     name: "ingress.t_optional"
     alias: "t_optional"
   }
@@ -20,24 +20,24 @@ tables {
     match_type: OPTIONAL
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33556639
+      table_id: 44370079
       match {
         field_id: 1
         ternary {
@@ -12,7 +12,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\001"
@@ -27,7 +27,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33556639
+      table_id: 44370079
       match {
         field_id: 1
         ternary {
@@ -37,7 +37,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\002"
@@ -52,7 +52,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33556639
+      table_id: 44370079
       match {
         field_id: 1
         ternary {
@@ -62,7 +62,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\003"

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33556639
+    id: 44370079
     name: "ingress.t_ternary"
     alias: "t_ternary"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33595117
+      table_id: 34184941
       match {
         field_id: 1
         range {
@@ -12,7 +12,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\025"
@@ -27,7 +27,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33595117
+      table_id: 34184941
       match {
         field_id: 1
         range {
@@ -37,7 +37,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\026"
@@ -52,7 +52,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33595117
+      table_id: 34184941
       match {
         field_id: 1
         range {
@@ -62,7 +62,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\030"
@@ -77,10 +77,10 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33595117
+      table_id: 34184941
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\027"

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33595117
+    id: 34184941
     name: "ingress.t_range"
     alias: "t_range"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: RANGE
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33556639
+      table_id: 44370079
       match {
         field_id: 1
         exact {
@@ -11,7 +11,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\001"
@@ -26,7 +26,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33556639
+      table_id: 44370079
       match {
         field_id: 1
         exact {
@@ -42,7 +42,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\002"
@@ -57,7 +57,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33556639
+      table_id: 44370079
       match {
         field_id: 1
         exact {
@@ -66,7 +66,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\003"

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33556639
+    id: 44370079
     name: "ingress.t_ternary"
     alias: "t_ternary"
   }
@@ -20,25 +20,25 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
-  const_default_action_id: 16795253
+  const_default_action_id: 21186165
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33556639
+      table_id: 44370079
       match {
         field_id: 1
         ternary {
@@ -12,7 +12,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\001"
@@ -27,7 +27,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33556639
+      table_id: 44370079
       match {
         field_id: 1
         ternary {
@@ -37,7 +37,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\002"
@@ -52,7 +52,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33556639
+      table_id: 44370079
       match {
         field_id: 1
         ternary {
@@ -62,7 +62,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\003"
@@ -77,10 +77,10 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33556639
+      table_id: 44370079
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\004"

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33556639
+    id: 44370079
     name: "ingress.t_ternary"
     alias: "t_ternary"
   }
@@ -14,24 +14,24 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33573312
+      table_id: 40847808
       match {
         field_id: 1
         exact {
@@ -17,7 +17,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\001"
@@ -31,7 +31,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33573312
+      table_id: 40847808
       match {
         field_id: 1
         exact {
@@ -46,7 +46,7 @@ updates {
       }
       action {
         action {
-          action_id: 16837978
+          action_id: 17165658
           params {
             param_id: 1
             value: "\000\002"

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33573312
+    id: 40847808
     name: "ingress.t_valid"
     alias: "t_valid"
   }
@@ -20,24 +20,24 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   action_refs {
-    id: 16837978
+    id: 17165658
   }
   size: 1024
   is_const_table: true
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }
 }
 actions {
   preamble {
-    id: 16837978
+    id: 17165658
     name: "ingress.a_with_control_params"
     alias: "a_with_control_params"
   }

--- a/testdata/p4_16_samples_outputs/table-key-serenum.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/table-key-serenum.p4.entries.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33555305
+      table_id: 48497513
       match {
         field_id: 1
         exact {
@@ -11,7 +11,7 @@ updates {
       }
       action {
         action {
-          action_id: 16828138
+          action_id: 22922986
           params {
             param_id: 1
             value: "\000\000\010\000"
@@ -25,7 +25,7 @@ updates {
   type: INSERT
   entity {
     table_entry {
-      table_id: 33555305
+      table_id: 48497513
       match {
         field_id: 1
         exact {
@@ -34,7 +34,7 @@ updates {
       }
       action {
         action {
-          action_id: 16828138
+          action_id: 22922986
           params {
             param_id: 1
             value: "\000\000\201\000"

--- a/testdata/p4_16_samples_outputs/table-key-serenum.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/table-key-serenum.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33555305
+    id: 48497513
     name: "c.tns"
     alias: "tns"
   }
@@ -14,10 +14,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16828138
+    id: 22922986
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -26,14 +26,14 @@ tables {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16828138
+    id: 22922986
     name: "c.do_act"
     alias: "do_act"
   }

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33619894
+    id: 36962230
     name: "ingress.test1"
     alias: "test1"
   }
@@ -14,16 +14,16 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16778653
+    id: 28312989
   }
   action_refs {
-    id: 16807129
+    id: 27489497
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33606910
+    id: 38325502
     name: "ingress.ex1"
     alias: "ex1"
   }
@@ -34,25 +34,25 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16785148
+    id: 23207676
   }
   action_refs {
-    id: 16836042
+    id: 17753546
   }
   action_refs {
-    id: 16803121
+    id: 29844785
   }
   action_refs {
-    id: 16826812
+    id: 17613244
   }
   action_refs {
-    id: 16807129
+    id: 27489497
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33611382
+    id: 33873526
     name: "ingress.tbl1"
     alias: "tbl1"
   }
@@ -63,16 +63,16 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16785148
+    id: 23207676
   }
   action_refs {
-    id: 16807129
+    id: 27489497
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33569485
+    id: 36715213
     name: "ingress.tbl2"
     alias: "tbl2"
   }
@@ -83,16 +83,16 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16785148
+    id: 23207676
   }
   action_refs {
-    id: 16807129
+    id: 27489497
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33593185
+    id: 41523041
     name: "ingress.tbl3"
     alias: "tbl3"
   }
@@ -103,16 +103,16 @@ tables {
     match_type: TERNARY
   }
   action_refs {
-    id: 16785148
+    id: 23207676
   }
   action_refs {
-    id: 16807129
+    id: 27489497
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16778653
+    id: 28312989
     name: "ingress.setb1"
     alias: "setb1"
   }
@@ -129,14 +129,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16807129
+    id: 27489497
     name: "ingress.noop"
     alias: "noop"
   }
 }
 actions {
   preamble {
-    id: 16785148
+    id: 23207676
     name: "ingress.setbyte"
     alias: "setbyte"
   }
@@ -148,7 +148,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16836042
+    id: 17753546
     name: "ingress.act1"
     alias: "act1"
   }
@@ -160,7 +160,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16803121
+    id: 29844785
     name: "ingress.act2"
     alias: "act2"
   }
@@ -172,7 +172,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16826812
+    id: 17613244
     name: "ingress.act3"
     alias: "act3"
   }

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
@@ -14,13 +14,13 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16795253
+    id: 21186165
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16795253
+    id: 21186165
     name: "ingress.a"
     alias: "a"
   }

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4.p4info.txt
@@ -3,20 +3,20 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33614349
+    id: 34728461
     name: "ingress.t"
     alias: "t"
   }
   action_refs {
-    id: 16801679
+    id: 32530319
   }
-  const_default_action_id: 16801679
-  direct_resource_ids: 318771034
+  const_default_action_id: 32530319
+  direct_resource_ids: 330698586
   size: 1024
 }
 actions {
   preamble {
-    id: 16801679
+    id: 32530319
     name: "ingress.my_action"
     alias: "my_action"
   }
@@ -28,14 +28,14 @@ actions {
 }
 direct_counters {
   preamble {
-    id: 318771034
+    id: 330698586
     name: "ingress.c"
     alias: "c"
   }
   spec {
     unit: PACKETS
   }
-  direct_table_id: 33614349
+  direct_table_id: 34728461
 }
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33615889
+    id: 46460945
     name: "MyIngress.forward"
     alias: "forward"
   }
@@ -14,19 +14,19 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16837735
+    id: 33025127
   }
   action_refs {
-    id: 16805608
+    id: 25652968
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33574068
+    id: 37375156
     name: "MyIngress.ipv4_lpm"
     alias: "ipv4_lpm"
   }
@@ -37,19 +37,19 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16826124
+    id: 24952588
   }
   action_refs {
-    id: 16805608
+    id: 25652968
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33604441
+    id: 49202009
     name: "MyEgress.send_frame"
     alias: "send_frame"
   }
@@ -60,23 +60,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16828148
+    id: 22398708
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16837735
+    id: 33025127
     name: "MyIngress.set_dmac"
     alias: "set_dmac"
   }
@@ -88,14 +88,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16805608
+    id: 25652968
     name: "MyIngress.drop"
     alias: "drop"
   }
 }
 actions {
   preamble {
-    id: 16826124
+    id: 24952588
     name: "MyIngress.set_nhop"
     alias: "set_nhop"
   }
@@ -112,14 +112,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16842278
+    id: 23592486
     name: "MyIngress.send_digest"
     alias: "send_digest"
   }
 }
 actions {
   preamble {
-    id: 16828148
+    id: 22398708
     name: "MyEgress.rewrite_mac"
     alias: "rewrite_mac"
   }
@@ -131,7 +131,7 @@ actions {
 }
 digests {
   preamble {
-    id: 385901477
+    id: 387015589
     name: "test_digest_t"
     alias: "test_digest_t"
   }
@@ -143,7 +143,7 @@ digests {
 }
 digests {
   preamble {
-    id: 385915136
+    id: 392468736
     name: "test_digest2_t"
     alias: "test_digest2_t"
   }
@@ -155,7 +155,7 @@ digests {
 }
 digests {
   preamble {
-    id: 385934163
+    id: 399106899
     name: "test_digest3_t"
     alias: "test_digest3_t"
   }

--- a/testdata/p4_16_samples_outputs/v1model-digest-custom-type.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/v1model-digest-custom-type.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33615889
+    id: 46460945
     name: "MyIngress.forward"
     alias: "forward"
   }
@@ -17,19 +17,19 @@ tables {
     }
   }
   action_refs {
-    id: 16837735
+    id: 33025127
   }
   action_refs {
-    id: 16805608
+    id: 25652968
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33574068
+    id: 37375156
     name: "MyIngress.ipv4_lpm"
     alias: "ipv4_lpm"
   }
@@ -43,19 +43,19 @@ tables {
     }
   }
   action_refs {
-    id: 16826124
+    id: 24952588
   }
   action_refs {
-    id: 16805608
+    id: 25652968
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33604441
+    id: 49202009
     name: "MyEgress.send_frame"
     alias: "send_frame"
   }
@@ -66,23 +66,23 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16828148
+    id: 22398708
   }
   action_refs {
-    id: 16800567
+    id: 21257015
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16837735
+    id: 33025127
     name: "MyIngress.set_dmac"
     alias: "set_dmac"
   }
@@ -97,14 +97,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16805608
+    id: 25652968
     name: "MyIngress.drop"
     alias: "drop"
   }
 }
 actions {
   preamble {
-    id: 16826124
+    id: 24952588
     name: "MyIngress.set_nhop"
     alias: "set_nhop"
   }
@@ -124,14 +124,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16842278
+    id: 23592486
     name: "MyIngress.send_digest"
     alias: "send_digest"
   }
 }
 actions {
   preamble {
-    id: 16828148
+    id: 22398708
     name: "MyEgress.rewrite_mac"
     alias: "rewrite_mac"
   }
@@ -146,7 +146,7 @@ actions {
 }
 digests {
   preamble {
-    id: 385901477
+    id: 387015589
     name: "test_digest_t"
     alias: "test_digest_t"
   }

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33586815
+    id: 42499711
     name: "ingress.custom_table"
     alias: "custom_table"
   }
@@ -227,19 +227,19 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16829338
+    id: 28429210
   }
   action_refs {
-    id: 16797750
+    id: 21844022
   }
   action_refs {
-    id: 16796819
+    id: 21580947
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16829338
+    id: 28429210
     name: "ingress.set_output"
     alias: "set_output"
   }
@@ -251,7 +251,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16797750
+    id: 21844022
     name: "ingress.set_headers"
     alias: "set_headers"
   }
@@ -451,14 +451,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16796819
+    id: 21580947
     name: "ingress.my_drop"
     alias: "my_drop"
   }
 }
 controller_packet_metadata {
   preamble {
-    id: 67146229
+    id: 81826293
     name: "packet_in"
     alias: "packet_in"
     annotations: "@controller_header(\"packet_in\")"
@@ -471,7 +471,7 @@ controller_packet_metadata {
 }
 controller_packet_metadata {
   preamble {
-    id: 67121543
+    id: 76689799
     name: "packet_out"
     alias: "packet_out"
     annotations: "@controller_header(\"packet_out\")"
@@ -667,7 +667,7 @@ controller_packet_metadata {
 }
 value_sets {
   preamble {
-    id: 50344301
+    id: 63713645
     name: "ParserImpl.valueset1"
     alias: "valueset1"
   }

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4.p4info.txt
@@ -3,7 +3,7 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 33571396
+    id: 35996228
     name: "ingress.ipv4_da_lpm"
     alias: "ipv4_da_lpm"
   }
@@ -14,25 +14,25 @@ tables {
     match_type: LPM
   }
   action_refs {
-    id: 16798847
+    id: 26563711
   }
   action_refs {
-    id: 16839149
+    id: 21164525
   }
   action_refs {
-    id: 16780718
+    id: 20843950
   }
   action_refs {
-    id: 16779407
+    id: 30804111
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33594010
+    id: 43424410
     name: "ingress.mac_da"
     alias: "mac_da"
   }
@@ -43,16 +43,16 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16832597
+    id: 28039253
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 tables {
   preamble {
-    id: 33603625
+    id: 34324521
     name: "egress.get_multicast_copy_out_bd"
     alias: "get_multicast_copy_out_bd"
   }
@@ -69,10 +69,10 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16826665
+    id: 22004009
   }
   action_refs {
-    id: 16800567
+    id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
@@ -80,7 +80,7 @@ tables {
 }
 tables {
   preamble {
-    id: 33573008
+    id: 49367184
     name: "egress.send_frame"
     alias: "send_frame"
   }
@@ -91,29 +91,29 @@ tables {
     match_type: EXACT
   }
   action_refs {
-    id: 16781737
+    id: 23531945
   }
   action_refs {
-    id: 16805783
+    id: 22048663
   }
   action_refs {
-    id: 16794299
+    id: 31081147
   }
   action_refs {
-    id: 16815499
+    id: 32609675
   }
   size: 1024
 }
 actions {
   preamble {
-    id: 16815499
+    id: 32609675
     name: "my_drop"
     alias: "my_drop"
   }
 }
 actions {
   preamble {
-    id: 16798847
+    id: 26563711
     name: "ingress.set_l2ptr"
     alias: "set_l2ptr"
   }
@@ -125,7 +125,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16839149
+    id: 21164525
     name: "ingress.set_mcast_grp"
     alias: "set_mcast_grp"
   }
@@ -137,7 +137,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16780718
+    id: 20843950
     name: "ingress.do_resubmit"
     alias: "do_resubmit"
   }
@@ -149,7 +149,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16779407
+    id: 30804111
     name: "ingress.do_clone_i2e"
     alias: "do_clone_i2e"
   }
@@ -161,7 +161,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16832597
+    id: 28039253
     name: "ingress.set_bd_dmac_intf"
     alias: "set_bd_dmac_intf"
   }
@@ -183,14 +183,14 @@ actions {
 }
 actions {
   preamble {
-    id: 16800567
+    id: 21257015
     name: "NoAction"
     alias: "NoAction"
   }
 }
 actions {
   preamble {
-    id: 16826665
+    id: 22004009
     name: "egress.set_out_bd"
     alias: "set_out_bd"
   }
@@ -202,7 +202,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16781737
+    id: 23531945
     name: "egress.rewrite_mac"
     alias: "rewrite_mac"
   }
@@ -214,7 +214,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16805783
+    id: 22048663
     name: "egress.do_recirculate"
     alias: "do_recirculate"
   }
@@ -226,7 +226,7 @@ actions {
 }
 actions {
   preamble {
-    id: 16794299
+    id: 31081147
     name: "egress.do_clone_e2e"
     alias: "do_clone_e2e"
   }


### PR DESCRIPTION
As per the P4Runtime specification, when the '@id' annotation is used:
  * if a prefix is missing (i.e. it is 0), assign the correct prefix
    based on the resource type.
  * if a prefix is present (i.e. not 0), ensure that the provided value
    is correct for the resource type - this is not part of P4Runtime
    v1.1, but is being added to the unreleased v1.2 specification.

Fixes #2241