### PR TITLE
Rename ERROR and WARNING macros

### DIFF
--- a/lib/log.h
+++ b/lib/log.h
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -125,11 +125,11 @@ void increaseVerbosity();
                           << X << std::endl                                     \
                       : std::clog)
 
-#define ERROR(X) (std::clog << "ERROR: " << X << std::endl)
-#define WARNING(X) (::Log::verbose()                               \
+#define P4C_ERROR(X) (std::clog << "ERROR: " << X << std::endl)
+#define P4C_WARNING(X) (::Log::verbose()                               \
                       ? std::clog << "WARNING: " << X << std::endl \
                       : std::clog)
-#define ERRWARN(C, X) ((C) ? ERROR(X) : WARNING(X))
+#define ERRWARN(C, X) ((C) ? P4C_ERROR(X) : P4C_WARNING(X))
 
 static inline std::ostream &operator<<(std::ostream &out,
                                        std::function<std::ostream &(std::ostream&)> fn) {


### PR DESCRIPTION
This PR prefixes the `ERROR` and `WARNING` macro with `P4C_` to prevent collisions with other libraries (`windows.h`, glog).

After inspecting the code, I went for a minimal change here. There are no other uses of these inside p4c.

Alternatives:
If the code were better structured (i.e. would not include internal headers in public headers), this rename would not be necessary. This would require a larger restructure, though.

There is also this piece of code, which might cause surpises: https://github.com/p4lang/p4c/blob/5e05765e0c0d8d69e0ffe4ed4392e0e976203937/lib/log.h#L150-L166
I'm not sure if publicly overloading `ostream` for STL types is good practice.

Closes #2523 