### PR TITLE
Make PSA recirculate test verify more packet_path values filled in co…

### DIFF
--- a/testdata/p4_16_samples/psa-recirculate-no-meta-bmv2.stf
+++ b/testdata/p4_16_samples/psa-recirculate-no-meta-bmv2.stf
@@ -8,20 +8,20 @@ packet 1 000000000000 000000000001 ffff   deadbeef deadbeef deadbeef deadbeef
 #                                  This field -->  ^^^^^^^^
 # is where the ingress_port field is recorded during ingress processing.
 # It should be fffffffa for PSA_RECIRCULATE_PORT if packet was recirculated.
-expect 4 000000000005 000000000001 ffff   deadbeef fffffffa deadbeef deadbeef $
+expect 4 000000000005 000000000001 ffff   00000001 fffffffa 00000007 00000002 $
 
 # First time packet processed in ingress, dstAddr is 1, then it becomes 3 in egress and recirculates.
 #   2nd time packet processed in ingress, dstAddr is 3, then it becomes 5 in egress and recirculates.
 #   3rd time packet processed in ingress, dstAddr is 5, then it becomes 7 in egress and goes out port 5
-packet 2 000000000001 000000000002 ffff   deadbeef deadbeef deadbeef deadbeef
-expect 5 000000000007 000000000002 ffff   deadbeef fffffffa deadbeef deadbeef $
+packet 2 000000000001 000000000002 ffff   deadbeef deadbeef 00000007 deadbeef
+expect 5 000000000007 000000000002 ffff   00000001 fffffffa 00000007 00000002 $
 
 # First time packet processed in ingress, dstAddr is 0, then it becomes 3 in egress and recirculates.
 #   2nd time packet processed in ingress, dstAddr is 3, then it becomes 6 in egress and recirculates.
 #   3rd time packet processed in ingress, dstAddr is 6, then it becomes 9 in egress and goes out port 6
-packet 3 000000000000 000000000003 ffff   deadbeef deadbeef deadbeef deadbeef
-expect 6 000000000009 000000000003 ffff   deadbeef fffffffa deadbeef deadbeef $
+packet 3 000000000000 000000000003 ffff   deadbeef deadbeef 00000007 deadbeef
+expect 6 000000000009 000000000003 ffff   00000001 fffffffa 00000007 00000002 $
 
 # First time packet processed in ingress, dstAddr is 8, then it becomes 0xb in egress and packet goes out port 8
 packet 7 000000000008 000000000003 ffff   deadbeef deadbeef deadbeef deadbeef
-expect 8 00000000000b 000000000003 ffff   deadbeef 00000007 deadbeef deadbeef $
+expect 8 00000000000b 000000000003 ffff   00000001 00000007 deadbeef deadbeef $

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-first.p4
@@ -26,6 +26,27 @@ struct headers_t {
     output_data_t output_data;
 }
 
+control packet_path_to_int(in PSA_PacketPath_t packet_path, out bit<32> ret) {
+    apply {
+        ret = 32w8;
+        if (packet_path == PSA_PacketPath_t.NORMAL) {
+            ret = 32w1;
+        } else if (packet_path == PSA_PacketPath_t.NORMAL_UNICAST) {
+            ret = 32w2;
+        } else if (packet_path == PSA_PacketPath_t.NORMAL_MULTICAST) {
+            ret = 32w3;
+        } else if (packet_path == PSA_PacketPath_t.CLONE_I2E) {
+            ret = 32w4;
+        } else if (packet_path == PSA_PacketPath_t.CLONE_E2E) {
+            ret = 32w5;
+        } else if (packet_path == PSA_PacketPath_t.RESUBMIT) {
+            ret = 32w6;
+        } else if (packet_path == PSA_PacketPath_t.RECIRCULATE) {
+            ret = 32w7;
+        }
+    }
+}
+
 parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
         pkt.extract<ethernet_t>(hdr.ethernet);
@@ -35,6 +56,8 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("packet_path_to_int") packet_path_to_int() packet_path_to_int_inst;
+    bit<32> int_packet_path;
     action record_ingress_ports_in_pkt() {
         hdr.output_data.word1 = (PortIdUint_t)istd.ingress_port;
     }
@@ -45,17 +68,25 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         } else {
             send_to_port(ostd, (PortId_t)32w0xfffffffa);
         }
+        packet_path_to_int_inst.apply(istd.packet_path, int_packet_path);
+        if (istd.packet_path == PSA_PacketPath_t.RECIRCULATE) {
+            hdr.output_data.word2 = int_packet_path;
+        } else {
+            hdr.output_data.word0 = int_packet_path;
+        }
     }
 }
 
-parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+parser EgressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
     state start {
-        buffer.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
         transition accept;
     }
 }
 
 control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    @name("packet_path_to_int") packet_path_to_int() packet_path_to_int_inst_0;
     action add() {
         hdr.ethernet.dstAddr = hdr.ethernet.dstAddr + hdr.ethernet.srcAddr;
     }
@@ -67,6 +98,9 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
     }
     apply {
         e.apply();
+        if (istd.egress_port == (PortId_t)32w0xfffffffa) {
+            packet_path_to_int_inst_0.apply(istd.packet_path, hdr.output_data.word3);
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-frontend.p4
@@ -45,6 +45,7 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         meta_2.multicast_group = (MulticastGroup_t)32w0;
         meta_2.egress_port = egress_port_2;
     }
+    bit<32> int_packet_path_0;
     @name("cIngress.record_ingress_ports_in_pkt") action record_ingress_ports_in_pkt() {
         hdr.output_data.word1 = (PortIdUint_t)istd.ingress_port;
     }
@@ -55,12 +56,34 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         } else {
             send_to_port_0(ostd, (PortId_t)32w0xfffffffa);
         }
+        int_packet_path_0 = 32w8;
+        if (istd.packet_path == PSA_PacketPath_t.NORMAL) {
+            int_packet_path_0 = 32w1;
+        } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_UNICAST) {
+            int_packet_path_0 = 32w2;
+        } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_MULTICAST) {
+            int_packet_path_0 = 32w3;
+        } else if (istd.packet_path == PSA_PacketPath_t.CLONE_I2E) {
+            int_packet_path_0 = 32w4;
+        } else if (istd.packet_path == PSA_PacketPath_t.CLONE_E2E) {
+            int_packet_path_0 = 32w5;
+        } else if (istd.packet_path == PSA_PacketPath_t.RESUBMIT) {
+            int_packet_path_0 = 32w6;
+        } else if (istd.packet_path == PSA_PacketPath_t.RECIRCULATE) {
+            int_packet_path_0 = 32w7;
+        }
+        if (istd.packet_path == PSA_PacketPath_t.RECIRCULATE) {
+            hdr.output_data.word2 = int_packet_path_0;
+        } else {
+            hdr.output_data.word0 = int_packet_path_0;
+        }
     }
 }
 
-parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+parser EgressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
     state start {
-        buffer.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
         transition accept;
     }
 }
@@ -77,6 +100,24 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
     }
     apply {
         e_0.apply();
+        if (istd.egress_port == (PortId_t)32w0xfffffffa) {
+            hdr.output_data.word3 = 32w8;
+            if (istd.packet_path == PSA_PacketPath_t.NORMAL) {
+                hdr.output_data.word3 = 32w1;
+            } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_UNICAST) {
+                hdr.output_data.word3 = 32w2;
+            } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_MULTICAST) {
+                hdr.output_data.word3 = 32w3;
+            } else if (istd.packet_path == PSA_PacketPath_t.CLONE_I2E) {
+                hdr.output_data.word3 = 32w4;
+            } else if (istd.packet_path == PSA_PacketPath_t.CLONE_E2E) {
+                hdr.output_data.word3 = 32w5;
+            } else if (istd.packet_path == PSA_PacketPath_t.RESUBMIT) {
+                hdr.output_data.word3 = 32w6;
+            } else if (istd.packet_path == PSA_PacketPath_t.RECIRCULATE) {
+                hdr.output_data.word3 = 32w7;
+            }
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-midend.p4
@@ -35,6 +35,7 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    bit<32> int_packet_path_0;
     @noWarnUnused @name(".send_to_port") action send_to_port() {
         ostd.drop = false;
         ostd.multicast_group = 32w0;
@@ -47,6 +48,36 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
     }
     @name("cIngress.record_ingress_ports_in_pkt") action record_ingress_ports_in_pkt() {
         hdr.output_data.word1 = (PortIdUint_t)istd.ingress_port;
+    }
+    @hidden action psarecirculatenometabmv2l56() {
+        int_packet_path_0 = 32w1;
+    }
+    @hidden action psarecirculatenometabmv2l58() {
+        int_packet_path_0 = 32w2;
+    }
+    @hidden action psarecirculatenometabmv2l60() {
+        int_packet_path_0 = 32w3;
+    }
+    @hidden action psarecirculatenometabmv2l62() {
+        int_packet_path_0 = 32w4;
+    }
+    @hidden action psarecirculatenometabmv2l64() {
+        int_packet_path_0 = 32w5;
+    }
+    @hidden action psarecirculatenometabmv2l66() {
+        int_packet_path_0 = 32w6;
+    }
+    @hidden action psarecirculatenometabmv2l68() {
+        int_packet_path_0 = 32w7;
+    }
+    @hidden action psarecirculatenometabmv2l54() {
+        int_packet_path_0 = 32w8;
+    }
+    @hidden action psarecirculatenometabmv2l110() {
+        hdr.output_data.word2 = int_packet_path_0;
+    }
+    @hidden action psarecirculatenometabmv2l115() {
+        hdr.output_data.word0 = int_packet_path_0;
     }
     @hidden table tbl_record_ingress_ports_in_pkt {
         actions = {
@@ -66,6 +97,66 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         }
         const default_action = send_to_port_0();
     }
