### PR TITLE
Fix: Predication issue #2345

### DIFF
--- a/midend/predication.h
+++ b/midend/predication.h
@@ -75,29 +75,27 @@ class Predication final : public Transform {
     unsigned ifNestingLevel;
     // Tracking the nesting level of dependency assignment
     unsigned depNestingLevel;
-    // Stores last liveAssignments[dependency]
-    // Used for pushing dependencies on rv before visiting if-else
-    const IR::AssignmentStatement* dependencyAssignment;
-    // Name of assignment that is dependant
-    cstring dependantName;
-    // To store assignment statements.
-    // If any dependant is equal to any member of statNames,
-    // isStatementDependant is set to true.
-    std::vector<cstring> statNames;
+    // To store dependent assignments.
+    // If current statement is equal to any member of dependentNames,
+    // isStatementdependent of the coresponding statement is set to true.
+    std::vector<cstring> dependentNames;
     // Traverse path of nested if-else statements
     // true at the end of the vector means that you are currently visiting 'then' branch'
     // false at the end of the vector means that you are in the else branch of the if statement.
     // Size of this vector is the current if nesting level.
     std::vector<bool> travesalPath;
-    ordered_set<cstring> orderedNames;
     std::vector<cstring> dependencies;
+    // Collects assignment statements with transformed right expression.
+    // liveAssignments are pushed at the back of liveAssigns vetor.
     std::map<cstring, const IR::AssignmentStatement *> liveAssignments;
-    // Control when to push an assignment on rv block.
-    // True of corresponding assignemnt means that
-    // the assignment has already been pushed when handeling dependencies.
-    // False of corresponding assignemnt means that
-    // the assignment should be pushed on rv block at that point.
-    std::map<const IR::AssignmentStatement *, bool> isAssignmentPushed;
+    // Vector of assignment statements which collects assignments from
+    // liveAssignments and dependencies in adequate order. In preorder
+    // of if statements assignments from liveAssigns are pushed on rv block.
+    std::vector<const IR::AssignmentStatement*> liveAssigns;
+    // Map that shows if the current statement is dependent.
+    // Bool value is true for dependent statements,
+    // false for statements that are not dependent.
+    std::map<cstring, bool> isStatementDependent;
     const IR::Statement* error(const IR::Statement* statement) const {
         if (inside_action && ifNestingLevel > 0)
             ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
@@ -108,8 +106,7 @@ class Predication final : public Transform {
 
  public:
     explicit Predication(NameGenerator* gen) :
-        generator(gen), inside_action(false), ifNestingLevel(0), depNestingLevel(0),
-            dependencyAssignment(nullptr)
+        generator(gen), inside_action(false), ifNestingLevel(0), depNestingLevel(0)
     { setName("Predication"); }
     const IR::Expression* clone(const IR::Expression* expression);
     const IR::Node* clone(const IR::AssignmentStatement* statement);

--- a/testdata/p4_16_samples/hdr_stacks2345.p4
+++ b/testdata/p4_16_samples/hdr_stacks2345.p4
@@ -1,0 +1,55 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8>  a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]  h;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h.next);
+        pkt.extract(hdr.h.next);
+        transition accept;
+    }
+}
+
+action dummy(inout Headers val) {}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.src_addr != h.eth_hdr.dst_addr) {
+            h.h[0].a = 2;
+        } else {
+            h.h[1].a = 1;
+        }
+    }
+    apply {
+        simple_action();
+    }
+}
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {b.emit(h);} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples/issue2345-1.p4
+++ b/testdata/p4_16_samples/issue2345-1.p4
@@ -1,0 +1,62 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+action dummy(inout Headers val) { 
+		val.eth_hdr.dst_addr = 48w2; 
+		val.eth_hdr.eth_type = 16w4; 
+	}
+action dummy2(inout Headers val1) { 
+		dummy(val1);  
+		val1.eth_hdr.dst_addr = 48w3; 
+	}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        // this serves as a barrier
+        dummy2(h);
+    }
+
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+
+        simple_action();
+    }
+}
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {b.emit(h);} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples/issue2345-2.p4
+++ b/testdata/p4_16_samples/issue2345-2.p4
@@ -1,0 +1,64 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+void dummy2(inout Headers val1) { 
+	val1.eth_hdr.dst_addr = val1.eth_hdr.dst_addr + 48w3;
+} 
+void dummy(inout Headers val) { 
+	dummy2(val);
+	val.eth_hdr.eth_type = 16w2;
+	dummy2(val);
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        // this serves as a barrier
+        dummy(h);
+	h.eth_hdr.dst_addr = h.eth_hdr.dst_addr + 48w4;
+    }
+
+    apply {	     
+	h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+	simple_action();
+        
+    }
+}
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {b.emit(h);} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples/issue2345-multiple_dependencies.p4
+++ b/testdata/p4_16_samples/issue2345-multiple_dependencies.p4
@@ -1,0 +1,75 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+action dummy1(inout bit<48> dst, inout bit<16> type) {
+	bool c = true;
+	bool c1 = false;
+	if(c) {
+		type = type + 16w0;
+		if(c1) {
+			dst = 48w1;		
+		}	
+		else {
+			dst = 48w2;		
+		}
+	} else {
+		type = 16w3;
+	}
+}
+
+action dummy(inout Headers val1) { 
+	dummy1(val1.eth_hdr.dst_addr, val1.eth_hdr.eth_type);
+	val1.eth_hdr.dst_addr = val1.eth_hdr.dst_addr + 48w3;
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        // this serves as a barrier
+        dummy(h);
+    }
+
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+
+        simple_action();
+    }
+}
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {b.emit(h);} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples/issue2345-with_nested_if.p4
+++ b/testdata/p4_16_samples/issue2345-with_nested_if.p4
@@ -1,0 +1,80 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+action dummy(inout Headers val) {
+	bool c = true;
+	bool c1 = false;
+	bool c2 = true;
+	if(c) {
+		val.eth_hdr.eth_type = 16w0;
+		if(c1) {
+			val.eth_hdr.eth_type = val.eth_hdr.eth_type + 1;
+		}
+		else {
+			val.eth_hdr.eth_type = val.eth_hdr.eth_type + 2;
+		}
+		val.eth_hdr.eth_type = val.eth_hdr.eth_type + 3;
+	}
+	else if (c2) {
+		val.eth_hdr.eth_type = val.eth_hdr.eth_type + 4;
+	} else {
+		val.eth_hdr.eth_type = val.eth_hdr.eth_type + 5;
+	}
+}
+
+action dummy2(inout Headers val1) { 
+	dummy(val1);  
+	val1.eth_hdr.dst_addr = 48w3; 
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        // this serves as a barrier
+        dummy2(h);
+    }
+
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+
+        simple_action();
+    }
+}
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {b.emit(h);} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples/issue2345.p4
+++ b/testdata/p4_16_samples/issue2345.p4
@@ -1,0 +1,55 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+void dummy(inout Headers val) { }
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        // this serves as a barrier
+        dummy(h);
+    }
+
+    apply {	     
+	h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+	simple_action();
+        
+    }
+}
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {b.emit(h);} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples/xor_test.p4
+++ b/testdata/p4_16_samples/xor_test.p4
@@ -1,0 +1,236 @@
+/* -*- P4_16 -*- */
+#include <core.p4>
+#include <v1model.p4>
+
+const bit<16> TYPE_IPV4 = 0x800;
+
+/*************************************************************************
+*********************** H E A D E R S  ***********************************
+*************************************************************************/
+
+typedef bit<9>  egressSpec_t;
+typedef bit<48> macAddr_t;
+typedef bit<32> ip4Addr_t;
+
+header ethernet_t {
+    macAddr_t dstAddr;
+    macAddr_t srcAddr;
+    bit<16>   etherType;
+}
+
+header ipv4_t {
+    bit<4>    version;
+    bit<4>    ihl;
+    bit<8>    diffserv;
+    bit<16>   totalLen;
+    bit<16>   identification;
+    bit<3>    flags;
+    bit<13>   fragOffset;
+    bit<8>    ttl;
+    bit<8>    protocol;
+    bit<16>   hdrChecksum;
+    ip4Addr_t srcAddr;
+    ip4Addr_t dstAddr;
+}
+
+struct metadata {
+    /* empty */
+    bit<32>     before1;
+    bit<32>     before2;
+    bit<32>     before3;
+    bit<32>     before4;
+    bit<32>     after1;
+    bit<32>     after2;
+    bit<32>     after3;
+    bit<32>     after4;
+}
+
+struct headers {
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+}
+
+/*************************************************************************
+*********************** P A R S E R  ***********************************
+*************************************************************************/
+
+parser MyParser(packet_in packet,
+                out headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t standard_metadata) {
+
+    state start {
+        transition parse_ethernet;
+    }
+
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            TYPE_IPV4 : parse_ipv4;
+        }
+    }
+
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+
+/*************************************************************************
+************   C H E C K S U M    V E R I F I C A T I O N   *************
+*************************************************************************/
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+    apply {  
+        /* TODO: checksum function here, if applicable */
+    }
+}
+
+
+/*************************************************************************
+**************  I N G R E S S   P R O C E S S I N G   *******************
+*************************************************************************/
+
+control MyIngress(inout headers hdr,
+                  inout metadata meta,
+                  inout standard_metadata_t standard_metadata) {
+    action drop() {
+        mark_to_drop(standard_metadata);
+    }
+    
+    action srcAddr () {
+        meta.before1 = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = hdr.ipv4.srcAddr ^ 32w0x12345678;
+        meta.after1 = hdr.ipv4.srcAddr;
+    }
+
+    action dstAddr(){
+        if (hdr.ethernet.isValid()) {
+            // Do nothing here
+            hdr.ipv4.protocol = hdr.ipv4.protocol ^ 1; 
+        }
+        meta.before2 = hdr.ipv4.dstAddr;
+        hdr.ipv4.dstAddr = hdr.ipv4.dstAddr ^ 32w0x12345678;
+        meta.after2 = hdr.ipv4.dstAddr;
+    }
+    
+    action forward_and_do_something(egressSpec_t port) {
+        standard_metadata.egress_spec = port;
+
+        if(hdr.ipv4.isValid()) {
+            srcAddr();
+        }
+        if(hdr.ethernet.isValid()) {
+            dstAddr();
+        }
+
+        meta.before3 = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = hdr.ipv4.srcAddr ^ 32w0x12345678;
+        meta.after3 = hdr.ipv4.srcAddr;
+
+        meta.before4 = hdr.ipv4.dstAddr;
+        hdr.ipv4.dstAddr = hdr.ipv4.dstAddr ^ 32w0x12345678;
+        meta.after4 = hdr.ipv4.dstAddr;
+    }
+    
+    table ipv4_lpm {
+        key = {
+            standard_metadata.ingress_port : exact;
+        }
+        actions = {
+            forward_and_do_something;
+            NoAction;
+        }
+        const entries = {
+            1 : forward_and_do_something(2);
+            2 : forward_and_do_something(1);
+        }
+        default_action = NoAction();
+    }
+
+    table debug {
+        key = {
+            meta.before1 : exact;
+            meta.after1 : exact;
+            meta.before2 : exact;
+            meta.after2 : exact;
+            meta.before3 : exact;
+            meta.after3 : exact;
+            meta.before4 : exact;
+            meta.after4 : exact;
+        }
+        actions = {
+            NoAction;
+        }
+        default_action = NoAction();
+    }
+    
+    apply {
+        if(hdr.ipv4.isValid()) {
+            ipv4_lpm.apply();
+            debug.apply();
+        }
+    }
+}
+
+/*************************************************************************
+****************  E G R E S S   P R O C E S S I N G   *******************
+*************************************************************************/
+
+control MyEgress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply {  }
+}
+
+/*************************************************************************
+*************   C H E C K S U M    C O M P U T A T I O N   **************
+*************************************************************************/
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+     apply {
+        update_checksum(
+            hdr.ipv4.isValid(),
+            { 
+                hdr.ipv4.version,
+                hdr.ipv4.ihl,
+                hdr.ipv4.diffserv,
+                hdr.ipv4.totalLen,
+                hdr.ipv4.identification,
+                hdr.ipv4.flags,
+                hdr.ipv4.fragOffset,
+                hdr.ipv4.ttl,
+                hdr.ipv4.protocol,
+                hdr.ipv4.srcAddr,
+                hdr.ipv4.dstAddr 
+            },
+            hdr.ipv4.hdrChecksum,
+            HashAlgorithm.csum16
+            );
+    }
+}
+
+
+/*************************************************************************
+***********************  D E P A R S E R  *******************************
+*************************************************************************/
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+        /* TODO: add deparser logic */
+    }
+}
+
+/*************************************************************************
+***********************  S W I T C H  *******************************
+*************************************************************************/
+
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;

