### PR TITLE
error and exit if --help-pragmas used for bmv2

### DIFF
--- a/tools/driver/p4c_src/p4c.bmv2.cfg
+++ b/tools/driver/p4c_src/p4c.bmv2.cfg
@@ -34,6 +34,10 @@ class BMV2Backend(BackendDriver):
     def process_command_line_options(self, opts):
         BackendDriver.process_command_line_options(self, opts)
 
+        if (opts.help_pragmas):
+            print(self, "backend does not provide help message for pragmas/annotations")
+            exit(0)
+
         # process the options related to source file
         basepath = "{}/{}".format(opts.output_directory, self._source_basename)
         # preprocessor


### PR DESCRIPTION
pragmas are specific to each backend, bmv2 backend currently does not provide help message for pragmas.

Fix #2521 