### PR TITLE
Fix compiler Bug in local copy propagation #1985

### DIFF
--- a/midend/has_side_effects.h
+++ b/midend/has_side_effects.h
@@ -30,15 +30,26 @@ class hasSideEffects : public Inspector {
     bool result = false;
     bool preorder(const IR::AssignmentStatement *) override { result = true; return false; }
     bool preorder(const IR::MethodCallExpression *mc) override {
-        if (result) return false;
+        if (result) {
+            return false;
+        }
         /* assume has side effects if we can't look it up */
         if (refMap && typeMap) {
             auto *mi = P4::MethodInstance::resolve(mc, refMap, typeMap, true);
+            if (auto *bm = mi->to<P4::BuiltInMethod>()) {
+                if (bm->name == "isValid") {
+                    return true;
+                }
+            }
             if (auto *em = mi->to<P4::ExternMethod>()) {
                 if (em->method->getAnnotation(IR::Annotation::noSideEffectsAnnotation))
-                    return true; } }
+                    return true;
+                }
+            }
         result = true;
-        return false; }
+        return false;
+    }
+
     bool preorder(const IR::Primitive *) override { result = true; return false; }
     bool preorder(const IR::Expression *) override { return !result; }
 

--- a/testdata/p4_16_samples/issue1985.p4
+++ b/testdata/p4_16_samples/issue1985.p4
@@ -1,0 +1,41 @@
+#include <core.p4>
+#include <v1model.p4>
+header h_t {
+     bit<8> x;
+}
+struct headers {
+    h_t h;
+}
+struct metadata { }
+parser p(packet_in pkt,out headers hdr,inout metadata meta,inout standard_metadata_t std_meta) {
+    state start {
+        transition accept;
+    }
+}
+control c1(inout headers hdr,inout metadata meta) {
+    apply { }
+}
+control c2(inout headers hdr,inout metadata meta,inout standard_metadata_t std_meta) {
+    apply { }
+}
+control c3(inout headers hdr,inout metadata meta,inout standard_metadata_t std_meta) {
+    action a(in bool b) {
+        hdr.h.x = 8w0;
+    }
+    table t {
+        key = { }
+        actions = {
+            a(hdr.h.isValid() || (bool) 1w1);
+        }
+    }
+    apply {
+        t.apply();
+    }
+}
+control c4(inout headers hdr,inout metadata meta) {
+    apply { }
+}
+control c5(packet_out pkt,in headers hdr) {
+    apply { }
+}
+V1Switch(p(),c1(),c2(),c3(),c4(),c5()) main;

--- a/testdata/p4_16_samples_outputs/issue1025-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1025-bmv2-midend.p4
@@ -86,23 +86,17 @@ parser parserI(packet_in pkt, out headers hdr, inout metadata meta, inout standa
 }
 
 control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
