### PR TITLE
[PSA] Supporting extern psa-random

### DIFF
--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -49,7 +49,7 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
         // for all of them?
 
         IR::MethodCallExpression *mce2;
-        auto isR = false;
+        auto isPsaExtern = false;
         if (s->is<IR::AssignmentStatement>()) {
             auto assign = s->to<IR::AssignmentStatement>();
             const IR::Expression *l, *r;
@@ -60,17 +60,18 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                 auto mi = P4::MethodInstance::resolve(mce, ctxt->refMap, ctxt->typeMap);
                 auto em = mi->to<P4::ExternMethod>();
                 if (em != nullptr) {
-                    if ((em->originalExternType->name.name == "Register" ||
-                                                em->method->name.name == "read") ||
-                        (em->originalExternType->name.name == "Meter" &&
-                                                em->method->name.name == "execute")) {
-                        isR = true;
-                        // l = l->to<IR::PathExpression>();
-                        // BUG_CHECK(l != nullptr, "register_read dest cast failed");
+                    auto externName = em->originalExternType->name.name;
+                    auto methodName = em->method->name.name;
+                    if ((externName == "Register" && methodName == "read") ||
+                        (externName == "Meter" && methodName == "execute") ||
+                        (externName == "Random" && methodName == "read")) {
+                        isPsaExtern = true;
+
                         auto dest = new IR::Argument(l);
                         auto args = new IR::Vector<IR::Argument>();
                         args->push_back(dest);  // dest
-                        args->push_back(mce->arguments->at(0));  // index
+                        if (externName == "Register" || externName == "Meter")
+                            args->push_back(mce->arguments->at(0));  // index
                         mce2 = new IR::MethodCallExpression(mce->method, mce->typeArguments);
                         mce2->arguments = args;
                         s = new IR::MethodCallStatement(mce);
@@ -154,7 +155,7 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                 auto em = mi->to<P4::ExternMethod>();
                 LOG3("P4V1:: convert " << s);
                 Util::IJson* json;
-                if (isR) {
+                if (isPsaExtern) {
                     json = ExternConverter::cvtExternObject(ctxt, em, mce2, s, emitExterns);
                 } else {
                     json = ExternConverter::cvtExternObject(ctxt, em, mc, s, emitExterns);

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -700,21 +700,22 @@ Util::IJson* ExternConverter_Random::convertExternObject(
     UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
     UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
     UNUSED const bool& emitExterns) {
-    if (mc->arguments->size() != 3) {
-        modelError("Expected 3 arguments for %1%", mc);
+
+    if (mc->arguments->size() != 1) {
+        modelError("Expected 1 arguments for %1%", mc);
         return nullptr;
     }
-    auto primitive =
-        mkPrimitive("modify_field_rng_uniform");
-    auto params = mkParameters(primitive);
-    primitive->emplace_non_null("source_info", em->method->sourceInfoJsonObj());
+
+    auto primitive = mkPrimitive("_" + em->originalExternType->name +
+                                 "_" + em->method->name);
+    auto parameters = mkParameters(primitive);
+    primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
+    auto rnd = new Util::JsonObject();
+    rnd->emplace("type", "extern");
+    rnd->emplace("value", em->object->controlPlaneName());
+    parameters->append(rnd);
     auto dest = ctxt->conv->convert(mc->arguments->at(0)->expression);
-    /* TODO */
-    // auto lo = ctxt->conv->convert(mc->arguments->at(1)->expression);
-    // auto hi = ctxt->conv->convert(mc->arguments->at(2)->expression);
-    params->append(dest);
-    // params->append(lo);
-    // params->append(hi);
+    parameters->append(dest);
     return primitive;
 }
 
@@ -1042,8 +1043,61 @@ void ExternConverter_Register::convertExternInstance(
 
 void ExternConverter_Random::convertExternInstance(
     UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
-    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns)
-{ /* TODO */ }
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
+
+    if (eb->getConstructorParameters()->size() != 2) {
+      modelError("%1%: expected two parameters", eb);
+      return;
+    }
+
+    auto inst = c->to<IR::Declaration_Instance>();
+    cstring name = inst->controlPlaneName();
+
+    // adding random instance into extern_instances
+    auto jext_mtr = new Util::JsonObject();
+    jext_mtr->emplace("name", name);
+    jext_mtr->emplace("id", nextId("extern_instances"));
+    jext_mtr->emplace("type", eb->getName());
+    jext_mtr->emplace_non_null("source_info", eb->sourceInfoJsonObj());
+    ctxt->json->externs->append(jext_mtr);
+
+    // adding attributes to random extern_instance
+    Util::JsonArray *arr = ctxt->json->insert_array_field(jext_mtr, "attribute_values");
+
+    // range min
+    auto min = eb->findParameterValue("min");
+    CHECK_NULL(min);
+    if (!min->is<IR::Constant>()) {
+        modelError("%1%: expected a constant", min->getNode());
+        return;
+    }
+    auto attr0 = eb->getConstructorParameters()->getParameter(0);
+    auto min_c = min->to<IR::Constant>();
+    auto bitwidth0 = ctxt->typeMap->minWidthBits(min_c->type, min->getNode());
+    cstring val0 = BMV2::stringRepr(min_c->value, ROUNDUP(bitwidth0, 8));
+    auto rmin = new Util::JsonObject();
+    rmin->emplace("name", attr0->toString());
+    rmin->emplace("type", "hexstr");
+    rmin->emplace("value", val0);
+    arr->append(rmin);
+
+    // range max
+    auto max = eb->findParameterValue("max");
+    CHECK_NULL(max);
+    if (!max->is<IR::Constant>()) {
+        modelError("%1%: expected a constant", max->getNode());
+        return;
+    }
+    auto attr1 = eb->getConstructorParameters()->getParameter(1);
+    auto max_c = max->to<IR::Constant>();
+    auto bitwidth1 = ctxt->typeMap->minWidthBits(max_c->type, max->getNode());
+    cstring val1 = BMV2::stringRepr(max_c->value, ROUNDUP(bitwidth1, 8));
+    auto rmax = new Util::JsonObject();
+    rmax->emplace("name", attr1->toString());
+    rmax->emplace("type", "hexstr");
+    rmax->emplace("value", val1);
+    arr->append(rmax);
+}
 
 void ExternConverter_ActionProfile::convertExternInstance(
     UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,

--- a/testdata/p4_16_samples/psa-random-bmv2.p4
+++ b/testdata/p4_16_samples/psa-random-bmv2.p4
@@ -1,0 +1,137 @@
+/*
+Copyright 2020 Cornell University
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "psa.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
+parser IngressParserImpl(packet_in pkt,
+                         out headers_t hdr,
+                         inout metadata_t user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr,
+                 inout metadata_t user_meta,
+                 in    psa_ingress_input_metadata_t  istd,
+                 inout psa_ingress_output_metadata_t ostd)
+{
+    Random<bit<48>>(1, 4) rand;
+    apply {
+        hdr.ethernet.dstAddr = 2;
+        if (rand.read() < 5) {
+             hdr.ethernet.dstAddr = 3;
+        }
+        // To see random behavior, un-comment the line below this comment to see
+        // package coming out from different ports. 
+        // The line is currently commented so that STF test can pass.
+        // hdr.ethernet.dstAddr = rand.read();
+        send_to_port(ostd, (PortId_t) (PortIdUint_t) hdr.ethernet.dstAddr);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers_t hdr,
+                        inout metadata_t user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr,
+                inout metadata_t user_meta,
+                in    psa_egress_input_metadata_t  istd,
+                inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control CommonDeparserImpl(packet_out packet,
+                           inout headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers_t hdr,
+                            in metadata_t meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers_t hdr,
+                           in metadata_t meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                cIngress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               cEgress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-random-bmv2.stf
+++ b/testdata/p4_16_samples/psa-random-bmv2.stf
@@ -1,0 +1,3 @@
+# cmd | port | dest | src | ethertype
+packet 4 000000000001 000000000000 ffff
+expect 3 000000000003 000000000000 ffff


### PR DESCRIPTION
Testing filename: testdata/p4_16_samples/psa-random-bmv2.p4 (.stf)

A corresponding PR has been submitted to bmv2 as well: [here](https://github.com/p4lang/behavioral-model/pull/931).

Once bmv2 PR is merged, Travis build for this PR should be able to pass.