### PR TITLE
Fixes #2546: Side-effect function call in table key

### DIFF
--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -381,7 +381,7 @@ class FindUninitialized : public Inspector {
         if (!isFinalRead(getContext(), expression))
             return;
         const LocationSet* read = getReads(expression);
-        if (read == nullptr || read->isEmpty())
+        if (read == nullptr || read->isEmpty() || currentDefinitions->empty())
             return;
         auto points = currentDefinitions->getPoints(read);
         if (reportUninitialized && !lhs && points->containsBeforeStart()) {

--- a/testdata/p4_16_samples/nested_tbl_apply-1.p4
+++ b/testdata/p4_16_samples/nested_tbl_apply-1.p4
@@ -1,0 +1,48 @@
+#include <core.p4>
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    table simple_table_1 {
+        key = {
+        	h.eth_hdr.eth_type: exact @name("KOXpQP") ;
+        }
+        actions = {
+        }
+    }
+    table simple_table_2 {
+        key = {
+            (simple_table_1.apply().hit  ? 8w1 : 8w2): exact @name("key") ;
+        }
+        actions = {
+        }
+    }
+    apply {
+        if (simple_table_2.apply().hit) {
+            h.eth_hdr.dst_addr = 1;
+        }
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples/nested_tbl_apply.p4
+++ b/testdata/p4_16_samples/nested_tbl_apply.p4
@@ -1,0 +1,48 @@
+#include <core.p4>
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    table simple_table_1 {
+        key = {
+        	48w1: exact @name("KOXpQP") ;
+        }
+        actions = {
+        }
+    }
+    table simple_table_2 {
+        key = {
+            (simple_table_1.apply().hit  ? 8w1 : 8w2): exact @name("key") ;
+        }
+        actions = {
+        }
+    }
+    apply {
+        if (simple_table_2.apply().hit) {
+            h.eth_hdr.dst_addr = 1;
+        }
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/nested_tbl_apply-1-first.p4
+++ b/testdata/p4_16_samples_outputs/nested_tbl_apply-1-first.p4
@@ -1,0 +1,53 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    table simple_table_1 {
+        key = {
+            h.eth_hdr.eth_type: exact @name("KOXpQP") ;
+        }
+        actions = {
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    table simple_table_2 {
+        key = {
+            (simple_table_1.apply().hit ? 8w1 : 8w2): exact @name("key") ;
+        }
+        actions = {
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (simple_table_2.apply().hit) {
+            h.eth_hdr.dst_addr = 48w1;
+        }
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/nested_tbl_apply-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested_tbl_apply-1-frontend.p4
@@ -1,0 +1,54 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_3() {
+    }
+    @name("ingress.simple_table_1") table simple_table {
+        key = {
+            h.eth_hdr.eth_type: exact @name("KOXpQP") ;
+        }
+        actions = {
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    @name("ingress.simple_table_2") table simple_table_0 {
+        key = {
+            (simple_table.apply().hit ? 8w1 : 8w2): exact @name("key") ;
+        }
+        actions = {
+            @defaultonly NoAction_3();
+        }
+        default_action = NoAction_3();
+    }
+    apply {
+        if (simple_table_0.apply().hit) {
+            h.eth_hdr.dst_addr = 48w1;
+        }
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/nested_tbl_apply-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested_tbl_apply-1-midend.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    bit<8> key_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_3() {
+    }
+    @name("ingress.simple_table_1") table simple_table {
+        key = {
+            h.eth_hdr.eth_type: exact @name("KOXpQP") ;
+        }
+        actions = {
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    @name("ingress.simple_table_2") table simple_table_0 {
+        key = {
+            key_0: exact @name("key") ;
+        }
+        actions = {
+            @defaultonly NoAction_3();
+        }
+        default_action = NoAction_3();
+    }
+    @hidden action nested_tbl_apply1l39() {
+        h.eth_hdr.dst_addr = 48w1;
+    }
+    @hidden action nested_tbl_apply1l32() {
+        key_0 = (simple_table.apply().hit ? 8w1 : 8w2);
+    }
+    @hidden table tbl_nested_tbl_apply1l32 {
+        actions = {
+            nested_tbl_apply1l32();
+        }
+        const default_action = nested_tbl_apply1l32();
+    }
+    @hidden table tbl_nested_tbl_apply1l39 {
+        actions = {
+            nested_tbl_apply1l39();
+        }
+        const default_action = nested_tbl_apply1l39();
+    }
+    apply {
+        tbl_nested_tbl_apply1l32.apply();
+        if (simple_table_0.apply().hit) {
+            tbl_nested_tbl_apply1l39.apply();
+        }
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/nested_tbl_apply-1.p4
+++ b/testdata/p4_16_samples_outputs/nested_tbl_apply-1.p4
@@ -1,0 +1,49 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    table simple_table_1 {
+        key = {
+            h.eth_hdr.eth_type: exact @name("KOXpQP") ;
+        }
+        actions = {
+        }
+    }
+    table simple_table_2 {
+        key = {
+            (simple_table_1.apply().hit ? 8w1 : 8w2): exact @name("key") ;
+        }
+        actions = {
+        }
+    }
+    apply {
+        if (simple_table_2.apply().hit) {
+            h.eth_hdr.dst_addr = 1;
+        }
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/nested_tbl_apply-first.p4
+++ b/testdata/p4_16_samples_outputs/nested_tbl_apply-first.p4
@@ -1,0 +1,53 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    table simple_table_1 {
+        key = {
+            48w1: exact @name("KOXpQP") ;
+        }
+        actions = {
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    table simple_table_2 {
+        key = {
+            (simple_table_1.apply().hit ? 8w1 : 8w2): exact @name("key") ;
+        }
+        actions = {
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (simple_table_2.apply().hit) {
+            h.eth_hdr.dst_addr = 48w1;
+        }
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/nested_tbl_apply-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested_tbl_apply-frontend.p4
@@ -1,0 +1,54 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_3() {
+    }
+    @name("ingress.simple_table_1") table simple_table {
+        key = {
+            48w1: exact @name("KOXpQP") ;
+        }
+        actions = {
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    @name("ingress.simple_table_2") table simple_table_0 {
+        key = {
+            (simple_table.apply().hit ? 8w1 : 8w2): exact @name("key") ;
+        }
+        actions = {
+            @defaultonly NoAction_3();
+        }
+        default_action = NoAction_3();
+    }
+    apply {
+        if (simple_table_0.apply().hit) {
+            h.eth_hdr.dst_addr = 48w1;
+        }
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/nested_tbl_apply-midend.p4
+++ b/testdata/p4_16_samples_outputs/nested_tbl_apply-midend.p4
@@ -1,0 +1,76 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    bit<48> key_0;
+    bit<8> key_1;
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_3() {
+    }
+    @name("ingress.simple_table_1") table simple_table {
+        key = {
+            key_0: exact @name("KOXpQP") ;
+        }
+        actions = {
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    @name("ingress.simple_table_2") table simple_table_0 {
+        key = {
+            key_1: exact @name("key") ;
+        }
+        actions = {
+            @defaultonly NoAction_3();
+        }
+        default_action = NoAction_3();
+    }
+    @hidden action nested_tbl_apply39() {
+        h.eth_hdr.dst_addr = 48w1;
+    }
+    @hidden action nested_tbl_apply25() {
+        key_0 = 48w1;
+        key_1 = (simple_table.apply().hit ? 8w1 : 8w2);
+    }
+    @hidden table tbl_nested_tbl_apply25 {
+        actions = {
+            nested_tbl_apply25();
+        }
+        const default_action = nested_tbl_apply25();
+    }
+    @hidden table tbl_nested_tbl_apply39 {
+        actions = {
+            nested_tbl_apply39();
+        }
+        const default_action = nested_tbl_apply39();
+    }
+    apply {
+        tbl_nested_tbl_apply25.apply();
+        if (simple_table_0.apply().hit) {
+            tbl_nested_tbl_apply39.apply();
+        }
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/nested_tbl_apply.p4
+++ b/testdata/p4_16_samples_outputs/nested_tbl_apply.p4
@@ -1,0 +1,49 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    table simple_table_1 {
+        key = {
+            48w1: exact @name("KOXpQP") ;
+        }
+        actions = {
+        }
+    }
+    table simple_table_2 {
+        key = {
+            (simple_table_1.apply().hit ? 8w1 : 8w2): exact @name("key") ;
+        }
+        actions = {
+        }
+    }
+    apply {
+        if (simple_table_2.apply().hit) {
+            h.eth_hdr.dst_addr = 1;
+        }
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+


### PR DESCRIPTION
Change made in simplifyDefUse.cpp file ensures that getPoints function isn't called if currentDefinitions is empty. With this change, there are no compiler bugs in a situation where a key is e.g. eth_type.