### PR TITLE
P4 runtime corner case handling

### DIFF
--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -403,8 +403,9 @@ struct Counterlike {
             auto typeArg = type->arguments->at(*indexTypeParamIdx);
             // We ignore the return type on purpose, but the call is required to update p4RtTypeInfo
             // if the index has a user-defined type.
-            TypeSpecConverter::convert(refMap, typeMap, typeArg, p4RtTypeInfo);
-            index_type_name = getTypeName(typeArg, typeMap);
+            if (!dynamic_cast<const IR::Type_Dontcare *>(typeArg)) {
+                TypeSpecConverter::convert(refMap, typeMap, typeArg, p4RtTypeInfo);
+                index_type_name = getTypeName(typeArg, typeMap); }
         }
 
         return Counterlike<Kind>{declaration->controlPlaneName(),

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -489,7 +489,7 @@ class P4RuntimeSymbolTable : public P4RuntimeSymbolTableIface {
             // resolve hash collisions, the id that we select depends on the order in
             // which the names are hashed. This is why we sort the names above.
             boost::optional<p4rt_id_t> id = probeForId(nameId, [=](uint32_t nameId) {
-                return (resourceType << 24) | (nameId & 0xffffff);
+                return (resourceType << 24) | (nameId & 0xffff);
             });
 
             if (!id) {


### PR DESCRIPTION
I've run into some problems trying to update fonrtend refpoint with some of our internal tests

- avoid crashing for Type_Dontcare in API generation
  we have a number of tests that use a `_` (dontcare) type for the index type -- the backend will infer the index type based on the counter/meter/register size, but the API generation has trouble.  Should probably fix API generation to do the same inference.

- 16 bit id masking to make things work
  test cases fail without this due to disagreeing on what the ids of various things should be.

Antonin, if you could give some advice on better ways of dealing with these problems and/or pointer on where to look?  We won't merge this change but may need it as a temporary hack to make things work.