### PR TITLE
Use an older version of python-xdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,5 @@ jobs:
   include:
     - name: "Validation"
       os: linux
-      install:
-        - tools/start_ccache
-        - docker build --network ccache_network -t p4c --build-arg P4C_VALIDATION=ON .
       script:
         - docker run -w /gauntlet p4c python3.6 -m pytest test.py -vrf -k "test_p4c" -n $CTEST_PARALLEL_LEVEL

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
     - name: "Validation"
       os: linux
       install:
+        - tools/start_ccache
         - docker build --network ccache_network -t p4c --build-arg P4C_VALIDATION=ON .
       script:
         - docker run -w /gauntlet p4c python3.6 -m pytest test.py -vrf -k "test_p4c" -n $CTEST_PARALLEL_LEVEL

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,5 +55,7 @@ jobs:
   include:
     - name: "Validation"
       os: linux
+      install:
+        - docker build --network ccache_network -t p4c --build-arg P4C_VALIDATION=ON .
       script:
         - docker run -w /gauntlet p4c python3.6 -m pytest test.py -vrf -k "test_p4c" -n $CTEST_PARALLEL_LEVEL

--- a/tools/travis-build
+++ b/tools/travis-build
@@ -94,6 +94,7 @@ rm -rf /tmp/pip
 pip install $P4C_PIP_PACKAGES
 # ! ------  END Python2 ----------------------------------------------------
 
+if test -z $P4C_VALIDATION; then
 # ! ------  BEGIN VALIDATION -----------------------------------------------
 # These steps are necessary to validate the correct compilation of the P4C test
 # suite programs. See also https://github.com/p4gauntlet/p4_tv.
@@ -116,12 +117,11 @@ ln -sf /gauntlet/modules/toz3 /p4c/extensions/toz3
 add-apt-repository ppa:deadsnakes/ppa
 apt update
 apt install -y python3.6
-python3.6 -m pip install z3-solver
-python3.6 -m pip install pytest
-# to parallelize tests
-python3.6 -m pip install pytest-xdist==1.34.0
-python3.6 -m pip install dataclasses
+# pytest-xdist to parallelize tests
+# dataclasses for Python3.6 compatibility
+python3.6 -m pip install z3-solver pytest pytest-xdist==1.34.0 dataclasses
 # ! ------  END VALIDATION ------------------------------------------------
+fi
 
 function build() {
   if [ -e build ]; then /bin/rm -rf build; fi

--- a/tools/travis-build
+++ b/tools/travis-build
@@ -119,7 +119,7 @@ apt install -y python3.6
 python3.6 -m pip install z3-solver
 python3.6 -m pip install pytest
 # to parallelize tests
-python3.6 -m pip install pytest-xdist
+python3.6 -m pip install pytest-xdist==1.34.0
 python3.6 -m pip install dataclasses
 # ! ------  END VALIDATION ------------------------------------------------
 

--- a/tools/travis-build
+++ b/tools/travis-build
@@ -94,7 +94,6 @@ rm -rf /tmp/pip
 pip install $P4C_PIP_PACKAGES
 # ! ------  END Python2 ----------------------------------------------------
 
-if test -z $P4C_VALIDATION; then
 # ! ------  BEGIN VALIDATION -----------------------------------------------
 # These steps are necessary to validate the correct compilation of the P4C test
 # suite programs. See also https://github.com/p4gauntlet/p4_tv.
@@ -121,7 +120,6 @@ apt install -y python3.6
 # dataclasses for Python3.6 compatibility
 python3.6 -m pip install z3-solver pytest pytest-xdist==1.34.0 dataclasses
 # ! ------  END VALIDATION ------------------------------------------------
-fi
 
 function build() {
   if [ -e build ]; then /bin/rm -rf build; fi


### PR DESCRIPTION
`python-xdist` recently upgraded to 2.0.0, which seems to cause some issues with older Python or Ubuntu versions. This pull request fixes the dependency to 1.34.0 for the time being. 