### PR TITLE
[PSA] Supporting Indexed Meter as a Extern

### DIFF
--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -410,6 +410,8 @@ class RunBMV2(object):
             # Pass through multicast group commands unchanged, with
             # same arguments as expected by simple_switch_CLI
             self.do_cli_command(first + " " + cmd)
+        elif first == "meter_get_rates" or first == "meter_set_rates" or first == "meter_array_set_rates":
+            self.do_cli_command(first + " " + cmd)
         elif first == "packet":
             interface, data = nextWord(cmd)
             interface = int(interface)

--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -185,8 +185,8 @@ ActionConverter::convertActionParams(const IR::ParameterList *parameters,
         auto param = new Util::JsonObject();
         param->emplace("name", p->name);
         auto type = ctxt->typeMap->getType(p, true);
-        //TODO: added IR::Type_Enum here to support PSA_MeterColor_t
-        //should re-consider how to support action parameters that is neither bit<> nor int<>
+        // TODO: added IR::Type_Enum here to support PSA_MeterColor_t
+        // should re-consider how to support action parameters that is neither bit<> nor int<>
         if (!(type->is<IR::Type_Bits>() || type->is<IR::Type_Enum>()))
             ::error(ErrorType::ERR_INVALID,
                     "%1%: action parameters must be bit<> or int<> on this target", p);

--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -60,8 +60,10 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                 auto mi = P4::MethodInstance::resolve(mce, ctxt->refMap, ctxt->typeMap);
                 auto em = mi->to<P4::ExternMethod>();
                 if (em != nullptr) {
-                    if (em->originalExternType->name.name == "Register" ||
-                    em->method->name.name == "read") {
+                    if ((em->originalExternType->name.name == "Register" ||
+                                                em->method->name.name == "read") ||
+                        (em->originalExternType->name.name == "Meter" &&
+                                                em->method->name.name == "execute")) {
                         isR = true;
                         // l = l->to<IR::PathExpression>();
                         // BUG_CHECK(l != nullptr, "register_read dest cast failed");
@@ -184,7 +186,7 @@ ActionConverter::convertActionParams(const IR::ParameterList *parameters,
         param->emplace("name", p->name);
         auto type = ctxt->typeMap->getType(p, true);
         //TODO: added IR::Type_Enum here to support PSA_MeterColor_t
-        //should consider how to support action parameters that is neither bit<> nor int<>
+        //should re-consider how to support action parameters that is neither bit<> nor int<>
         if (!(type->is<IR::Type_Bits>() || type->is<IR::Type_Enum>()))
             ::error(ErrorType::ERR_INVALID,
                     "%1%: action parameters must be bit<> or int<> on this target", p);

--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -183,7 +183,9 @@ ActionConverter::convertActionParams(const IR::ParameterList *parameters,
         auto param = new Util::JsonObject();
         param->emplace("name", p->name);
         auto type = ctxt->typeMap->getType(p, true);
-        if (!type->is<IR::Type_Bits>())
+        //TODO: added IR::Type_Enum here to support PSA_MeterColor_t
+        //should consider how to support action parameters that is neither bit<> nor int<>
+        if (!(type->is<IR::Type_Bits>() || type->is<IR::Type_Enum>()))
             ::error(ErrorType::ERR_INVALID,
                     "%1%: action parameters must be bit<> or int<> on this target", p);
         param->emplace("bitwidth", type->width_bits());

--- a/backends/bmv2/psa_switch/midend.cpp
+++ b/backends/bmv2/psa_switch/midend.cpp
@@ -73,6 +73,8 @@ class PsaEnumOn32Bits : public P4::ChooseEnumRepresentation {
     bool convert(const IR::Type_Enum* type) const override {
         if (type->name == "PSA_PacketPath_t")
             return true;
+        if (type->name == "PSA_MeterColor_t")
+            return true;
         if (type->srcInfo.isValid()) {
             auto sourceFile = type->srcInfo.getSourceFile();
             if (sourceFile.endsWith(filename))
@@ -103,6 +105,9 @@ PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions& options, std::ostream* outStre
             return true;
         if (em->originalExternType->name.name == "Register" ||
                 em->method->name.name == "read")
+            return false;
+        if (em->originalExternType->name.name == "Meter" &&
+                em->method->name.name == "execute")
             return false;
         return true;
     };

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -903,7 +903,7 @@ void ExternConverter_Meter::convertExternInstance(
     // is_direct
     auto is_direct = new Util::JsonObject();
     is_direct->emplace("name", "is_direct");
-    is_direct->emplace("type", "string");
+    is_direct->emplace("type", "expression");
     is_direct->emplace("value", "false");
     arr->append(is_direct);
 

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -771,22 +771,23 @@ void ExternConverter_Counter::convertExternInstance(
     UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
-    auto jctr = new Util::JsonObject();
-    jctr->emplace("name", name);
-    jctr->emplace("id", nextId("counter_arrays"));
-    jctr->emplace_non_null("source_info", eb->sourceInfoJsonObj());
     auto sz = eb->findParameterValue("n_counters");
     CHECK_NULL(sz);
     if (!sz->is<IR::Constant>()) {
         modelError("%1%: expected a constant", sz->getNode());
         return;
     }
+
+    // adding counter instance to counter_arrays[]
+    auto jctr = new Util::JsonObject();
+    jctr->emplace("name", name);
+    jctr->emplace("id", nextId("counter_arrays"));
+    jctr->emplace_non_null("source_info", eb->sourceInfoJsonObj());
     jctr->emplace("size", sz->to<IR::Constant>()->value);
     jctr->emplace("is_direct", false);
     ctxt->json->counters->append(jctr);
 
-    // Code below used to add json into EXTERN_INSTANCES NODE
-
+    // add counter instance to extern_instances
     auto extern_obj = new Util::JsonObject();
     extern_obj->emplace("name", name);
     extern_obj->emplace("id", nextId("extern_instances"));

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -878,21 +878,57 @@ void ExternConverter_DirectCounter::convertExternInstance(
 void ExternConverter_Meter::convertExternInstance(
     UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
     UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
+    if (eb->getConstructorParameters()->size() != 2) {
+      modelError("%1%: expected two parameters", eb);
+      return;
+    }
+
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
-    auto jmtr = new Util::JsonObject();
-    jmtr->emplace("name", name);
-    jmtr->emplace("id", nextId("meter_arrays"));
-    jmtr->emplace_non_null("source_info", eb->sourceInfoJsonObj());
-    jmtr->emplace("is_direct", false);
+
+    // adding meter instance into extern_instances
+    auto jext_mtr = new Util::JsonObject();
+    jext_mtr->emplace("name", name);
+    jext_mtr->emplace("id", nextId("extern_instances"));
+    jext_mtr->emplace("type", eb->getName());
+    jext_mtr->emplace_non_null("source_info", eb->sourceInfoJsonObj());
+    ctxt->json->externs->append(jext_mtr);
+
+    // adding attributes to meter extern_instance
+    Util::JsonArray *arr = ctxt->json->insert_array_field(jext_mtr, "attribute_values");
+
+    // is_direct
+    auto is_direct = new Util::JsonObject();
+    is_direct->emplace("name", "is_direct");
+    is_direct->emplace("type", "string");
+    is_direct->emplace("value", "false");
+    arr->append(is_direct);
+
+    // meter_array size
     auto sz = eb->findParameterValue("n_meters");
     CHECK_NULL(sz);
     if (!sz->is<IR::Constant>()) {
         modelError("%1%: expected a constant", sz->getNode());
         return;
     }
-    jmtr->emplace("size", sz->to<IR::Constant>()->value);
-    jmtr->emplace("rate_count", 2);
+    auto attr_name = eb->getConstructorParameters()->getParameter(0);
+    auto s = sz->to<IR::Constant>();
+    auto bitwidth = ctxt->typeMap->minWidthBits(s->type, sz->getNode());
+    cstring val = BMV2::stringRepr(s->value, ROUNDUP(bitwidth, 8));
+    auto msz = new Util::JsonObject();
+    msz->emplace("name", attr_name->toString());
+    msz->emplace("type", "hexstr");
+    msz->emplace("value", val);
+    arr->append(msz);
+
+    // rate count
+    auto rc = new Util::JsonObject();
+    rc->emplace("name", "rate_count");
+    rc->emplace("type", "hexstr");
+    rc->emplace("value", 2);
+    arr->append(rc);
+
+    // meter kind
     auto mkind = eb->findParameterValue("type");
     CHECK_NULL(mkind);
     if (!mkind->is<IR::Declaration_ID>()) {
@@ -907,8 +943,11 @@ void ExternConverter_Meter::convertExternInstance(
         type = "bytes";
     else
         ::error(ErrorType::ERR_UNEXPECTED, "%1%: unexpected meter type", mkind->getNode());
-    jmtr->emplace("type", type);
-    ctxt->json->meter_arrays->append(jmtr);
+    auto k = new Util::JsonObject();
+    k->emplace("name", "type");
+    k->emplace("type", "string");
+    k->emplace("value", type);
+    arr->append(k);
 }
 
 void ExternConverter_DirectMeter::convertExternInstance(

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -903,8 +903,8 @@ void ExternConverter_Meter::convertExternInstance(
     // is_direct
     auto is_direct = new Util::JsonObject();
     is_direct->emplace("name", "is_direct");
-    is_direct->emplace("type", "expression");
-    is_direct->emplace("value", "false");
+    is_direct->emplace("type", "hexstr");
+    is_direct->emplace("value", 0);
     arr->append(is_direct);
 
     // meter_array size

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -619,21 +619,24 @@ Util::IJson* ExternConverter_Meter::convertExternObject(
     UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
     UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
     UNUSED const bool& emitExterns) {
-    if (mc->arguments->size() != 2) {
+    if (mc->arguments->size() != 1 && mc->arguments->size() != 2) {
         modelError("Expected 2 arguments for %1%", mc);
         return nullptr;
     }
-    auto primitive = mkPrimitive("execute_meter");
+    auto primitive = mkPrimitive("_" + em->originalExternType->name +
+                                 "_" + em->method->name);
     auto parameters = mkParameters(primitive);
     primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
     auto mtr = new Util::JsonObject();
-    mtr->emplace("type", "meter_array");
+    mtr->emplace("type", "extern");
     mtr->emplace("value", em->object->controlPlaneName());
     parameters->append(mtr);
+    if (mc->arguments->size() == 2) {
+        auto result = ctxt->conv->convert(mc->arguments->at(1)->expression);
+        parameters->append(result);
+    }
     auto index = ctxt->conv->convert(mc->arguments->at(0)->expression);
     parameters->append(index);
-    auto result = ctxt->conv->convert(mc->arguments->at(1)->expression);
-    parameters->append(result);
     return primitive;
 }
 

--- a/testdata/p4_16_samples/psa-meter7-bmv2.p4
+++ b/testdata/p4_16_samples/psa-meter7-bmv2.p4
@@ -57,7 +57,7 @@ control cIngress(inout headers_t hdr,
     Meter<bit<12>>(1024, PSA_MeterType_t.PACKETS) meter0;
     apply {
         hdr.ethernet.dstAddr = 2;
-        if (meter0.execute(1) == PSA_MeterColor_t.RED) {
+        if (meter0.execute(1) == PSA_MeterColor_t.GREEN) {
             hdr.ethernet.dstAddr = 3;
         }
         send_to_port(ostd, (PortId_t) (PortIdUint_t) hdr.ethernet.dstAddr);

--- a/testdata/p4_16_samples/psa-meter7-bmv2.p4
+++ b/testdata/p4_16_samples/psa-meter7-bmv2.p4
@@ -1,0 +1,133 @@
+/*
+Copyright 2020 Cornell University
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "psa.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt,
+                         out headers_t hdr,
+                         inout metadata_t user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr,
+                 inout metadata_t user_meta,
+                 in    psa_ingress_input_metadata_t  istd,
+                 inout psa_ingress_output_metadata_t ostd)
+{
+    Meter<bit<12>>(1024, PSA_MeterType_t.PACKETS) meter0;
+    apply {
+        hdr.ethernet.dstAddr = 2;
+        if (meter0.execute(1) == PSA_MeterColor_t.RED) {
+            hdr.ethernet.dstAddr = 3;
+        }
+        send_to_port(ostd, (PortId_t) (PortIdUint_t) hdr.ethernet.dstAddr);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers_t hdr,
+                        inout metadata_t user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr,
+                inout metadata_t user_meta,
+                in    psa_egress_input_metadata_t  istd,
+                inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control CommonDeparserImpl(packet_out packet,
+                           inout headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers_t hdr,
+                            in metadata_t meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers_t hdr,
+                           in metadata_t meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                cIngress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               cEgress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-meter7-bmv2.stf
+++ b/testdata/p4_16_samples/psa-meter7-bmv2.stf
@@ -1,0 +1,3 @@
+# cmd | port | dest | src | ethertype
+packet 4 000000000001 000000000000 ffff
+expect 3 000000000003 000000000000 ffff $

--- a/testdata/p4_16_samples/psa-meter7-bmv2.stf
+++ b/testdata/p4_16_samples/psa-meter7-bmv2.stf
@@ -1,3 +1,9 @@
 # cmd | port | dest | src | ethertype
 packet 4 000000000001 000000000000 ffff
-expect 3 000000000003 000000000000 ffff $
+expect 3 000000000003 000000000000 ffff
+
+meter_set_rates cIngress.meter0 2 0.000005:4 0.00002:5
+meter_get_rates cIngress.meter0 2
+meter_array_set_rates cIngress.meter0 0.000006:7 0.00008:9
+meter_get_rates cIngress.meter0 1
+meter_get_rates cIngress.meter0 2


### PR DESCRIPTION
Supporting meter extern on PSA:

meter.execute(): Syntax exposed to programmer is `ret = meter.execute(index)`. Internally, the compiler backend generate .json for `meter.execute(dst, ret)`, where `ret` is a parameter of `execute()` in the .json file.

`meter` is generated in `extern_instances` section of the .json file instead of the `meter_arrays` section.

Testing filename: `testdata/p4_16_samples/psa-meter7-bmv2.p4 (.stf)`
* A PR has been submitted to bmv2 end to support `psa-meter` as well.