### PR TITLE
out-of-memory fixes/improvements

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -19,6 +19,7 @@ set (LIBP4CTOOLKIT_SRCS
 	crash.cpp
 	cstring.cpp
         error_catalog.cpp
+        exename.cpp
 	gc.cpp
 	gmputil.cpp
 	hash.cpp
@@ -49,6 +50,7 @@ set (LIBP4CTOOLKIT_HDRS
         error_helper.h
 	error_reporter.h
 	exceptions.h
+        exename.h
 	gc.h
 	gmputil.h
 	hash.h

--- a/lib/exename.cpp
+++ b/lib/exename.cpp
@@ -1,0 +1,64 @@
+/*
+Copyright 2020-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "exename.h"
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "exceptions.h"
+
+template <size_t N>
+static void convertToAbsPath(const char* const relPath, char (&output)[N]) {
+    output[0] = '\0';  // Default to the empty string, indicating failure.
+
+    char cwd[PATH_MAX];
+    if (!getcwd(cwd, sizeof(cwd))) return;
+    const size_t cwdLen = strlen(cwd);
+    if (cwdLen == 0) return;
+    const char* separator = cwd[cwdLen - 1] == '/' ? "" : "/";
+
+    // Construct an absolute path. We're assuming that @relPath is relative to
+    // the current working directory.
+    int n = snprintf(output, N, "%s%s%s", cwd, separator, relPath);
+    BUG_CHECK(n >= 0, "Pathname too long");
+}
+
+const char *exename(const char *argv0) {
+    static char buffer[PATH_MAX];
+    if (buffer[0]) return buffer;  // done already
+    int len;
+    /* find the path of the executable.  We use a number of techniques that may fail
+     * or work on different systems, and take the first working one we find.  Fall
+     * back to not overriding the compiled-in installation path */
+    if ((len = readlink("/proc/self/exe", buffer, sizeof(buffer))) > 0 ||
+        (len = readlink("/proc/curproc/exe", buffer, sizeof(buffer))) > 0 ||
+        (len = readlink("/proc/curproc/file", buffer, sizeof(buffer))) > 0 ||
+        (len = readlink("/proc/self/path/a.out", buffer, sizeof(buffer))) > 0) {
+        buffer[len] = 0;
+    } else if (argv0 && argv0[0] == '/') {
+        snprintf(buffer, sizeof(buffer), "%s", argv0);
+    } else if (argv0 && strchr(argv0, '/')) {
+        convertToAbsPath(argv0, buffer);
+    } else if (getenv("_")) {
+        strncpy(buffer, getenv("_"), sizeof(buffer));
+        buffer[sizeof(buffer) - 1] = 0;
+    } else {
+        buffer[0] = 0; }
+    return buffer;
+}

--- a/lib/exename.h
+++ b/lib/exename.h
@@ -1,0 +1,23 @@
+/*
+Copyright 2020-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef LIB_EXENAME_H_
+#define LIB_EXENAME_H_
+
+/** Attempt to determine the executable name and return a static path to it.  Will use
+ * argv0 if provided and nothing better can be found */
+const char *exename(const char *argv0 = nullptr);
+
+#endif /* LIB_EXENAME_H_ */

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 #include "gc.h"
 #include "cstring.h"
 #include "n4.h"
+#include "backtrace.h"
 
 /* glibc++ requires defining global delete with this exception spec to avoid warnings.
  * If it's not defined, probably not using glibc++ and don't need anything */
@@ -32,9 +33,14 @@ limitations under the License.
 #define _GLIBCXX_USE_NOEXCEPT _NOEXCEPT
 #endif
 
+static bool done_init, started_init;
+// emergency pool to allow a few extra allocations after a bad_alloc is thrown so we
+// can generate reasonable errors, a stack trace, etc
+static char emergency_pool[16*1024];
+static char *emergency_ptr;
+
 // One can disable the GC, e.g., to run under Valgrind, by editing config.h
 #if HAVE_LIBGC
-static bool done_init, started_init;
 void *operator new(std::size_t size) {
     /* DANGER -- on OSX, can't safely call the garbage collector allocation
      * routines from a static global constructor without manually initializing
@@ -44,17 +50,24 @@ void *operator new(std::size_t size) {
         started_init = true;
         GC_INIT();
         done_init = true; }
-    return ::operator new(size, UseGC, 0, 0);
+    auto *rv = ::operator new(size, UseGC, 0, 0);
+    if (!rv && emergency_ptr && emergency_ptr + size < emergency_pool + sizeof(emergency_pool)) {
+        rv = emergency_ptr;
+        size += -size & 0xf;  // align to 16 bytes
+        emergency_ptr += size; }
+    if (!rv) {
+        if (!emergency_ptr) emergency_ptr = emergency_pool;
+        throw backtrace_exception<std::bad_alloc>(); }
+    return rv;
 }
-void *operator new[](std::size_t size) {
-    if (!done_init) {
-        started_init = true;
-        GC_INIT();
-        done_init = true; }
-    return ::operator new(size, UseGC, 0, 0);
+void operator delete(void *p) _GLIBCXX_USE_NOEXCEPT {
+    if (p >= emergency_pool && p < emergency_pool + sizeof(emergency_pool))
+        return;
+    gc::operator delete(p);
 }
-void operator delete(void *p) _GLIBCXX_USE_NOEXCEPT { return gc::operator delete(p); }
-void operator delete[](void *p) _GLIBCXX_USE_NOEXCEPT { return gc::operator delete(p); }
+
+void *operator new[](std::size_t size) { return ::operator new(size); }
+void operator delete[](void *p) _GLIBCXX_USE_NOEXCEPT { ::operator delete(p); }
 
 void *realloc(void *ptr, size_t size) {
     if (!done_init) {


### PR DESCRIPTION
- fix OOM to throw std::bad_alloc properly
- emergency pool of a little extra memory for use after throwing a
  bad_alloc (to allow generating reasonable error messgages and a
  stack trace before exiting)
- fix stack trace code to avoid some low-memory problems.