### PR TITLE
Fix Range error found with Issue 2485

### DIFF
--- a/lib/gmputil.h
+++ b/lib/gmputil.h
@@ -84,7 +84,7 @@ static inline unsigned bitcount(big_int v) {
 }
 
 static inline int ffs(big_int v) {
-    if (v <= 0) return (v < 0) ? -1 : 0;
+    if (v <= 0) return -1;
     return boost::multiprecision::lsb(v);
 }
 

--- a/lib/gmputil.h
+++ b/lib/gmputil.h
@@ -84,7 +84,7 @@ static inline unsigned bitcount(big_int v) {
 }
 
 static inline int ffs(big_int v) {
-    if (v <= 0) return -1;
+    if (v <= 0) return (v < 0) ? -1 : 0;
     return boost::multiprecision::lsb(v);
 }
 

--- a/midend/replaceSelectRange.cpp
+++ b/midend/replaceSelectRange.cpp
@@ -53,7 +53,7 @@ DoReplaceSelectRange::rangeToMasks(const IR::Range *r) {
     big_int range_size_remaining = max - min + 1;
 
     while (range_size_remaining > 0) {
-        big_int range_size = ((big_int) 1) << ffs(min);
+        big_int range_size = ((big_int) 1) << ((min == 0) ? 0 : ffs(min));
 
         while (range_size > range_size_remaining)
             range_size >>= 1;

--- a/testdata/p4_16_samples/issue2485.p4
+++ b/testdata/p4_16_samples/issue2485.p4
@@ -1,0 +1,34 @@
+#include <core.p4>
+
+header H {
+    bit<16> a;
+}
+
+
+struct metadata {
+}
+
+struct Headers {
+    H h;
+}
+
+parser p(packet_in packet, out Headers hdr) {
+    state start {
+        packet.extract(hdr.h);
+        transition select(hdr.h.a) {
+            0x0000 .. 0x0004: parse;
+            default: accept;
+        }
+    }
+    state parse {
+        hdr.h.a = 1;
+        transition accept;
+    }
+
+}
+
+
+
+parser Parser(packet_in b, out Headers hdr);
+package top(Parser p);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/issue2485-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2485-first.p4
@@ -1,0 +1,31 @@
+#include <core.p4>
+
+header H {
+    bit<16> a;
+}
+
+struct metadata {
+}
+
+struct Headers {
+    H h;
+}
+
+parser p(packet_in packet, out Headers hdr) {
+    state start {
+        packet.extract<H>(hdr.h);
+        transition select(hdr.h.a) {
+            16w0x0 .. 16w0x4: parse;
+            default: accept;
+        }
+    }
+    state parse {
+        hdr.h.a = 16w1;
+        transition accept;
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+package top(Parser p);
+top(p()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2485-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2485-frontend.p4
@@ -1,0 +1,31 @@
+#include <core.p4>
+
+header H {
+    bit<16> a;
+}
+
+struct metadata {
+}
+
+struct Headers {
+    H h;
+}
+
+parser p(packet_in packet, out Headers hdr) {
+    state start {
+        packet.extract<H>(hdr.h);
+        transition select(hdr.h.a) {
+            16w0x0 .. 16w0x4: parse;
+            default: accept;
+        }
+    }
+    state parse {
+        hdr.h.a = 16w1;
+        transition accept;
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+package top(Parser p);
+top(p()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2485-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2485-midend.p4
@@ -1,0 +1,34 @@
+#include <core.p4>
+
+header H {
+    bit<16> a;
+}
+
+struct metadata {
+}
+
+struct Headers {
+    H h;
+}
+
+parser p(packet_in packet, out Headers hdr) {
+    state start {
+        packet.extract<H>(hdr.h);
+        transition select(hdr.h.a) {
+            16w0x0 &&& 16w0xffff: parse;
+            16w0x1 &&& 16w0xffff: parse;
+            16w0x2 &&& 16w0xfffe: parse;
+            16w0x4 &&& 16w0xffff: parse;
+            default: accept;
+        }
+    }
+    state parse {
+        hdr.h.a = 16w1;
+        transition accept;
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+package top(Parser p);
+top(p()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2485.p4
+++ b/testdata/p4_16_samples_outputs/issue2485.p4
@@ -1,0 +1,31 @@
+#include <core.p4>
+
+header H {
+    bit<16> a;
+}
+
+struct metadata {
+}
+
+struct Headers {
+    H h;
+}
+
+parser p(packet_in packet, out Headers hdr) {
+    state start {
+        packet.extract(hdr.h);
+        transition select(hdr.h.a) {
+            0x0 .. 0x4: parse;
+            default: accept;
+        }
+    }
+    state parse {
+        hdr.h.a = 1;
+        transition accept;
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+package top(Parser p);
+top(p()) main;
+


### PR DESCRIPTION
See https://github.com/p4lang/p4c/issues/2485 and this error from it:

`Can not shift by a negative value.`

This issue is caused by using ffs() from gmputil.h which returns `-1` when v is 0.  