### PR TITLE
Do not allow function calls in select labels 

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -3270,10 +3270,6 @@ const IR::Node* TypeInference::postorder(IR::MethodCallExpression* expression) {
         auto prop = findContext<IR::Property>();
         if (prop != nullptr && prop->name == IR::TableProperties::actionsPropertyName)
             inActionsList = true;
-        if (findContext<IR::Key>()) {
-            typeError("%1%: Action calls are not allowed in table keys", expression);
-            return expression;
-        }
         return actionCall(inActionsList, expression);
     } else {
         // Constant-fold minSizeInBits, minSizeInBytes

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -3397,7 +3397,7 @@ const IR::Node* TypeInference::postorder(IR::MethodCallExpression* expression) {
             checkCorelibMethods(mi->to<ExternMethod>());
 
         auto bi = mi->to<BuiltInMethod>();
-        if ((findContext<IR::SelectCase>() || findContext<IR::Key>()) &&
+        if ((findContext<IR::SelectCase>()) &&
             (!bi || (bi->name == IR::Type_Stack::pop_front ||
                      bi->name == IR::Type_Stack::push_front))) {
             typeError("%1%: no function calls allowed in this context", expression);

--- a/testdata/p4_16_errors/issue122.p4
+++ b/testdata/p4_16_errors/issue122.p4
@@ -1,0 +1,55 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+bit<16> simple_action() {
+    return 16w1;
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition select(hdr.eth_hdr.eth_type) {
+            simple_action(): reject;
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    table simple_table {
+        key = {
+            simple_action(): exact @name("dummy_name") ;
+        }
+        actions = {
+        }
+    }
+    apply {
+        simple_table.apply();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {b.emit(h);} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_errors_outputs/issue122.p4
+++ b/testdata/p4_16_errors_outputs/issue122.p4
@@ -1,0 +1,69 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+bit<16> simple_action() {
+    return 16w1;
+}
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition select(hdr.eth_hdr.eth_type) {
+            simple_action(): reject;
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    table simple_table {
+        key = {
+            simple_action(): exact @name("dummy_name") ;
+        }
+        actions = {
+        }
+    }
+    apply {
+        simple_table.apply();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_errors_outputs/issue122.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue122.p4-stderr
@@ -1,0 +1,3 @@
+issue122.p4(28): [--Werror=type-error] error: simple_action: no function calls allowed in this context
+            simple_action(): reject;
+            ^^^^^^^^^^^^^^^


### PR DESCRIPTION
I think that this is the right approach; otherwise it's very complicated to explain when the possible side-effects of the function call may take place. But the working group has to validate this restriction.

Fixes #122 
