### PR TITLE
Simple stf parser fix.

### DIFF
--- a/tools/stf/stf_parser.py
+++ b/tools/stf/stf_parser.py
@@ -80,12 +80,13 @@ from .stf_lexer import STFLexer
 
 # PARSER ----------------------------------------------------------------------
 
+
 class STFParser:
     def __init__(self):
         self.lexer = STFLexer()
         self.lexer.build()
         self.tokens = self.lexer.tokens
-        self.parser = yacc.yacc(module = self)
+        self.parser = yacc.yacc(module=self)
         self.errors_cnt = 0
 
     def parse(self, data=None, filename=''):
@@ -99,8 +100,8 @@ class STFParser:
 
         self.lexer.filename = filename
         self.lexer.reset_lineno()
-        stf_ast = self.parser.parse(input = data,
-                                    lexer = self.lexer)
+        stf_ast = self.parser.parse(input=data,
+                                    lexer=self.lexer)
         self.errors_cnt += self.lexer.errors_cnt
         return stf_ast, self.errors_cnt
 

--- a/tools/stf/stf_parser.py
+++ b/tools/stf/stf_parser.py
@@ -88,13 +88,14 @@ class STFParser:
         self.parser = yacc.yacc(module = self)
         self.errors_cnt = 0
 
-    def parse(self, data = None, filename=''):
+    def parse(self, data=None, filename=''):
         if data is None and filename == '':
             raise ValueError("Please specify either a filename or data")
 
         # if we specified only the filename, initialize the data
         if data is None:
-            with file(filename) as f: data = f.read()
+            with open(filename) as f:
+                data = f.read()
 
         self.lexer.filename = filename
         self.lexer.reset_lineno()


### PR DESCRIPTION
There was a problem trying to parse files with the stf parser. The filename class was not imported. Opening directly as file should fix the issue.