### PR TITLE
ir generator fixes

### DIFF
--- a/ir/pass_manager.cpp
+++ b/ir/pass_manager.cpp
@@ -53,11 +53,12 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
                 backup.emplace_back(it, program); } }
         try {
             try {
-                size_t maxmem;
                 LOG1(log_indent << name() << " invoking " << v->name());
                 auto after = program->apply(**it);
-                LOG3(log_indent << "heap after " << v->name() << ": in use " <<
-                     n4(gc_mem_inuse(&maxmem)) << "B, max " << n4(maxmem) << "B");
+                if (LOGGING(3)) {
+                    size_t maxmem, mem = gc_mem_inuse(&maxmem);  // triggers gc
+                    LOG3(log_indent << "heap after " << v->name() << ": in use " <<
+                         n4(mem) << "B, max " << n4(maxmem) << "B"); }
                 if (stop_on_error && ::errorCount() > initial_error_count)
                     break;
                 if ((program = after) == nullptr) break;

--- a/lib/n4.h
+++ b/lib/n4.h
@@ -40,8 +40,13 @@ class n4 {
         } else if (v < UINT64_C(9950000000)) {
             v = (v + UINT64_C(50000000))/UINT64_C(100000000);
             os << v/10 << '.' << v%10 << 'G';
-        } else {
+        } else if (v < UINT64_C(999500000000)) {
             os << std::setw(3) << (v + UINT64_C(500000000))/UINT64_C(1000000000) << 'G';
+        } else if (v < UINT64_C(9950000000000)) {
+            v = (v + UINT64_C(50000000000))/UINT64_C(100000000000);
+            os << v/10 << '.' << v%10 << 'T';
+        } else {
+            os << std::setw(3) << (v + UINT64_C(500000000000))/UINT64_C(1000000000000) << 'T';
         }
         return os; }
 };

--- a/tools/ir-generator/irclass.h
+++ b/tools/ir-generator/irclass.h
@@ -49,6 +49,8 @@ class IrNamespace {
     static void add_class(IrClass *);
     IrNamespace *lookupChild(cstring name) const { return ::get(children, name); }
     IrClass *lookupClass(cstring name) const { return ::get(classes, name); }
+    cstring qualified_name(const IrNamespace *ctxt = nullptr) const;
+    // name with scope qual if needed in the context
 };
 
 std::ostream &operator<<(std::ostream &, IrNamespace *);
@@ -270,6 +272,8 @@ class IrClass : public IrElement {
     std::string fullName() const;
     Util::Enumerator<IrField*>* getFields() const;
     Util::Enumerator<IrMethod*>* getUserMethods() const;
+    cstring qualified_name(const IrNamespace *ctxt = nullptr) const;
+    // name with scope qual if needed in the context
 };
 
 class IrDefinitions {

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -42,8 +42,8 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
             if (parent->name == "Node")
                 buf << "typeid(*this) == typeid(a)";
             else
-                buf << parent->name << "::operator==(static_cast<const "
-                    << parent->name << " &>(a))";
+                buf << parent->qualified_name(cl->containedIn) << "::operator==(static_cast<const "
+                    << parent->qualified_name(cl->containedIn) << " &>(a))";
             first = false; }
         for (auto f : *cl->getFields()) {
             if (*f->type == NamedType::SourceInfo()) continue;  // FIXME -- deal with SourcInfo
@@ -75,7 +75,8 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
                 buf << cl->indent << cl->indent << "if (typeid(*this) != typeid(a_)) "
                                                    "return false;\n";
             } else {
-                buf << cl->indent << cl->indent << "if (!" << parent->name
+                buf << cl->indent << cl->indent << "if (!"
+                    << parent->qualified_name(cl->containedIn)
                     << "::equiv(a_)) return false;\n"; } }
         if (body) {
             buf << cl->indent << cl->indent << "auto &a = static_cast<const " << cl->name
@@ -121,7 +122,8 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
         std::stringstream buf;
         buf << "{" << std::endl;
         if (auto parent = cl->getParent())
-            buf << cl->indent << parent->name << "::visit_children(v);" << std::endl;
+            buf << cl->indent << parent->qualified_name(cl->containedIn)
+                << "::visit_children(v);" << std::endl;
         for (auto f : *cl->getFields()) {
             if (f->type->resolve(cl->containedIn) == nullptr)
                 // This is not an IR pointer
@@ -170,7 +172,8 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
         std::stringstream buf;
         buf << "{" << std::endl;
         if (auto parent = cl->getParent())
-            buf << cl->indent << parent->name << "::dump_fields(out);" << std::endl;
+            buf << cl->indent << parent->qualified_name(cl->containedIn)
+                << "::dump_fields(out);" << std::endl;
         bool needed = false;
         for (auto f : *cl->getFields()) {
             if (*f->type == NamedType::SourceInfo()) continue;  // FIXME -- deal with SourcInfo
@@ -189,7 +192,8 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
         std::stringstream buf;
         buf << "{" << std::endl;
         if (auto parent = cl->getParent())
-            buf << cl->indent << parent->name << "::toJSON(json);" << std::endl;
+            buf << cl->indent << parent->qualified_name(cl->containedIn)
+                << "::toJSON(json);" << std::endl;
         for (auto f : *cl->getFields()) {
             if (*f->type == NamedType::SourceInfo()) continue;  // FIXME -- deal with SourcInfo
             if (!f->isInline && f->nullOK)
@@ -203,7 +207,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
     [](IrClass *cl, Util::SourceInfo, cstring) -> cstring {
         std::stringstream buf;
         if (auto parent = cl->getParent())
-            buf << ": " << parent->name << "(json)";
+            buf << ": " << parent->qualified_name(cl->containedIn) << "(json)";
         buf << " {" << std::endl;
         for (auto f : *cl->getFields()) {
             if (*f->type == NamedType::SourceInfo()) continue;  // FIXME -- deal with SourcInfo


### PR DESCRIPTION
- use qualified name for classes when the unqualified would be
  ambiguous/incorrect (multiple classes with the same name in different
  namespaces)
- Fix gc memory reporting in pass manager (pre C++20 undefined order of eval)