### PR TITLE
Support regex matching for toP4 dumps.

### DIFF
--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -396,14 +396,14 @@ void CompilerOptions::dumpPass(const char* manager, unsigned seq, const char* pa
     for (auto s : top4) {
         bool match = false;
         try {
-           auto s_regex = std::regex(s, std::regex_constants::extended);
+           auto s_regex = std::regex(s, std::regex_constants::ECMAScript);
             // we use regex_search instead of regex_match
             // regex_match compares the regex against the entire string
             // regex_search checks if the regex is contained as substring
             match = std::regex_search(name.begin(), name.end(), s_regex);
         } catch (const std::regex_error &e) {
             ::error("Malformed toP4 regex string \"%s\".", s);
-            ::error("The regex matcher follows extended POSIX syntax.");
+            ::error("The regex matcher follows ECMAScript syntax.");
             exit(1);
         }
         if (match) {

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -396,13 +396,14 @@ void CompilerOptions::dumpPass(const char* manager, unsigned seq, const char* pa
     for (auto s : top4) {
         bool match = false;
         try {
+           auto s_regex = std::regex(s, std::regex_constants::extended);
             // we use regex_search instead of regex_match
             // regex_match compares the regex against the entire string
             // regex_search checks if the regex is contained as substring
-            match = std::regex_search(name.begin(), name.end(), std::regex(s));
+            match = std::regex_search(name.begin(), name.end(), s_regex);
         } catch (const std::regex_error &e) {
             ::error("Malformed toP4 regex string \"%s\".", s);
-            ::error("The regex matcher follows ECMAScript syntax.");
+            ::error("The regex matcher follows extended POSIX syntax.");
             exit(1);
         }
         if (match) {

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -396,10 +396,13 @@ void CompilerOptions::dumpPass(const char* manager, unsigned seq, const char* pa
     for (auto s : top4) {
         bool match = false;
         try {
+            // we use regex_search instead of regex_match
+            // regex_match compares the regex against the entire string
+            // regex_search checks if the regex is contained as substring
             match = std::regex_search(name.begin(), name.end(), std::regex(s));
-        } catch (const std::regex_error& e) {
-          ::error("Malformed toP4 regex string \"%s\".", s);
-          ::error("The regex matcher follows ECMAScript syntax.");
+        } catch (const std::regex_error &e) {
+            ::error("Malformed toP4 regex string \"%s\".", s);
+            ::error("The regex matcher follows ECMAScript syntax.");
             exit(1);
         }
         if (match) {

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <sys/stat.h>
 #include <unistd.h>
 #include <unordered_set>
+#include <regex>
 
 #include "options.h"
 #include "lib/log.h"
@@ -393,7 +394,15 @@ void CompilerOptions::dumpPass(const char* manager, unsigned seq, const char* pa
         std::cerr << name << std::endl;
 
     for (auto s : top4) {
-        if (strstr(name.c_str(), s.c_str()) != nullptr) {
+        bool match = false;
+        try {
+            match = std::regex_search(name.begin(), name.end(), std::regex(s));
+        } catch (const std::regex_error& e) {
+          ::error("Malformed toP4 regex string \"%s\".", s);
+          ::error("The regex matcher follows ECMAScript syntax.");
+            exit(1);
+        }
+        if (match) {
             cstring suffix = cstring("-") + name;
             cstring filename = file;
             if (filename == "-")


### PR DESCRIPTION
Currently it is not possible to perform more complex queries for toP4 compiler pass dumps. We can only check for substrings. This pull request enables matches using regular expressions. Functionality should remain the same, but now it is possible to use commands like `p4c/build/p4test --dump dmp prog.p4 --top4 "FrontEnd.*PassRepeated"` which only dumps PassRepeated in the FrontEnd. Or `p4c/build/p4test --dump dmp prog.p4 --top4 ".*"` which dumps all compiler passes. 

Afaik C++ regex matching is supported after `gcc4.9`, which is the minimum version `p4c` requires. 