--- a/testdata/p4_16_samples_outputs/hdr_stacks2345-first.p4
+++ b/testdata/p4_16_samples_outputs/hdr_stacks2345-first.p4
@@ -8,8 +8,13 @@ header ethernet_t {
     bit<16> eth_type;
 }
 
+header H {
+    bit<8> a;
+}
+
 struct Headers {
     ethernet_t eth_hdr;
+    H[2]       h;
 }
 
 struct Meta {
@@ -17,28 +22,28 @@ struct Meta {
 
 parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
     state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
         pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h.next);
+        pkt.extract<H>(hdr.h.next);
         transition accept;
     }
 }
 
+action dummy(inout Headers val) {
+}
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bit<48> tmp;
-    bit<16> val_0;
-    @name("ingress.do_action") action do_action() {
-        val_0 = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? h.eth_hdr.eth_type : val_0);
-        h.eth_hdr.eth_type = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? val_0 : h.eth_hdr.eth_type);
-        tmp = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? 48w1 : tmp);
-        h.eth_hdr.src_addr = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? tmp : h.eth_hdr.src_addr);
-    }
-    @hidden table tbl_do_action {
-        actions = {
-            do_action();
+    action simple_action() {
+        if (h.eth_hdr.src_addr != h.eth_hdr.dst_addr) {
+            h.h[0].a = 8w2;
+        } else {
+            h.h[1].a = 8w1;
         }
-        const default_action = do_action();
     }
     apply {
-        tbl_do_action.apply();
+        simple_action();
     }
 }
 
@@ -57,9 +62,9 @@ control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
 }
 
