### PR TITLE
Ignore crashes in Gauntlet validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,4 @@ jobs:
     - name: "Validation"
       os: linux
       script:
-        - docker run -w /gauntlet p4c python3.6 -m pytest test.py -vrf -k "test_p4c" -n $CTEST_PARALLEL_LEVEL
+        - docker run -w /gauntlet p4c python3.6 -m pytest test.py -vrf -k "test_p4c" -n $CTEST_PARALLEL_LEVEL --suppress-crashes


### PR DESCRIPTION
I wanted to add this in a more substantial pull request but considering there are new features being developed it makes sense to add this now. With this Gauntlet no longer should report an error if there is a language construct that is not implemented. I will have to fix those at my end later.