### PR TITLE
Fix: don't supply arguments twice in p4_library.

### DIFF
--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -52,7 +52,6 @@ def _p4_library_impl(ctx):
             p4c = p4c.path,
             p4c_args = " ".join(args),
         ),
-        arguments = args,
         inputs = p4deps + [p4file],
         tools = depset(
             direct = [p4c],


### PR DESCRIPTION
Sorry for the noise, I missed this in #2539.