### PR TITLE
Supporting scalar type in PSA

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -173,7 +173,6 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/issue1205-bmv2.p4
   # These psa tests are not ready to run on bmv2 yet
   testdata/p4_16_samples/psa-example-digest-bmv2.p4
-  testdata/p4_16_samples/psa-example-register2-bmv2.p4
   # This reads stack.next
   testdata/p4_16_samples/issue692-bmv2.p4
   # These test use computations in the verify/update checksum controls - unsupported

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -130,6 +130,8 @@ void PsaProgramStructure::createScalars(ConversionContext* ctxt) {
             field->append(kv.second->name);
             field->append(type->size);
             field->append(type->isSigned);
+        } else {
+            BUG_CHECK(kv.second, "%1 is not of Type_Bits");
         }
         ctxt->json->add_header_field("scalars_t", field);
     }

--- a/backends/bmv2/psa_switch/psaSwitch.h
+++ b/backends/bmv2/psa_switch/psaSwitch.h
@@ -121,9 +121,8 @@ class PsaProgramStructure : public ProgramStructure {
 
  public:
     // We place scalar user metadata fields (i.e., bit<>, bool)
-    // in the scalarsName metadata object, so we may need to rename
-    // these fields.  This map holds the new names.
-    std::vector<const IR::StructField*> scalars;
+    // in the scalars map.
+    ordered_map<cstring, const IR::Declaration_Variable*> scalars;
     unsigned                            scalars_width = 0;
     unsigned                            error_width = 32;
     unsigned                            bool_width = 1;
@@ -160,6 +159,7 @@ class PsaProgramStructure : public ProgramStructure {
     void createStructLike(ConversionContext* ctxt, const IR::Type_StructLike* st);
     void createTypes(ConversionContext* ctxt);
     void createHeaders(ConversionContext* ctxt);
+    void createScalars(ConversionContext* ctxt);
     void createParsers(ConversionContext* ctxt);
     void createExterns();
     void createActions(ConversionContext* ctxt);
@@ -220,6 +220,7 @@ class InspectPsaProgram : public Inspector {
     void addTypesAndInstances(const IR::Type_StructLike* type, bool meta);
     void addHeaderType(const IR::Type_StructLike *st);
     void addHeaderInstance(const IR::Type_StructLike *st, cstring name);
+    bool preorder(const IR::Declaration_Variable* dv) override;
     bool preorder(const IR::Parameter* parameter) override;
 };
 
@@ -243,7 +244,7 @@ class ConvertPsaToJson : public Inspector {
         CHECK_NULL(structure); }
 
     void postorder(UNUSED const IR::P4Program* program) override {
-        cstring scalarsName = refMap->newName("scalars");
+        cstring scalarsName = "scalars";
         // This visitor is used in multiple passes to convert expression to json
         auto conv = new PsaSwitchExpressionConverter(refMap, typeMap, structure, scalarsName);
         auto ctxt = new ConversionContext(refMap, typeMap, toplevel, structure, conv, json);

--- a/testdata/p4_16_samples/psa-example-register2-bmv2.p4
+++ b/testdata/p4_16_samples/psa-example-register2-bmv2.p4
@@ -121,6 +121,9 @@ control ingress(inout headers hdr,
 
     apply {
         ostd.egress_port = (PortId_t) 0;
+        hdr.ipv4.setValid();
+        // dstAddr (48 bits), srcAddr (48 bits), etherType (16 bits)
+        hdr.ipv4.totalLen = (48 + 48 + 16) / 8;
         if (hdr.ipv4.isValid()) {
             @atomic {
                 PacketByteCountState_t tmp;

--- a/testdata/p4_16_samples/psa-example-register2-bmv2.stf
+++ b/testdata/p4_16_samples/psa-example-register2-bmv2.stf
@@ -1,1 +1,13 @@
-# empty stf for testing
+# cmd | port | dest | src | ethertype
+packet 4 000000000001 000000000002 ffff
+
+register_read ingress.port_pkt_ip_bytes_in 4
+# expect 281474976710670
+
+# Here is the reason:
+# PACKET_BYTE_COUNT_WIDTH = 80
+# PACKET_COUNT_WIDTH = 32
+# BYTE_COUNT_WIDTH = 48
+# PACKET_BYTE [79:0] = PACKET[79:48] | BYTE[47:0]
+# The test case generates 1 packet which has 14 bytes
+# Thus we expect (1 << 48) + 14 = 281474976710670

--- a/testdata/p4_16_samples/psa-example-register2-bmv2.stf
+++ b/testdata/p4_16_samples/psa-example-register2-bmv2.stf
@@ -1,0 +1,1 @@
+# empty stf for testing

--- a/testdata/p4_16_samples/psa-register-complex-bmv2.p4
+++ b/testdata/p4_16_samples/psa-register-complex-bmv2.p4
@@ -1,0 +1,141 @@
+/*
+Copyright 2020 Cornell Univ.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "psa.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt,
+                         out headers_t hdr,
+                         inout metadata_t user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr,
+                 inout metadata_t user_meta,
+                 in    psa_ingress_input_metadata_t  istd,
+                 inout psa_ingress_output_metadata_t ostd)
+{
+    Register<EthernetAddress, bit<32>>(128) regfile;
+
+    apply {
+        regfile.write(1, 3);
+        regfile.write(2, 4);
+        hdr.ethernet.dstAddr = regfile.read(1) + regfile.read(2) - 5;
+
+        // Direct packets out of a port number equal to the least
+        // significant bits of the Ethernet destination address.  On
+        // the BMv2 PSA implementation, type PortIdUint_t is 32 bits
+        // wide, so the least significant 32 bits are significant, and
+        // the upper 16 bits are always ignored.
+        if (hdr.ethernet.dstAddr == 2) {
+            send_to_port(ostd, (PortId_t) (PortIdUint_t) hdr.ethernet.dstAddr);
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers_t hdr,
+                        inout metadata_t user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr,
+                inout metadata_t user_meta,
+                in    psa_egress_input_metadata_t  istd,
+                inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control CommonDeparserImpl(packet_out packet,
+                           inout headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers_t hdr,
+                            in metadata_t meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers_t hdr,
+                           in metadata_t meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                cIngress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               cEgress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-register-complex-bmv2.stf
+++ b/testdata/p4_16_samples/psa-register-complex-bmv2.stf
@@ -1,0 +1,15 @@
+# cmd | port | dest | src | ethertype
+packet 4 000000000001 000000000000 ffff
+expect 2 000000000002 000000000000 ffff $
+
+packet 4 000000000002 000000000000 ffff
+expect 2 000000000002 000000000000 ffff $
+
+packet 4 000000000003 000000000000 ffff
+expect 2 000000000002 000000000000 ffff $
+
+packet 0 000000000003 000000000000 ffff
+expect 2 000000000002 000000000000 ffff
+
+register_read cIngress.regfile 1
+register_read cIngress.regfile 2

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-first.p4
@@ -65,6 +65,8 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
     Register<PacketByteCountState_t, PortId_t>(32w512) port_pkt_ip_bytes_in;
     apply {
         ostd.egress_port = (PortId_t)32w0;
+        hdr.ipv4.setValid();
+        hdr.ipv4.totalLen = 16w14;
         if (hdr.ipv4.isValid()) @atomic {
             PacketByteCountState_t tmp;
             tmp = port_pkt_ip_bytes_in.read(istd.ingress_port);

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-frontend.p4
@@ -62,6 +62,8 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
     @name("ingress.port_pkt_ip_bytes_in") Register<PacketByteCountState_t, PortId_t>(32w512) port_pkt_ip_bytes_in_0;
     apply {
         ostd.egress_port = (PortId_t)32w0;
+        hdr.ipv4.setValid();
+        hdr.ipv4.totalLen = 16w14;
         if (hdr.ipv4.isValid()) @atomic {
             tmp_0 = port_pkt_ip_bytes_in_0.read(istd.ingress_port);
             update_pkt_ip_byte_count(tmp_0, hdr.ipv4.totalLen);

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-midend.p4
@@ -62,14 +62,16 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
         tmp_0 = s;
     }
     @name("ingress.port_pkt_ip_bytes_in") Register<PacketByteCountState_t, PortId_t>(32w512) port_pkt_ip_bytes_in_0;
-    @hidden action psaexampleregister2bmv2l127() {
+    @hidden action psaexampleregister2bmv2l130() {
         tmp_0 = port_pkt_ip_bytes_in_0.read(istd.ingress_port);
     }
-    @hidden action psaexampleregister2bmv2l129() {
+    @hidden action psaexampleregister2bmv2l132() {
         port_pkt_ip_bytes_in_0.write(istd.ingress_port, tmp_0);
     }
     @hidden action psaexampleregister2bmv2l123() {
         ostd.egress_port = 32w0;
+        hdr.ipv4.setValid();
+        hdr.ipv4.totalLen = 16w14;
     }
     @hidden table tbl_psaexampleregister2bmv2l123 {
         actions = {
@@ -77,11 +79,11 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
         }
         const default_action = psaexampleregister2bmv2l123();
     }
-    @hidden table tbl_psaexampleregister2bmv2l127 {
+    @hidden table tbl_psaexampleregister2bmv2l130 {
         actions = {
-            psaexampleregister2bmv2l127();
+            psaexampleregister2bmv2l130();
         }
-        const default_action = psaexampleregister2bmv2l127();
+        const default_action = psaexampleregister2bmv2l130();
     }
     @hidden table tbl_update_pkt_ip_byte_count {
         actions = {
@@ -89,18 +91,18 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
         }
         const default_action = update_pkt_ip_byte_count();
     }
-    @hidden table tbl_psaexampleregister2bmv2l129 {
+    @hidden table tbl_psaexampleregister2bmv2l132 {
         actions = {
-            psaexampleregister2bmv2l129();
+            psaexampleregister2bmv2l132();
         }
-        const default_action = psaexampleregister2bmv2l129();
+        const default_action = psaexampleregister2bmv2l132();
     }
     apply {
         tbl_psaexampleregister2bmv2l123.apply();
         if (hdr.ipv4.isValid()) @atomic {
-            tbl_psaexampleregister2bmv2l127.apply();
+            tbl_psaexampleregister2bmv2l130.apply();
             tbl_update_pkt_ip_byte_count.apply();
-            tbl_psaexampleregister2bmv2l129.apply();
+            tbl_psaexampleregister2bmv2l132.apply();
         }
     }
 }
@@ -117,34 +119,34 @@ control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action psaexampleregister2bmv2l161() {
+    @hidden action psaexampleregister2bmv2l164() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_psaexampleregister2bmv2l161 {
+    @hidden table tbl_psaexampleregister2bmv2l164 {
         actions = {
-            psaexampleregister2bmv2l161();
+            psaexampleregister2bmv2l164();
         }
-        const default_action = psaexampleregister2bmv2l161();
+        const default_action = psaexampleregister2bmv2l164();
     }
     apply {
-        tbl_psaexampleregister2bmv2l161.apply();
+        tbl_psaexampleregister2bmv2l164.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action psaexampleregister2bmv2l161_0() {
+    @hidden action psaexampleregister2bmv2l164_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_psaexampleregister2bmv2l161_0 {
+    @hidden table tbl_psaexampleregister2bmv2l164_0 {
         actions = {
-            psaexampleregister2bmv2l161_0();
+            psaexampleregister2bmv2l164_0();
         }
-        const default_action = psaexampleregister2bmv2l161_0();
+        const default_action = psaexampleregister2bmv2l164_0();
     }
     apply {
-        tbl_psaexampleregister2bmv2l161_0.apply();
+        tbl_psaexampleregister2bmv2l164_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4
@@ -65,6 +65,8 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
     Register<PacketByteCountState_t, PortId_t>(NUM_PORTS) port_pkt_ip_bytes_in;
     apply {
         ostd.egress_port = (PortId_t)0;
+        hdr.ipv4.setValid();
+        hdr.ipv4.totalLen = (48 + 48 + 16) / 8;
         if (hdr.ipv4.isValid()) {
             @atomic {
                 PacketByteCountState_t tmp;


### PR DESCRIPTION
Adding scalar type support in PSA:

When source code contains a more complex expression, for example:
`T a = register.read(x) + register.read(y);` (assume T has a width of 48 bits.)

p4c will transform the source code into:
```c
bit<48> tmp_0;
bit<48> tmp_1; 
tmp_0 = register.read(x);
tmp_1 = register.read(y);
a = tmp_0 + tmp_1;
```

In v1model, `bit<x> tmp;` is supported by:  
(1) create a `scalars` object in the headers section of the generated json file.    
(2) create a `scalars_t` object in the header_types section of the generated json file.   
(3) For each `bit<x> varName;` add a field to header_type `scalars_t`.  

This is not implemented for PSA yet and more complex expressions like the one mentioned above fails to run on bmv2. This PR implements the three points listed above for PSA to support `bit<x> varName`, thus more complex expressions like one mentioned above can run on bmv2.