### PR TITLE
Implementation of advance() for parser in uBPF backend

### DIFF
--- a/backends/ubpf/ubpfParser.cpp
+++ b/backends/ubpf/ubpfParser.cpp
@@ -341,22 +341,23 @@ void
 UBPFStateTranslationVisitor::compileAdvance(const IR::Expression* expr) {
     auto type = state->parser->typeMap->getType(expr);
     auto etype = UBPFTypeFactory::instance->create(type);
-    const char * tmpVarName = "__tmp_9507";  // need to be some random name
+    cstring tmpVarName = refMap->newName("tmp");
 
     builder->emitIndent();
     builder->blockStart();
     // declare temp var
     builder->emitIndent();
     etype->emit(builder);
-    builder->appendFormat(" %s = ", tmpVarName);
+    builder->appendFormat(" %s = ", tmpVarName.c_str());
     visit(expr);
     builder->endOfStatement(true);
 
     // check packet's length
-    emitCheckPacketLength(tmpVarName);
+    emitCheckPacketLength(tmpVarName.c_str());
 
     builder->emitIndent();
-    builder->appendFormat("%s += %s", state->parser->program->offsetVar.c_str(), tmpVarName);
+    builder->appendFormat("%s += %s",
+            state->parser->program->offsetVar.c_str(), tmpVarName.c_str());
     builder->endOfStatement(true);
     builder->blockEnd(true);
     builder->newline();

--- a/backends/ubpf/ubpfParser.cpp
+++ b/backends/ubpf/ubpfParser.cpp
@@ -397,7 +397,7 @@ bool UBPFStateTranslationVisitor::preorder(const IR::MethodCallExpression* expre
 
             if (extMethod->method->name.name == p4lib.packetIn.advance.name) {
                 if (expression->arguments->size() != 1) {
-                    ::error("Exactly one argument expected %1%", expression);
+                    ::error(ErrorType::ERR_EXPECTED, "%1%: expected 1 argument", expression);
                     return false;
                 }
                 compileAdvance(expression->arguments->at(0)->expression);

--- a/testdata/p4_16_samples/advance_ubpf.p4
+++ b/testdata/p4_16_samples/advance_ubpf.p4
@@ -1,0 +1,34 @@
+#include <core.p4>
+#define UBPF_MODEL_VERSION 20200515
+#include <ubpf_model.p4>
+
+header test_header {
+    bit<8> bits_to_skip;
+}
+
+struct Headers_t {
+    test_header skip;
+}
+
+struct metadata {
+}
+
+parser prs(packet_in p, out Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
+    state start {
+        p.extract(headers.skip);
+        p.advance((bit<32>) headers.skip.bits_to_skip);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
+    apply { }
+}
+
+control dprs(packet_out packet, in Headers_t headers) {
+    apply {
+        packet.emit(headers.skip);
+    }
+}
+
+ubpf(prs(), pipe(), dprs()) main;

--- a/testdata/p4_16_samples/advance_ubpf.stf
+++ b/testdata/p4_16_samples/advance_ubpf.stf
@@ -1,0 +1,17 @@
+packet 0 00 0123456789abcdef
+expect 0 00 0123456789abcdef
+
+packet 0 10 0123456789abcdef
+expect 0 10 456789abcdef
+
+packet 0 30 0123456789abcdef
+expect 0 30 cdef
+
+packet 0 40 0123456789abcdef
+expect 0 40
+
+packet 0 48 0123456789abcdef
+expect 0 48 0123456789abcdef
+
+packet 0 ff 0123456789abcdef
+expect 0 ff 0123456789abcdef


### PR DESCRIPTION
I've implemented `advance()` in the uBPF parser. This allows to skip some bits without need to define headers.

In this implementation parser advances the packet cursor. When the packet is too short, it goes to reject state.

I think that @osinstom should be assigned.