### PR TITLE
use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/backends/ebpf/targets/ebpfenv.py
+++ b/backends/ebpf/targets/ebpfenv.py
@@ -67,7 +67,7 @@ class Bridge(object):
 
     def ns_proc_open(self):
         """ Open a bash process in the namespace and return the handle """
-        cmd = self.get_ns_prefix() + " /bin/bash "
+        cmd = self.get_ns_prefix() + " /usr/bin/env bash "
         return open_process(self.verbose, cmd, self.outputs)
 
     def ns_proc_write(self, proc, cmd):

--- a/cmake/P4CUtils.cmake
+++ b/cmake/P4CUtils.cmake
@@ -83,7 +83,7 @@ endmacro(p4c_test_set_name)
 #
 macro(p4c_add_test_with_args tag driver isXfail alias p4test test_args cmake_args)
   set(__testfile "${P4C_BINARY_DIR}/${tag}/${p4test}.test")
-  file (WRITE  ${__testfile} "#! /bin/bash\n")
+  file (WRITE  ${__testfile} "#! /usr/bin/env bash\n")
   file (APPEND ${__testfile} "# Generated file, modify with care\n\n")
   file (APPEND ${__testfile} "cd ${P4C_BINARY_DIR}\n")
   file (APPEND ${__testfile} "${driver} ${P4C_SOURCE_DIR} ${test_args} \"$@\" ${P4C_SOURCE_DIR}/${p4test}")


### PR DESCRIPTION
Like most of the shebangs in the rest of the repo, /usr/bin/env to pick
bash from `$PATH`, instead of invoking it from /bin/bash.

This fixes execution on systems that don't have bash in /bin/bash, or
have explicitly configured another one to be used.