### PR TITLE
Support arbitrary unsigned integer ids

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -98,8 +98,8 @@ static boost::optional<p4rt_id_t> getIdAnnotation(const IR::IAnnotated* node) {
     if (!idAnnotation) return boost::none;
     auto idConstant = idAnnotation->expr[0]->to<IR::Constant>();
     CHECK_NULL(idConstant);
-    if (!idConstant->fitsInt()) {
-        ::error(ErrorType::ERR_INVALID, "%1%: @id should be an integer", node);
+    if (!idConstant->fitsUint()) {
+        ::error(ErrorType::ERR_INVALID, "%1%: @id should be an unsigned integer", node);
         return boost::none;
     }
     return static_cast<p4rt_id_t>(idConstant->value);

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -399,10 +399,19 @@ TEST_F(P4Runtime, FieldIdAssignment) {
                 actions = { a; }
             }
 
+            @name("igTableLargeId")
+            table t4 {
+                key = {
+                    m.f1: exact @id(0xffffffff);
+                }
+                actions = { a; }
+            }
+
             apply {
                 t1.apply();
                 t2.apply();
                 t3.apply();
+                t4.apply();
             }
         }
 
@@ -456,6 +465,16 @@ TEST_F(P4Runtime, FieldIdAssignment) {
         const auto& mf2 = igTable->match_fields(1);
         EXPECT_EQ(1u, mf1.id());
         EXPECT_EQ(2u, mf2.id());
+    }
+
+    {
+        // Check the ids for igTableLargeId's match fields. The compiler should
+        // be able to handle all unsigned 32-bit integers greater than 0,
+        // including 0xffffffff.
+        auto* igTable = findTable(*test, "ingress.igTableLargeId");
+        ASSERT_TRUE(igTable != nullptr);
+        const auto& mf1 = igTable->match_fields(0);
+        EXPECT_EQ(0xffffffff, mf1.id());
     }
 
     {


### PR DESCRIPTION
The P4Info generation code was incorrectly treating programmer-provided
ids as signed integers instead of unsigned. Thanks @jafingerhut for
reporting this issue to me.