### PR TITLE
Infer counter/meter/register index sizes from P4_14 instance count

### DIFF
--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -560,7 +560,7 @@ void ExternConverter_register::convertExternInstance(
         return;
     }
     auto st = eb->instanceType->to<IR::Type_SpecializedCanonical>();
-    if (st->arguments->size() != 1) {
+    if (st->arguments->size() != 2) {
         modelError("%1%: expected 1 type argument", st);
         return;
     }

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -560,8 +560,8 @@ void ExternConverter_register::convertExternInstance(
         return;
     }
     auto st = eb->instanceType->to<IR::Type_SpecializedCanonical>();
-    if (st->arguments->size() != 2) {
-        modelError("%1%: expected 1 type argument", st);
+    if (st->arguments->size() < 1 || st->arguments->size() > 2) {
+        modelError("%1%: expected 1 or 2 type arguments", st);
         return;
     }
     auto regType = st->arguments->at(0);

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -107,7 +107,9 @@ template<> struct RegisterTraits<Arch::V1MODEL> {
     // the index of the type parameter for the data stored in the register, in
     // the type parameter list of the extern type declaration
     static size_t dataTypeParamIdx() { return 0; }
-    static boost::optional<size_t> indexTypeParamIdx() { return boost::none; }
+    static boost::optional<size_t> indexTypeParamIdx() {
+        if (P4V1::V1Model::instance.haveIndexTypeParam()) return 1;
+        return boost::none; }
 };
 
 template<> struct RegisterTraits<Arch::PSA> {
@@ -165,7 +167,9 @@ template<> struct CounterlikeTraits<Standard::CounterExtern<Standard::Arch::V1MO
         else if (name == "packets_and_bytes") return CounterSpec::BOTH;
         return CounterSpec::UNSPECIFIED;
     }
-    static boost::optional<size_t> indexTypeParamIdx() { return boost::none; }
+    static boost::optional<size_t> indexTypeParamIdx() {
+        if (P4V1::V1Model::instance.haveIndexTypeParam()) return 0;
+        return boost::none; }
 };
 
 /// @ref CounterlikeTraits<> specialization for @ref CounterExtern for PSA
@@ -216,7 +220,9 @@ template<> struct CounterlikeTraits<Standard::MeterExtern<Standard::Arch::V1MODE
         else if (name == "bytes") return MeterSpec::BYTES;
         return MeterSpec::UNSPECIFIED;
     }
-    static boost::optional<size_t> indexTypeParamIdx() { return boost::none; }
+    static boost::optional<size_t> indexTypeParamIdx() {
+        if (P4V1::V1Model::instance.haveIndexTypeParam()) return 0;
+        return boost::none; }
 };
 
 /// @ref CounterlikeTraits<> specialization for @ref MeterExtern for PSA

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include <algorithm>
 
 #include "lib/path.h"
+#include "lib/bitops.h"
 #include "lib/gmputil.h"
 #include "converters.h"
 
