### PR TITLE
EmptyEnumerator instread of nullptr

### DIFF
--- a/frontends/p4/parameterSubstitution.h
+++ b/frontends/p4/parameterSubstitution.h
@@ -84,7 +84,7 @@ class ParameterSubstitution : public IHasDbPrint {
     /// Only works if parameters were inserted using populate.
     Util::Enumerator<const IR::Parameter*>* getParametersInOrder() const {
         if (paramList == nullptr)
-            return nullptr;
+            return new Util::EmptyEnumerator<const IR::Parameter*>;
         return paramList->getEnumerator();
     }
 

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -62,7 +62,7 @@ Util::Enumerator<const IDeclaration*>* INestedNamespace::getDeclarations() const
                 rv = rv->concat(nested->getDeclarations());
             else
                 rv = nested->getDeclarations(); } }
-    return rv;
+    return rv ? rv : new Util::EmptyEnumerator<const IDeclaration*>;
 }
 
 bool IFunctional::callMatches(const Vector<Argument> *arguments) const {

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -190,6 +190,18 @@ class GenericEnumerator : public Enumerator<typename Iter::value_type> {
 
 /////////////////////////////////////////////////////////////////////
 
+/* always returns false */
+template <typename T>
+class EmptyEnumerator : public Enumerator<T> {
+ public:
+    cstring toString() const { return "EmptyEnumerator"; }
+    bool moveNext() { return false; }
+    T getCurrent() const {
+        throw std::logic_error("You cannot call 'getCurrent' on an EmptyEnumerator"); }
+};
+
+/////////////////////////////////////////////////////////////////////
+
 /* filters according to a predicate */
 template <typename T>
 class FilterEnumerator final : public Enumerator<T> {


### PR DESCRIPTION
Static analysis identified locations where we immediately dereference a returned `Util::Enumerator *` that might be null.  Add an `EmptyEnumerator` to avoid the undefined behavior.