### PR TITLE
Fix compiler bug confusing physical equality with semantic equality.

### DIFF
--- a/ir/base.def
+++ b/ir/base.def
@@ -17,7 +17,11 @@
 #end
 
 /// a value that can be evaluated at compile-time
-interface CompileTimeValue {}
+interface CompileTimeValue {
+    bool equiv(const CompileTimeValue& other) const {
+        return this->getNode()->equiv(*other.getNode());
+    }
+}
 
 /// Base class for P4 types
 abstract Type {

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -205,7 +205,7 @@ void Block::setValue(const Node* node, const CompileTimeValue* value) {
     CHECK_NULL(node);
     auto it = constantValue.find(node);
     if (it != constantValue.end())
-        BUG_CHECK(value == constantValue[node],
+        BUG_CHECK(value->equiv(*constantValue[node]),
                       "%1% already set in %2% to %3%, not %4%",
                   node, this, value, constantValue[node]);
     else


### PR DESCRIPTION
The removed code checked if two CompileTimeValues were equal by checking pointer equality.
This can cause errors such as the following:

    In file: third_party/p4lang_p4c/ir/ir.cpp:210
    Compiler Bug: <redacted>: hdr.ipv4_base.isValid(); already set in <ControlBlock>(2443131) ingress(); instance type=control ingress<>(inout parsed_packet_t hdr, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata); to hdr.ipv4_base.isValid();, not hdr.ipv4_base.isValid();
        if (hdr.ipv4_base.isValid()) {

Unfortunately I cannot provide a small example provoking the error at this time.