### PR TITLE
Get rid of symlinks in include paths to avoid mismatches

### DIFF
--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -284,7 +284,10 @@ bool setIncludePathIfExists(const char*& includePathOut,
                             const char* possiblePath) {
     struct stat st;
     if (!(stat(possiblePath, &st) >= 0 && S_ISDIR(st.st_mode))) return false;
-    includePathOut = strdup(possiblePath);
+    if (auto path = realpath(possiblePath, NULL))
+        includePathOut = path;
+    else
+        includePathOut = strdup(possiblePath);
     return true;
 }
 

--- a/tools/driver/p4c.in
+++ b/tools/driver/p4c.in
@@ -42,8 +42,8 @@ sys.path.insert(1, artifacts_dir)
 os.environ['P4C_BUILD_TYPE'] = build_type
 os.environ['P4C_BIN_DIR'] = install_dir
 os.environ['P4C_CFG_PATH'] = os.path.join(artifacts_dir, "p4c_src")
-os.environ['P4C_16_INCLUDE_PATH'] = os.path.join(artifacts_dir, "p4include")
-os.environ['P4C_14_INCLUDE_PATH'] = os.path.join(artifacts_dir, "p4_14include")
+os.environ['P4C_16_INCLUDE_PATH'] = os.path.realpath(os.path.join(artifacts_dir, "p4include"))
+os.environ['P4C_14_INCLUDE_PATH'] = os.path.realpath(os.path.join(artifacts_dir, "p4_14include"))
 
 from p4c_src.main import main
 from p4c_src.main import set_version


### PR DESCRIPTION
- toP4 compares paths to decide when to output #include directives,
  which sometime fails when symlinks are involved, as there can be
  mulitple different but equivalent paths.