-control deparser(packet_out pkt, in Headers h) {
+control deparser(packet_out b, in Headers h) {
     apply {
-        pkt.emit<ethernet_t>(h.eth_hdr);
+        b.emit<Headers>(h);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/hdr_stacks2345-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hdr_stacks2345-frontend.p4
@@ -8,8 +8,13 @@ header ethernet_t {
     bit<16> eth_type;
 }
 
+header H {
+    bit<8> a;
+}
+
 struct Headers {
     ethernet_t eth_hdr;
+    H[2]       h;
 }
 
 struct Meta {
@@ -18,27 +23,22 @@ struct Meta {
 parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
     state start {
         pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h.next);
+        pkt.extract<H>(hdr.h.next);
         transition accept;
     }
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bit<48> tmp;
-    bit<16> val_0;
-    @name("ingress.do_action") action do_action() {
-        val_0 = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? h.eth_hdr.eth_type : val_0);
-        h.eth_hdr.eth_type = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? val_0 : h.eth_hdr.eth_type);
-        tmp = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? 48w1 : tmp);
-        h.eth_hdr.src_addr = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? tmp : h.eth_hdr.src_addr);
-    }
-    @hidden table tbl_do_action {
-        actions = {
-            do_action();
+    @name("ingress.simple_action") action simple_action() {
+        if (h.eth_hdr.src_addr != h.eth_hdr.dst_addr) {
+            h.h[0].a = 8w2;
+        } else {
+            h.h[1].a = 8w1;
         }
-        const default_action = do_action();
     }
     apply {
-        tbl_do_action.apply();
+        simple_action();
     }
 }
 
@@ -57,9 +57,9 @@ control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
 }
 
-control deparser(packet_out pkt, in Headers h) {
+control deparser(packet_out b, in Headers h) {
     apply {
-        pkt.emit<ethernet_t>(h.eth_hdr);
+        b.emit<Headers>(h);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/hdr_stacks2345-midend.p4
+++ b/testdata/p4_16_samples_outputs/hdr_stacks2345-midend.p4
@@ -8,8 +8,13 @@ header ethernet_t {
     bit<16> eth_type;
 }
 
+header H {
+    bit<8> a;
+}
+
 struct Headers {
     ethernet_t eth_hdr;
+    H[2]       h;
 }
 
 struct Meta {
@@ -18,27 +23,25 @@ struct Meta {
 parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
     state start {
         pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h.next);
+        pkt.extract<H>(hdr.h.next);
         transition accept;
     }
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bit<48> tmp;
-    bit<16> val_0;
-    @name("ingress.do_action") action do_action() {
-        val_0 = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? h.eth_hdr.eth_type : val_0);
-        h.eth_hdr.eth_type = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? val_0 : h.eth_hdr.eth_type);
-        tmp = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? 48w1 : tmp);
-        h.eth_hdr.src_addr = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? tmp : h.eth_hdr.src_addr);
+    @name("ingress.simple_action") action simple_action() {
+        h.h[0].a = (h.eth_hdr.src_addr != h.eth_hdr.dst_addr ? 8w2 : h.h[0].a);
+        h.h[1].a = (h.eth_hdr.src_addr != h.eth_hdr.dst_addr ? h.h[1].a : 8w1);
     }
-    @hidden table tbl_do_action {
+    @hidden table tbl_simple_action {
         actions = {
-            do_action();
+            simple_action();
         }
-        const default_action = do_action();
+        const default_action = simple_action();
     }
     apply {
-        tbl_do_action.apply();
+        tbl_simple_action.apply();
     }
 }
 
@@ -57,9 +60,11 @@ control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
 }
 
-control deparser(packet_out pkt, in Headers h) {
+control deparser(packet_out b, in Headers h) {
     apply {
-        pkt.emit<ethernet_t>(h.eth_hdr);
+        b.emit<ethernet_t>(h.eth_hdr);
+        b.emit<H>(h.h[0]);
+        b.emit<H>(h.h[1]);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/hdr_stacks2345.p4
+++ b/testdata/p4_16_samples_outputs/hdr_stacks2345.p4
@@ -1,0 +1,72 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h.next);
+        pkt.extract(hdr.h.next);
+        transition accept;
+    }
+}
+
+action dummy(inout Headers val) {
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.src_addr != h.eth_hdr.dst_addr) {
+            h.h[0].a = 2;
+        } else {
+            h.h[1].a = 1;
+        }
+    }
+    apply {
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2330-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2330-1-midend.p4
@@ -32,7 +32,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         h.eth_hdr.eth_type = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? val1_0 : h.eth_hdr.eth_type);
         h.eth_hdr.src_addr = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? val2_0 : h.eth_hdr.src_addr);
         tmp = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? 48w1 : tmp);
-        tmp = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? tmp : tmp);
         h.eth_hdr.src_addr = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? tmp : h.eth_hdr.src_addr);
     }
     @hidden table tbl_do_action {

--- a/testdata/p4_16_samples_outputs/issue2345-1-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-1-first.p4
@@ -17,28 +17,35 @@ struct Meta {
 
 parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
     state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
         pkt.extract<ethernet_t>(hdr.eth_hdr);
         transition accept;
     }
 }
 
+action dummy(inout Headers val) {
+    val.eth_hdr.dst_addr = 48w2;
+    val.eth_hdr.eth_type = 16w4;
+}
+action dummy2(inout Headers val1) {
+    dummy(val1);
+    val1.eth_hdr.dst_addr = 48w3;
+}
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bit<48> tmp;
-    bit<16> val_0;
-    @name("ingress.do_action") action do_action() {
-        val_0 = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? h.eth_hdr.eth_type : val_0);
-        h.eth_hdr.eth_type = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? val_0 : h.eth_hdr.eth_type);
-        tmp = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? 48w1 : tmp);
-        h.eth_hdr.src_addr = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? tmp : h.eth_hdr.src_addr);
-    }
-    @hidden table tbl_do_action {
-        actions = {
-            do_action();
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 16w1) {
+            return;
         }
-        const default_action = do_action();
+        h.eth_hdr.src_addr = 48w1;
+        dummy2(h);
     }
     apply {
-        tbl_do_action.apply();
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
     }
 }
 
@@ -57,9 +64,9 @@ control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
 }
 
-control deparser(packet_out pkt, in Headers h) {
+control deparser(packet_out b, in Headers h) {
     apply {
-        pkt.emit<ethernet_t>(h.eth_hdr);
+        b.emit<Headers>(h);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2345-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-1-midend.p4
@@ -1,0 +1,83 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    ethernet_t val1_eth_hdr;
+    ethernet_t val_eth_hdr;
+    @name("ingress.simple_action") action simple_action() {
+        h.eth_hdr.src_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? 48w1 : h.eth_hdr.src_addr);
+        val1_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? h.eth_hdr : val1_eth_hdr);
+        val_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_eth_hdr : val_eth_hdr);
+        val_eth_hdr.dst_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? 48w2 : val_eth_hdr.dst_addr);
+        val_eth_hdr.eth_type = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? 16w4 : val_eth_hdr.eth_type);
+        val1_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val_eth_hdr : val1_eth_hdr);
+        val1_eth_hdr.dst_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? 48w3 : val1_eth_hdr.dst_addr);
+        h.eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_eth_hdr : h.eth_hdr);
+    }
+    @hidden action issue23451l47() {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+    }
+    @hidden table tbl_issue23451l47 {
+        actions = {
+            issue23451l47();
+        }
+        const default_action = issue23451l47();
+    }
+    @hidden table tbl_simple_action {
+        actions = {
+            simple_action();
+        }
+        const default_action = simple_action();
+    }
+    apply {
+        tbl_issue23451l47.apply();
+        tbl_simple_action.apply();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<ethernet_t>(h.eth_hdr);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-1.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-1.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+action dummy(inout Headers val) {
+    val.eth_hdr.dst_addr = 48w2;
+    val.eth_hdr.eth_type = 16w4;
+}
+action dummy2(inout Headers val1) {
+    dummy(val1);
+    val1.eth_hdr.dst_addr = 48w3;
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        dummy2(h);
+    }
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-2-first.p4
@@ -17,28 +17,36 @@ struct Meta {
 
 parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
     state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
         pkt.extract<ethernet_t>(hdr.eth_hdr);
         transition accept;
     }
 }
 