@@ -1478,7 +1479,7 @@ CONVERT_PRIMITIVE(count) {
     auto counterref = new IR::PathExpression(newname);
     auto methodName = structure->v1model.counter.increment.Id();
     auto method = new IR::Member(counterref, methodName);
-    auto arg = new IR::Cast(structure->v1model.counter.index_type,
+    auto arg = new IR::Cast(IR::Type::Bits::get(counter->index_width()),
                             conv.convert(primitive->operands.at(1)));
     return new IR::MethodCallStatement(
         primitive->srcInfo, method, { new IR::Argument(arg) });
@@ -1618,7 +1619,7 @@ CONVERT_PRIMITIVE(execute_meter) {
     auto methodName = structure->v1model.meter.executeMeter.Id();
     auto method = new IR::Member(meterref, methodName);
     auto args = new IR::Vector<IR::Argument>();
-    auto arg = new IR::Cast(structure->v1model.meter.index_type,
+    auto arg = new IR::Cast(IR::Type::Bits::get(meter->index_width()),
                             conv.convert(primitive->operands.at(1)));
     args->push_back(new IR::Argument(arg));
     auto dest = conv.convert(primitive->operands.at(2));
@@ -1724,7 +1725,7 @@ CONVERT_PRIMITIVE(register_read) {
     auto methodName = structure->v1model.registers.read.Id();
     auto method = new IR::Member(registerref, methodName);
     auto args = new IR::Vector<IR::Argument>();
-    auto arg = new IR::Cast(structure->v1model.registers.index_type,
+    auto arg = new IR::Cast(IR::Type::Bits::get(reg->index_width()),
                             conv.convert(primitive->operands.at(2)));
     args->push_back(new IR::Argument(left));
     args->push_back(new IR::Argument(arg));
@@ -1757,7 +1758,7 @@ CONVERT_PRIMITIVE(register_write) {
     auto method = new IR::Member(registerref, methodName);
     auto args = new IR::Vector<IR::Argument>();
     auto arg0 = new IR::Cast(primitive->operands.at(1)->srcInfo,
-                             structure->v1model.registers.index_type,
+                             IR::Type::Bits::get(reg->index_width()),
                              conv.convert(primitive->operands.at(1)));
     const IR::Expression* arg1 = conv.convert(primitive->operands.at(2));
     if (castType != nullptr)
@@ -1954,8 +1955,8 @@ ProgramStructure::convert(const IR::Register* reg, cstring newName,
     IR::ID ext = v1model.registers.Id();
     auto typepath = new IR::Path(ext);
     auto type = new IR::Type_Name(typepath);
-    auto typeargs = new IR::Vector<IR::Type>();
-    typeargs->push_back(regElementType);
+    auto typeargs = new IR::Vector<IR::Type>({ regElementType,
+                                               IR::Type::Bits::get(reg->index_width()) });
     auto spectype = new IR::Type_Specialized(type, typeargs);
     auto args = new IR::Vector<IR::Argument>();
     if (reg->direct) {
@@ -1979,7 +1980,8 @@ ProgramStructure::convert(const IR::CounterOrMeter* cm, cstring newName) {
     else
         ext = v1model.meter.Id();
     auto typepath = new IR::Path(ext);
-    auto type = new IR::Type_Name(typepath);
+    auto type = new IR::Type_Specialized(new IR::Type_Name(typepath),
+        new IR::Vector<IR::Type>({ IR::Type_Bits::get(cm->index_width()) }));
     auto args = new IR::Vector<IR::Argument>();
     args->push_back(
         new IR::Argument(cm->srcInfo,

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -604,7 +604,9 @@ void ProgramStructure::include(cstring filename, cstring ppoptions) {
 
 void ProgramStructure::loadModel() {
     // This includes in turn core.p4
-    include("v1model.p4");
+    std::stringstream versionArg;
+    versionArg << "-DV1MODEL_VERSION=" << V1Model::instance.version;
+    include(V1Model::instance.file.name, versionArg.str());
 
     metadataInstances.insert(v1model.standardMetadataType.name);
     metadataTypes.insert(v1model.standardMetadataType.name);

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -265,6 +265,7 @@ class V1Model : public ::Model::Model {
     {}
 
  public:
+    unsigned      version = 20200408;
     ::Model::Elem       file;
     ::Model::Elem       standardMetadata;
     ::Model::Elem       intrinsicMetadata;
@@ -306,7 +307,18 @@ class V1Model : public ::Model::Model {
     DirectMeter_Model   directMeter;
     DirectCounter_Model directCounter;
 
+    bool haveIndexTypeParam() const { return version >= 20200408; }  // depends on version
+
     static V1Model instance;
+};
+
+class getV1ModelVersion : public Inspector {
+    bool preorder(const IR::Declaration_Constant *dc) override {
+        if (dc->name == "__v1model_version") {
+            auto val = dc->initializer->to<IR::Constant>();
+            V1Model::instance.version = static_cast<unsigned>(val->value); }
+        return false; }
+    bool preorder(const IR::Declaration *) override { return false; }
 };
 
 }  // namespace P4V1

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -123,12 +123,10 @@ class Truncate : public Model::Extern_Model {
 struct CounterOrMeter_Model : public ::Model::Extern_Model {
     explicit CounterOrMeter_Model(cstring name) : Extern_Model(name),
                       sizeParam("size"), typeParam("type"),
-                      size_type(IR::Type_Bits::get(32)),
-                      index_type(IR::Type_Bits::get(32)), counterType() {}
+                      size_type(IR::Type_Bits::get(32)), counterType() {}
     ::Model::Elem sizeParam;
     ::Model::Elem typeParam;
     const IR::Type* size_type;
-    const IR::Type* index_type;
     CounterType_Model counterType;
     MeterType_Model meterType;
 };
@@ -136,13 +134,11 @@ struct CounterOrMeter_Model : public ::Model::Extern_Model {
 struct Register_Model : public ::Model::Extern_Model {
     Register_Model() : Extern_Model("register"),
                        sizeParam("size"), read("read"), write("write"),
-                       size_type(IR::Type_Bits::get(32)),
-                       index_type(IR::Type_Bits::get(32)) {}
+                       size_type(IR::Type_Bits::get(32)) {}
     ::Model::Elem sizeParam;
     ::Model::Elem read;
     ::Model::Elem write;
     const IR::Type* size_type;
-    const IR::Type* index_type;
 };
 
 struct DigestReceiver_Model : public ::Model::Elem {

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -26,6 +26,7 @@ limitations under the License.
 #include "frontends/p4/typeMap.h"
 #include "frontends/p4/typeChecking/bindVariables.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
+#include "frontends/p4/fromv1.0/v1model.h"
 // Passes
 #include "actionsInlining.h"
 #include "checkConstants.h"
@@ -127,6 +128,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
 
     auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
     std::initializer_list<Visitor *> frontendPasses = {
+        new P4V1::getV1ModelVersion,
         // Parse annotations
         new ParseAnnotationBodies(&parseAnnotations, &typeMap),
         new PrettyPrint(options),

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include "toP4.h"
 #include "frontends/common/options.h"
 #include "frontends/parsers/p4/p4parser.hpp"
+#include "frontends/p4/fromv1.0/v1model.h"
 
 namespace P4 {
 
@@ -165,15 +166,18 @@ bool ToP4::preorder(const IR::P4Program* program) {
              * we ignore mainFile and don't emit #includes for any non-system header */
 
             if (includesEmitted.find(sourceFile) == includesEmitted.end()) {
-                builder.append("#include ");
                 if (sourceFile.startsWith(p4includePath)) {
                     const char *p = sourceFile.c_str() + strlen(p4includePath);
                     if (*p == '/') p++;
-                    builder.append("<");
+                    if (P4V1::V1Model::instance.file.name == p) {
+                        std::stringstream buf;
+                        buf << "#define V1MODEL_VERSION " << P4V1::V1Model::instance.version;
+                        builder.appendLine(buf.str()); }
+                    builder.append("#include <");
                     builder.append(p);
                     builder.appendLine(">");
                 } else {
-                    builder.append("\"");
+                    builder.append("#include \"");
                     builder.append(sourceFile);
                     builder.appendLine("\"");
                 }

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -306,6 +306,7 @@ abstract Stateful : Attached {
     bool        saturating = false;
     int         instance_count = -1;
     virtual bool indexed() const override { return !direct; }
+    int index_width() const;  // width of index in bits
 }
 
 abstract CounterOrMeter : Stateful {

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -51,6 +51,10 @@ limitations under the License.
 
 #include "core.p4"
 
+#ifndef V1MODEL_VERSION
+#define V1MODEL_VERSION 20180101
+#endif
+
 match_kind {
     range,
     // Either an exact match, or a wildcard (matching any value).
@@ -59,13 +63,21 @@ match_kind {
     selector
 }
 
+#if V1MODEL_VERSION >= 20200408
 typedef bit<9>  PortId_t;       // should not be a constant size?
+#endif
 
 @metadata @name("standard_metadata")
 struct standard_metadata_t {
+#if V1MODEL_VERSION >= 20200408
     PortId_t    ingress_port;
     PortId_t    egress_spec;
     PortId_t    egress_port;
+#else
+    bit<9>      ingress_port;
+    bit<9>      egress_spec;
+    bit<9>      egress_port;
+#endif
     bit<32>     instance_type;
     bit<32>     packet_length;
     //
@@ -119,7 +131,11 @@ enum MeterType {
     bytes
 }
 
-extern counter<I> {
+extern counter
+#if V1MODEL_VERSION >= 20200408
+<I>
+#endif
+{
     /***
      * A counter object is created by calling its constructor.  This
      * creates an array of counter states, with the number of counter
@@ -150,7 +166,11 @@ extern counter<I> {
      *              size-1].  If index >= size, no counter state will be
      *              updated.
      */
+#if V1MODEL_VERSION >= 20200408
     void count(in I index);
+#else
+    void count(in bit<32> index);
+#endif
 }
 
 extern direct_counter {
@@ -189,7 +209,11 @@ extern direct_counter {
 #define V1MODEL_METER_COLOR_YELLOW 1
 #define V1MODEL_METER_COLOR_RED    2
 
-extern meter<I> {
+extern meter
+#if V1MODEL_VERSION >= 20200408
+<I>
+#endif
+{
     /***
      * A meter object is created by calling its constructor.  This
      * creates an array of meter states, with the number of meter
@@ -226,7 +250,11 @@ extern meter<I> {
      *              range, the final value of result is not specified,
      *              and should be ignored by the caller.
      */
+#if V1MODEL_VERSION >= 20200408
     void execute_meter<T>(in I index, out T result);
+#else
+    void execute_meter<T>(in bit<32> index, out T result);
+#endif
 }
 
 extern direct_meter<T> {
@@ -265,7 +293,12 @@ extern direct_meter<T> {
     void read(out T result);
 }
 
-extern register<T, I> {
+#if V1MODEL_VERSION >= 20200408
+extern register<T, I>
+#else
+extern register<T>
+#endif
+{
     /***
      * A register object is created by calling its constructor.  This
      * creates an array of 'size' identical elements, each with type
@@ -292,7 +325,11 @@ extern register<T, I> {
      *              ignored by the caller.
      */
     @noSideEffects
+#if V1MODEL_VERSION >= 20200408
     void read(out T result, in I index);
+#else
+    void read(out T result, in bit<32> index);
+#endif
     /***
      * write() writes the state of the register array at the specified
      * index, with the value provided by the value parameter.
@@ -315,7 +352,11 @@ extern register<T, I> {
      *              parameter's value is written into the register
      *              array element specified by index.
      */
+#if V1MODEL_VERSION >= 20200408
     void write(in I index, in T value);
+#else
+    void write(in bit<32> index, in T value);
+#endif
 }
 
 // used as table implementation attribute
@@ -714,5 +755,7 @@ package V1Switch<H, M>(Parser<H, M> p,
                        ComputeChecksum<H, M> ck,
                        Deparser<H> dep
                        );
+
+const bit<32> __v1model_version = V1MODEL_VERSION;
 
 #endif  /* _V1_MODEL_P4_ */

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -59,13 +59,15 @@ match_kind {
     selector
 }
 
+typedef bit<9>  PortId_t;       // should not be a constant size?
+
 @metadata @name("standard_metadata")
 struct standard_metadata_t {
-    bit<9>  ingress_port;
-    bit<9>  egress_spec;
-    bit<9>  egress_port;
-    bit<32> instance_type;
-    bit<32> packet_length;
+    PortId_t    ingress_port;
+    PortId_t    egress_spec;
+    PortId_t    egress_port;
+    bit<32>     instance_type;
+    bit<32>     packet_length;
     //
     // @alias is used to generate the field_alias section of the BMV2 JSON.
     // Field alias creates a mapping from the metadata name in P4 program to
@@ -117,7 +119,7 @@ enum MeterType {
     bytes
 }
 
-extern counter {
+extern counter<I> {
     /***
      * A counter object is created by calling its constructor.  This
      * creates an array of counter states, with the number of counter
@@ -134,6 +136,8 @@ extern counter {
      * register.
      */
     counter(bit<32> size, CounterType type);
+    // FIXME -- size arg should be `int` but that breaks typechecking
+
     /***
      * count() causes the counter state with the specified index to be
      * read, modified, and written back, atomically relative to the
@@ -146,7 +150,7 @@ extern counter {
      *              size-1].  If index >= size, no counter state will be
      *              updated.
      */
-    void count(in bit<32> index);
+    void count(in I index);
 }
 
 extern direct_counter {
@@ -185,7 +189,7 @@ extern direct_counter {
 #define V1MODEL_METER_COLOR_YELLOW 1
 #define V1MODEL_METER_COLOR_RED    2
 
-extern meter {
+extern meter<I> {
     /***
      * A meter object is created by calling its constructor.  This
      * creates an array of meter states, with the number of meter
@@ -201,6 +205,8 @@ extern meter {
      * packets contain (MeterType.bytes).
      */
     meter(bit<32> size, MeterType type);
+    // FIXME -- size arg should be `int` but that breaks typechecking
+
     /***
      * execute_meter() causes the meter state with the specified index
      * to be read, modified, and written back, atomically relative to
@@ -220,7 +226,7 @@ extern meter {
      *              range, the final value of result is not specified,
      *              and should be ignored by the caller.
      */
-    void execute_meter<T>(in bit<32> index, out T result);
+    void execute_meter<T>(in I index, out T result);
 }
 
 extern direct_meter<T> {
@@ -259,7 +265,7 @@ extern direct_meter<T> {
     void read(out T result);
 }
 
-extern register<T> {
+extern register<T, I> {
     /***
      * A register object is created by calling its constructor.  This
      * creates an array of 'size' identical elements, each with type
@@ -270,7 +276,7 @@ extern register<T> {
      *
      * allocates storage for 512 values, each with type bit<32>.
      */
-    register(bit<32> size);
+    register(bit<32> size);  // FIXME -- arg should be `int` but that breaks typechecking
     /***
      * read() reads the state of the register array stored at the
      * specified index, and returns it as the value written to the
@@ -286,7 +292,7 @@ extern register<T> {
      *              ignored by the caller.
      */
     @noSideEffects
-    void read(out T result, in bit<32> index);
+    void read(out T result, in I index);
     /***
      * write() writes the state of the register array at the specified
      * index, with the value provided by the value parameter.
@@ -309,7 +315,7 @@ extern register<T> {
      *              parameter's value is written into the register
      *              array element specified by index.
      */
-    void write(in bit<32> index, in T value);
+    void write(in I index, in T value);
 }
 
 // used as table implementation attribute

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -522,12 +522,12 @@ TEST_F(P4Runtime, IdAssignmentCounters) {
             }
 
             @name(".myCounter")
-            counter(32w1024, CounterType.packets) myCounter;
+            counter<bit<10>>(32w1024, CounterType.packets) myCounter;
 
             apply {
                 myTable1.apply();
                 myTable2.apply();
-                myCounter.count(32w128);
+                myCounter.count(128);
             }
         }
 
@@ -1361,11 +1361,11 @@ TEST_F(P4Runtime, Register) {
         control ingress(inout Headers h, inout Metadata m,
                         inout standard_metadata_t sm) {
             @my_anno("This is an annotation!")
-            register<tuple<bit<16>, bit<8> > >(128) my_register_1;
-            register<Header>(128) my_register_2;
+            register<tuple<bit<16>, bit<8> >, bit<7>>(128) my_register_1;
+            register<Header, bit<7>>(128) my_register_2;
             apply {
-                my_register_1.write(32w10, {16w1, 8w2});
-                my_register_2.write(32w10, h.h); } }
+                my_register_1.write(7w10, {16w1, 8w2});
+                my_register_2.write(7w10, h.h); } }
         V1Switch(parse(), verifyChecksum(), ingress(), egress(),
                  computeChecksum(), deparse()) main;
     )"), ParseAnnotations());

--- a/testdata/p4_14_errors_outputs/issue1853.p4
+++ b/testdata/p4_14_errors_outputs/issue1853.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header mpls_t {

--- a/testdata/p4_14_samples_outputs/01-BigMatch-first.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/01-BigMatch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/01-BigMatch-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/01-BigMatch.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1-first.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/01-DeadMetadata1.p4
+++ b/testdata/p4_14_samples_outputs/01-DeadMetadata1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/01-FullPHV-first.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/01-FullPHV-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/01-FullPHV-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/01-FullPHV.p4
+++ b/testdata/p4_14_samples_outputs/01-FullPHV.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/01-JustEthernet-first.p4
+++ b/testdata/p4_14_samples_outputs/01-JustEthernet-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/01-JustEthernet-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-JustEthernet-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/01-JustEthernet-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-JustEthernet-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/01-JustEthernet.p4
+++ b/testdata/p4_14_samples_outputs/01-JustEthernet.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/01-NoDeps-first.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/01-NoDeps-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/01-NoDeps-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/01-NoDeps.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-first.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/02-BadSizeField.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2-first.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/02-DeadMetadata2.p4
+++ b/testdata/p4_14_samples_outputs/02-DeadMetadata2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/02-FullPHV1-first.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/02-FullPHV1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/02-FullPHV1-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/02-FullPHV1.p4
+++ b/testdata/p4_14_samples_outputs/02-FullPHV1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet-first.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header len_or_type_t {

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header len_or_type_t {

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header len_or_type_t {

--- a/testdata/p4_14_samples_outputs/02-SplitEthernet.p4
+++ b/testdata/p4_14_samples_outputs/02-SplitEthernet.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header len_or_type_t {

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3-first.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/03-DeadMetadata3.p4
+++ b/testdata/p4_14_samples_outputs/03-DeadMetadata3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/03-FullPHV2-first.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/03-FullPHV2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/03-FullPHV2-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/03-FullPHV2.p4
+++ b/testdata/p4_14_samples_outputs/03-FullPHV2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/03-Gateway-first.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/03-Gateway-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/03-Gateway-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/03-Gateway.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-first.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header len_or_type_t {

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header len_or_type_t {

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header len_or_type_t {

--- a/testdata/p4_14_samples_outputs/03-SplitEthernetCompact.p4
+++ b/testdata/p4_14_samples_outputs/03-SplitEthernetCompact.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header len_or_type_t {

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-first.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-frontend.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-midend.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan-first.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan-frontend.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan-midend.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/04-SimpleVlan.p4
+++ b/testdata/p4_14_samples_outputs/04-SimpleVlan.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-first.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/05-FieldProblem.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-first.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/05-FullTPHV.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1-first.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/05-SimpleVlan1.p4
+++ b/testdata/p4_14_samples_outputs/05-SimpleVlan1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-first.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-midend.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack-first.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack-frontend.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack-midend.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/06-SimpleVlanStack.p4
+++ b/testdata/p4_14_samples_outputs/06-SimpleVlanStack.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-first.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-first.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP.p4
+++ b/testdata/p4_14_samples_outputs/07-SimpleVlanStackIP.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-first.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct m_t {

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-first.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-first.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags.p4
+++ b/testdata/p4_14_samples_outputs/08-SimpleVlanStackIPSplitFlags.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-first.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-first.p4
@@ -16,6 +16,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-frontend.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-frontend.p4
@@ -16,6 +16,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
@@ -16,6 +16,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed.p4
@@ -16,6 +16,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities-first.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities-frontend.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities-midend.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/10-SelectPriorities.p4
+++ b/testdata/p4_14_samples_outputs/10-SelectPriorities.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/11-MultiTags-first.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/11-MultiTags-frontend.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/11-MultiTags-midend.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/11-MultiTags.p4
+++ b/testdata/p4_14_samples_outputs/11-MultiTags.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/12-Counters-first.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/12-Counters-first.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-first.p4
@@ -27,11 +27,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".count_c1_1") action count_c1_1() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".t1") table t1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/12-Counters-frontend.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/12-Counters-frontend.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-frontend.p4
@@ -27,7 +27,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -35,10 +35,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name(".count_c1_1") action count_c1_0() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".count_c1_1") action count_c1_2() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/12-Counters-midend.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/12-Counters-midend.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters-midend.p4
@@ -27,7 +27,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -35,10 +35,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name(".count_c1_1") action count_c1_0() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".count_c1_1") action count_c1_2() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/12-Counters.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/12-Counters.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters.p4
@@ -31,7 +31,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".count_c1_1") action count_c1_1() {
-        c1.count((bit<32>)32w1);
+        c1.count((bit<32>)10w1);
     }
     @name(".t1") table t1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/12-Counters.p4
+++ b/testdata/p4_14_samples_outputs/12-Counters.p4
@@ -27,11 +27,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".count_c1_1") action count_c1_1() {
-        c1.count((bit<32>)10w1);
+        c1.count((bit<10>)10w1);
     }
     @name(".t1") table t1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-first.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-frontend.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-midend.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop.p4
+++ b/testdata/p4_14_samples_outputs/12-MultiTagsNoLoop.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-first.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-first.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-first.p4
@@ -27,14 +27,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".count_c1_1") action count_c1_1() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".count_c1_2") action count_c1_2() {
-        c1.count(32w2);
+        c1.count(10w2);
     }
     @name(".t1") table t1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-frontend.p4
@@ -27,7 +27,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -35,10 +35,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name(".count_c1_1") action count_c1_1() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".count_c1_2") action count_c1_2() {
-        c1.count(32w2);
+        c1.count(10w2);
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-midend.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/13-Counters1and2-midend.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2-midend.p4
@@ -27,7 +27,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -35,10 +35,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name(".count_c1_1") action count_c1_1() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".count_c1_2") action count_c1_2() {
-        c1.count(32w2);
+        c1.count(10w2);
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/13-Counters1and2.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/13-Counters1and2.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2.p4
@@ -31,10 +31,10 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".count_c1_1") action count_c1_1() {
-        c1.count((bit<32>)32w1);
+        c1.count((bit<32>)10w1);
     }
     @name(".count_c1_2") action count_c1_2() {
-        c1.count((bit<32>)32w2);
+        c1.count((bit<32>)10w2);
     }
     @name(".t1") table t1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/13-Counters1and2.p4
+++ b/testdata/p4_14_samples_outputs/13-Counters1and2.p4
@@ -27,14 +27,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".count_c1_1") action count_c1_1() {
-        c1.count((bit<32>)10w1);
+        c1.count((bit<10>)10w1);
     }
     @name(".count_c1_2") action count_c1_2() {
-        c1.count((bit<32>)10w2);
+        c1.count((bit<10>)10w2);
     }
     @name(".t1") table t1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-first.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-frontend.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-midend.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/13-MultiTagsCorrect.p4
+++ b/testdata/p4_14_samples_outputs/13-MultiTagsCorrect.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/14-Counter-first.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/14-Counter-first.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-first.p4
@@ -27,11 +27,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".count_c1_1") action count_c1_1() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".t1") table t1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/14-Counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/14-Counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-frontend.p4
@@ -27,13 +27,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".count_c1_1") action count_c1_0() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/14-Counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/14-Counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter-midend.p4
@@ -27,13 +27,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".count_c1_1") action count_c1_0() {
-        c1.count(32w1);
+        c1.count(10w1);
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/14-Counter.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/14-Counter.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter.p4
@@ -31,7 +31,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".count_c1_1") action count_c1_1() {
-        c1.count((bit<32>)32w1);
+        c1.count((bit<32>)10w1);
     }
     @name(".t1") table t1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/14-Counter.p4
+++ b/testdata/p4_14_samples_outputs/14-Counter.p4
@@ -27,11 +27,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".c1") counter(32w1024, CounterType.packets) c1;
+@name(".c1") counter<bit<10>>(32w1024, CounterType.packets) c1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".count_c1_1") action count_c1_1() {
-        c1.count((bit<32>)10w1);
+        c1.count((bit<10>)10w1);
     }
     @name(".t1") table t1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-first.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-frontend.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-midend.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/14-GatewayGreaterThan.p4
+++ b/testdata/p4_14_samples_outputs/14-GatewayGreaterThan.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-first.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-frontend.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-midend.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/16-NoHeaders-first.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/16-NoHeaders-frontend.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/16-NoHeaders-midend.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/16-NoHeaders.p4
+++ b/testdata/p4_14_samples_outputs/16-NoHeaders.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-first.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-frontend.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-midend.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/16-TwoReferences.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/17-Minimal-first.p4
+++ b/testdata/p4_14_samples_outputs/17-Minimal-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/17-Minimal-frontend.p4
+++ b/testdata/p4_14_samples_outputs/17-Minimal-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/17-Minimal-midend.p4
+++ b/testdata/p4_14_samples_outputs/17-Minimal-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/17-Minimal.p4
+++ b/testdata/p4_14_samples_outputs/17-Minimal.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/18-EmptyPipelines-first.p4
+++ b/testdata/p4_14_samples_outputs/18-EmptyPipelines-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/18-EmptyPipelines-frontend.p4
+++ b/testdata/p4_14_samples_outputs/18-EmptyPipelines-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/18-EmptyPipelines-midend.p4
+++ b/testdata/p4_14_samples_outputs/18-EmptyPipelines-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/18-EmptyPipelines.p4
+++ b/testdata/p4_14_samples_outputs/18-EmptyPipelines.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
@@ -4,6 +4,7 @@ header ipv4_option_timestamp_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
@@ -4,6 +4,7 @@ header ipv4_option_timestamp_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
@@ -4,6 +4,7 @@ header ipv4_option_timestamp_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/TLV_parsing.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing.p4
@@ -4,6 +4,7 @@ header ipv4_option_timestamp_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/acl1-first.p4
+++ b/testdata/p4_14_samples_outputs/acl1-first.p4
@@ -165,13 +165,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".drop_stats") counter(32w256, CounterType.packets) drop_stats;
+@name(".drop_stats") counter<bit<8>>(32w256, CounterType.packets) drop_stats;
 
-@name(".drop_stats_2") counter(32w256, CounterType.packets) drop_stats_2;
+@name(".drop_stats_2") counter<bit<8>>(32w256, CounterType.packets) drop_stats_2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".drop_stats_update") action drop_stats_update() {
-        drop_stats_2.count((bit<32>)meta.ingress_metadata.drop_reason);
+        drop_stats_2.count(meta.ingress_metadata.drop_reason);
     }
     @name(".nop") action nop() {
     }
@@ -184,7 +184,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".drop_packet") action drop_packet() {
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<8> drop_reason) {
-        drop_stats.count((bit<32>)drop_reason);
+        drop_stats.count(drop_reason);
     }
     @name(".negative_mirror") action negative_mirror(bit<8> session_id) {
     }

--- a/testdata/p4_14_samples_outputs/acl1-first.p4
+++ b/testdata/p4_14_samples_outputs/acl1-first.p4
@@ -183,8 +183,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".drop_packet") action drop_packet() {
     }
-    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
-        drop_stats.count(drop_reason);
+    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<8> drop_reason) {
+        drop_stats.count((bit<32>)drop_reason);
     }
     @name(".negative_mirror") action negative_mirror(bit<8> session_id) {
     }

--- a/testdata/p4_14_samples_outputs/acl1-first.p4
+++ b/testdata/p4_14_samples_outputs/acl1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct acl_metadata_t {

--- a/testdata/p4_14_samples_outputs/acl1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct acl_metadata_t {

--- a/testdata/p4_14_samples_outputs/acl1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-frontend.p4
@@ -187,8 +187,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".drop_packet") action drop_packet() {
     }
-    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
-        drop_stats.count(drop_reason);
+    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<8> drop_reason) {
+        drop_stats.count((bit<32>)drop_reason);
     }
     @name(".negative_mirror") action negative_mirror(bit<8> session_id) {
     }

--- a/testdata/p4_14_samples_outputs/acl1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-frontend.p4
@@ -165,9 +165,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".drop_stats") counter(32w256, CounterType.packets) drop_stats;
+@name(".drop_stats") counter<bit<8>>(32w256, CounterType.packets) drop_stats;
 
-@name(".drop_stats_2") counter(32w256, CounterType.packets) drop_stats_2;
+@name(".drop_stats_2") counter<bit<8>>(32w256, CounterType.packets) drop_stats_2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -175,7 +175,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name(".drop_stats_update") action drop_stats_update() {
-        drop_stats_2.count((bit<32>)meta.ingress_metadata.drop_reason);
+        drop_stats_2.count(meta.ingress_metadata.drop_reason);
     }
     @name(".nop") action nop() {
     }
@@ -188,7 +188,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".drop_packet") action drop_packet() {
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<8> drop_reason) {
-        drop_stats.count((bit<32>)drop_reason);
+        drop_stats.count(drop_reason);
     }
     @name(".negative_mirror") action negative_mirror(bit<8> session_id) {
     }

--- a/testdata/p4_14_samples_outputs/acl1-midend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-midend.p4
@@ -261,8 +261,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".drop_packet") action drop_packet() {
     }
-    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
-        drop_stats.count(drop_reason);
+    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<8> drop_reason) {
+        drop_stats.count((bit<32>)drop_reason);
     }
     @name(".negative_mirror") action negative_mirror(bit<8> session_id) {
     }

--- a/testdata/p4_14_samples_outputs/acl1-midend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct acl_metadata_t {

--- a/testdata/p4_14_samples_outputs/acl1-midend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-midend.p4
@@ -239,9 +239,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".drop_stats") counter(32w256, CounterType.packets) drop_stats;
+@name(".drop_stats") counter<bit<8>>(32w256, CounterType.packets) drop_stats;
 
-@name(".drop_stats_2") counter(32w256, CounterType.packets) drop_stats_2;
+@name(".drop_stats_2") counter<bit<8>>(32w256, CounterType.packets) drop_stats_2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -249,7 +249,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name(".drop_stats_update") action drop_stats_update() {
-        drop_stats_2.count((bit<32>)meta._ingress_metadata_drop_reason21);
+        drop_stats_2.count(meta._ingress_metadata_drop_reason21);
     }
     @name(".nop") action nop() {
     }
@@ -262,7 +262,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".drop_packet") action drop_packet() {
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<8> drop_reason) {
-        drop_stats.count((bit<32>)drop_reason);
+        drop_stats.count(drop_reason);
     }
     @name(".negative_mirror") action negative_mirror(bit<8> session_id) {
     }

--- a/testdata/p4_14_samples_outputs/acl1.p4
+++ b/testdata/p4_14_samples_outputs/acl1.p4
@@ -165,13 +165,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".drop_stats") counter(32w256, CounterType.packets) drop_stats;
+@name(".drop_stats") counter<bit<8>>(32w256, CounterType.packets) drop_stats;
 
-@name(".drop_stats_2") counter(32w256, CounterType.packets) drop_stats_2;
+@name(".drop_stats_2") counter<bit<8>>(32w256, CounterType.packets) drop_stats_2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".drop_stats_update") action drop_stats_update() {
-        drop_stats_2.count((bit<32>)meta.ingress_metadata.drop_reason);
+        drop_stats_2.count((bit<8>)meta.ingress_metadata.drop_reason);
     }
     @name(".nop") action nop() {
     }
@@ -184,7 +184,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".drop_packet") action drop_packet() {
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<8> drop_reason) {
-        drop_stats.count((bit<32>)drop_reason);
+        drop_stats.count((bit<8>)drop_reason);
     }
     @name(".negative_mirror") action negative_mirror(bit<8> session_id) {
     }

--- a/testdata/p4_14_samples_outputs/acl1.p4
+++ b/testdata/p4_14_samples_outputs/acl1.p4
@@ -171,7 +171,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".drop_stats_update") action drop_stats_update() {
-        drop_stats_2.count((bit<32>)(bit<32>)meta.ingress_metadata.drop_reason);
+        drop_stats_2.count((bit<32>)meta.ingress_metadata.drop_reason);
     }
     @name(".nop") action nop() {
     }
@@ -183,7 +183,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".drop_packet") action drop_packet() {
     }
-    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
+    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<8> drop_reason) {
         drop_stats.count((bit<32>)drop_reason);
     }
     @name(".negative_mirror") action negative_mirror(bit<8> session_id) {

--- a/testdata/p4_14_samples_outputs/acl1.p4
+++ b/testdata/p4_14_samples_outputs/acl1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct acl_metadata_t {

--- a/testdata/p4_14_samples_outputs/action_bus1-first.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_bus1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_bus1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_bus1.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_chain1-first.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_chain1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_chain1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_chain1.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_inline-first.p4
+++ b/testdata/p4_14_samples_outputs/action_inline-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ht {

--- a/testdata/p4_14_samples_outputs/action_inline-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ht {

--- a/testdata/p4_14_samples_outputs/action_inline-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ht {

--- a/testdata/p4_14_samples_outputs/action_inline.p4
+++ b/testdata/p4_14_samples_outputs/action_inline.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ht {

--- a/testdata/p4_14_samples_outputs/action_inline1-first.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_inline1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_inline1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_inline1.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_inline2-first.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_inline2-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/action_inline2.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/axon-first.p4
+++ b/testdata/p4_14_samples_outputs/axon-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct my_metadata_t {

--- a/testdata/p4_14_samples_outputs/axon-frontend.p4
+++ b/testdata/p4_14_samples_outputs/axon-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct my_metadata_t {

--- a/testdata/p4_14_samples_outputs/axon-midend.p4
+++ b/testdata/p4_14_samples_outputs/axon-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct my_metadata_t {

--- a/testdata/p4_14_samples_outputs/axon.p4
+++ b/testdata/p4_14_samples_outputs/axon.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct my_metadata_t {

--- a/testdata/p4_14_samples_outputs/basic_conditionals-first.p4
+++ b/testdata/p4_14_samples_outputs/basic_conditionals-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/basic_conditionals-frontend.p4
+++ b/testdata/p4_14_samples_outputs/basic_conditionals-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/basic_conditionals-midend.p4
+++ b/testdata/p4_14_samples_outputs/basic_conditionals-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/basic_conditionals.p4
+++ b/testdata/p4_14_samples_outputs/basic_conditionals.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/basic_routing-first.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/basic_routing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/basic_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/basic_routing.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/bigfield1-first.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/bigfield1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/bigfield1-midend.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/bigfield1.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/bridge1-first.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/bridge1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/bridge1-midend.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/bridge1.p4
+++ b/testdata/p4_14_samples_outputs/bridge1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/checksum-first.p4
+++ b/testdata/p4_14_samples_outputs/checksum-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/checksum-frontend.p4
+++ b/testdata/p4_14_samples_outputs/checksum-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/checksum-midend.p4
+++ b/testdata/p4_14_samples_outputs/checksum-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/checksum.p4
+++ b/testdata/p4_14_samples_outputs/checksum.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/checksum1-first.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/checksum1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/checksum1-midend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/checksum1.p4
+++ b/testdata/p4_14_samples_outputs/checksum1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/checksum_pragma-first.p4
+++ b/testdata/p4_14_samples_outputs/checksum_pragma-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/checksum_pragma-frontend.p4
+++ b/testdata/p4_14_samples_outputs/checksum_pragma-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/checksum_pragma-midend.p4
+++ b/testdata/p4_14_samples_outputs/checksum_pragma-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/checksum_pragma.p4
+++ b/testdata/p4_14_samples_outputs/checksum_pragma.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/const_default_action-first.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/const_default_action-frontend.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/const_default_action-midend.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/const_default_action.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/copy_to_cpu.p4
+++ b/testdata/p4_14_samples_outputs/copy_to_cpu.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/counter-first.p4
+++ b/testdata/p4_14_samples_outputs/counter-first.p4
@@ -41,19 +41,19 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_indirect_counter") counter(32w16384, CounterType.packets) my_indirect_counter;
+@name(".my_indirect_counter") counter<bit<14>>(32w16384, CounterType.packets) my_indirect_counter;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_direct_counter") direct_counter(CounterType.bytes) my_direct_counter;
     @name(".m_action") action m_action(bit<14> idx) {
-        my_indirect_counter.count((bit<32>)idx);
+        my_indirect_counter.count(idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }
     @name(".m_action") action m_action_0(bit<14> idx) {
         my_direct_counter.count();
-        my_indirect_counter.count((bit<32>)idx);
+        my_indirect_counter.count(idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {

--- a/testdata/p4_14_samples_outputs/counter-first.p4
+++ b/testdata/p4_14_samples_outputs/counter-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/counter-first.p4
+++ b/testdata/p4_14_samples_outputs/counter-first.p4
@@ -45,15 +45,15 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_direct_counter") direct_counter(CounterType.bytes) my_direct_counter;
-    @name(".m_action") action m_action(bit<32> idx) {
-        my_indirect_counter.count(idx);
+    @name(".m_action") action m_action(bit<14> idx) {
+        my_indirect_counter.count((bit<32>)idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }
-    @name(".m_action") action m_action_0(bit<32> idx) {
+    @name(".m_action") action m_action_0(bit<14> idx) {
         my_direct_counter.count();
-        my_indirect_counter.count(idx);
+        my_indirect_counter.count((bit<32>)idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {

--- a/testdata/p4_14_samples_outputs/counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter-frontend.p4
@@ -41,7 +41,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_indirect_counter") counter(32w16384, CounterType.packets) my_indirect_counter;
+@name(".my_indirect_counter") counter<bit<14>>(32w16384, CounterType.packets) my_indirect_counter;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -49,7 +49,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".my_direct_counter") direct_counter(CounterType.bytes) my_direct_counter_0;
     @name(".m_action") action m_action_0(bit<14> idx) {
         my_direct_counter_0.count();
-        my_indirect_counter.count((bit<32>)idx);
+        my_indirect_counter.count(idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {

--- a/testdata/p4_14_samples_outputs/counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter-frontend.p4
@@ -47,9 +47,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".my_direct_counter") direct_counter(CounterType.bytes) my_direct_counter_0;
-    @name(".m_action") action m_action_0(bit<32> idx) {
+    @name(".m_action") action m_action_0(bit<14> idx) {
         my_direct_counter_0.count();
-        my_indirect_counter.count(idx);
+        my_indirect_counter.count((bit<32>)idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {

--- a/testdata/p4_14_samples_outputs/counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter-midend.p4
@@ -40,7 +40,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_indirect_counter") counter(32w16384, CounterType.packets) my_indirect_counter;
+@name(".my_indirect_counter") counter<bit<14>>(32w16384, CounterType.packets) my_indirect_counter;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -48,7 +48,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".my_direct_counter") direct_counter(CounterType.bytes) my_direct_counter_0;
     @name(".m_action") action m_action_0(bit<14> idx) {
         my_direct_counter_0.count();
-        my_indirect_counter.count((bit<32>)idx);
+        my_indirect_counter.count(idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {

--- a/testdata/p4_14_samples_outputs/counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter-midend.p4
@@ -46,9 +46,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".my_direct_counter") direct_counter(CounterType.bytes) my_direct_counter_0;
-    @name(".m_action") action m_action_0(bit<32> idx) {
+    @name(".m_action") action m_action_0(bit<14> idx) {
         my_direct_counter_0.count();
-        my_indirect_counter.count(idx);
+        my_indirect_counter.count((bit<32>)idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {

--- a/testdata/p4_14_samples_outputs/counter.p4
+++ b/testdata/p4_14_samples_outputs/counter.p4
@@ -41,19 +41,19 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_indirect_counter") counter(32w16384, CounterType.packets) my_indirect_counter;
+@name(".my_indirect_counter") counter<bit<14>>(32w16384, CounterType.packets) my_indirect_counter;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_direct_counter") direct_counter(CounterType.bytes) my_direct_counter;
     @name(".m_action") action m_action(bit<14> idx) {
-        my_indirect_counter.count((bit<32>)idx);
+        my_indirect_counter.count((bit<14>)idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }
     @name(".m_action") action m_action_0(bit<14> idx) {
         my_direct_counter.count();
-        my_indirect_counter.count((bit<32>)idx);
+        my_indirect_counter.count((bit<14>)idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop_0() {

--- a/testdata/p4_14_samples_outputs/counter.p4
+++ b/testdata/p4_14_samples_outputs/counter.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/counter.p4
+++ b/testdata/p4_14_samples_outputs/counter.p4
@@ -45,13 +45,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".my_direct_counter") direct_counter(CounterType.bytes) my_direct_counter;
-    @name(".m_action") action m_action(bit<32> idx) {
+    @name(".m_action") action m_action(bit<14> idx) {
         my_indirect_counter.count((bit<32>)idx);
         mark_to_drop(standard_metadata);
     }
     @name("._nop") action _nop() {
     }
-    @name(".m_action") action m_action_0(bit<32> idx) {
+    @name(".m_action") action m_action_0(bit<14> idx) {
         my_direct_counter.count();
         my_indirect_counter.count((bit<32>)idx);
         mark_to_drop(standard_metadata);

--- a/testdata/p4_14_samples_outputs/counter1-first.p4
+++ b/testdata/p4_14_samples_outputs/counter1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter1.p4
+++ b/testdata/p4_14_samples_outputs/counter1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter2-first.p4
+++ b/testdata/p4_14_samples_outputs/counter2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter2-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter2.p4
+++ b/testdata/p4_14_samples_outputs/counter2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter3-first.p4
+++ b/testdata/p4_14_samples_outputs/counter3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter3-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter3.p4
+++ b/testdata/p4_14_samples_outputs/counter3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter4-first.p4
+++ b/testdata/p4_14_samples_outputs/counter4-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter4-first.p4
+++ b/testdata/p4_14_samples_outputs/counter4-first.p4
@@ -28,12 +28,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") counter(32w200, CounterType.packets) cntDum;
+@name(".cntDum") counter<bit<8>>(32w200, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".act") action act(bit<9> port, bit<8> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tab1") table tab1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter4-first.p4
+++ b/testdata/p4_14_samples_outputs/counter4-first.p4
@@ -31,9 +31,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 @name(".cntDum") counter(32w200, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<8> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tab1") table tab1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-frontend.p4
@@ -28,14 +28,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") counter(32w200, CounterType.packets) cntDum;
+@name(".cntDum") counter<bit<8>>(32w200, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".act") action act(bit<9> port, bit<8> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tab1") table tab1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-frontend.p4
@@ -33,9 +33,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<8> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tab1") table tab1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter4-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter4-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-midend.p4
@@ -28,14 +28,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") counter(32w200, CounterType.packets) cntDum;
+@name(".cntDum") counter<bit<8>>(32w200, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".act") action act(bit<9> port, bit<8> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tab1") table tab1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter4-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-midend.p4
@@ -33,9 +33,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<8> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tab1") table tab1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter4.p4
+++ b/testdata/p4_14_samples_outputs/counter4.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter4.p4
+++ b/testdata/p4_14_samples_outputs/counter4.p4
@@ -28,12 +28,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") counter(32w200, CounterType.packets) cntDum;
+@name(".cntDum") counter<bit<8>>(32w200, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".act") action act(bit<9> port, bit<8> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count((bit<8>)idx);
     }
     @name(".tab1") table tab1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter4.p4
+++ b/testdata/p4_14_samples_outputs/counter4.p4
@@ -31,7 +31,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 @name(".cntDum") counter(32w200, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<8> idx) {
         standard_metadata.egress_spec = port;
         cntDum.count((bit<32>)idx);
     }

--- a/testdata/p4_14_samples_outputs/counter5-first.p4
+++ b/testdata/p4_14_samples_outputs/counter5-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter5-first.p4
+++ b/testdata/p4_14_samples_outputs/counter5-first.p4
@@ -31,9 +31,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 @name(".cntDum") @min_width(64) counter(32w70000, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<17> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tab1") table tab1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter5-first.p4
+++ b/testdata/p4_14_samples_outputs/counter5-first.p4
@@ -28,12 +28,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") @min_width(64) counter(32w70000, CounterType.packets) cntDum;
+@name(".cntDum") @min_width(64) counter<bit<17>>(32w70000, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".act") action act(bit<9> port, bit<17> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tab1") table tab1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-frontend.p4
@@ -28,14 +28,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") @min_width(64) counter(32w70000, CounterType.packets) cntDum;
+@name(".cntDum") @min_width(64) counter<bit<17>>(32w70000, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".act") action act(bit<9> port, bit<17> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tab1") table tab1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-frontend.p4
@@ -33,9 +33,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<17> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tab1") table tab1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter5-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter5-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-midend.p4
@@ -28,14 +28,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") @min_width(64) counter(32w70000, CounterType.packets) cntDum;
+@name(".cntDum") @min_width(64) counter<bit<17>>(32w70000, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".act") action act(bit<9> port, bit<17> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tab1") table tab1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter5-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-midend.p4
@@ -33,9 +33,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<17> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tab1") table tab1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter5.p4
+++ b/testdata/p4_14_samples_outputs/counter5.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/counter5.p4
+++ b/testdata/p4_14_samples_outputs/counter5.p4
@@ -28,12 +28,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") @min_width(64) counter(32w70000, CounterType.packets) cntDum;
+@name(".cntDum") @min_width(64) counter<bit<17>>(32w70000, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".act") action act(bit<9> port, bit<17> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count((bit<17>)idx);
     }
     @name(".tab1") table tab1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter5.p4
+++ b/testdata/p4_14_samples_outputs/counter5.p4
@@ -31,7 +31,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 @name(".cntDum") @min_width(64) counter(32w70000, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<17> idx) {
         standard_metadata.egress_spec = port;
         cntDum.count((bit<32>)idx);
     }

--- a/testdata/p4_14_samples_outputs/counter6-first.p4
+++ b/testdata/p4_14_samples_outputs/counter6-first.p4
@@ -56,12 +56,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") @min_width(64) counter(32w4096, CounterType.packets) cntDum;
+@name(".cntDum") @min_width(64) counter<bit<12>>(32w4096, CounterType.packets) cntDum;
 
 control processA(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".act") action act(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tabA") table tabA {
         actions = {
@@ -81,7 +81,7 @@ control processA(inout headers hdr, inout metadata meta, inout standard_metadata
 control processB(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".act") action act(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tabB") table tabB {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter6-first.p4
+++ b/testdata/p4_14_samples_outputs/counter6-first.p4
@@ -59,9 +59,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 @name(".cntDum") @min_width(64) counter(32w4096, CounterType.packets) cntDum;
 
 control processA(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tabA") table tabA {
         actions = {
@@ -79,9 +79,9 @@ control processA(inout headers hdr, inout metadata meta, inout standard_metadata
 }
 
 control processB(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tabB") table tabB {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter6-first.p4
+++ b/testdata/p4_14_samples_outputs/counter6-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("A_t") header A_t_0 {

--- a/testdata/p4_14_samples_outputs/counter6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter6-frontend.p4
@@ -56,7 +56,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") @min_width(64) counter(32w4096, CounterType.packets) cntDum;
+@name(".cntDum") @min_width(64) counter<bit<12>>(32w4096, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -65,7 +65,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".act") action _act_1(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tabA") table _tabA {
         actions = {
@@ -79,7 +79,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".act") action _act_2(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tabB") table _tabB {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter6-frontend.p4
@@ -63,9 +63,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".act") action _act_1(bit<9> port, bit<32> idx) {
+    @name(".act") action _act_1(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tabA") table _tabA {
         actions = {
@@ -77,9 +77,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = NoAction_0();
     }
-    @name(".act") action _act_2(bit<9> port, bit<32> idx) {
+    @name(".act") action _act_2(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tabB") table _tabB {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter6-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("A_t") header A_t_0 {

--- a/testdata/p4_14_samples_outputs/counter6-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter6-midend.p4
@@ -68,9 +68,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".act") action _act_1(bit<9> port, bit<32> idx) {
+    @name(".act") action _act_1(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tabA") table _tabA {
         actions = {
@@ -82,9 +82,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = NoAction_0();
     }
-    @name(".act") action _act_2(bit<9> port, bit<32> idx) {
+    @name(".act") action _act_2(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+        cntDum.count((bit<32>)idx);
     }
     @name(".tabB") table _tabB {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter6-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter6-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("A_t") header A_t_0 {

--- a/testdata/p4_14_samples_outputs/counter6-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter6-midend.p4
@@ -61,7 +61,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") @min_width(64) counter(32w4096, CounterType.packets) cntDum;
+@name(".cntDum") @min_width(64) counter<bit<12>>(32w4096, CounterType.packets) cntDum;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -70,7 +70,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".act") action _act_1(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tabA") table _tabA {
         actions = {
@@ -84,7 +84,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".act") action _act_2(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count(idx);
     }
     @name(".tabB") table _tabB {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter6.p4
+++ b/testdata/p4_14_samples_outputs/counter6.p4
@@ -56,12 +56,12 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cntDum") @min_width(64) counter(32w4096, CounterType.packets) cntDum;
+@name(".cntDum") @min_width(64) counter<bit<12>>(32w4096, CounterType.packets) cntDum;
 
 control processA(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".act") action act(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count((bit<12>)idx);
     }
     @name(".tabA") table tabA {
         actions = {
@@ -79,7 +79,7 @@ control processA(inout headers hdr, inout metadata meta, inout standard_metadata
 control processB(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".act") action act(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
-        cntDum.count((bit<32>)idx);
+        cntDum.count((bit<12>)idx);
     }
     @name(".tabB") table tabB {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter6.p4
+++ b/testdata/p4_14_samples_outputs/counter6.p4
@@ -59,7 +59,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 @name(".cntDum") @min_width(64) counter(32w4096, CounterType.packets) cntDum;
 
 control processA(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
         cntDum.count((bit<32>)idx);
     }
@@ -77,7 +77,7 @@ control processA(inout headers hdr, inout metadata meta, inout standard_metadata
 }
 
 control processB(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".act") action act(bit<9> port, bit<32> idx) {
+    @name(".act") action act(bit<9> port, bit<12> idx) {
         standard_metadata.egress_spec = port;
         cntDum.count((bit<32>)idx);
     }

--- a/testdata/p4_14_samples_outputs/counter6.p4
+++ b/testdata/p4_14_samples_outputs/counter6.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("A_t") header A_t_0 {

--- a/testdata/p4_14_samples_outputs/do_nothing-first.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/do_nothing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/do_nothing-midend.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/do_nothing.p4
+++ b/testdata/p4_14_samples_outputs/do_nothing.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/double_apply-first.p4
+++ b/testdata/p4_14_samples_outputs/double_apply-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct h {

--- a/testdata/p4_14_samples_outputs/double_apply-frontend.p4
+++ b/testdata/p4_14_samples_outputs/double_apply-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct h {

--- a/testdata/p4_14_samples_outputs/double_apply-midend.p4
+++ b/testdata/p4_14_samples_outputs/double_apply-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct h {

--- a/testdata/p4_14_samples_outputs/double_apply.p4
+++ b/testdata/p4_14_samples_outputs/double_apply.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct h {

--- a/testdata/p4_14_samples_outputs/exact_match1-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match1.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match2-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match2-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match2.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match3-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match3-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match3.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match4-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match4-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match4.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match5-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match5-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match5.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match6-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/exact_match6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/exact_match6-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/exact_match6.p4
+++ b/testdata/p4_14_samples_outputs/exact_match6.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/exact_match7-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match7-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match7-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match7.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match8-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match8-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match8-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match8.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match9-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match9-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match9-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match9.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match_mask1.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-first.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/exact_match_valid1.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-first.p4
@@ -113,9 +113,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".flowlet_id") register<bit<16>>(32w8192) flowlet_id;
+@name(".flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id;
 
-@name(".flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
+@name(".flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
@@ -131,18 +131,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_id.read(meta.ingress_metadata.flowlet_id, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name(".update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id.write((bit<32>)meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
+        flowlet_id.write(meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
     }
     @name(".ecmp_group") table ecmp_group {
         actions = {

--- a/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
@@ -115,9 +115,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".flowlet_id") register<bit<16>>(32w8192) flowlet_id;
+@name(".flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id;
 
-@name(".flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
+@name(".flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
@@ -149,18 +149,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_id.read(meta.ingress_metadata.flowlet_id, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name(".update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id.write((bit<32>)meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
+        flowlet_id.write(meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
     }
     @name(".ecmp_group") table ecmp_group_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -119,9 +119,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".flowlet_id") register<bit<16>>(32w8192) flowlet_id;
+@name(".flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id;
 
-@name(".flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
+@name(".flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime;
 
 struct tuple_0 {
     bit<32> field;
@@ -170,18 +170,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple_1, bit<26>>(meta._ingress_metadata_flowlet_map_index1, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id.read(meta._ingress_metadata_flowlet_id2, (bit<32>)meta._ingress_metadata_flowlet_map_index1);
+        flowlet_id.read(meta._ingress_metadata_flowlet_id2, meta._ingress_metadata_flowlet_map_index1);
         meta._ingress_metadata_flow_ipg0 = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime.read(meta._ingress_metadata_flowlet_lasttime3, (bit<32>)meta._ingress_metadata_flowlet_map_index1);
+        flowlet_lasttime.read(meta._ingress_metadata_flowlet_lasttime3, meta._ingress_metadata_flowlet_map_index1);
         meta._ingress_metadata_flow_ipg0 = (bit<32>)standard_metadata.ingress_global_timestamp - meta._ingress_metadata_flowlet_lasttime3;
-        flowlet_lasttime.write((bit<32>)meta._ingress_metadata_flowlet_map_index1, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write(meta._ingress_metadata_flowlet_map_index1, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name(".update_flowlet_id") action update_flowlet_id() {
         meta._ingress_metadata_flowlet_id2 = meta._ingress_metadata_flowlet_id2 + 16w1;
-        flowlet_id.write((bit<32>)meta._ingress_metadata_flowlet_map_index1, meta._ingress_metadata_flowlet_id2);
+        flowlet_id.write(meta._ingress_metadata_flowlet_map_index1, meta._ingress_metadata_flowlet_id2);
     }
     @name(".ecmp_group") table ecmp_group_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/flowlet_switching.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/flowlet_switching.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching.p4
@@ -111,9 +111,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".flowlet_id") register<bit<16>>(32w8192) flowlet_id;
+@name(".flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id;
 
-@name(".flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
+@name(".flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
@@ -129,18 +129,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".lookup_flowlet_map") action lookup_flowlet_map() {
         hash(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, (bit<13>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<26>)13);
-        flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<13>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<13>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write((bit<13>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name(".set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name(".update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<16>)meta.ingress_metadata.flowlet_id);
+        flowlet_id.write((bit<13>)meta.ingress_metadata.flowlet_map_index, (bit<16>)meta.ingress_metadata.flowlet_id);
     }
     @name(".ecmp_group") table ecmp_group {
         actions = {

--- a/testdata/p4_14_samples_outputs/gateway1-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway1-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway1.p4
+++ b/testdata/p4_14_samples_outputs/gateway1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway2-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway2.p4
+++ b/testdata/p4_14_samples_outputs/gateway2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway3-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway3-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway3.p4
+++ b/testdata/p4_14_samples_outputs/gateway3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway4-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway4-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway4.p4
+++ b/testdata/p4_14_samples_outputs/gateway4.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway5-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway5-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway5.p4
+++ b/testdata/p4_14_samples_outputs/gateway5.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway6-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway6-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway6.p4
+++ b/testdata/p4_14_samples_outputs/gateway6.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway7-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway7-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway7-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway7.p4
+++ b/testdata/p4_14_samples_outputs/gateway7.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway8-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway8-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway8-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway8-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway8-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway8-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/gateway8.p4
+++ b/testdata/p4_14_samples_outputs/gateway8.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/hash_action_basic-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-first.p4
@@ -39,7 +39,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta.counter_metadata.counter_index);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_basic-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-first.p4
@@ -31,7 +31,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_index") action set_index(bit<16> index, bit<9> port) {
@@ -39,7 +39,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        count1.count((bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_basic-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_basic-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-frontend.p4
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta.counter_metadata.counter_index);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_basic-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_basic-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-frontend.p4
@@ -31,7 +31,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        count1.count((bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_basic-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-midend.p4
@@ -40,7 +40,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta._counter_metadata_counter_index0);
+        count1.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index0);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_basic-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-midend.p4
@@ -30,7 +30,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -40,7 +40,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index0);
+        count1.count((bit<14>)meta._counter_metadata_counter_index0);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_basic-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_basic.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic.p4
@@ -39,7 +39,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<32>)meta.counter_metadata.counter_index);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_basic.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic.p4
@@ -31,7 +31,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_index") action set_index(bit<16> index, bit<9> port) {
@@ -39,7 +39,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        count1.count((bit<14>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_basic.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-first.p4
@@ -32,7 +32,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_index") action set_index(bit<16> index, bit<9> port) {
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        count1.count((bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-first.p4
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta.counter_metadata.counter_index);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-frontend.p4
@@ -43,7 +43,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta.counter_metadata.counter_index);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-frontend.p4
@@ -32,7 +32,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -43,7 +43,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        count1.count((bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-midend.p4
@@ -43,7 +43,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._counter_metadata_counter_run1 = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta._counter_metadata_counter_index0);
+        count1.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index0);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-midend.p4
@@ -32,7 +32,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -43,7 +43,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._counter_metadata_counter_run1 = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index0);
+        count1.count((bit<14>)meta._counter_metadata_counter_index0);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway.p4
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<32>)meta.counter_metadata.counter_index);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway.p4
@@ -32,7 +32,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_index") action set_index(bit<16> index, bit<9> port) {
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        count1.count((bit<14>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-first.p4
@@ -32,7 +32,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_index") action set_index(bit<16> index, bit<9> port) {
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        count1.count((bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".seth2") action seth2(bit<16> val) {
         hdr.data.h2 = val;

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-first.p4
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta.counter_metadata.counter_index);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".seth2") action seth2(bit<16> val) {
         hdr.data.h2 = val;

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-frontend.p4
@@ -47,7 +47,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta.counter_metadata.counter_index);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".seth2") action seth2(bit<16> val) {
         hdr.data.h2 = val;

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-frontend.p4
@@ -32,7 +32,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -47,7 +47,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        count1.count((bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".seth2") action seth2(bit<16> val) {
         hdr.data.h2 = val;

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-midend.p4
@@ -47,7 +47,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._counter_metadata_counter_run1 = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta._counter_metadata_counter_index0);
+        count1.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index0);
     }
     @name(".seth2") action seth2(bit<16> val) {
         hdr.data.h2 = val;

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-midend.p4
@@ -32,7 +32,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -47,7 +47,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._counter_metadata_counter_run1 = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index0);
+        count1.count((bit<14>)meta._counter_metadata_counter_index0);
     }
     @name(".seth2") action seth2(bit<16> val) {
         hdr.data.h2 = val;

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2.p4
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<32>)meta.counter_metadata.counter_index);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".seth2") action seth2(bit<16> val) {
         hdr.data.h2 = val;

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2.p4
@@ -32,7 +32,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_index") action set_index(bit<16> index, bit<9> port) {
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        count1.count((bit<14>)(bit<14>)meta.counter_metadata.counter_index);
     }
     @name(".seth2") action seth2(bit<16> val) {
         hdr.data.h2 = val;

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-first.p4
@@ -40,9 +40,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
-@name(".meter1") meter(32w1024, MeterType.bytes) meter1;
+@name(".meter1") meter<bit<10>>(32w1024, MeterType.bytes) meter1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_index") action set_index(bit<16> index, bit<9> port) {
@@ -51,8 +51,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
-        meter1.execute_meter<bit<8>>((bit<32>)(bit<10>)meta.meter_metadata.meter_index, hdr.data.color_1);
+        count1.count((bit<14>)meta.counter_metadata.counter_index);
+        meter1.execute_meter<bit<8>>((bit<10>)meta.meter_metadata.meter_index, hdr.data.color_1);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-first.p4
@@ -51,8 +51,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta.counter_metadata.counter_index);
-        meter1.execute_meter<bit<8>>((bit<32>)meta.meter_metadata.meter_index, hdr.data.color_1);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        meter1.execute_meter<bit<8>>((bit<32>)(bit<10>)meta.meter_metadata.meter_index, hdr.data.color_1);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-frontend.p4
@@ -55,8 +55,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta.counter_metadata.counter_index);
-        meter1.execute_meter<bit<8>>((bit<32>)meta.meter_metadata.meter_index, hdr.data.color_1);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        meter1.execute_meter<bit<8>>((bit<32>)(bit<10>)meta.meter_metadata.meter_index, hdr.data.color_1);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-frontend.p4
@@ -40,9 +40,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
-@name(".meter1") meter(32w1024, MeterType.bytes) meter1;
+@name(".meter1") meter<bit<10>>(32w1024, MeterType.bytes) meter1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -55,8 +55,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
-        meter1.execute_meter<bit<8>>((bit<32>)(bit<10>)meta.meter_metadata.meter_index, hdr.data.color_1);
+        count1.count((bit<14>)meta.counter_metadata.counter_index);
+        meter1.execute_meter<bit<8>>((bit<10>)meta.meter_metadata.meter_index, hdr.data.color_1);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-midend.p4
@@ -53,8 +53,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta._counter_metadata_counter_index0);
-        meter1.execute_meter<bit<8>>((bit<32>)meta._meter_metadata_meter_index1, hdr.data.color_1);
+        count1.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index0);
+        meter1.execute_meter<bit<8>>((bit<32>)(bit<10>)meta._meter_metadata_meter_index1, hdr.data.color_1);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-midend.p4
@@ -38,9 +38,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
-@name(".meter1") meter(32w1024, MeterType.bytes) meter1;
+@name(".meter1") meter<bit<10>>(32w1024, MeterType.bytes) meter1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -53,8 +53,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index0);
-        meter1.execute_meter<bit<8>>((bit<32>)(bit<10>)meta._meter_metadata_meter_index1, hdr.data.color_1);
+        count1.count((bit<14>)meta._counter_metadata_counter_index0);
+        meter1.execute_meter<bit<8>>((bit<10>)meta._meter_metadata_meter_index1, hdr.data.color_1);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same.p4
@@ -40,9 +40,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
-@name(".meter1") meter(32w1024, MeterType.bytes) meter1;
+@name(".meter1") meter<bit<10>>(32w1024, MeterType.bytes) meter1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_index") action set_index(bit<16> index, bit<9> port) {
@@ -51,8 +51,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
-        meter1.execute_meter((bit<32>)(bit<10>)meta.meter_metadata.meter_index, hdr.data.color_1);
+        count1.count((bit<14>)(bit<14>)meta.counter_metadata.counter_index);
+        meter1.execute_meter((bit<10>)(bit<10>)meta.meter_metadata.meter_index, hdr.data.color_1);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same.p4
@@ -51,8 +51,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<32>)meta.counter_metadata.counter_index);
-        meter1.execute_meter((bit<32>)(bit<32>)meta.meter_metadata.meter_index, hdr.data.color_1);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index);
+        meter1.execute_meter((bit<32>)(bit<10>)meta.meter_metadata.meter_index, hdr.data.color_1);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-first.p4
@@ -43,10 +43,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta.counter_metadata.counter_index_first);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_first);
     }
     @name(".count_entries2") action count_entries2() {
-        count2.count((bit<32>)meta.counter_metadata.counter_index_second);
+        count2.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_second);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-first.p4
@@ -32,9 +32,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
-@name(".count2") @min_width(32) counter(32w16384, CounterType.packets) count2;
+@name(".count2") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_index") action set_index(bit<16> index1, bit<16> index2, bit<9> port) {
@@ -43,10 +43,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_first);
+        count1.count((bit<14>)meta.counter_metadata.counter_index_first);
     }
     @name(".count_entries2") action count_entries2() {
-        count2.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_second);
+        count2.count((bit<14>)meta.counter_metadata.counter_index_second);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-first.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-frontend.p4
@@ -45,10 +45,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta.counter_metadata.counter_index_first);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_first);
     }
     @name(".count_entries2") action count_entries2() {
-        count2.count((bit<32>)meta.counter_metadata.counter_index_second);
+        count2.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_second);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-frontend.p4
@@ -32,9 +32,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
-@name(".count2") @min_width(32) counter(32w16384, CounterType.packets) count2;
+@name(".count2") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -45,10 +45,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_first);
+        count1.count((bit<14>)meta.counter_metadata.counter_index_first);
     }
     @name(".count_entries2") action count_entries2() {
-        count2.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_second);
+        count2.count((bit<14>)meta.counter_metadata.counter_index_second);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-midend.p4
@@ -45,10 +45,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)meta._counter_metadata_counter_index_first0);
+        count1.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index_first0);
     }
     @name(".count_entries2") action count_entries2() {
-        count2.count((bit<32>)meta._counter_metadata_counter_index_second1);
+        count2.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index_second1);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-midend.p4
@@ -32,9 +32,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
-@name(".count2") @min_width(32) counter(32w16384, CounterType.packets) count2;
+@name(".count2") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -45,10 +45,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index_first0);
+        count1.count((bit<14>)meta._counter_metadata_counter_index_first0);
     }
     @name(".count_entries2") action count_entries2() {
-        count2.count((bit<32>)(bit<14>)meta._counter_metadata_counter_index_second1);
+        count2.count((bit<14>)meta._counter_metadata_counter_index_second1);
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate.p4
@@ -43,10 +43,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<32>)meta.counter_metadata.counter_index_first);
+        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_first);
     }
     @name(".count_entries2") action count_entries2() {
-        count2.count((bit<32>)(bit<32>)meta.counter_metadata.counter_index_second);
+        count2.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_second);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate.p4
@@ -32,9 +32,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".count1") @min_width(32) counter(32w16384, CounterType.packets) count1;
+@name(".count1") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count1;
 
-@name(".count2") @min_width(32) counter(32w16384, CounterType.packets) count2;
+@name(".count2") @min_width(32) counter<bit<14>>(32w16384, CounterType.packets) count2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".set_index") action set_index(bit<16> index1, bit<16> index2, bit<9> port) {
@@ -43,10 +43,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {
-        count1.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_first);
+        count1.count((bit<14>)(bit<14>)meta.counter_metadata.counter_index_first);
     }
     @name(".count_entries2") action count_entries2() {
-        count2.count((bit<32>)(bit<14>)meta.counter_metadata.counter_index_second);
+        count2.count((bit<14>)(bit<14>)meta.counter_metadata.counter_index_second);
     }
     @name(".index_setter") table index_setter {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct counter_metadata_t {

--- a/testdata/p4_14_samples_outputs/header-stack-ops-bmv2-first.p4
+++ b/testdata/p4_14_samples_outputs/header-stack-ops-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/header-stack-ops-bmv2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/header-stack-ops-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/header-stack-ops-bmv2-midend.p4
+++ b/testdata/p4_14_samples_outputs/header-stack-ops-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/header-stack-ops-bmv2.p4
+++ b/testdata/p4_14_samples_outputs/header-stack-ops-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/hit-first.p4
+++ b/testdata/p4_14_samples_outputs/hit-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/hit-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hit-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/hit-midend.p4
+++ b/testdata/p4_14_samples_outputs/hit-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/hit.p4
+++ b/testdata/p4_14_samples_outputs/hit.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/hitmiss-first.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/hitmiss-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/hitmiss-midend.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/hitmiss.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/inline-first.p4
+++ b/testdata/p4_14_samples_outputs/inline-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct h {

--- a/testdata/p4_14_samples_outputs/inline-frontend.p4
+++ b/testdata/p4_14_samples_outputs/inline-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct h {

--- a/testdata/p4_14_samples_outputs/inline-midend.p4
+++ b/testdata/p4_14_samples_outputs/inline-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct h {

--- a/testdata/p4_14_samples_outputs/inline.p4
+++ b/testdata/p4_14_samples_outputs/inline.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct h {

--- a/testdata/p4_14_samples_outputs/instruct1-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct1-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct1.p4
+++ b/testdata/p4_14_samples_outputs/instruct1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct2-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct2-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct2.p4
+++ b/testdata/p4_14_samples_outputs/instruct2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct3-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct3-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct3.p4
+++ b/testdata/p4_14_samples_outputs/instruct3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct4-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct4-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct4-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct4-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct4-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct4.p4
+++ b/testdata/p4_14_samples_outputs/instruct4.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct5-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct5-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct5.p4
+++ b/testdata/p4_14_samples_outputs/instruct5.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct6-first.p4
+++ b/testdata/p4_14_samples_outputs/instruct6-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct6-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct6-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct6-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/instruct6.p4
+++ b/testdata/p4_14_samples_outputs/instruct6.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/issue-1426-first.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue-1426-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue-1426.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue-1436-first.p4
+++ b/testdata/p4_14_samples_outputs/issue-1436-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header inboxes {

--- a/testdata/p4_14_samples_outputs/issue-1436-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1436-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header inboxes {

--- a/testdata/p4_14_samples_outputs/issue-1436-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1436-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header inboxes {

--- a/testdata/p4_14_samples_outputs/issue-1436.p4
+++ b/testdata/p4_14_samples_outputs/issue-1436.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header inboxes {

--- a/testdata/p4_14_samples_outputs/issue-1559-first.p4
+++ b/testdata/p4_14_samples_outputs/issue-1559-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct user_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue-1559-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1559-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct user_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue-1559-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1559-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct user_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue-1559.p4
+++ b/testdata/p4_14_samples_outputs/issue-1559.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct user_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue1013-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1013-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("headers") header headers_0 {

--- a/testdata/p4_14_samples_outputs/issue1013-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1013-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("headers") header headers_0 {

--- a/testdata/p4_14_samples_outputs/issue1013-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1013-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("headers") header headers_0 {

--- a/testdata/p4_14_samples_outputs/issue1013.p4
+++ b/testdata/p4_14_samples_outputs/issue1013.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("headers") header headers_0 {

--- a/testdata/p4_14_samples_outputs/issue1057-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1057-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/issue1057-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1057-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/issue1057-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1057-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/issue1057.p4
+++ b/testdata/p4_14_samples_outputs/issue1057.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/issue1058-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1058-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue1058-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1058-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue1058-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1058-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue1058.p4
+++ b/testdata/p4_14_samples_outputs/issue1058.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue1237-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1237-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("backs") header backs_0 {

--- a/testdata/p4_14_samples_outputs/issue1237-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1237-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("backs") header backs_0 {

--- a/testdata/p4_14_samples_outputs/issue1237-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1237-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("backs") header backs_0 {

--- a/testdata/p4_14_samples_outputs/issue1237.p4
+++ b/testdata/p4_14_samples_outputs/issue1237.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("backs") header backs_0 {

--- a/testdata/p4_14_samples_outputs/issue1397-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1397-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr1_t {

--- a/testdata/p4_14_samples_outputs/issue1397-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1397-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr1_t {

--- a/testdata/p4_14_samples_outputs/issue1397-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1397-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr1_t {

--- a/testdata/p4_14_samples_outputs/issue1397.p4
+++ b/testdata/p4_14_samples_outputs/issue1397.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr1_t {

--- a/testdata/p4_14_samples_outputs/issue1428-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1428-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue1428-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1428-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue1428-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1428-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue1428.p4
+++ b/testdata/p4_14_samples_outputs/issue1428.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue1696-1-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1696-1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header stack_t {

--- a/testdata/p4_14_samples_outputs/issue1696-1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1696-1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header stack_t {

--- a/testdata/p4_14_samples_outputs/issue1696-1-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1696-1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header stack_t {

--- a/testdata/p4_14_samples_outputs/issue1696-1.p4
+++ b/testdata/p4_14_samples_outputs/issue1696-1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header stack_t {

--- a/testdata/p4_14_samples_outputs/issue1696-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1696-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header stack_t {

--- a/testdata/p4_14_samples_outputs/issue1696-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1696-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header stack_t {

--- a/testdata/p4_14_samples_outputs/issue1696-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1696-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header stack_t {

--- a/testdata/p4_14_samples_outputs/issue1696.p4
+++ b/testdata/p4_14_samples_outputs/issue1696.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header stack_t {

--- a/testdata/p4_14_samples_outputs/issue1873-first.p4
+++ b/testdata/p4_14_samples_outputs/issue1873-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct test_t {

--- a/testdata/p4_14_samples_outputs/issue1873-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue1873-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct test_t {

--- a/testdata/p4_14_samples_outputs/issue1873-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue1873-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct test_t {

--- a/testdata/p4_14_samples_outputs/issue1873.p4
+++ b/testdata/p4_14_samples_outputs/issue1873.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct test_t {

--- a/testdata/p4_14_samples_outputs/issue2196-first.p4
+++ b/testdata/p4_14_samples_outputs/issue2196-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct my_meta_t {

--- a/testdata/p4_14_samples_outputs/issue2196-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue2196-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct my_meta_t {

--- a/testdata/p4_14_samples_outputs/issue2196-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue2196-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct my_meta_t {

--- a/testdata/p4_14_samples_outputs/issue2196.p4
+++ b/testdata/p4_14_samples_outputs/issue2196.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct my_meta_t {

--- a/testdata/p4_14_samples_outputs/issue576-first.p4
+++ b/testdata/p4_14_samples_outputs/issue576-first.p4
@@ -14,6 +14,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue576-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue576-frontend.p4
@@ -14,6 +14,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue576-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue576-midend.p4
@@ -14,6 +14,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue576.p4
+++ b/testdata/p4_14_samples_outputs/issue576.p4
@@ -14,6 +14,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue583-first.p4
+++ b/testdata/p4_14_samples_outputs/issue583-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue583-first.p4
+++ b/testdata/p4_14_samples_outputs/issue583-first.p4
@@ -182,7 +182,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cnt1") counter(32w32, CounterType.packets) cnt1;
+@name(".cnt1") counter<bit<5>>(32w32, CounterType.packets) cnt1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".drop_pkt") action drop_pkt() {
@@ -196,7 +196,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hop(hdr.ipv4.ttl, egress_spec);
     }
     @name(".act") action act() {
-        cnt1.count(32w10);
+        cnt1.count(5w10);
     }
     @name(".ipv4_routing") table ipv4_routing {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue583-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-frontend.p4
@@ -182,7 +182,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cnt1") counter(32w32, CounterType.packets) cnt1;
+@name(".cnt1") counter<bit<5>>(32w32, CounterType.packets) cnt1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -201,7 +201,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
     }
     @name(".act") action act() {
-        cnt1.count(32w10);
+        cnt1.count(5w10);
     }
     @name(".ipv4_routing") table ipv4_routing_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue583-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue583-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue583-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-midend.p4
@@ -189,7 +189,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cnt1") counter(32w32, CounterType.packets) cnt1;
+@name(".cnt1") counter<bit<5>>(32w32, CounterType.packets) cnt1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -204,7 +204,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
     @name(".act") action act() {
-        cnt1.count(32w10);
+        cnt1.count(5w10);
     }
     @name(".ipv4_routing") table ipv4_routing_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue583.p4
+++ b/testdata/p4_14_samples_outputs/issue583.p4
@@ -196,7 +196,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hop(hdr.ipv4.ttl, egress_spec);
     }
     @name(".act") action act() {
-        cnt1.count((bit<32>)32w10);
+        cnt1.count((bit<32>)5w10);
     }
     @name(".ipv4_routing") table ipv4_routing {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue583.p4
+++ b/testdata/p4_14_samples_outputs/issue583.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue583.p4
+++ b/testdata/p4_14_samples_outputs/issue583.p4
@@ -182,7 +182,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".cnt1") counter(32w32, CounterType.packets) cnt1;
+@name(".cnt1") counter<bit<5>>(32w32, CounterType.packets) cnt1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".drop_pkt") action drop_pkt() {
@@ -196,7 +196,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hop(hdr.ipv4.ttl, egress_spec);
     }
     @name(".act") action act() {
-        cnt1.count((bit<32>)5w10);
+        cnt1.count((bit<5>)5w10);
     }
     @name(".ipv4_routing") table ipv4_routing {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue60-first.p4
+++ b/testdata/p4_14_samples_outputs/issue60-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue60-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue60-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue60-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue60-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue60.p4
+++ b/testdata/p4_14_samples_outputs/issue60.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue604-first.p4
+++ b/testdata/p4_14_samples_outputs/issue604-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue604-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue604-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue604-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue604-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue604.p4
+++ b/testdata/p4_14_samples_outputs/issue604.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue638-2-first.p4
+++ b/testdata/p4_14_samples_outputs/issue638-2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue638-2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue638-2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue638-2-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue638-2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue638-2.p4
+++ b/testdata/p4_14_samples_outputs/issue638-2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue767-first.p4
+++ b/testdata/p4_14_samples_outputs/issue767-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue767-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue767-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue767-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue767-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue767.p4
+++ b/testdata/p4_14_samples_outputs/issue767.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/issue780-1-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("headers") header headers_0 {

--- a/testdata/p4_14_samples_outputs/issue780-1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("headers") header headers_0 {

--- a/testdata/p4_14_samples_outputs/issue780-1-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("headers") header headers_0 {

--- a/testdata/p4_14_samples_outputs/issue780-1.p4
+++ b/testdata/p4_14_samples_outputs/issue780-1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("headers") header headers_0 {

--- a/testdata/p4_14_samples_outputs/issue780-2-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("main") header main_0 {

--- a/testdata/p4_14_samples_outputs/issue780-2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("main") header main_0 {

--- a/testdata/p4_14_samples_outputs/issue780-2-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("main") header main_0 {

--- a/testdata/p4_14_samples_outputs/issue780-2.p4
+++ b/testdata/p4_14_samples_outputs/issue780-2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("main") header main_0 {

--- a/testdata/p4_14_samples_outputs/issue780-3-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("metadata") header metadata_0 {

--- a/testdata/p4_14_samples_outputs/issue780-3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("metadata") header metadata_0 {

--- a/testdata/p4_14_samples_outputs/issue780-3-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("metadata") header metadata_0 {

--- a/testdata/p4_14_samples_outputs/issue780-3.p4
+++ b/testdata/p4_14_samples_outputs/issue780-3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("metadata") header metadata_0 {

--- a/testdata/p4_14_samples_outputs/issue780-5-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-5-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("computeChecksum") header computeChecksum_0 {

--- a/testdata/p4_14_samples_outputs/issue780-5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-5-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("computeChecksum") header computeChecksum_0 {

--- a/testdata/p4_14_samples_outputs/issue780-5-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-5-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("computeChecksum") header computeChecksum_0 {

--- a/testdata/p4_14_samples_outputs/issue780-5.p4
+++ b/testdata/p4_14_samples_outputs/issue780-5.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("computeChecksum") header computeChecksum_0 {

--- a/testdata/p4_14_samples_outputs/issue780-7-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-7-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("exact") header exact_0 {

--- a/testdata/p4_14_samples_outputs/issue780-7-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-7-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("exact") header exact_0 {

--- a/testdata/p4_14_samples_outputs/issue780-7-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-7-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("exact") header exact_0 {

--- a/testdata/p4_14_samples_outputs/issue780-7.p4
+++ b/testdata/p4_14_samples_outputs/issue780-7.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("exact") header exact_0 {

--- a/testdata/p4_14_samples_outputs/issue780-8-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-8-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_14_samples_outputs/issue780-8-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-8-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_14_samples_outputs/issue780-8-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-8-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_14_samples_outputs/issue780-8.p4
+++ b/testdata/p4_14_samples_outputs/issue780-8.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_14_samples_outputs/issue780-9-first.p4
+++ b/testdata/p4_14_samples_outputs/issue780-9-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("exact") header exact_0 {

--- a/testdata/p4_14_samples_outputs/issue780-9-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-9-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("exact") header exact_0 {

--- a/testdata/p4_14_samples_outputs/issue780-9-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue780-9-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("exact") header exact_0 {

--- a/testdata/p4_14_samples_outputs/issue780-9.p4
+++ b/testdata/p4_14_samples_outputs/issue780-9.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("exact") header exact_0 {

--- a/testdata/p4_14_samples_outputs/issue781-first.p4
+++ b/testdata/p4_14_samples_outputs/issue781-first.p4
@@ -14,6 +14,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue781-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue781-frontend.p4
@@ -14,6 +14,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue781-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue781-midend.p4
@@ -14,6 +14,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue781.p4
+++ b/testdata/p4_14_samples_outputs/issue781.p4
@@ -14,6 +14,7 @@ header ipv4_t_1 {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_14_samples_outputs/issue846-first.p4
+++ b/testdata/p4_14_samples_outputs/issue846-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/issue846-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue846-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/issue846-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue846-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/issue846.p4
+++ b/testdata/p4_14_samples_outputs/issue846.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_14_samples_outputs/issue894-first.p4
+++ b/testdata/p4_14_samples_outputs/issue894-first.p4
@@ -106,9 +106,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".heavy_hitter_counter1") register<bit<16>>(32w16) heavy_hitter_counter1;
+@name(".heavy_hitter_counter1") register<bit<16>, bit<4>>(32w16) heavy_hitter_counter1;
 
-@name(".heavy_hitter_counter2") register<bit<16>>(32w16) heavy_hitter_counter2;
+@name(".heavy_hitter_counter2") register<bit<16>, bit<4>>(32w16) heavy_hitter_counter2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
@@ -124,13 +124,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_heavy_hitter_count") action set_heavy_hitter_count() {
         hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.custom_metadata.hash_val1, HashAlgorithm.csum16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<32>)(bit<4>)meta.custom_metadata.hash_val1);
+        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<4>)meta.custom_metadata.hash_val1);
         meta.custom_metadata.count_val1 = meta.custom_metadata.count_val1 + 16w1;
-        heavy_hitter_counter1.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val1, meta.custom_metadata.count_val1);
+        heavy_hitter_counter1.write((bit<4>)meta.custom_metadata.hash_val1, meta.custom_metadata.count_val1);
         hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.custom_metadata.hash_val2, HashAlgorithm.crc16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<32>)(bit<4>)meta.custom_metadata.hash_val2);
+        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<4>)meta.custom_metadata.hash_val2);
         meta.custom_metadata.count_val2 = meta.custom_metadata.count_val2 + 16w1;
-        heavy_hitter_counter2.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val2, meta.custom_metadata.count_val2);
+        heavy_hitter_counter2.write((bit<4>)meta.custom_metadata.hash_val2, meta.custom_metadata.count_val2);
     }
     @name(".drop_heavy_hitter_table") table drop_heavy_hitter_table {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue894-first.p4
+++ b/testdata/p4_14_samples_outputs/issue894-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct custom_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue894-first.p4
+++ b/testdata/p4_14_samples_outputs/issue894-first.p4
@@ -124,13 +124,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_heavy_hitter_count") action set_heavy_hitter_count() {
         hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.custom_metadata.hash_val1, HashAlgorithm.csum16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<32>)meta.custom_metadata.hash_val1);
+        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<32>)(bit<4>)meta.custom_metadata.hash_val1);
         meta.custom_metadata.count_val1 = meta.custom_metadata.count_val1 + 16w1;
-        heavy_hitter_counter1.write((bit<32>)meta.custom_metadata.hash_val1, meta.custom_metadata.count_val1);
+        heavy_hitter_counter1.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val1, meta.custom_metadata.count_val1);
         hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.custom_metadata.hash_val2, HashAlgorithm.crc16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<32>)meta.custom_metadata.hash_val2);
+        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<32>)(bit<4>)meta.custom_metadata.hash_val2);
         meta.custom_metadata.count_val2 = meta.custom_metadata.count_val2 + 16w1;
-        heavy_hitter_counter2.write((bit<32>)meta.custom_metadata.hash_val2, meta.custom_metadata.count_val2);
+        heavy_hitter_counter2.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val2, meta.custom_metadata.count_val2);
     }
     @name(".drop_heavy_hitter_table") table drop_heavy_hitter_table {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue894-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct custom_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue894-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-frontend.p4
@@ -108,9 +108,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".heavy_hitter_counter1") register<bit<16>>(32w16) heavy_hitter_counter1;
+@name(".heavy_hitter_counter1") register<bit<16>, bit<4>>(32w16) heavy_hitter_counter1;
 
-@name(".heavy_hitter_counter2") register<bit<16>>(32w16) heavy_hitter_counter2;
+@name(".heavy_hitter_counter2") register<bit<16>, bit<4>>(32w16) heavy_hitter_counter2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
@@ -140,13 +140,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_heavy_hitter_count") action set_heavy_hitter_count() {
         hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.custom_metadata.hash_val1, HashAlgorithm.csum16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<32>)(bit<4>)meta.custom_metadata.hash_val1);
+        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<4>)meta.custom_metadata.hash_val1);
         meta.custom_metadata.count_val1 = meta.custom_metadata.count_val1 + 16w1;
-        heavy_hitter_counter1.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val1, meta.custom_metadata.count_val1);
+        heavy_hitter_counter1.write((bit<4>)meta.custom_metadata.hash_val1, meta.custom_metadata.count_val1);
         hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.custom_metadata.hash_val2, HashAlgorithm.crc16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<32>)(bit<4>)meta.custom_metadata.hash_val2);
+        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<4>)meta.custom_metadata.hash_val2);
         meta.custom_metadata.count_val2 = meta.custom_metadata.count_val2 + 16w1;
-        heavy_hitter_counter2.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val2, meta.custom_metadata.count_val2);
+        heavy_hitter_counter2.write((bit<4>)meta.custom_metadata.hash_val2, meta.custom_metadata.count_val2);
     }
     @name(".drop_heavy_hitter_table") table drop_heavy_hitter_table_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue894-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-frontend.p4
@@ -140,13 +140,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_heavy_hitter_count") action set_heavy_hitter_count() {
         hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.custom_metadata.hash_val1, HashAlgorithm.csum16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<32>)meta.custom_metadata.hash_val1);
+        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<32>)(bit<4>)meta.custom_metadata.hash_val1);
         meta.custom_metadata.count_val1 = meta.custom_metadata.count_val1 + 16w1;
-        heavy_hitter_counter1.write((bit<32>)meta.custom_metadata.hash_val1, meta.custom_metadata.count_val1);
+        heavy_hitter_counter1.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val1, meta.custom_metadata.count_val1);
         hash<bit<16>, bit<16>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<32>>(meta.custom_metadata.hash_val2, HashAlgorithm.crc16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<32>)meta.custom_metadata.hash_val2);
+        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<32>)(bit<4>)meta.custom_metadata.hash_val2);
         meta.custom_metadata.count_val2 = meta.custom_metadata.count_val2 + 16w1;
-        heavy_hitter_counter2.write((bit<32>)meta.custom_metadata.hash_val2, meta.custom_metadata.count_val2);
+        heavy_hitter_counter2.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val2, meta.custom_metadata.count_val2);
     }
     @name(".drop_heavy_hitter_table") table drop_heavy_hitter_table_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue894-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-midend.p4
@@ -151,13 +151,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_heavy_hitter_count") action set_heavy_hitter_count() {
         hash<bit<16>, bit<16>, tuple_0, bit<32>>(meta._custom_metadata_hash_val11, HashAlgorithm.csum16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter1.read(meta._custom_metadata_count_val13, (bit<32>)meta._custom_metadata_hash_val11);
+        heavy_hitter_counter1.read(meta._custom_metadata_count_val13, (bit<32>)(bit<4>)meta._custom_metadata_hash_val11);
         meta._custom_metadata_count_val13 = meta._custom_metadata_count_val13 + 16w1;
-        heavy_hitter_counter1.write((bit<32>)meta._custom_metadata_hash_val11, meta._custom_metadata_count_val13);
+        heavy_hitter_counter1.write((bit<32>)(bit<4>)meta._custom_metadata_hash_val11, meta._custom_metadata_count_val13);
         hash<bit<16>, bit<16>, tuple_0, bit<32>>(meta._custom_metadata_hash_val22, HashAlgorithm.crc16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter2.read(meta._custom_metadata_count_val24, (bit<32>)meta._custom_metadata_hash_val22);
+        heavy_hitter_counter2.read(meta._custom_metadata_count_val24, (bit<32>)(bit<4>)meta._custom_metadata_hash_val22);
         meta._custom_metadata_count_val24 = meta._custom_metadata_count_val24 + 16w1;
-        heavy_hitter_counter2.write((bit<32>)meta._custom_metadata_hash_val22, meta._custom_metadata_count_val24);
+        heavy_hitter_counter2.write((bit<32>)(bit<4>)meta._custom_metadata_hash_val22, meta._custom_metadata_count_val24);
     }
     @name(".drop_heavy_hitter_table") table drop_heavy_hitter_table_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue894-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct custom_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue894-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-midend.p4
@@ -111,9 +111,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".heavy_hitter_counter1") register<bit<16>>(32w16) heavy_hitter_counter1;
+@name(".heavy_hitter_counter1") register<bit<16>, bit<4>>(32w16) heavy_hitter_counter1;
 
-@name(".heavy_hitter_counter2") register<bit<16>>(32w16) heavy_hitter_counter2;
+@name(".heavy_hitter_counter2") register<bit<16>, bit<4>>(32w16) heavy_hitter_counter2;
 
 struct tuple_0 {
     bit<32> field;
@@ -151,13 +151,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_heavy_hitter_count") action set_heavy_hitter_count() {
         hash<bit<16>, bit<16>, tuple_0, bit<32>>(meta._custom_metadata_hash_val11, HashAlgorithm.csum16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter1.read(meta._custom_metadata_count_val13, (bit<32>)(bit<4>)meta._custom_metadata_hash_val11);
+        heavy_hitter_counter1.read(meta._custom_metadata_count_val13, (bit<4>)meta._custom_metadata_hash_val11);
         meta._custom_metadata_count_val13 = meta._custom_metadata_count_val13 + 16w1;
-        heavy_hitter_counter1.write((bit<32>)(bit<4>)meta._custom_metadata_hash_val11, meta._custom_metadata_count_val13);
+        heavy_hitter_counter1.write((bit<4>)meta._custom_metadata_hash_val11, meta._custom_metadata_count_val13);
         hash<bit<16>, bit<16>, tuple_0, bit<32>>(meta._custom_metadata_hash_val22, HashAlgorithm.crc16, 16w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 32w16);
-        heavy_hitter_counter2.read(meta._custom_metadata_count_val24, (bit<32>)(bit<4>)meta._custom_metadata_hash_val22);
+        heavy_hitter_counter2.read(meta._custom_metadata_count_val24, (bit<4>)meta._custom_metadata_hash_val22);
         meta._custom_metadata_count_val24 = meta._custom_metadata_count_val24 + 16w1;
-        heavy_hitter_counter2.write((bit<32>)(bit<4>)meta._custom_metadata_hash_val22, meta._custom_metadata_count_val24);
+        heavy_hitter_counter2.write((bit<4>)meta._custom_metadata_hash_val22, meta._custom_metadata_count_val24);
     }
     @name(".drop_heavy_hitter_table") table drop_heavy_hitter_table_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue894.p4
+++ b/testdata/p4_14_samples_outputs/issue894.p4
@@ -104,9 +104,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".heavy_hitter_counter1") register<bit<16>>(32w16) heavy_hitter_counter1;
+@name(".heavy_hitter_counter1") register<bit<16>, bit<4>>(32w16) heavy_hitter_counter1;
 
-@name(".heavy_hitter_counter2") register<bit<16>>(32w16) heavy_hitter_counter2;
+@name(".heavy_hitter_counter2") register<bit<16>, bit<4>>(32w16) heavy_hitter_counter2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
@@ -122,13 +122,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_heavy_hitter_count") action set_heavy_hitter_count() {
         hash(meta.custom_metadata.hash_val1, HashAlgorithm.csum16, (bit<16>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<32>)16);
-        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<32>)(bit<4>)meta.custom_metadata.hash_val1);
+        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<4>)(bit<4>)meta.custom_metadata.hash_val1);
         meta.custom_metadata.count_val1 = meta.custom_metadata.count_val1 + 16w1;
-        heavy_hitter_counter1.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val1, (bit<16>)meta.custom_metadata.count_val1);
+        heavy_hitter_counter1.write((bit<4>)(bit<4>)meta.custom_metadata.hash_val1, (bit<16>)meta.custom_metadata.count_val1);
         hash(meta.custom_metadata.hash_val2, HashAlgorithm.crc16, (bit<16>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<32>)16);
-        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<32>)(bit<4>)meta.custom_metadata.hash_val2);
+        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<4>)(bit<4>)meta.custom_metadata.hash_val2);
         meta.custom_metadata.count_val2 = meta.custom_metadata.count_val2 + 16w1;
-        heavy_hitter_counter2.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val2, (bit<16>)meta.custom_metadata.count_val2);
+        heavy_hitter_counter2.write((bit<4>)(bit<4>)meta.custom_metadata.hash_val2, (bit<16>)meta.custom_metadata.count_val2);
     }
     @name(".drop_heavy_hitter_table") table drop_heavy_hitter_table {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue894.p4
+++ b/testdata/p4_14_samples_outputs/issue894.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct custom_metadata_t {

--- a/testdata/p4_14_samples_outputs/issue894.p4
+++ b/testdata/p4_14_samples_outputs/issue894.p4
@@ -122,13 +122,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_heavy_hitter_count") action set_heavy_hitter_count() {
         hash(meta.custom_metadata.hash_val1, HashAlgorithm.csum16, (bit<16>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<32>)16);
-        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<32>)meta.custom_metadata.hash_val1);
+        heavy_hitter_counter1.read(meta.custom_metadata.count_val1, (bit<32>)(bit<4>)meta.custom_metadata.hash_val1);
         meta.custom_metadata.count_val1 = meta.custom_metadata.count_val1 + 16w1;
-        heavy_hitter_counter1.write((bit<32>)meta.custom_metadata.hash_val1, (bit<16>)meta.custom_metadata.count_val1);
+        heavy_hitter_counter1.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val1, (bit<16>)meta.custom_metadata.count_val1);
         hash(meta.custom_metadata.hash_val2, HashAlgorithm.crc16, (bit<16>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<32>)16);
-        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<32>)meta.custom_metadata.hash_val2);
+        heavy_hitter_counter2.read(meta.custom_metadata.count_val2, (bit<32>)(bit<4>)meta.custom_metadata.hash_val2);
         meta.custom_metadata.count_val2 = meta.custom_metadata.count_val2 + 16w1;
-        heavy_hitter_counter2.write((bit<32>)meta.custom_metadata.hash_val2, (bit<16>)meta.custom_metadata.count_val2);
+        heavy_hitter_counter2.write((bit<32>)(bit<4>)meta.custom_metadata.hash_val2, (bit<16>)meta.custom_metadata.count_val2);
     }
     @name(".drop_heavy_hitter_table") table drop_heavy_hitter_table {
         actions = {

--- a/testdata/p4_14_samples_outputs/issue946-first.p4
+++ b/testdata/p4_14_samples_outputs/issue946-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue946-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue946-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue946-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue946-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/issue946.p4
+++ b/testdata/p4_14_samples_outputs/issue946.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/mac_rewrite-first.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct egress_metadata_t {

--- a/testdata/p4_14_samples_outputs/mac_rewrite-frontend.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct egress_metadata_t {

--- a/testdata/p4_14_samples_outputs/mac_rewrite-midend.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct egress_metadata_t {

--- a/testdata/p4_14_samples_outputs/mac_rewrite.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct egress_metadata_t {

--- a/testdata/p4_14_samples_outputs/meter-first.p4
+++ b/testdata/p4_14_samples_outputs/meter-first.p4
@@ -49,8 +49,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop() {
     }
-    @name(".m_action") action m_action(bit<32> meter_idx) {
-        my_meter.execute_meter<bit<32>>(meter_idx, meta.meta.meter_tag);
+    @name(".m_action") action m_action(bit<14> meter_idx) {
+        my_meter.execute_meter<bit<32>>((bit<32>)meter_idx, meta.meta.meter_tag);
         standard_metadata.egress_spec = 9w1;
     }
     @name(".m_filter") table m_filter {

--- a/testdata/p4_14_samples_outputs/meter-first.p4
+++ b/testdata/p4_14_samples_outputs/meter-first.p4
@@ -41,7 +41,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_meter") meter(32w16384, MeterType.packets) my_meter;
+@name(".my_meter") meter<bit<14>>(32w16384, MeterType.packets) my_meter;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
@@ -50,7 +50,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._nop") action _nop() {
     }
     @name(".m_action") action m_action(bit<14> meter_idx) {
-        my_meter.execute_meter<bit<32>>((bit<32>)meter_idx, meta.meta.meter_tag);
+        my_meter.execute_meter<bit<32>>(meter_idx, meta.meta.meter_tag);
         standard_metadata.egress_spec = 9w1;
     }
     @name(".m_filter") table m_filter {

--- a/testdata/p4_14_samples_outputs/meter-first.p4
+++ b/testdata/p4_14_samples_outputs/meter-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/meter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter-frontend.p4
@@ -55,8 +55,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop_2() {
     }
-    @name(".m_action") action m_action(bit<32> meter_idx) {
-        my_meter.execute_meter<bit<32>>(meter_idx, meta.meta.meter_tag);
+    @name(".m_action") action m_action(bit<14> meter_idx) {
+        my_meter.execute_meter<bit<32>>((bit<32>)meter_idx, meta.meta.meter_tag);
         standard_metadata.egress_spec = 9w1;
     }
     @name(".m_filter") table m_filter_0 {

--- a/testdata/p4_14_samples_outputs/meter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/meter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter-frontend.p4
@@ -41,7 +41,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_meter") meter(32w16384, MeterType.packets) my_meter;
+@name(".my_meter") meter<bit<14>>(32w16384, MeterType.packets) my_meter;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -56,7 +56,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._nop") action _nop_2() {
     }
     @name(".m_action") action m_action(bit<14> meter_idx) {
-        my_meter.execute_meter<bit<32>>((bit<32>)meter_idx, meta.meta.meter_tag);
+        my_meter.execute_meter<bit<32>>(meter_idx, meta.meta.meter_tag);
         standard_metadata.egress_spec = 9w1;
     }
     @name(".m_filter") table m_filter_0 {

--- a/testdata/p4_14_samples_outputs/meter-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter-midend.p4
@@ -54,8 +54,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop_2() {
     }
-    @name(".m_action") action m_action(bit<32> meter_idx) {
-        my_meter.execute_meter<bit<32>>(meter_idx, meta._meta_meter_tag0);
+    @name(".m_action") action m_action(bit<14> meter_idx) {
+        my_meter.execute_meter<bit<32>>((bit<32>)meter_idx, meta._meta_meter_tag0);
         standard_metadata.egress_spec = 9w1;
     }
     @name(".m_filter") table m_filter_0 {

--- a/testdata/p4_14_samples_outputs/meter-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/meter-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter-midend.p4
@@ -40,7 +40,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_meter") meter(32w16384, MeterType.packets) my_meter;
+@name(".my_meter") meter<bit<14>>(32w16384, MeterType.packets) my_meter;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._nop") action _nop_2() {
     }
     @name(".m_action") action m_action(bit<14> meter_idx) {
-        my_meter.execute_meter<bit<32>>((bit<32>)meter_idx, meta._meta_meter_tag0);
+        my_meter.execute_meter<bit<32>>(meter_idx, meta._meta_meter_tag0);
         standard_metadata.egress_spec = 9w1;
     }
     @name(".m_filter") table m_filter_0 {

--- a/testdata/p4_14_samples_outputs/meter.p4
+++ b/testdata/p4_14_samples_outputs/meter.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/meter.p4
+++ b/testdata/p4_14_samples_outputs/meter.p4
@@ -49,7 +49,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop() {
     }
-    @name(".m_action") action m_action(bit<32> meter_idx) {
+    @name(".m_action") action m_action(bit<14> meter_idx) {
         my_meter.execute_meter((bit<32>)meter_idx, meta.meta.meter_tag);
         standard_metadata.egress_spec = 9w1;
     }

--- a/testdata/p4_14_samples_outputs/meter.p4
+++ b/testdata/p4_14_samples_outputs/meter.p4
@@ -41,7 +41,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_meter") meter(32w16384, MeterType.packets) my_meter;
+@name(".my_meter") meter<bit<14>>(32w16384, MeterType.packets) my_meter;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("._drop") action _drop() {
@@ -50,7 +50,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._nop") action _nop() {
     }
     @name(".m_action") action m_action(bit<14> meter_idx) {
-        my_meter.execute_meter((bit<32>)meter_idx, meta.meta.meter_tag);
+        my_meter.execute_meter((bit<14>)meter_idx, meta.meta.meter_tag);
         standard_metadata.egress_spec = 9w1;
     }
     @name(".m_filter") table m_filter {

--- a/testdata/p4_14_samples_outputs/meter1-first.p4
+++ b/testdata/p4_14_samples_outputs/meter1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/meter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/meter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/meter1.p4
+++ b/testdata/p4_14_samples_outputs/meter1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/misc_prim-first.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header pkt_t {

--- a/testdata/p4_14_samples_outputs/misc_prim-frontend.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header pkt_t {

--- a/testdata/p4_14_samples_outputs/misc_prim-midend.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header pkt_t {

--- a/testdata/p4_14_samples_outputs/misc_prim.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header pkt_t {

--- a/testdata/p4_14_samples_outputs/miss-first.p4
+++ b/testdata/p4_14_samples_outputs/miss-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/miss-frontend.p4
+++ b/testdata/p4_14_samples_outputs/miss-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/miss-midend.p4
+++ b/testdata/p4_14_samples_outputs/miss-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/miss.p4
+++ b/testdata/p4_14_samples_outputs/miss.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/modify_conditionally-first.p4
+++ b/testdata/p4_14_samples_outputs/modify_conditionally-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_global_t {

--- a/testdata/p4_14_samples_outputs/modify_conditionally-frontend.p4
+++ b/testdata/p4_14_samples_outputs/modify_conditionally-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_global_t {

--- a/testdata/p4_14_samples_outputs/modify_conditionally-midend.p4
+++ b/testdata/p4_14_samples_outputs/modify_conditionally-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_global_t {

--- a/testdata/p4_14_samples_outputs/modify_conditionally.p4
+++ b/testdata/p4_14_samples_outputs/modify_conditionally.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_global_t {

--- a/testdata/p4_14_samples_outputs/name_collision-first.p4
+++ b/testdata/p4_14_samples_outputs/name_collision-first.p4
@@ -34,7 +34,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".B") counter(32w1024, CounterType.packets_and_bytes) B_1;
+@name(".B") counter<bit<10>>(32w1024, CounterType.packets_and_bytes) B_1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".A") action A_3(bit<8> val, bit<9> port, bit<10> idx) {
@@ -45,7 +45,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".noop") action noop() {
     }
     @name(".B") action B_2() {
-        B_1.count((bit<32>)meta.meta.B);
+        B_1.count(meta.meta.B);
     }
     @name(".A") table A_4 {
         actions = {

--- a/testdata/p4_14_samples_outputs/name_collision-first.p4
+++ b/testdata/p4_14_samples_outputs/name_collision-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct B {

--- a/testdata/p4_14_samples_outputs/name_collision-frontend.p4
+++ b/testdata/p4_14_samples_outputs/name_collision-frontend.p4
@@ -34,7 +34,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".B") counter(32w1024, CounterType.packets_and_bytes) B_1;
+@name(".B") counter<bit<10>>(32w1024, CounterType.packets_and_bytes) B_1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -47,7 +47,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".noop") action noop() {
     }
     @name(".B") action B_2() {
-        B_1.count((bit<32>)meta.meta.B);
+        B_1.count(meta.meta.B);
     }
     @name(".A") table A_3 {
         actions = {

--- a/testdata/p4_14_samples_outputs/name_collision-frontend.p4
+++ b/testdata/p4_14_samples_outputs/name_collision-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct B {

--- a/testdata/p4_14_samples_outputs/name_collision-midend.p4
+++ b/testdata/p4_14_samples_outputs/name_collision-midend.p4
@@ -34,7 +34,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".B") counter(32w1024, CounterType.packets_and_bytes) B_1;
+@name(".B") counter<bit<10>>(32w1024, CounterType.packets_and_bytes) B_1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
@@ -47,7 +47,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".noop") action noop() {
     }
     @name(".B") action B_2() {
-        B_1.count((bit<32>)meta._meta_B1);
+        B_1.count(meta._meta_B1);
     }
     @name(".A") table A_3 {
         actions = {

--- a/testdata/p4_14_samples_outputs/name_collision-midend.p4
+++ b/testdata/p4_14_samples_outputs/name_collision-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct B {

--- a/testdata/p4_14_samples_outputs/name_collision.p4
+++ b/testdata/p4_14_samples_outputs/name_collision.p4
@@ -45,7 +45,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".noop") action noop() {
     }
     @name(".B") action B_2() {
-        B_1.count((bit<32>)(bit<32>)meta.meta.B);
+        B_1.count((bit<32>)meta.meta.B);
     }
     @name(".A") table A_4 {
         actions = {

--- a/testdata/p4_14_samples_outputs/name_collision.p4
+++ b/testdata/p4_14_samples_outputs/name_collision.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct B {

--- a/testdata/p4_14_samples_outputs/name_collision.p4
+++ b/testdata/p4_14_samples_outputs/name_collision.p4
@@ -34,7 +34,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
 }
 
-@name(".B") counter(32w1024, CounterType.packets_and_bytes) B_1;
+@name(".B") counter<bit<10>>(32w1024, CounterType.packets_and_bytes) B_1;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".A") action A_3(bit<8> val, bit<9> port, bit<10> idx) {
@@ -45,7 +45,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".noop") action noop() {
     }
     @name(".B") action B_2() {
-        B_1.count((bit<32>)meta.meta.B);
+        B_1.count((bit<10>)meta.meta.B);
     }
     @name(".A") table A_4 {
         actions = {

--- a/testdata/p4_14_samples_outputs/overflow-first.p4
+++ b/testdata/p4_14_samples_outputs/overflow-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/overflow-frontend.p4
+++ b/testdata/p4_14_samples_outputs/overflow-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/overflow-midend.p4
+++ b/testdata/p4_14_samples_outputs/overflow-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/overflow.p4
+++ b/testdata/p4_14_samples_outputs/overflow.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-first.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-midend.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-3-bmv2-first.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-3-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-3-bmv2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-3-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-3-bmv2-midend.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-3-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-3-bmv2.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-3-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-first.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-frontend.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops-midend.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/p414-special-ops.p4
+++ b/testdata/p4_14_samples_outputs/p414-special-ops.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/packet_redirect-first.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/packet_redirect.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/parser-exception-first.p4
+++ b/testdata/p4_14_samples_outputs/parser-exception-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser-exception-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser-exception-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser-exception-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser-exception-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser-exception.p4
+++ b/testdata/p4_14_samples_outputs/parser-exception.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser1-first.p4
+++ b/testdata/p4_14_samples_outputs/parser1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser1-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser1.p4
+++ b/testdata/p4_14_samples_outputs/parser1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser2-first.p4
+++ b/testdata/p4_14_samples_outputs/parser2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser2-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser2.p4
+++ b/testdata/p4_14_samples_outputs/parser2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser3-first.p4
+++ b/testdata/p4_14_samples_outputs/parser3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data1_t {

--- a/testdata/p4_14_samples_outputs/parser3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data1_t {

--- a/testdata/p4_14_samples_outputs/parser3-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data1_t {

--- a/testdata/p4_14_samples_outputs/parser3.p4
+++ b/testdata/p4_14_samples_outputs/parser3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data1_t {

--- a/testdata/p4_14_samples_outputs/parser4-first.p4
+++ b/testdata/p4_14_samples_outputs/parser4-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser4-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser4-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser4-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser4.p4
+++ b/testdata/p4_14_samples_outputs/parser4.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_dc_full-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header arp_rarp_t {

--- a/testdata/p4_14_samples_outputs/parser_dc_full-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header arp_rarp_t {

--- a/testdata/p4_14_samples_outputs/parser_dc_full-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header arp_rarp_t {

--- a/testdata/p4_14_samples_outputs/parser_dc_full.p4
+++ b/testdata/p4_14_samples_outputs/parser_dc_full.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header arp_rarp_t {

--- a/testdata/p4_14_samples_outputs/parser_pragma-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-first.p4
@@ -5,6 +5,7 @@
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser_pragma-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-frontend.p4
@@ -5,6 +5,7 @@
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser_pragma-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser_pragma.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma.p4
@@ -5,6 +5,7 @@
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser_pragma2-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2-first.p4
@@ -5,6 +5,7 @@
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser_pragma2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2-frontend.p4
@@ -5,6 +5,7 @@
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser_pragma2-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser_pragma2.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2.p4
@@ -5,6 +5,7 @@
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_14_samples_outputs/parser_value_set0-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set0-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set0-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set0.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set0.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set1-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set1-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set1.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set2-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set2-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/parser_value_set2.p4
+++ b/testdata/p4_14_samples_outputs/parser_value_set2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-first.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-frontend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/queueing-first.p4
+++ b/testdata/p4_14_samples_outputs/queueing-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct queueing_metadata_t {

--- a/testdata/p4_14_samples_outputs/queueing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct queueing_metadata_t {

--- a/testdata/p4_14_samples_outputs/queueing-midend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct queueing_metadata_t {

--- a/testdata/p4_14_samples_outputs/queueing.p4
+++ b/testdata/p4_14_samples_outputs/queueing.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct queueing_metadata_t {

--- a/testdata/p4_14_samples_outputs/register-first.p4
+++ b/testdata/p4_14_samples_outputs/register-first.p4
@@ -41,11 +41,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_register") register<bit<32>>(32w16384) my_register;
+@name(".my_register") register<bit<32>, bit<14>>(32w16384) my_register;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".m_action") action m_action(bit<14> register_idx) {
-        my_register.read(meta.meta.register_tmp, (bit<32>)register_idx);
+        my_register.read(meta.meta.register_tmp, register_idx);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/register-first.p4
+++ b/testdata/p4_14_samples_outputs/register-first.p4
@@ -44,7 +44,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 @name(".my_register") register<bit<32>>(32w16384) my_register;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".m_action") action m_action(bit<8> register_idx) {
+    @name(".m_action") action m_action(bit<14> register_idx) {
         my_register.read(meta.meta.register_tmp, (bit<32>)register_idx);
     }
     @name("._nop") action _nop() {

--- a/testdata/p4_14_samples_outputs/register-first.p4
+++ b/testdata/p4_14_samples_outputs/register-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/register-frontend.p4
+++ b/testdata/p4_14_samples_outputs/register-frontend.p4
@@ -41,13 +41,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_register") register<bit<32>>(32w16384) my_register;
+@name(".my_register") register<bit<32>, bit<14>>(32w16384) my_register;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".m_action") action m_action(bit<14> register_idx) {
-        my_register.read(meta.meta.register_tmp, (bit<32>)register_idx);
+        my_register.read(meta.meta.register_tmp, register_idx);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/register-frontend.p4
+++ b/testdata/p4_14_samples_outputs/register-frontend.p4
@@ -46,7 +46,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".m_action") action m_action(bit<8> register_idx) {
+    @name(".m_action") action m_action(bit<14> register_idx) {
         my_register.read(meta.meta.register_tmp, (bit<32>)register_idx);
     }
     @name("._nop") action _nop() {

--- a/testdata/p4_14_samples_outputs/register-frontend.p4
+++ b/testdata/p4_14_samples_outputs/register-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/register-midend.p4
+++ b/testdata/p4_14_samples_outputs/register-midend.p4
@@ -40,13 +40,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_register") register<bit<32>>(32w16384) my_register;
+@name(".my_register") register<bit<32>, bit<14>>(32w16384) my_register;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".m_action") action m_action(bit<14> register_idx) {
-        my_register.read(meta._meta_register_tmp0, (bit<32>)register_idx);
+        my_register.read(meta._meta_register_tmp0, register_idx);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/register-midend.p4
+++ b/testdata/p4_14_samples_outputs/register-midend.p4
@@ -45,7 +45,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".m_action") action m_action(bit<8> register_idx) {
+    @name(".m_action") action m_action(bit<14> register_idx) {
         my_register.read(meta._meta_register_tmp0, (bit<32>)register_idx);
     }
     @name("._nop") action _nop() {

--- a/testdata/p4_14_samples_outputs/register-midend.p4
+++ b/testdata/p4_14_samples_outputs/register-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/register.p4
+++ b/testdata/p4_14_samples_outputs/register.p4
@@ -41,11 +41,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".my_register") register<bit<32>>(32w16384) my_register;
+@name(".my_register") register<bit<32>, bit<14>>(32w16384) my_register;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".m_action") action m_action(bit<14> register_idx) {
-        my_register.read(meta.meta.register_tmp, (bit<32>)register_idx);
+        my_register.read(meta.meta.register_tmp, (bit<14>)register_idx);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/register.p4
+++ b/testdata/p4_14_samples_outputs/register.p4
@@ -44,7 +44,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 @name(".my_register") register<bit<32>>(32w16384) my_register;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".m_action") action m_action(bit<8> register_idx) {
+    @name(".m_action") action m_action(bit<14> register_idx) {
         my_register.read(meta.meta.register_tmp, (bit<32>)register_idx);
     }
     @name("._nop") action _nop() {

--- a/testdata/p4_14_samples_outputs/register.p4
+++ b/testdata/p4_14_samples_outputs/register.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/register.p4-stderr
+++ b/testdata/p4_14_samples_outputs/register.p4-stderr
@@ -1,3 +1,0 @@
-register.p4(65): [--Wwarn=type-inference] warning: Could not infer type for register_idx, using bit<8>
-action m_action(register_idx) {
-                ^^^^^^^^^^^^

--- a/testdata/p4_14_samples_outputs/repeater-first.p4
+++ b/testdata/p4_14_samples_outputs/repeater-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/repeater-frontend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/repeater-midend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/repeater.p4
+++ b/testdata/p4_14_samples_outputs/repeater.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/resubmit-first.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/resubmit-frontend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/resubmit-midend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/resubmit.p4
+++ b/testdata/p4_14_samples_outputs/resubmit.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/sai_p4-first.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct egress_metadata_t {

--- a/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct egress_metadata_t {

--- a/testdata/p4_14_samples_outputs/sai_p4-midend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct egress_metadata_t {

--- a/testdata/p4_14_samples_outputs/sai_p4.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct egress_metadata_t {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("hdr") header hdr_0 {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("hdr") header hdr_0 {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("hdr") header hdr_0 {

--- a/testdata/p4_14_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_14_samples_outputs/saturated-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 @name("hdr") header hdr_0 {

--- a/testdata/p4_14_samples_outputs/selector0-first.p4
+++ b/testdata/p4_14_samples_outputs/selector0-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector0-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector0-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector0-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector0-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector0.p4
+++ b/testdata/p4_14_samples_outputs/selector0.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector1-first.p4
+++ b/testdata/p4_14_samples_outputs/selector1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector1-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector1.p4
+++ b/testdata/p4_14_samples_outputs/selector1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector2-first.p4
+++ b/testdata/p4_14_samples_outputs/selector2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector2-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector2.p4
+++ b/testdata/p4_14_samples_outputs/selector2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector3-first.p4
+++ b/testdata/p4_14_samples_outputs/selector3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector3-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/selector3.p4
+++ b/testdata/p4_14_samples_outputs/selector3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/simple_nat-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/simple_nat-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/simple_nat.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct intrinsic_metadata_t {

--- a/testdata/p4_14_samples_outputs/simple_router-first.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_14_samples_outputs/simple_router-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_14_samples_outputs/simple_router-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_14_samples_outputs/simple_router.p4
+++ b/testdata/p4_14_samples_outputs/simple_router.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_14_samples_outputs/source_routing-first.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header easyroute_head_t {

--- a/testdata/p4_14_samples_outputs/source_routing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header easyroute_head_t {

--- a/testdata/p4_14_samples_outputs/source_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/source_routing-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header easyroute_head_t {

--- a/testdata/p4_14_samples_outputs/source_routing.p4
+++ b/testdata/p4_14_samples_outputs/source_routing.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header easyroute_head_t {

--- a/testdata/p4_14_samples_outputs/swap_1-first.p4
+++ b/testdata/p4_14_samples_outputs/swap_1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr1_t {

--- a/testdata/p4_14_samples_outputs/swap_1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/swap_1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr1_t {

--- a/testdata/p4_14_samples_outputs/swap_1-midend.p4
+++ b/testdata/p4_14_samples_outputs/swap_1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr1_t {

--- a/testdata/p4_14_samples_outputs/swap_1.p4
+++ b/testdata/p4_14_samples_outputs/swap_1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr1_t {

--- a/testdata/p4_14_samples_outputs/swap_2-first.p4
+++ b/testdata/p4_14_samples_outputs/swap_2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr2_t {

--- a/testdata/p4_14_samples_outputs/swap_2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/swap_2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr2_t {

--- a/testdata/p4_14_samples_outputs/swap_2-midend.p4
+++ b/testdata/p4_14_samples_outputs/swap_2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr2_t {

--- a/testdata/p4_14_samples_outputs/swap_2.p4
+++ b/testdata/p4_14_samples_outputs/swap_2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdr2_t {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -4347,9 +4347,9 @@ control process_ingress_sflow(inout headers hdr, inout metadata meta, inout stan
 control process_storm_control(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".nop") action nop() {
     }
-    @name(".set_storm_control_meter") action set_storm_control_meter(bit<32> meter_idx) {
-        storm_control_meter.execute_meter<bit<2>>(meter_idx, meta.meter_metadata.meter_color);
-        meta.meter_metadata.meter_index = (bit<16>)meter_idx;
+    @name(".set_storm_control_meter") action set_storm_control_meter(bit<16> meter_idx) {
+        storm_control_meter.execute_meter<bit<2>>((bit<32>)(bit<10>)meter_idx, meta.meter_metadata.meter_color);
+        meta.meter_metadata.meter_index = meter_idx;
     }
     @name(".storm_control") table storm_control {
         actions = {
@@ -5500,7 +5500,7 @@ control process_meter_action(inout headers hdr, inout metadata meta, inout stand
 
 control process_ingress_bd_stats(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".update_ingress_bd_stats") action update_ingress_bd_stats() {
-        ingress_bd_stats_count.count((bit<32>)meta.l2_metadata.bd_stats_idx);
+        ingress_bd_stats_count.count((bit<32>)(bit<10>)meta.l2_metadata.bd_stats_idx);
     }
     @name(".ingress_bd_stats") table ingress_bd_stats {
         actions = {
@@ -5519,7 +5519,7 @@ control process_ingress_bd_stats(inout headers hdr, inout metadata meta, inout s
 
 control process_ingress_acl_stats(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".acl_stats_update") action acl_stats_update() {
-        acl_stats_count.count((bit<32>)meta.acl_metadata.acl_stats_index);
+        acl_stats_count.count((bit<32>)(bit<10>)meta.acl_metadata.acl_stats_index);
     }
     @name(".acl_stats") table acl_stats {
         actions = {
@@ -5845,7 +5845,7 @@ control process_fabric_lag(inout headers hdr, inout metadata meta, inout standar
 
 control process_system_acl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".drop_stats_update") action drop_stats_update() {
-        drop_stats_2.count((bit<32>)meta.ingress_metadata.drop_reason);
+        drop_stats_2.count((bit<32>)(bit<10>)meta.ingress_metadata.drop_reason);
     }
     @name(".nop") action nop() {
     }
@@ -5864,8 +5864,8 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     @name(".drop_packet") action drop_packet() {
         mark_to_drop(standard_metadata);
     }
-    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
-        drop_stats.count(drop_reason);
+    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<10> drop_reason) {
+        drop_stats.count((bit<32>)drop_reason);
         mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct acl_metadata_t {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -4342,13 +4342,13 @@ control process_ingress_sflow(inout headers hdr, inout metadata meta, inout stan
     }
 }
 
-@name(".storm_control_meter") meter(32w1024, MeterType.bytes) storm_control_meter;
+@name(".storm_control_meter") meter<bit<10>>(32w1024, MeterType.bytes) storm_control_meter;
 
 control process_storm_control(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".nop") action nop() {
     }
     @name(".set_storm_control_meter") action set_storm_control_meter(bit<16> meter_idx) {
-        storm_control_meter.execute_meter<bit<2>>((bit<32>)(bit<10>)meter_idx, meta.meter_metadata.meter_color);
+        storm_control_meter.execute_meter<bit<2>>((bit<10>)meter_idx, meta.meter_metadata.meter_color);
         meta.meter_metadata.meter_index = meter_idx;
     }
     @name(".storm_control") table storm_control {
@@ -5496,11 +5496,11 @@ control process_meter_action(inout headers hdr, inout metadata meta, inout stand
     }
 }
 
-@name(".ingress_bd_stats_count") @min_width(32) counter(32w1024, CounterType.packets_and_bytes) ingress_bd_stats_count;
+@name(".ingress_bd_stats_count") @min_width(32) counter<bit<10>>(32w1024, CounterType.packets_and_bytes) ingress_bd_stats_count;
 
 control process_ingress_bd_stats(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".update_ingress_bd_stats") action update_ingress_bd_stats() {
-        ingress_bd_stats_count.count((bit<32>)(bit<10>)meta.l2_metadata.bd_stats_idx);
+        ingress_bd_stats_count.count((bit<10>)meta.l2_metadata.bd_stats_idx);
     }
     @name(".ingress_bd_stats") table ingress_bd_stats {
         actions = {
@@ -5515,11 +5515,11 @@ control process_ingress_bd_stats(inout headers hdr, inout metadata meta, inout s
     }
 }
 
-@name(".acl_stats_count") @min_width(16) counter(32w1024, CounterType.packets_and_bytes) acl_stats_count;
+@name(".acl_stats_count") @min_width(16) counter<bit<10>>(32w1024, CounterType.packets_and_bytes) acl_stats_count;
 
 control process_ingress_acl_stats(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".acl_stats_update") action acl_stats_update() {
-        acl_stats_count.count((bit<32>)(bit<10>)meta.acl_metadata.acl_stats_index);
+        acl_stats_count.count((bit<10>)meta.acl_metadata.acl_stats_index);
     }
     @name(".acl_stats") table acl_stats {
         actions = {
@@ -5839,13 +5839,13 @@ control process_fabric_lag(inout headers hdr, inout metadata meta, inout standar
     }
 }
 
-@name(".drop_stats") counter(32w1024, CounterType.packets) drop_stats;
+@name(".drop_stats") counter<bit<10>>(32w1024, CounterType.packets) drop_stats;
 
-@name(".drop_stats_2") counter(32w1024, CounterType.packets) drop_stats_2;
+@name(".drop_stats_2") counter<bit<10>>(32w1024, CounterType.packets) drop_stats_2;
 
 control process_system_acl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".drop_stats_update") action drop_stats_update() {
-        drop_stats_2.count((bit<32>)(bit<10>)meta.ingress_metadata.drop_reason);
+        drop_stats_2.count((bit<10>)meta.ingress_metadata.drop_reason);
     }
     @name(".nop") action nop() {
     }
@@ -5865,7 +5865,7 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
         mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<10> drop_reason) {
-        drop_stats.count((bit<32>)drop_reason);
+        drop_stats.count(drop_reason);
         mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -4358,9 +4358,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_70() {
     }
-    @name(".set_storm_control_meter") action _set_storm_control_meter_0(bit<32> meter_idx) {
-        storm_control_meter.execute_meter<bit<2>>(meter_idx, meta.meter_metadata.meter_color);
-        meta.meter_metadata.meter_index = (bit<16>)meter_idx;
+    @name(".set_storm_control_meter") action _set_storm_control_meter_0(bit<16> meter_idx) {
+        storm_control_meter.execute_meter<bit<2>>((bit<32>)(bit<10>)meter_idx, meta.meter_metadata.meter_color);
+        meta.meter_metadata.meter_index = meter_idx;
     }
     @name(".storm_control") table _storm_control {
         actions = {
@@ -5309,7 +5309,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_213();
     }
     @name(".update_ingress_bd_stats") action _update_ingress_bd_stats_0() {
-        ingress_bd_stats_count.count((bit<32>)meta.l2_metadata.bd_stats_idx);
+        ingress_bd_stats_count.count((bit<32>)(bit<10>)meta.l2_metadata.bd_stats_idx);
     }
     @name(".ingress_bd_stats") table _ingress_bd_stats {
         actions = {
@@ -5320,7 +5320,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_214();
     }
     @name(".acl_stats_update") action _acl_stats_update_0() {
-        acl_stats_count.count((bit<32>)meta.acl_metadata.acl_stats_index);
+        acl_stats_count.count((bit<32>)(bit<10>)meta.acl_metadata.acl_stats_index);
     }
     @name(".acl_stats") table _acl_stats {
         actions = {
@@ -5580,7 +5580,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_223();
     }
     @name(".drop_stats_update") action _drop_stats_update_0() {
-        drop_stats_2.count((bit<32>)meta.ingress_metadata.drop_reason);
+        drop_stats_2.count((bit<32>)(bit<10>)meta.ingress_metadata.drop_reason);
     }
     @name(".nop") action _nop_108() {
     }
@@ -5600,8 +5600,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".drop_packet") action _drop_packet_0() {
         mark_to_drop(standard_metadata);
     }
-    @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<32> drop_reason) {
-        drop_stats.count(drop_reason);
+    @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<10> drop_reason) {
+        drop_stats.count((bit<32>)drop_reason);
         mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct acl_metadata_t {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -3135,11 +3135,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".storm_control_meter") meter(32w1024, MeterType.bytes) storm_control_meter;
+@name(".storm_control_meter") meter<bit<10>>(32w1024, MeterType.bytes) storm_control_meter;
 
-@name(".ingress_bd_stats_count") @min_width(32) counter(32w1024, CounterType.packets_and_bytes) ingress_bd_stats_count;
+@name(".ingress_bd_stats_count") @min_width(32) counter<bit<10>>(32w1024, CounterType.packets_and_bytes) ingress_bd_stats_count;
 
-@name(".acl_stats_count") @min_width(16) counter(32w1024, CounterType.packets_and_bytes) acl_stats_count;
+@name(".acl_stats_count") @min_width(16) counter<bit<10>>(32w1024, CounterType.packets_and_bytes) acl_stats_count;
 
 @name("mac_learn_digest") struct mac_learn_digest {
     bit<16> bd;
@@ -3147,9 +3147,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     bit<16> ifindex;
 }
 
-@name(".drop_stats") counter(32w1024, CounterType.packets) drop_stats;
+@name(".drop_stats") counter<bit<10>>(32w1024, CounterType.packets) drop_stats;
 
-@name(".drop_stats_2") counter(32w1024, CounterType.packets) drop_stats_2;
+@name(".drop_stats_2") counter<bit<10>>(32w1024, CounterType.packets) drop_stats_2;
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_148() {
@@ -4359,7 +4359,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_70() {
     }
     @name(".set_storm_control_meter") action _set_storm_control_meter_0(bit<16> meter_idx) {
-        storm_control_meter.execute_meter<bit<2>>((bit<32>)(bit<10>)meter_idx, meta.meter_metadata.meter_color);
+        storm_control_meter.execute_meter<bit<2>>((bit<10>)meter_idx, meta.meter_metadata.meter_color);
         meta.meter_metadata.meter_index = meter_idx;
     }
     @name(".storm_control") table _storm_control {
@@ -5309,7 +5309,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_213();
     }
     @name(".update_ingress_bd_stats") action _update_ingress_bd_stats_0() {
-        ingress_bd_stats_count.count((bit<32>)(bit<10>)meta.l2_metadata.bd_stats_idx);
+        ingress_bd_stats_count.count((bit<10>)meta.l2_metadata.bd_stats_idx);
     }
     @name(".ingress_bd_stats") table _ingress_bd_stats {
         actions = {
@@ -5320,7 +5320,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_214();
     }
     @name(".acl_stats_update") action _acl_stats_update_0() {
-        acl_stats_count.count((bit<32>)(bit<10>)meta.acl_metadata.acl_stats_index);
+        acl_stats_count.count((bit<10>)meta.acl_metadata.acl_stats_index);
     }
     @name(".acl_stats") table _acl_stats {
         actions = {
@@ -5580,7 +5580,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_223();
     }
     @name(".drop_stats_update") action _drop_stats_update_0() {
-        drop_stats_2.count((bit<32>)(bit<10>)meta.ingress_metadata.drop_reason);
+        drop_stats_2.count((bit<10>)meta.ingress_metadata.drop_reason);
     }
     @name(".nop") action _nop_108() {
     }
@@ -5601,7 +5601,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<10> drop_reason) {
-        drop_stats.count((bit<32>)drop_reason);
+        drop_stats.count(drop_reason);
         mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -3252,11 +3252,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
 }
 
-@name(".storm_control_meter") meter(32w1024, MeterType.bytes) storm_control_meter;
+@name(".storm_control_meter") meter<bit<10>>(32w1024, MeterType.bytes) storm_control_meter;
 
-@name(".ingress_bd_stats_count") @min_width(32) counter(32w1024, CounterType.packets_and_bytes) ingress_bd_stats_count;
+@name(".ingress_bd_stats_count") @min_width(32) counter<bit<10>>(32w1024, CounterType.packets_and_bytes) ingress_bd_stats_count;
 
-@name(".acl_stats_count") @min_width(16) counter(32w1024, CounterType.packets_and_bytes) acl_stats_count;
+@name(".acl_stats_count") @min_width(16) counter<bit<10>>(32w1024, CounterType.packets_and_bytes) acl_stats_count;
 
 @name("mac_learn_digest") struct mac_learn_digest {
     bit<16> bd;
@@ -3264,9 +3264,9 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     bit<16> ifindex;
 }
 
-@name(".drop_stats") counter(32w1024, CounterType.packets) drop_stats;
+@name(".drop_stats") counter<bit<10>>(32w1024, CounterType.packets) drop_stats;
 
-@name(".drop_stats_2") counter(32w1024, CounterType.packets) drop_stats_2;
+@name(".drop_stats_2") counter<bit<10>>(32w1024, CounterType.packets) drop_stats_2;
 
 struct tuple_2 {
     bit<1>  field_5;
@@ -4535,7 +4535,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".nop") action _nop_70() {
     }
     @name(".set_storm_control_meter") action _set_storm_control_meter_0(bit<16> meter_idx) {
-        storm_control_meter.execute_meter<bit<2>>((bit<32>)(bit<10>)meter_idx, meta._meter_metadata_meter_color106);
+        storm_control_meter.execute_meter<bit<2>>((bit<10>)meter_idx, meta._meter_metadata_meter_color106);
         meta._meter_metadata_meter_index107 = meter_idx;
     }
     @name(".storm_control") table _storm_control {
@@ -5485,7 +5485,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_213();
     }
     @name(".update_ingress_bd_stats") action _update_ingress_bd_stats_0() {
-        ingress_bd_stats_count.count((bit<32>)(bit<10>)meta._l2_metadata_bd_stats_idx76);
+        ingress_bd_stats_count.count((bit<10>)meta._l2_metadata_bd_stats_idx76);
     }
     @name(".ingress_bd_stats") table _ingress_bd_stats {
         actions = {
@@ -5496,7 +5496,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_214();
     }
     @name(".acl_stats_update") action _acl_stats_update_0() {
-        acl_stats_count.count((bit<32>)(bit<10>)meta._acl_metadata_acl_stats_index11);
+        acl_stats_count.count((bit<10>)meta._acl_metadata_acl_stats_index11);
     }
     @name(".acl_stats") table _acl_stats {
         actions = {
@@ -5756,7 +5756,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_223();
     }
     @name(".drop_stats_update") action _drop_stats_update_0() {
-        drop_stats_2.count((bit<32>)(bit<10>)meta._ingress_metadata_drop_reason44);
+        drop_stats_2.count((bit<10>)meta._ingress_metadata_drop_reason44);
     }
     @name(".nop") action _nop_108() {
     }
@@ -5777,7 +5777,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<10> drop_reason) {
-        drop_stats.count((bit<32>)drop_reason);
+        drop_stats.count(drop_reason);
         mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct acl_metadata_t {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -4534,9 +4534,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_70() {
     }
-    @name(".set_storm_control_meter") action _set_storm_control_meter_0(bit<32> meter_idx) {
-        storm_control_meter.execute_meter<bit<2>>(meter_idx, meta._meter_metadata_meter_color106);
-        meta._meter_metadata_meter_index107 = (bit<16>)meter_idx;
+    @name(".set_storm_control_meter") action _set_storm_control_meter_0(bit<16> meter_idx) {
+        storm_control_meter.execute_meter<bit<2>>((bit<32>)(bit<10>)meter_idx, meta._meter_metadata_meter_color106);
+        meta._meter_metadata_meter_index107 = meter_idx;
     }
     @name(".storm_control") table _storm_control {
         actions = {
@@ -5485,7 +5485,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_213();
     }
     @name(".update_ingress_bd_stats") action _update_ingress_bd_stats_0() {
-        ingress_bd_stats_count.count((bit<32>)meta._l2_metadata_bd_stats_idx76);
+        ingress_bd_stats_count.count((bit<32>)(bit<10>)meta._l2_metadata_bd_stats_idx76);
     }
     @name(".ingress_bd_stats") table _ingress_bd_stats {
         actions = {
@@ -5496,7 +5496,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_214();
     }
     @name(".acl_stats_update") action _acl_stats_update_0() {
-        acl_stats_count.count((bit<32>)meta._acl_metadata_acl_stats_index11);
+        acl_stats_count.count((bit<32>)(bit<10>)meta._acl_metadata_acl_stats_index11);
     }
     @name(".acl_stats") table _acl_stats {
         actions = {
@@ -5756,7 +5756,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_223();
     }
     @name(".drop_stats_update") action _drop_stats_update_0() {
-        drop_stats_2.count((bit<32>)meta._ingress_metadata_drop_reason44);
+        drop_stats_2.count((bit<32>)(bit<10>)meta._ingress_metadata_drop_reason44);
     }
     @name(".nop") action _nop_108() {
     }
@@ -5776,8 +5776,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".drop_packet") action _drop_packet_0() {
         mark_to_drop(standard_metadata);
     }
-    @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<32> drop_reason) {
-        drop_stats.count(drop_reason);
+    @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<10> drop_reason) {
+        drop_stats.count((bit<32>)drop_reason);
         mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -4214,13 +4214,13 @@ control process_ingress_sflow(inout headers hdr, inout metadata meta, inout stan
     }
 }
 
-@name(".storm_control_meter") meter(32w1024, MeterType.bytes) storm_control_meter;
+@name(".storm_control_meter") meter<bit<10>>(32w1024, MeterType.bytes) storm_control_meter;
 
 control process_storm_control(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".nop") action nop() {
     }
     @name(".set_storm_control_meter") action set_storm_control_meter(bit<16> meter_idx) {
-        storm_control_meter.execute_meter((bit<32>)(bit<10>)meter_idx, meta.meter_metadata.meter_color);
+        storm_control_meter.execute_meter((bit<10>)(bit<10>)meter_idx, meta.meter_metadata.meter_color);
         meta.meter_metadata.meter_index = meter_idx;
     }
     @name(".storm_control") table storm_control {
@@ -5292,11 +5292,11 @@ control process_meter_action(inout headers hdr, inout metadata meta, inout stand
     }
 }
 
-@name(".ingress_bd_stats_count") @min_width(32) counter(32w1024, CounterType.packets_and_bytes) ingress_bd_stats_count;
+@name(".ingress_bd_stats_count") @min_width(32) counter<bit<10>>(32w1024, CounterType.packets_and_bytes) ingress_bd_stats_count;
 
 control process_ingress_bd_stats(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".update_ingress_bd_stats") action update_ingress_bd_stats() {
-        ingress_bd_stats_count.count((bit<32>)(bit<10>)meta.l2_metadata.bd_stats_idx);
+        ingress_bd_stats_count.count((bit<10>)(bit<10>)meta.l2_metadata.bd_stats_idx);
     }
     @name(".ingress_bd_stats") table ingress_bd_stats {
         actions = {
@@ -5309,11 +5309,11 @@ control process_ingress_bd_stats(inout headers hdr, inout metadata meta, inout s
     }
 }
 
-@name(".acl_stats_count") @min_width(16) counter(32w1024, CounterType.packets_and_bytes) acl_stats_count;
+@name(".acl_stats_count") @min_width(16) counter<bit<10>>(32w1024, CounterType.packets_and_bytes) acl_stats_count;
 
 control process_ingress_acl_stats(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".acl_stats_update") action acl_stats_update() {
-        acl_stats_count.count((bit<32>)(bit<10>)meta.acl_metadata.acl_stats_index);
+        acl_stats_count.count((bit<10>)(bit<10>)meta.acl_metadata.acl_stats_index);
     }
     @name(".acl_stats") table acl_stats {
         actions = {
@@ -5615,13 +5615,13 @@ control process_fabric_lag(inout headers hdr, inout metadata meta, inout standar
     }
 }
 
-@name(".drop_stats") counter(32w1024, CounterType.packets) drop_stats;
+@name(".drop_stats") counter<bit<10>>(32w1024, CounterType.packets) drop_stats;
 
-@name(".drop_stats_2") counter(32w1024, CounterType.packets) drop_stats_2;
+@name(".drop_stats_2") counter<bit<10>>(32w1024, CounterType.packets) drop_stats_2;
 
 control process_system_acl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".drop_stats_update") action drop_stats_update() {
-        drop_stats_2.count((bit<32>)(bit<10>)meta.ingress_metadata.drop_reason);
+        drop_stats_2.count((bit<10>)(bit<10>)meta.ingress_metadata.drop_reason);
     }
     @name(".nop") action nop() {
     }
@@ -5641,7 +5641,7 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
         mark_to_drop(standard_metadata);
     }
     @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<10> drop_reason) {
-        drop_stats.count((bit<32>)drop_reason);
+        drop_stats.count((bit<10>)drop_reason);
         mark_to_drop(standard_metadata);
     }
     @name(".negative_mirror") action negative_mirror(bit<32> session_id) {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -4219,9 +4219,9 @@ control process_ingress_sflow(inout headers hdr, inout metadata meta, inout stan
 control process_storm_control(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".nop") action nop() {
     }
-    @name(".set_storm_control_meter") action set_storm_control_meter(bit<32> meter_idx) {
-        storm_control_meter.execute_meter((bit<32>)meter_idx, meta.meter_metadata.meter_color);
-        meta.meter_metadata.meter_index = (bit<16>)meter_idx;
+    @name(".set_storm_control_meter") action set_storm_control_meter(bit<16> meter_idx) {
+        storm_control_meter.execute_meter((bit<32>)(bit<10>)meter_idx, meta.meter_metadata.meter_color);
+        meta.meter_metadata.meter_index = meter_idx;
     }
     @name(".storm_control") table storm_control {
         actions = {
@@ -5296,7 +5296,7 @@ control process_meter_action(inout headers hdr, inout metadata meta, inout stand
 
 control process_ingress_bd_stats(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".update_ingress_bd_stats") action update_ingress_bd_stats() {
-        ingress_bd_stats_count.count((bit<32>)(bit<32>)meta.l2_metadata.bd_stats_idx);
+        ingress_bd_stats_count.count((bit<32>)(bit<10>)meta.l2_metadata.bd_stats_idx);
     }
     @name(".ingress_bd_stats") table ingress_bd_stats {
         actions = {
@@ -5313,7 +5313,7 @@ control process_ingress_bd_stats(inout headers hdr, inout metadata meta, inout s
 
 control process_ingress_acl_stats(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".acl_stats_update") action acl_stats_update() {
-        acl_stats_count.count((bit<32>)(bit<32>)meta.acl_metadata.acl_stats_index);
+        acl_stats_count.count((bit<32>)(bit<10>)meta.acl_metadata.acl_stats_index);
     }
     @name(".acl_stats") table acl_stats {
         actions = {
@@ -5621,7 +5621,7 @@ control process_fabric_lag(inout headers hdr, inout metadata meta, inout standar
 
 control process_system_acl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name(".drop_stats_update") action drop_stats_update() {
-        drop_stats_2.count((bit<32>)(bit<32>)meta.ingress_metadata.drop_reason);
+        drop_stats_2.count((bit<32>)(bit<10>)meta.ingress_metadata.drop_reason);
     }
     @name(".nop") action nop() {
     }
@@ -5640,7 +5640,7 @@ control process_system_acl(inout headers hdr, inout metadata meta, inout standar
     @name(".drop_packet") action drop_packet() {
         mark_to_drop(standard_metadata);
     }
-    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<32> drop_reason) {
+    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<10> drop_reason) {
         drop_stats.count((bit<32>)drop_reason);
         mark_to_drop(standard_metadata);
     }

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct acl_metadata_t {

--- a/testdata/p4_14_samples_outputs/ternary_match0-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match0-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match0-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match0.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match0.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match1-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match1-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match1.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match2-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match2-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match2.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match3-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match3-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match3.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match4-first.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match4-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/ternary_match4.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-first.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/test_7_storm_control.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-first.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header pkt_t {

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header pkt_t {

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header pkt_t {

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header pkt_t {

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-first.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/testgw-first.p4
+++ b/testdata/p4_14_samples_outputs/testgw-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/testgw-frontend.p4
+++ b/testdata/p4_14_samples_outputs/testgw-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/testgw-midend.p4
+++ b/testdata/p4_14_samples_outputs/testgw-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/testgw.p4
+++ b/testdata/p4_14_samples_outputs/testgw.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tmvalid-first.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tmvalid-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tmvalid-midend.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tmvalid.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2a-first.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2a-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2a-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2a.p4
+++ b/testdata/p4_14_samples_outputs/tp2a.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2b-first.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2b-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2b-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2b.p4
+++ b/testdata/p4_14_samples_outputs/tp2b.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2c-first.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2c-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2c-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp2c.p4
+++ b/testdata/p4_14_samples_outputs/tp2c.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp3a-first.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp3a-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp3a-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/tp3a.p4
+++ b/testdata/p4_14_samples_outputs/tp3a.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header data_t {

--- a/testdata/p4_14_samples_outputs/triv_eth-first.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/triv_eth-frontend.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/triv_eth-midend.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/triv_eth.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/triv_ipv4-first.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/triv_ipv4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/triv_ipv4-midend.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/triv_ipv4.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_14_samples_outputs/truncate-first.p4
+++ b/testdata/p4_14_samples_outputs/truncate-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdrA_t {

--- a/testdata/p4_14_samples_outputs/truncate-frontend.p4
+++ b/testdata/p4_14_samples_outputs/truncate-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdrA_t {

--- a/testdata/p4_14_samples_outputs/truncate-midend.p4
+++ b/testdata/p4_14_samples_outputs/truncate-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdrA_t {

--- a/testdata/p4_14_samples_outputs/truncate.p4
+++ b/testdata/p4_14_samples_outputs/truncate.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 header hdrA_t {

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet-first.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet-frontend.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet-midend.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/validate_outer_ethernet.p4
+++ b/testdata/p4_14_samples_outputs/validate_outer_ethernet.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_14_samples_outputs/wide_action1-first.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/wide_action1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/wide_action1-midend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/wide_action1.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/wide_action3-first.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/wide_action3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/wide_action3-midend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_14_samples_outputs/wide_action3.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20200408
 #include <v1model.p4>
 
 struct metadata_t {

--- a/testdata/p4_16_errors/issue1777-bmv2.p4
+++ b/testdata/p4_16_errors/issue1777-bmv2.p4
@@ -51,19 +51,19 @@ control ingress(inout headers_t hdr,
                 inout metadata_t meta,
                 inout standard_metadata_t stdmeta)
 {
-    register<bit<8>, bit<4>>(16) reg1;
-    register<reg_data2_t, bit<4>>(16) reg2;
+    register<bit<8> >(16) reg1;
+    register<reg_data2_t>(16) reg2;
 
     apply {
         bit<4> reg_idx = hdr.ethernet.dstAddr[3:0];
 
-        reg1.read(meta.reg_data1, reg_idx);
+        reg1.read(meta.reg_data1, (bit<32>) reg_idx);
         meta.reg_data1 = meta.reg_data1 + 1;
-        reg1.write(reg_idx, meta.reg_data1);
+        reg1.write((bit<32>) reg_idx, meta.reg_data1);
 
-        reg2.read(meta.reg_data2, reg_idx);
+        reg2.read(meta.reg_data2, (bit<32>) reg_idx);
         meta.reg_data2.reg_fld1 = meta.reg_data2.reg_fld1 + 1;
-        reg2.write(reg_idx, meta.reg_data2);
+        reg2.write((bit<32>) reg_idx, meta.reg_data2);
     }
 }
 

--- a/testdata/p4_16_errors/issue1777-bmv2.p4
+++ b/testdata/p4_16_errors/issue1777-bmv2.p4
@@ -51,19 +51,19 @@ control ingress(inout headers_t hdr,
                 inout metadata_t meta,
                 inout standard_metadata_t stdmeta)
 {
-    register<bit<8> >(16) reg1;
-    register<reg_data2_t>(16) reg2;
+    register<bit<8>, bit<4>>(16) reg1;
+    register<reg_data2_t, bit<4>>(16) reg2;
 
     apply {
         bit<4> reg_idx = hdr.ethernet.dstAddr[3:0];
 
-        reg1.read(meta.reg_data1, (bit<32>) reg_idx);
+        reg1.read(meta.reg_data1, reg_idx);
         meta.reg_data1 = meta.reg_data1 + 1;
-        reg1.write((bit<32>) reg_idx, meta.reg_data1);
+        reg1.write(reg_idx, meta.reg_data1);
 
-        reg2.read(meta.reg_data2, (bit<32>) reg_idx);
+        reg2.read(meta.reg_data2, reg_idx);
         meta.reg_data2.reg_fld1 = meta.reg_data2.reg_fld1 + 1;
-        reg2.write((bit<32>) reg_idx, meta.reg_data2);
+        reg2.write(reg_idx, meta.reg_data2);
     }
 }
 

--- a/testdata/p4_16_errors/slice_out_of_bound.p4
+++ b/testdata/p4_16_errors/slice_out_of_bound.p4
@@ -73,7 +73,7 @@ control Ing(inout Headers headers,
             inout Metadata meta,
             inout standard_metadata_t standard_meta) {
 
-    register<bit<8>>(32w2) debug;
+    register<bit<8>, bit<1>>(32w2) debug;
 
     apply {
         bit<8> n = 8w0b11111111;

--- a/testdata/p4_16_errors/slice_out_of_bound.p4
+++ b/testdata/p4_16_errors/slice_out_of_bound.p4
@@ -73,7 +73,7 @@ control Ing(inout Headers headers,
             inout Metadata meta,
             inout standard_metadata_t standard_meta) {
 
-    register<bit<8>, bit<1>>(32w2) debug;
+    register<bit<8>>(32w2) debug;
 
     apply {
         bit<8> n = 8w0b11111111;

--- a/testdata/p4_16_errors_outputs/control-inline.p4
+++ b/testdata/p4_16_errors_outputs/control-inline.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_m;

--- a/testdata/p4_16_errors_outputs/issue-2123_e-first.p4
+++ b/testdata/p4_16_errors_outputs/issue-2123_e-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_errors_outputs/issue-2123_e-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue-2123_e-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_errors_outputs/issue-2123_e.p4
+++ b/testdata/p4_16_errors_outputs/issue-2123_e.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_errors_outputs/issue1541.p4
+++ b/testdata/p4_16_errors_outputs/issue1541.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_16_errors_outputs/issue1541.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1541.p4-stderr
@@ -1,7 +1,7 @@
 issue1541.p4(25): [--Wwarn=shadow] warning: hash shadows hash
     action hash() {
            ^^^^
-v1model.p4(404)
+v1model.p4(410)
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
             ^^^^
 issue1541.p4(26): [--Werror=type-error] error: hash: Recursive action call

--- a/testdata/p4_16_errors_outputs/issue1541.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1541.p4-stderr
@@ -1,7 +1,7 @@
 issue1541.p4(25): [--Wwarn=shadow] warning: hash shadows hash
     action hash() {
            ^^^^
-v1model.p4(410)
+v1model.p4(451)
 extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
             ^^^^
 issue1541.p4(26): [--Werror=type-error] error: hash: Recursive action call

--- a/testdata/p4_16_errors_outputs/issue1557-bmv2.p4
+++ b/testdata/p4_16_errors_outputs/issue1557-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_errors_outputs/issue1557-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1557-bmv2.p4-stderr
@@ -1,7 +1,7 @@
 issue1557-bmv2.p4(17): [--Werror=type-error] error: Field drop is not a member of structure struct standard_metadata
     action drop() { smeta.drop = 1; }
                           ^^^^
-v1model.p4(63)
+v1model.p4(65)
 struct standard_metadata_t {
        ^^^^^^^^^^^^^^^^^^^
 issue1557-bmv2.p4(19): [--Werror=type-error] error: idx: parameter should be assigned in call rewrite

--- a/testdata/p4_16_errors_outputs/issue1557-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1557-bmv2.p4-stderr
@@ -1,7 +1,7 @@
 issue1557-bmv2.p4(17): [--Werror=type-error] error: Field drop is not a member of structure struct standard_metadata
     action drop() { smeta.drop = 1; }
                           ^^^^
-v1model.p4(65)
+v1model.p4(71)
 struct standard_metadata_t {
        ^^^^^^^^^^^^^^^^^^^
 issue1557-bmv2.p4(19): [--Werror=type-error] error: idx: parameter should be assigned in call rewrite

--- a/testdata/p4_16_errors_outputs/issue1580.p4
+++ b/testdata/p4_16_errors_outputs/issue1580.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_errors_outputs/issue1777-bmv2-first.p4
+++ b/testdata/p4_16_errors_outputs/issue1777-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {
@@ -28,16 +29,16 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, in
 }
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    register<bit<8>, bit<4>>(32w16) reg1;
-    register<reg_data2_t, bit<4>>(32w16) reg2;
+    register<bit<8>>(32w16) reg1;
+    register<reg_data2_t>(32w16) reg2;
     apply {
         bit<4> reg_idx = hdr.ethernet.dstAddr[3:0];
-        reg1.read(meta.reg_data1, reg_idx);
+        reg1.read(meta.reg_data1, (bit<32>)reg_idx);
         meta.reg_data1 = meta.reg_data1 + 8w1;
-        reg1.write(reg_idx, meta.reg_data1);
-        reg2.read(meta.reg_data2, reg_idx);
+        reg1.write((bit<32>)reg_idx, meta.reg_data1);
+        reg2.read(meta.reg_data2, (bit<32>)reg_idx);
         meta.reg_data2.reg_fld1 = meta.reg_data2.reg_fld1 + 8w1;
-        reg2.write(reg_idx, meta.reg_data2);
+        reg2.write((bit<32>)reg_idx, meta.reg_data2);
     }
 }
 

--- a/testdata/p4_16_errors_outputs/issue1777-bmv2-first.p4
+++ b/testdata/p4_16_errors_outputs/issue1777-bmv2-first.p4
@@ -28,16 +28,16 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, in
 }
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    register<bit<8>>(32w16) reg1;
-    register<reg_data2_t>(32w16) reg2;
+    register<bit<8>, bit<4>>(32w16) reg1;
+    register<reg_data2_t, bit<4>>(32w16) reg2;
     apply {
         bit<4> reg_idx = hdr.ethernet.dstAddr[3:0];
-        reg1.read(meta.reg_data1, (bit<32>)reg_idx);
+        reg1.read(meta.reg_data1, reg_idx);
         meta.reg_data1 = meta.reg_data1 + 8w1;
-        reg1.write((bit<32>)reg_idx, meta.reg_data1);
-        reg2.read(meta.reg_data2, (bit<32>)reg_idx);
+        reg1.write(reg_idx, meta.reg_data1);
+        reg2.read(meta.reg_data2, reg_idx);
         meta.reg_data2.reg_fld1 = meta.reg_data2.reg_fld1 + 8w1;
-        reg2.write((bit<32>)reg_idx, meta.reg_data2);
+        reg2.write(reg_idx, meta.reg_data2);
     }
 }
 

--- a/testdata/p4_16_errors_outputs/issue1777-bmv2-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue1777-bmv2-frontend.p4
@@ -29,16 +29,16 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, in
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
     bit<4> reg_idx_0;
-    @name("ingress.reg1") register<bit<8>>(32w16) reg1_0;
-    @name("ingress.reg2") register<reg_data2_t>(32w16) reg2_0;
+    @name("ingress.reg1") register<bit<8>, bit<4>>(32w16) reg1_0;
+    @name("ingress.reg2") register<reg_data2_t, bit<4>>(32w16) reg2_0;
     apply {
         reg_idx_0 = hdr.ethernet.dstAddr[3:0];
-        reg1_0.read(meta.reg_data1, (bit<32>)reg_idx_0);
+        reg1_0.read(meta.reg_data1, reg_idx_0);
         meta.reg_data1 = meta.reg_data1 + 8w1;
-        reg1_0.write((bit<32>)reg_idx_0, meta.reg_data1);
-        reg2_0.read(meta.reg_data2, (bit<32>)reg_idx_0);
+        reg1_0.write(reg_idx_0, meta.reg_data1);
+        reg2_0.read(meta.reg_data2, reg_idx_0);
         meta.reg_data2.reg_fld1 = meta.reg_data2.reg_fld1 + 8w1;
-        reg2_0.write((bit<32>)reg_idx_0, meta.reg_data2);
+        reg2_0.write(reg_idx_0, meta.reg_data2);
     }
 }
 

--- a/testdata/p4_16_errors_outputs/issue1777-bmv2-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue1777-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {
@@ -29,16 +30,16 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, in
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
     bit<4> reg_idx_0;
-    @name("ingress.reg1") register<bit<8>, bit<4>>(32w16) reg1_0;
-    @name("ingress.reg2") register<reg_data2_t, bit<4>>(32w16) reg2_0;
+    @name("ingress.reg1") register<bit<8>>(32w16) reg1_0;
+    @name("ingress.reg2") register<reg_data2_t>(32w16) reg2_0;
     apply {
         reg_idx_0 = hdr.ethernet.dstAddr[3:0];
-        reg1_0.read(meta.reg_data1, reg_idx_0);
+        reg1_0.read(meta.reg_data1, (bit<32>)reg_idx_0);
         meta.reg_data1 = meta.reg_data1 + 8w1;
-        reg1_0.write(reg_idx_0, meta.reg_data1);
-        reg2_0.read(meta.reg_data2, reg_idx_0);
+        reg1_0.write((bit<32>)reg_idx_0, meta.reg_data1);
+        reg2_0.read(meta.reg_data2, (bit<32>)reg_idx_0);
         meta.reg_data2.reg_fld1 = meta.reg_data2.reg_fld1 + 8w1;
-        reg2_0.write(reg_idx_0, meta.reg_data2);
+        reg2_0.write((bit<32>)reg_idx_0, meta.reg_data2);
     }
 }
 

--- a/testdata/p4_16_errors_outputs/issue1777-bmv2.p4
+++ b/testdata/p4_16_errors_outputs/issue1777-bmv2.p4
@@ -28,16 +28,16 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, in
 }
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    register<bit<8>>(16) reg1;
-    register<reg_data2_t>(16) reg2;
+    register<bit<8>, bit<4>>(16) reg1;
+    register<reg_data2_t, bit<4>>(16) reg2;
     apply {
         bit<4> reg_idx = hdr.ethernet.dstAddr[3:0];
-        reg1.read(meta.reg_data1, (bit<32>)reg_idx);
+        reg1.read(meta.reg_data1, reg_idx);
         meta.reg_data1 = meta.reg_data1 + 1;
-        reg1.write((bit<32>)reg_idx, meta.reg_data1);
-        reg2.read(meta.reg_data2, (bit<32>)reg_idx);
+        reg1.write(reg_idx, meta.reg_data1);
+        reg2.read(meta.reg_data2, reg_idx);
         meta.reg_data2.reg_fld1 = meta.reg_data2.reg_fld1 + 1;
-        reg2.write((bit<32>)reg_idx, meta.reg_data2);
+        reg2.write(reg_idx, meta.reg_data2);
     }
 }
 

--- a/testdata/p4_16_errors_outputs/issue1777-bmv2.p4
+++ b/testdata/p4_16_errors_outputs/issue1777-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {
@@ -28,16 +29,16 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, in
 }
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    register<bit<8>, bit<4>>(16) reg1;
-    register<reg_data2_t, bit<4>>(16) reg2;
+    register<bit<8>>(16) reg1;
+    register<reg_data2_t>(16) reg2;
     apply {
         bit<4> reg_idx = hdr.ethernet.dstAddr[3:0];
-        reg1.read(meta.reg_data1, reg_idx);
+        reg1.read(meta.reg_data1, (bit<32>)reg_idx);
         meta.reg_data1 = meta.reg_data1 + 1;
-        reg1.write(reg_idx, meta.reg_data1);
-        reg2.read(meta.reg_data2, reg_idx);
+        reg1.write((bit<32>)reg_idx, meta.reg_data1);
+        reg2.read(meta.reg_data2, (bit<32>)reg_idx);
         meta.reg_data2.reg_fld1 = meta.reg_data2.reg_fld1 + 1;
-        reg2.write(reg_idx, meta.reg_data2);
+        reg2.write((bit<32>)reg_idx, meta.reg_data2);
     }
 }
 

--- a/testdata/p4_16_errors_outputs/issue1777-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1777-bmv2.p4-stderr
@@ -1,3 +1,3 @@
 issue1777-bmv2.p4(64): [--Werror=unsupported] error: meta.reg_data2: writing to a structure is not supported on this target
-        reg2.read(meta.reg_data2, (bit<32>) reg_idx);
+        reg2.read(meta.reg_data2, reg_idx);
                   ^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue1777-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1777-bmv2.p4-stderr
@@ -1,3 +1,3 @@
 issue1777-bmv2.p4(64): [--Werror=unsupported] error: meta.reg_data2: writing to a structure is not supported on this target
-        reg2.read(meta.reg_data2, reg_idx);
+        reg2.read(meta.reg_data2, (bit<32>) reg_idx);
                   ^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue1803_same_table_name-first.p4
+++ b/testdata/p4_16_errors_outputs/issue1803_same_table_name-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_errors_outputs/issue1803_same_table_name-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue1803_same_table_name-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_errors_outputs/issue1803_same_table_name-midend.p4
+++ b/testdata/p4_16_errors_outputs/issue1803_same_table_name-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_errors_outputs/issue1803_same_table_name.p4
+++ b/testdata/p4_16_errors_outputs/issue1803_same_table_name.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_errors_outputs/issue1932-2.p4
+++ b/testdata/p4_16_errors_outputs/issue1932-2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_errors_outputs/issue2206.p4
+++ b/testdata/p4_16_errors_outputs/issue2206.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_errors_outputs/issue2230-1-bmv2.p4
+++ b/testdata/p4_16_errors_outputs/issue2230-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_errors_outputs/issue2230.p4
+++ b/testdata/p4_16_errors_outputs/issue2230.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_errors_outputs/issue306.p4
+++ b/testdata/p4_16_errors_outputs/issue306.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header instr_h {

--- a/testdata/p4_16_errors_outputs/issue388.p4
+++ b/testdata/p4_16_errors_outputs/issue388.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_16_errors_outputs/issue401.p4
+++ b/testdata/p4_16_errors_outputs/issue401.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_16_errors_outputs/issue413.p4
+++ b/testdata/p4_16_errors_outputs/issue413.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_errors_outputs/issue473.p4
+++ b/testdata/p4_16_errors_outputs/issue473.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_errors_outputs/issue513-first.p4
+++ b/testdata/p4_16_errors_outputs/issue513-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_errors_outputs/issue513-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue513-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_errors_outputs/issue513.p4
+++ b/testdata/p4_16_errors_outputs/issue513.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_errors_outputs/issue513.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue513.p4-stderr
@@ -1,7 +1,7 @@
 issue513.p4(60): [--Wwarn=deprecated] warning: mark_to_drop: Using deprecated feature mark_to_drop. Please use mark_to_drop(standard_metadata) instead.
             mark_to_drop();
             ^^^^^^^^^^^^
-v1model.p4(366)
+v1model.p4(372)
 extern void mark_to_drop();
             ^^^^^^^^^^^^
 issue513.p4(60): [--Werror=target-error] error: MethodCallStatement: Conditional execution in actions unsupported on this target

--- a/testdata/p4_16_errors_outputs/issue513.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue513.p4-stderr
@@ -1,7 +1,7 @@
 issue513.p4(60): [--Wwarn=deprecated] warning: mark_to_drop: Using deprecated feature mark_to_drop. Please use mark_to_drop(standard_metadata) instead.
             mark_to_drop();
             ^^^^^^^^^^^^
-v1model.p4(372)
+v1model.p4(413)
 extern void mark_to_drop();
             ^^^^^^^^^^^^
 issue513.p4(60): [--Werror=target-error] error: MethodCallStatement: Conditional execution in actions unsupported on this target

--- a/testdata/p4_16_errors_outputs/issue532-first.p4
+++ b/testdata/p4_16_errors_outputs/issue532-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct s1_t {

--- a/testdata/p4_16_errors_outputs/issue532-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue532-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct s1_t {

--- a/testdata/p4_16_errors_outputs/issue532.p4
+++ b/testdata/p4_16_errors_outputs/issue532.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct s1_t {

--- a/testdata/p4_16_errors_outputs/issue584.p4
+++ b/testdata/p4_16_errors_outputs/issue584.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<16> Hash;

--- a/testdata/p4_16_errors_outputs/issue774-2-first.p4
+++ b/testdata/p4_16_errors_outputs/issue774-2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {

--- a/testdata/p4_16_errors_outputs/issue774-2.p4
+++ b/testdata/p4_16_errors_outputs/issue774-2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {

--- a/testdata/p4_16_errors_outputs/key-name.p4
+++ b/testdata/p4_16_errors_outputs/key-name.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/local_instance.p4
+++ b/testdata/p4_16_errors_outputs/local_instance.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_m;

--- a/testdata/p4_16_errors_outputs/not_bound-first.p4
+++ b/testdata/p4_16_errors_outputs/not_bound-first.p4
@@ -5,6 +5,7 @@ struct metadata {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {

--- a/testdata/p4_16_errors_outputs/not_bound-frontend.p4
+++ b/testdata/p4_16_errors_outputs/not_bound-frontend.p4
@@ -5,6 +5,7 @@ struct metadata {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {

--- a/testdata/p4_16_errors_outputs/not_bound-midend.p4
+++ b/testdata/p4_16_errors_outputs/not_bound-midend.p4
@@ -5,6 +5,7 @@ struct metadata {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {

--- a/testdata/p4_16_errors_outputs/not_bound.p4
+++ b/testdata/p4_16_errors_outputs/not_bound.p4
@@ -5,6 +5,7 @@ struct metadata {
 }
 
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {

--- a/testdata/p4_16_errors_outputs/slice_out_of_bound.p4
+++ b/testdata/p4_16_errors_outputs/slice_out_of_bound.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -39,7 +40,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<8>, bit<1>>(32w2) debug;
+    register<bit<8>>(32w2) debug;
     apply {
         bit<8> n = 8w0b11111111;
         n[7:4][5:2] = 4w0;

--- a/testdata/p4_16_errors_outputs/slice_out_of_bound.p4
+++ b/testdata/p4_16_errors_outputs/slice_out_of_bound.p4
@@ -39,7 +39,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<8>>(32w2) debug;
+    register<bit<8>, bit<1>>(32w2) debug;
     apply {
         bit<8> n = 8w0b11111111;
         n[7:4][5:2] = 4w0;

--- a/testdata/p4_16_errors_outputs/table-entries-decl-order.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-decl-order.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-exact.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-exact.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2-first.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2-frontend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2-midend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-lpm.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-first.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-frontend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-midend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-range.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-range.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/table-entries-ternary.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-ternary.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_errors_outputs/type-field.p4
+++ b/testdata/p4_16_errors_outputs/type-field.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header d_t {

--- a/testdata/p4_16_samples/fabric_20190420/include/control/port_counter.p4
+++ b/testdata/p4_16_samples/fabric_20190420/include/control/port_counter.p4
@@ -23,15 +23,15 @@ control PortCountersControl(inout parsed_headers_t hdr,
                             inout fabric_metadata_t fabric_metadata,
                             inout standard_metadata_t standard_metadata) {
 
-    counter(MAX_PORTS, CounterType.packets_and_bytes) egress_port_counter;
-    counter(MAX_PORTS, CounterType.packets_and_bytes) ingress_port_counter;
+    counter<PortId_t>(MAX_PORTS, CounterType.packets_and_bytes) egress_port_counter;
+    counter<PortId_t>(MAX_PORTS, CounterType.packets_and_bytes) ingress_port_counter;
 
     apply {
         if (standard_metadata.egress_spec < MAX_PORTS) {
-            egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
+            egress_port_counter.count(standard_metadata.egress_spec);
         }
         if (standard_metadata.ingress_port < MAX_PORTS) {
-            ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
+            ingress_port_counter.count(standard_metadata.ingress_port);
         }
     }
 }

--- a/testdata/p4_16_samples/fabric_20190420/include/control/port_counter.p4
+++ b/testdata/p4_16_samples/fabric_20190420/include/control/port_counter.p4
@@ -23,15 +23,15 @@ control PortCountersControl(inout parsed_headers_t hdr,
                             inout fabric_metadata_t fabric_metadata,
                             inout standard_metadata_t standard_metadata) {
 
-    counter<PortId_t>(MAX_PORTS, CounterType.packets_and_bytes) egress_port_counter;
-    counter<PortId_t>(MAX_PORTS, CounterType.packets_and_bytes) ingress_port_counter;
+    counter(MAX_PORTS, CounterType.packets_and_bytes) egress_port_counter;
+    counter(MAX_PORTS, CounterType.packets_and_bytes) ingress_port_counter;
 
     apply {
         if (standard_metadata.egress_spec < MAX_PORTS) {
-            egress_port_counter.count(standard_metadata.egress_spec);
+            egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
         }
         if (standard_metadata.ingress_port < MAX_PORTS) {
-            ingress_port_counter.count(standard_metadata.ingress_port);
+            ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
         }
     }
 }

--- a/testdata/p4_16_samples/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples/flowlet_switching-bmv2.p4
@@ -108,8 +108,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
-    @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
+    @name("flowlet_id") register<bit<16>,bit<13>>(32w8192) flowlet_id;
+    @name("flowlet_lasttime") register<bit<32>,bit<13>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
@@ -123,18 +123,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("lookup_flowlet_map") action lookup_flowlet_map() {
         hash(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, (bit<13>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<26>)13);
-        flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_id.read(meta.ingress_metadata.flowlet_id, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<16>)meta.ingress_metadata.flowlet_id);
+        flowlet_id.write(meta.ingress_metadata.flowlet_map_index, (bit<16>)meta.ingress_metadata.flowlet_id);
     }
     @name("ecmp_group") table ecmp_group {
         actions = {

--- a/testdata/p4_16_samples/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples/flowlet_switching-bmv2.p4
@@ -108,8 +108,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("flowlet_id") register<bit<16>,bit<13>>(32w8192) flowlet_id;
-    @name("flowlet_lasttime") register<bit<32>,bit<13>>(32w8192) flowlet_lasttime;
+    @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
+    @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
@@ -123,18 +123,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("lookup_flowlet_map") action lookup_flowlet_map() {
         hash(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, (bit<13>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<26>)13);
-        flowlet_id.read(meta.ingress_metadata.flowlet_id, meta.ingress_metadata.flowlet_map_index);
+        flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id.write(meta.ingress_metadata.flowlet_map_index, (bit<16>)meta.ingress_metadata.flowlet_id);
+        flowlet_id.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<16>)meta.ingress_metadata.flowlet_id);
     }
     @name("ecmp_group") table ecmp_group {
         actions = {

--- a/testdata/p4_16_samples/issue1097-2-bmv2.p4
+++ b/testdata/p4_16_samples/issue1097-2-bmv2.p4
@@ -40,7 +40,7 @@ parser p(packet_in b,
     }
 }
 
-register<bit<8>>(256) r;
+register<bit<8>, bit<8>>(256) r;
 
 control ingress(inout Headers h,
     inout Meta m,
@@ -48,8 +48,8 @@ control ingress(inout Headers h,
 {
     apply {
         bit<8> x;
-        r.read(x, (bit<32>) h.myhdr.reg_idx_to_update);
-        r.write((bit<32>) h.myhdr.reg_idx_to_update, 0x2a);
+        r.read(x, h.myhdr.reg_idx_to_update);
+        r.write(h.myhdr.reg_idx_to_update, 0x2a);
     }
 }
 
@@ -59,9 +59,9 @@ control egress(inout Headers h,
 {
     apply {
         bit<8> tmp;
-        r.read(tmp, (bit<32>) h.myhdr.reg_idx_to_update);
+        r.read(tmp, h.myhdr.reg_idx_to_update);
         tmp = tmp + h.myhdr.value_to_add;
-        r.write((bit<32>) h.myhdr.reg_idx_to_update, tmp);
+        r.write(h.myhdr.reg_idx_to_update, tmp);
         h.myhdr.debug_last_reg_value_written = tmp;
     }
 }

--- a/testdata/p4_16_samples/issue1097-2-bmv2.p4
+++ b/testdata/p4_16_samples/issue1097-2-bmv2.p4
@@ -40,7 +40,7 @@ parser p(packet_in b,
     }
 }
 
-register<bit<8>, bit<8>>(256) r;
+register<bit<8>>(256) r;
 
 control ingress(inout Headers h,
     inout Meta m,
@@ -48,8 +48,8 @@ control ingress(inout Headers h,
 {
     apply {
         bit<8> x;
-        r.read(x, h.myhdr.reg_idx_to_update);
-        r.write(h.myhdr.reg_idx_to_update, 0x2a);
+        r.read(x, (bit<32>) h.myhdr.reg_idx_to_update);
+        r.write((bit<32>) h.myhdr.reg_idx_to_update, 0x2a);
     }
 }
 
@@ -59,9 +59,9 @@ control egress(inout Headers h,
 {
     apply {
         bit<8> tmp;
-        r.read(tmp, h.myhdr.reg_idx_to_update);
+        r.read(tmp, (bit<32>) h.myhdr.reg_idx_to_update);
         tmp = tmp + h.myhdr.value_to_add;
-        r.write(h.myhdr.reg_idx_to_update, tmp);
+        r.write((bit<32>) h.myhdr.reg_idx_to_update, tmp);
         h.myhdr.debug_last_reg_value_written = tmp;
     }
 }

--- a/testdata/p4_16_samples/issue1097-bmv2.p4
+++ b/testdata/p4_16_samples/issue1097-bmv2.p4
@@ -11,7 +11,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>, bit<1>>(2) r;
+register<bit<8>>(2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {

--- a/testdata/p4_16_samples/issue1097-bmv2.p4
+++ b/testdata/p4_16_samples/issue1097-bmv2.p4
@@ -11,7 +11,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>>(2) r;
+register<bit<8>, bit<1>>(2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {

--- a/testdata/p4_16_samples/issue1210.p4
+++ b/testdata/p4_16_samples/issue1210.p4
@@ -17,16 +17,16 @@ limitations under the License.
 #include "core.p4"
 #include "v1model.p4"
 
-struct _PortId_t { bit<9> _v; }
+struct PortId_t { bit<9> _v; }
 
-const _PortId_t PSA_CPU_PORT = {9w192};
+const PortId_t PSA_CPU_PORT = {9w192};
 
 struct parsed_headers_t {
 }
 
 struct metadata_t {
-    _PortId_t foo;
-    _PortId_t bar;
+    PortId_t foo;
+    PortId_t bar;
 }
 
 parser ParserImpl (packet_in packet,
@@ -53,7 +53,7 @@ control IngressImpl (inout parsed_headers_t hdr,
         // Latest p4test and p4c-bm2-ss as of Apr 3, 2018 gives an
         // error for the == comparison below:
 
-        // struct-variable-to-constant-compare-error.p4(58): error: ==: not defined on struct _PortId_t and Tuple(1)
+        // struct-variable-to-constant-compare-error.p4(58): error: ==: not defined on struct PortId_t and Tuple(1)
 
         if (meta.foo == PSA_CPU_PORT) {
             meta.foo._v = meta.foo._v + 1;

--- a/testdata/p4_16_samples/issue1210.p4
+++ b/testdata/p4_16_samples/issue1210.p4
@@ -17,16 +17,16 @@ limitations under the License.
 #include "core.p4"
 #include "v1model.p4"
 
-struct PortId_t { bit<9> _v; }
+struct _PortId_t { bit<9> _v; }
 
-const PortId_t PSA_CPU_PORT = {9w192};
+const _PortId_t PSA_CPU_PORT = {9w192};
 
 struct parsed_headers_t {
 }
 
 struct metadata_t {
-    PortId_t foo;
-    PortId_t bar;
+    _PortId_t foo;
+    _PortId_t bar;
 }
 
 parser ParserImpl (packet_in packet,
@@ -53,7 +53,7 @@ control IngressImpl (inout parsed_headers_t hdr,
         // Latest p4test and p4c-bm2-ss as of Apr 3, 2018 gives an
         // error for the == comparison below:
 
-        // struct-variable-to-constant-compare-error.p4(58): error: ==: not defined on struct PortId_t and Tuple(1)
+        // struct-variable-to-constant-compare-error.p4(58): error: ==: not defined on struct _PortId_t and Tuple(1)
 
         if (meta.foo == PSA_CPU_PORT) {
             meta.foo._v = meta.foo._v + 1;

--- a/testdata/p4_16_samples/issue1520-bmv2.p4
+++ b/testdata/p4_16_samples/issue1520-bmv2.p4
@@ -28,7 +28,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control C(inout headers hdr, inout metadata meta)(bool b) {
-    register<bit<16>>(32w8) r;
+    register<bit<16>, bit<3>>(32w8) r;
     apply {
 	r.read(hdr.h.x, 0);
     }

--- a/testdata/p4_16_samples/issue1520-bmv2.p4
+++ b/testdata/p4_16_samples/issue1520-bmv2.p4
@@ -28,7 +28,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control C(inout headers hdr, inout metadata meta)(bool b) {
-    register<bit<16>, bit<3>>(32w8) r;
+    register<bit<16>>(32w8) r;
     apply {
 	r.read(hdr.h.x, 0);
     }

--- a/testdata/p4_16_samples/issue1566-bmv2.p4
+++ b/testdata/p4_16_samples/issue1566-bmv2.p4
@@ -39,10 +39,10 @@ control my_control_type(inout bit<16> x);
 
 control C1(inout bit<16> x)
 {
-    counter((bit<32>) 65536, CounterType.packets) stats;
+    counter<bit<16>>((bit<32>) 65536, CounterType.packets) stats;
     apply {
         x = x + 1;
-        stats.count((bit<32>) x);
+        stats.count(x);
     }
 };
 

--- a/testdata/p4_16_samples/issue1566-bmv2.p4
+++ b/testdata/p4_16_samples/issue1566-bmv2.p4
@@ -39,10 +39,10 @@ control my_control_type(inout bit<16> x);
 
 control C1(inout bit<16> x)
 {
-    counter<bit<16>>((bit<32>) 65536, CounterType.packets) stats;
+    counter((bit<32>) 65536, CounterType.packets) stats;
     apply {
         x = x + 1;
-        stats.count(x);
+        stats.count((bit<32>) x);
     }
 };
 

--- a/testdata/p4_16_samples/issue1566.p4
+++ b/testdata/p4_16_samples/issue1566.p4
@@ -39,10 +39,10 @@ control my_control_type(inout bit<16> x);
 
 control C1(inout bit<16> x)
 {
-    counter((bit<32>) 65536, CounterType.packets) stats;
+    counter<bit<16>>((bit<32>) 65536, CounterType.packets) stats;
     apply {
         x = x + 1;
-        stats.count((bit<32>) x);
+        stats.count(x);
     }
 };
 

--- a/testdata/p4_16_samples/issue1566.p4
+++ b/testdata/p4_16_samples/issue1566.p4
@@ -39,10 +39,10 @@ control my_control_type(inout bit<16> x);
 
 control C1(inout bit<16> x)
 {
-    counter<bit<16>>((bit<32>) 65536, CounterType.packets) stats;
+    counter((bit<32>) 65536, CounterType.packets) stats;
     apply {
         x = x + 1;
-        stats.count(x);
+        stats.count((bit<32>) x);
     }
 };
 

--- a/testdata/p4_16_samples/issue1814-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue1814-1-bmv2.p4
@@ -17,7 +17,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>, bit<1>>(1) testRegister;
+    register<bit<1>>(1) testRegister;
 
     action drop() {
         mark_to_drop(standard_metadata);

--- a/testdata/p4_16_samples/issue1814-1-bmv2.p4
+++ b/testdata/p4_16_samples/issue1814-1-bmv2.p4
@@ -17,7 +17,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>>(1) testRegister;
+    register<bit<1>, bit<1>>(1) testRegister;
 
     action drop() {
         mark_to_drop(standard_metadata);

--- a/testdata/p4_16_samples/issue1814-bmv2.p4
+++ b/testdata/p4_16_samples/issue1814-bmv2.p4
@@ -17,7 +17,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>, bit<1>>(1) testRegister;
+    register<bit<1>>(1) testRegister;
 
     table debug_table {
         key = {

--- a/testdata/p4_16_samples/issue1814-bmv2.p4
+++ b/testdata/p4_16_samples/issue1814-bmv2.p4
@@ -17,7 +17,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>>(1) testRegister;
+    register<bit<1>, bit<1>>(1) testRegister;
 
     table debug_table {
         key = {

--- a/testdata/p4_16_samples/issue242.p4
+++ b/testdata/p4_16_samples/issue242.p4
@@ -78,8 +78,8 @@ control Eg(inout Headers hdrs,
            inout Metadata meta,
            inout standard_metadata_t standard_meta) {
 
-    register<bit<32>, bit<7>>(32w100) debug;
-    register<bit<32>, bit<1>>(32w1) reg;
+    register<bit<32>>(32w100) debug;
+    register<bit<32>>(32w1) reg;
 
     // Using register regKeys, regValues.
     action test() {
@@ -92,7 +92,7 @@ control Eg(inout Headers hdrs,
 	val.field1 = 32w1;
         debug.write(2, inc); // Print inc again
 
-        reg.write(0, val.field1);
+        reg.write(32w0, val.field1);
     }
 
     apply {

--- a/testdata/p4_16_samples/issue242.p4
+++ b/testdata/p4_16_samples/issue242.p4
@@ -78,8 +78,8 @@ control Eg(inout Headers hdrs,
            inout Metadata meta,
            inout standard_metadata_t standard_meta) {
 
-    register<bit<32>>(32w100) debug;
-    register<bit<32>>(32w1) reg;
+    register<bit<32>, bit<7>>(32w100) debug;
+    register<bit<32>, bit<1>>(32w1) reg;
 
     // Using register regKeys, regValues.
     action test() {
@@ -92,7 +92,7 @@ control Eg(inout Headers hdrs,
 	val.field1 = 32w1;
         debug.write(2, inc); // Print inc again
 
-        reg.write(32w0, val.field1);
+        reg.write(0, val.field1);
     }
 
     apply {

--- a/testdata/p4_16_samples/issue298-bmv2.p4
+++ b/testdata/p4_16_samples/issue298-bmv2.p4
@@ -166,7 +166,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<ROUND_SIZE>>(INSTANCE_COUNT) registerRound;
+    register<bit<ROUND_SIZE>,bit<INSTANCE_SIZE>>(INSTANCE_COUNT) registerRound;
 
     action read_round() {
         registerRound.read(meta.local_metadata.round, hdr.myhdr.inst);

--- a/testdata/p4_16_samples/issue298-bmv2.p4
+++ b/testdata/p4_16_samples/issue298-bmv2.p4
@@ -166,7 +166,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<ROUND_SIZE>,bit<INSTANCE_SIZE>>(INSTANCE_COUNT) registerRound;
+    register<bit<ROUND_SIZE>>(INSTANCE_COUNT) registerRound;
 
     action read_round() {
         registerRound.read(meta.local_metadata.round, hdr.myhdr.inst);

--- a/testdata/p4_16_samples/issue696-bmv2.p4
+++ b/testdata/p4_16_samples/issue696-bmv2.p4
@@ -9,8 +9,8 @@ typedef bit<48>  EthernetAddress;
 typedef bit<32>  IPv4Address;
 
 
-register<bit<32>, bit<7>>(32w100) debug;
-register<bit<32>, bit<1>>(32w1) reg;
+register<bit<32>>(32w100) debug;
+register<bit<32>>(32w1) reg;
 // standard Ethernet header
 header ethernet_t {
     EthernetAddress dstAddr;
@@ -94,7 +94,7 @@ control Eg(inout Headers hdrs,
     val.field1 = 32w1;
         debug.write(2, inc); // Print inc again
 
-        reg.write(0, val.field1);
+        reg.write(32w0, val.field1);
     }
 
     apply {

--- a/testdata/p4_16_samples/issue696-bmv2.p4
+++ b/testdata/p4_16_samples/issue696-bmv2.p4
@@ -9,8 +9,8 @@ typedef bit<48>  EthernetAddress;
 typedef bit<32>  IPv4Address;
 
 
-register<bit<32>>(32w100) debug;
-register<bit<32>>(32w1) reg;
+register<bit<32>, bit<7>>(32w100) debug;
+register<bit<32>, bit<1>>(32w1) reg;
 // standard Ethernet header
 header ethernet_t {
     EthernetAddress dstAddr;
@@ -94,7 +94,7 @@ control Eg(inout Headers hdrs,
     val.field1 = 32w1;
         debug.write(2, inc); // Print inc again
 
-        reg.write(32w0, val.field1);
+        reg.write(0, val.field1);
     }
 
     apply {

--- a/testdata/p4_16_samples/issue907-bmv2.p4
+++ b/testdata/p4_16_samples/issue907-bmv2.p4
@@ -17,7 +17,7 @@ parser P(packet_in b,
 control Ing(inout Headers headers,
             inout Metadata meta,
             inout standard_metadata_t standard_meta) {
-    register<S, bit<7>>(32w100) r;
+    register<S>(32w100) r;
     apply {
         S s = { 0 };
         r.write(0, s);

--- a/testdata/p4_16_samples/issue907-bmv2.p4
+++ b/testdata/p4_16_samples/issue907-bmv2.p4
@@ -17,7 +17,7 @@ parser P(packet_in b,
 control Ing(inout Headers headers,
             inout Metadata meta,
             inout standard_metadata_t standard_meta) {
-    register<S>(32w100) r;
+    register<S, bit<7>>(32w100) r;
     apply {
         S s = { 0 };
         r.write(0, s);

--- a/testdata/p4_16_samples/register-serenum.p4
+++ b/testdata/p4_16_samples/register-serenum.p4
@@ -34,7 +34,7 @@ parser prs(packet_in p, out Headers h) {
 }
 
 control c(inout Headers h, inout standard_metadata_t sm) {
-    register<EthTypes>(1) reg;
+    register<EthTypes, bit<1>>(1) reg;
 
     apply {
         reg.write(0, h.eth.type);

--- a/testdata/p4_16_samples/register-serenum.p4
+++ b/testdata/p4_16_samples/register-serenum.p4
@@ -34,7 +34,7 @@ parser prs(packet_in p, out Headers h) {
 }
 
 control c(inout Headers h, inout standard_metadata_t sm) {
-    register<EthTypes, bit<1>>(1) reg;
+    register<EthTypes>(1) reg;
 
     apply {
         reg.write(0, h.eth.type);

--- a/testdata/p4_16_samples/simplify_slice.p4
+++ b/testdata/p4_16_samples/simplify_slice.p4
@@ -73,7 +73,7 @@ control Ing(inout Headers headers,
             inout Metadata meta,
             inout standard_metadata_t standard_meta) {
 
-    register<bit<8>>(32w2) debug;
+    register<bit<8>, bit<1>>(32w2) debug;
 
     apply {
         bit<8> n = 8w0b11111111;

--- a/testdata/p4_16_samples/simplify_slice.p4
+++ b/testdata/p4_16_samples/simplify_slice.p4
@@ -73,7 +73,7 @@ control Ing(inout Headers headers,
             inout Metadata meta,
             inout standard_metadata_t standard_meta) {
 
-    register<bit<8>, bit<1>>(32w2) debug;
+    register<bit<8>>(32w2) debug;
 
     apply {
         bit<8> n = 8w0b11111111;

--- a/testdata/p4_16_samples/slice-def-use.p4
+++ b/testdata/p4_16_samples/slice-def-use.p4
@@ -73,7 +73,7 @@ control Ing(inout Headers headers,
             inout Metadata meta,
             inout standard_metadata_t standard_meta) {
 
-    register<bit<8>>(32w2) debug;
+    register<bit<8>, bit<1>>(32w2) debug;
 
     apply {
         bit<8> n = 8w0b11111111;

--- a/testdata/p4_16_samples/slice-def-use.p4
+++ b/testdata/p4_16_samples/slice-def-use.p4
@@ -73,7 +73,7 @@ control Ing(inout Headers headers,
             inout Metadata meta,
             inout standard_metadata_t standard_meta) {
 
-    register<bit<8>, bit<1>>(32w2) debug;
+    register<bit<8>>(32w2) debug;
 
     apply {
         bit<8> n = 8w0b11111111;

--- a/testdata/p4_16_samples/slice-def-use1.p4
+++ b/testdata/p4_16_samples/slice-def-use1.p4
@@ -40,11 +40,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n;
-    @name("debug") register<bit<8>, bit<1>>(32w2) debug;
+    @name("debug") register<bit<8>>(32w2) debug;
     action act() {
         n = 8w0b11111111;
         n[7:4] = 4w0;
-        debug.write(1, n);
+        debug.write(32w1, n);
         standard_meta.egress_spec = 9w0;
     }
     table tbl_act {

--- a/testdata/p4_16_samples/slice-def-use1.p4
+++ b/testdata/p4_16_samples/slice-def-use1.p4
@@ -40,11 +40,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n;
-    @name("debug") register<bit<8>>(32w2) debug;
+    @name("debug") register<bit<8>, bit<1>>(32w2) debug;
     action act() {
         n = 8w0b11111111;
         n[7:4] = 4w0;
-        debug.write(32w1, n);
+        debug.write(1, n);
         standard_meta.egress_spec = 9w0;
     }
     table tbl_act {

--- a/testdata/p4_16_samples_outputs/action-synth-first.p4
+++ b/testdata/p4_16_samples_outputs/action-synth-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action-synth-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action-synth-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action-synth-midend.p4
+++ b/testdata/p4_16_samples_outputs/action-synth-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action-synth.p4
+++ b/testdata/p4_16_samples_outputs/action-synth.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action-two-params-first.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/action-two-params-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/action-two-params-midend.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/action-two-params.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-first.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/action_selector_unused-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/arith-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith2-inline-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith2-inline-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith4-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith5-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith5-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith5-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/arith5-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/array-copy-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/array-copy-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr {

--- a/testdata/p4_16_samples_outputs/array-copy-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/array-copy-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr {

--- a/testdata/p4_16_samples_outputs/array-copy-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/array-copy-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr {

--- a/testdata/p4_16_samples_outputs/array-copy-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/array-copy-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr {

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_samples_outputs/bitwise-and-first.p4
+++ b/testdata/p4_16_samples_outputs/bitwise-and-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control C(bit<1> meta) {

--- a/testdata/p4_16_samples_outputs/bitwise-and-frontend.p4
+++ b/testdata/p4_16_samples_outputs/bitwise-and-frontend.p4
@@ -1,3 +1,4 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 

--- a/testdata/p4_16_samples_outputs/bitwise-and.p4
+++ b/testdata/p4_16_samples_outputs/bitwise-and.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control C(bit<1> meta) {

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct row_t {

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct row_t {

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct row_t {

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct row_t {

--- a/testdata/p4_16_samples_outputs/bvec_union-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/bvec_union-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/bvec_union-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/bvec_union-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/bvec_union-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/bvec_union-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/bvec_union-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/bvec_union-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/checksum1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/checksum1-bmv2-first.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/checksum1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/checksum1-bmv2-frontend.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/checksum1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/checksum1-bmv2-midend.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/checksum1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/checksum1-bmv2.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/checksum2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/checksum2-bmv2-first.p4
@@ -3,6 +3,7 @@ error {
     IPv4IncorrectVersion
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/checksum2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/checksum2-bmv2-frontend.p4
@@ -3,6 +3,7 @@ error {
     IPv4IncorrectVersion
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/checksum2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/checksum2-bmv2-midend.p4
@@ -3,6 +3,7 @@ error {
     IPv4IncorrectVersion
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/checksum2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/checksum2-bmv2.p4
@@ -3,6 +3,7 @@ error {
     IPv4IncorrectVersion
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/checksum3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/checksum3-bmv2-first.p4
@@ -3,6 +3,7 @@ error {
     IPv4IncorrectVersion
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/checksum3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/checksum3-bmv2-frontend.p4
@@ -3,6 +3,7 @@ error {
     IPv4IncorrectVersion
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/checksum3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/checksum3-bmv2-midend.p4
@@ -3,6 +3,7 @@ error {
     IPv4IncorrectVersion
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/checksum3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/checksum3-bmv2.p4
@@ -3,6 +3,7 @@ error {
     IPv4IncorrectVersion
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/concat-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/concat-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/concat-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/concat-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/concat-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/concat-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/concat-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/concat-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/constant-in-calculation-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields-first.p4
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 @p4runtime_translation("com.fingerhutpress/andysp4arch/v1/EthernetAddr_t" , 32) type bit<48> EthernetAddr_t;

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields-frontend.p4
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 @p4runtime_translation("com.fingerhutpress/andysp4arch/v1/EthernetAddr_t" , 32) type bit<48> EthernetAddr_t;

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields-midend.p4
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddr_t;

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields.p4
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 @p4runtime_translation("com.fingerhutpress/andysp4arch/v1/EthernetAddr_t" , 32) type bit<48> EthernetAddr_t;

--- a/testdata/p4_16_samples_outputs/def-use-first.p4
+++ b/testdata/p4_16_samples_outputs/def-use-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/def-use-frontend.p4
+++ b/testdata/p4_16_samples_outputs/def-use-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/def-use-midend.p4
+++ b/testdata/p4_16_samples_outputs/def-use-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/def-use.p4
+++ b/testdata/p4_16_samples_outputs/def-use.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/default_action-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/empty-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/empty-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/empty-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/empty-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/empty-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/empty-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/empty-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/empty-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/enum-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/enum-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/enum-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/enum-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/enum-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/equality-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/equality-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/equality-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/equality-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/equality-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/equality-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/equality-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/equality-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/equality-varbit-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/equality-varbit-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/equality-varbit-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/equality-varbit-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/equality-varbit-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/equality-varbit-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/equality-varbit-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/equality-varbit-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/extern-funcs-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/extern-funcs-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 extern void extern_func(out bit<32> d, bit<32> s);

--- a/testdata/p4_16_samples_outputs/extern-funcs-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/extern-funcs-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 extern void extern_func(out bit<32> d, bit<32> s);

--- a/testdata/p4_16_samples_outputs/extern-funcs-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/extern-funcs-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 extern void extern_func(out bit<32> d, bit<32> s);

--- a/testdata/p4_16_samples_outputs/extern-funcs-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/extern-funcs-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 extern void extern_func(out bit<32> d, bit<32> s);

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-first.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<3> fwd_type_t;
@@ -908,14 +909,14 @@ control FabricDeparser(packet_out packet, in parsed_headers_t hdr) {
 }
 
 control PortCountersControl(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_metadata, inout standard_metadata_t standard_metadata) {
-    counter<PortId_t>(32w511, CounterType.packets_and_bytes) egress_port_counter;
-    counter<PortId_t>(32w511, CounterType.packets_and_bytes) ingress_port_counter;
+    counter(32w511, CounterType.packets_and_bytes) egress_port_counter;
+    counter(32w511, CounterType.packets_and_bytes) ingress_port_counter;
     apply {
         if (standard_metadata.egress_spec < 9w511) {
-            egress_port_counter.count(standard_metadata.egress_spec);
+            egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
         }
         if (standard_metadata.ingress_port < 9w511) {
-            ingress_port_counter.count(standard_metadata.ingress_port);
+            ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-first.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-first.p4
@@ -908,14 +908,14 @@ control FabricDeparser(packet_out packet, in parsed_headers_t hdr) {
 }
 
 control PortCountersControl(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_metadata, inout standard_metadata_t standard_metadata) {
-    counter(32w511, CounterType.packets_and_bytes) egress_port_counter;
-    counter(32w511, CounterType.packets_and_bytes) ingress_port_counter;
+    counter<PortId_t>(32w511, CounterType.packets_and_bytes) egress_port_counter;
+    counter<PortId_t>(32w511, CounterType.packets_and_bytes) ingress_port_counter;
     apply {
         if (standard_metadata.egress_spec < 9w511) {
-            egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
+            egress_port_counter.count(standard_metadata.egress_spec);
         }
         if (standard_metadata.ingress_port < 9w511) {
-            ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
+            ingress_port_counter.count(standard_metadata.ingress_port);
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-frontend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<3> fwd_type_t;
@@ -659,8 +660,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         const default_action = nop_17();
         size = 1024;
     }
-    @name("FabricIngress.port_counters_control.egress_port_counter") counter<PortId_t>(32w511, CounterType.packets_and_bytes) port_counters_control_egress_port_counter;
-    @name("FabricIngress.port_counters_control.ingress_port_counter") counter<PortId_t>(32w511, CounterType.packets_and_bytes) port_counters_control_ingress_port_counter;
+    @name("FabricIngress.port_counters_control.egress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_egress_port_counter;
+    @name("FabricIngress.port_counters_control.ingress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_ingress_port_counter;
     apply {
         {
             hdr.gtpu_ipv4.setInvalid();
@@ -731,10 +732,10 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
             next_multicast.apply();
             next_next_vlan.apply();
             if (standard_metadata.egress_spec < 9w511) {
-                port_counters_control_egress_port_counter.count(standard_metadata.egress_spec);
+                port_counters_control_egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
             }
             if (standard_metadata.ingress_port < 9w511) {
-                port_counters_control_ingress_port_counter.count(standard_metadata.ingress_port);
+                port_counters_control_ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
             }
         }
     }

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-frontend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-frontend.p4
@@ -659,8 +659,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         const default_action = nop_17();
         size = 1024;
     }
-    @name("FabricIngress.port_counters_control.egress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_egress_port_counter;
-    @name("FabricIngress.port_counters_control.ingress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_ingress_port_counter;
+    @name("FabricIngress.port_counters_control.egress_port_counter") counter<PortId_t>(32w511, CounterType.packets_and_bytes) port_counters_control_egress_port_counter;
+    @name("FabricIngress.port_counters_control.ingress_port_counter") counter<PortId_t>(32w511, CounterType.packets_and_bytes) port_counters_control_ingress_port_counter;
     apply {
         {
             hdr.gtpu_ipv4.setInvalid();
@@ -731,10 +731,10 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
             next_multicast.apply();
             next_next_vlan.apply();
             if (standard_metadata.egress_spec < 9w511) {
-                port_counters_control_egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
+                port_counters_control_egress_port_counter.count(standard_metadata.egress_spec);
             }
             if (standard_metadata.ingress_port < 9w511) {
-                port_counters_control_ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
+                port_counters_control_ingress_port_counter.count(standard_metadata.ingress_port);
             }
         }
     }

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<3> fwd_type_t;
@@ -651,8 +652,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         const default_action = nop_17();
         size = 1024;
     }
-    @name("FabricIngress.port_counters_control.egress_port_counter") counter<PortId_t>(32w511, CounterType.packets_and_bytes) port_counters_control_egress_port_counter;
-    @name("FabricIngress.port_counters_control.ingress_port_counter") counter<PortId_t>(32w511, CounterType.packets_and_bytes) port_counters_control_ingress_port_counter;
+    @name("FabricIngress.port_counters_control.egress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_egress_port_counter;
+    @name("FabricIngress.port_counters_control.ingress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_ingress_port_counter;
     @hidden action spgw30() {
         spgw_normalizer_hasReturned = true;
     }
@@ -708,10 +709,10 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         fabric_metadata._spgw_ipv4_len18 = hdr.ipv4.total_len;
     }
     @hidden action port_counter31() {
-        port_counters_control_egress_port_counter.count(standard_metadata.egress_spec);
+        port_counters_control_egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
     }
     @hidden action port_counter34() {
-        port_counters_control_ingress_port_counter.count(standard_metadata.ingress_port);
+        port_counters_control_ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
     }
     @hidden table tbl_fabric78 {
         actions = {

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
@@ -651,8 +651,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         const default_action = nop_17();
         size = 1024;
     }
-    @name("FabricIngress.port_counters_control.egress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_egress_port_counter;
-    @name("FabricIngress.port_counters_control.ingress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_ingress_port_counter;
+    @name("FabricIngress.port_counters_control.egress_port_counter") counter<PortId_t>(32w511, CounterType.packets_and_bytes) port_counters_control_egress_port_counter;
+    @name("FabricIngress.port_counters_control.ingress_port_counter") counter<PortId_t>(32w511, CounterType.packets_and_bytes) port_counters_control_ingress_port_counter;
     @hidden action spgw30() {
         spgw_normalizer_hasReturned = true;
     }
@@ -708,10 +708,10 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         fabric_metadata._spgw_ipv4_len18 = hdr.ipv4.total_len;
     }
     @hidden action port_counter31() {
-        port_counters_control_egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
+        port_counters_control_egress_port_counter.count(standard_metadata.egress_spec);
     }
     @hidden action port_counter34() {
-        port_counters_control_ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
+        port_counters_control_ingress_port_counter.count(standard_metadata.ingress_port);
     }
     @hidden table tbl_fabric78 {
         actions = {

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric.p4
@@ -909,14 +909,14 @@ control FabricDeparser(packet_out packet, in parsed_headers_t hdr) {
 }
 
 control PortCountersControl(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_metadata, inout standard_metadata_t standard_metadata) {
-    counter(511, CounterType.packets_and_bytes) egress_port_counter;
-    counter(511, CounterType.packets_and_bytes) ingress_port_counter;
+    counter<PortId_t>(511, CounterType.packets_and_bytes) egress_port_counter;
+    counter<PortId_t>(511, CounterType.packets_and_bytes) ingress_port_counter;
     apply {
         if (standard_metadata.egress_spec < 511) {
-            egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
+            egress_port_counter.count(standard_metadata.egress_spec);
         }
         if (standard_metadata.ingress_port < 511) {
-            ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
+            ingress_port_counter.count(standard_metadata.ingress_port);
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<3> fwd_type_t;
@@ -909,14 +910,14 @@ control FabricDeparser(packet_out packet, in parsed_headers_t hdr) {
 }
 
 control PortCountersControl(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_metadata, inout standard_metadata_t standard_metadata) {
-    counter<PortId_t>(511, CounterType.packets_and_bytes) egress_port_counter;
-    counter<PortId_t>(511, CounterType.packets_and_bytes) ingress_port_counter;
+    counter(511, CounterType.packets_and_bytes) egress_port_counter;
+    counter(511, CounterType.packets_and_bytes) ingress_port_counter;
     apply {
         if (standard_metadata.egress_spec < 511) {
-            egress_port_counter.count(standard_metadata.egress_spec);
+            egress_port_counter.count((bit<32>)standard_metadata.egress_spec);
         }
         if (standard_metadata.ingress_port < 511) {
-            ingress_port_counter.count(standard_metadata.ingress_port);
+            ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {
@@ -108,8 +109,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id;
-    @name("flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime;
+    @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
+    @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
@@ -123,18 +124,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id.read(meta.ingress_metadata.flowlet_id, meta.ingress_metadata.flowlet_map_index);
+        flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id.write(meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
+        flowlet_id.write((bit<32>)meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
     }
     @name("ecmp_group") table ecmp_group {
         actions = {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-first.p4
@@ -108,8 +108,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
-    @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
+    @name("flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id;
+    @name("flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
@@ -123,18 +123,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_id.read(meta.ingress_metadata.flowlet_id, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id.write((bit<32>)meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
+        flowlet_id.write(meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
     }
     @name("ecmp_group") table ecmp_group {
         actions = {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {
@@ -120,8 +121,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name("ingress.flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id_0;
-    @name("ingress.flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime_0;
+    @name("ingress.flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
+    @name("ingress.flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
     @name("ingress._drop") action _drop_2() {
         mark_to_drop(standard_metadata);
     }
@@ -141,18 +142,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id_0.read(meta.ingress_metadata.flowlet_id, meta.ingress_metadata.flowlet_map_index);
+        flowlet_id_0.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime_0.read(meta.ingress_metadata.flowlet_lasttime, meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime_0.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime_0.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("ingress.set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("ingress.update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id_0.write(meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
+        flowlet_id_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
     }
     @name("ingress.ecmp_group") table ecmp_group_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
@@ -120,8 +120,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name("ingress.flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
-    @name("ingress.flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
+    @name("ingress.flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id_0;
+    @name("ingress.flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime_0;
     @name("ingress._drop") action _drop_2() {
         mark_to_drop(standard_metadata);
     }
@@ -141,18 +141,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>>, bit<26>>(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id_0.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_id_0.read(meta.ingress_metadata.flowlet_id, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime_0.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime_0.read(meta.ingress_metadata.flowlet_lasttime, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime_0.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("ingress.set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("ingress.update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
+        flowlet_id_0.write(meta.ingress_metadata.flowlet_map_index, meta.ingress_metadata.flowlet_id);
     }
     @name("ingress.ecmp_group") table ecmp_group_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {
@@ -141,8 +142,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name("ingress.flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id_0;
-    @name("ingress.flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime_0;
+    @name("ingress.flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
+    @name("ingress.flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
     @name("ingress._drop") action _drop_2() {
         mark_to_drop(standard_metadata);
     }
@@ -162,18 +163,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple_1, bit<26>>(meta._ingress_metadata_flowlet_map_index1, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id_0.read(meta._ingress_metadata_flowlet_id2, meta._ingress_metadata_flowlet_map_index1);
+        flowlet_id_0.read(meta._ingress_metadata_flowlet_id2, (bit<32>)meta._ingress_metadata_flowlet_map_index1);
         meta._ingress_metadata_flow_ipg0 = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime_0.read(meta._ingress_metadata_flowlet_lasttime3, meta._ingress_metadata_flowlet_map_index1);
+        flowlet_lasttime_0.read(meta._ingress_metadata_flowlet_lasttime3, (bit<32>)meta._ingress_metadata_flowlet_map_index1);
         meta._ingress_metadata_flow_ipg0 = (bit<32>)standard_metadata.ingress_global_timestamp - meta._ingress_metadata_flowlet_lasttime3;
-        flowlet_lasttime_0.write(meta._ingress_metadata_flowlet_map_index1, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime_0.write((bit<32>)meta._ingress_metadata_flowlet_map_index1, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("ingress.set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("ingress.update_flowlet_id") action update_flowlet_id() {
         meta._ingress_metadata_flowlet_id2 = meta._ingress_metadata_flowlet_id2 + 16w1;
-        flowlet_id_0.write(meta._ingress_metadata_flowlet_map_index1, meta._ingress_metadata_flowlet_id2);
+        flowlet_id_0.write((bit<32>)meta._ingress_metadata_flowlet_map_index1, meta._ingress_metadata_flowlet_id2);
     }
     @name("ingress.ecmp_group") table ecmp_group_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -141,8 +141,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name("ingress.flowlet_id") register<bit<16>>(32w8192) flowlet_id_0;
-    @name("ingress.flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime_0;
+    @name("ingress.flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id_0;
+    @name("ingress.flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime_0;
     @name("ingress._drop") action _drop_2() {
         mark_to_drop(standard_metadata);
     }
@@ -162,18 +162,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.lookup_flowlet_map") action lookup_flowlet_map() {
         hash<bit<13>, bit<13>, tuple_1, bit<26>>(meta._ingress_metadata_flowlet_map_index1, HashAlgorithm.crc16, 13w0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, 26w13);
-        flowlet_id_0.read(meta._ingress_metadata_flowlet_id2, (bit<32>)meta._ingress_metadata_flowlet_map_index1);
+        flowlet_id_0.read(meta._ingress_metadata_flowlet_id2, meta._ingress_metadata_flowlet_map_index1);
         meta._ingress_metadata_flow_ipg0 = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime_0.read(meta._ingress_metadata_flowlet_lasttime3, (bit<32>)meta._ingress_metadata_flowlet_map_index1);
+        flowlet_lasttime_0.read(meta._ingress_metadata_flowlet_lasttime3, meta._ingress_metadata_flowlet_map_index1);
         meta._ingress_metadata_flow_ipg0 = (bit<32>)standard_metadata.ingress_global_timestamp - meta._ingress_metadata_flowlet_lasttime3;
-        flowlet_lasttime_0.write((bit<32>)meta._ingress_metadata_flowlet_map_index1, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime_0.write(meta._ingress_metadata_flowlet_map_index1, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("ingress.set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("ingress.update_flowlet_id") action update_flowlet_id() {
         meta._ingress_metadata_flowlet_id2 = meta._ingress_metadata_flowlet_id2 + 16w1;
-        flowlet_id_0.write((bit<32>)meta._ingress_metadata_flowlet_map_index1, meta._ingress_metadata_flowlet_id2);
+        flowlet_id_0.write(meta._ingress_metadata_flowlet_map_index1, meta._ingress_metadata_flowlet_id2);
     }
     @name("ingress.ecmp_group") table ecmp_group_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {
@@ -108,8 +109,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id;
-    @name("flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime;
+    @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
+    @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
@@ -123,18 +124,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("lookup_flowlet_map") action lookup_flowlet_map() {
         hash(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, (bit<13>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<26>)13);
-        flowlet_id.read(meta.ingress_metadata.flowlet_id, meta.ingress_metadata.flowlet_map_index);
+        flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id.write(meta.ingress_metadata.flowlet_map_index, (bit<16>)meta.ingress_metadata.flowlet_id);
+        flowlet_id.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<16>)meta.ingress_metadata.flowlet_id);
     }
     @name("ecmp_group") table ecmp_group {
         actions = {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4
@@ -108,8 +108,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("flowlet_id") register<bit<16>>(32w8192) flowlet_id;
-    @name("flowlet_lasttime") register<bit<32>>(32w8192) flowlet_lasttime;
+    @name("flowlet_id") register<bit<16>, bit<13>>(32w8192) flowlet_id;
+    @name("flowlet_lasttime") register<bit<32>, bit<13>>(32w8192) flowlet_lasttime;
     @name("_drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
@@ -123,18 +123,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("lookup_flowlet_map") action lookup_flowlet_map() {
         hash(meta.ingress_metadata.flowlet_map_index, HashAlgorithm.crc16, (bit<13>)0, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort }, (bit<26>)13);
-        flowlet_id.read(meta.ingress_metadata.flowlet_id, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_id.read(meta.ingress_metadata.flowlet_id, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = (bit<32>)standard_metadata.ingress_global_timestamp;
-        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, (bit<32>)meta.ingress_metadata.flowlet_map_index);
+        flowlet_lasttime.read(meta.ingress_metadata.flowlet_lasttime, meta.ingress_metadata.flowlet_map_index);
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
-        flowlet_lasttime.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
+        flowlet_lasttime.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
     @name("set_dmac") action set_dmac(bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("update_flowlet_id") action update_flowlet_id() {
         meta.ingress_metadata.flowlet_id = meta.ingress_metadata.flowlet_id + 16w1;
-        flowlet_id.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<16>)meta.ingress_metadata.flowlet_id);
+        flowlet_id.write(meta.ingress_metadata.flowlet_map_index, (bit<16>)meta.ingress_metadata.flowlet_id);
     }
     @name("ecmp_group") table ecmp_group {
         actions = {

--- a/testdata/p4_16_samples_outputs/free-form-annotation-first.p4
+++ b/testdata/p4_16_samples_outputs/free-form-annotation-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 @scrabble(- What do you get if you multiply six by nine ? - Six by nine . Forty two . - That ' s it . That ' s all there is . - I always thought there was something fundamentally wrong with the universe . 0xdeadbeef) header hdr {

--- a/testdata/p4_16_samples_outputs/free-form-annotation-frontend.p4
+++ b/testdata/p4_16_samples_outputs/free-form-annotation-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 @scrabble(- What do you get if you multiply six by nine ? - Six by nine . Forty two . - That ' s it . That ' s all there is . - I always thought there was something fundamentally wrong with the universe . 0xdeadbeef) header hdr {

--- a/testdata/p4_16_samples_outputs/free-form-annotation-midend.p4
+++ b/testdata/p4_16_samples_outputs/free-form-annotation-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 @scrabble(- What do you get if you multiply six by nine ? - Six by nine . Forty two . - That ' s it . That ' s all there is . - I always thought there was something fundamentally wrong with the universe . 0xdeadbeef) header hdr {

--- a/testdata/p4_16_samples_outputs/free-form-annotation.p4
+++ b/testdata/p4_16_samples_outputs/free-form-annotation.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 @scrabble(- What do you get if you multiply six by nine ? - Six by nine . Forty two . - That ' s it . That ' s all there is . - I always thought there was something fundamentally wrong with the universe . 0xdeadbeef) header hdr {

--- a/testdata/p4_16_samples_outputs/hash-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/hash-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/hash-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/hash-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/hash-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/header-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/header-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/header-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/header-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/header-bool-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/header-bool-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/header-bool-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/header-bool-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/header-bool-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/header-bool-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/header-bool-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/header-bool-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/header-stack-ops-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/header-stack-ops-bmv2-first.p4
@@ -2,6 +2,7 @@ error {
     BadHeaderType
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/header-stack-ops-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/header-stack-ops-bmv2-frontend.p4
@@ -2,6 +2,7 @@ error {
     BadHeaderType
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/header-stack-ops-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/header-stack-ops-bmv2-midend.p4
@@ -2,6 +2,7 @@ error {
     BadHeaderType
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/header-stack-ops-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/header-stack-ops-bmv2.p4
@@ -2,6 +2,7 @@ error {
     BadHeaderType
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/hit-expr-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/hit-expr-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/hit-expr-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hit-expr-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/hit-expr-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/hit-expr-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/hit-expr-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/hit-expr-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/inline-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/inline-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/inline-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline-stack-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/inline-stack-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/inline1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/intrinsic-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/intrinsic-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_m;

--- a/testdata/p4_16_samples_outputs/intrinsic-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/intrinsic-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_m;

--- a/testdata/p4_16_samples_outputs/intrinsic-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/intrinsic-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_m;

--- a/testdata/p4_16_samples_outputs/intrinsic-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/intrinsic-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_m;

--- a/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/issue-2123-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue-2123-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue-2123-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue-2123-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue-2123-3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-3-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue-2123-3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-3-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue-2123-3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-3-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue-2123-3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-3-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue-2123-first.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue-2123-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue-2123-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue-2123.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct ingress_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue1000-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1000-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue1000-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1000-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue1000-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1000-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue1000-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1000-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue1001-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1001-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {

--- a/testdata/p4_16_samples_outputs/issue1001-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1001-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {

--- a/testdata/p4_16_samples_outputs/issue1001-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1001-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {

--- a/testdata/p4_16_samples_outputs/issue1001-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1001-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {

--- a/testdata/p4_16_samples_outputs/issue1025-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1025-bmv2-first.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1025-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1025-bmv2-frontend.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/issue1025-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1025-bmv2-midend.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/issue1025-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1025-bmv2.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1043-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1043-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1043-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1043-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1043-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1043-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1043-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1043-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1049-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1049-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1049-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1049-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/issue1049-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1049-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/issue1049-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1049-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1062-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1062-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1062-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1062-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1062-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1062-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1062-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1062-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header empty {

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header empty {

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header empty {

--- a/testdata/p4_16_samples_outputs/issue1079-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1079-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header empty {

--- a/testdata/p4_16_samples_outputs/issue1097-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-2-bmv2-first.p4
@@ -21,22 +21,22 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>>(32w256) r;
+register<bit<8>, bit<8>>(32w256) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> x;
-        r.read(x, (bit<32>)h.myhdr.reg_idx_to_update);
-        r.write((bit<32>)h.myhdr.reg_idx_to_update, 8w0x2a);
+        r.read(x, h.myhdr.reg_idx_to_update);
+        r.write(h.myhdr.reg_idx_to_update, 8w0x2a);
     }
 }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> tmp;
-        r.read(tmp, (bit<32>)h.myhdr.reg_idx_to_update);
+        r.read(tmp, h.myhdr.reg_idx_to_update);
         tmp = tmp + h.myhdr.value_to_add;
-        r.write((bit<32>)h.myhdr.reg_idx_to_update, tmp);
+        r.write(h.myhdr.reg_idx_to_update, tmp);
         h.myhdr.debug_last_reg_value_written = tmp;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1097-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header myhdr_t {
@@ -21,22 +22,22 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>, bit<8>>(32w256) r;
+register<bit<8>>(32w256) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> x;
-        r.read(x, h.myhdr.reg_idx_to_update);
-        r.write(h.myhdr.reg_idx_to_update, 8w0x2a);
+        r.read(x, (bit<32>)h.myhdr.reg_idx_to_update);
+        r.write((bit<32>)h.myhdr.reg_idx_to_update, 8w0x2a);
     }
 }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> tmp;
-        r.read(tmp, h.myhdr.reg_idx_to_update);
+        r.read(tmp, (bit<32>)h.myhdr.reg_idx_to_update);
         tmp = tmp + h.myhdr.value_to_add;
-        r.write(h.myhdr.reg_idx_to_update, tmp);
+        r.write((bit<32>)h.myhdr.reg_idx_to_update, tmp);
         h.myhdr.debug_last_reg_value_written = tmp;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1097-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header myhdr_t {
@@ -21,22 +22,22 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>, bit<8>>(32w256) r;
+register<bit<8>>(32w256) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> x_0;
     apply {
-        r.read(x_0, h.myhdr.reg_idx_to_update);
-        r.write(h.myhdr.reg_idx_to_update, 8w0x2a);
+        r.read(x_0, (bit<32>)h.myhdr.reg_idx_to_update);
+        r.write((bit<32>)h.myhdr.reg_idx_to_update, 8w0x2a);
     }
 }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> tmp_0;
     apply {
-        r.read(tmp_0, h.myhdr.reg_idx_to_update);
+        r.read(tmp_0, (bit<32>)h.myhdr.reg_idx_to_update);
         tmp_0 = tmp_0 + h.myhdr.value_to_add;
-        r.write(h.myhdr.reg_idx_to_update, tmp_0);
+        r.write((bit<32>)h.myhdr.reg_idx_to_update, tmp_0);
         h.myhdr.debug_last_reg_value_written = tmp_0;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1097-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-2-bmv2-frontend.p4
@@ -21,22 +21,22 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>>(32w256) r;
+register<bit<8>, bit<8>>(32w256) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> x_0;
     apply {
-        r.read(x_0, (bit<32>)h.myhdr.reg_idx_to_update);
-        r.write((bit<32>)h.myhdr.reg_idx_to_update, 8w0x2a);
+        r.read(x_0, h.myhdr.reg_idx_to_update);
+        r.write(h.myhdr.reg_idx_to_update, 8w0x2a);
     }
 }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> tmp_0;
     apply {
-        r.read(tmp_0, (bit<32>)h.myhdr.reg_idx_to_update);
+        r.read(tmp_0, h.myhdr.reg_idx_to_update);
         tmp_0 = tmp_0 + h.myhdr.value_to_add;
-        r.write((bit<32>)h.myhdr.reg_idx_to_update, tmp_0);
+        r.write(h.myhdr.reg_idx_to_update, tmp_0);
         h.myhdr.debug_last_reg_value_written = tmp_0;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1097-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header myhdr_t {
@@ -21,13 +22,13 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>, bit<8>>(32w256) r;
+register<bit<8>>(32w256) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> x_0;
     @hidden action issue10972bmv2l51() {
-        r.read(x_0, h.myhdr.reg_idx_to_update);
-        r.write(h.myhdr.reg_idx_to_update, 8w0x2a);
+        r.read(x_0, (bit<32>)h.myhdr.reg_idx_to_update);
+        r.write((bit<32>)h.myhdr.reg_idx_to_update, 8w0x2a);
     }
     @hidden table tbl_issue10972bmv2l51 {
         actions = {
@@ -43,9 +44,9 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> tmp_0;
     @hidden action issue10972bmv2l62() {
-        r.read(tmp_0, h.myhdr.reg_idx_to_update);
+        r.read(tmp_0, (bit<32>)h.myhdr.reg_idx_to_update);
         tmp_0 = tmp_0 + h.myhdr.value_to_add;
-        r.write(h.myhdr.reg_idx_to_update, tmp_0);
+        r.write((bit<32>)h.myhdr.reg_idx_to_update, tmp_0);
         h.myhdr.debug_last_reg_value_written = tmp_0;
     }
     @hidden table tbl_issue10972bmv2l62 {

--- a/testdata/p4_16_samples_outputs/issue1097-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-2-bmv2-midend.p4
@@ -21,13 +21,13 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>>(32w256) r;
+register<bit<8>, bit<8>>(32w256) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> x_0;
     @hidden action issue10972bmv2l51() {
-        r.read(x_0, (bit<32>)h.myhdr.reg_idx_to_update);
-        r.write((bit<32>)h.myhdr.reg_idx_to_update, 8w0x2a);
+        r.read(x_0, h.myhdr.reg_idx_to_update);
+        r.write(h.myhdr.reg_idx_to_update, 8w0x2a);
     }
     @hidden table tbl_issue10972bmv2l51 {
         actions = {
@@ -43,9 +43,9 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> tmp_0;
     @hidden action issue10972bmv2l62() {
-        r.read(tmp_0, (bit<32>)h.myhdr.reg_idx_to_update);
+        r.read(tmp_0, h.myhdr.reg_idx_to_update);
         tmp_0 = tmp_0 + h.myhdr.value_to_add;
-        r.write((bit<32>)h.myhdr.reg_idx_to_update, tmp_0);
+        r.write(h.myhdr.reg_idx_to_update, tmp_0);
         h.myhdr.debug_last_reg_value_written = tmp_0;
     }
     @hidden table tbl_issue10972bmv2l62 {

--- a/testdata/p4_16_samples_outputs/issue1097-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header myhdr_t {
@@ -21,22 +22,22 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>, bit<8>>(256) r;
+register<bit<8>>(256) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> x;
-        r.read(x, h.myhdr.reg_idx_to_update);
-        r.write(h.myhdr.reg_idx_to_update, 0x2a);
+        r.read(x, (bit<32>)h.myhdr.reg_idx_to_update);
+        r.write((bit<32>)h.myhdr.reg_idx_to_update, 0x2a);
     }
 }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> tmp;
-        r.read(tmp, h.myhdr.reg_idx_to_update);
+        r.read(tmp, (bit<32>)h.myhdr.reg_idx_to_update);
         tmp = tmp + h.myhdr.value_to_add;
-        r.write(h.myhdr.reg_idx_to_update, tmp);
+        r.write((bit<32>)h.myhdr.reg_idx_to_update, tmp);
         h.myhdr.debug_last_reg_value_written = tmp;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1097-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-2-bmv2.p4
@@ -21,22 +21,22 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>>(256) r;
+register<bit<8>, bit<8>>(256) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> x;
-        r.read(x, (bit<32>)h.myhdr.reg_idx_to_update);
-        r.write((bit<32>)h.myhdr.reg_idx_to_update, 0x2a);
+        r.read(x, h.myhdr.reg_idx_to_update);
+        r.write(h.myhdr.reg_idx_to_update, 0x2a);
     }
 }
 
 control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> tmp;
-        r.read(tmp, (bit<32>)h.myhdr.reg_idx_to_update);
+        r.read(tmp, h.myhdr.reg_idx_to_update);
         tmp = tmp + h.myhdr.value_to_add;
-        r.write((bit<32>)h.myhdr.reg_idx_to_update, tmp);
+        r.write(h.myhdr.reg_idx_to_update, tmp);
         h.myhdr.debug_last_reg_value_written = tmp;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1097-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-bmv2-first.p4
@@ -13,12 +13,12 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>>(32w2) r;
+register<bit<8>, bit<1>>(32w2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> x;
-        r.read(x, 32w0);
+        r.read(x, 1w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1097-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {
@@ -13,12 +14,12 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>, bit<1>>(32w2) r;
+register<bit<8>>(32w2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> x;
-        r.read(x, 1w0);
+        r.read(x, 32w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1097-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-bmv2-frontend.p4
@@ -13,12 +13,12 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>>(32w2) r;
+register<bit<8>, bit<1>>(32w2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> x_0;
     apply {
-        r.read(x_0, 32w0);
+        r.read(x_0, 1w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1097-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {
@@ -13,12 +14,12 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>, bit<1>>(32w2) r;
+register<bit<8>>(32w2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> x_0;
     apply {
-        r.read(x_0, 1w0);
+        r.read(x_0, 32w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1097-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-bmv2-midend.p4
@@ -13,12 +13,12 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>>(32w2) r;
+register<bit<8>, bit<1>>(32w2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> x_0;
     @hidden action issue1097bmv2l19() {
-        r.read(x_0, 32w0);
+        r.read(x_0, 1w0);
     }
     @hidden table tbl_issue1097bmv2l19 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1097-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {
@@ -13,12 +14,12 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>, bit<1>>(32w2) r;
+register<bit<8>>(32w2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bit<8> x_0;
     @hidden action issue1097bmv2l19() {
-        r.read(x_0, 1w0);
+        r.read(x_0, 32w0);
     }
     @hidden table tbl_issue1097bmv2l19 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1097-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-bmv2.p4
@@ -13,7 +13,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>>(2) r;
+register<bit<8>, bit<1>>(2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {

--- a/testdata/p4_16_samples_outputs/issue1097-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1097-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {
@@ -13,7 +14,7 @@ parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm)
     }
 }
 
-register<bit<8>, bit<1>>(2) r;
+register<bit<8>>(2) r;
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {

--- a/testdata/p4_16_samples_outputs/issue1107-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1107-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue1107-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1107-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue1107-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1107-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue1107.p4
+++ b/testdata/p4_16_samples_outputs/issue1107.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue1127-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1127-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1127-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1127-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1127-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1127-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1127-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1127-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1193-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1193-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 extern jnf_counter {

--- a/testdata/p4_16_samples_outputs/issue1193-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1193-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 extern jnf_counter {

--- a/testdata/p4_16_samples_outputs/issue1193-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1193-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 extern jnf_counter {

--- a/testdata/p4_16_samples_outputs/issue1193-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1193-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 extern jnf_counter {

--- a/testdata/p4_16_samples_outputs/issue1210-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1210-first.p4
@@ -1,17 +1,18 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
-struct _PortId_t {
+struct PortId_t {
     bit<9> _v;
 }
 
-const _PortId_t PSA_CPU_PORT = { 9w192 };
+const PortId_t PSA_CPU_PORT = { 9w192 };
 struct parsed_headers_t {
 }
 
 struct metadata_t {
-    _PortId_t foo;
-    _PortId_t bar;
+    PortId_t foo;
+    PortId_t bar;
 }
 
 parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {

--- a/testdata/p4_16_samples_outputs/issue1210-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1210-first.p4
@@ -1,17 +1,17 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct PortId_t {
+struct _PortId_t {
     bit<9> _v;
 }
 
-const PortId_t PSA_CPU_PORT = { 9w192 };
+const _PortId_t PSA_CPU_PORT = { 9w192 };
 struct parsed_headers_t {
 }
 
 struct metadata_t {
-    PortId_t foo;
-    PortId_t bar;
+    _PortId_t foo;
+    _PortId_t bar;
 }
 
 parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {

--- a/testdata/p4_16_samples_outputs/issue1210-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1210-frontend.p4
@@ -1,7 +1,8 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
-struct _PortId_t {
+struct PortId_t {
     bit<9> _v;
 }
 
@@ -9,8 +10,8 @@ struct parsed_headers_t {
 }
 
 struct metadata_t {
-    _PortId_t foo;
-    _PortId_t bar;
+    PortId_t foo;
+    PortId_t bar;
 }
 
 parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {

--- a/testdata/p4_16_samples_outputs/issue1210-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1210-frontend.p4
@@ -1,7 +1,7 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct PortId_t {
+struct _PortId_t {
     bit<9> _v;
 }
 
@@ -9,8 +9,8 @@ struct parsed_headers_t {
 }
 
 struct metadata_t {
-    PortId_t foo;
-    PortId_t bar;
+    _PortId_t foo;
+    _PortId_t bar;
 }
 
 parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {

--- a/testdata/p4_16_samples_outputs/issue1210-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1210-midend.p4
@@ -1,7 +1,8 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
-struct _PortId_t {
+struct PortId_t {
     bit<9> _v;
 }
 

--- a/testdata/p4_16_samples_outputs/issue1210-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1210-midend.p4
@@ -1,7 +1,7 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct PortId_t {
+struct _PortId_t {
     bit<9> _v;
 }
 

--- a/testdata/p4_16_samples_outputs/issue1210.p4
+++ b/testdata/p4_16_samples_outputs/issue1210.p4
@@ -1,17 +1,18 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
-struct _PortId_t {
+struct PortId_t {
     bit<9> _v;
 }
 
-const _PortId_t PSA_CPU_PORT = { 9w192 };
+const PortId_t PSA_CPU_PORT = { 9w192 };
 struct parsed_headers_t {
 }
 
 struct metadata_t {
-    _PortId_t foo;
-    _PortId_t bar;
+    PortId_t foo;
+    PortId_t bar;
 }
 
 parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {

--- a/testdata/p4_16_samples_outputs/issue1210.p4
+++ b/testdata/p4_16_samples_outputs/issue1210.p4
@@ -1,17 +1,17 @@
 #include <core.p4>
 #include <v1model.p4>
 
-struct PortId_t {
+struct _PortId_t {
     bit<9> _v;
 }
 
-const PortId_t PSA_CPU_PORT = { 9w192 };
+const _PortId_t PSA_CPU_PORT = { 9w192 };
 struct parsed_headers_t {
 }
 
 struct metadata_t {
-    PortId_t foo;
-    PortId_t bar;
+    _PortId_t foo;
+    _PortId_t bar;
 }
 
 parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {

--- a/testdata/p4_16_samples_outputs/issue1291-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1291-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/issue1291-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1291-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/issue1291-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1291-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/issue1291-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1291-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/issue1304-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1304-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 package Pipeline<H, M>(Parser<H, M> p, Ingress<H, M> ig, Egress<H, M> eg, Deparser<H> dp);

--- a/testdata/p4_16_samples_outputs/issue1304-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1304-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 package Pipeline<H, M>(Parser<H, M> p, Ingress<H, M> ig, Egress<H, M> eg, Deparser<H> dp);

--- a/testdata/p4_16_samples_outputs/issue1304-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1304-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 package Pipeline<H, M>(Parser<H, M> p, Ingress<H, M> ig, Egress<H, M> eg, Deparser<H> dp);

--- a/testdata/p4_16_samples_outputs/issue1304.p4
+++ b/testdata/p4_16_samples_outputs/issue1304.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 package Pipeline<H, M>(Parser<H, M> p, Ingress<H, M> ig, Egress<H, M> eg, Deparser<H> dp);

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-first.p4
@@ -2,6 +2,7 @@ error {
     Unused
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct parsed_packet_t {

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-frontend.p4
@@ -2,6 +2,7 @@ error {
     Unused
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct parsed_packet_t {

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2-midend.p4
@@ -2,6 +2,7 @@ error {
     Unused
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct parsed_packet_t {

--- a/testdata/p4_16_samples_outputs/issue1325-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1325-bmv2.p4
@@ -2,6 +2,7 @@ error {
     Unused
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct parsed_packet_t {

--- a/testdata/p4_16_samples_outputs/issue134-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/issue134-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/issue134-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/issue134-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue134-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-first.p4
@@ -2,6 +2,7 @@ error {
     UnreachableState
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-frontend.p4
@@ -2,6 +2,7 @@ error {
     UnreachableState
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-midend.p4
@@ -2,6 +2,7 @@ error {
     UnreachableState
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2.p4
@@ -2,6 +2,7 @@ error {
     UnreachableState
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 0x800;

--- a/testdata/p4_16_samples_outputs/issue1386-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1386-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1386-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1386-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1386-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1386-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1386.p4
+++ b/testdata/p4_16_samples_outputs/issue1386.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1406-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1406-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header_t {

--- a/testdata/p4_16_samples_outputs/issue1406-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1406-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header_t {

--- a/testdata/p4_16_samples_outputs/issue1406-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1406-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header_t {

--- a/testdata/p4_16_samples_outputs/issue1406.p4
+++ b/testdata/p4_16_samples_outputs/issue1406.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header_t {

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header_t {

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header_t {

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header_t {

--- a/testdata/p4_16_samples_outputs/issue1409-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1409-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header_t {

--- a/testdata/p4_16_samples_outputs/issue1412-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1412-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/issue1412-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1412-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/issue1412-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1412-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/issue1412-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1412-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/issue1470-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1470-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/issue1470-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1470-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/issue1470-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1470-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/issue1470-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1470-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/issue1478-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1478-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1478-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1478-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1478-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1478-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1478-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1478-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue1517-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1517-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {
@@ -25,9 +26,9 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control C(inout headers hdr, inout metadata meta)(bool b) {
-    register<bit<16>, bit<3>>(32w8) r;
+    register<bit<16>>(32w8) r;
     apply {
-        r.read(hdr.h.x, 3w0);
+        r.read(hdr.h.x, 32w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2-first.p4
@@ -25,9 +25,9 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control C(inout headers hdr, inout metadata meta)(bool b) {
-    register<bit<16>>(32w8) r;
+    register<bit<16>, bit<3>>(32w8) r;
     apply {
-        r.read(hdr.h.x, 32w0);
+        r.read(hdr.h.x, 3w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {
@@ -25,11 +26,11 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("MyIngress.h.c1.r") register<bit<16>, bit<3>>(32w8) h_c1_r;
-    @name("MyIngress.h.c2.r") register<bit<16>, bit<3>>(32w8) h_c2_r;
+    @name("MyIngress.h.c1.r") register<bit<16>>(32w8) h_c1_r;
+    @name("MyIngress.h.c2.r") register<bit<16>>(32w8) h_c2_r;
     apply {
-        h_c1_r.read(hdr.h.x, 3w0);
-        h_c2_r.read(hdr.h.x, 3w0);
+        h_c1_r.read(hdr.h.x, 32w0);
+        h_c2_r.read(hdr.h.x, 32w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2-frontend.p4
@@ -25,11 +25,11 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("MyIngress.h.c1.r") register<bit<16>>(32w8) h_c1_r;
-    @name("MyIngress.h.c2.r") register<bit<16>>(32w8) h_c2_r;
+    @name("MyIngress.h.c1.r") register<bit<16>, bit<3>>(32w8) h_c1_r;
+    @name("MyIngress.h.c2.r") register<bit<16>, bit<3>>(32w8) h_c2_r;
     apply {
-        h_c1_r.read(hdr.h.x, 32w0);
-        h_c2_r.read(hdr.h.x, 32w0);
+        h_c1_r.read(hdr.h.x, 3w0);
+        h_c2_r.read(hdr.h.x, 3w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2-midend.p4
@@ -25,11 +25,11 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("MyIngress.h.c1.r") register<bit<16>>(32w8) h_c1_r;
-    @name("MyIngress.h.c2.r") register<bit<16>>(32w8) h_c2_r;
+    @name("MyIngress.h.c1.r") register<bit<16>, bit<3>>(32w8) h_c1_r;
+    @name("MyIngress.h.c2.r") register<bit<16>, bit<3>>(32w8) h_c2_r;
     @hidden action issue1520bmv2l33() {
-        h_c1_r.read(hdr.h.x, 32w0);
-        h_c2_r.read(hdr.h.x, 32w0);
+        h_c1_r.read(hdr.h.x, 3w0);
+        h_c2_r.read(hdr.h.x, 3w0);
     }
     @hidden table tbl_issue1520bmv2l33 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {
@@ -25,11 +26,11 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("MyIngress.h.c1.r") register<bit<16>, bit<3>>(32w8) h_c1_r;
-    @name("MyIngress.h.c2.r") register<bit<16>, bit<3>>(32w8) h_c2_r;
+    @name("MyIngress.h.c1.r") register<bit<16>>(32w8) h_c1_r;
+    @name("MyIngress.h.c2.r") register<bit<16>>(32w8) h_c2_r;
     @hidden action issue1520bmv2l33() {
-        h_c1_r.read(hdr.h.x, 3w0);
-        h_c2_r.read(hdr.h.x, 3w0);
+        h_c1_r.read(hdr.h.x, 32w0);
+        h_c2_r.read(hdr.h.x, 32w0);
     }
     @hidden table tbl_issue1520bmv2l33 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {
@@ -25,7 +26,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control C(inout headers hdr, inout metadata meta)(bool b) {
-    register<bit<16>, bit<3>>(32w8) r;
+    register<bit<16>>(32w8) r;
     apply {
         r.read(hdr.h.x, 0);
     }

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2.p4
@@ -25,7 +25,7 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control C(inout headers hdr, inout metadata meta)(bool b) {
-    register<bit<16>>(32w8) r;
+    register<bit<16>, bit<3>>(32w8) r;
     apply {
         r.read(hdr.h.x, 0);
     }

--- a/testdata/p4_16_samples_outputs/issue1524-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1524-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 type bit<7> foo_t;

--- a/testdata/p4_16_samples_outputs/issue1524-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1524-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue1524.p4
+++ b/testdata/p4_16_samples_outputs/issue1524.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 type bit<7> foo_t;

--- a/testdata/p4_16_samples_outputs/issue1535-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1535-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<7> FooUint_t;

--- a/testdata/p4_16_samples_outputs/issue1535-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1535-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<7> FooUint_t;

--- a/testdata/p4_16_samples_outputs/issue1535-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1535-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<7> FooUint_t;

--- a/testdata/p4_16_samples_outputs/issue1535.p4
+++ b/testdata/p4_16_samples_outputs/issue1535.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<7> FooUint_t;

--- a/testdata/p4_16_samples_outputs/issue1538-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 bit<16> incr(in bit<16> x) {

--- a/testdata/p4_16_samples_outputs/issue1538-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_16_samples_outputs/issue1538-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_16_samples_outputs/issue1538.p4
+++ b/testdata/p4_16_samples_outputs/issue1538.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 bit<16> incr(in bit<16> x) {

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 bit<16> sometimes_dec(in bit<16> x) {

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 bit<16> sometimes_dec(in bit<16> x) {

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 bit<16> sometimes_dec(in bit<16> x) {

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 bit<16> sometimes_dec(in bit<16> x) {

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 bit<16> sometimes_dec(in bit<16> x) {

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct metadata {

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 bit<16> sometimes_dec(in bit<16> x) {

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2-first.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2-frontend.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2-midend.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2-first.p4
@@ -19,10 +19,10 @@ struct metadata_t {
 
 control my_control_type(inout bit<16> x);
 control C1(inout bit<16> x) {
-    counter(32w65536, CounterType.packets) stats;
+    counter<bit<16>>(32w65536, CounterType.packets) stats;
     apply {
         x = x + 16w1;
-        stats.count((bit<32>)x);
+        stats.count(x);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -19,10 +20,10 @@ struct metadata_t {
 
 control my_control_type(inout bit<16> x);
 control C1(inout bit<16> x) {
-    counter<bit<16>>(32w65536, CounterType.packets) stats;
+    counter(32w65536, CounterType.packets) stats;
     apply {
         x = x + 16w1;
-        stats.count(x);
+        stats.count((bit<32>)x);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -25,14 +26,14 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 }
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("cIngress.E.c1.stats") counter<bit<16>>(32w65536, CounterType.packets) E_c1_stats;
+    @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
     apply {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count(hdr.ethernet.etherType);
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count(hdr.ethernet.etherType);
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2-frontend.p4
@@ -25,14 +25,14 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 }
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
+    @name("cIngress.E.c1.stats") counter<bit<16>>(32w65536, CounterType.packets) E_c1_stats;
     apply {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
+        E_c1_stats.count(hdr.ethernet.etherType);
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
+        E_c1_stats.count(hdr.ethernet.etherType);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -25,14 +26,14 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 }
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("cIngress.E.c1.stats") counter<bit<16>>(32w65536, CounterType.packets) E_c1_stats;
+    @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
     @hidden action issue1566bmv2l44() {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count(hdr.ethernet.etherType);
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count(hdr.ethernet.etherType);
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
     }
     @hidden table tbl_issue1566bmv2l44 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2-midend.p4
@@ -25,14 +25,14 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 }
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
+    @name("cIngress.E.c1.stats") counter<bit<16>>(32w65536, CounterType.packets) E_c1_stats;
     @hidden action issue1566bmv2l44() {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
+        E_c1_stats.count(hdr.ethernet.etherType);
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
+        E_c1_stats.count(hdr.ethernet.etherType);
     }
     @hidden table tbl_issue1566bmv2l44 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -19,10 +20,10 @@ struct metadata_t {
 
 control my_control_type(inout bit<16> x);
 control C1(inout bit<16> x) {
-    counter<bit<16>>((bit<32>)65536, CounterType.packets) stats;
+    counter((bit<32>)65536, CounterType.packets) stats;
     apply {
         x = x + 1;
-        stats.count(x);
+        stats.count((bit<32>)x);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-bmv2.p4
@@ -19,10 +19,10 @@ struct metadata_t {
 
 control my_control_type(inout bit<16> x);
 control C1(inout bit<16> x) {
-    counter((bit<32>)65536, CounterType.packets) stats;
+    counter<bit<16>>((bit<32>)65536, CounterType.packets) stats;
     apply {
         x = x + 1;
-        stats.count((bit<32>)x);
+        stats.count(x);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-first.p4
@@ -19,10 +19,10 @@ struct metadata_t {
 
 control my_control_type(inout bit<16> x);
 control C1(inout bit<16> x) {
-    counter(32w65536, CounterType.packets) stats;
+    counter<bit<16>>(32w65536, CounterType.packets) stats;
     apply {
         x = x + 16w1;
-        stats.count((bit<32>)x);
+        stats.count(x);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -19,10 +20,10 @@ struct metadata_t {
 
 control my_control_type(inout bit<16> x);
 control C1(inout bit<16> x) {
-    counter<bit<16>>(32w65536, CounterType.packets) stats;
+    counter(32w65536, CounterType.packets) stats;
     apply {
         x = x + 16w1;
-        stats.count(x);
+        stats.count((bit<32>)x);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -25,14 +26,14 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 }
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("cIngress.E.c1.stats") counter<bit<16>>(32w65536, CounterType.packets) E_c1_stats;
+    @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
     apply {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count(hdr.ethernet.etherType);
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count(hdr.ethernet.etherType);
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-frontend.p4
@@ -25,14 +25,14 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 }
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
+    @name("cIngress.E.c1.stats") counter<bit<16>>(32w65536, CounterType.packets) E_c1_stats;
     apply {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
+        E_c1_stats.count(hdr.ethernet.etherType);
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
+        E_c1_stats.count(hdr.ethernet.etherType);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-midend.p4
@@ -25,14 +25,14 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 }
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
+    @name("cIngress.E.c1.stats") counter<bit<16>>(32w65536, CounterType.packets) E_c1_stats;
     @hidden action issue1566l44() {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
+        E_c1_stats.count(hdr.ethernet.etherType);
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
+        E_c1_stats.count(hdr.ethernet.etherType);
     }
     @hidden table tbl_issue1566l44 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1566-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1566-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -25,14 +26,14 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout metadata_t meta, inou
 }
 
 control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("cIngress.E.c1.stats") counter<bit<16>>(32w65536, CounterType.packets) E_c1_stats;
+    @name("cIngress.E.c1.stats") counter(32w65536, CounterType.packets) E_c1_stats;
     @hidden action issue1566l44() {
         hdr.ethernet.etherType = hdr.ethernet.etherType << 1;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count(hdr.ethernet.etherType);
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
         hdr.ethernet.etherType = hdr.ethernet.etherType << 3;
         hdr.ethernet.etherType = hdr.ethernet.etherType + 16w1;
-        E_c1_stats.count(hdr.ethernet.etherType);
+        E_c1_stats.count((bit<32>)hdr.ethernet.etherType);
     }
     @hidden table tbl_issue1566l44 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1566.p4
+++ b/testdata/p4_16_samples_outputs/issue1566.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -19,10 +20,10 @@ struct metadata_t {
 
 control my_control_type(inout bit<16> x);
 control C1(inout bit<16> x) {
-    counter<bit<16>>((bit<32>)65536, CounterType.packets) stats;
+    counter((bit<32>)65536, CounterType.packets) stats;
     apply {
         x = x + 1;
-        stats.count(x);
+        stats.count((bit<32>)x);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1566.p4
+++ b/testdata/p4_16_samples_outputs/issue1566.p4
@@ -19,10 +19,10 @@ struct metadata_t {
 
 control my_control_type(inout bit<16> x);
 control C1(inout bit<16> x) {
-    counter((bit<32>)65536, CounterType.packets) stats;
+    counter<bit<16>>((bit<32>)65536, CounterType.packets) stats;
     apply {
         x = x + 1;
-        stats.count((bit<32>)x);
+        stats.count(x);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1595-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1595-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1595-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1595.p4
+++ b/testdata/p4_16_samples_outputs/issue1595.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1607-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1607-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header elem {

--- a/testdata/p4_16_samples_outputs/issue1607-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1607-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header elem {

--- a/testdata/p4_16_samples_outputs/issue1607-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1607-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header elem {

--- a/testdata/p4_16_samples_outputs/issue1607-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1607-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header elem {

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 0x800;

--- a/testdata/p4_16_samples_outputs/issue1642-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1642-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header short {

--- a/testdata/p4_16_samples_outputs/issue1642-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1642-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header short {

--- a/testdata/p4_16_samples_outputs/issue1642-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1642-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header short {

--- a/testdata/p4_16_samples_outputs/issue1642-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1642-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header short {

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header bitvec_hdr {

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header bitvec_hdr {

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header bitvec_hdr {

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header bitvec_hdr {

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<16> EthTypes {

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<16> EthTypes {

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<16> EthTypes {

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct HasBool {

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct HasBool {

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct HasBool {

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct HasBool {

--- a/testdata/p4_16_samples_outputs/issue1670-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1670-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct switch_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue1670-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1670-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct switch_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue1670-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1670-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct switch_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue1670-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1670-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct switch_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue1713-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1713-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1713-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1713-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1713-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1713-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1713-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1713-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddressUint_t;

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddressUint_t;

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddressUint_t;

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddressUint_t;

--- a/testdata/p4_16_samples_outputs/issue1755-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1755-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue1755-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1755-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue1755-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1755-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue1755-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1755-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue1755-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1755-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1755-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1755-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1755-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1755-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1755-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1755-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/issue1765-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-bmv2-first.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1765-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-bmv2-frontend.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/issue1765-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-bmv2-midend.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<32> IPv4Address;

--- a/testdata/p4_16_samples_outputs/issue1765-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-bmv2.p4
@@ -4,6 +4,7 @@ error {
     IPv4ChecksumError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct B8 {

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct B8 {

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct B8 {

--- a/testdata/p4_16_samples_outputs/issue1768-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1768-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct B8 {

--- a/testdata/p4_16_samples_outputs/issue1781-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1781-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1781-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1781-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1781-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1781-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1781-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1781-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1806-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1806-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Ethernet {

--- a/testdata/p4_16_samples_outputs/issue1806-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1806-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Ethernet {

--- a/testdata/p4_16_samples_outputs/issue1806-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1806-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Ethernet {

--- a/testdata/p4_16_samples_outputs/issue1806.p4
+++ b/testdata/p4_16_samples_outputs/issue1806.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Ethernet {

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2-first.p4
@@ -15,7 +15,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>>(32w1) testRegister;
+    register<bit<1>, bit<1>>(32w1) testRegister;
     action drop() {
         mark_to_drop(standard_metadata);
     }
@@ -35,7 +35,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     }
     apply {
         bit<1> registerData;
-        testRegister.read(registerData, 32w0);
+        testRegister.read(registerData, 1w0);
         meta.test = (bool)registerData;
         debug_table.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {
@@ -15,7 +16,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>, bit<1>>(32w1) testRegister;
+    register<bit<1>>(32w1) testRegister;
     action drop() {
         mark_to_drop(standard_metadata);
     }
@@ -35,7 +36,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     }
     apply {
         bit<1> registerData;
-        testRegister.read(registerData, 1w0);
+        testRegister.read(registerData, 32w0);
         meta.test = (bool)registerData;
         debug_table.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {
@@ -18,7 +19,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     bit<1> registerData_0;
-    @name("IngressImpl.testRegister") register<bit<1>, bit<1>>(32w1) testRegister_0;
+    @name("IngressImpl.testRegister") register<bit<1>>(32w1) testRegister_0;
     @name("IngressImpl.drop") action drop() {
         mark_to_drop(standard_metadata);
     }
@@ -37,7 +38,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
         default_action = NoAction_0();
     }
     apply {
-        testRegister_0.read(registerData_0, 1w0);
+        testRegister_0.read(registerData_0, 32w0);
         meta.test = (bool)registerData_0;
         debug_table_0.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2-frontend.p4
@@ -18,7 +18,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     bit<1> registerData_0;
-    @name("IngressImpl.testRegister") register<bit<1>>(32w1) testRegister_0;
+    @name("IngressImpl.testRegister") register<bit<1>, bit<1>>(32w1) testRegister_0;
     @name("IngressImpl.drop") action drop() {
         mark_to_drop(standard_metadata);
     }
@@ -37,7 +37,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
         default_action = NoAction_0();
     }
     apply {
-        testRegister_0.read(registerData_0, 32w0);
+        testRegister_0.read(registerData_0, 1w0);
         meta.test = (bool)registerData_0;
         debug_table_0.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2-midend.p4
@@ -18,7 +18,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     bit<1> registerData_0;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("IngressImpl.testRegister") register<bit<1>>(32w1) testRegister_0;
+    @name("IngressImpl.testRegister") register<bit<1>, bit<1>>(32w1) testRegister_0;
     @name("IngressImpl.drop") action drop() {
         mark_to_drop(standard_metadata);
     }
@@ -37,7 +37,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
         default_action = NoAction_0();
     }
     @hidden action issue18141bmv2l42() {
-        testRegister_0.read(registerData_0, 32w0);
+        testRegister_0.read(registerData_0, 1w0);
         meta.test = (bool)registerData_0;
     }
     @hidden table tbl_issue18141bmv2l42 {

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {
@@ -18,7 +19,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     bit<1> registerData_0;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("IngressImpl.testRegister") register<bit<1>, bit<1>>(32w1) testRegister_0;
+    @name("IngressImpl.testRegister") register<bit<1>>(32w1) testRegister_0;
     @name("IngressImpl.drop") action drop() {
         mark_to_drop(standard_metadata);
     }
@@ -37,7 +38,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
         default_action = NoAction_0();
     }
     @hidden action issue18141bmv2l42() {
-        testRegister_0.read(registerData_0, 1w0);
+        testRegister_0.read(registerData_0, 32w0);
         meta.test = (bool)registerData_0;
     }
     @hidden table tbl_issue18141bmv2l42 {

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {
@@ -15,7 +16,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>, bit<1>>(1) testRegister;
+    register<bit<1>>(1) testRegister;
     action drop() {
         mark_to_drop(standard_metadata);
     }

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2.p4
@@ -15,7 +15,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>>(1) testRegister;
+    register<bit<1>, bit<1>>(1) testRegister;
     action drop() {
         mark_to_drop(standard_metadata);
     }

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2-first.p4
@@ -15,7 +15,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>>(32w1) testRegister;
+    register<bit<1>, bit<1>>(32w1) testRegister;
     table debug_table {
         key = {
             meta.test: exact @name("meta.test") ;
@@ -27,7 +27,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     }
     apply {
         bit<1> registerData;
-        testRegister.read(registerData, 32w0);
+        testRegister.read(registerData, 1w0);
         meta.test = (bool)registerData;
         debug_table.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {
@@ -15,7 +16,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>, bit<1>>(32w1) testRegister;
+    register<bit<1>>(32w1) testRegister;
     table debug_table {
         key = {
             meta.test: exact @name("meta.test") ;
@@ -27,7 +28,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     }
     apply {
         bit<1> registerData;
-        testRegister.read(registerData, 1w0);
+        testRegister.read(registerData, 32w0);
         meta.test = (bool)registerData;
         debug_table.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {
@@ -18,7 +19,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     bit<1> registerData_0;
-    @name("IngressImpl.testRegister") register<bit<1>, bit<1>>(32w1) testRegister_0;
+    @name("IngressImpl.testRegister") register<bit<1>>(32w1) testRegister_0;
     @name("IngressImpl.debug_table") table debug_table_0 {
         key = {
             meta.test: exact @name("meta.test") ;
@@ -29,7 +30,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
         default_action = NoAction_0();
     }
     apply {
-        testRegister_0.read(registerData_0, 1w0);
+        testRegister_0.read(registerData_0, 32w0);
         meta.test = (bool)registerData_0;
         debug_table_0.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2-frontend.p4
@@ -18,7 +18,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     bit<1> registerData_0;
-    @name("IngressImpl.testRegister") register<bit<1>>(32w1) testRegister_0;
+    @name("IngressImpl.testRegister") register<bit<1>, bit<1>>(32w1) testRegister_0;
     @name("IngressImpl.debug_table") table debug_table_0 {
         key = {
             meta.test: exact @name("meta.test") ;
@@ -29,7 +29,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
         default_action = NoAction_0();
     }
     apply {
-        testRegister_0.read(registerData_0, 32w0);
+        testRegister_0.read(registerData_0, 1w0);
         meta.test = (bool)registerData_0;
         debug_table_0.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {
@@ -18,7 +19,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     bit<1> registerData_0;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("IngressImpl.testRegister") register<bit<1>, bit<1>>(32w1) testRegister_0;
+    @name("IngressImpl.testRegister") register<bit<1>>(32w1) testRegister_0;
     @name("IngressImpl.debug_table") table debug_table_0 {
         key = {
             meta.test: exact @name("meta.test") ;
@@ -29,7 +30,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
         default_action = NoAction_0();
     }
     @hidden action issue1814bmv2l33() {
-        testRegister_0.read(registerData_0, 1w0);
+        testRegister_0.read(registerData_0, 32w0);
         meta.test = (bool)registerData_0;
     }
     @hidden table tbl_issue1814bmv2l33 {

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2-midend.p4
@@ -18,7 +18,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
     bit<1> registerData_0;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("IngressImpl.testRegister") register<bit<1>>(32w1) testRegister_0;
+    @name("IngressImpl.testRegister") register<bit<1>, bit<1>>(32w1) testRegister_0;
     @name("IngressImpl.debug_table") table debug_table_0 {
         key = {
             meta.test: exact @name("meta.test") ;
@@ -29,7 +29,7 @@ control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metad
         default_action = NoAction_0();
     }
     @hidden action issue1814bmv2l33() {
-        testRegister_0.read(registerData_0, 32w0);
+        testRegister_0.read(registerData_0, 1w0);
         meta.test = (bool)registerData_0;
     }
     @hidden table tbl_issue1814bmv2l33 {

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2.p4
@@ -15,7 +15,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>>(1) testRegister;
+    register<bit<1>, bit<1>>(1) testRegister;
     table debug_table {
         key = {
             meta.test: exact;

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {
@@ -15,7 +16,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<1>, bit<1>>(1) testRegister;
+    register<bit<1>>(1) testRegister;
     table debug_table {
         key = {
             meta.test: exact;

--- a/testdata/p4_16_samples_outputs/issue1824-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1824-bmv2-first.p4
@@ -5,6 +5,7 @@ error {
     IPv4BadPacket
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header {

--- a/testdata/p4_16_samples_outputs/issue1824-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1824-bmv2-frontend.p4
@@ -5,6 +5,7 @@ error {
     IPv4BadPacket
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header {

--- a/testdata/p4_16_samples_outputs/issue1824-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1824-bmv2-midend.p4
@@ -5,6 +5,7 @@ error {
     IPv4BadPacket
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header {

--- a/testdata/p4_16_samples_outputs/issue1824-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1824-bmv2.p4
@@ -5,6 +5,7 @@ error {
     IPv4BadPacket
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header test_header {

--- a/testdata/p4_16_samples_outputs/issue1829-4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1829-4-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1829-4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1829-4-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1829-4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1829-4-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1829-4-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1829-4-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1834-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1834-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1834-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1834-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1834-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1834-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1834-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1834-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers {

--- a/testdata/p4_16_samples_outputs/issue1876-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1876-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue1876-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1876-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue1876-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1876-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue1876.p4
+++ b/testdata/p4_16_samples_outputs/issue1876.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<6> TYPE_ADDR_IPV4 = 6w0x1;

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header preamble_t {

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header preamble_t {

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<6> TYPE_ADDR_IPV4 = 0x1;

--- a/testdata/p4_16_samples_outputs/issue1882-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1882-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1882-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1882-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1882-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1882-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1882-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1882-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1882-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1882-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1882-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1882-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1882-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1882-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1882-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1882-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header addr_type_t {

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header addr_type_t {

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header addr_type_t {

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header addr_type_t {

--- a/testdata/p4_16_samples_outputs/issue1937-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-3-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-3-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-3-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1937-3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-3-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/issue1955-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1955-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1955-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1955-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1955-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1955-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1955.p4
+++ b/testdata/p4_16_samples_outputs/issue1955.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue1989-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1989-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum meter_color_t {

--- a/testdata/p4_16_samples_outputs/issue1989-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1989-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum meter_color_t {

--- a/testdata/p4_16_samples_outputs/issue1989-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1989-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum meter_color_t {

--- a/testdata/p4_16_samples_outputs/issue1989-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1989-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum meter_color_t {

--- a/testdata/p4_16_samples_outputs/issue2044-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2044-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue2044-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2044-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue2044-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2044-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue2044-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue2044-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue2104-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2104-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control c() {

--- a/testdata/p4_16_samples_outputs/issue2104-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2104-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control c() {

--- a/testdata/p4_16_samples_outputs/issue2104-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2104-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control c() {

--- a/testdata/p4_16_samples_outputs/issue2104.p4
+++ b/testdata/p4_16_samples_outputs/issue2104.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control c() {

--- a/testdata/p4_16_samples_outputs/issue2105-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2105-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2105-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2105-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2105-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2105-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2105.p4
+++ b/testdata/p4_16_samples_outputs/issue2105.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2148-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2148-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2148-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2148-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2148-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2148-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2148.p4
+++ b/testdata/p4_16_samples_outputs/issue2148.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2170-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2170-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2170-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2170-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2170-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2170-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2170-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue2170-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2176-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2176-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2176-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2176-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2176-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2176-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2176-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue2176-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2190-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2190-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2190-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2190-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2190-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2190-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2190.p4
+++ b/testdata/p4_16_samples_outputs/issue2190.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue2208-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2208-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2208-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2208-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2208-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2208-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2208.p4
+++ b/testdata/p4_16_samples_outputs/issue2208.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2213-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2213-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue2213-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2213-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue2213-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2213-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue2213-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue2213-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue2221-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2221-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2221-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2221-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2221-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2221-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2221-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue2221-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2261-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2261-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2261-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2261-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2261-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2261-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2261.p4
+++ b/testdata/p4_16_samples_outputs/issue2261.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2287-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2287-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2287-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2287-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2287-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2287-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2287-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue2287-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2291-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2291-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2291-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2291-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2291-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2291-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue2291-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue2291-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue232-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue232-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {

--- a/testdata/p4_16_samples_outputs/issue232-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {

--- a/testdata/p4_16_samples_outputs/issue232-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue242-first.p4
+++ b/testdata/p4_16_samples_outputs/issue242-first.p4
@@ -56,17 +56,17 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 }
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<32>>(32w100) debug;
-    register<bit<32>>(32w1) reg;
+    register<bit<32>, bit<7>>(32w100) debug;
+    register<bit<32>, bit<1>>(32w1) reg;
     action test() {
         Value val = (Value){field1 = 32w0};
         bool _pred = val.field1 != 32w0;
         bit<32> inc = (_pred ? 32w1 : 32w0);
-        debug.write(32w0, (_pred ? 32w1 : 32w0));
-        debug.write(32w1, inc);
+        debug.write(7w0, (_pred ? 32w1 : 32w0));
+        debug.write(7w1, inc);
         val.field1 = 32w1;
-        debug.write(32w2, inc);
-        reg.write(32w0, val.field1);
+        debug.write(7w2, inc);
+        reg.write(1w0, val.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue242-first.p4
+++ b/testdata/p4_16_samples_outputs/issue242-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -56,17 +57,17 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 }
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<32>, bit<7>>(32w100) debug;
-    register<bit<32>, bit<1>>(32w1) reg;
+    register<bit<32>>(32w100) debug;
+    register<bit<32>>(32w1) reg;
     action test() {
         Value val = (Value){field1 = 32w0};
         bool _pred = val.field1 != 32w0;
         bit<32> inc = (_pred ? 32w1 : 32w0);
-        debug.write(7w0, (_pred ? 32w1 : 32w0));
-        debug.write(7w1, inc);
+        debug.write(32w0, (_pred ? 32w1 : 32w0));
+        debug.write(32w1, inc);
         val.field1 = 32w1;
-        debug.write(7w2, inc);
-        reg.write(1w0, val.field1);
+        debug.write(32w2, inc);
+        reg.write(32w0, val.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue242-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-frontend.p4
@@ -61,8 +61,8 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
     bit<32> inc_0;
     bit<32> tmp;
     bit<32> tmp_0;
-    @name("Eg.debug") register<bit<32>>(32w100) debug_0;
-    @name("Eg.reg") register<bit<32>>(32w1) reg_0;
+    @name("Eg.debug") register<bit<32>, bit<7>>(32w100) debug_0;
+    @name("Eg.reg") register<bit<32>, bit<1>>(32w1) reg_0;
     @name("Eg.test") action test() {
         val_0 = (Value){field1 = 32w0};
         _pred_0 = val_0.field1 != 32w0;
@@ -77,11 +77,11 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         } else {
             tmp_0 = 32w0;
         }
-        debug_0.write(32w0, tmp_0);
-        debug_0.write(32w1, inc_0);
+        debug_0.write(7w0, tmp_0);
+        debug_0.write(7w1, inc_0);
         val_0.field1 = 32w1;
-        debug_0.write(32w2, inc_0);
-        reg_0.write(32w0, val_0.field1);
+        debug_0.write(7w2, inc_0);
+        reg_0.write(1w0, val_0.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue242-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -61,8 +62,8 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
     bit<32> inc_0;
     bit<32> tmp;
     bit<32> tmp_0;
-    @name("Eg.debug") register<bit<32>, bit<7>>(32w100) debug_0;
-    @name("Eg.reg") register<bit<32>, bit<1>>(32w1) reg_0;
+    @name("Eg.debug") register<bit<32>>(32w100) debug_0;
+    @name("Eg.reg") register<bit<32>>(32w1) reg_0;
     @name("Eg.test") action test() {
         val_0 = (Value){field1 = 32w0};
         _pred_0 = val_0.field1 != 32w0;
@@ -77,11 +78,11 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         } else {
             tmp_0 = 32w0;
         }
-        debug_0.write(7w0, tmp_0);
-        debug_0.write(7w1, inc_0);
+        debug_0.write(32w0, tmp_0);
+        debug_0.write(32w1, inc_0);
         val_0.field1 = 32w1;
-        debug_0.write(7w2, inc_0);
-        reg_0.write(1w0, val_0.field1);
+        debug_0.write(32w2, inc_0);
+        reg_0.write(32w0, val_0.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue242-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -70,13 +71,13 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 }
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    @name("Eg.debug") register<bit<32>, bit<7>>(32w100) debug_0;
-    @name("Eg.reg") register<bit<32>, bit<1>>(32w1) reg_0;
+    @name("Eg.debug") register<bit<32>>(32w100) debug_0;
+    @name("Eg.reg") register<bit<32>>(32w1) reg_0;
     @name("Eg.test") action test() {
-        debug_0.write(7w0, 32w0);
-        debug_0.write(7w1, 32w0);
-        debug_0.write(7w2, 32w0);
-        reg_0.write(1w0, 32w1);
+        debug_0.write(32w0, 32w0);
+        debug_0.write(32w1, 32w0);
+        debug_0.write(32w2, 32w0);
+        reg_0.write(32w0, 32w1);
     }
     @hidden table tbl_test {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue242-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue242-midend.p4
@@ -70,13 +70,13 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 }
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    @name("Eg.debug") register<bit<32>>(32w100) debug_0;
-    @name("Eg.reg") register<bit<32>>(32w1) reg_0;
+    @name("Eg.debug") register<bit<32>, bit<7>>(32w100) debug_0;
+    @name("Eg.reg") register<bit<32>, bit<1>>(32w1) reg_0;
     @name("Eg.test") action test() {
-        debug_0.write(32w0, 32w0);
-        debug_0.write(32w1, 32w0);
-        debug_0.write(32w2, 32w0);
-        reg_0.write(32w0, 32w1);
+        debug_0.write(7w0, 32w0);
+        debug_0.write(7w1, 32w0);
+        debug_0.write(7w2, 32w0);
+        reg_0.write(1w0, 32w1);
     }
     @hidden table tbl_test {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue242.p4
+++ b/testdata/p4_16_samples_outputs/issue242.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -56,8 +57,8 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 }
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<32>, bit<7>>(32w100) debug;
-    register<bit<32>, bit<1>>(32w1) reg;
+    register<bit<32>>(32w100) debug;
+    register<bit<32>>(32w1) reg;
     action test() {
         Value val = { 0 };
         bool _pred = val.field1 != 0;
@@ -66,7 +67,7 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         debug.write(1, inc);
         val.field1 = 32w1;
         debug.write(2, inc);
-        reg.write(0, val.field1);
+        reg.write(32w0, val.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue242.p4
+++ b/testdata/p4_16_samples_outputs/issue242.p4
@@ -56,8 +56,8 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 }
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<32>>(32w100) debug;
-    register<bit<32>>(32w1) reg;
+    register<bit<32>, bit<7>>(32w100) debug;
+    register<bit<32>, bit<1>>(32w1) reg;
     action test() {
         Value val = { 0 };
         bool _pred = val.field1 != 0;
@@ -66,7 +66,7 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         debug.write(1, inc);
         val.field1 = 32w1;
         debug.write(2, inc);
-        reg.write(32w0, val.field1);
+        reg.write(0, val.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue249-first.p4
+++ b/testdata/p4_16_samples_outputs/issue249-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue249-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue249-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue249-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue249-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue249.p4
+++ b/testdata/p4_16_samples_outputs/issue249.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue270-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/issue270-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/issue270-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/issue270-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue270-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/issue272-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue272-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue272-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue272-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue272-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue272-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue272-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue272-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue272-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue272-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue272-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue272-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue272-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue272-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue272-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue272-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue281-first.p4
+++ b/testdata/p4_16_samples_outputs/issue281-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue281-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue281-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue281-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue281-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue281.p4
+++ b/testdata/p4_16_samples_outputs/issue281.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue297-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
@@ -132,7 +132,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<16>>(32w65536) registerRound;
+    register<bit<16>, bit<32>>(32w65536) registerRound;
     action read_round() {
         registerRound.read(meta.local_metadata.round, hdr.myhdr.inst);
     }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -132,7 +133,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<16>, bit<32>>(32w65536) registerRound;
+    register<bit<16>>(32w65536) registerRound;
     action read_round() {
         registerRound.read(meta.local_metadata.round, hdr.myhdr.inst);
     }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
@@ -129,7 +129,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("ingress.registerRound") register<bit<16>>(32w65536) registerRound_0;
+    @name("ingress.registerRound") register<bit<16>, bit<32>>(32w65536) registerRound_0;
     @name("ingress.read_round") action read_round() {
         registerRound_0.read(meta.local_metadata.round, hdr.myhdr.inst);
     }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -129,7 +130,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("ingress.registerRound") register<bit<16>, bit<32>>(32w65536) registerRound_0;
+    @name("ingress.registerRound") register<bit<16>>(32w65536) registerRound_0;
     @name("ingress.read_round") action read_round() {
         registerRound_0.read(meta.local_metadata.round, hdr.myhdr.inst);
     }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
@@ -148,7 +148,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("ingress.registerRound") register<bit<16>>(32w65536) registerRound_0;
+    @name("ingress.registerRound") register<bit<16>, bit<32>>(32w65536) registerRound_0;
     @name("ingress.read_round") action read_round() {
         registerRound_0.read(meta._local_metadata_round0, hdr.myhdr.inst);
     }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -148,7 +149,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("ingress.registerRound") register<bit<16>, bit<32>>(32w65536) registerRound_0;
+    @name("ingress.registerRound") register<bit<16>>(32w65536) registerRound_0;
     @name("ingress.read_round") action read_round() {
         registerRound_0.read(meta._local_metadata_round0, hdr.myhdr.inst);
     }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -132,7 +133,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<16>, bit<32>>(65536) registerRound;
+    register<bit<16>>(65536) registerRound;
     action read_round() {
         registerRound.read(meta.local_metadata.round, hdr.myhdr.inst);
     }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2.p4
@@ -132,7 +132,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    register<bit<16>>(65536) registerRound;
+    register<bit<16>, bit<32>>(65536) registerRound;
     action read_round() {
         registerRound.read(meta.local_metadata.round, hdr.myhdr.inst);
     }

--- a/testdata/p4_16_samples_outputs/issue323-first.p4
+++ b/testdata/p4_16_samples_outputs/issue323-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue323-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue323-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue323-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue323-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue323.p4
+++ b/testdata/p4_16_samples_outputs/issue323.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue355-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue355-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue355-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue355-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue355-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue355-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue355-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue355-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue356-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue356-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue356-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue356-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue356-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue356-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue356-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue356-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/issue361-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue361-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue361-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue361-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue364-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue364-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue364-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue364-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/issue383-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/issue407-2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue407-2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue407-2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue407-2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue407-2.p4
+++ b/testdata/p4_16_samples_outputs/issue407-2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue407-3-first.p4
+++ b/testdata/p4_16_samples_outputs/issue407-3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue407-3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue407-3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue407-3.p4
+++ b/testdata/p4_16_samples_outputs/issue407-3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue414-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue414-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue414-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue414-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue420-first.p4
+++ b/testdata/p4_16_samples_outputs/issue420-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue420-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue420-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue420-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue420-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue420.p4
+++ b/testdata/p4_16_samples_outputs/issue420.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue422-first.p4
+++ b/testdata/p4_16_samples_outputs/issue422-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue422-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue422-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue422-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue422-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue422.p4
+++ b/testdata/p4_16_samples_outputs/issue422.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue430-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue430-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue430-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue430-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue430-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue430-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue430-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue430-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue430-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue447-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue447-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue447-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue447-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue447-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-3-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-3-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-3-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-3-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-4-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-4-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-5-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-5-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue447-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue447-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue447-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue447-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue447-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue447-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue447-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct fwd_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct fwd_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct fwd_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue461-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct fwd_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue486-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue486-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue486-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue486-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header X {

--- a/testdata/p4_16_samples_outputs/issue486-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue486-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header X {

--- a/testdata/p4_16_samples_outputs/issue486-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue486-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue496-first.p4
+++ b/testdata/p4_16_samples_outputs/issue496-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_16_samples_outputs/issue496-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue496-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_16_samples_outputs/issue496-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue496-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_16_samples_outputs/issue496.p4
+++ b/testdata/p4_16_samples_outputs/issue496.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_16_samples_outputs/issue510-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue510-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header simple {

--- a/testdata/p4_16_samples_outputs/issue510-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue510-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header simple {

--- a/testdata/p4_16_samples_outputs/issue510-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue510-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header simple {

--- a/testdata/p4_16_samples_outputs/issue510-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue510-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header simple {

--- a/testdata/p4_16_samples_outputs/issue512-first.p4
+++ b/testdata/p4_16_samples_outputs/issue512-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue512-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue512-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue512-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue512-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue512.p4
+++ b/testdata/p4_16_samples_outputs/issue512.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue561-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue561-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue561-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-3-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-3-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-3-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue561-3-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-4-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-4-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-4-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-4-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue561-4-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-5-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-5-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-5-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-5-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-5-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-5-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-5-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue561-5-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-6-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-6-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-6-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-6-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-6-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-6-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-6-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue561-6-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-7-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-7-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-7-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-7-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-7-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-7-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-7-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue561-7-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header S {

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-first.p4
@@ -4,6 +4,7 @@ error {
     TcpBadSackOptionLength
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
@@ -4,6 +4,7 @@ error {
     TcpBadSackOptionLength
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
@@ -4,6 +4,7 @@ error {
     TcpBadSackOptionLength
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue561-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2.p4
@@ -4,6 +4,7 @@ error {
     TcpBadSackOptionLength
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue562-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue562-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/issue562-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue562-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/issue562-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue562-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/issue562-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue562-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/issue584-1-first.p4
+++ b/testdata/p4_16_samples_outputs/issue584-1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<16> Hash;

--- a/testdata/p4_16_samples_outputs/issue584-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue584-1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control p();

--- a/testdata/p4_16_samples_outputs/issue584-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue584-1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control p();

--- a/testdata/p4_16_samples_outputs/issue584-1.p4
+++ b/testdata/p4_16_samples_outputs/issue584-1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<16> Hash;

--- a/testdata/p4_16_samples_outputs/issue635-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue635-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue635-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue635-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue635-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue635-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue635-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue635-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue655-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue655-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue655-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue655-first.p4
+++ b/testdata/p4_16_samples_outputs/issue655-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue655-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue655-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue655-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue655.p4
+++ b/testdata/p4_16_samples_outputs/issue655.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header H {

--- a/testdata/p4_16_samples_outputs/issue677-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue677-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t SM;

--- a/testdata/p4_16_samples_outputs/issue677-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue677-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t SM;

--- a/testdata/p4_16_samples_outputs/issue677-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue677-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t SM;

--- a/testdata/p4_16_samples_outputs/issue677-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue677-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t SM;

--- a/testdata/p4_16_samples_outputs/issue692-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue692-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue692-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue692-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue692-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue692-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue692-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue692-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-first.p4
@@ -3,9 +3,9 @@
 
 typedef bit<48> EthernetAddress;
 typedef bit<32> IPv4Address;
-register<bit<32>>(32w100) debug;
+register<bit<32>, bit<7>>(32w100) debug;
 
-register<bit<32>>(32w1) reg;
+register<bit<32>, bit<1>>(32w1) reg;
 
 header ethernet_t {
     EthernetAddress dstAddr;
@@ -64,11 +64,11 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         Value val = (Value){field1 = 32w0};
         bool _pred = val.field1 != 32w0;
         bit<32> inc = (_pred ? 32w1 : 32w0);
-        debug.write(32w0, (_pred ? 32w1 : 32w0));
-        debug.write(32w1, inc);
+        debug.write(7w0, (_pred ? 32w1 : 32w0));
+        debug.write(7w1, inc);
         val.field1 = 32w1;
-        debug.write(32w2, inc);
-        reg.write(32w0, val.field1);
+        debug.write(7w2, inc);
+        reg.write(1w0, val.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-first.p4
@@ -1,11 +1,12 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
 typedef bit<32> IPv4Address;
-register<bit<32>, bit<7>>(32w100) debug;
+register<bit<32>>(32w100) debug;
 
-register<bit<32>, bit<1>>(32w1) reg;
+register<bit<32>>(32w1) reg;
 
 header ethernet_t {
     EthernetAddress dstAddr;
@@ -64,11 +65,11 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         Value val = (Value){field1 = 32w0};
         bool _pred = val.field1 != 32w0;
         bit<32> inc = (_pred ? 32w1 : 32w0);
-        debug.write(7w0, (_pred ? 32w1 : 32w0));
-        debug.write(7w1, inc);
+        debug.write(32w0, (_pred ? 32w1 : 32w0));
+        debug.write(32w1, inc);
         val.field1 = 32w1;
-        debug.write(7w2, inc);
-        reg.write(1w0, val.field1);
+        debug.write(32w2, inc);
+        reg.write(32w0, val.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-frontend.p4
@@ -1,11 +1,12 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
 typedef bit<32> IPv4Address;
-register<bit<32>, bit<7>>(32w100) debug;
+register<bit<32>>(32w100) debug;
 
-register<bit<32>, bit<1>>(32w1) reg;
+register<bit<32>>(32w1) reg;
 
 header ethernet_t {
     EthernetAddress dstAddr;
@@ -79,11 +80,11 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         } else {
             tmp_0 = 32w0;
         }
-        debug.write(7w0, tmp_0);
-        debug.write(7w1, inc_0);
+        debug.write(32w0, tmp_0);
+        debug.write(32w1, inc_0);
         val_0.field1 = 32w1;
-        debug.write(7w2, inc_0);
-        reg.write(1w0, val_0.field1);
+        debug.write(32w2, inc_0);
+        reg.write(32w0, val_0.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-frontend.p4
@@ -3,9 +3,9 @@
 
 typedef bit<48> EthernetAddress;
 typedef bit<32> IPv4Address;
-register<bit<32>>(32w100) debug;
+register<bit<32>, bit<7>>(32w100) debug;
 
-register<bit<32>>(32w1) reg;
+register<bit<32>, bit<1>>(32w1) reg;
 
 header ethernet_t {
     EthernetAddress dstAddr;
@@ -79,11 +79,11 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         } else {
             tmp_0 = 32w0;
         }
-        debug.write(32w0, tmp_0);
-        debug.write(32w1, inc_0);
+        debug.write(7w0, tmp_0);
+        debug.write(7w1, inc_0);
         val_0.field1 = 32w1;
-        debug.write(32w2, inc_0);
-        reg.write(32w0, val_0.field1);
+        debug.write(7w2, inc_0);
+        reg.write(1w0, val_0.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-midend.p4
@@ -3,9 +3,9 @@
 
 typedef bit<48> EthernetAddress;
 typedef bit<32> IPv4Address;
-register<bit<32>>(32w100) debug;
+register<bit<32>, bit<7>>(32w100) debug;
 
-register<bit<32>>(32w1) reg;
+register<bit<32>, bit<1>>(32w1) reg;
 
 header ethernet_t {
     EthernetAddress dstAddr;
@@ -75,10 +75,10 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
     @name("Eg.test") action test() {
-        debug.write(32w0, 32w0);
-        debug.write(32w1, 32w0);
-        debug.write(32w2, 32w0);
-        reg.write(32w0, 32w1);
+        debug.write(7w0, 32w0);
+        debug.write(7w1, 32w0);
+        debug.write(7w2, 32w0);
+        reg.write(1w0, 32w1);
     }
     @hidden table tbl_test {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue696-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2-midend.p4
@@ -1,11 +1,12 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
 typedef bit<32> IPv4Address;
-register<bit<32>, bit<7>>(32w100) debug;
+register<bit<32>>(32w100) debug;
 
-register<bit<32>, bit<1>>(32w1) reg;
+register<bit<32>>(32w1) reg;
 
 header ethernet_t {
     EthernetAddress dstAddr;
@@ -75,10 +76,10 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
     @name("Eg.test") action test() {
-        debug.write(7w0, 32w0);
-        debug.write(7w1, 32w0);
-        debug.write(7w2, 32w0);
-        reg.write(1w0, 32w1);
+        debug.write(32w0, 32w0);
+        debug.write(32w1, 32w0);
+        debug.write(32w2, 32w0);
+        reg.write(32w0, 32w1);
     }
     @hidden table tbl_test {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue696-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2.p4
@@ -3,9 +3,9 @@
 
 typedef bit<48> EthernetAddress;
 typedef bit<32> IPv4Address;
-register<bit<32>>(32w100) debug;
+register<bit<32>, bit<7>>(32w100) debug;
 
-register<bit<32>>(32w1) reg;
+register<bit<32>, bit<1>>(32w1) reg;
 
 header ethernet_t {
     EthernetAddress dstAddr;
@@ -68,7 +68,7 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         debug.write(1, inc);
         val.field1 = 32w1;
         debug.write(2, inc);
-        reg.write(32w0, val.field1);
+        reg.write(0, val.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue696-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue696-bmv2.p4
@@ -1,11 +1,12 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
 typedef bit<32> IPv4Address;
-register<bit<32>, bit<7>>(32w100) debug;
+register<bit<32>>(32w100) debug;
 
-register<bit<32>, bit<1>>(32w1) reg;
+register<bit<32>>(32w1) reg;
 
 header ethernet_t {
     EthernetAddress dstAddr;
@@ -68,7 +69,7 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         debug.write(1, inc);
         val.field1 = 32w1;
         debug.write(2, inc);
-        reg.write(0, val.field1);
+        reg.write(32w0, val.field1);
     }
     apply {
         test();

--- a/testdata/p4_16_samples_outputs/issue737-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue737-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header fixedLenHeader_h {

--- a/testdata/p4_16_samples_outputs/issue737-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue737-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header fixedLenHeader_h {

--- a/testdata/p4_16_samples_outputs/issue737-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue737-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header fixedLenHeader_h {

--- a/testdata/p4_16_samples_outputs/issue737-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue737-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header fixedLenHeader_h {

--- a/testdata/p4_16_samples_outputs/issue774-4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue774-4-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {

--- a/testdata/p4_16_samples_outputs/issue774-4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue774-4-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {

--- a/testdata/p4_16_samples_outputs/issue774-4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue774-4-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {

--- a/testdata/p4_16_samples_outputs/issue774-4-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue774-4-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {

--- a/testdata/p4_16_samples_outputs/issue841-first.p4
+++ b/testdata/p4_16_samples_outputs/issue841-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_16_samples_outputs/issue841-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue841-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_16_samples_outputs/issue841-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue841-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_16_samples_outputs/issue841.p4
+++ b/testdata/p4_16_samples_outputs/issue841.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h_t {

--- a/testdata/p4_16_samples_outputs/issue841.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue841.p4-stderr
@@ -1,6 +1,6 @@
 issue841.p4(39): [--Wwarn=deprecated] warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
     Checksum16() checksum;
     ^^^^^^^^^^
-v1model.p4(416)
+v1model.p4(422)
 extern Checksum16 {
        ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue841.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue841.p4-stderr
@@ -1,6 +1,6 @@
 issue841.p4(39): [--Wwarn=deprecated] warning: Checksum16: Using deprecated feature Checksum16. Please use verify_checksum/update_checksum instead.
     Checksum16() checksum;
     ^^^^^^^^^^
-v1model.p4(422)
+v1model.p4(463)
 extern Checksum16 {
        ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue887-first.p4
+++ b/testdata/p4_16_samples_outputs/issue887-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header mpls {

--- a/testdata/p4_16_samples_outputs/issue887-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue887-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header mpls {

--- a/testdata/p4_16_samples_outputs/issue887-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue887-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header mpls {

--- a/testdata/p4_16_samples_outputs/issue887.p4
+++ b/testdata/p4_16_samples_outputs/issue887.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header mpls {

--- a/testdata/p4_16_samples_outputs/issue891-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue891-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header mpls {

--- a/testdata/p4_16_samples_outputs/issue891-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue891-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header mpls {

--- a/testdata/p4_16_samples_outputs/issue891-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue891-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header mpls {

--- a/testdata/p4_16_samples_outputs/issue891-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue891-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header mpls {

--- a/testdata/p4_16_samples_outputs/issue907-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {
@@ -18,10 +19,10 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<S, bit<7>>(32w100) r;
+    register<S>(32w100) r;
     apply {
         S s = (S){f = 32w0};
-        r.write(7w0, s);
+        r.write(32w0, s);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue907-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2-first.p4
@@ -18,10 +18,10 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<S>(32w100) r;
+    register<S, bit<7>>(32w100) r;
     apply {
         S s = (S){f = 32w0};
-        r.write(32w0, s);
+        r.write(7w0, s);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue907-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {
@@ -19,10 +20,10 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     S s_0;
-    @name("Ing.r") register<S, bit<7>>(32w100) r_0;
+    @name("Ing.r") register<S>(32w100) r_0;
     apply {
         s_0 = (S){f = 32w0};
-        r_0.write(7w0, s_0);
+        r_0.write(32w0, s_0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue907-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2-frontend.p4
@@ -19,10 +19,10 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     S s_0;
-    @name("Ing.r") register<S>(32w100) r_0;
+    @name("Ing.r") register<S, bit<7>>(32w100) r_0;
     apply {
         s_0 = (S){f = 32w0};
-        r_0.write(32w0, s_0);
+        r_0.write(7w0, s_0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue907-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2-midend.p4
@@ -19,10 +19,10 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     S s_0;
-    @name("Ing.r") register<S>(32w100) r_0;
+    @name("Ing.r") register<S, bit<7>>(32w100) r_0;
     @hidden action issue907bmv2l22() {
         s_0.f = 32w0;
-        r_0.write(32w0, s_0);
+        r_0.write(7w0, s_0);
     }
     @hidden table tbl_issue907bmv2l22 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue907-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {
@@ -19,10 +20,10 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     S s_0;
-    @name("Ing.r") register<S, bit<7>>(32w100) r_0;
+    @name("Ing.r") register<S>(32w100) r_0;
     @hidden action issue907bmv2l22() {
         s_0.f = 32w0;
-        r_0.write(7w0, s_0);
+        r_0.write(32w0, s_0);
     }
     @hidden table tbl_issue907bmv2l22 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue907-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {
@@ -18,7 +19,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<S, bit<7>>(32w100) r;
+    register<S>(32w100) r;
     apply {
         S s = { 0 };
         r.write(0, s);

--- a/testdata/p4_16_samples_outputs/issue907-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue907-bmv2.p4
@@ -18,7 +18,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<S>(32w100) r;
+    register<S, bit<7>>(32w100) r;
     apply {
         S s = { 0 };
         r.write(0, s);

--- a/testdata/p4_16_samples_outputs/issue914-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue914-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue914-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue914-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue914-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue914-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue914-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue914-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue949-first.p4
+++ b/testdata/p4_16_samples_outputs/issue949-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue949-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue949-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue949-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue949-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue949.p4
+++ b/testdata/p4_16_samples_outputs/issue949.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/issue955-first.p4
+++ b/testdata/p4_16_samples_outputs/issue955-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {

--- a/testdata/p4_16_samples_outputs/issue955-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue955-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {

--- a/testdata/p4_16_samples_outputs/issue955-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue955-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {

--- a/testdata/p4_16_samples_outputs/issue955.p4
+++ b/testdata/p4_16_samples_outputs/issue955.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Header {

--- a/testdata/p4_16_samples_outputs/issue983-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue983-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue983-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue983-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue983-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue983-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue983-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue983-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/issue986-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue986-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Meta {

--- a/testdata/p4_16_samples_outputs/issue986-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue986-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Meta {

--- a/testdata/p4_16_samples_outputs/issue986-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue986-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Meta {

--- a/testdata/p4_16_samples_outputs/issue986-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue986-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Meta {

--- a/testdata/p4_16_samples_outputs/issue986-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue986-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Meta {

--- a/testdata/p4_16_samples_outputs/issue986-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue986-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Meta {

--- a/testdata/p4_16_samples_outputs/issue986-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue986-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Meta {

--- a/testdata/p4_16_samples_outputs/issue986-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue986-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Meta {

--- a/testdata/p4_16_samples_outputs/issue995-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue995-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue995-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue995-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue995-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue995-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/issue995-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue995-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/key-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/key-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/key-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/key-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/key-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/key1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/key1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/key1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/key1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/key1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/key1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/key1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/key1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/logging-first.p4
+++ b/testdata/p4_16_samples_outputs/logging-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control c(inout bit<32> x, inout bit<32> y) {

--- a/testdata/p4_16_samples_outputs/logging-frontend.p4
+++ b/testdata/p4_16_samples_outputs/logging-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control c(inout bit<32> x, inout bit<32> y) {

--- a/testdata/p4_16_samples_outputs/logging-midend.p4
+++ b/testdata/p4_16_samples_outputs/logging-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct tuple_0 {

--- a/testdata/p4_16_samples_outputs/logging.p4
+++ b/testdata/p4_16_samples_outputs/logging.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control c(inout bit<32> x, inout bit<32> y) {

--- a/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/match-on-exprs-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/multicast-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct routing_metadata_t {

--- a/testdata/p4_16_samples_outputs/mux-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {

--- a/testdata/p4_16_samples_outputs/mux-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {

--- a/testdata/p4_16_samples_outputs/mux-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {

--- a/testdata/p4_16_samples_outputs/mux-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct Headers {

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct meta_t {

--- a/testdata/p4_16_samples_outputs/nested_if_else-first.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_else-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/nested_if_else-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_else-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> macAddr_t;

--- a/testdata/p4_16_samples_outputs/nested_if_else-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_else-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> macAddr_t;

--- a/testdata/p4_16_samples_outputs/nested_if_else.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_else.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 0x800;

--- a/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies-first.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> macAddr_t;

--- a/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> macAddr_t;

--- a/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 0x800;

--- a/testdata/p4_16_samples_outputs/nested_if_statement-first.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_statement-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/nested_if_statement-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_statement-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> macAddr_t;

--- a/testdata/p4_16_samples_outputs/nested_if_statement-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_statement-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> macAddr_t;

--- a/testdata/p4_16_samples_outputs/nested_if_statement.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_statement.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 0x800;

--- a/testdata/p4_16_samples_outputs/noMatch-first.p4
+++ b/testdata/p4_16_samples_outputs/noMatch-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 parser p() {

--- a/testdata/p4_16_samples_outputs/noMatch-frontend.p4
+++ b/testdata/p4_16_samples_outputs/noMatch-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 parser p() {

--- a/testdata/p4_16_samples_outputs/noMatch-midend.p4
+++ b/testdata/p4_16_samples_outputs/noMatch-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 parser p() {

--- a/testdata/p4_16_samples_outputs/noMatch.p4
+++ b/testdata/p4_16_samples_outputs/noMatch.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 parser p() {

--- a/testdata/p4_16_samples_outputs/p416-type-use3-first.p4
+++ b/testdata/p4_16_samples_outputs/p416-type-use3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthD_t;

--- a/testdata/p4_16_samples_outputs/p416-type-use3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/p416-type-use3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthD_t;

--- a/testdata/p4_16_samples_outputs/p416-type-use3-midend.p4
+++ b/testdata/p4_16_samples_outputs/p416-type-use3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthD_t;

--- a/testdata/p4_16_samples_outputs/p416-type-use3.p4
+++ b/testdata/p4_16_samples_outputs/p416-type-use3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthD_t;

--- a/testdata/p4_16_samples_outputs/parser-locals2-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-locals2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/parser-locals2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-locals2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/parser-locals2-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-locals2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/parser-locals2.p4
+++ b/testdata/p4_16_samples_outputs/parser-locals2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/parser_error-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/parser_error-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Ethernet {

--- a/testdata/p4_16_samples_outputs/parser_error-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser_error-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Ethernet {

--- a/testdata/p4_16_samples_outputs/parser_error-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser_error-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Ethernet {

--- a/testdata/p4_16_samples_outputs/parser_error-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/parser_error-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Ethernet {

--- a/testdata/p4_16_samples_outputs/pred-first.p4
+++ b/testdata/p4_16_samples_outputs/pred-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pred-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred-midend.p4
+++ b/testdata/p4_16_samples_outputs/pred-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred.p4
+++ b/testdata/p4_16_samples_outputs/pred.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred1-first.p4
+++ b/testdata/p4_16_samples_outputs/pred1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pred1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred1-midend.p4
+++ b/testdata/p4_16_samples_outputs/pred1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred1.p4
+++ b/testdata/p4_16_samples_outputs/pred1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred2-first.p4
+++ b/testdata/p4_16_samples_outputs/pred2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pred2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pred2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pred2.p4
+++ b/testdata/p4_16_samples_outputs/pred2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 control empty();

--- a/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-nested-struct-first.p4
+++ b/testdata/p4_16_samples_outputs/pvs-nested-struct-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-nested-struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-nested-struct-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-nested-struct-midend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-nested-struct-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-nested-struct.p4
+++ b/testdata/p4_16_samples_outputs/pvs-nested-struct.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/register-serenum-first.p4
+++ b/testdata/p4_16_samples_outputs/register-serenum-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<16> EthTypes {
@@ -34,9 +35,9 @@ parser prs(packet_in p, out Headers h) {
 }
 
 control c(inout Headers h, inout standard_metadata_t sm) {
-    register<EthTypes, bit<1>>(32w1) reg;
+    register<EthTypes>(32w1) reg;
     apply {
-        reg.write(1w0, h.eth.type);
+        reg.write(32w0, h.eth.type);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/register-serenum-first.p4
+++ b/testdata/p4_16_samples_outputs/register-serenum-first.p4
@@ -34,9 +34,9 @@ parser prs(packet_in p, out Headers h) {
 }
 
 control c(inout Headers h, inout standard_metadata_t sm) {
-    register<EthTypes>(32w1) reg;
+    register<EthTypes, bit<1>>(32w1) reg;
     apply {
-        reg.write(32w0, h.eth.type);
+        reg.write(1w0, h.eth.type);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/register-serenum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/register-serenum-frontend.p4
@@ -34,9 +34,9 @@ parser prs(packet_in p, out Headers h) {
 }
 
 control c(inout Headers h, inout standard_metadata_t sm) {
-    @name("c.reg") register<EthTypes>(32w1) reg_0;
+    @name("c.reg") register<EthTypes, bit<1>>(32w1) reg_0;
     apply {
-        reg_0.write(32w0, h.eth.type);
+        reg_0.write(1w0, h.eth.type);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/register-serenum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/register-serenum-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<16> EthTypes {
@@ -34,9 +35,9 @@ parser prs(packet_in p, out Headers h) {
 }
 
 control c(inout Headers h, inout standard_metadata_t sm) {
-    @name("c.reg") register<EthTypes, bit<1>>(32w1) reg_0;
+    @name("c.reg") register<EthTypes>(32w1) reg_0;
     apply {
-        reg_0.write(1w0, h.eth.type);
+        reg_0.write(32w0, h.eth.type);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/register-serenum-midend.p4
+++ b/testdata/p4_16_samples_outputs/register-serenum-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Ethernet {
@@ -24,9 +25,9 @@ parser prs(packet_in p, out Headers h) {
 }
 
 control c(inout Headers h, inout standard_metadata_t sm) {
-    @name("c.reg") register<bit<16>, bit<1>>(32w1) reg_0;
+    @name("c.reg") register<bit<16>>(32w1) reg_0;
     @hidden action registerserenum40() {
-        reg_0.write(1w0, h.eth.type);
+        reg_0.write(32w0, h.eth.type);
     }
     @hidden table tbl_registerserenum40 {
         actions = {

--- a/testdata/p4_16_samples_outputs/register-serenum-midend.p4
+++ b/testdata/p4_16_samples_outputs/register-serenum-midend.p4
@@ -24,9 +24,9 @@ parser prs(packet_in p, out Headers h) {
 }
 
 control c(inout Headers h, inout standard_metadata_t sm) {
-    @name("c.reg") register<bit<16>>(32w1) reg_0;
+    @name("c.reg") register<bit<16>, bit<1>>(32w1) reg_0;
     @hidden action registerserenum40() {
-        reg_0.write(32w0, h.eth.type);
+        reg_0.write(1w0, h.eth.type);
     }
     @hidden table tbl_registerserenum40 {
         actions = {

--- a/testdata/p4_16_samples_outputs/register-serenum.p4
+++ b/testdata/p4_16_samples_outputs/register-serenum.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<16> EthTypes {
@@ -34,7 +35,7 @@ parser prs(packet_in p, out Headers h) {
 }
 
 control c(inout Headers h, inout standard_metadata_t sm) {
-    register<EthTypes, bit<1>>(1) reg;
+    register<EthTypes>(1) reg;
     apply {
         reg.write(0, h.eth.type);
     }

--- a/testdata/p4_16_samples_outputs/register-serenum.p4
+++ b/testdata/p4_16_samples_outputs/register-serenum.p4
@@ -34,7 +34,7 @@ parser prs(packet_in p, out Headers h) {
 }
 
 control c(inout Headers h, inout standard_metadata_t sm) {
-    register<EthTypes>(1) reg;
+    register<EthTypes, bit<1>>(1) reg;
     apply {
         reg.write(0, h.eth.type);
     }

--- a/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/runtime-index-2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/runtime-index-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/runtime-index-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/runtime-index-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/runtime-index-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/runtime-index-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> mac_addr_t;

--- a/testdata/p4_16_samples_outputs/same_name_for_table_and_action-first.p4
+++ b/testdata/p4_16_samples_outputs/same_name_for_table_and_action-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/same_name_for_table_and_action-frontend.p4
+++ b/testdata/p4_16_samples_outputs/same_name_for_table_and_action-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/same_name_for_table_and_action-midend.p4
+++ b/testdata/p4_16_samples_outputs/same_name_for_table_and_action-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/same_name_for_table_and_action.p4
+++ b/testdata/p4_16_samples_outputs/same_name_for_table_and_action.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct H {

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<8> USat_t;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<8> USat_t;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<8> USat_t;

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<8> USat_t;

--- a/testdata/p4_16_samples_outputs/scalarmeta-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/scalarmeta-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header d {

--- a/testdata/p4_16_samples_outputs/scalarmeta-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/scalarmeta-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header d {

--- a/testdata/p4_16_samples_outputs/scalarmeta-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/scalarmeta-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header d {

--- a/testdata/p4_16_samples_outputs/scalarmeta-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/scalarmeta-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header d {

--- a/testdata/p4_16_samples_outputs/simplify_slice-first.p4
+++ b/testdata/p4_16_samples_outputs/simplify_slice-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -39,7 +40,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<8>, bit<1>>(32w2) debug;
+    register<bit<8>>(32w2) debug;
     apply {
         bit<8> n = 8w0b11111111;
         bit<8> m = 8w0b11111111;
@@ -47,7 +48,7 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
         n[7:4] = 4w0;
         m[7:5] = 3w0;
         x[5:5] = 1w0;
-        debug.write(1w1, n);
+        debug.write(32w1, n);
         standard_meta.egress_spec = 9w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/simplify_slice-first.p4
+++ b/testdata/p4_16_samples_outputs/simplify_slice-first.p4
@@ -39,7 +39,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<8>>(32w2) debug;
+    register<bit<8>, bit<1>>(32w2) debug;
     apply {
         bit<8> n = 8w0b11111111;
         bit<8> m = 8w0b11111111;
@@ -47,7 +47,7 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
         n[7:4] = 4w0;
         m[7:5] = 3w0;
         x[5:5] = 1w0;
-        debug.write(32w1, n);
+        debug.write(1w1, n);
         standard_meta.egress_spec = 9w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/simplify_slice-frontend.p4
+++ b/testdata/p4_16_samples_outputs/simplify_slice-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -42,13 +43,13 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
     bit<8> n_0;
     bit<8> m_0;
     bit<8> x_0;
-    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
     apply {
         n_0 = 8w0b11111111;
         m_0 = 8w0b11111111;
         x_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(1w1, n_0);
+        debug_0.write(32w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/simplify_slice-frontend.p4
+++ b/testdata/p4_16_samples_outputs/simplify_slice-frontend.p4
@@ -42,13 +42,13 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
     bit<8> n_0;
     bit<8> m_0;
     bit<8> x_0;
-    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
     apply {
         n_0 = 8w0b11111111;
         m_0 = 8w0b11111111;
         x_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(32w1, n_0);
+        debug_0.write(1w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/simplify_slice-midend.p4
+++ b/testdata/p4_16_samples_outputs/simplify_slice-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -40,11 +41,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
-    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
     @hidden action simplify_slice79() {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(1w1, n_0);
+        debug_0.write(32w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
     @hidden table tbl_simplify_slice79 {

--- a/testdata/p4_16_samples_outputs/simplify_slice-midend.p4
+++ b/testdata/p4_16_samples_outputs/simplify_slice-midend.p4
@@ -40,11 +40,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
-    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
     @hidden action simplify_slice79() {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(32w1, n_0);
+        debug_0.write(1w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
     @hidden table tbl_simplify_slice79 {

--- a/testdata/p4_16_samples_outputs/simplify_slice.p4
+++ b/testdata/p4_16_samples_outputs/simplify_slice.p4
@@ -39,7 +39,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<8>>(32w2) debug;
+    register<bit<8>, bit<1>>(32w2) debug;
     apply {
         bit<8> n = 8w0b11111111;
         bit<8> m = 8w0b11111111;

--- a/testdata/p4_16_samples_outputs/simplify_slice.p4
+++ b/testdata/p4_16_samples_outputs/simplify_slice.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -39,7 +40,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<8>, bit<1>>(32w2) debug;
+    register<bit<8>>(32w2) debug;
     apply {
         bit<8> n = 8w0b11111111;
         bit<8> m = 8w0b11111111;

--- a/testdata/p4_16_samples_outputs/slice-def-use-first.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -39,11 +40,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<8>, bit<1>>(32w2) debug;
+    register<bit<8>>(32w2) debug;
     apply {
         bit<8> n = 8w0b11111111;
         n[7:4] = 4w0;
-        debug.write(1w1, n);
+        debug.write(32w1, n);
         standard_meta.egress_spec = 9w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use-first.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use-first.p4
@@ -39,11 +39,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<8>>(32w2) debug;
+    register<bit<8>, bit<1>>(32w2) debug;
     apply {
         bit<8> n = 8w0b11111111;
         n[7:4] = 4w0;
-        debug.write(32w1, n);
+        debug.write(1w1, n);
         standard_meta.egress_spec = 9w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use-frontend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -40,11 +41,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
-    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
     apply {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(1w1, n_0);
+        debug_0.write(32w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use-frontend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use-frontend.p4
@@ -40,11 +40,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
-    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
     apply {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(32w1, n_0);
+        debug_0.write(1w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/slice-def-use-midend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -40,11 +41,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
-    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
     @hidden action slicedefuse79() {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(1w1, n_0);
+        debug_0.write(32w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
     @hidden table tbl_slicedefuse79 {

--- a/testdata/p4_16_samples_outputs/slice-def-use-midend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use-midend.p4
@@ -40,11 +40,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
-    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
     @hidden action slicedefuse79() {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(32w1, n_0);
+        debug_0.write(1w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
     @hidden table tbl_slicedefuse79 {

--- a/testdata/p4_16_samples_outputs/slice-def-use.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -39,7 +40,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<8>, bit<1>>(32w2) debug;
+    register<bit<8>>(32w2) debug;
     apply {
         bit<8> n = 8w0b11111111;
         n[7:4] = 4w0;

--- a/testdata/p4_16_samples_outputs/slice-def-use.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use.p4
@@ -39,7 +39,7 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 }
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    register<bit<8>>(32w2) debug;
+    register<bit<8>, bit<1>>(32w2) debug;
     apply {
         bit<8> n = 8w0b11111111;
         n[7:4] = 4w0;

--- a/testdata/p4_16_samples_outputs/slice-def-use1-first.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -40,11 +41,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n;
-    @name("debug") register<bit<8>, bit<1>>(32w2) debug;
+    @name("debug") register<bit<8>>(32w2) debug;
     action act() {
         n = 8w0b11111111;
         n[7:4] = 4w0;
-        debug.write(1w1, n);
+        debug.write(32w1, n);
         standard_meta.egress_spec = 9w0;
     }
     table tbl_act {

--- a/testdata/p4_16_samples_outputs/slice-def-use1-first.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1-first.p4
@@ -40,11 +40,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n;
-    @name("debug") register<bit<8>>(32w2) debug;
+    @name("debug") register<bit<8>, bit<1>>(32w2) debug;
     action act() {
         n = 8w0b11111111;
         n[7:4] = 4w0;
-        debug.write(32w1, n);
+        debug.write(1w1, n);
         standard_meta.egress_spec = 9w0;
     }
     table tbl_act {

--- a/testdata/p4_16_samples_outputs/slice-def-use1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -40,11 +41,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
-    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
     @name("Ing.act") action act() {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(1w1, n_0);
+        debug_0.write(32w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
     @name("Ing.tbl_act") table tbl_act_0 {

--- a/testdata/p4_16_samples_outputs/slice-def-use1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1-frontend.p4
@@ -40,11 +40,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
-    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
     @name("Ing.act") action act() {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(32w1, n_0);
+        debug_0.write(1w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
     @name("Ing.tbl_act") table tbl_act_0 {

--- a/testdata/p4_16_samples_outputs/slice-def-use1-midend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -40,11 +41,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
-    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
     @name("Ing.act") action act() {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(1w1, n_0);
+        debug_0.write(32w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
     @name("Ing.tbl_act") table tbl_act_0 {

--- a/testdata/p4_16_samples_outputs/slice-def-use1-midend.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1-midend.p4
@@ -40,11 +40,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n_0;
-    @name("Ing.debug") register<bit<8>>(32w2) debug_0;
+    @name("Ing.debug") register<bit<8>, bit<1>>(32w2) debug_0;
     @name("Ing.act") action act() {
         n_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
-        debug_0.write(32w1, n_0);
+        debug_0.write(1w1, n_0);
         standard_meta.egress_spec = 9w0;
     }
     @name("Ing.tbl_act") table tbl_act_0 {

--- a/testdata/p4_16_samples_outputs/slice-def-use1.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;
@@ -40,11 +41,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n;
-    @name("debug") register<bit<8>, bit<1>>(32w2) debug;
+    @name("debug") register<bit<8>>(32w2) debug;
     action act() {
         n = 8w0b11111111;
         n[7:4] = 4w0;
-        debug.write(1, n);
+        debug.write(32w1, n);
         standard_meta.egress_spec = 9w0;
     }
     table tbl_act {

--- a/testdata/p4_16_samples_outputs/slice-def-use1.p4
+++ b/testdata/p4_16_samples_outputs/slice-def-use1.p4
@@ -40,11 +40,11 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     bit<8> n;
-    @name("debug") register<bit<8>>(32w2) debug;
+    @name("debug") register<bit<8>, bit<1>>(32w2) debug;
     action act() {
         n = 8w0b11111111;
         n[7:4] = 4w0;
-        debug.write(32w1, n);
+        debug.write(1, n);
         standard_meta.egress_spec = 9w0;
     }
     table tbl_act {

--- a/testdata/p4_16_samples_outputs/stack-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/stack-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/stack-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/stack-bvec-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/stack-bvec-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/stack-bvec-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bvec-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/stack-bvec-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bvec-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/stack-bvec-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/stack-bvec-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct alt_t {

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/std_meta_inlining-first.p4
+++ b/testdata/p4_16_samples_outputs/std_meta_inlining-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/std_meta_inlining-frontend.p4
+++ b/testdata/p4_16_samples_outputs/std_meta_inlining-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/std_meta_inlining-midend.p4
+++ b/testdata/p4_16_samples_outputs/std_meta_inlining-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/std_meta_inlining.p4
+++ b/testdata/p4_16_samples_outputs/std_meta_inlining.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/strength3-first.p4
+++ b/testdata/p4_16_samples_outputs/strength3-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/strength3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/strength3-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/strength3-midend.p4
+++ b/testdata/p4_16_samples_outputs/strength3-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/strength3.p4
+++ b/testdata/p4_16_samples_outputs/strength3.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/strength4-first.p4
+++ b/testdata/p4_16_samples_outputs/strength4-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/strength4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/strength4-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/strength4-midend.p4
+++ b/testdata/p4_16_samples_outputs/strength4-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/strength4.p4
+++ b/testdata/p4_16_samples_outputs/strength4.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/structured_annotations-first.p4
+++ b/testdata/p4_16_samples_outputs/structured_annotations-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/structured_annotations-frontend.p4
+++ b/testdata/p4_16_samples_outputs/structured_annotations-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/structured_annotations-midend.p4
+++ b/testdata/p4_16_samples_outputs/structured_annotations-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/structured_annotations.p4
+++ b/testdata/p4_16_samples_outputs/structured_annotations.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct headers_t {

--- a/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-first.p4
@@ -2,6 +2,7 @@ error {
     BadHeaderType
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-frontend.p4
@@ -2,6 +2,7 @@ error {
     BadHeaderType
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2-midend.p4
@@ -2,6 +2,7 @@ error {
     BadHeaderType
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2.p4
@@ -2,6 +2,7 @@ error {
     BadHeaderType
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header h1_t {

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<8> MyEnum1B {

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<8> MyEnum1B {

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<8> MyEnum1B {

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/table-key-serenum-first.p4
+++ b/testdata/p4_16_samples_outputs/table-key-serenum-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<16> EthTypes {

--- a/testdata/p4_16_samples_outputs/table-key-serenum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-key-serenum-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<16> EthTypes {

--- a/testdata/p4_16_samples_outputs/table-key-serenum-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-key-serenum-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Ethernet {

--- a/testdata/p4_16_samples_outputs/table-key-serenum.p4
+++ b/testdata/p4_16_samples_outputs/table-key-serenum.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 enum bit<16> EthTypes {

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header data_h {

--- a/testdata/p4_16_samples_outputs/test-parserinvalidargument-error-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/test-parserinvalidargument-error-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/test-parserinvalidargument-error-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/test-parserinvalidargument-error-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/test-parserinvalidargument-error-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/test-parserinvalidargument-error-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/test-parserinvalidargument-error-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/test-parserinvalidargument-error-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> EthernetAddress;

--- a/testdata/p4_16_samples_outputs/union-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union1-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union1-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union1-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union1-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union1-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union1-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union2-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union2-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union2-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union2-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union3-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union3-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union3-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union3-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union3-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union3-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/union4-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/union4-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/union4-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/union4-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/union4-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header Hdr1 {

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header hdr {

--- a/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-first.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-first.p4
@@ -2,6 +2,7 @@ error {
     UnreachableState
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-frontend.p4
@@ -2,6 +2,7 @@ error {
     UnreachableState
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-midend.p4
@@ -2,6 +2,7 @@ error {
     UnreachableState
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum.p4
@@ -2,6 +2,7 @@ error {
     UnreachableState
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 0x800;

--- a/testdata/p4_16_samples_outputs/v1model-digest-custom-type-first.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-custom-type-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 16w0x800;

--- a/testdata/p4_16_samples_outputs/v1model-digest-custom-type-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-custom-type-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/v1model-digest-custom-type-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-custom-type-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<9> egressSpec_t;

--- a/testdata/p4_16_samples_outputs/v1model-digest-custom-type.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-custom-type.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<16> TYPE_IPV4 = 0x800;

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1-first.p4
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> Eth0_t;

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> Eth0_t;

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> Eth0_t;

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1.p4
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef bit<48> Eth0_t;

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<32> BMV2_V1MODEL_INSTANCE_TYPE_NORMAL = 32w0;

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 const bit<32> BMV2_V1MODEL_INSTANCE_TYPE_NORMAL = 0;

--- a/testdata/p4_16_samples_outputs/verify-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2-first.p4
@@ -2,6 +2,7 @@ error {
     NewError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct m {

--- a/testdata/p4_16_samples_outputs/verify-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2-frontend.p4
@@ -2,6 +2,7 @@ error {
     NewError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct m {

--- a/testdata/p4_16_samples_outputs/verify-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2-midend.p4
@@ -2,6 +2,7 @@ error {
     NewError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct m {

--- a/testdata/p4_16_samples_outputs/verify-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/verify-bmv2.p4
@@ -2,6 +2,7 @@ error {
     NewError
 }
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 struct m {

--- a/testdata/p4_16_samples_outputs/x-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/x-bmv2-first.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/x-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/x-bmv2-frontend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/x-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/x-bmv2-midend.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;

--- a/testdata/p4_16_samples_outputs/x-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/x-bmv2.p4
@@ -1,4 +1,5 @@
 #include <core.p4>
+#define V1MODEL_VERSION 20180101
 #include <v1model.p4>
 
 typedef standard_metadata_t std_meta_t;


### PR DESCRIPTION
The first of these changes is fairly straight-forward and non-controversial -- it infers the size of action arguments use as indexes for counters/meters/registers in P4_14 code based on the size of the object in question.  This is the common way P4_14 compilers (like the old p4-hlir based stuff) worked.

The second change is wider-ranging in effect.  It changes the v1model to have an index size type parameter for counter/meter/register externs (much as is done in PSA), and uses the inferred size as above when translating from P4_14.  This is a "first step" to changing the P4_14 translation code to generating PSA model code instead of v1model (and getting rid of v1model altogether).