### PR TITLE
Fix bmv2 default parser transitions

### DIFF
--- a/backends/bmv2/common/JsonObjects.cpp
+++ b/backends/bmv2/common/JsonObjects.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 namespace BMV2 {
 
 const int JSON_MAJOR_VERSION = 2;
-const int JSON_MINOR_VERSION = 18;
+const int JSON_MINOR_VERSION = 23;
 
 JsonObjects::JsonObjects() {
     toplevel = new Util::JsonObject();

--- a/backends/bmv2/common/parser.cpp
+++ b/backends/bmv2/common/parser.cpp
@@ -401,7 +401,8 @@ ParserConverter::convertSelectExpression(const IR::SelectExpression* expr) {
             trans->emplace("next_state", stateName(sc->state->path->name));
         } else {
             if (mask == 0) {
-                trans->emplace("value", "default");
+                trans->emplace("type", "default");
+                trans->emplace("value", Util::JsonValue::null);
                 trans->emplace("mask", Util::JsonValue::null);
                 trans->emplace("next_state", stateName(sc->state->path->name));
             } else {
@@ -430,7 +431,8 @@ ParserConverter::convertSelectKey(const IR::SelectExpression* expr) {
 Util::IJson*
 ParserConverter::convertPathExpression(const IR::PathExpression* pe) {
     auto trans = new Util::JsonObject();
-    trans->emplace("value", "default");
+    trans->emplace("type", "default");
+    trans->emplace("value", Util::JsonValue::null);
     trans->emplace("mask", Util::JsonValue::null);
     trans->emplace("next_state", stateName(pe->path->name));
     return trans;
@@ -439,7 +441,8 @@ ParserConverter::convertPathExpression(const IR::PathExpression* pe) {
 Util::IJson*
 ParserConverter::createDefaultTransition() {
     auto trans = new Util::JsonObject();
-    trans->emplace("value", "default");
+    trans->emplace("type", "default");
+    trans->emplace("value", Util::JsonValue::null);
     trans->emplace("mask", Util::JsonValue::null);
     trans->emplace("next_state", Util::JsonValue::null);
     return trans;


### PR DESCRIPTION
The bmv2 backend was still using a very old format (from 2016), and
while it is still supported by bmv2 for backwards-compatibility reasons,
it is confusing to people who compare the generated JSON files to the
bmv2 JSON format spec.

We also update JSON_MINOR_VERSION to the latest version.

Fixes #2311