### PR TITLE
Change precedence of '<' based on symbol immediately before it

### DIFF
--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -77,8 +77,6 @@ set (P4RUNTIME_EXCLUDE
 )
 
 set (P4_XFAIL_TESTS
-  # issue #13
-  testdata/p4_16_samples/cast-call.p4
   # This program is invalid according to the PSA specification as one direct
   # counter is shared by multiple match tables: "A DirectCounter instance must
   # appear as the value of the psa_direct_counter table attribute for at most

--- a/frontends/p4/symbol_table.h
+++ b/frontends/p4/symbol_table.h
@@ -44,12 +44,13 @@ class ProgramStructure final {
     Namespace* currentNamespace;
 
     struct PathContext {
-        Namespace* lookupContext;
-        PathContext() : lookupContext(nullptr) {}
+        const NamedSymbol* previousSymbol;
+        const Namespace* lookupContext;
+        PathContext() : previousSymbol(nullptr), lookupContext(nullptr) {}
     } identifierContext;
 
     void push(Namespace* ns);
-    NamedSymbol* lookup(const cstring identifier) const;
+    NamedSymbol* lookup(const cstring identifier);
     void declare(NamedSymbol* symbol);
 
  public:
@@ -66,16 +67,18 @@ class ProgramStructure final {
     void pushNamespace(SourceInfo info, bool allowDuplicates);
     void pushContainerType(IR::ID id, bool allowDuplicates);
     void declareType(IR::ID id);
-    void declareObject(IR::ID id);
+    void declareObject(IR::ID id, cstring type);
     void markAsTemplate(IR::ID id);  // the symbol expects template args
 
     // the last namespace has been exited
     void pop();
     // Declares these types in the current scope
     void declareTypes(const IR::IndexedVector<IR::Type_Var>* typeVars);
-    SymbolKind lookupIdentifier(cstring identifier) const;
+    void declareParameters(const IR::IndexedVector<IR::Parameter>* params);
+    SymbolKind lookupIdentifier(cstring identifier);
 
     void startAbsolutePath();
+    void relativePathFromLastSymbol();
     void clearPath();
 
     void endParse();

--- a/frontends/p4/symbol_table.h
+++ b/frontends/p4/symbol_table.h
@@ -55,7 +55,9 @@ class ProgramStructure final {
  public:
     enum class SymbolKind {
         Identifier,
-        Type
+        TemplateIdentifier,
+        Type,
+        TemplateType,
     };
 
     ProgramStructure();
@@ -65,6 +67,7 @@ class ProgramStructure final {
     void pushContainerType(IR::ID id, bool allowDuplicates);
     void declareType(IR::ID id);
     void declareObject(IR::ID id);
+    void markAsTemplate(IR::ID id);  // the symbol expects template args
 
     // the last namespace has been exited
     void pop();

--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -91,69 +91,120 @@ using Parser = P4::P4Parser;
 <STRING>\\\"    { driver.stringLiteral += yytext; }
 <STRING>\\\\    { driver.stringLiteral += yytext; }
 <STRING>\"      { BEGIN(driver.saveState);
+                  driver.template_args = false;
                   auto string = cstring(driver.stringLiteral);
                   return Parser::make_STRING_LITERAL(string, driver.yylloc); }
 <STRING>.       { driver.stringLiteral += yytext; }
 <STRING>\n      { driver.stringLiteral += yytext; }
 
 "@pragma"       { BEGIN((driver.saveState = PRAGMA_LINE));
+                  driver.template_args = false;
                   return makeToken(PRAGMA); }
 
-"abstract"      { BEGIN(driver.saveState); return makeToken(ABSTRACT); }
-"action"        { BEGIN(driver.saveState); return makeToken(ACTION); }
-"actions"       { BEGIN(driver.saveState); return makeToken(ACTIONS); }
-"apply"         { BEGIN(driver.saveState); return makeToken(APPLY); }
-"bool"          { BEGIN(driver.saveState); return makeToken(BOOL); }
-"bit"           { BEGIN(driver.saveState); return makeToken(BIT); }
-"const"         { BEGIN(driver.saveState); return makeToken(CONST); }
-"control"       { BEGIN(driver.saveState); return makeToken(CONTROL); }
-"default"       { BEGIN(driver.saveState); return makeToken(DEFAULT); }
-"else"          { BEGIN(driver.saveState); return makeToken(ELSE); }
-"entries"       { BEGIN(driver.saveState); return makeToken(ENTRIES); }
-"enum"          { BEGIN(driver.saveState); return makeToken(ENUM); }
-"error"         { BEGIN(driver.saveState); return makeToken(ERROR); }
-"exit"          { BEGIN(driver.saveState); return makeToken(EXIT); }
-"extern"        { BEGIN(driver.saveState); return makeToken(EXTERN); }
-"false"         { BEGIN(driver.saveState); return makeToken(FALSE); }
-"header"        { BEGIN(driver.saveState); return makeToken(HEADER); }
-"header_union"  { BEGIN(driver.saveState); return makeToken(HEADER_UNION); }
-"if"            { BEGIN(driver.saveState); return makeToken(IF); }
-"in"            { BEGIN(driver.saveState); return makeToken(IN); }
-"inout"         { BEGIN(driver.saveState); return makeToken(INOUT); }
-"int"           { BEGIN(driver.saveState); return makeToken(INT); }
-"key"           { BEGIN(driver.saveState); return makeToken(KEY); }
-"match_kind"    { BEGIN(driver.saveState); return makeToken(MATCH_KIND); }
-"type"          { BEGIN(driver.saveState); return makeToken(TYPE); }
-"out"           { BEGIN(driver.saveState); return makeToken(OUT); }
-"parser"        { BEGIN(driver.saveState); return makeToken(PARSER); }
-"package"       { BEGIN(driver.saveState); return makeToken(PACKAGE); }
-"return"        { BEGIN(driver.saveState); return makeToken(RETURN); }
-"select"        { BEGIN(driver.saveState); return makeToken(SELECT); }
-"state"         { BEGIN(driver.saveState); return makeToken(STATE); }
-"string"        { BEGIN(driver.saveState); return makeToken(STRING); }
-"struct"        { BEGIN(driver.saveState); return makeToken(STRUCT); }
-"switch"        { BEGIN(driver.saveState); return makeToken(SWITCH); }
-"table"         { BEGIN(driver.saveState); return makeToken(TABLE); }
-"this"          { BEGIN(driver.saveState); return makeToken(THIS); }
-"transition"    { BEGIN(driver.saveState); return makeToken(TRANSITION); }
-"true"          { BEGIN(driver.saveState); return makeToken(TRUE); }
-"tuple"         { BEGIN(driver.saveState); return makeToken(TUPLE); }
-"typedef"       { BEGIN(driver.saveState); return makeToken(TYPEDEF); }
-"varbit"        { BEGIN(driver.saveState); return makeToken(VARBIT); }
-"value_set"     { BEGIN(driver.saveState); return makeToken(VALUESET); }
-"void"          { BEGIN(driver.saveState); return makeToken(VOID); }
-"_"             { BEGIN(driver.saveState); return makeToken(DONTCARE); }
+"abstract"      { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(ABSTRACT); }
+"action"        { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(ACTION); }
+"actions"       { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(ACTIONS); }
+"apply"         { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(APPLY); }
+"bool"          { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(BOOL); }
+"bit"           { BEGIN(driver.saveState); driver.template_args = true;
+                  return makeToken(BIT); }
+"const"         { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(CONST); }
+"control"       { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(CONTROL); }
+"default"       { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(DEFAULT); }
+"else"          { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(ELSE); }
+"entries"       { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(ENTRIES); }
+"enum"          { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(ENUM); }
+"error"         { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(ERROR); }
+"exit"          { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(EXIT); }
+"extern"        { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(EXTERN); }
+"false"         { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(FALSE); }
+"header"        { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(HEADER); }
+"header_union"  { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(HEADER_UNION); }
+"if"            { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(IF); }
+"in"            { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(IN); }
+"inout"         { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(INOUT); }
+"int"           { BEGIN(driver.saveState); driver.template_args = true;
+                  return makeToken(INT); }
+"key"           { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(KEY); }
+"match_kind"    { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(MATCH_KIND); }
+"type"          { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(TYPE); }
+"out"           { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(OUT); }
+"parser"        { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(PARSER); }
+"package"       { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(PACKAGE); }
+"return"        { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(RETURN); }
+"select"        { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(SELECT); }
+"state"         { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(STATE); }
+"string"        { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(STRING); }
+"struct"        { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(STRUCT); }
+"switch"        { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(SWITCH); }
+"table"         { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(TABLE); }
+"this"          { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(THIS); }
+"transition"    { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(TRANSITION); }
+"true"          { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(TRUE); }
+"tuple"         { BEGIN(driver.saveState); driver.template_args = true;
+                  return makeToken(TUPLE); }
+"typedef"       { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(TYPEDEF); }
+"varbit"        { BEGIN(driver.saveState); driver.template_args = true;
+                  return makeToken(VARBIT); }
+"value_set"     { BEGIN(driver.saveState); driver.template_args = true;
+                  return makeToken(VALUESET); }
+"void"          { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(VOID); }
+"_"             { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(DONTCARE); }
 [A-Za-z_][A-Za-z0-9_]* {
                   BEGIN(driver.saveState);
+                  driver.template_args = false;
                   cstring name = yytext;
                   Util::ProgramStructure::SymbolKind kind =
                       driver.structure->lookupIdentifier(name);
                   switch (kind)
                   {
                   /* FIXME: if the type is a reserved keyword this doesn't work */
+                  case Util::ProgramStructure::SymbolKind::TemplateIdentifier:
+                      driver.template_args = true;
                   case Util::ProgramStructure::SymbolKind::Identifier:
                       driver.onReadIdentifier(name);
                       return Parser::make_IDENTIFIER(name, driver.yylloc);
+                  case Util::ProgramStructure::SymbolKind::TemplateType:
+                      driver.template_args = true;
                   case Util::ProgramStructure::SymbolKind::Type:
                       return Parser::make_TYPE_IDENTIFIER(name, driver.yylloc);
                   default:
@@ -162,79 +213,90 @@ using Parser = P4::P4Parser;
                 }
 
 0[xX][0-9a-fA-F_]+ { BEGIN(driver.saveState);
+                     driver.template_args = false;
                      UnparsedConstant constant{yytext, 2, 16, false};
                      return Parser::make_INTEGER(constant, driver.yylloc); }
 0[dD][0-9_]+       { BEGIN(driver.saveState);
+                     driver.template_args = false;
                      UnparsedConstant constant{yytext, 2, 10, false};
                      return Parser::make_INTEGER(constant, driver.yylloc); }
 0[oO][0-7_]+       { BEGIN(driver.saveState);
+                     driver.template_args = false;
                      UnparsedConstant constant{yytext, 2, 8, false};
                      return Parser::make_INTEGER(constant, driver.yylloc); }
 0[bB][01_]+        { BEGIN(driver.saveState);
+                     driver.template_args = false;
                      UnparsedConstant constant{yytext, 2, 2, false};
                      return Parser::make_INTEGER(constant, driver.yylloc); }
 [0-9][0-9_]*       { BEGIN(driver.saveState);
+                     driver.template_args = false;
                      UnparsedConstant constant{yytext, 0, 10, false};
                      return Parser::make_INTEGER(constant, driver.yylloc); }
 
 [0-9]+[ws]0[xX][0-9a-fA-F_]+ { BEGIN(driver.saveState);
+                               driver.template_args = false;
                                UnparsedConstant constant{yytext, 2, 16, true};
                                return Parser::make_INTEGER(constant, driver.yylloc); }
 [0-9]+[ws]0[dD][0-9_]+  { BEGIN(driver.saveState);
+                          driver.template_args = false;
                           UnparsedConstant constant{yytext, 2, 10, true};
                           return Parser::make_INTEGER(constant, driver.yylloc); }
 [0-9]+[ws]0[oO][0-7_]+  { BEGIN(driver.saveState);
+                          driver.template_args = false;
                           UnparsedConstant constant{yytext, 2, 8, true};
                           return Parser::make_INTEGER(constant, driver.yylloc); }
 [0-9]+[ws]0[bB][01_]+   { BEGIN(driver.saveState);
+                          driver.template_args = false;
                           UnparsedConstant constant{yytext, 2, 2, true};
                           return Parser::make_INTEGER(constant, driver.yylloc); }
 [0-9]+[ws][0-9_]+       { BEGIN(driver.saveState);
+                          driver.template_args = false;
                           UnparsedConstant constant{yytext, 0, 10, true};
                           return Parser::make_INTEGER(constant, driver.yylloc); }
 
-"&&&"           { BEGIN(driver.saveState); return makeToken(MASK); }
-".."            { BEGIN(driver.saveState); return makeToken(RANGE); }
-"<<"            { BEGIN(driver.saveState); return makeToken(SHL); }
-"&&"            { BEGIN(driver.saveState); return makeToken(AND); }
-"||"            { BEGIN(driver.saveState); return makeToken(OR); }
-"=="            { BEGIN(driver.saveState); return makeToken(EQ); }
-"!="            { BEGIN(driver.saveState); return makeToken(NE); }
-">="            { BEGIN(driver.saveState); return makeToken(GE); }
-"<="            { BEGIN(driver.saveState); return makeToken(LE); }
-"++"            { BEGIN(driver.saveState); return makeToken(PP); }
+"&&&"   { BEGIN(driver.saveState); driver.template_args = false; return makeToken(MASK); }
+".."    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(RANGE); }
+"<<"    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(SHL); }
+"&&"    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(AND); }
+"||"    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(OR); }
+"=="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(EQ); }
+"!="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(NE); }
+">="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(GE); }
+"<="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(LE); }
+"++"    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(PP); }
 
