### PR TITLE
Predication fixes and cleanup

### DIFF
--- a/backends/bmv2/psa_switch/midend.cpp
+++ b/backends/bmv2/psa_switch/midend.cpp
@@ -123,7 +123,7 @@ PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions& options, std::ostream* outStre
             new P4::FlattenHeaders(&refMap, &typeMap),
             new P4::FlattenInterfaceStructs(&refMap, &typeMap),
             new P4::ReplaceSelectRange(&refMap, &typeMap),
-            new P4::Predication(),
+            new P4::Predication(&refMap),
             new P4::MoveDeclarations(),  // more may have been introduced
             new P4::ConstantFolding(&refMap, &typeMap),
             new P4::LocalCopyPropagation(&refMap, &typeMap),

--- a/backends/bmv2/psa_switch/midend.cpp
+++ b/backends/bmv2/psa_switch/midend.cpp
@@ -123,7 +123,7 @@ PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions& options, std::ostream* outStre
             new P4::FlattenHeaders(&refMap, &typeMap),
             new P4::FlattenInterfaceStructs(&refMap, &typeMap),
             new P4::ReplaceSelectRange(&refMap, &typeMap),
-            new P4::Predication(&refMap),
+            new P4::Predication(),
             new P4::MoveDeclarations(),  // more may have been introduced
             new P4::ConstantFolding(&refMap, &typeMap),
             new P4::LocalCopyPropagation(&refMap, &typeMap),

