### PR TITLE
fix ninja builds

### DIFF
--- a/backends/ubpf/CMakeLists.txt
+++ b/backends/ubpf/CMakeLists.txt
@@ -57,7 +57,7 @@ set(P4C_UBPF_HEADERS
 
 set (P4C_UBPF_DIST_HEADERS p4include/ubpf_model.p4)
 
-add_cpplint_files(${CMAKE_CURRENT_SOURCE_DIR} "$(P4C_UBPF_SOURCES)")
+add_cpplint_files(${CMAKE_CURRENT_SOURCE_DIR} "$$(P4C_UBPF_SOURCES)")
 
 build_unified(P4C_UBPF_SOURCES ALL)
 add_executable(p4c-ubpf ${P4C_UBPF_SOURCES})


### PR DESCRIPTION
Hi,
My ninja build stopped working with:
    ninja: error: build.ninja:1517: bad $-escape (literal $ must be written as 19185)
The fix was to add the second '$' in the CMakeList.txt file.