### PR TITLE
Unset bitwidth for string controller types in P4Info

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -715,13 +715,14 @@ getMatchType(cstring matchTypeName) {
 }
 
 // getTypeWidth returns the width in bits for the @type, except if it is a
-// user-defined type with a @p4runtime_translation annotation whose controller
-// type is bit<W>, in which case it returns W.
+// user-defined type with a @p4runtime_translation annotation, in which case it
+// returns W if the type is bit<W>, and 0 otherwise (i.e. if the type is
+// string).
 static int
 getTypeWidth(const IR::Type* type, TypeMap* typeMap) {
     TranslationAnnotation annotation;
-    if (hasTranslationAnnotation(type, &annotation) &&
-        annotation.controller_type.type == ControllerType::kBit) {
+    if (hasTranslationAnnotation(type, &annotation)) {
+        // W if the type is bit<W>, and 0 if the type is string
         return annotation.controller_type.width;
     }
     return typeMap->minWidthBits(type, type->getNode());

--- a/control-plane/typeSpecConverter.h
+++ b/control-plane/typeSpecConverter.h
@@ -90,7 +90,7 @@ class TypeSpecConverter : public Inspector {
 struct ControllerType {
     enum Type { kBit, kString };
     Type type;  // Supported controller types are `string` and `bit<W>`.
-    int width;  // Meaningful only if type == kBit.
+    int width;  // 0 if type == kString.
 };
 
 /// Payload of @p4runtime_translation annotation.

--- a/testdata/p4_16_samples_outputs/issue2283_1-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2283_1-bmv2.p4.p4info.txt
@@ -28,7 +28,6 @@ tables {
   match_fields {
     id: 3
     name: "h.ports.port3"
-    bitwidth: 16
     match_type: EXACT
     type_name {
       name: "PortId3_t"

--- a/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-first.p4
@@ -45,11 +45,8 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
         }
         const entries = {
                         48w0xa0102030000 &&& 48w0xffffffffffff : act_hit(48w1);
-
                         48w0xa0000000000 &&& 48w0xff0000000000 : act_hit(48w2);
-
                         48w0x0 &&& 48w0x0 : act_hit(48w3);
-
         }
 
         const default_action = act_miss();

--- a/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-frontend.p4
@@ -45,11 +45,8 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
         }
         const entries = {
                         48w0xa0102030000 &&& 48w0xffffffffffff : act_hit(48w1);
-
                         48w0xa0000000000 &&& 48w0xff0000000000 : act_hit(48w2);
-
                         48w0x0 &&& 48w0x0 : act_hit(48w3);
-
         }
 
         const default_action = act_miss();

--- a/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-midend.p4
@@ -45,11 +45,8 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
         }
         const entries = {
                         48w0xa0102030000 &&& 48w0xffffffffffff : act_hit(48w1);
-
                         48w0xa0000000000 &&& 48w0xff0000000000 : act_hit(48w2);
-
                         48w0x0 &&& 48w0x0 : act_hit(48w3);
-
         }
 
         const default_action = act_miss();

--- a/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2.p4
@@ -45,11 +45,8 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
         }
         const entries = {
                         0xa0102030000 &&& 0xffffffffffff : act_hit(1);
-
                         0xa0000000000 &&& 0xff0000000000 : act_hit(2);
-
                         0x0 &&& 0x0 : act_hit(3);
-
         }
 
         const default_action = act_miss();


### PR DESCRIPTION
When a user-defined type is translated to a string controller type, the
bitwidth fields for match fields, action params and controller metadata
fields with this type must be unset in the P4Info message.

See https://github.com/p4lang/p4runtime/pull/294