-"+"            { BEGIN(driver.saveState); return makeToken(PLUS); }
-"|+|"          { BEGIN(driver.saveState); return makeToken(PLUS_SAT); }
-"-"            { BEGIN(driver.saveState); return makeToken(MINUS); }
-"|-|"          { BEGIN(driver.saveState); return makeToken(MINUS_SAT); }
-"*"            { BEGIN(driver.saveState); return makeToken(MUL); }
-"/"            { BEGIN(driver.saveState); return makeToken(DIV); }
-"%"            { BEGIN(driver.saveState); return makeToken(MOD); }
+"+"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(PLUS); }
+"|+|"   { BEGIN(driver.saveState); driver.template_args = false; return makeToken(PLUS_SAT); }
+"-"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(MINUS); }
+"|-|"   { BEGIN(driver.saveState); driver.template_args = false; return makeToken(MINUS_SAT); }
+"*"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(MUL); }
+"/"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(DIV); }
+"%"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(MOD); }
 
-"|"            { BEGIN(driver.saveState); return makeToken(BIT_OR); }
-"&"            { BEGIN(driver.saveState); return makeToken(BIT_AND); }
-"^"            { BEGIN(driver.saveState); return makeToken(BIT_XOR); }
-"~"            { BEGIN(driver.saveState); return makeToken(COMPLEMENT); }
+"|"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(BIT_OR); }
+"&"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(BIT_AND); }
+"^"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(BIT_XOR); }
+"~"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(COMPLEMENT); }
 
