### PR TITLE
python3 missing from p4lang/p4c docker image

### DIFF
--- a/tools/travis-build
+++ b/tools/travis-build
@@ -4,6 +4,8 @@
 
 set -e  # Exit on error.
 
+export P4C_PYTHON3="python3" # Python3 is required for p4c to run, P4C_DEPS would otherwise uninstall it
+
 export P4C_DEPS="bison \
              build-essential \
              cmake \
@@ -18,7 +20,6 @@ export P4C_DEPS="bison \
              libgmp-dev \
              pkg-config \
              python \
-             python3 \
              python3-pip \
              python3-setuptools \
              tcpdump"
@@ -51,6 +52,7 @@ export P4C_PIP3_PACKAGES="ipaddr \
 apt-get update
 apt-get install -y --no-install-recommends \
   ${P4C_DEPS} \
+  ${P4C_PYTHON3} \
   ${P4C_EBPF_DEPS} \
   ${P4C_RUNTIME_DEPS} \
   git


### PR DESCRIPTION
Build script for docker images cleans up packages including python3, but python3 is required for p4c to run. 

Installing python3 in docker image fixes the bug. Travis build works as packages don't get removed from that. 

Suggest listing python3 as a separate dependency in the build script, so it doesn't get removed on docker build