### PR TITLE
Fix incorrect invocation of pass; unrolling still disabled

### DIFF
--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -43,7 +43,6 @@ limitations under the License.
 #include "midend/midEndLast.h"
 #include "midend/nestedStructs.h"
 #include "midend/noMatch.h"
-#include "midend/parserUnroll.h"
 #include "midend/predication.h"
 #include "midend/removeExits.h"
 #include "midend/removeMiss.h"
@@ -77,9 +76,6 @@ MidEnd::MidEnd(CompilerOptions& options) {
 
     auto v1controls = new std::set<cstring>();
 
-    // TODO: parser loop unrolling
-    // TODO: lower errors to integers
-    // TODO: handle bit-slices as out arguments
     addPasses({
         options.ndebug ? new P4::RemoveAssertAssume(&refMap, &typeMap) : nullptr,
         new P4::RemoveMiss(&refMap, &typeMap),

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -8,7 +8,7 @@ namespace P4 {
 unsigned SymbolicValue::crtid = 0;
 
 SymbolicValue* SymbolicValueFactory::create(const IR::Type* type, bool uninitialized) const {
-    type = typeMap->getType(type, true);
+    type = typeMap->getTypeType(type, true);
     if (type->is<IR::Type_Bits>())
         return new SymbolicInteger(ScalarValue::init(uninitialized), type->to<IR::Type_Bits>());
     if (type->is<IR::Type_Boolean>())

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -4,7 +4,7 @@
 namespace P4 {
 
 bool AnalyzeParser::preorder(const IR::ParserState* state) {
-    LOG1("Found state " << state << " of " << current->parser);
+    LOG1("Found state " << dbp(state) << " of " << current->parser->name);
     if (state->name.name == IR::ParserState::start)
         current->start = state;
     current->addState(state);
@@ -24,20 +24,20 @@ void AnalyzeParser::postorder(const IR::PathExpression* expression) {
 
 namespace ParserStructureImpl {
 
-// Set of possible definitions of a variable
+/// Set of possible definitions of a variable
 struct VarDef {
     const SymbolicValue* leftValue;
     std::vector<const IR::Node*> definitions;  // statements or parameters
 };
 
-// Definitions for all variables at a program point
+/// Definitions for all variables at a program point
 struct Definitions {
     std::map<const SymbolicValue*, VarDef*> definitions;
     void add(VarDef* def)
     { definitions[def->leftValue] = def; }
 };
 
-// For each program point the definitions of all variables
+/// For each program point the definitions of all variables
 struct AllDefinitions {
     std::map<const IR::Node*, Definitions*> perStatement;
 };
@@ -113,7 +113,7 @@ class ParserSymbolicInterpreter {
         return result.str();
     }
 
-    // Return false if an error can be detected statically
+    /// Return false if an error can be detected statically
     bool reportIfError(const ParserStateInfo* state, SymbolicValue* value) const {
         if (value->is<SymbolicException>()) {
             auto exc = value->to<SymbolicException>();
@@ -144,9 +144,9 @@ class ParserSymbolicInterpreter {
         return false;
     }
 
-    // Executes symbolically the specified statement.
-    // Returns 'true' if execution completes successfully,
-    // and 'false' if an error occurred.
+    /// Executes symbolically the specified statement.
+    /// Returns 'true' if execution completes successfully,
+    /// and 'false' if an error occurred.
     bool executeStatement(const ParserStateInfo* state, const IR::StatOrDecl* sord,
                           ValueMap* valueMap) const {
         ExpressionEvaluator ev(refMap, typeMap, valueMap);
@@ -236,7 +236,7 @@ class ParserSymbolicInterpreter {
         return false;
     }
 
-    // True if any header has changed its "validity" bit
+    /// True if any header has changed its "validity" bit
     static bool headerValidityChange(const ValueMap* before, const ValueMap* after) {
         for (auto v : before->map) {
             auto value = v.second;
@@ -246,7 +246,7 @@ class ParserSymbolicInterpreter {
         return false;
     }
 
-    // Return true if we have detected a loop we cannot unroll
+    /// Return true if we have detected a loop we cannot unroll
     bool checkLoops(ParserStateInfo* state) const {
         const ParserStateInfo* crt = state;
         while (true) {


### PR DESCRIPTION
Fixes #289.
The loop unrolling pass is still not used anywhere - as implemented it may generate lots of parser states (millions) in some circumstances. But this PR fixes a the bug reported in issue 289 that throws an exception when this pass is called. The pass could still be useful in some backends... although there are currently no tests that exercise it.