+void dummy2(inout Headers val1) {
+    val1.eth_hdr.dst_addr = val1.eth_hdr.dst_addr + 48w3;
+}
+void dummy(inout Headers val) {
+    dummy2(val);
+    val.eth_hdr.eth_type = 16w2;
+    dummy2(val);
+}
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bit<48> tmp;
-    bit<16> val_0;
-    @name("ingress.do_action") action do_action() {
-        val_0 = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? h.eth_hdr.eth_type : val_0);
-        h.eth_hdr.eth_type = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? val_0 : h.eth_hdr.eth_type);
-        tmp = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? 48w1 : tmp);
-        h.eth_hdr.src_addr = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? tmp : h.eth_hdr.src_addr);
-    }
-    @hidden table tbl_do_action {
-        actions = {
-            do_action();
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 16w1) {
+            return;
         }
-        const default_action = do_action();
+        h.eth_hdr.src_addr = 48w1;
+        dummy(h);
+        h.eth_hdr.dst_addr = h.eth_hdr.dst_addr + 48w4;
     }
     apply {
-        tbl_do_action.apply();
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
     }
 }
 
@@ -57,9 +65,9 @@ control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
 }
 
-control deparser(packet_out pkt, in Headers h) {
+control deparser(packet_out b, in Headers h) {
     apply {
-        pkt.emit<ethernet_t>(h.eth_hdr);
+        b.emit<Headers>(h);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2345-2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-2-frontend.p4
@@ -1,0 +1,81 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @name("ingress.simple_action") action simple_action() {
+        bool hasReturned = false;
+        if (h.eth_hdr.eth_type == 16w1) {
+            hasReturned = true;
+        }
+        if (!hasReturned) {
+            h.eth_hdr.src_addr = 48w1;
+            {
+                Headers val_0 = h;
+                {
+                    Headers val1_0 = val_0;
+                    val1_0.eth_hdr.dst_addr = val1_0.eth_hdr.dst_addr + 48w3;
+                    val_0 = val1_0;
+                }
+                val_0.eth_hdr.eth_type = 16w2;
+                {
+                    Headers val1_1 = val_0;
+                    val1_1.eth_hdr.dst_addr = val1_1.eth_hdr.dst_addr + 48w3;
+                    val_0 = val1_1;
+                }
+                h = val_0;
+            }
+            h.eth_hdr.dst_addr = h.eth_hdr.dst_addr + 48w4;
+        }
+    }
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<Headers>(h);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-2-midend.p4
@@ -1,0 +1,89 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    ethernet_t val_0_eth_hdr;
+    ethernet_t val1_0_eth_hdr;
+    ethernet_t val1_1_eth_hdr;
+    bool cond_0;
+    @name("ingress.simple_action") action simple_action() {
+        cond_0 = !(h.eth_hdr.eth_type == 16w1 ? true : false);
+        h.eth_hdr.src_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? 48w1 : h.eth_hdr.src_addr);
+        val_0_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? h.eth_hdr : val_0_eth_hdr);
+        val1_0_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val_0_eth_hdr : val1_0_eth_hdr);
+        val1_0_eth_hdr.dst_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_0_eth_hdr.dst_addr + 48w3 : val1_0_eth_hdr.dst_addr);
+        val_0_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_0_eth_hdr : val_0_eth_hdr);
+        val_0_eth_hdr.eth_type = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? 16w2 : val_0_eth_hdr.eth_type);
+        val1_1_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val_0_eth_hdr : val1_1_eth_hdr);
+        val1_1_eth_hdr.dst_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_1_eth_hdr.dst_addr + 48w3 : val1_1_eth_hdr.dst_addr);
+        val_0_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_1_eth_hdr : val_0_eth_hdr);
+        h.eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val_0_eth_hdr : h.eth_hdr);
+        h.eth_hdr.dst_addr = (cond_0 ? h.eth_hdr.dst_addr + 48w4 : h.eth_hdr.dst_addr);
+    }
+    @hidden action issue23452l49() {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+    }
+    @hidden table tbl_issue23452l49 {
+        actions = {
+            issue23452l49();
+        }
+        const default_action = issue23452l49();
+    }
+    @hidden table tbl_simple_action {
+        actions = {
+            simple_action();
+        }
+        const default_action = simple_action();
+    }
+    apply {
+        tbl_issue23452l49.apply();
+        tbl_simple_action.apply();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<ethernet_t>(h.eth_hdr);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-2.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-2.p4
@@ -1,0 +1,75 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+void dummy2(inout Headers val1) {
+    val1.eth_hdr.dst_addr = val1.eth_hdr.dst_addr + 48w3;
+}
+void dummy(inout Headers val) {
+    dummy2(val);
+    val.eth_hdr.eth_type = 16w2;
+    dummy2(val);
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        dummy(h);
+        h.eth_hdr.dst_addr = h.eth_hdr.dst_addr + 48w4;
+    }
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-frontend.p4
@@ -23,22 +23,24 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bit<48> tmp;
-    bit<16> val_0;
-    @name("ingress.do_action") action do_action() {
-        val_0 = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? h.eth_hdr.eth_type : val_0);
-        h.eth_hdr.eth_type = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? val_0 : h.eth_hdr.eth_type);
-        tmp = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? 48w1 : tmp);
-        h.eth_hdr.src_addr = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? tmp : h.eth_hdr.src_addr);
-    }
-    @hidden table tbl_do_action {
-        actions = {
-            do_action();
+    @name("ingress.simple_action") action simple_action() {
+        bool hasReturned = false;
+        if (h.eth_hdr.eth_type == 16w1) {
+            hasReturned = true;
         }
-        const default_action = do_action();
+        if (!hasReturned) {
+            h.eth_hdr.src_addr = 48w1;
+            {
+                Headers val_0 = h;
+                h = val_0;
+            }
+        }
     }
     apply {
-        tbl_do_action.apply();
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
     }
 }
 
@@ -57,9 +59,9 @@ control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
 }
 
