### PR TITLE
Small updates to CMakeLists.txt for PSA test programs

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -176,8 +176,6 @@ set (XFAIL_TESTS
   # These test use computations in the verify/update checksum controls - unsupported
   testdata/p4_16_samples/issue1765-bmv2.p4
   testdata/p4_16_samples/issue1765-1-bmv2.p4
-  # These tests require bmv2's psa_switch to support std metadata passing at minimum
-  testdata/p4_16_samples/psa-ingress-input-meta-bmv2.p4
   # Next two use unknown externs
   testdata/p4_16_samples/issue1882-bmv2.p4
   testdata/p4_16_samples/issue1882-1-bmv2.p4

--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -59,7 +59,11 @@ set (P4TEST_SUITES
 # would not make sense to run all the tests twice (one with and one without
 # P4Runtime).
 set (P4RUNTIME_EXCLUDE
-  # Need to convert PSA_MeterColor_t to a serializable enum
+  # See discussion on this p4c PR: https://github.com/p4lang/p4c/pull/2425
+  # It seems that the best long term approach for supporting programs
+  # like this one is to enhance the P4Runtime API to support enum
+  # types as action parameters, as requested in this issue:
+  # https://github.com/p4lang/p4runtime/issues/191
   testdata/p4_16_samples/psa-meter1.p4
   # error not supported in static entries, not strictly required for P4Info
   # generation though
@@ -69,10 +73,14 @@ set (P4RUNTIME_EXCLUDE
   # that when the type parameter of a Value Set is a struct, all the fields of
   # the struct must be of type bit<W>, but inner is not
   testdata/p4_16_samples/pvs-nested-struct.p4
-  # Two tests below use `error` for table key which p4runtime 1.0
+  # The tests below use type `error` for table key which P4Runtime 1.x
   # does not support.
+  # table t_exact key named m.my_err is type error
   testdata/p4_16_samples/issue1062-1-bmv2.p4
+  # table t key named meta.err is type error
   testdata/p4_16_samples/issue1304.p4
+  # table parser_error_count_and_convert key named istd.parser_error
+  # is type error
   testdata/p4_16_samples/psa-example-parser-checksum.p4
 )
 


### PR DESCRIPTION
Remove mention of a test program psa-ingress-input-meta-bmv2.p4, which
as far as I can tell was never added to the p4c repository.

Update some comments in backends/p4test/CMakeLists.txt to reflect the
reason why some tests are excluded.