### PR TITLE
Fix P4_16 name resolution

### DIFF
--- a/ir/base.def
+++ b/ir/base.def
@@ -70,6 +70,13 @@ interface IGeneralNamespace : INamespace {
     validate{ checkDuplicateDeclarations(); }
 }
 
+// A "namespace" that really consists of several nested namespaces
+// Note that it might also contain a Simple or General namespace nested in these
+interface INestedNamespace : INamespace {
+    virtual std::vector<INamespace> getNestedNamespaces() const = 0;
+    Util::Enumerator<IDeclaration> *getDeclarations() const;
+}
+
 /// Interface implemented by something that can be called
 /// like a function.
 interface IFunctional {

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -54,6 +54,17 @@ Util::Enumerator<const IR::IDeclaration*>* IGeneralNamespace::getDeclsByName(cst
     return getDeclarations()->where(filter);
 }
 
+Util::Enumerator<const IDeclaration*>* INestedNamespace::getDeclarations() const {
+    Util::Enumerator<const IDeclaration*>* rv = nullptr;
+    for (auto nested : getNestedNamespaces()) {
+        if (nested) {
+            if (rv)
+                rv = rv->concat(nested->getDeclarations());
+            else
+                rv = nested->getDeclarations(); } }
+    return rv;
+}
+
 bool IFunctional::callMatches(const Vector<Argument> *arguments) const {
     auto paramList = getParameters()->parameters;
     std::map<cstring, const IR::Parameter*> paramNames;

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -81,25 +81,20 @@ class ParserState : ISimpleNamespace, Declaration, IAnnotated {
 }
 
 // A parser that contains all states (unlike the P4 v1.0 parser, which is really just a state)
-class P4Parser : Type_Declaration, ISimpleNamespace, IApply, IContainer {
+class P4Parser : Type_Declaration, INestedNamespace, ISimpleNamespace, IApply, IContainer {
     Type_Parser                                 type;
     optional ParameterList                      constructorParams = new ParameterList;
     optional inline IndexedVector<Declaration>  parserLocals;
     optional inline IndexedVector<ParserState>  states;
 
     TypeParameters getTypeParameters() const override { return type->getTypeParameters(); }
+    std::vector<INamespace> getNestedNamespaces() const {
+        return { type->typeParameters, type->applyParams, constructorParams }; }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return type->typeParameters->getDeclarations()
-                ->concat(type->applyParams->getDeclarations())
-                ->concat(constructorParams->getDeclarations())
-                ->concat(parserLocals.getDeclarations())
-                ->concat(states.getDeclarations()); }
-    IDeclaration getDeclByName(cstring name) const override {
+        return parserLocals.getDeclarations()->concat(states.getDeclarations()); }
+    IDeclaration getDeclByName(cstring name) const {
         auto decl = parserLocals.getDeclaration(name);
         if (!decl) decl = states.getDeclaration(name);
-        if (!decl) decl = type->applyParams->getDeclByName(name);
-        if (!decl) decl = constructorParams->getDeclByName(name);
-        if (!decl) decl = type->typeParameters->getDeclByName(name);
         return decl; }
     Type_Method getApplyMethodType() const override { return type->getApplyMethodType(); }
     ParameterList getApplyParameters() const override { return type->getApplyParameters(); }
@@ -117,27 +112,22 @@ class P4Parser : Type_Declaration, ISimpleNamespace, IApply, IContainer {
     toString { return cstring("parser ") + externalName(); }
 }
 
-class P4Control : Type_Declaration, ISimpleNamespace, IApply, IContainer {
+class P4Control : Type_Declaration, INestedNamespace, ISimpleNamespace, IApply, IContainer {
     Type_Control                                type;
     optional ParameterList                      constructorParams = new ParameterList;
     optional inline IndexedVector<Declaration>  controlLocals;
     BlockStatement                              body;
 
     TypeParameters getTypeParameters() const override { return type->getTypeParameters(); }
+    std::vector<INamespace> getNestedNamespaces() const {
+        return { type->typeParameters, type->applyParams, constructorParams }; }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return type->typeParameters->getDeclarations()
-                ->concat(type->applyParams->getDeclarations())
-                ->concat(constructorParams->getDeclarations())
-                ->concat(controlLocals.getDeclarations()); }
+        return controlLocals.getDeclarations(); }
     Type_Method getApplyMethodType() const override { return type->getApplyMethodType(); }
     ParameterList getApplyParameters() const override { return type->getApplyParameters(); }
     Type_Method getConstructorMethodType() const override;
     IDeclaration getDeclByName(cstring name) const override {
-        auto decl = controlLocals.getDeclaration(name);
-        if (!decl) decl = type->applyParams->getDeclByName(name);
-        if (!decl) decl = constructorParams->getDeclByName(name);
-        if (!decl) decl = type->typeParameters->getDeclByName(name);
-        return decl; }
+        return controlLocals.getDeclaration(name); }
     ParameterList getConstructorParameters() const override { return constructorParams; }
 #apply
     validate {

--- a/ir/node.h
+++ b/ir/node.h
@@ -53,9 +53,9 @@ class INode : public Util::IHasSourceInfo, public IHasDbPrint {
     virtual cstring node_type_name() const = 0;
     virtual void validate() const {}
     virtual const Annotation *getAnnotation(cstring) const { return nullptr; }
-    template<typename T> bool is() const;
-    template<typename T> const T *to() const;
-    template<typename T> const T &as() const;
+    template<typename T> bool is() const { return to<T>() != nullptr; }
+    template<typename T> const T *to() const { return dynamic_cast<const T*>(this); }
+    template<typename T> const T &as() const { return dynamic_cast<const T&>(*this); }
 };
 
 class Node : public virtual INode {
@@ -130,10 +130,6 @@ class Node : public virtual INode {
 
 // simple version of dbprint
 cstring dbp(const INode* node);
-
-template<typename T> bool INode::is() const { return getNode()->is<T>(); }
-template<typename T> const T *INode::to() const { return getNode()->to<T>(); }
-template<typename T> const T &INode::as() const { return getNode()->as<T>(); }
 
 inline bool equal(const Node *a, const Node *b) {
     return a == b || (a && b && *a == *b); }

--- a/ir/type.def
+++ b/ir/type.def
@@ -596,15 +596,16 @@ class Type_Newtype : Type_Declaration, IAnnotated {
 }
 
 /// An 'extern' black-box (not a function)
-class Type_Extern : Type_Declaration, IGeneralNamespace, IMayBeGenericType, IAnnotated {
+class Type_Extern : Type_Declaration, INestedNamespace, IGeneralNamespace,
+                    IMayBeGenericType, IAnnotated {
     optional TypeParameters typeParameters = new TypeParameters;
     optional inline Vector<Method> methods;  // methods can be overloaded, so this is not NameMap
     optional inline NameMap<Attribute, ordered_map> attributes;  // P4_14 only, currently
     optional Annotations annotations = Annotations::empty;
 
+    std::vector<INamespace> getNestedNamespaces() const { return { typeParameters }; }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
-        return typeParameters->getDeclarations()
-            ->concat(attributes.valueEnumerator()->as<const IDeclaration*>())
+        return attributes.valueEnumerator()->as<const IDeclaration*>()
             ->concat(methods.getEnumerator()->as<const IDeclaration*>()); }
     virtual TypeParameters getTypeParameters() const override { return typeParameters; }
     validate{ methods.check_null(); }

--- a/testdata/p4_16_samples/shadow-after-use.p4
+++ b/testdata/p4_16_samples/shadow-after-use.p4
@@ -1,0 +1,32 @@
+/*
+Copyright 2020 Intel, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <core.p4>
+
+control c(inout bit<16> x) {
+    action incx() { x = x + 1; }
+    action nop() { }
+    table x {
+        actions = { incx; nop; }
+    }
+    apply {
+        x.apply();
+    }
+}
+
+control C(inout bit<16> x);
+
+package top(C _c);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/shadow-after-use-first.p4
+++ b/testdata/p4_16_samples_outputs/shadow-after-use-first.p4
@@ -1,0 +1,25 @@
+#include <core.p4>
+
+control c(inout bit<16> x) {
+    action incx() {
+        x = x + 16w1;
+    }
+    action nop() {
+    }
+    table x {
+        actions = {
+            incx();
+            nop();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        x.apply();
+    }
+}
+
+control C(inout bit<16> x);
+package top(C _c);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/shadow-after-use-frontend.p4
+++ b/testdata/p4_16_samples_outputs/shadow-after-use-frontend.p4
@@ -1,0 +1,27 @@
+#include <core.p4>
+
+control c(inout bit<16> x) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("c.incx") action incx() {
+        x = x + 16w1;
+    }
+    @name("c.nop") action nop() {
+    }
+    @name("c.x") table x_0 {
+        actions = {
+            incx();
+            nop();
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        x_0.apply();
+    }
+}
+
+control C(inout bit<16> x);
+package top(C _c);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/shadow-after-use-midend.p4
+++ b/testdata/p4_16_samples_outputs/shadow-after-use-midend.p4
@@ -1,0 +1,27 @@
+#include <core.p4>
+
+control c(inout bit<16> x) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("c.incx") action incx() {
+        x = x + 16w1;
+    }
+    @name("c.nop") action nop() {
+    }
+    @name("c.x") table x_0 {
+        actions = {
+            incx();
+            nop();
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        x_0.apply();
+    }
+}
+
+control C(inout bit<16> x);
+package top(C _c);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/shadow-after-use.p4
+++ b/testdata/p4_16_samples_outputs/shadow-after-use.p4
@@ -1,0 +1,23 @@
+#include <core.p4>
+
+control c(inout bit<16> x) {
+    action incx() {
+        x = x + 1;
+    }
+    action nop() {
+    }
+    table x {
+        actions = {
+            incx;
+            nop;
+        }
+    }
+    apply {
+        x.apply();
+    }
+}
+
+control C(inout bit<16> x);
+package top(C _c);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/shadow-after-use.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow-after-use.p4-stderr
@@ -1,0 +1,6 @@
+shadow-after-use.p4(21): [--Wwarn=shadow] warning: x shadows x
+    table x {
+          ^
+shadow-after-use.p4(18)
+control c(inout bit<16> x) {
+                        ^


### PR DESCRIPTION
- when multiple namespaces exist in a single IR::Node, and symbols in
  those namespaces may shadow each other, lookup depends on the location
  of the name.

This is a subtle corner case that is a consequence of the decision to prohibit uses before definitions in P4_16 -- it also means that symbols in inner scopes only partly shadow symbols in enclosing scopes (only in the part of the scope after they are defined.)  Which means that in objects embodying multiple scopes, we must keep those scopes separate for symbol lookup.