### PR TITLE
Infer don't care for type args used only by @optional args

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1044,6 +1044,16 @@ TypeInference::containerInstantiation(
     BUG_CHECK(tvs != nullptr || ::errorCount(), "Null substitution");
     if (tvs == nullptr)
         return std::pair<const IR::Type*, const IR::Vector<IR::Argument>*>(nullptr, nullptr);
+    // Infer Dont_Care for type vars used only in not-present optional params
+    auto typeParams = constructor->typeParameters;
+    for (auto p : params->parameters) {
+        if (!p->isOptional()) continue;
+        forAllMatching<IR::Type_Var>(p, [tvs, typeParams](const IR::Type_Var *tv) {
+            if (tvs->lookup(tv)) return;  // already bound
+            if (typeParams->getDeclByName(tv->name) != tv) return;  // not a tv of this call
+            tvs->setBinding(tv, new IR::Type_Dontcare);
+        });
+    }
     addSubstitutions(tvs);
 
     ConstantTypeSubstitution cts(tvs, refMap, typeMap, this);

--- a/frontends/p4/typeChecking/typeSubstitution.cpp
+++ b/frontends/p4/typeChecking/typeSubstitution.cpp
@@ -125,4 +125,8 @@ bool TypeVariableSubstitution::setBindings(const IR::Node* errorLocation,
     return true;
 }
 
+// to call from gdb
+void dump(P4::TypeVariableSubstitution &tvs) { std::cout << tvs << std::endl; }
+void dump(P4::TypeVariableSubstitution *tvs) { std::cout << *tvs << std::endl; }
+
 }  // namespace P4

--- a/testdata/p4_16_samples/issue2492.p4
+++ b/testdata/p4_16_samples/issue2492.p4
@@ -1,0 +1,20 @@
+#include <core.p4>
+
+header data_t {
+    bit<16> h1;
+}
+
+struct headers {
+    data_t data;
+}
+
+control ingress(inout headers hdr) {
+    apply {
+        hdr.data.h1 = 1;
+    }
+}
+
+control ctr<H>(inout H hdr);
+package top<H1, H2, H3>(ctr<H1> ctrl1, @optional ctr<H2> ctrl2, @optional ctr<H3> ctrl3);
+
+top(ingress()) main;

--- a/testdata/p4_16_samples_outputs/issue2492-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2492-first.p4
@@ -1,0 +1,20 @@
+#include <core.p4>
+
+header data_t {
+    bit<16> h1;
+}
+
+struct headers {
+    data_t data;
+}
+
+control ingress(inout headers hdr) {
+    apply {
+        hdr.data.h1 = 16w1;
+    }
+}
+
+control ctr<H>(inout H hdr);
+package top<H1, H2, H3>(ctr<H1> ctrl1, @optional ctr<H2> ctrl2, @optional ctr<H3> ctrl3);
+top<headers, _, _>(ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2492-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2492-frontend.p4
@@ -1,0 +1,20 @@
+#include <core.p4>
+
+header data_t {
+    bit<16> h1;
+}
+
+struct headers {
+    data_t data;
+}
+
+control ingress(inout headers hdr) {
+    apply {
+        hdr.data.h1 = 16w1;
+    }
+}
+
+control ctr<H>(inout H hdr);
+package top<H1, H2, H3>(ctr<H1> ctrl1, @optional ctr<H2> ctrl2, @optional ctr<H3> ctrl3);
+top<headers, _, _>(ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2492-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2492-midend.p4
@@ -1,0 +1,29 @@
+#include <core.p4>
+
+header data_t {
+    bit<16> h1;
+}
+
+struct headers {
+    data_t data;
+}
+
+control ingress(inout headers hdr) {
+    @hidden action issue2492l13() {
+        hdr.data.h1 = 16w1;
+    }
+    @hidden table tbl_issue2492l13 {
+        actions = {
+            issue2492l13();
+        }
+        const default_action = issue2492l13();
+    }
+    apply {
+        tbl_issue2492l13.apply();
+    }
+}
+
+control ctr<H>(inout H hdr);
+package top<H1, H2, H3>(ctr<H1> ctrl1, @optional ctr<H2> ctrl2, @optional ctr<H3> ctrl3);
+top<headers, _, _>(ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2492.p4
+++ b/testdata/p4_16_samples_outputs/issue2492.p4
@@ -1,0 +1,20 @@
+#include <core.p4>
+
+header data_t {
+    bit<16> h1;
+}
+
+struct headers {
+    data_t data;
+}
+
+control ingress(inout headers hdr) {
+    apply {
+        hdr.data.h1 = 1;
+    }
+}
+
+control ctr<H>(inout H hdr);
+package top<H1, H2, H3>(ctr<H1> ctrl1, @optional ctr<H2> ctrl2, @optional ctr<H3> ctrl3);
+top(ingress()) main;
+


### PR DESCRIPTION
This fixes the immediate problem in issue #2492 -- at least with respect to package instantiations.  Its possible something additional is needed for extern instantiations and/or other method calls.