### PR TITLE
Make PSA resubmit test slightly more strict

### DIFF
--- a/testdata/p4_16_samples/psa-resubmit-bmv2.stf
+++ b/testdata/p4_16_samples/psa-resubmit-bmv2.stf
@@ -1,3 +1,3 @@
 # this packet should be resubmitted once only
-packet 4 000000000000 000000000001 ffff
-expect 4 000000000004 000000000001 ffff $
+packet 4 000000000002 000000000001 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 2 000000000002 000000000001 f00d   00000006 deadbeef deadbeef deadbeef $

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2-frontend.p4
@@ -8,6 +8,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
 struct empty_metadata_t {
 }
 
@@ -15,12 +22,14 @@ struct metadata_t {
 }
 
 struct headers_t {
-    ethernet_t ethernet;
+    ethernet_t    ethernet;
+    output_data_t output_data;
 }
 
 parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
         pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
         transition accept;
     }
 }
@@ -31,20 +40,30 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         meta_1.multicast_group = (MulticastGroup_t)32w0;
         meta_1.egress_port = egress_port_1;
     }
-    @name("cIngress.resubmit") action resubmit_1() {
-        hdr.ethernet.srcAddr = 48w256;
-        ostd.resubmit = true;
-    }
-    @name("cIngress.pkt_write") action pkt_write() {
-        ostd.drop = false;
-        hdr.ethernet.dstAddr = 48w4;
-    }
     apply {
-        pkt_write();
+        ostd.drop = false;
         if (istd.packet_path != PSA_PacketPath_t.RESUBMIT) {
-            resubmit_1();
+            hdr.ethernet.srcAddr = 48w256;
+            ostd.resubmit = true;
         } else {
+            hdr.ethernet.etherType = 16w0xf00d;
             send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr);
+            hdr.output_data.word0 = 32w8;
+            if (istd.packet_path == PSA_PacketPath_t.NORMAL) {
+                hdr.output_data.word0 = 32w1;
+            } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_UNICAST) {
+                hdr.output_data.word0 = 32w2;
+            } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_MULTICAST) {
+                hdr.output_data.word0 = 32w3;
+            } else if (istd.packet_path == PSA_PacketPath_t.CLONE_I2E) {
+                hdr.output_data.word0 = 32w4;
+            } else if (istd.packet_path == PSA_PacketPath_t.CLONE_E2E) {
+                hdr.output_data.word0 = 32w5;
+            } else if (istd.packet_path == PSA_PacketPath_t.RESUBMIT) {
+                hdr.output_data.word0 = 32w6;
+            } else if (istd.packet_path == PSA_PacketPath_t.RECIRCULATE) {
+                hdr.output_data.word0 = 32w7;
+            }
         }
     }
 }
@@ -64,12 +83,14 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
     apply {
         buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<output_data_t>(hdr.output_data);
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
     apply {
         buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<output_data_t>(hdr.output_data);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2-midend.p4
@@ -8,6 +8,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
 struct empty_metadata_t {
 }
 
@@ -15,12 +22,14 @@ struct metadata_t {
 }
 
 struct headers_t {
-    ethernet_t ethernet;
+    ethernet_t    ethernet;
+    output_data_t output_data;
 }
 
 parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
         pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
         transition accept;
     }
 }
@@ -31,25 +40,57 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         ostd.multicast_group = 32w0;
         ostd.egress_port = (PortIdUint_t)hdr.ethernet.dstAddr;
     }
