### PR TITLE
Fix default p4c driver name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ set (P4C_LIBRARY_OUTPUT_DIRECTORY lib)
 set (P4C_ARTIFACTS_OUTPUT_DIRECTORY share/p4c)
 set (CMAKE_USE_RELATIVE_PATHS 1)
 
-OPTION (P4C_DRIVER_NAME "Customize the name of the driver script" "p4c")
 OPTION (ENABLE_DOCS "Build the documentation" OFF)
 OPTION (ENABLE_GTESTS "Enable building and running GTest unit tests" ON)
 OPTION (ENABLE_BMV2 "Build the BMV2 backend (required for the full test suite)" ON)
@@ -40,6 +39,8 @@ OPTION (ENABLE_PROTOBUF_STATIC "Link against Protobuf statically" ON)
 OPTION (ENABLE_GC "Use libgc" ON)
 OPTION (ENABLE_MULTITHREAD "Use multithreading" OFF)
 OPTION (ENABLE_GMP "Use GMP library" ON)
+
+set (P4C_DRIVER_NAME "p4c" CACHE STRING "Customize the name of the driver script")
 
 set(MAX_LOGGING_LEVEL 10 CACHE STRING "Control the maximum logging level for -T logs")
 set_property(CACHE MAX_LOGGING_LEVEL PROPERTY STRINGS 0 1 2 3 4 5 6 7 8 9 10)


### PR DESCRIPTION
OPTION only supports boolean values, which means the default p4c driver
name is currently 'OFF'...

Fixes #2557