--- a/backends/bmv2/simple_switch/midend.cpp
+++ b/backends/bmv2/simple_switch/midend.cpp
@@ -99,7 +99,7 @@ SimpleSwitchMidEnd::SimpleSwitchMidEnd(CompilerOptions& options, std::ostream* o
             new P4::FlattenHeaders(&refMap, &typeMap),
             new P4::FlattenInterfaceStructs(&refMap, &typeMap),
             new P4::ReplaceSelectRange(&refMap, &typeMap),
-            new P4::Predication(&refMap),
+            new P4::Predication(),
             new P4::MoveDeclarations(),  // more may have been introduced
             new P4::ConstantFolding(&refMap, &typeMap),
             new P4::LocalCopyPropagation(&refMap, &typeMap),

--- a/backends/bmv2/simple_switch/midend.cpp
+++ b/backends/bmv2/simple_switch/midend.cpp
@@ -99,7 +99,7 @@ SimpleSwitchMidEnd::SimpleSwitchMidEnd(CompilerOptions& options, std::ostream* o
             new P4::FlattenHeaders(&refMap, &typeMap),
             new P4::FlattenInterfaceStructs(&refMap, &typeMap),
             new P4::ReplaceSelectRange(&refMap, &typeMap),
-            new P4::Predication(),
+            new P4::Predication(&refMap),
             new P4::MoveDeclarations(),  // more may have been introduced
             new P4::ConstantFolding(&refMap, &typeMap),
             new P4::LocalCopyPropagation(&refMap, &typeMap),

--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -107,7 +107,7 @@ MidEnd::MidEnd(CompilerOptions& options) {
         new P4::FlattenHeaders(&refMap, &typeMap),
         new P4::FlattenInterfaceStructs(&refMap, &typeMap),
         new P4::ReplaceSelectRange(&refMap, &typeMap),
-        new P4::Predication(&refMap),
+        new P4::Predication(),
         new P4::MoveDeclarations(),  // more may have been introduced
         new P4::ConstantFolding(&refMap, &typeMap),
         new P4::LocalCopyPropagation(&refMap, &typeMap),

--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -107,7 +107,7 @@ MidEnd::MidEnd(CompilerOptions& options) {
         new P4::FlattenHeaders(&refMap, &typeMap),
         new P4::FlattenInterfaceStructs(&refMap, &typeMap),
         new P4::ReplaceSelectRange(&refMap, &typeMap),
-        new P4::Predication(),
+        new P4::Predication(&refMap),
         new P4::MoveDeclarations(),  // more may have been introduced
         new P4::ConstantFolding(&refMap, &typeMap),
         new P4::LocalCopyPropagation(&refMap, &typeMap),

--- a/midend/predication.cpp
+++ b/midend/predication.cpp
@@ -136,13 +136,10 @@ const IR::Node* Predication::clone(const IR::AssignmentStatement* statement) {
 const IR::Node* Predication::preorder(IR::AssignmentStatement* statement) {
     if (!inside_action || ifNestingLevel == 0)
         return statement;
-    auto context = getContext();
+    const Context * ctxt = nullptr;
     std::vector<const IR::Expression*> conditions;
-    while (context != nullptr) {
-        if (context->node->is<IR::IfStatement>()) {
-            conditions.push_back(context->node->to<IR::IfStatement>()->condition);
-        }
-        context = context->parent;
+    while (auto ifs = findContext<IR::IfStatement>(ctxt)) {
+        conditions.push_back(ifs->condition);
     }
     auto clonedStatement = clone(statement)->to<IR::AssignmentStatement>();
     ExpressionReplacer replacer(clonedStatement, travesalPath, conditions);

--- a/midend/predication.cpp
+++ b/midend/predication.cpp
@@ -193,7 +193,6 @@ const IR::Node* Predication::preorder(IR::IfStatement* statement) {
 
     ++ifNestingLevel;
     auto rv = new IR::BlockStatement;
-
     if (!statement->condition->is<IR::PathExpression>()) {
         cstring conditionName = generator->newName("cond");
         auto condDecl = new IR::Declaration_Variable(conditionName, IR::Type::Boolean::get());
@@ -202,7 +201,6 @@ const IR::Node* Predication::preorder(IR::IfStatement* statement) {
         rv->push_back(new IR::AssignmentStatement(clone(condition), statement->condition));
         statement->condition = condition;  // replace with variable cond
     }
-
     blocks.push_back(new IR::BlockStatement);
     travesalPath.push_back(true);
     visit(statement->ifTrue);

--- a/midend/predication.cpp
+++ b/midend/predication.cpp
@@ -202,6 +202,16 @@ const IR::Node* Predication::preorder(IR::IfStatement* statement) {
 
     ++ifNestingLevel;
     auto rv = new IR::BlockStatement;
+
+    if (!statement->condition->is<IR::PathExpression>()) {
+        cstring conditionName = generator->newName("cond");
+        auto condDecl = new IR::Declaration_Variable(conditionName, IR::Type::Boolean::get());
+        rv->push_back(condDecl);
+        auto condition = new IR::PathExpression(IR::ID(conditionName));
+        rv->push_back(new IR::AssignmentStatement(clone(condition), statement->condition));
+        statement->condition = condition; // replace with variable cond
+    }
+
     blocks.push_back(new IR::BlockStatement);
     travesalPath.push_back(true);
     visit(statement->ifTrue);

--- a/midend/predication.cpp
+++ b/midend/predication.cpp
@@ -161,7 +161,7 @@ const IR::Node* Predication::preorder(IR::AssignmentStatement* statement) {
     for (auto dependency : dependencies) {
         if (liveAssignments.find(dependency) != liveAssignments.end()) {
             // print out dependecy
-            currentBlock->push_back(liveAssignments[dependency]);
+            blocks.back()->push_back(liveAssignments[dependency]);
             // remove from names to not duplicate
             orderedNames.erase(dependency);
             liveAssignments.erase(dependency);
@@ -202,7 +202,7 @@ const IR::Node* Predication::preorder(IR::IfStatement* statement) {
 
     ++ifNestingLevel;
     auto rv = new IR::BlockStatement;
-    currentBlock = rv;
+    blocks.push_back(new IR::BlockStatement);
     travesalPath.push_back(true);
     visit(statement->ifTrue);
     rv->push_back(statement->ifTrue);
@@ -214,12 +214,14 @@ const IR::Node* Predication::preorder(IR::IfStatement* statement) {
         rv->push_back(statement->ifFalse);
     }
 
+    rv->push_back(blocks.back());
     for (auto exprName : orderedNames) {
         rv->push_back(liveAssignments[exprName]);
     }
     liveAssignments.clear();
     orderedNames.clear();
     travesalPath.pop_back();
+    blocks.pop_back();
     --ifNestingLevel;
 
     prune();

--- a/midend/predication.h
+++ b/midend/predication.h
@@ -53,19 +53,17 @@ class Predication final : public Transform {
      */
     class ExpressionReplacer final : public Transform {
      private:
-        const IR::Expression * rightExpression;
+        const IR::AssignmentStatement * statement;
         const std::vector<bool>& travesalPath;
-        const Visitor::Context * context;
-        std::vector<const IR::Expression*> conditions;
+        std::vector<const IR::Expression*>& conditions;
         unsigned currentNestingLevel = 0;
      public:
-        explicit ExpressionReplacer(const IR::Expression * e,
+        explicit ExpressionReplacer(const IR::AssignmentStatement * a,
                                     std::vector<bool>& t,
-                                    const Visitor::Context * c)
-        : rightExpression(e), travesalPath(t), context(c)
-        { CHECK_NULL(e); }
+                                    std::vector<const IR::Expression*>& c)
+        : statement(a), travesalPath(t), conditions(c)
+        { CHECK_NULL(a); }
         const IR::Mux * preorder(IR::Mux * mux) override;
-        const IR::AssignmentStatement * preorder(IR::AssignmentStatement * statement) override;
         void emplaceExpression(IR::Mux * mux);
         void visitBranch(IR::Mux * mux, bool then);
     };
@@ -93,7 +91,7 @@ class Predication final : public Transform {
     }
 
  public:
-    Predication(NameGenerator* gen) :
+    explicit Predication(NameGenerator* gen) :
         generator(gen), inside_action(false), ifNestingLevel(0)
     { setName("Predication"); }
     const IR::Expression* clone(const IR::Expression* expression);

--- a/midend/predication.h
+++ b/midend/predication.h
@@ -67,8 +67,7 @@ class Predication final : public Transform {
         const IR::Mux * preorder(IR::Mux * mux) override;
         const IR::AssignmentStatement * preorder(IR::AssignmentStatement * statement) override;
         void emplaceExpression(IR::Mux * mux);
-        void visitThen(IR::Mux * mux);
-        void visitElse(IR::Mux * mux);
+        void visitBranch(IR::Mux * mux, bool then);
     };
 
     EmptyStatementRemover remover;
@@ -93,9 +92,9 @@ class Predication final : public Transform {
     }
 
  public:
-    explicit Predication(NameGenerator* generator) :
+    Predication() :
         inside_action(false), ifNestingLevel(0)
-    { CHECK_NULL(generator); setName("Predication"); }
+    { setName("Predication"); }
     const IR::Expression* clone(const IR::Expression* expression);
     const IR::Node* clone(const IR::AssignmentStatement* statement);
     const IR::Node* preorder(IR::IfStatement* statement) override;

--- a/midend/predication.h
+++ b/midend/predication.h
@@ -70,6 +70,7 @@ class Predication final : public Transform {
         void visitBranch(IR::Mux * mux, bool then);
     };
 
+    NameGenerator* generator;
     EmptyStatementRemover remover;
     std::vector<IR::BlockStatement*> blocks;
     bool inside_action;
@@ -92,8 +93,8 @@ class Predication final : public Transform {
     }
 
  public:
-    Predication() :
-        inside_action(false), ifNestingLevel(0)
+    Predication(NameGenerator* gen) :
+        generator(gen), inside_action(false), ifNestingLevel(0)
     { setName("Predication"); }
     const IR::Expression* clone(const IR::Expression* expression);
     const IR::Node* clone(const IR::AssignmentStatement* statement);

--- a/midend/predication.h
+++ b/midend/predication.h
@@ -71,7 +71,7 @@ class Predication final : public Transform {
     };
 
     EmptyStatementRemover remover;
-    IR::BlockStatement * currentBlock;
+    std::vector<IR::BlockStatement*> blocks;
     bool inside_action;
     unsigned ifNestingLevel;
     // Traverse path of nested if-else statements

--- a/testdata/p4_16_samples/issue2248.p4
+++ b/testdata/p4_16_samples/issue2248.p4
@@ -1,0 +1,50 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type != 0) {
+            bit<48> tmp_val = h.eth_hdr.src_addr != 0 ? 48w1 : 48w2;
+            h.eth_hdr.dst_addr = tmp_val;
+        }
+    }
+
+    apply {
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {b.emit(h);} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2248-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2248-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2248-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2248-first.p4
@@ -1,0 +1,62 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type != 16w0) {
+            bit<48> tmp_val = (h.eth_hdr.src_addr != 48w0 ? 48w1 : 48w2);
+            h.eth_hdr.dst_addr = tmp_val;
+        }
+    }
+    apply {
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { 
+    apply {
+    } 
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    } 
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    } 
+}
+
+control deparser(packet_out b, in Headers h) { 
+    apply {
+        b.emit<Headers>(h);
+    } 
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2248-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2248-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2248-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2248-frontend.p4
@@ -1,0 +1,65 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    bit<48> tmp_val_0;
+    bit<48> tmp;
+    @name("ingress.simple_action") action simple_action() {
+        if (h.eth_hdr.eth_type != 16w0) {
+            if (h.eth_hdr.src_addr != 48w0) {
+                tmp = 48w1;
+            } else {
+                tmp = 48w2;
+            }
+            tmp_val_0 = tmp;
+            h.eth_hdr.dst_addr = tmp_val_0;
+        }
+    }
+    apply {
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<Headers>(h);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2248-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2248-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2248-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2248-midend.p4
@@ -1,0 +1,65 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    bit<48> tmp_val_0;
+    bit<48> tmp;
+    @name("ingress.simple_action") action simple_action() {
+        tmp = (h.eth_hdr.eth_type != 16w0 ? (h.eth_hdr.src_addr != 48w0 ? 48w1 : 48w2) : tmp);
+        tmp_val_0 = (h.eth_hdr.eth_type != 16w0 ? tmp : tmp_val_0);
+        h.eth_hdr.dst_addr = (h.eth_hdr.eth_type != 16w0 ? tmp_val_0 : h.eth_hdr.dst_addr);
+    }
+    @hidden table tbl_simple_action {
+        actions = {
+            simple_action();
+        }
+        const default_action = simple_action();
+    }
+    apply {
+        tbl_simple_action.apply();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<ethernet_t>(h.eth_hdr);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2248.p4
+++ b/testdata/p4_16_samples_outputs/issue2248.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2248.p4
+++ b/testdata/p4_16_samples_outputs/issue2248.p4
@@ -1,0 +1,62 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type != 0) {
+            bit<48> tmp_val = (h.eth_hdr.src_addr != 0 ? 48w1 : 48w2);
+            h.eth_hdr.dst_addr = tmp_val;
+        }
+    }
+    apply {
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { 
+    apply {
+    } 
+}
+
+control update(inout Headers h, inout Meta m) { 
+    apply {
+    } 
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    } 
+}
+
+control deparser(packet_out b, in Headers h) { 
+    apply {
+        b.emit(h);
+    } 
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2248.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2248.p4.p4info.txt
@@ -1,0 +1,10 @@
+pkg_info {
+  arch: "v1model"
+}
+actions {
+  preamble {
+    id: 25524983
+    name: "ingress.simple_action"
+    alias: "simple_action"
+  }
+}

--- a/testdata/p4_16_samples_outputs/issue512-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue512-midend.p4
@@ -32,10 +32,12 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout mystruct1 meta, inout
 }
 
 control cIngress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_metadata_t stdmeta) {
+    bool cond;
     @name("cIngress.foo") action foo() {
         meta.b = meta.b + 4w5;
+        cond = meta.b > 4w10;
         meta.b = (meta.b > 4w10 ? meta.b ^ 4w5 : meta.b);
-        meta.b = (!(meta.b > 4w10 ? true : false) ? meta.b + 4w5 : meta.b);
+        meta.b = (!(cond ? true : false) ? meta.b + 4w5 : meta.b);
     }
     @name("cIngress.guh") table guh_0 {
         key = {


### PR DESCRIPTION
This PR is follow-up of the #2231 
expr_name refactored to lvalue_name because it's used only for lvalue in every assignemnt.
visitThen and visitElse  merged to visitBranch with extra bool parameter.
Comments for functions fixed, unnecessary name generator removed. 