### PR TITLE
Adding register support to PSA

### DIFF
--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -402,6 +402,14 @@ class RunBMV2(object):
             # Pass through multicast group commands unchanged, with
             # same arguments as expected by simple_switch_CLI
             self.do_cli_command(first + " " + cmd)
+        elif first == "counter_read" or first == "counter_write":
+            # Pass through multicast group commands unchanged, with
+            # same arguments as expected by simple_switch_CLI
+            self.do_cli_command(first + " " + cmd)
+        elif first == "register_read" or first == "register_write" or first == "register_reset":
+            # Pass through multicast group commands unchanged, with
+            # same arguments as expected by simple_switch_CLI
+            self.do_cli_command(first + " " + cmd)
         elif first == "packet":
             interface, data = nextWord(cmd)
             interface = int(interface)

--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -47,7 +47,7 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
         // TODO(jafingerhut) - add line/col at all individual cases below,
         // or perhaps it can be done as a common case above or below
         // for all of them?
-        
+
         IR::MethodCallExpression *mce2;
         auto isR = false;
         if (s->is<IR::AssignmentStatement>()) {
@@ -57,18 +57,18 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
             r = assign->right;
             auto mce = r->to<IR::MethodCallExpression>();
             if (mce != nullptr) {
-                auto mi = P4::MethodInstance::resolve(mce, ctxt->refMap, ctxt->typeMap); 
+                auto mi = P4::MethodInstance::resolve(mce, ctxt->refMap, ctxt->typeMap);
                 auto em = mi->to<P4::ExternMethod>();
-                if (em != nullptr){
-                    if (em->originalExternType->name.name == "Register" || 
+                if (em != nullptr) {
+                    if (em->originalExternType->name.name == "Register" ||
                     em->method->name.name == "read") {
                         isR = true;
                         // l = l->to<IR::PathExpression>();
                         // BUG_CHECK(l != nullptr, "register_read dest cast failed");
                         auto dest = new IR::Argument(l);
                         auto args = new IR::Vector<IR::Argument>();
-                        args->push_back(dest); //dest
-                        args->push_back(mce->arguments->at(0)); //index
+                        args->push_back(dest);  // dest
+                        args->push_back(mce->arguments->at(0));  // index
                         mce2 = new IR::MethodCallExpression(mce->method, mce->typeArguments);
                         mce2->arguments = args;
                         s = new IR::MethodCallStatement(mce);

--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -47,6 +47,36 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
         // TODO(jafingerhut) - add line/col at all individual cases below,
         // or perhaps it can be done as a common case above or below
         // for all of them?
+        
+        IR::MethodCallExpression *mce2;
+        auto isR = false;
+        if (s->is<IR::AssignmentStatement>()) {
+            auto assign = s->to<IR::AssignmentStatement>();
+            const IR::Expression *l, *r;
+            l = assign->left;
+            r = assign->right;
+            auto mce = r->to<IR::MethodCallExpression>();
+            if (mce != nullptr) {
+                auto mi = P4::MethodInstance::resolve(mce, ctxt->refMap, ctxt->typeMap); 
+                auto em = mi->to<P4::ExternMethod>();
+                if (em != nullptr){
+                    if (em->originalExternType->name.name == "Register" || 
+                    em->method->name.name == "read") {
+                        isR = true;
+                        // l = l->to<IR::PathExpression>();
+                        // BUG_CHECK(l != nullptr, "register_read dest cast failed");
+                        auto dest = new IR::Argument(l);
+                        auto args = new IR::Vector<IR::Argument>();
+                        args->push_back(dest); //dest
+                        args->push_back(mce->arguments->at(0)); //index
+                        mce2 = new IR::MethodCallExpression(mce->method, mce->typeArguments);
+                        mce2->arguments = args;
+                        s = new IR::MethodCallStatement(mce);
+                    }
+                }
+            }
+        }
+
         if (!s->is<IR::Statement>()) {
             continue;
         } else if (auto block = s->to<IR::BlockStatement>()) {
@@ -64,7 +94,6 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
             auto assign = s->to<IR::AssignmentStatement>();
             l = assign->left;
             r = assign->right;
-
             auto type = ctxt->typeMap->getType(l, true);
             cstring operation = jsonAssignment(type, false);
             auto primitive = mkPrimitive(operation, result);
@@ -122,7 +151,12 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
             } else if (mi->is<P4::ExternMethod>()) {
                 auto em = mi->to<P4::ExternMethod>();
                 LOG3("P4V1:: convert " << s);
-                auto json = ExternConverter::cvtExternObject(ctxt, em, mc, s, emitExterns);
+                Util::IJson* json;
+                if (isR) {
+                    json = ExternConverter::cvtExternObject(ctxt, em, mce2, s, emitExterns);
+                } else {
+                    json = ExternConverter::cvtExternObject(ctxt, em, mc, s, emitExterns);
+                }
                 if (json)
                     result->append(json);
                 continue;

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -915,6 +915,10 @@ void ExternConverter_DirectMeter::convertExternInstance(
 void ExternConverter_Register::convertExternInstance(
     UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
     UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
+    size_t paramSize = eb->getConstructorParameters()->size();
+    if (paramSize == 2) {
+        modelError("%1%: Expecting 1 parameter. Initial value not supported", eb->constructor);
+    }
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto jreg = new Util::JsonObject();

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -616,8 +616,14 @@ Util::IJson* ExternConverter_Register::convertExternObject(
     UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
     UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
     UNUSED const bool& emitExterns) {
-    if (mc->arguments->size() != 2) {
+    if (em->method->name != "write" && em->method->name != "read") {
+        modelError("Unsupported register method %1%", mc);
+        return nullptr;
+    } else if (em->method->name == "write" && mc->arguments->size() != 2) {
         modelError("Expected 2 arguments for %1%", mc);
+        return nullptr;
+    } else if (em->method->name == "read" && mc->arguments->size() != 1) {
+        modelError("Expected 1 arguments for %1%", mc);
         return nullptr;
     }
     auto reg = new Util::JsonObject();
@@ -930,8 +936,8 @@ void ExternConverter_Register::convertExternInstance(
         return;
     }
     auto st = eb->instanceType->to<IR::Type_SpecializedCanonical>();
-    if (st->arguments->size() != 1) {
-        modelError("%1%: expected 1 type argument", st);
+    if (st->arguments->size() != 2) {
+        modelError("%1%: expected 2 type argument", st);
         return;
     }
     auto regType = st->arguments->at(0);

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -622,8 +622,8 @@ Util::IJson* ExternConverter_Register::convertExternObject(
     } else if (em->method->name == "write" && mc->arguments->size() != 2) {
         modelError("Expected 2 arguments for %1%", mc);
         return nullptr;
-    } else if (em->method->name == "read" && mc->arguments->size() != 1) {
-        modelError("Expected 1 arguments for %1%", mc);
+    } else if (em->method->name == "read" && mc->arguments->size() != 2) {
+        modelError("p4c-psa internally requires 2 arguments for %1%", mc);
         return nullptr;
     }
     auto reg = new Util::JsonObject();
@@ -634,12 +634,11 @@ Util::IJson* ExternConverter_Register::convertExternObject(
         auto primitive = mkPrimitive("register_read");
         auto parameters = mkParameters(primitive);
         primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
-        /* TODO */
-        // auto dest = ctxt->conv->convert(mc->arguments->at(0)->expression);
-        // parameters->append(dest);
+        auto dest = ctxt->conv->convert(mc->arguments->at(0)->expression);
+        parameters->append(dest);
         parameters->append(reg);
-        // auto index = ctxt->conv->convert(mc->arguments->at(1)->expression);
-        // parameters->append(index);
+        auto index = ctxt->conv->convert(mc->arguments->at(1)->expression);
+        parameters->append(index);
         return primitive;
     } else if (em->method->name == "write") {
         auto primitive = mkPrimitive("register_write");

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -131,19 +131,19 @@ class LocalCopyPropagation : public PassManager {
         if (!typeChecking)
             typeChecking = new TypeChecking(refMap, typeMap, true);
         passes.push_back(typeChecking);
-        policy = 
-            [refMap, typeMap](const Context *, const IR::Expression *e) -> bool { 
+        policy =
+            [refMap, typeMap](const Context *, const IR::Expression *e) -> bool {
                 auto mce = e->to<IR::MethodCallExpression>();
                 if (mce == nullptr)
                     return true;
-                auto mi = P4::MethodInstance::resolve(mce, refMap, typeMap); 
+                auto mi = P4::MethodInstance::resolve(mce, refMap, typeMap);
                 auto em = mi->to<P4::ExternMethod>();
                 if (em == nullptr)
                     return true;
-                if (em->originalExternType->name.name == "Register" || 
+                if (em->originalExternType->name.name == "Register" ||
                         em->method->name.name == "read")
                     return false;
-                return true; 
+                return true;
             };
         passes.push_back(new DoLocalCopyPropagation(refMap, typeMap, policy));
         setName("LocalCopyPropagation");

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -131,20 +131,6 @@ class LocalCopyPropagation : public PassManager {
         if (!typeChecking)
             typeChecking = new TypeChecking(refMap, typeMap, true);
         passes.push_back(typeChecking);
-        policy =
-            [refMap, typeMap](const Context *, const IR::Expression *e) -> bool {
-                auto mce = e->to<IR::MethodCallExpression>();
-                if (mce == nullptr)
-                    return true;
-                auto mi = P4::MethodInstance::resolve(mce, refMap, typeMap);
-                auto em = mi->to<P4::ExternMethod>();
-                if (em == nullptr)
-                    return true;
-                if (em->originalExternType->name.name == "Register" ||
-                        em->method->name.name == "read")
-                    return false;
-                return true;
-            };
         passes.push_back(new DoLocalCopyPropagation(refMap, typeMap, policy));
         setName("LocalCopyPropagation");
     }

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -131,6 +131,20 @@ class LocalCopyPropagation : public PassManager {
         if (!typeChecking)
             typeChecking = new TypeChecking(refMap, typeMap, true);
         passes.push_back(typeChecking);
+        policy = 
+            [refMap, typeMap](const Context *, const IR::Expression *e) -> bool { 
+                auto mce = e->to<IR::MethodCallExpression>();
+                if (mce == nullptr)
+                    return true;
+                auto mi = P4::MethodInstance::resolve(mce, refMap, typeMap); 
+                auto em = mi->to<P4::ExternMethod>();
+                if (em == nullptr)
+                    return true;
+                if (em->originalExternType->name.name == "Register" || 
+                        em->method->name.name == "read")
+                    return false;
+                return true; 
+            };
         passes.push_back(new DoLocalCopyPropagation(refMap, typeMap, policy));
         setName("LocalCopyPropagation");
     }

--- a/testdata/p4_16_samples/psa-register-read-write-bmv2.p4
+++ b/testdata/p4_16_samples/psa-register-read-write-bmv2.p4
@@ -1,0 +1,148 @@
+/*
+Copyright 2019 Cisco Systems, Inc.
+Modified for register testing by third party 2020.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "psa.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt,
+                         out headers_t hdr,
+                         inout metadata_t user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr,
+                 inout metadata_t user_meta,
+                 in    psa_ingress_input_metadata_t  istd,
+                 inout psa_ingress_output_metadata_t ostd)
+{
+    Register<EthernetAddress, bit<32>>(128) regfile;
+
+    apply {
+        regfile.write(1, 3);
+        hdr.ethernet.dstAddr = regfile.read(1);
+
+        // Direct packets out of a port number equal to the least
+        // significant bits of the Ethernet destination address.  On
+        // the BMv2 PSA implementation, type PortIdUint_t is 32 bits
+        // wide, so the least significant 32 bits are significant, and
+        // the upper 16 bits are always ignored.
+        send_to_port(ostd, (PortId_t) (PortIdUint_t) hdr.ethernet.dstAddr);
+
+        if (hdr.ethernet.dstAddr == 0) {
+        // if (hdr.ethernet.dstAddr == 0) {
+            // This action should overwrite the ostd.drop field that
+            // was assigned a value via the send_to_port() action
+            // above, causing this packet to be dropped, _not_ sent
+            // out of port 0.
+            ingress_drop(ostd);
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers_t hdr,
+                        inout metadata_t user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr,
+                inout metadata_t user_meta,
+                in    psa_egress_input_metadata_t  istd,
+                inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control CommonDeparserImpl(packet_out packet,
+                           inout headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers_t hdr,
+                            in metadata_t meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers_t hdr,
+                           in metadata_t meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                cIngress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               cEgress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-register-read-write-bmv2.stf
+++ b/testdata/p4_16_samples/psa-register-read-write-bmv2.stf
@@ -1,0 +1,25 @@
+# cmd | port | dest | src | ethertype
+packet 4 000000000001 000000000000 ffff
+expect 3 000000000003 000000000000 ffff $
+
+packet 4 000000000002 000000000000 ffff
+expect 3 000000000003 000000000000 ffff $
+
+packet 4 000000000003 000000000000 ffff
+expect 3 000000000003 000000000000 ffff $
+
+packet 0 000000000003 000000000000 ffff
+expect 3 000000000003 000000000000 ffff
+
+register_read cIngress.regfile 1
+# expect 3
+register_read cIngress.regfile 5
+# expect 0
+register_write cIngress.regfile 5 100
+register_read cIngress.regfile 5
+# expect 100
+
+register_reset cIngress.regfile
+register_read cIngress.regfile 1
+register_read cIngress.regfile 5
+# expect 0


### PR DESCRIPTION
Adding register support for PSA:
1. register_write().
2. register_read(). Syntax exposed to programmer is `dst = register_read(index)`. Internally, the compiler backend generate .json for `register_read(dst, index)`. This way, the generated .json shares the same .json format as v1model and is compatible with existing bmv2 backend.
3. Add register control plane commands support to STF: register_read, register_write, register_reset.  

Testing filename: testdata/p4_16_samples/psa-register-read-write-bmv2.p4 (.stf)