-"("            { BEGIN(driver.saveState); return makeToken(L_PAREN); }
-")"            { BEGIN(driver.saveState); return makeToken(R_PAREN); }
-"["            { BEGIN(driver.saveState); return makeToken(L_BRACKET); }
-"]"            { BEGIN(driver.saveState); return makeToken(R_BRACKET); }
-"{"            { BEGIN(driver.saveState); return makeToken(L_BRACE); }
-"}"            { BEGIN(driver.saveState); return makeToken(R_BRACE); }
-"<"            { BEGIN(driver.saveState); return makeToken(L_ANGLE); }
-">"/">"        { BEGIN(driver.saveState); return makeToken(R_ANGLE_SHIFT); }
-">"            { BEGIN(driver.saveState); return makeToken(R_ANGLE); }
+"("     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(L_PAREN); }
+")"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(R_PAREN); }
+"["     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(L_BRACKET); }
+"]"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(R_BRACKET); }
+"{"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(L_BRACE); }
+"}"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(R_BRACE); }
+"<"     { BEGIN(driver.saveState);
+          return driver.template_args ? makeToken(L_ANGLE_ARGS) : makeToken(L_ANGLE); }
+">"/">" { BEGIN(driver.saveState); driver.template_args = false; return makeToken(R_ANGLE_SHIFT); }
+">"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(R_ANGLE); }
 
