### PR TITLE
Fix #2399 - duplication error with __v1model_version in v1model

### DIFF
--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -69,8 +69,6 @@ const bit<32> __v1model_version = V1MODEL_VERSION;
 typedef bit<9>  PortId_t;       // should not be a constant size?
 #endif
 
-const bit<32> __v1model_version = V1MODEL_VERSION;
-
 @metadata @name("standard_metadata")
 struct standard_metadata_t {
 #if V1MODEL_VERSION >= 20200408


### PR DESCRIPTION
When you try to compile using `p4c-bm2-ss --p4v 16 "foo.p4" -o "bar.json"`, 
where `foo.p4` includes `v1model.p4`, it throws this error - 

```
/usr/local/share/p4c/p4include/v1model.p4(72): [--Werror=duplicate] error: __v1model_version duplicates __v1model_version.
const bit<32> __v1model_version = 20180101;
              ^^^^^^^^^^^^^^^^^
/usr/local/share/p4c/p4include/v1model.p4(66)
const bit<32> __v1model_version = 20180101;
              ^^^^^^^^^^^^^^^^^
```

This because __v1model_version is declared twice. This PR fixes that by, well, removing a line. Felt it would be better to just create a PR than creating an issue. This fixes issue #2399 

