### PR TITLE
Make PSA packet recirculation test more strict

### DIFF
--- a/testdata/p4_16_samples/psa-recirculate-no-meta-bmv2.p4
+++ b/testdata/p4_16_samples/psa-recirculate-no-meta-bmv2.p4
@@ -26,6 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
 struct empty_metadata_t {
 }
 
@@ -34,6 +41,7 @@ struct metadata_t {
 
 struct headers_t {
     ethernet_t       ethernet;
+    output_data_t    output_data;
 }
 
 parser IngressParserImpl(packet_in pkt,
@@ -45,6 +53,7 @@ parser IngressParserImpl(packet_in pkt,
 {
     state start {
         pkt.extract(hdr.ethernet);
+        pkt.extract(hdr.output_data);
         transition accept;
     }
 }
@@ -54,8 +63,13 @@ control cIngress(inout headers_t hdr,
                  in    psa_ingress_input_metadata_t  istd,
                  inout psa_ingress_output_metadata_t ostd)
 {   
+    action record_ingress_ports_in_pkt() {
+        hdr.output_data.word1 = (bit<32>) ((PortIdUint_t) istd.ingress_port);
+    }
+
     apply {
         if (hdr.ethernet.dstAddr[3:0] >= 4) {
+            record_ingress_ports_in_pkt();
             send_to_port(ostd, (PortId_t) (PortIdUint_t) hdr.ethernet.dstAddr);
         } else {
             send_to_port(ostd, PSA_PORT_RECIRCULATE);
@@ -99,6 +113,7 @@ control CommonDeparserImpl(packet_out packet,
 {
     apply {
         packet.emit(hdr.ethernet);
+        packet.emit(hdr.output_data);
     }
 }
 

--- a/testdata/p4_16_samples/psa-recirculate-no-meta-bmv2.p4
+++ b/testdata/p4_16_samples/psa-recirculate-no-meta-bmv2.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Cisco Systems, Inc.
+Copyright 2019-2020 Cisco Systems, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/testdata/p4_16_samples/psa-recirculate-no-meta-bmv2.stf
+++ b/testdata/p4_16_samples/psa-recirculate-no-meta-bmv2.stf
@@ -1,8 +1,27 @@
-packet 1 000000000000 000000000001 ffff
-expect 4 000000000005 000000000001 ffff $
+# First time packet processed in ingress, dstAddr is 0, then it becomes 1 in egress and recirculates.
+#   2nd time packet processed in ingress, dstAddr is 1, then it becomes 2 in egress and recirculates.
+#   3rd time packet processed in ingress, dstAddr is 2, then it becomes 3 in egress and recirculates.
+#   4th time packet processed in ingress, dstAddr is 3, then it becomes 4 in egress and recirculates.
+#   5th time packet processed in ingress, dstAddr is 4, then it becomes 5 in egress and goes out port 4
+# 
+packet 1 000000000000 000000000001 ffff   deadbeef deadbeef deadbeef deadbeef
+#                                  This field -->  ^^^^^^^^
+# is where the ingress_port field is recorded during ingress processing.
+# It should be fffffffa for PSA_RECIRCULATE_PORT if packet was recirculated.
+expect 4 000000000005 000000000001 ffff   deadbeef fffffffa deadbeef deadbeef $
 
-packet 2 000000000001 000000000002 ffff
-expect 5 000000000007 000000000002 ffff $
+# First time packet processed in ingress, dstAddr is 1, then it becomes 3 in egress and recirculates.
+#   2nd time packet processed in ingress, dstAddr is 3, then it becomes 5 in egress and recirculates.
+#   3rd time packet processed in ingress, dstAddr is 5, then it becomes 7 in egress and goes out port 5
+packet 2 000000000001 000000000002 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 5 000000000007 000000000002 ffff   deadbeef fffffffa deadbeef deadbeef $
 
-packet 3 000000000000 000000000003 ffff
-expect 6 000000000009 000000000003 ffff $
+# First time packet processed in ingress, dstAddr is 0, then it becomes 3 in egress and recirculates.
+#   2nd time packet processed in ingress, dstAddr is 3, then it becomes 6 in egress and recirculates.
+#   3rd time packet processed in ingress, dstAddr is 6, then it becomes 9 in egress and goes out port 6
+packet 3 000000000000 000000000003 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 6 000000000009 000000000003 ffff   deadbeef fffffffa deadbeef deadbeef $
+
+# First time packet processed in ingress, dstAddr is 8, then it becomes 0xb in egress and packet goes out port 8
+packet 7 000000000008 000000000003 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 8 00000000000b 000000000003 ffff   deadbeef 00000007 deadbeef deadbeef $

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-first.p4
@@ -8,6 +8,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
 struct empty_metadata_t {
 }
 
@@ -15,19 +22,25 @@ struct metadata_t {
 }
 
 struct headers_t {
-    ethernet_t ethernet;
+    ethernet_t    ethernet;
+    output_data_t output_data;
 }
 
 parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
         pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
         transition accept;
     }
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action record_ingress_ports_in_pkt() {
+        hdr.output_data.word1 = (PortIdUint_t)istd.ingress_port;
+    }
     apply {
         if (hdr.ethernet.dstAddr[3:0] >= 4w4) {
+            record_ingress_ports_in_pkt();
             send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr);
         } else {
             send_to_port(ostd, (PortId_t)32w0xfffffffa);
@@ -60,6 +73,7 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
     apply {
         packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<output_data_t>(hdr.output_data);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-frontend.p4
@@ -8,6 +8,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
 struct empty_metadata_t {
 }
 
@@ -15,12 +22,14 @@ struct metadata_t {
 }
 
 struct headers_t {
-    ethernet_t ethernet;
+    ethernet_t    ethernet;
+    output_data_t output_data;
 }
 
 parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
         pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
         transition accept;
     }
 }
@@ -36,8 +45,12 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         meta_2.multicast_group = (MulticastGroup_t)32w0;
         meta_2.egress_port = egress_port_2;
     }
+    @name("cIngress.record_ingress_ports_in_pkt") action record_ingress_ports_in_pkt() {
+        hdr.output_data.word1 = (PortIdUint_t)istd.ingress_port;
+    }
     apply {
         if (hdr.ethernet.dstAddr[3:0] >= 4w4) {
+            record_ingress_ports_in_pkt();
             send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr);
         } else {
             send_to_port_0(ostd, (PortId_t)32w0xfffffffa);
@@ -70,12 +83,14 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
     apply {
         buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<output_data_t>(hdr.output_data);
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
     apply {
         buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<output_data_t>(hdr.output_data);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-midend.p4
@@ -8,6 +8,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
 struct empty_metadata_t {
 }
 
@@ -15,12 +22,14 @@ struct metadata_t {
 }
 
 struct headers_t {
-    ethernet_t ethernet;
+    ethernet_t    ethernet;
+    output_data_t output_data;
 }
 
 parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
         pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
         transition accept;
     }
 }
@@ -36,6 +45,15 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         ostd.multicast_group = 32w0;
         ostd.egress_port = 32w0xfffffffa;
     }
+    @name("cIngress.record_ingress_ports_in_pkt") action record_ingress_ports_in_pkt() {
+        hdr.output_data.word1 = (PortIdUint_t)istd.ingress_port;
+    }
+    @hidden table tbl_record_ingress_ports_in_pkt {
+        actions = {
+            record_ingress_ports_in_pkt();
+        }
+        const default_action = record_ingress_ports_in_pkt();
+    }
     @hidden table tbl_send_to_port {
         actions = {
             send_to_port();
@@ -50,6 +68,7 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
     }
     apply {
         if (hdr.ethernet.dstAddr[3:0] >= 4w4) {
+            tbl_record_ingress_ports_in_pkt.apply();
             tbl_send_to_port.apply();
         } else {
             tbl_send_to_port_0.apply();
@@ -80,32 +99,34 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action psarecirculatenometabmv2l101() {
+    @hidden action psarecirculatenometabmv2l115() {
         buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<output_data_t>(hdr.output_data);
     }
-    @hidden table tbl_psarecirculatenometabmv2l101 {
+    @hidden table tbl_psarecirculatenometabmv2l115 {
         actions = {
-            psarecirculatenometabmv2l101();
+            psarecirculatenometabmv2l115();
         }
-        const default_action = psarecirculatenometabmv2l101();
+        const default_action = psarecirculatenometabmv2l115();
     }
     apply {
-        tbl_psarecirculatenometabmv2l101.apply();
+        tbl_psarecirculatenometabmv2l115.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action psarecirculatenometabmv2l101_0() {
+    @hidden action psarecirculatenometabmv2l115_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<output_data_t>(hdr.output_data);
     }
-    @hidden table tbl_psarecirculatenometabmv2l101_0 {
+    @hidden table tbl_psarecirculatenometabmv2l115_0 {
         actions = {
-            psarecirculatenometabmv2l101_0();
+            psarecirculatenometabmv2l115_0();
         }
-        const default_action = psarecirculatenometabmv2l101_0();
+        const default_action = psarecirculatenometabmv2l115_0();
     }
     apply {
-        tbl_psarecirculatenometabmv2l101_0.apply();
+        tbl_psarecirculatenometabmv2l115_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4
@@ -8,6 +8,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
 struct empty_metadata_t {
 }
 
@@ -15,19 +22,25 @@ struct metadata_t {
 }
 
 struct headers_t {
-    ethernet_t ethernet;
+    ethernet_t    ethernet;
+    output_data_t output_data;
 }
 
 parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
         pkt.extract(hdr.ethernet);
+        pkt.extract(hdr.output_data);
         transition accept;
     }
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action record_ingress_ports_in_pkt() {
+        hdr.output_data.word1 = (bit<32>)(PortIdUint_t)istd.ingress_port;
+    }
     apply {
         if (hdr.ethernet.dstAddr[3:0] >= 4) {
+            record_ingress_ports_in_pkt();
             send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr);
         } else {
             send_to_port(ostd, PSA_PORT_RECIRCULATE);
@@ -60,6 +73,7 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
     apply {
         packet.emit(hdr.ethernet);
+        packet.emit(hdr.output_data);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txt
@@ -23,6 +23,13 @@ actions {
 }
 actions {
   preamble {
+    id: 20711895
+    name: "cIngress.record_ingress_ports_in_pkt"
+    alias: "record_ingress_ports_in_pkt"
+  }
+}
+actions {
+  preamble {
     id: 25218586
     name: "cEgress.add"
     alias: "add"


### PR DESCRIPTION
It still does not exercise recirculation of packets with preserved
user-defined metadata, since that is not yet implemented in p4c for
PSA, but it does copy the value received for ingress_port by the
ingress control into the output packet, so the STF test can check
whether it has the expected value.