-"!"            { BEGIN(driver.saveState); return makeToken(NOT); }
-":"            { BEGIN(driver.saveState); return makeToken(COLON); }
-","            { BEGIN(driver.saveState); return makeToken(COMMA); }
-"?"            { BEGIN(driver.saveState); return makeToken(QUESTION); }
-"."            { BEGIN(driver.saveState); return makeToken(DOT); }
-"="            { BEGIN(driver.saveState); return makeToken(ASSIGN); }
-";"            { BEGIN(driver.saveState); return makeToken(SEMICOLON); }
-"@"            { BEGIN(driver.saveState); return makeToken(AT); }
+"!"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(NOT); }
+":"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(COLON); }
+","     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(COMMA); }
+"?"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(QUESTION); }
+"."     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(DOT); }
+"="     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN); }
+";"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(SEMICOLON); }
+"@"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(AT); }
 
 <*>.|\n        { return makeToken(UNEXPECTED_TOKEN); }
 

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -221,7 +221,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 // End of token definitions ///////////////////////////////////////////////////
 
 
-%type<IR::ID*>              name nonTypeName nonTableKwName
+%type<IR::ID*>              name dot_name nonTypeName nonTableKwName
 %type<IR::Direction>        direction
 %type<IR::Path*>            prefixedNonTypeName prefixedType
 %type<IR::IndexedVector<IR::Type_Var>*>  typeParameterList
@@ -315,6 +315,16 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %left DOT
 
 %right THEN ELSE /* THEN is a fake token */
+
+/*
+FIXME -- we need this %destructor for correct error recovery, but because of the
+broken bison C++ skeleton, it gets declarations in the wrong order and it won't
+compile.  Not having it (just) means that the symbol table may get confused after
+a syntax error causing a spurious error cascade, which isn't too bad.
+
+%destructor { driver.structure->pop(); } functionPrototype parserTypeDeclaration
+                                         controlTypeDeclaration
+*/
 
 %%
 
@@ -621,27 +631,29 @@ packageTypeDeclaration
       optTypeParameters {
           if (!$5->empty()) driver.structure->markAsTemplate(*$3);
           driver.structure->declareTypes(&$5->parameters); }
-      "(" parameterList ")"        { auto pl = new IR::ParameterList(@8, *$8);
-                                     $$ = new IR::Type_Package(@3, *$3, $1, $5, pl); }
+      "(" parameterList ")"        {
+          driver.structure->declareParameters($8);
+          auto pl = new IR::ParameterList(@8, *$8);
+          $$ = new IR::Type_Package(@3, *$3, $1, $5, pl); }
     ;
 
 instantiation
       : annotations typeRef "(" argumentList ")" name ";"
                      { $$ = new IR::Declaration_Instance(@6, *$6, new IR::Annotations(*$1),
                                                          $2, $4);
-                       driver.structure->declareObject(*$6); }
+                       driver.structure->declareObject(*$6, $2->toString()); }
       | typeRef "(" argumentList ")" name ";"
                      { $$ = new IR::Declaration_Instance(@5, *$5, $1, $3);
-                       driver.structure->declareObject(*$5); }
+                       driver.structure->declareObject(*$5, $1->toString()); }
       /* experimental */
       | annotations typeRef "(" argumentList ")" name "=" objInitializer ";"
                      { $$ = new IR::Declaration_Instance(@6, *$6, new IR::Annotations(*$1),
                                                          $2, $4, $8);
-                       driver.structure->declareObject(*$6); }
+                       driver.structure->declareObject(*$6, $2->toString()); }
       /* experimental */
       | typeRef "(" argumentList ")" name "=" objInitializer ";"
                      { $$ = new IR::Declaration_Instance(@5, *$5, $1, $3, $7);
-                       driver.structure->declareObject(*$5); }
+                       driver.structure->declareObject(*$5, $1->toString()); }
     ;
 
 /* experimental; includes the following 3 productions */
@@ -695,10 +707,11 @@ parserLocalElement
 
 parserTypeDeclaration
     : optAnnotations
-        PARSER name       { driver.structure->pushContainerType(*$3, false); }
+        PARSER name       { driver.structure->pushContainerType(*$3, true); }
         optTypeParameters { if (!$5->empty()) driver.structure->markAsTemplate(*$3);
                             driver.structure->declareTypes(&$5->parameters); }
