### PR TITLE
Illegal P4 to report error rather than  compiler-error

### DIFF
--- a/ir/ir.def
+++ b/ir/ir.def
@@ -476,7 +476,7 @@ class SwitchCase {
     validate{
         if (!(label->is<IR::DefaultExpression>() || label->is<IR::PathExpression>()))
             ::error(ErrorType::ERR_EXPRESSION,
-                    "%1%: Unexpected expression for switch case", label);
+                    "%1%: Unexpected expression for switch case", *this);
         BUG_CHECK(statement == nullptr || statement->is<IR::BlockStatement>(),
                   "%1%: Expected a block statement",
                   statement);

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -474,7 +474,7 @@ class SwitchCase {
     NullOK Statement statement;  // If missing then it's a fall-through
 #nodbprint
     validate{
-        if (label->is<IR::DefaultExpression>() || label->is<IR::PathExpression>())
+        if (!(label->is<IR::DefaultExpression>() || label->is<IR::PathExpression>()))
             ::error(ErrorType::ERR_EXPRESSION,
                     "%1%: Unexpected expression for switch case", label);
         BUG_CHECK(statement == nullptr || statement->is<IR::BlockStatement>(),

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -474,10 +474,9 @@ class SwitchCase {
     NullOK Statement statement;  // If missing then it's a fall-through
 #nodbprint
     validate{
-        BUG_CHECK(label->is<IR::DefaultExpression>() ||
-                  label->is<IR::PathExpression>(),
-                  "%1%: Unexpected expression for switch case",
-                  label);
+        if (label->is<IR::DefaultExpression>() || label->is<IR::PathExpression>())
+            ::error(ErrorType::ERR_EXPRESSION,
+                    "%1%: Unexpected expression for switch case", label);
         BUG_CHECK(statement == nullptr || statement->is<IR::BlockStatement>(),
                   "%1%: Expected a block statement",
                   statement);

--- a/testdata/p4_16_errors/switch_expression.p4
+++ b/testdata/p4_16_errors/switch_expression.p4
@@ -1,6 +1,7 @@
 
 
 const bit<8> NumConstant = 0x55;
+const bit<8> Another = 0xee;
 
 header headers {
   bit<8> field;

--- a/testdata/p4_16_errors/switch_expression.p4
+++ b/testdata/p4_16_errors/switch_expression.p4
@@ -1,0 +1,15 @@
+
+
+const bit<8> NumConstant = 0x55;
+
+header headers {
+  bit<8> field;
+}
+
+control ctrl (in headers hdr) {
+    apply {
+        switch (hdr.field) {
+            NumConstant: { }
+        }
+    }
+}

--- a/testdata/p4_16_errors_outputs/switch_expression.p4-stderr
+++ b/testdata/p4_16_errors_outputs/switch_expression.p4-stderr
@@ -1,0 +1,3 @@
+switch_expression.p4(3): [--Werror=expr] error: 0x55: Unexpected expression for switch case
+const bit<8> NumConstant = 0x55;
+                           ^^^^

--- a/testdata/p4_16_errors_outputs/switch_expression.p4-stderr
+++ b/testdata/p4_16_errors_outputs/switch_expression.p4-stderr
@@ -1,3 +1,3 @@
-switch_expression.p4(3): [--Werror=expr] error: 0x55: Unexpected expression for switch case
-const bit<8> NumConstant = 0x55;
-                           ^^^^
+switch_expression.p4(13): [--Werror=expr] error: SwitchCase: Unexpected expression for switch case
+            NumConstant: { }
+            ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Hi,
This is a tweak to the way an error is reported from:
```
In file: /home/rlytton/repos/p4c/ir/ir.def:479
Compiler Bug: ../testdata/p4_16_errors/switch_expression.p4(3): 85: Unexpected expression for switch case
const bit<8> NumConstant = 0x55;
                           ^^^^
```
to:
```
switch_expression.p4(3): [--Werror=expr] error: 0x55: Unexpected expression for switch case
const bit<8> NumConstant = 0x55;
                           ^^^^
```