### PR TITLE
Update Travis CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/p4lang/p4c.svg?branch=master)](https://travis-ci.org/p4lang/p4c)
+[![Build Status](https://travis-ci.com/p4lang/p4c.svg?branch=master)](https://travis-ci.com/p4lang/p4c)
 
 # p4c
 


### PR DESCRIPTION
From travis-ci.org to travis-ci.com.
Travis is in the process of transitioning all repos to travis-ci.com
(used to be for paid accounts only). I just did the transition for
p4lang/p4c in order to fix some build issues (status not reported in a
timely fashion for PRs), which means that the status badge link needs to
be updated.