+    @hidden table tbl_psarecirculatenometabmv2l54 {
+        actions = {
+            psarecirculatenometabmv2l54();
+        }
+        const default_action = psarecirculatenometabmv2l54();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l56 {
+        actions = {
+            psarecirculatenometabmv2l56();
+        }
+        const default_action = psarecirculatenometabmv2l56();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l58 {
+        actions = {
+            psarecirculatenometabmv2l58();
+        }
+        const default_action = psarecirculatenometabmv2l58();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l60 {
+        actions = {
+            psarecirculatenometabmv2l60();
+        }
+        const default_action = psarecirculatenometabmv2l60();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l62 {
+        actions = {
+            psarecirculatenometabmv2l62();
+        }
+        const default_action = psarecirculatenometabmv2l62();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l64 {
+        actions = {
+            psarecirculatenometabmv2l64();
+        }
+        const default_action = psarecirculatenometabmv2l64();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l66 {
+        actions = {
+            psarecirculatenometabmv2l66();
+        }
+        const default_action = psarecirculatenometabmv2l66();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l68 {
+        actions = {
+            psarecirculatenometabmv2l68();
+        }
+        const default_action = psarecirculatenometabmv2l68();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l110 {
+        actions = {
+            psarecirculatenometabmv2l110();
+        }
+        const default_action = psarecirculatenometabmv2l110();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l115 {
+        actions = {
+            psarecirculatenometabmv2l115();
+        }
+        const default_action = psarecirculatenometabmv2l115();
+    }
     apply {
         if (hdr.ethernet.dstAddr[3:0] >= 4w4) {
             tbl_record_ingress_ports_in_pkt.apply();
@@ -73,12 +164,34 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         } else {
             tbl_send_to_port_0.apply();
         }
+        tbl_psarecirculatenometabmv2l54.apply();
+        if (istd.packet_path == PSA_PacketPath_t.NORMAL) {
+            tbl_psarecirculatenometabmv2l56.apply();
+        } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_UNICAST) {
+            tbl_psarecirculatenometabmv2l58.apply();
+        } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_MULTICAST) {
+            tbl_psarecirculatenometabmv2l60.apply();
+        } else if (istd.packet_path == PSA_PacketPath_t.CLONE_I2E) {
+            tbl_psarecirculatenometabmv2l62.apply();
+        } else if (istd.packet_path == PSA_PacketPath_t.CLONE_E2E) {
+            tbl_psarecirculatenometabmv2l64.apply();
+        } else if (istd.packet_path == PSA_PacketPath_t.RESUBMIT) {
+            tbl_psarecirculatenometabmv2l66.apply();
+        } else if (istd.packet_path == PSA_PacketPath_t.RECIRCULATE) {
+            tbl_psarecirculatenometabmv2l68.apply();
+        }
+        if (istd.packet_path == PSA_PacketPath_t.RECIRCULATE) {
+            tbl_psarecirculatenometabmv2l110.apply();
+        } else {
+            tbl_psarecirculatenometabmv2l115.apply();
+        }
     }
 }
 
-parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+parser EgressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
     state start {
-        buffer.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
         transition accept;
     }
 }
@@ -93,40 +206,130 @@ control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_i
         }
         default_action = add_1();
     }
+    @hidden action psarecirculatenometabmv2l56_0() {
+        hdr.output_data.word3 = 32w1;
+    }
+    @hidden action psarecirculatenometabmv2l58_0() {
+        hdr.output_data.word3 = 32w2;
+    }
+    @hidden action psarecirculatenometabmv2l60_0() {
+        hdr.output_data.word3 = 32w3;
+    }
+    @hidden action psarecirculatenometabmv2l62_0() {
+        hdr.output_data.word3 = 32w4;
+    }
+    @hidden action psarecirculatenometabmv2l64_0() {
+        hdr.output_data.word3 = 32w5;
+    }
+    @hidden action psarecirculatenometabmv2l66_0() {
+        hdr.output_data.word3 = 32w6;
+    }
+    @hidden action psarecirculatenometabmv2l68_0() {
+        hdr.output_data.word3 = 32w7;
+    }
+    @hidden action psarecirculatenometabmv2l54_0() {
+        hdr.output_data.word3 = 32w8;
+    }
+    @hidden table tbl_psarecirculatenometabmv2l54_0 {
+        actions = {
+            psarecirculatenometabmv2l54_0();
+        }
+        const default_action = psarecirculatenometabmv2l54_0();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l56_0 {
+        actions = {
+            psarecirculatenometabmv2l56_0();
+        }
+        const default_action = psarecirculatenometabmv2l56_0();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l58_0 {
+        actions = {
+            psarecirculatenometabmv2l58_0();
+        }
+        const default_action = psarecirculatenometabmv2l58_0();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l60_0 {
+        actions = {
+            psarecirculatenometabmv2l60_0();
+        }
+        const default_action = psarecirculatenometabmv2l60_0();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l62_0 {
+        actions = {
+            psarecirculatenometabmv2l62_0();
+        }
+        const default_action = psarecirculatenometabmv2l62_0();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l64_0 {
+        actions = {
+            psarecirculatenometabmv2l64_0();
+        }
+        const default_action = psarecirculatenometabmv2l64_0();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l66_0 {
+        actions = {
+            psarecirculatenometabmv2l66_0();
+        }
+        const default_action = psarecirculatenometabmv2l66_0();
+    }
+    @hidden table tbl_psarecirculatenometabmv2l68_0 {
+        actions = {
+            psarecirculatenometabmv2l68_0();
+        }
+        const default_action = psarecirculatenometabmv2l68_0();
+    }
     apply {
         e_0.apply();
+        if (istd.egress_port == 32w0xfffffffa) {
+            tbl_psarecirculatenometabmv2l54_0.apply();
+            if (istd.packet_path == PSA_PacketPath_t.NORMAL) {
+                tbl_psarecirculatenometabmv2l56_0.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_UNICAST) {
+                tbl_psarecirculatenometabmv2l58_0.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.NORMAL_MULTICAST) {
+                tbl_psarecirculatenometabmv2l60_0.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.CLONE_I2E) {
+                tbl_psarecirculatenometabmv2l62_0.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.CLONE_E2E) {
+                tbl_psarecirculatenometabmv2l64_0.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.RESUBMIT) {
+                tbl_psarecirculatenometabmv2l66_0.apply();
+            } else if (istd.packet_path == PSA_PacketPath_t.RECIRCULATE) {
+                tbl_psarecirculatenometabmv2l68_0.apply();
+            }
+        }
     }
 }
 
 control IngressDeparserImpl(packet_out buffer, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers_t hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action psarecirculatenometabmv2l115() {
+    @hidden action psarecirculatenometabmv2l159() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<output_data_t>(hdr.output_data);
     }
-    @hidden table tbl_psarecirculatenometabmv2l115 {
+    @hidden table tbl_psarecirculatenometabmv2l159 {
         actions = {
-            psarecirculatenometabmv2l115();
+            psarecirculatenometabmv2l159();
         }
-        const default_action = psarecirculatenometabmv2l115();
+        const default_action = psarecirculatenometabmv2l159();
     }
     apply {
-        tbl_psarecirculatenometabmv2l115.apply();
+        tbl_psarecirculatenometabmv2l159.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out buffer, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers_t hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action psarecirculatenometabmv2l115_0() {
+    @hidden action psarecirculatenometabmv2l159_0() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<output_data_t>(hdr.output_data);
     }
-    @hidden table tbl_psarecirculatenometabmv2l115_0 {
+    @hidden table tbl_psarecirculatenometabmv2l159_0 {
         actions = {
-            psarecirculatenometabmv2l115_0();
+            psarecirculatenometabmv2l159_0();
         }
-        const default_action = psarecirculatenometabmv2l115_0();
+        const default_action = psarecirculatenometabmv2l159_0();
     }
     apply {
-        tbl_psarecirculatenometabmv2l115_0.apply();
+        tbl_psarecirculatenometabmv2l159_0.apply();
     }
 }
 


### PR DESCRIPTION
…rrectly

This more strict test already passes with latest version of bmv2
psa_switch as of 2020-Aug-21.