-control deparser(packet_out pkt, in Headers h) {
+control deparser(packet_out b, in Headers h) {
     apply {
-        pkt.emit<ethernet_t>(h.eth_hdr);
+        b.emit<Headers>(h);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2345-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-midend.p4
@@ -1,0 +1,77 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    ethernet_t val_0_eth_hdr;
+    @name("ingress.simple_action") action simple_action() {
+        h.eth_hdr.src_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? 48w1 : h.eth_hdr.src_addr);
+        val_0_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? h.eth_hdr : val_0_eth_hdr);
+        h.eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val_0_eth_hdr : h.eth_hdr);
+    }
+    @hidden action issue2345l40() {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+    }
+    @hidden table tbl_issue2345l40 {
+        actions = {
+            issue2345l40();
+        }
+        const default_action = issue2345l40();
+    }
+    @hidden table tbl_simple_action {
+        actions = {
+            simple_action();
+        }
+        const default_action = simple_action();
+    }
+    apply {
+        tbl_issue2345l40.apply();
+        tbl_simple_action.apply();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<ethernet_t>(h.eth_hdr);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-first.p4
@@ -17,28 +17,45 @@ struct Meta {
 
 parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
     state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
         pkt.extract<ethernet_t>(hdr.eth_hdr);
         transition accept;
     }
 }
 
-control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bit<48> tmp;
-    bit<16> val_0;
-    @name("ingress.do_action") action do_action() {
-        val_0 = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? h.eth_hdr.eth_type : val_0);
-        h.eth_hdr.eth_type = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? val_0 : h.eth_hdr.eth_type);
-        tmp = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? 48w1 : tmp);
-        h.eth_hdr.src_addr = (!(h.eth_hdr.dst_addr != 48w0 ? false : true) ? tmp : h.eth_hdr.src_addr);
-    }
-    @hidden table tbl_do_action {
-        actions = {
-            do_action();
+action dummy1(inout bit<48> dst, inout bit<16> type) {
+    bool c = true;
+    bool c1 = false;
+    if (c) {
+        type = type;
+        if (c1) {
+            dst = 48w1;
+        } else {
+            dst = 48w2;
         }
-        const default_action = do_action();
+    } else {
+        type = 16w3;
+    }
+}
+action dummy(inout Headers val1) {
+    dummy1(val1.eth_hdr.dst_addr, val1.eth_hdr.eth_type);
+    val1.eth_hdr.dst_addr = val1.eth_hdr.dst_addr + 48w3;
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 16w1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        dummy(h);
     }
     apply {
-        tbl_do_action.apply();
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
     }
 }
 
@@ -57,9 +74,9 @@ control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
 }
 
