### PR TITLE
Re-introduce legacy version of `::warning`.

### DIFF
--- a/lib/error.h
+++ b/lib/error.h
@@ -106,6 +106,16 @@ void error(const int kind, const char *format, Args... args) {
 /// Report an error if condition e is false.
 #define ERROR_CHECK(e, ...) do { if (!(e)) ::error(__VA_ARGS__); } while (0)
 
+#if LEGACY
+/// Report a warning with the given message.
+template <typename... T>
+inline void warning(const char* format, T... args) {
+    auto& context = BaseCompileContext::get();
+    auto action = context.getDefaultWarningDiagnosticAction();
+    context.errorReporter().diagnose(action, nullptr, format, args...);
+}
+#endif
+
 /// Report warnings of type kind. Requires that the node argument have source info.
 template<class T,
          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,


### PR DESCRIPTION
This adds back the legacy version of `::warning`, which was removed in #2531. Like the legacy version of `::error`, the legacy `::warning` is guarded by the `LEGACY` cpp symbol.