### PR TITLE
Use std::string instead of cstring in InputSources

### DIFF
--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -79,7 +79,7 @@ void InputSources::seal() {
 
 unsigned InputSources::lineCount() const {
     int size = contents.size();
-    if (contents.back().isNullOrEmpty()) {
+    if (contents.back().empty()) {
         // do not count the last line if it is empty.
         size -= 1;
         if (size < 0)

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -266,7 +266,7 @@ class Comment final : IHasDbPrint {
     Comment(SourceInfo srcInfo, bool singleLine, cstring body):
             srcInfo(srcInfo), singleLine(singleLine), body(body) {}
     cstring toString() const {
-        cstring result;
+        std::string result;
         if (singleLine)
             result = "//";
         else
@@ -340,7 +340,7 @@ class InputSources final {
     std::map<unsigned, SourceFileLine> line_file_map;
 
     /// Each line also stores the end-of-line character(s)
-    std::vector<cstring> contents;
+    std::vector<std::string> contents;
     /// The commends found in the file.
     std::vector<Comment*> comments;
 };


### PR DESCRIPTION
We build strings one token at a time in InputSources, which is extremely inefficient with cstring, as it involves copying and reallocating the string for each added token.  Using std::string instead is significantly better for building strings incrementally.

The java equivalence is

- cstring <-> java.lang.String
- std::string <-> java.lang.StringBuilder