### PR TITLE
Fix clang equality comparison warning in generated [eu]bpf (and xdp) code

### DIFF
--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -67,13 +67,11 @@ bool CodeGenInspector::comparison(const IR::Operation_Relation* b) {
                    EBPFScalarType::generatesScalar(et->to<EBPFScalarType>()->widthInBits()))
                   || et->is<EBPFBoolType>();
     if (scalar) {
-        builder->append("(");
         visit(b->left);
         builder->spc();
         builder->append(b->getStringOp());
         builder->spc();
         visit(b->right);
-        builder->append(")");
     } else {
         if (!et->is<IHasWidth>())
             BUG("%1%: Comparisons for type %2% not yet implemented", type);


### PR DESCRIPTION
I am trying to compile a toy P4 program to XDP. But, clang warns me about an equality comparison in if statement condition.

#### Problematic snippet in P4:

```p4
control Ingress(inout Headers hdr, in xdp_input xin, out xdp_output xout) {
    apply {
        xout.output_port = 0;
        xout.output_action = xdp_action.XDP_DROP;
        if (hdr.udp.isValid()) {
	  if (hdr.udp.dstPort == 16w1234) {
	    hdr.udp.dstPort = 16w1235;
	  }
	  xout.output_action = xdp_action.XDP_PASS;
        }
    }

}
```

#### C code generated via `p4c-xdp basic.p4 -o basic.c`:

```c

    accept:
    {
        u8 hit;
        {
xout.output_port = 0;
            xout.output_action = XDP_DROP;
            if (/* hd.udp.isValid()*/
            hd.udp.ebpf_valid) {
if ((hd.udp.dstPort == 1234))
                    hd.udp.dstPort = 1235;
                xout.output_action = XDP_PASS;
            }
        }
    }
```

And the clang (version 9.0.1-14) warning:

```sh
basic.c:224:21: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
if ((hd.udp.dstPort == 1234))
     ~~~~~~~~~~~~~~~^~~~~~~
basic.c:224:21: note: remove extraneous parentheses around the comparison to silence this warning
if ((hd.udp.dstPort == 1234))
    ~               ^      ~
basic.c:224:21: note: use '=' to turn this equality comparison into an assignment
if ((hd.udp.dstPort == 1234))
                    ^~
                    =
1 warning generated.
```

This PR fixes the warning for me. I am not sure about its generality. It passes `make check-ebpf` and `make check-ubpf`. Comments are welcome.