-        "(" parameterList ")" { auto pl = new IR::ParameterList(@8, *$8);
+        "(" parameterList ")" { driver.structure->declareParameters($8);
+                                auto pl = new IR::ParameterList(@8, *$8);
                                 $$ = new IR::Type_Parser(@3, *$3, $1, $5, pl); }
     ;
 
@@ -809,10 +822,11 @@ controlDeclaration
 
 controlTypeDeclaration
     : optAnnotations
-        CONTROL name { driver.structure->pushContainerType(*$3, false); }
+        CONTROL name { driver.structure->pushContainerType(*$3, true); }
         optTypeParameters { if (!$5->empty()) driver.structure->markAsTemplate(*$3);
                             driver.structure->declareTypes(&$5->parameters); }
-        "(" parameterList ")" { auto pl = new IR::ParameterList(@8, *$8);
+        "(" parameterList ")" { driver.structure->declareParameters($8);
+                                auto pl = new IR::ParameterList(@8, *$8);
                                 $$ = new IR::Type_Control(@3, *$3, $1, $5, pl); }
     ;
 
@@ -842,7 +856,10 @@ externDeclaration
                             driver.structure->declareTypes(&$5->parameters); }
         "{" methodPrototypes "}" { driver.structure->pop();
                                    $$ = new IR::Type_Extern(@3, *$3, $5, *$8, $1); }
-    | optAnnotations EXTERN functionPrototype ";" { $$ = $3; $3->annotations = $1; }
+    | optAnnotations EXTERN functionPrototype ";" {
+            driver.structure->pop();
+            $$ = $3;
+            $3->annotations = $1; }
     | optAnnotations EXTERN name ";" {
             // forward declaration;
             driver.structure->pushContainerType(*$3, true);
@@ -858,20 +875,24 @@ methodPrototypes
 functionPrototype
     : typeOrVoid
         name optTypeParameters {
-            driver.structure->declareObject(*$2);
+            driver.structure->declareObject(*$2, $1->toString());
             if (!$3->empty()) driver.structure->markAsTemplate(*$2);
             driver.structure->pushNamespace(@2, false);
             driver.structure->declareTypes(&$3->parameters); }
-        "(" parameterList ")" { driver.structure->pop(); }
-                           { auto params = new IR::ParameterList(@6, *$6);
-                             auto mt = new IR::Type_Method(@2, $3, $1, params);
-                             $$ = new IR::Method(@2, *$2, mt); }
+        "(" parameterList ")" { driver.structure->declareParameters($6);
+                                auto params = new IR::ParameterList(@6, *$6);
+                                auto mt = new IR::Type_Method(@2, $3, $1, params);
+                                $$ = new IR::Method(@2, *$2, mt); }
     ;
 
 methodPrototype
-    : optAnnotations functionPrototype ";" { $$ = $2; $2->annotations = $1; }
-    | optAnnotations ABSTRACT functionPrototype ";"    { $$ = $3; $$->setAbstract();
-                                                         $3->annotations = $1; }  // experimental
+    : optAnnotations functionPrototype ";" {
+            driver.structure->pop();
+            $$ = $2; $2->annotations = $1; }
+    | optAnnotations ABSTRACT functionPrototype ";" {
+            driver.structure->pop();
+            $$ = $3; $$->setAbstract();
+            $3->annotations = $1; }  // experimental
     | optAnnotations TYPE_IDENTIFIER "(" parameterList ")" ";"  // constructor
                                         { auto par = new IR::ParameterList(@4, *$4);
                                           auto mt = new IR::Type_Method(@2, par);
@@ -1255,16 +1276,16 @@ variableDeclaration
     : annotations typeRef name optInitializer ";"
                                      { auto ann = new IR::Annotations(@1, *$1);
                                        $$ = new IR::Declaration_Variable(@1+@4, *$3, ann, $2, $4);
-                                       driver.structure->declareObject(*$3); }
+                                       driver.structure->declareObject(*$3, $2->toString()); }
     | typeRef name optInitializer ";"
                                      { $$ = new IR::Declaration_Variable(@1+@4, *$2, $1, $3);
-                                       driver.structure->declareObject(*$2); }
+                                       driver.structure->declareObject(*$2, $1->toString()); }
     ;
 
 constantDeclaration
     : optAnnotations CONST typeRef name "=" initializer ";"
                                      { $$ = new IR::Declaration_Constant(@1+@6, *$4, $1, $3, $6);
-                                       driver.structure->declareObject(*$4); }
+                                       driver.structure->declareObject(*$4, $3->toString()); }
     ;
 
 optInitializer
@@ -1279,7 +1300,9 @@ initializer
 /**************** Expressions ****************/
 
 functionDeclaration
-    : functionPrototype blockStatement   { $$ = new IR::Function($1->srcInfo, $1->name, $1->type, $2); }
+    : functionPrototype blockStatement   {
+            driver.structure->pop();
+            $$ = new IR::Function($1->srcInfo, $1->name, $1->type, $2); }
     ;
 
 argumentList
@@ -1312,10 +1335,14 @@ prefixedNonTypeName
                                            driver.structure->clearPath(); }
     ;
 
+dot_name:
+    "." { driver.structure->relativePathFromLastSymbol(); } name {
+          driver.structure->clearPath(); $$ = $3; }
+
 lvalue
     : prefixedNonTypeName                { $$ = new IR::PathExpression($1); }
     | THIS                               { $$ = new IR::This(@1); }  // experimental
