### PR TITLE
Packet truncation support for uBPF backend

### DIFF
--- a/backends/ubpf/p4include/ubpf_model.p4
+++ b/backends/ubpf/p4include/ubpf_model.p4
@@ -99,8 +99,15 @@ extern Register<T, S> {
  */
 extern bit<48> ubpf_time_get_ns();
 
-/*
- * Truncate packet
+/***
+ * Truncate packet to the maximum size
+ *
+ * @param len   Maximum length of the packet (from beginning of packet) in
+ *              bytes, further bytes will be removed. If deparsed packet is
+ *              shorter than len, this extern has no effect.
+ *              Minimum value for len is 14, as a packet in Open vSwitch must
+ *              have at least Ethernet header. Smaller values than 14 will be
+ *              adjusted to the minimum value by switch.
  */
 extern void truncate(in bit<32> len);
 

--- a/backends/ubpf/p4include/ubpf_model.p4
+++ b/backends/ubpf/p4include/ubpf_model.p4
@@ -99,6 +99,10 @@ extern Register<T, S> {
  */
 extern bit<48> ubpf_time_get_ns();
 
+/*
+ * Truncate packet
+ */
+extern void truncate(in bit<32> len);
 
 enum HashAlgorithm {
     lookup3

--- a/backends/ubpf/runtime/ebpf_runtime_ubpf.h
+++ b/backends/ubpf/runtime/ebpf_runtime_ubpf.h
@@ -47,6 +47,8 @@ static void inline init_ubpf_table_test(char *name, unsigned int key_size, unsig
     ubpf_packet_data_test(ctx)
 #define ubpf_adjust_head(ctx, ofs) \
     ubpf_adjust_head_test(ctx, ofs)
+#define ubpf_truncate_packet(ctx, maxlen) \
+    ubpf_truncate_packet_test(ctx, maxlen)
 #define ubpf_map_lookup(table, key) \
     registry_lookup_table_elem(#table, key)
 #define ubpf_map_update(table, key, value) \

--- a/backends/ubpf/runtime/ubpf_test.h
+++ b/backends/ubpf/runtime/ubpf_test.h
@@ -62,6 +62,24 @@ static inline void *ubpf_adjust_head_test(void *ctx, int offset) {
     }
 }
 
+static inline uint32_t ubpf_truncate_packet_test(void *ctx, int maxlen)
+{
+    struct dp_packet *dp = (struct dp_packet *) ctx;
+    uint32_t cutlen= 0;
+
+    if (maxlen < 0)
+        return 0;
+
+    if (maxlen >= dp->size_) {
+        cutlen = 0;
+    } else {
+        cutlen = dp->size_ - maxlen;
+        dp->data = realloc(dp->data, maxlen);
+        dp->size_ = maxlen;
+    }
+
+    return cutlen;
+}
 
 
 #endif //P4C_UBPF_TEST_H

--- a/backends/ubpf/target.cpp
+++ b/backends/ubpf/target.cpp
@@ -73,6 +73,7 @@ namespace UBPF {
                 "static void (*ubpf_printf)(const char *fmt, ...) = (void *)7;\n"
                 "static void *(*ubpf_packet_data)(const void *) = (void *)9;\n"
                 "static void *(*ubpf_adjust_head)(const void *, uint64_t) = (void *)8;\n"
+                "static uint32_t (*ubpf_truncate_packet)(const void *, uint64_t) = (void *)11;\n"
                 "\n");
         builder->newline();
         builder->appendLine(

--- a/backends/ubpf/ubpfControl.cpp
+++ b/backends/ubpf/ubpfControl.cpp
@@ -67,6 +67,16 @@ namespace UBPF {
             }
 
             return;
+        } else if (function->method->name.name == control->program->model.truncate.name) {
+            if (function->expr->arguments->size() == 1) {
+                builder->appendFormat("%s = (int) (",
+                        control->program->packetTruncatedSizeVar.c_str());
+                visit(function->expr->arguments->at(0)->expression);
+                builder->append(")");
+            } else {
+                ::error("%1%: One argument expected", function->expr);
+            }
+            return;
         }
         processCustomExternFunction(function, UBPFTypeFactory::instance);
     }

--- a/backends/ubpf/ubpfDeparser.cpp
+++ b/backends/ubpf/ubpfDeparser.cpp
@@ -352,6 +352,17 @@ void UBPFDeparser::emit(EBPF::CodeBuilder *builder) {
     builder->appendFormat("%s = 0", program->offsetVar.c_str());
     builder->endOfStatement(true);
 
+    builder->emitIndent();
+    builder->appendFormat("if (%s > 0) ", program->packetTruncatedSizeVar.c_str());
+    builder->blockStart();
+    builder->emitIndent();
+    builder->appendFormat("%s -= ubpf_truncate_packet(%s, %s)", program->lengthVar.c_str(),
+                          program->contextVar.c_str(), program->packetTruncatedSizeVar.c_str());
+    builder->endOfStatement(true);
+    builder->blockEnd(true);
+    builder->emitIndent();
+    builder->newline();
+
     codeGen->setBuilder(builder);
     controlBlock->container->body->apply(*codeGen);
 }

--- a/backends/ubpf/ubpfModel.h
+++ b/backends/ubpf/ubpfModel.h
@@ -69,6 +69,7 @@ namespace UBPF {
                       drop("mark_to_drop"),
                       pass("mark_to_pass"),
                       ubpf_time_get_ns("ubpf_time_get_ns"),
+                      truncate("truncate"),
                       csum_replace2("csum_replace2"),
                       csum_replace4("csum_replace4"),
                       hashAlgorithm(),
@@ -85,6 +86,7 @@ namespace UBPF {
         ::Model::Elem drop;
         ::Model::Elem pass;
         ::Model::Elem ubpf_time_get_ns;
+        ::Model::Elem truncate;
         ::Model::Extern_Model csum_replace2;
         ::Model::Extern_Model csum_replace4;
         Algorithm_Model hashAlgorithm;

--- a/backends/ubpf/ubpfProgram.cpp
+++ b/backends/ubpf/ubpfProgram.cpp
@@ -246,6 +246,10 @@ namespace UBPF {
         builder->emitIndent();
         builder->appendFormat("unsigned char %s;", byteVar.c_str());
         builder->newline();
+
+        builder->emitIndent();
+        builder->appendFormat("int %s = -1;", packetTruncatedSizeVar.c_str());
+        builder->newline();
     }
 
     void UBPFProgram::emitPipeline(EBPF::CodeBuilder *builder) {

--- a/backends/ubpf/ubpfProgram.h
+++ b/backends/ubpf/ubpfProgram.h
@@ -44,6 +44,7 @@ namespace UBPF {
 
         cstring contextVar, outerHdrOffsetVar, outerHdrLengthVar;
         cstring stdMetadataVar;
+        cstring packetTruncatedSizeVar;
 
         UBPFProgram(const EbpfOptions &options, const IR::P4Program *program,
                     P4::ReferenceMap *refMap, P4::TypeMap *typeMap, const IR::ToplevelBlock *toplevel) :
@@ -56,6 +57,7 @@ namespace UBPF {
             lengthVar = cstring("pkt_len");
             endLabel = cstring("deparser");
             stdMetadataVar = cstring("std_meta");
+            packetTruncatedSizeVar = cstring("packetTruncatedSize");
         }
 
         bool build() override;

--- a/testdata/p4_16_samples/truncate_ubpf.p4
+++ b/testdata/p4_16_samples/truncate_ubpf.p4
@@ -1,0 +1,44 @@
+#include <core.p4>
+#define UBPF_MODEL_VERSION 20200515
+#include <ubpf_model.p4>
+
+header truncate_spec_t {
+    bit<8>  bytes_to_save;
+}
+header next_header_t {
+    bit<32> data;
+}
+
+struct Headers_t {
+    truncate_spec_t spec;
+    next_header_t   data;
+}
+
+struct metadata {
+}
+
+parser prs(packet_in p, out Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
+    state start {
+        p.extract(headers.spec);
+        p.extract(headers.data);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
+
+    apply {
+        truncate((bit<32>) headers.spec.bytes_to_save);
+        // modify header to be able to check whether it is emitted
+        headers.data.data = 32w0xFF_FE_FD_FC;
+    }
+
+}
+
+control dprs(packet_out packet, in Headers_t headers) {
+    apply {
+        packet.emit(headers.data);
+    }
+}
+
+ubpf(prs(), pipe(), dprs()) main;

--- a/testdata/p4_16_samples/truncate_ubpf.stf
+++ b/testdata/p4_16_samples/truncate_ubpf.stf
@@ -1,0 +1,21 @@
+# packet_in = { bit<8> out_size, bit<32> header, data }
+# packet_out = { bit<32> header, data }
+# In a output packet header will changed to 0xFF_FE_FD_FC to be able to check whether it is emitted
+
+# truncate after all headers
+packet 0 06 01020304 fedc ba98 7654 3210
+expect 0 fffefdfc fedc
+
+# truncate after the end of a packet
+packet 0 ff 01020304 fedc ba98 7654 3210
+expect 0 fffefdfc fedc ba98 7654 3210
+
+# size of truncated packet equal to original
+packet 0 06 01020304 fedc
+expect 0 fffefdfc fedc
+packet 0 07 01020304 fedc
+expect 0 fffefdfc fedc
+
+# truncate inside of header, so it wouldn't be emitted
+packet 0 02 01020304 fedc ba98 7654 3210
+expect 0 0102


### PR DESCRIPTION
I've implemented support for `truncate()` extern in the uBPF backend. This allows cut off some last bytes from a packet, but dataplane must support that.

I think that @osinstom should be assigned.