### PR TITLE
Handle Mux when generating struct initializers

### DIFF
--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -39,15 +39,14 @@ StorageLocation* StorageFactory::create(const IR::Type* type, cstring name) cons
         // Since we don't have any operations except assignment for a
         // type described by a type variable, we treat is as a base type.
         type->is<IR::Type_Var>() ||
-        // Similarly for tuples.  This may need to be revisited if we
-        // add tuple field accessors.
+        // The following may need to be revisited when we add tuple
+        // field accessors.
         type->is<IR::Type_Tuple>() ||
+        type->is<IR::Type_List>() ||
         // Also for newtype
         type->is<IR::Type_Newtype>())
         return new BaseLocation(type, name);
-    if (type->is<IR::Type_StructLike>()) {
-        type = typeMap->getTypeType(type, true);  // get the canonical version
-        auto st = type->to<IR::Type_StructLike>();
+    if (auto st = type->to<IR::Type_StructLike>()) {
         auto result = new StructLocation(type, name);
 
         // For header unions we will model all of the valid fields
@@ -71,10 +70,7 @@ StorageLocation* StorageFactory::create(const IR::Type* type, cstring name) cons
             result->addField(validFieldName, valid);
         }
         return result;
-    }
-    if (type->is<IR::Type_Stack>()) {
-        type = typeMap->getTypeType(type, true);  // get the canonical version
-        auto st = type->to<IR::Type_Stack>();
+    } else if (auto st = type->to<IR::Type_Stack>()) {
         auto result = new ArrayLocation(st, name);
         for (unsigned i = 0; i < st->getSize(); i++) {
             auto sl = create(st->elementType, name + "[" + Util::toString(i) + "]");

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -74,7 +74,7 @@ class BaseLocation : public StorageLocation {
                 type->is<IR::Type_Boolean>() || type->is<IR::Type_Var>() ||
                 type->is<IR::Type_Tuple>() || type->is<IR::Type_Error>() ||
                 type->is<IR::Type_Varbits>() || type->is<IR::Type_Newtype>() ||
-                type->is<IR::Type_SerEnum>(),
+                type->is<IR::Type_SerEnum>() || type->is<IR::Type_List>(),
                 "%1%: unexpected type", type); }
     void addValidBits(LocationSet*) const override {}
     void addLastIndexField(LocationSet*) const override {}

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -143,11 +143,11 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         // Desugars direct parser and control applications
         // into instantiations followed by application
         new InstantiateDirectCalls(&refMap),
-        // Type checking and type inference.  Also inserts
-        // explicit casts where implicit casts exist.
         new ResolveReferences(&refMap),  // check shadowing
         new Deprecated(&refMap),
         new CheckNamedArgs(),
+        // Type checking and type inference.  Also inserts
+        // explicit casts where implicit casts exist.
         new TypeInference(&refMap, &typeMap, false),  // insert casts
         new ValidateMatchAnnotations(&typeMap),
         new BindTypeVariables(&refMap, &typeMap),

--- a/frontends/p4/structInitializers.cpp
+++ b/frontends/p4/structInitializers.cpp
@@ -55,6 +55,10 @@ convert(const IR::Expression* expression, const IR::Type* type) {
                     expression->srcInfo, type, type, *si);
                 return result;
             }
+        } else if (auto mux = expression->to<IR::Mux>()) {
+            auto e1 = convert(mux->e1, type);
+            auto e2 = convert(mux->e2, type);
+            return new IR::Mux(mux->e0, e1, e2);
         }
     } else if (auto tup = type->to<IR::Type_BaseList>()) {
         auto le = expression->to<IR::ListExpression>();

--- a/testdata/p4_16_samples/issue2487.p4
+++ b/testdata/p4_16_samples/issue2487.p4
@@ -1,0 +1,25 @@
+#include <core.p4>
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    apply {
+        h.eth_hdr = h.eth_hdr.eth_type == 1 ? {48w1, 48w1, 16w1} : {48w2, 48w2, 16w2};
+    }
+}
+
+control Ingress(inout Headers hdr);
+package top(Ingress ig);
+top(ingress()) main;

--- a/testdata/p4_16_samples_outputs/issue2487-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2487-first.p4
@@ -1,0 +1,26 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    apply {
+        h.eth_hdr = (h.eth_hdr.eth_type == 16w1 ? (ethernet_t){dst_addr = 48w1,src_addr = 48w1,eth_type = 16w1} : (ethernet_t){dst_addr = 48w2,src_addr = 48w2,eth_type = 16w2});
+    }
+}
+
+control Ingress(inout Headers hdr);
+package top(Ingress ig);
+top(ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2487-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2487-frontend.p4
@@ -1,0 +1,34 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    ethernet_t tmp;
+    apply {
+        if (h.eth_hdr.eth_type == 16w1) {
+            tmp.setValid();
+            tmp = (ethernet_t){dst_addr = 48w1,src_addr = 48w1,eth_type = 16w1};
+        } else {
+            tmp.setValid();
+            tmp = (ethernet_t){dst_addr = 48w2,src_addr = 48w2,eth_type = 16w2};
+        }
+        h.eth_hdr = tmp;
+    }
+}
+
+control Ingress(inout Headers hdr);
+package top(Ingress ig);
+top(ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2487-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2487-midend.p4
@@ -1,0 +1,67 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    ethernet_t tmp;
+    @hidden action issue2487l19() {
+        tmp.setValid();
+        tmp.setValid();
+        tmp.dst_addr = 48w1;
+        tmp.src_addr = 48w1;
+        tmp.eth_type = 16w1;
+    }
+    @hidden action issue2487l19_0() {
+        tmp.setValid();
+        tmp.setValid();
+        tmp.dst_addr = 48w2;
+        tmp.src_addr = 48w2;
+        tmp.eth_type = 16w2;
+    }
+    @hidden action issue2487l19_1() {
+        h.eth_hdr = tmp;
+    }
+    @hidden table tbl_issue2487l19 {
+        actions = {
+            issue2487l19();
+        }
+        const default_action = issue2487l19();
+    }
+    @hidden table tbl_issue2487l19_0 {
+        actions = {
+            issue2487l19_0();
+        }
+        const default_action = issue2487l19_0();
+    }
+    @hidden table tbl_issue2487l19_1 {
+        actions = {
+            issue2487l19_1();
+        }
+        const default_action = issue2487l19_1();
+    }
+    apply {
+        if (h.eth_hdr.eth_type == 16w1) {
+            tbl_issue2487l19.apply();
+        } else {
+            tbl_issue2487l19_0.apply();
+        }
+        tbl_issue2487l19_1.apply();
+    }
+}
+
+control Ingress(inout Headers hdr);
+package top(Ingress ig);
+top(ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2487.p4
+++ b/testdata/p4_16_samples_outputs/issue2487.p4
@@ -1,0 +1,26 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    apply {
+        h.eth_hdr = (h.eth_hdr.eth_type == 1 ? { 48w1, 48w1, 16w1 } : { 48w2, 48w2, 16w2 });
+    }
+}
+
+control Ingress(inout Headers hdr);
+package top(Ingress ig);
+top(ingress()) main;
+


### PR DESCRIPTION
There was actually also a second bug in the def_use analysis in the handling of list expressions.
Fixes #2487.
The fix is essentially to push the type of the result down in both branches of a Mux if it is useful.