-    | lvalue "." name                    { $$ = new IR::Member(@1 + @3, $1, *$3); }
+    | lvalue dot_name %prec DOT          { $$ = new IR::Member(@1 + @2, $1, *$2); }
     | lvalue "[" expression "]"          { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | lvalue "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
     ;
@@ -1338,12 +1365,12 @@ expression
     | "~" expression %prec PREFIX        { $$ = new IR::Cmpl(@1 + @2, $2); }
     | "-" expression %prec PREFIX        { $$ = new IR::Neg(@1 + @2, $2); }
     | "+" expression %prec PREFIX        { $$ = $2; }
-    | typeName "." name
-        { $$ = new IR::Member(@1 + @3, new IR::TypeNameExpression(@1, $1), *$3); }
+    | typeName dot_name %prec DOT
+        { $$ = new IR::Member(@1 + @2, new IR::TypeNameExpression(@1, $1), *$2); }
     | ERROR "." name
         { auto typeName = new IR::Type_Name(@1, new IR::Path(IR::ID(@1, "error")));
           $$ = new IR::Member(@1+@3, new IR::TypeNameExpression(@1+@3, typeName), *$3); }
-    | expression "." name                { $$ = new IR::Member(@1 + @3, $1, *$3); }
+    | expression dot_name %prec DOT      { $$ = new IR::Member(@1 + @2, $1, *$2); }
     | expression "*" expression          { $$ = new IR::Mul(@1 + @3, $1, $3); }
     | expression "/" expression          { $$ = new IR::Div(@1 + @3, $1, $3); }
     | expression "%" expression          { $$ = new IR::Mod(@1 + @3, $1, $3); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -192,6 +192,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %token<Token>      L_BRACE "{"
 %token<Token>      R_BRACE "}"
 %token<Token>      L_ANGLE "<"
+%token<Token>      L_ANGLE_ARGS    // < where template args are expected
 %token<Token>      R_ANGLE ">"
 %token<Token>      R_ANGLE_SHIFT   // > immediately followed by another >
 %token<Token>      L_PAREN "("
@@ -310,7 +311,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %left PP PLUS MINUS PLUS_SAT MINUS_SAT
 %left MUL DIV MOD
 %right PREFIX
-%nonassoc R_BRACKET L_PAREN L_BRACKET
+%nonassoc R_BRACKET L_PAREN L_BRACKET L_ANGLE_ARGS
 %left DOT
 
 %right THEN ELSE /* THEN is a fake token */
@@ -569,6 +570,7 @@ annotationToken
     | "{"              { $$ = $1; }
     | "}"              { $$ = $1; }
     | "<"              { $$ = $1; }
+    | L_ANGLE_ARGS     { $$ = $1; }
     | ">"              { $$ = $1; }
     | R_ANGLE_SHIFT    { $$ = $1; }
 
@@ -616,7 +618,9 @@ direction
 
 packageTypeDeclaration
     : optAnnotations PACKAGE name { driver.structure->pushContainerType(*$3, false); }
-      optTypeParameters { driver.structure->declareTypes(&$5->parameters); }
+      optTypeParameters {
+          if (!$5->empty()) driver.structure->markAsTemplate(*$3);
+          driver.structure->declareTypes(&$5->parameters); }
       "(" parameterList ")"        { auto pl = new IR::ParameterList(@8, *$8);
                                      $$ = new IR::Type_Package(@3, *$3, $1, $5, pl); }
     ;
@@ -692,7 +696,8 @@ parserLocalElement
 parserTypeDeclaration
     : optAnnotations
         PARSER name       { driver.structure->pushContainerType(*$3, false); }
-        optTypeParameters { driver.structure->declareTypes(&$5->parameters); }
+        optTypeParameters { if (!$5->empty()) driver.structure->markAsTemplate(*$3);
+                            driver.structure->declareTypes(&$5->parameters); }
         "(" parameterList ")" { auto pl = new IR::ParameterList(@8, *$8);
                                 $$ = new IR::Type_Parser(@3, *$3, $1, $5, pl); }
     ;
@@ -782,13 +787,13 @@ simpleKeysetExpression
 
 valueSetDeclaration
     : optAnnotations
-        VALUESET "<" baseType r_angle "(" expression ")" name ";"
+        VALUESET l_angle baseType r_angle "(" expression ")" name ";"
         { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
     | optAnnotations
-        VALUESET "<" tupleType r_angle "(" expression ")" name ";"
+        VALUESET l_angle tupleType r_angle "(" expression ")" name ";"
         { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
     | optAnnotations
-        VALUESET "<" typeName r_angle "(" expression ")" name ";"
+        VALUESET l_angle typeName r_angle "(" expression ")" name ";"
         { $$ = new IR::P4ValueSet(@9, *$9, $1, $4, $7); }
     ;
 
@@ -805,7 +810,8 @@ controlDeclaration
 controlTypeDeclaration
     : optAnnotations
         CONTROL name { driver.structure->pushContainerType(*$3, false); }
-        optTypeParameters { driver.structure->declareTypes(&$5->parameters); }
+        optTypeParameters { if (!$5->empty()) driver.structure->markAsTemplate(*$3);
+                            driver.structure->declareTypes(&$5->parameters); }
         "(" parameterList ")" { auto pl = new IR::ParameterList(@8, *$8);
                                 $$ = new IR::Type_Control(@3, *$3, $1, $5, pl); }
     ;
@@ -832,7 +838,8 @@ controlBody
 externDeclaration
     : optAnnotations
         EXTERN nonTypeName { driver.structure->pushContainerType(*$3, true); }
-        optTypeParameters { driver.structure->declareTypes(&$5->parameters); }
+        optTypeParameters { if (!$5->empty()) driver.structure->markAsTemplate(*$3);
+                            driver.structure->declareTypes(&$5->parameters); }
         "{" methodPrototypes "}" { driver.structure->pop();
                                    $$ = new IR::Type_Extern(@3, *$3, $5, *$8, $1); }
     | optAnnotations EXTERN functionPrototype ";" { $$ = $3; $3->annotations = $1; }
@@ -850,8 +857,11 @@ methodPrototypes
 
 functionPrototype
     : typeOrVoid
-        name optTypeParameters { driver.structure->pushNamespace(@2, false);
-                                 driver.structure->declareTypes(&$3->parameters); }
+        name optTypeParameters {
+            driver.structure->declareObject(*$2);
+            if (!$3->empty()) driver.structure->markAsTemplate(*$2);
+            driver.structure->pushNamespace(@2, false);
+            driver.structure->declareTypes(&$3->parameters); }
         "(" parameterList ")" { driver.structure->pop(); }
                            { auto params = new IR::ParameterList(@6, *$6);
                              auto mt = new IR::Type_Method(@2, $3, $1, params);
@@ -894,7 +904,7 @@ typeName
     ;
 
 tupleType
-    : TUPLE "<" typeArgumentList r_angle    { $$ = new IR::Type_Tuple(@1+@4, *$3); }
+    : TUPLE l_angle typeArgumentList r_angle    { $$ = new IR::Type_Tuple(@1+@4, *$3); }
     ;
 
 headerStackType
@@ -902,7 +912,7 @@ headerStackType
     ;
 
 specializedType
-    : typeName "<" typeArgumentList r_angle { $$ = new IR::Type_Specialized(@1 + @4, $1, $3); }
+    : typeName l_angle typeArgumentList r_angle { $$ = new IR::Type_Specialized(@1 + @4, $1, $3); }
     ;
 
 baseType
@@ -911,18 +921,18 @@ baseType
     | BIT    { $$ = IR::Type::Bits::get(@1, 1); }
     | STRING { $$ = IR::Type::String::get(); }
     | INT    { $$ = new IR::Type_InfInt(); }
-    | BIT "<" INTEGER r_angle
+    | BIT l_angle INTEGER r_angle
       { $$ = IR::Type::Bits::get(@1+@4, parseConstantChecked(@3, $3), false); }
-    | INT "<" INTEGER r_angle
+    | INT l_angle INTEGER r_angle
       { $$ = IR::Type::Bits::get(@1+@4, parseConstantChecked(@3, $3), true); }
-    | VARBIT "<" INTEGER r_angle
+    | VARBIT l_angle INTEGER r_angle
       { $$ = IR::Type::Varbits::get(@1+@4, parseConstantChecked(@3, $3)); }
 
-    | BIT "<" "(" expression ")" r_angle
+    | BIT l_angle "(" expression ")" r_angle
       { $$ = new IR::Type_Bits(@1+@6, $4, false); }
-    | INT "<" "(" expression ")" r_angle
+    | INT l_angle "(" expression ")" r_angle
       { $$ = new IR::Type_Bits(@1+@6, $4, true); }
-    | VARBIT "<" "(" expression ")" r_angle
+    | VARBIT l_angle "(" expression ")" r_angle
       { $$ = new IR::Type_Varbits(@1+@6, $4); }
     ;
 
@@ -935,7 +945,7 @@ typeOrVoid
 
 optTypeParameters
     : /* empty */               { $$ = new IR::TypeParameters(); }
-    | "<" typeParameterList r_angle { $$ = new IR::TypeParameters(@1+@3, *$2); }
+    | l_angle typeParameterList r_angle { $$ = new IR::TypeParameters(@1+@3, *$2); }
     ;
 
 typeParameterList
@@ -1017,7 +1027,7 @@ enumDeclaration
     : optAnnotations
         ENUM name { driver.structure->declareType(*$3); }
         "{" identifierList "}" { $$ = new IR::Type_Enum(@3, *$3, *$6); }
-    | optAnnotations ENUM BIT "<" INTEGER r_angle name { driver.structure->declareType(*$7); }
+    | optAnnotations ENUM BIT l_angle INTEGER r_angle name { driver.structure->declareType(*$7); }
         "{" specifiedIdentifierList "}" {
             auto type = IR::Type::Bits::get(@3+@6, parseConstantChecked(@5, $5));
             $$ = new IR::Type_SerEnum(@7, *$7, type, *$10); }
@@ -1068,7 +1078,7 @@ assignmentOrMethodCallStatement
                                                  new IR::Vector<IR::Type>(), $3);
           $$ = new IR::MethodCallStatement(@1 + @4, mc); }
 
-    | lvalue "<" typeArgumentList r_angle "(" argumentList ")" ";"
+    | lvalue l_angle typeArgumentList r_angle "(" argumentList ")" ";"
         { auto mc = new IR::MethodCallExpression(@1 + @7,
                                                  $1, $3, $6);
           $$ = new IR::MethodCallStatement(@1 + @7, mc); }
@@ -1346,7 +1356,8 @@ expression
         { $$ = new IR::Shr(@1 + @4, $1, $4); }
     | expression "<=" expression         { $$ = new IR::Leq(@1 + @3, $1, $3); }
     | expression ">=" expression         { $$ = new IR::Geq(@1 + @3, $1, $3); }
-    | expression "<" expression          { $$ = new IR::Lss(@1 + @3, $1, $3); }
+    | expression l_angle expression %prec "<"
+                                         { $$ = new IR::Lss(@1 + @3, $1, $3); }
     | expression ">" expression          { $$ = new IR::Grt(@1 + @3, $1, $3); }
     | expression "!=" expression         { $$ = new IR::Neq(@1 + @3, $1, $3); }
     | expression "==" expression         { $$ = new IR::Equ(@1 + @3, $1, $3); }
@@ -1357,10 +1368,8 @@ expression
     | expression "&&" expression         { $$ = new IR::LAnd(@1 + @2 + @3, $1, $3); }
     | expression "||" expression         { $$ = new IR::LOr(@1 + @2 + @3, $1, $3); }
     | expression "?" expression ":" expression { $$ = new IR::Mux(@1 + @5, $1, $3, $5); }
-    | expression "<" realTypeArgumentList r_angle "(" argumentList ")"
+    | expression l_angle realTypeArgumentList r_angle "(" argumentList ")"
         { $$ = new IR::MethodCallExpression(@1 + @4, $1, $3, $6); }
-    // FIXME: the previous rule has the wrong precedence, and parses with
-    // precedence weaker than casts.  There is no easy way to fix this in bison.
     | expression "(" argumentList ")"
         { $$ = new IR::MethodCallExpression(@1 + @4, $1, $3); }
     | namedType "(" argumentList ")"
@@ -1394,6 +1403,7 @@ strList
                                    $$->push_back(new IR::StringLiteral(@3, $3)); }
     ;
 
+l_angle : "<" | L_ANGLE_ARGS ;
 r_angle : ">" | R_ANGLE_SHIFT ;
 
 /*****************************************************************************/

--- a/frontends/parsers/parserDriver.h
+++ b/frontends/parsers/parserDriver.h
@@ -208,6 +208,10 @@ class P4ParserDriver final : public AbstractParserDriver {
     /// incrementally, so we need to hold some state between tokens.)
     std::string stringLiteral;
 
+    // flag to track when template args are expected, to adjust the precedence
+    // of '<'
+    bool template_args;
+
  private:
     P4ParserDriver();
 

--- a/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param1.p4-stderr
@@ -1,6 +1,7 @@
-dup-param1.p4(17): [--Werror=duplicate] error: p duplicates p.
-control MyIngress<p>(inout bit<32> p) {
-                  ^
-dup-param1.p4(17)
-control MyIngress<p>(inout bit<32> p) {
+dup-param1.p4(17): [--Werror=duplicate] error: Re-declaration of p with different type: 
+control MyIngress<p>(inout bit<32> p)
                                    ^
+dup-param1.p4(17)
+control MyIngress<p>(inout bit<32> p)
+                  ^
+error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/dup-param3.p4-stderr
@@ -1,6 +1,7 @@
-dup-param3.p4(17): [--Werror=duplicate] error: p duplicates p.
-control MyIngress<p>(inout bit<32> p)(bit<32> p) {
-                  ^
-dup-param3.p4(17)
-control MyIngress<p>(inout bit<32> p)(bit<32> p) {
+dup-param3.p4(17): [--Werror=duplicate] error: Re-declaration of p with different type: 
+control MyIngress<p>(inout bit<32> p)
                                    ^
+dup-param3.p4(17)
+control MyIngress<p>(inout bit<32> p)
+                  ^
+error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/issue1932.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1932.p4-stderr
@@ -1,6 +1,7 @@
-issue1932.p4(2): [--Werror=duplicate] error: foo duplicates foo.
-bool foo() { return true; }
+issue1932.p4(2): [--Werror=duplicate] error: Re-declaration of foo with different type: 
+bool foo(
      ^^^
 issue1932.p4(1)
 control foo (in bit<8> x, out bit<8> y) { apply { y = x + 7; } }
         ^^^
+error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_samples_outputs/cast-call-first.p4
+++ b/testdata/p4_16_samples_outputs/cast-call-first.p4
@@ -1,0 +1,5 @@
+extern T f<T>(T x);
+action a() {
+    bit<32> x;
+    x = (bit<32>)(f<bit<6>>(6w5));
+}

--- a/testdata/p4_16_samples_outputs/cast-call.p4
+++ b/testdata/p4_16_samples_outputs/cast-call.p4
@@ -1,0 +1,5 @@
+extern T f<T>(T x);
+action a() {
+    bit<32> x;
+    x = (bit<32>)(f<bit<6>>(6w5));
+}

--- a/testdata/p4_16_samples_outputs/cast-call.p4-stderr
+++ b/testdata/p4_16_samples_outputs/cast-call.p4-stderr
@@ -1,0 +1,1 @@
+warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/precedence-lt-first.p4
+++ b/testdata/p4_16_samples_outputs/precedence-lt-first.p4
@@ -1,0 +1,18 @@
+extern T f<T>(T x);
+extern Object {
+    T foo<T>();
+}
+
+struct data {
+    bit<8> f;
+    bit<8> foo;
+}
+
+control C(inout data d, inout bit<16> foo, Object o) {
+    apply {
+        if (8w4 + d.f < 8w10) {
+            d.foo = (bit<8>)(o.foo<bit<16>>());
+        }
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/precedence-lt-frontend.p4
+++ b/testdata/p4_16_samples_outputs/precedence-lt-frontend.p4
@@ -1,0 +1,9 @@
+extern Object {
+    T foo<T>();
+}
+
+struct data {
+    bit<8> f;
+    bit<8> foo;
+}
+

--- a/testdata/p4_16_samples_outputs/precedence-lt.p4
+++ b/testdata/p4_16_samples_outputs/precedence-lt.p4
@@ -1,0 +1,18 @@
+extern T f<T>(T x);
+extern Object {
+    T foo<T>();
+}
+
+struct data {
+    bit<8> f;
+    bit<8> foo;
+}
+
+control C(inout data d, inout bit<16> foo, Object o) {
+    apply {
+        if (4 + d.f < 10) {
+            d.foo = (bit<8>)(o.foo<bit<16>>());
+        }
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/precedence-lt.p4-stderr
+++ b/testdata/p4_16_samples_outputs/precedence-lt.p4-stderr
@@ -1,0 +1,1 @@
+warning: Program does not contain a `main' module


### PR DESCRIPTION
- if the symbol before it is something that expects template args, we
  use a higher precedence (same as postfix operators) rather than
  normal less-than precedence.

Fixes issue #13