### PR TITLE
adding support for extern psa-hash

### DIFF
--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -49,7 +49,7 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
         // for all of them?
 
         IR::MethodCallExpression *mce2;
-        auto isR = false;
+        auto isPsaExtern = false;
         if (s->is<IR::AssignmentStatement>()) {
             auto assign = s->to<IR::AssignmentStatement>();
             const IR::Expression *l, *r;
@@ -60,17 +60,19 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                 auto mi = P4::MethodInstance::resolve(mce, ctxt->refMap, ctxt->typeMap);
                 auto em = mi->to<P4::ExternMethod>();
                 if (em != nullptr) {
-                    if ((em->originalExternType->name.name == "Register" ||
-                                                em->method->name.name == "read") ||
-                        (em->originalExternType->name.name == "Meter" &&
-                                                em->method->name.name == "execute")) {
-                        isR = true;
-                        // l = l->to<IR::PathExpression>();
-                        // BUG_CHECK(l != nullptr, "register_read dest cast failed");
+                    auto externName = em->originalExternType->name.name;
+                    auto methodName = em->method->name.name;
+                    if ((externName == "Register" && methodName == "read") ||
+                        (externName == "Meter" && methodName == "execute") ||
+                        (externName == "Hash" && methodName == "get_hash")) {
+                        isPsaExtern = true;
                         auto dest = new IR::Argument(l);
                         auto args = new IR::Vector<IR::Argument>();
                         args->push_back(dest);  // dest
-                        args->push_back(mce->arguments->at(0));  // index
+                        if (externName == "Register" || externName == "Meter")
+                            args->push_back(mce->arguments->at(0));  // index
+                        if (externName == "Hash" && methodName == "get_hash")
+                            args->push_back(mce->arguments->at(0));  // data
                         mce2 = new IR::MethodCallExpression(mce->method, mce->typeArguments);
                         mce2->arguments = args;
                         s = new IR::MethodCallStatement(mce);
@@ -154,7 +156,7 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl>* body,
                 auto em = mi->to<P4::ExternMethod>();
                 LOG3("P4V1:: convert " << s);
                 Util::IJson* json;
-                if (isR) {
+                if (isPsaExtern) {
                     json = ExternConverter::cvtExternObject(ctxt, em, mce2, s, emitExterns);
                 } else {
                     json = ExternConverter::cvtExternObject(ctxt, em, mc, s, emitExterns);

--- a/backends/bmv2/psa_switch/midend.cpp
+++ b/backends/bmv2/psa_switch/midend.cpp
@@ -103,11 +103,14 @@ PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions& options, std::ostream* outStre
         auto em = mi->to<P4::ExternMethod>();
         if (em == nullptr)
             return true;
-        if (em->originalExternType->name.name == "Register" ||
+        if (em->originalExternType->name.name == "Register" &&
                 em->method->name.name == "read")
             return false;
         if (em->originalExternType->name.name == "Meter" &&
                 em->method->name.name == "execute")
+            return false;
+        if (em->originalExternType->name.name == "Hash" &&
+                em->method->name.name == "get_hash")
             return false;
         return true;
     };

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -562,7 +562,31 @@ Util::IJson* ExternConverter_Hash::convertExternObject(
     UNUSED ConversionContext* ctxt, UNUSED const P4::ExternMethod* em,
     UNUSED const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl *s,
     UNUSED const bool& emitExterns) {
-    auto primitive = mkPrimitive("Hash");
+    if (em->method->name != "get_hash") {
+        modelError("Unsupported method %1%", mc);
+        return nullptr;
+    } else if (em->method->name == "get_hash" && mc->arguments->size() != 2) {
+        modelError("Expected 2 argument for %1%", mc);
+        return nullptr;
+    }
+
+    auto opName = "_" + em->originalExternType->name + "_" + em->method->name;
+
+    auto primitive = mkPrimitive(opName);
+
+    auto parameters = mkParameters(primitive);
+    primitive->emplace_non_null("source_info", s->sourceInfoJsonObj());
+    auto externObj = new Util::JsonObject();
+    externObj->emplace("type", "extern");
+    externObj->emplace("value", em->object->controlPlaneName());
+    parameters->append(externObj);
+
+    if (em->method->name == "get_hash") {
+        auto data = ctxt->conv->convert(mc->arguments->at(0)->expression);
+        parameters->append(data);
+        auto dest = ctxt->conv->convert(mc->arguments->at(1)->expression);
+        parameters->append(dest);
+    }
     return primitive;
 }
 
@@ -756,8 +780,44 @@ Util::IJson* ExternConverter_Digest::convertExternObject(
 
 void ExternConverter_Hash::convertExternInstance(
     UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,
-    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns)
-{ /* TODO */ }
+    UNUSED const IR::ExternBlock* eb, UNUSED const bool& emitExterns) {
+    if (eb->getConstructorParameters()->size() != 1) {
+        modelError("%1%: expected 1 parameter", eb);
+        return;
+    }
+
+    auto inst = c->to<IR::Declaration_Instance>();
+    cstring name = inst->controlPlaneName();
+
+    //adding hash instance into extern_instances
+    auto jext = new Util::JsonObject();
+    jext->emplace("name", name);
+    jext->emplace("id", nextId("extern_instances"));
+    jext->emplace("type", eb->getName());
+    jext->emplace_non_null("source_info", eb->sourceInfoJsonObj());
+    ctxt->json->externs->append(jext);
+
+    // adding attributes to hash instance
+    Util::JsonArray *arr = ctxt->json->insert_array_field(jext, "attribute_values");
+
+    // algo
+    auto algo = eb->findParameterValue("algo");
+    CHECK_NULL(algo);
+    if (!algo->is<IR::Declaration_ID>()) {
+        modelError("%1%: expected a member", algo->getNode());
+        return;
+    }
+    cstring algo_name = algo->to<IR::Declaration_ID>()->name;
+    cstring hash_algo = "?";
+    if (algo_name == "CRC16") {
+        hash_algo = "crc16";
+    }
+    auto aj = new Util::JsonObject();
+    aj->emplace("name", "algo");
+    aj->emplace("type", "string");
+    aj->emplace("value", hash_algo);
+    arr->append(aj);
+}
 
 void ExternConverter_Checksum::convertExternInstance(
     UNUSED ConversionContext* ctxt, UNUSED const IR::Declaration* c,

--- a/testdata/p4_16_samples/psa-hash-bmv2.p4
+++ b/testdata/p4_16_samples/psa-hash-bmv2.p4
@@ -1,0 +1,158 @@
+/*
+Copyright 2020 Cornell University
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "psa.p4"
+
+
+typedef bit<48>  EthernetAddress;
+typedef bit<32>  IPv4Address;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>       version;
+    bit<4>       ihl;
+    bit<8>       diffserv;
+    bit<16>      totalLen;
+    bit<16>      identification;
+    bit<3>       flags;
+    bit<13>      fragOffset;
+    bit<8>       ttl;
+    bit<8>       protocol;
+    bit<16>      hdrChecksum;
+    IPv4Address  srcAddr;
+    IPv4Address  dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+}
+
+parser IngressParserImpl(packet_in pkt,
+                         out headers_t hdr,
+                         inout metadata_t user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            // default: accept
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control cIngress(inout headers_t hdr,
+                 inout metadata_t user_meta,
+                 in    psa_ingress_input_metadata_t  istd,
+                 inout psa_ingress_output_metadata_t ostd)
+{
+    Hash<bit<16>>(PSA_HashAlgorithm_t.CRC16) h;
+    bit<16> r = h.get_hash(hdr.ethernet.srcAddr);
+    apply {
+        if (r == 0) {
+            hdr.ethernet.dstAddr = 3;
+        }
+        send_to_port(ostd, (PortId_t) (PortIdUint_t) hdr.ethernet.dstAddr);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers_t hdr,
+                        inout metadata_t user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control cEgress(inout headers_t hdr,
+                inout metadata_t user_meta,
+                in    psa_egress_input_metadata_t  istd,
+                inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control CommonDeparserImpl(packet_out packet,
+                           inout headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers_t hdr,
+                            in metadata_t meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers_t hdr,
+                           in metadata_t meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                cIngress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               cEgress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;


### PR DESCRIPTION
Enabling p4c to generate .json for psa-hash extern.

Testing filename: testdata/p4_16_samples/psa-hash-bmv2.p4

Currently working on the corresponding bmv2 implementation. A .stf test will be delivered together with the corresponding bmv2 implementation.