### PR TITLE
Allow customization of driver-script name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set (P4C_LIBRARY_OUTPUT_DIRECTORY lib)
 set (P4C_ARTIFACTS_OUTPUT_DIRECTORY share/p4c)
 set (CMAKE_USE_RELATIVE_PATHS 1)
 
+OPTION (P4C_DRIVER_NAME "Customize the name of the driver script" "p4c")
 OPTION (ENABLE_DOCS "Build the documentation" OFF)
 OPTION (ENABLE_GTESTS "Enable building and running GTest unit tests" ON)
 OPTION (ENABLE_BMV2 "Build the BMV2 backend (required for the full test suite)" ON)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -17,8 +17,8 @@
 set (prefix ${CMAKE_INSTALL_PREFIX})
 set (exec_prefix ${CMAKE_INSTALL_PREFIX})
 set (datarootdir "\${prefix}/share")
-configure_file ("p4c.in" "${P4C_BINARY_DIR}/p4c" @ONLY)
-execute_process(COMMAND chmod a+x ${P4C_BINARY_DIR}/p4c)
+configure_file ("p4c.in" "${P4C_BINARY_DIR}/${P4C_DRIVER_NAME}" @ONLY)
+execute_process(COMMAND chmod a+x ${P4C_BINARY_DIR}/${P4C_DRIVER_NAME})
 
 
 set (P4C_DRIVER_SRCS
@@ -37,7 +37,7 @@ if (ENABLE_EBPF)
   list (APPEND P4C_TARGET_CFGS p4c_src/p4c.ebpf.cfg)
 endif()
 
-install (PROGRAMS ${P4C_BINARY_DIR}/p4c
+install (PROGRAMS ${P4C_BINARY_DIR}/${P4C_DRIVER_NAME}
   DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})
 install (DIRECTORY p4c_src
   DESTINATION ${P4C_ARTIFACTS_OUTPUT_DIRECTORY}
@@ -55,7 +55,7 @@ add_custom_command(OUTPUT ${P4C_DRIVER_DST}
           for f in ${P4C_DRIVER_SRCS} ${P4C_TARGET_CFGS} \; do
           ${CMAKE_COMMAND} -E copy_if_different \$$f ${P4C_BINARY_DIR}/p4c_src \;
           done
-  COMMAND chmod a+x ${P4C_BINARY_DIR}/p4c
+  COMMAND chmod a+x ${P4C_BINARY_DIR}/${P4C_DRIVER_NAME}
   DEPENDS ${P4C_DRIVER_SRCS}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Copying p4c driver"


### PR DESCRIPTION
This introduces a `P4C_DRIVER_NAME` CMake parameter for customization of the name of the driver script that is produced.