-    bit<1> eth_valid_0;
-    bit<1> ipv4_valid_0;
-    bit<1> tcp_valid_0;
-    @hidden action issue1025bmv2l132() {
-        eth_valid_0 = (bit<1>)hdr.ethernet.isValid();
-        ipv4_valid_0 = (bit<1>)hdr.ipv4.isValid();
-        tcp_valid_0 = (bit<1>)hdr.tcp.isValid();
-        hdr.ethernet.dstAddr = 31w0 ++ eth_valid_0 ++ 7w0 ++ ipv4_valid_0 ++ 7w0 ++ tcp_valid_0;
+    @hidden action issue1025bmv2l135() {
+        hdr.ethernet.dstAddr = 31w0 ++ (bit<1>)hdr.ethernet.isValid() ++ 7w0 ++ (bit<1>)hdr.ipv4.isValid() ++ 7w0 ++ (bit<1>)hdr.tcp.isValid();
     }
-    @hidden table tbl_issue1025bmv2l132 {
+    @hidden table tbl_issue1025bmv2l135 {
         actions = {
-            issue1025bmv2l132();
+            issue1025bmv2l135();
         }
-        const default_action = issue1025bmv2l132();
+        const default_action = issue1025bmv2l135();
     }
     apply {
-        tbl_issue1025bmv2l132.apply();
+        tbl_issue1025bmv2l135.apply();
     }
 }
 
@@ -130,4 +124,3 @@ control DeparserI(packet_out packet, in headers hdr) {
 }
 
 V1Switch<headers, metadata>(parserI(), verifyChecksum(), cIngress(), cEgress(), updateChecksum(), DeparserI()) main;
-

--- a/testdata/p4_16_samples_outputs/issue1985-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1985-first.p4
@@ -1,0 +1,61 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header h_t {
+    bit<8> x;
+}
+
+struct headers {
+    h_t h;
+}
+
+struct metadata {
+}
+
+parser p(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control c1(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control c2(inout headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    apply {
+    }
+}
+
+control c3(inout headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    action a(in bool b) {
+        hdr.h.x = 8w0;
+    }
+    table t {
+        key = {
+        }
+        actions = {
+            a(hdr.h.isValid() || true);
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control c4(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control c5(packet_out pkt, in headers hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(p(), c1(), c2(), c3(), c4(), c5()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1985-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1985-frontend.p4
@@ -1,0 +1,63 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header h_t {
+    bit<8> x;
+}
+
+struct headers {
+    h_t h;
+}
+
+struct metadata {
+}
+
+parser p(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control c1(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control c2(inout headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    apply {
+    }
+}
+
+control c3(inout headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("c3.a") action a(in bool b_1) {
+        hdr.h.x = 8w0;
+    }
+    @name("c3.t") table t_0 {
+        key = {
+        }
+        actions = {
+            a(hdr.h.isValid() || true);
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control c4(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control c5(packet_out pkt, in headers hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(p(), c1(), c2(), c3(), c4(), c5()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1985-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1985-midend.p4
@@ -1,0 +1,63 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header h_t {
+    bit<8> x;
+}
+
+struct headers {
+    h_t h;
+}
+
+struct metadata {
+}
+
+parser p(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control c1(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control c2(inout headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    apply {
+    }
+}
+
+control c3(inout headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("c3.a") action a() {
+        hdr.h.x = 8w0;
+    }
+    @name("c3.t") table t_0 {
+        key = {
+        }
+        actions = {
+            a();
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control c4(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control c5(packet_out pkt, in headers hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(p(), c1(), c2(), c3(), c4(), c5()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1985.p4
+++ b/testdata/p4_16_samples_outputs/issue1985.p4
@@ -1,0 +1,59 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header h_t {
+    bit<8> x;
+}
+
+struct headers {
+    h_t h;
+}
+
+struct metadata {
+}
+
+parser p(packet_in pkt, out headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control c1(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control c2(inout headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    apply {
+    }
+}
+
+control c3(inout headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
+    action a(in bool b) {
+        hdr.h.x = 8w0;
+    }
+    table t {
+        key = {
+        }
+        actions = {
+            a(hdr.h.isValid() || (bool)1w1);
+        }
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control c4(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control c5(packet_out pkt, in headers hdr) {
+    apply {
+    }
+}
+
+V1Switch(p(), c1(), c2(), c3(), c4(), c5()) main;
+

--- a/testdata/p4_16_samples_outputs/issue396-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-midend.p4
@@ -12,9 +12,8 @@ control d(out bool b) {
     H h_0;
     H[2] h3_0;
     H s1_0_h;
-    bool eout_0;
     H tmp;
-    @hidden action issue396l28() {
+    @hidden action issue396l39() {
         h_0.setValid();
         h_0.x = 32w0;
         s1_0_h.setValid();
@@ -23,17 +22,16 @@ control d(out bool b) {
         h3_0[1].x = 32w1;
         tmp.setValid();
         tmp.x = 32w0;
-        eout_0 = tmp.isValid();
-        b = h_0.isValid() && eout_0 && h3_0[1].isValid() && s1_0_h.isValid();
+        b = h_0.isValid() && tmp.isValid() && h3_0[1].isValid() && s1_0_h.isValid();
     }
-    @hidden table tbl_issue396l28 {
+    @hidden table tbl_issue396l39 {
         actions = {
-            issue396l28();
+            issue396l39();
         }
-        const default_action = issue396l28();
+        const default_action = issue396l39();
     }
     apply {
-        tbl_issue396l28.apply();
+        tbl_issue396l39.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue561-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-midend.p4
@@ -16,8 +16,7 @@ package top(ct _ct);
 control c(out bit<32> x) {
     U u_0;
     U[2] u2_0;
-    @hidden action issue561l32() {
-        u_0.isValid();
+    @hidden action issue561l33() {
         u_0.h1.isValid();
         x = u_0.h1.f + u_0.h2.g;
         u_0.h1.setValid();
@@ -29,16 +28,15 @@ control c(out bit<32> x) {
         u2_0[0].h1.f = 32w2;
         x = x + u2_0[1].h2.g + 32w2;
     }
-    @hidden table tbl_issue561l32 {
+    @hidden table tbl_issue561l33 {
         actions = {
-            issue561l32();
+            issue561l33();
         }
-        const default_action = issue561l32();
+        const default_action = issue561l33();
     }
     apply {
-        tbl_issue561l32.apply();
+        tbl_issue561l33.apply();
     }
 }
 
 top(c()) main;
-


### PR DESCRIPTION
Change made in makeSideEffectStatement where the case which processed binary operator was missing.
After that a new bug appeared because isValid has not yet been processed in convertActionBody.

Change made:

In makeSideEffectStatement:
-Processing of unary operation was replaced with processing of unary and binary
-The given example illustrates the situation where the change needs to be applied

~~~ P4
control c3(inout headers hdr,inout metadata meta,inout standard_metadata_t std_meta) {
    action a(in bool b) {
        hdr.h.x = 8w0;
    }
    table t {
        key = { }
        actions = {
            a(hdr.h.isValid() || (bool) 1w1);
        }
    }
    apply {
        t.apply();
    }
}
~~~

or more complicated:

~~~ P4
control c3(inout headers hdr,inout metadata meta,inout standard_metadata_t std_meta) {
    action a(in bool b) {
        hdr.h.x = 8w0;
    }
    table t {
        key = { }
        actions = {
            a(!(!hdr.h.isValid() || !hdr.g.isValid()) ||  !(!hdr.f.isValid() || !hdr.e.isValid()) ||  !hdr.i.isValid());
        }
    }
    apply {
        t.apply();
    }
}
~~~

In convertActionBody:
-Added case that handles isValid
-Set prim with "no_op"
-The way we use isValid allows us to ignore the validity as opposed to the if-statement where this property is crucial
as in example:

    action a(in bool b) {
    if(b)
        hdr.h.x = 8w0;
    }
    table t {
        key = { }
        actions = {
            a(!(!hdr.h.isValid() || !hdr.g.isValid()) ||  !(!hdr.f.isValid() || !hdr.e.isValid()) ||  !hdr.i.isValid());
        }
    }
    apply {
        t.apply();
    }

    where no needed for makeSideEffectStatement because local variable is live