-control deparser(packet_out pkt, in Headers h) {
+control deparser(packet_out b, in Headers h) {
     apply {
-        pkt.emit<ethernet_t>(h.eth_hdr);
+        b.emit<Headers>(h);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-frontend.p4
@@ -1,0 +1,90 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @name("ingress.simple_action") action simple_action() {
+        bool hasReturned = false;
+        if (h.eth_hdr.eth_type == 16w1) {
+            hasReturned = true;
+        }
+        if (!hasReturned) {
+            h.eth_hdr.src_addr = 48w1;
+            {
+                Headers val1 = h;
+                {
+                    bit<48> dst = val1.eth_hdr.dst_addr;
+                    bit<16> type_1 = val1.eth_hdr.eth_type;
+                    bool c_0;
+                    bool c1_0;
+                    c_0 = true;
+                    c1_0 = false;
+                    if (c_0) {
+                        type_1 = type_1;
+                        if (c1_0) {
+                            dst = 48w1;
+                        } else {
+                            dst = 48w2;
+                        }
+                    } else {
+                        type_1 = 16w3;
+                    }
+                    val1.eth_hdr.dst_addr = dst;
+                    val1.eth_hdr.eth_type = type_1;
+                }
+                val1.eth_hdr.dst_addr = val1.eth_hdr.dst_addr + 48w3;
+                h = val1;
+            }
+        }
+    }
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<Headers>(h);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-midend.p4
@@ -1,0 +1,92 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    ethernet_t val1_eth_hdr;
+    bit<48> dst;
+    bit<16> type_1;
+    bool c_0;
+    bool c1_0;
+    @name("ingress.simple_action") action simple_action() {
+        h.eth_hdr.src_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? 48w1 : h.eth_hdr.src_addr);
+        val1_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? h.eth_hdr : val1_eth_hdr);
+        dst = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_eth_hdr.dst_addr : dst);
+        type_1 = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_eth_hdr.eth_type : type_1);
+        c_0 = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? true : c_0);
+        c1_0 = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? false : c1_0);
+        type_1 = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? (c_0 ? type_1 : type_1) : type_1);
+        dst = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? (c_0 ? (c1_0 ? 48w1 : dst) : dst) : dst);
+        dst = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? (c_0 ? (c1_0 ? dst : 48w2) : dst) : dst);
+        type_1 = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? (c_0 ? type_1 : 16w3) : type_1);
+        val1_eth_hdr.dst_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? dst : val1_eth_hdr.dst_addr);
+        val1_eth_hdr.eth_type = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? type_1 : val1_eth_hdr.eth_type);
+        val1_eth_hdr.dst_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_eth_hdr.dst_addr + 48w3 : val1_eth_hdr.dst_addr);
+        h.eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_eth_hdr : h.eth_hdr);
+    }
+    @hidden action issue2345multiple_dependencies60() {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+    }
+    @hidden table tbl_issue2345multiple_dependencies60 {
+        actions = {
+            issue2345multiple_dependencies60();
+        }
+        const default_action = issue2345multiple_dependencies60();
+    }
+    @hidden table tbl_simple_action {
+        actions = {
+            simple_action();
+        }
+        const default_action = simple_action();
+    }
+    apply {
+        tbl_issue2345multiple_dependencies60.apply();
+        tbl_simple_action.apply();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<ethernet_t>(h.eth_hdr);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies.p4
@@ -1,0 +1,84 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+action dummy1(inout bit<48> dst, inout bit<16> type) {
+    bool c = true;
+    bool c1 = false;
+    if (c) {
+        type = type + 16w0;
+        if (c1) {
+            dst = 48w1;
+        } else {
+            dst = 48w2;
+        }
+    } else {
+        type = 16w3;
+    }
+}
+action dummy(inout Headers val1) {
+    dummy1(val1.eth_hdr.dst_addr, val1.eth_hdr.eth_type);
+    val1.eth_hdr.dst_addr = val1.eth_hdr.dst_addr + 48w3;
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        dummy(h);
+    }
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-with_nested_if-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-with_nested_if-first.p4
@@ -1,0 +1,88 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+action dummy(inout Headers val) {
+    bool c = true;
+    bool c1 = false;
+    bool c2 = true;
+    if (c) {
+        val.eth_hdr.eth_type = 16w0;
+        if (c1) {
+            val.eth_hdr.eth_type = val.eth_hdr.eth_type + 16w1;
+        } else {
+            val.eth_hdr.eth_type = val.eth_hdr.eth_type + 16w2;
+        }
+        val.eth_hdr.eth_type = val.eth_hdr.eth_type + 16w3;
+    } else if (c2) {
+        val.eth_hdr.eth_type = val.eth_hdr.eth_type + 16w4;
+    } else {
+        val.eth_hdr.eth_type = val.eth_hdr.eth_type + 16w5;
+    }
+}
+action dummy2(inout Headers val1) {
+    dummy(val1);
+    val1.eth_hdr.dst_addr = 48w3;
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 16w1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        dummy2(h);
+    }
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<Headers>(h);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-with_nested_if-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-with_nested_if-frontend.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @name("ingress.simple_action") action simple_action() {
+        bool hasReturned = false;
+        if (h.eth_hdr.eth_type == 16w1) {
+            hasReturned = true;
+        }
+        if (!hasReturned) {
+            h.eth_hdr.src_addr = 48w1;
+            {
+                Headers val1 = h;
+                {
+                    Headers val = val1;
+                    bool c_0;
+                    bool c1_0;
+                    bool c2_0;
+                    c_0 = true;
+                    c1_0 = false;
+                    c2_0 = true;
+                    if (c_0) {
+                        val.eth_hdr.eth_type = 16w0;
+                        if (c1_0) {
+                            val.eth_hdr.eth_type = val.eth_hdr.eth_type + 16w1;
+                        } else {
+                            val.eth_hdr.eth_type = val.eth_hdr.eth_type + 16w2;
+                        }
+                        val.eth_hdr.eth_type = val.eth_hdr.eth_type + 16w3;
+                    } else if (c2_0) {
+                        val.eth_hdr.eth_type = val.eth_hdr.eth_type + 16w4;
+                    } else {
+                        val.eth_hdr.eth_type = val.eth_hdr.eth_type + 16w5;
+                    }
+                    val1 = val;
+                }
+                val1.eth_hdr.dst_addr = 48w3;
+                h = val1;
+            }
+        }
+    }
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<Headers>(h);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-with_nested_if-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-with_nested_if-midend.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    ethernet_t val1_eth_hdr;
+    ethernet_t val_eth_hdr;
+    bool c_0;
+    bool c1_0;
+    bool c2_0;
+    @name("ingress.simple_action") action simple_action() {
+        h.eth_hdr.src_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? 48w1 : h.eth_hdr.src_addr);
+        val1_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? h.eth_hdr : val1_eth_hdr);
+        val_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_eth_hdr : val_eth_hdr);
+        c_0 = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? true : c_0);
+        c1_0 = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? false : c1_0);
+        c2_0 = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? true : c2_0);
+        val_eth_hdr.eth_type = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? (c_0 ? 16w0 : val_eth_hdr.eth_type) : val_eth_hdr.eth_type);
+        val_eth_hdr.eth_type = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? (c_0 ? (c1_0 ? val_eth_hdr.eth_type + 16w1 : val_eth_hdr.eth_type) : val_eth_hdr.eth_type) : val_eth_hdr.eth_type);
+        val_eth_hdr.eth_type = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? (c_0 ? (c1_0 ? val_eth_hdr.eth_type : val_eth_hdr.eth_type + 16w2) : val_eth_hdr.eth_type) : val_eth_hdr.eth_type);
+        val_eth_hdr.eth_type = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? (c_0 ? val_eth_hdr.eth_type + 16w3 : val_eth_hdr.eth_type) : val_eth_hdr.eth_type);
+        val_eth_hdr.eth_type = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? (c_0 ? val_eth_hdr.eth_type : (c2_0 ? val_eth_hdr.eth_type + 16w4 : val_eth_hdr.eth_type)) : val_eth_hdr.eth_type);
+        val_eth_hdr.eth_type = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? (c_0 ? val_eth_hdr.eth_type : (c2_0 ? val_eth_hdr.eth_type : val_eth_hdr.eth_type + 16w5)) : val_eth_hdr.eth_type);
+        val1_eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val_eth_hdr : val1_eth_hdr);
+        val1_eth_hdr.dst_addr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? 48w3 : val1_eth_hdr.dst_addr);
+        h.eth_hdr = (!(h.eth_hdr.eth_type == 16w1 ? true : false) ? val1_eth_hdr : h.eth_hdr);
+    }
+    @hidden action issue2345with_nested_if65() {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+    }
+    @hidden table tbl_issue2345with_nested_if65 {
+        actions = {
+            issue2345with_nested_if65();
+        }
+        const default_action = issue2345with_nested_if65();
+    }
+    @hidden table tbl_simple_action {
+        actions = {
+            simple_action();
+        }
+        const default_action = simple_action();
+    }
+    apply {
+        tbl_issue2345with_nested_if65.apply();
+        tbl_simple_action.apply();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<ethernet_t>(h.eth_hdr);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-with_nested_if.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-with_nested_if.p4
@@ -1,0 +1,88 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+action dummy(inout Headers val) {
+    bool c = true;
+    bool c1 = false;
+    bool c2 = true;
+    if (c) {
+        val.eth_hdr.eth_type = 16w0;
+        if (c1) {
+            val.eth_hdr.eth_type = val.eth_hdr.eth_type + 1;
+        } else {
+            val.eth_hdr.eth_type = val.eth_hdr.eth_type + 2;
+        }
+        val.eth_hdr.eth_type = val.eth_hdr.eth_type + 3;
+    } else if (c2) {
+        val.eth_hdr.eth_type = val.eth_hdr.eth_type + 4;
+    } else {
+        val.eth_hdr.eth_type = val.eth_hdr.eth_type + 5;
+    }
+}
+action dummy2(inout Headers val1) {
+    dummy(val1);
+    val1.eth_hdr.dst_addr = 48w3;
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        dummy2(h);
+    }
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345.p4
+++ b/testdata/p4_16_samples_outputs/issue2345.p4
@@ -1,0 +1,68 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+void dummy(inout Headers val) {
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        if (h.eth_hdr.eth_type == 1) {
+            return;
+        }
+        h.eth_hdr.src_addr = 48w1;
+        dummy(h);
+    }
+    apply {
+        h.eth_hdr.src_addr = 48w2;
+        h.eth_hdr.dst_addr = 48w2;
+        h.eth_hdr.eth_type = 16w2;
+        simple_action();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/xor_test-first.p4
+++ b/testdata/p4_16_samples_outputs/xor_test-first.p4
@@ -1,0 +1,155 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+const bit<16> TYPE_IPV4 = 16w0x800;
+typedef bit<9> egressSpec_t;
+typedef bit<48> macAddr_t;
+typedef bit<32> ip4Addr_t;
+header ethernet_t {
+    macAddr_t dstAddr;
+    macAddr_t srcAddr;
+    bit<16>   etherType;
+}
+
+header ipv4_t {
+    bit<4>    version;
+    bit<4>    ihl;
+    bit<8>    diffserv;
+    bit<16>   totalLen;
+    bit<16>   identification;
+    bit<3>    flags;
+    bit<13>   fragOffset;
+    bit<8>    ttl;
+    bit<8>    protocol;
+    bit<16>   hdrChecksum;
+    ip4Addr_t srcAddr;
+    ip4Addr_t dstAddr;
+}
+
+struct metadata {
+    bit<32> before1;
+    bit<32> before2;
+    bit<32> before3;
+    bit<32> before4;
+    bit<32> after1;
+    bit<32> after2;
+    bit<32> after3;
+    bit<32> after4;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    action drop() {
+        mark_to_drop(standard_metadata);
+    }
+    action srcAddr() {
+        meta.before1 = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = hdr.ipv4.srcAddr ^ 32w0x12345678;
+        meta.after1 = hdr.ipv4.srcAddr;
+    }
+    action dstAddr() {
+        if (hdr.ethernet.isValid()) {
+            hdr.ipv4.protocol = hdr.ipv4.protocol ^ 8w1;
+        }
+        meta.before2 = hdr.ipv4.dstAddr;
+        hdr.ipv4.dstAddr = hdr.ipv4.dstAddr ^ 32w0x12345678;
+        meta.after2 = hdr.ipv4.dstAddr;
+    }
+    action forward_and_do_something(egressSpec_t port) {
+        standard_metadata.egress_spec = port;
+        if (hdr.ipv4.isValid()) {
+            srcAddr();
+        }
+        if (hdr.ethernet.isValid()) {
+            dstAddr();
+        }
+        meta.before3 = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = hdr.ipv4.srcAddr ^ 32w0x12345678;
+        meta.after3 = hdr.ipv4.srcAddr;
+        meta.before4 = hdr.ipv4.dstAddr;
+        hdr.ipv4.dstAddr = hdr.ipv4.dstAddr ^ 32w0x12345678;
+        meta.after4 = hdr.ipv4.dstAddr;
+    }
+    table ipv4_lpm {
+        key = {
+            standard_metadata.ingress_port: exact @name("standard_metadata.ingress_port") ;
+        }
+        actions = {
+            forward_and_do_something();
+            NoAction();
+        }
+        const entries = {
+                        9w1 : forward_and_do_something(9w2);
+                        9w2 : forward_and_do_something(9w1);
+        }
+
+        default_action = NoAction();
+    }
+    table debug {
+        key = {
+            meta.before1: exact @name("meta.before1") ;
+            meta.after1 : exact @name("meta.after1") ;
+            meta.before2: exact @name("meta.before2") ;
+            meta.after2 : exact @name("meta.after2") ;
+            meta.before3: exact @name("meta.before3") ;
+            meta.after3 : exact @name("meta.after3") ;
+            meta.before4: exact @name("meta.before4") ;
+            meta.after4 : exact @name("meta.after4") ;
+        }
+        actions = {
+            NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_lpm.apply();
+            debug.apply();
+        }
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/xor_test-frontend.p4
+++ b/testdata/p4_16_samples_outputs/xor_test-frontend.p4
@@ -1,0 +1,146 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+typedef bit<9> egressSpec_t;
+typedef bit<48> macAddr_t;
+typedef bit<32> ip4Addr_t;
+header ethernet_t {
+    macAddr_t dstAddr;
+    macAddr_t srcAddr;
+    bit<16>   etherType;
+}
+
+header ipv4_t {
+    bit<4>    version;
+    bit<4>    ihl;
+    bit<8>    diffserv;
+    bit<16>   totalLen;
+    bit<16>   identification;
+    bit<3>    flags;
+    bit<13>   fragOffset;
+    bit<8>    ttl;
+    bit<8>    protocol;
+    bit<16>   hdrChecksum;
+    ip4Addr_t srcAddr;
+    ip4Addr_t dstAddr;
+}
+
+struct metadata {
+    bit<32> before1;
+    bit<32> before2;
+    bit<32> before3;
+    bit<32> before4;
+    bit<32> after1;
+    bit<32> after2;
+    bit<32> after3;
+    bit<32> after4;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_3() {
+    }
+    @name("MyIngress.forward_and_do_something") action forward_and_do_something(egressSpec_t port) {
+        standard_metadata.egress_spec = port;
+        if (hdr.ipv4.isValid()) {
+            meta.before1 = hdr.ipv4.srcAddr;
+            hdr.ipv4.srcAddr = hdr.ipv4.srcAddr ^ 32w0x12345678;
+            meta.after1 = hdr.ipv4.srcAddr;
+        }
+        if (hdr.ethernet.isValid()) {
+            if (hdr.ethernet.isValid()) {
+                hdr.ipv4.protocol = hdr.ipv4.protocol ^ 8w1;
+            }
+            meta.before2 = hdr.ipv4.dstAddr;
+            hdr.ipv4.dstAddr = hdr.ipv4.dstAddr ^ 32w0x12345678;
+            meta.after2 = hdr.ipv4.dstAddr;
+        }
+        meta.before3 = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = hdr.ipv4.srcAddr ^ 32w0x12345678;
+        meta.after3 = hdr.ipv4.srcAddr;
+        meta.before4 = hdr.ipv4.dstAddr;
+        hdr.ipv4.dstAddr = hdr.ipv4.dstAddr ^ 32w0x12345678;
+        meta.after4 = hdr.ipv4.dstAddr;
+    }
+    @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
+        key = {
+            standard_metadata.ingress_port: exact @name("standard_metadata.ingress_port") ;
+        }
+        actions = {
+            forward_and_do_something();
+            NoAction_0();
+        }
+        const entries = {
+                        9w1 : forward_and_do_something(9w2);
+                        9w2 : forward_and_do_something(9w1);
+        }
+
+        default_action = NoAction_0();
+    }
+    @name("MyIngress.debug") table debug_0 {
+        key = {
+            meta.before1: exact @name("meta.before1") ;
+            meta.after1 : exact @name("meta.after1") ;
+            meta.before2: exact @name("meta.before2") ;
+            meta.after2 : exact @name("meta.after2") ;
+            meta.before3: exact @name("meta.before3") ;
+            meta.after3 : exact @name("meta.after3") ;
+            meta.before4: exact @name("meta.before4") ;
+            meta.after4 : exact @name("meta.after4") ;
+        }
+        actions = {
+            NoAction_3();
+        }
+        default_action = NoAction_3();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_lpm_0.apply();
+            debug_0.apply();
+        }
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        update_checksum<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/xor_test-midend.p4
+++ b/testdata/p4_16_samples_outputs/xor_test-midend.p4
@@ -1,0 +1,161 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+typedef bit<9> egressSpec_t;
+typedef bit<48> macAddr_t;
+typedef bit<32> ip4Addr_t;
+header ethernet_t {
+    macAddr_t dstAddr;
+    macAddr_t srcAddr;
+    bit<16>   etherType;
+}
+
+header ipv4_t {
+    bit<4>    version;
+    bit<4>    ihl;
+    bit<8>    diffserv;
+    bit<16>   totalLen;
+    bit<16>   identification;
+    bit<3>    flags;
+    bit<13>   fragOffset;
+    bit<8>    ttl;
+    bit<8>    protocol;
+    bit<16>   hdrChecksum;
+    ip4Addr_t srcAddr;
+    ip4Addr_t dstAddr;
+}
+
+struct metadata {
+    bit<32> before1;
+    bit<32> before2;
+    bit<32> before3;
+    bit<32> before4;
+    bit<32> after1;
+    bit<32> after2;
+    bit<32> after3;
+    bit<32> after4;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: noMatch;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bool cond_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_3() {
+    }
+    @name("MyIngress.forward_and_do_something") action forward_and_do_something(egressSpec_t port) {
+        standard_metadata.egress_spec = port;
+        meta.before1 = (hdr.ipv4.isValid() ? hdr.ipv4.srcAddr : meta.before1);
+        hdr.ipv4.srcAddr = (hdr.ipv4.isValid() ? hdr.ipv4.srcAddr ^ 32w0x12345678 : hdr.ipv4.srcAddr);
+        meta.after1 = (hdr.ipv4.isValid() ? hdr.ipv4.srcAddr : meta.after1);
+        cond_0 = hdr.ethernet.isValid();
+        hdr.ipv4.protocol = (cond_0 ? (hdr.ethernet.isValid() ? hdr.ipv4.protocol ^ 8w1 : hdr.ipv4.protocol) : hdr.ipv4.protocol);
+        meta.before2 = (cond_0 ? hdr.ipv4.dstAddr : meta.before2);
+        hdr.ipv4.dstAddr = (cond_0 ? hdr.ipv4.dstAddr ^ 32w0x12345678 : hdr.ipv4.dstAddr);
+        meta.after2 = (cond_0 ? hdr.ipv4.dstAddr : meta.after2);
+        meta.before3 = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = hdr.ipv4.srcAddr ^ 32w0x12345678;
+        meta.after3 = hdr.ipv4.srcAddr;
+        meta.before4 = hdr.ipv4.dstAddr;
+        hdr.ipv4.dstAddr = hdr.ipv4.dstAddr ^ 32w0x12345678;
+        meta.after4 = hdr.ipv4.dstAddr;
+    }
+    @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
+        key = {
+            standard_metadata.ingress_port: exact @name("standard_metadata.ingress_port") ;
+        }
+        actions = {
+            forward_and_do_something();
+            NoAction_0();
+        }
+        const entries = {
+                        9w1 : forward_and_do_something(9w2);
+                        9w2 : forward_and_do_something(9w1);
+        }
+
+        default_action = NoAction_0();
+    }
+    @name("MyIngress.debug") table debug_0 {
+        key = {
+            meta.before1: exact @name("meta.before1") ;
+            meta.after1 : exact @name("meta.after1") ;
+            meta.before2: exact @name("meta.before2") ;
+            meta.after2 : exact @name("meta.after2") ;
+            meta.before3: exact @name("meta.before3") ;
+            meta.after3 : exact @name("meta.after3") ;
+            meta.before4: exact @name("meta.before4") ;
+            meta.after4 : exact @name("meta.after4") ;
+        }
+        actions = {
+            NoAction_3();
+        }
+        default_action = NoAction_3();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_lpm_0.apply();
+            debug_0.apply();
+        }
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+struct tuple_0 {
+    bit<4>  f0;
+    bit<4>  f1;
+    bit<8>  f2;
+    bit<16> f3;
+    bit<16> f4;
+    bit<3>  f5;
+    bit<13> f6;
+    bit<8>  f7;
+    bit<8>  f8;
+    bit<32> f9;
+    bit<32> f10;
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;
+

--- a/testdata/p4_16_samples_outputs/xor_test.p4
+++ b/testdata/p4_16_samples_outputs/xor_test.p4
@@ -1,0 +1,155 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+const bit<16> TYPE_IPV4 = 0x800;
+typedef bit<9> egressSpec_t;
+typedef bit<48> macAddr_t;
+typedef bit<32> ip4Addr_t;
+header ethernet_t {
+    macAddr_t dstAddr;
+    macAddr_t srcAddr;
+    bit<16>   etherType;
+}
+
+header ipv4_t {
+    bit<4>    version;
+    bit<4>    ihl;
+    bit<8>    diffserv;
+    bit<16>   totalLen;
+    bit<16>   identification;
+    bit<3>    flags;
+    bit<13>   fragOffset;
+    bit<8>    ttl;
+    bit<8>    protocol;
+    bit<16>   hdrChecksum;
+    ip4Addr_t srcAddr;
+    ip4Addr_t dstAddr;
+}
+
+struct metadata {
+    bit<32> before1;
+    bit<32> before2;
+    bit<32> before3;
+    bit<32> before4;
+    bit<32> after1;
+    bit<32> after2;
+    bit<32> after3;
+    bit<32> after4;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            TYPE_IPV4: parse_ipv4;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    action drop() {
+        mark_to_drop(standard_metadata);
+    }
+    action srcAddr() {
+        meta.before1 = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = hdr.ipv4.srcAddr ^ 32w0x12345678;
+        meta.after1 = hdr.ipv4.srcAddr;
+    }
+    action dstAddr() {
+        if (hdr.ethernet.isValid()) {
+            hdr.ipv4.protocol = hdr.ipv4.protocol ^ 1;
+        }
+        meta.before2 = hdr.ipv4.dstAddr;
+        hdr.ipv4.dstAddr = hdr.ipv4.dstAddr ^ 32w0x12345678;
+        meta.after2 = hdr.ipv4.dstAddr;
+    }
+    action forward_and_do_something(egressSpec_t port) {
+        standard_metadata.egress_spec = port;
+        if (hdr.ipv4.isValid()) {
+            srcAddr();
+        }
+        if (hdr.ethernet.isValid()) {
+            dstAddr();
+        }
+        meta.before3 = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = hdr.ipv4.srcAddr ^ 32w0x12345678;
+        meta.after3 = hdr.ipv4.srcAddr;
+        meta.before4 = hdr.ipv4.dstAddr;
+        hdr.ipv4.dstAddr = hdr.ipv4.dstAddr ^ 32w0x12345678;
+        meta.after4 = hdr.ipv4.dstAddr;
+    }
+    table ipv4_lpm {
+        key = {
+            standard_metadata.ingress_port: exact;
+        }
+        actions = {
+            forward_and_do_something;
+            NoAction;
+        }
+        const entries = {
+                        1 : forward_and_do_something(2);
+                        2 : forward_and_do_something(1);
+        }
+
+        default_action = NoAction();
+    }
+    table debug {
+        key = {
+            meta.before1: exact;
+            meta.after1 : exact;
+            meta.before2: exact;
+            meta.after2 : exact;
+            meta.before3: exact;
+            meta.after3 : exact;
+            meta.before4: exact;
+            meta.after4 : exact;
+        }
+        actions = {
+            NoAction;
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_lpm.apply();
+            debug.apply();
+        }
+    }
+}
+
+control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+        update_checksum(hdr.ipv4.isValid(), { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr }, hdr.ipv4.hdrChecksum, HashAlgorithm.csum16);
+    }
+}
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;
+


### PR DESCRIPTION
This PR fixes issue #2345.

The issue was the incorrect order of assignment statements with a function like:
	void dummy(inout Headers val) { }
	...
	action simple_action() {
        if (h.eth_hdr.eth_type == 1) {
            return;
        }
        h.eth_hdr.src_addr = 48w1;
        // this serves as a barrier
        dummy(h);
    }

Predication output now looks like the folowing code:
	@name("ingress.simple_action") action simple_action() {
		hasReturned = false;
		{
			bool cond;
			cond = h.eth_hdr.eth_type == 16w1;
			hasReturned = (cond ? true : hasReturned);
		}
		{
			bool cond_0;
			cond_0 = !hasReturned;
			h.eth_hdr.src_addr = (cond_0 ? 48w1 : h.eth_hdr.src_addr);
			val_eth_hdr = (cond_0 ? h.eth_hdr : val_eth_hdr);
			h.eth_hdr = (cond_0 ? val_eth_hdr : h.eth_hdr);
		}
	}

and before these changes were implemented these three lines were falsely aranged:

	{
		val_eth_hdr = (cond_0 ? h.eth_hdr : val_eth_hdr);
	}
	h.eth_hdr.src_addr = (cond_0 ? 48w1 : h.eth_hdr.src_addr);
	h.eth_hdr = (cond_0 ? val_eth_hdr : h.eth_hdr);

since h.eth_hdr.src_addr should be assigned to 1 bofore the function call.

The cause of the problem was the need to push a block with dependencies before liveAssignments. Which is now not an issue because all assignments are pushed on rv block from the same vector (liveAssigns), in preorder of if statements. In preorder of assignment statements, statements are pushed on liveAssigns in order they have on the input of predication pass.

The xor test was added since it first showed this problem. This test now also has a correct output. Also, some tests were added, which show adequate behavior when mixing nested if else-es and dependencies.