-    @name("cIngress.resubmit") action resubmit_1() {
+    @hidden action psaresubmitbmv2l101() {
         hdr.ethernet.srcAddr = 48w256;
         ostd.resubmit = true;
     }
-    @name("cIngress.pkt_write") action pkt_write() {
+    @hidden action psaresubmitbmv2l107() {
+        hdr.ethernet.etherType = 16w0xf00d;
+    }
+    @hidden action psaresubmitbmv2l54() {
+        hdr.output_data.word0 = 32w1;
+    }
+    @hidden action psaresubmitbmv2l56() {
+        hdr.output_data.word0 = 32w2;
+    }
+    @hidden action psaresubmitbmv2l58() {
+        hdr.output_data.word0 = 32w3;
+    }
+    @hidden action psaresubmitbmv2l60() {
+        hdr.output_data.word0 = 32w4;
+    }
+    @hidden action psaresubmitbmv2l62() {
+        hdr.output_data.word0 = 32w5;
+    }
+    @hidden action psaresubmitbmv2l64() {
+        hdr.output_data.word0 = 32w6;
+    }
+    @hidden action psaresubmitbmv2l66() {
+        hdr.output_data.word0 = 32w7;
+    }
+    @hidden action psaresubmitbmv2l52() {
+        hdr.output_data.word0 = 32w8;
+    }
+    @hidden action psaresubmitbmv2l94() {
         ostd.drop = false;
-        hdr.ethernet.dstAddr = 48w4;
     }
-    @hidden table tbl_pkt_write {
+    @hidden table tbl_psaresubmitbmv2l94 {
         actions = {
-            pkt_write();
+            psaresubmitbmv2l94();
         }
-        const default_action = pkt_write();
+        const default_action = psaresubmitbmv2l94();
     }
-    @hidden table tbl_resubmit {
+    @hidden table tbl_psaresubmitbmv2l101 {
         actions = {
-            resubmit_1();
+            psaresubmitbmv2l101();
         }
-        const default_action = resubmit_1();
+        const default_action = psaresubmitbmv2l101();
+    }
+    @hidden table tbl_psaresubmitbmv2l107 {
+        actions = {
+            psaresubmitbmv2l107();
+        }
+        const default_action = psaresubmitbmv2l107();
     }
     @hidden table tbl_send_to_port {
         actions = {
@@ -57,12 +98,77 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         }
         const default_action = send_to_port();
     }
+    @hidden table tbl_psaresubmitbmv2l52 {
+        actions = {
+            psaresubmitbmv2l52();
+        }
+        const default_action = psaresubmitbmv2l52();
+    }
+    @hidden table tbl_psaresubmitbmv2l54 {
+        actions = {
+            psaresubmitbmv2l54();
+        }
+        const default_action = psaresubmitbmv2l54();
+    }
+    @hidden table tbl_psaresubmitbmv2l56 {
+        actions = {
+            psaresubmitbmv2l56();
+        }
+        const default_action = psaresubmitbmv2l56();
+    }
+    @hidden table tbl_psaresubmitbmv2l58 {
+        actions = {
+            psaresubmitbmv2l58();
+        }
+        const default_action = psaresubmitbmv2l58();
+    }
+    @hidden table tbl_psaresubmitbmv2l60 {
+        actions = {
+            psaresubmitbmv2l60();
+        }
+        const default_action = psaresubmitbmv2l60();
+    }
+    @hidden table tbl_psaresubmitbmv2l62 {
+        actions = {
+            psaresubmitbmv2l62();
+        }
+        const default_action = psaresubmitbmv2l62();
+    }
+    @hidden table tbl_psaresubmitbmv2l64 {
+        actions = {
+            psaresubmitbmv2l64();
+        }
+        const default_action = psaresubmitbmv2l64();
+    }
+    @hidden table tbl_psaresubmitbmv2l66 {
+        actions = {
+            psaresubmitbmv2l66();
+        }
+        const default_action = psaresubmitbmv2l66();
+    }
     apply {
-        tbl_pkt_write.apply();
+        tbl_psaresubmitbmv2l94.apply();
         if (istd.packet_path != PSA_PacketPath_t.RESUBMIT) {
-            tbl_resubmit.apply();
+            tbl_psaresubmitbmv2l101.apply();
         } else {
+            tbl_psaresubmitbmv2l107.apply();
             tbl_send_to_port.apply();
+            tbl_psaresubmitbmv2l52.apply();
+            if (istd.packet_path == PSA_PacketPath_t.NORMAL) {
+                tbl_psaresubmitbmv2l54.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_UNICAST) {
+                tbl_psaresubmitbmv2l56.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_MULTICAST) {
+                tbl_psaresubmitbmv2l58.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.CLONE_I2E) {
+                tbl_psaresubmitbmv2l60.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.CLONE_E2E) {
+                tbl_psaresubmitbmv2l62.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.RESUBMIT) {
+                tbl_psaresubmitbmv2l64.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.RECIRCULATE) {
+                tbl_psaresubmitbmv2l66.apply();
+            }
         }
     }
 }
@@ -80,32 +186,34 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action psaresubmitbmv2l104() {
+    @hidden action psaresubmitbmv2l140() {
         buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<output_data_t>(hdr.output_data);
     }
-    @hidden table tbl_psaresubmitbmv2l104 {
+    @hidden table tbl_psaresubmitbmv2l140 {
         actions = {
-            psaresubmitbmv2l104();
+            psaresubmitbmv2l140();
         }
-        const default_action = psaresubmitbmv2l104();
+        const default_action = psaresubmitbmv2l140();
     }
     apply {
-        tbl_psaresubmitbmv2l104.apply();
+        tbl_psaresubmitbmv2l140.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action psaresubmitbmv2l104_0() {
+    @hidden action psaresubmitbmv2l140_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
+        buffer.emit<output_data_t>(hdr.output_data);
     }
-    @hidden table tbl_psaresubmitbmv2l104_0 {
+    @hidden table tbl_psaresubmitbmv2l140_0 {
         actions = {
-            psaresubmitbmv2l104_0();
+            psaresubmitbmv2l140_0();
         }
-        const default_action = psaresubmitbmv2l104_0();
+        const default_action = psaresubmitbmv2l140_0();
     }
     apply {
-        tbl_psaresubmitbmv2l104_0.apply();
+        tbl_psaresubmitbmv2l140_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4
@@ -8,6 +8,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
 struct empty_metadata_t {
 }
 
@@ -15,31 +22,49 @@ struct metadata_t {
 }
 
 struct headers_t {
-    ethernet_t ethernet;
+    ethernet_t    ethernet;
+    output_data_t output_data;
+}
+
+control packet_path_to_int(in PSA_PacketPath_t packet_path, out bit<32> ret) {
+    apply {
+        ret = 8;
+        if (packet_path == PSA_PacketPath_t.NORMAL) {
+            ret = 1;
+        } else if (packet_path == PSA_PacketPath_t.NORMAL_UNICAST) {
+            ret = 2;
+        } else if (packet_path == PSA_PacketPath_t.NORMAL_MULTICAST) {
+            ret = 3;
+        } else if (packet_path == PSA_PacketPath_t.CLONE_I2E) {
+            ret = 4;
+        } else if (packet_path == PSA_PacketPath_t.CLONE_E2E) {
+            ret = 5;
+        } else if (packet_path == PSA_PacketPath_t.RESUBMIT) {
+            ret = 6;
+        } else if (packet_path == PSA_PacketPath_t.RECIRCULATE) {
+            ret = 7;
+        }
+    }
 }
 
 parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
         pkt.extract(hdr.ethernet);
+        pkt.extract(hdr.output_data);
         transition accept;
     }
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    action resubmit() {
-        hdr.ethernet.srcAddr = 48w256;
-        ostd.resubmit = true;
-    }
-    action pkt_write() {
-        ostd.drop = false;
-        hdr.ethernet.dstAddr = 48w4;
-    }
     apply {
-        pkt_write();
+        ostd.drop = false;
         if (istd.packet_path != PSA_PacketPath_t.RESUBMIT) {
-            resubmit();
+            hdr.ethernet.srcAddr = 256;
+            ostd.resubmit = true;
         } else {
+            hdr.ethernet.etherType = 0xf00d;
             send_to_port(ostd, (PortId_t)(PortIdUint_t)hdr.ethernet.dstAddr);
+            packet_path_to_int.apply(istd.packet_path, hdr.output_data.word0);
         }
     }
 }
@@ -59,6 +84,7 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
 control CommonDeparserImpl(packet_out packet, inout headers_t hdr) {
     apply {
         packet.emit(hdr.ethernet);
+        packet.emit(hdr.output_data);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.p4info.txt
@@ -9,17 +9,3 @@ actions {
     annotations: "@noWarnUnused"
   }
 }
-actions {
-  preamble {
-    id: 27400393
-    name: "cIngress.resubmit"
-    alias: "resubmit"
-  }
-}
-actions {
-  preamble {
-    id: 24095040
-    name: "cIngress.pkt_write"
-    alias: "pkt_write"
-  }
-}


### PR DESCRIPTION
by copying the packet_path value into the output packets, to verify
that the PSA implementation fills it in with PSA_PacketPath_t.RESUBMIT
value after the packet is resubmitted.

The current PSA implementation in bmv2 already does this as of
2020-Aug-21 so no changes are needed there for this test to pass.