### PR TITLE
Fix gmputil - ffs() to handle -ve big_int values

### DIFF
--- a/lib/gmputil.h
+++ b/lib/gmputil.h
@@ -84,7 +84,7 @@ static inline unsigned bitcount(big_int v) {
 }
 
 static inline int ffs(big_int v) {
-    if (v == 0) return -1;
+    if (v <= 0) return -1;
     return boost::multiprecision::lsb(v);
 }
 


### PR DESCRIPTION
A `big_int` with -ve value passed to `ffs()` will result in `boost::multiprecision` error,

```
Testing individual bits in negative values is not supported - results are undefined.
```
Adding a check