### PR TITLE
Support for generic structs

### DIFF
--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -213,7 +213,7 @@ RemoveComplexExpressions::simplifyExpression(const IR::Expression* expression, b
         auto simpl = simplifyExpressions(&si->components);
         if (simpl != &si->components)
             return new IR::StructExpression(
-                si->srcInfo, si->typeName, si->typeName, *simpl);
+                si->srcInfo, si->structType, si->structType, *simpl);
         return expression;
     } else {
         ComplexExpression ce;
@@ -318,7 +318,7 @@ RemoveComplexExpressions::postorder(IR::MethodCallExpression* expression) {
             } else if (auto si = arg1->to<IR::StructExpression>()) {
                 auto list = simplifyExpressions(&si->components);
                 arg1 = new IR::StructExpression(
-                    si->srcInfo, si->typeName, si->typeName, *list);
+                    si->srcInfo, si->structType, si->structType, *list);
                 vec->push_back(new IR::Argument(arg1));
             } else {
                 auto tmp = new IR::Argument(

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -53,6 +53,7 @@ set (P4_FRONTEND_SRCS
   p4/simplifyParsers.cpp
   p4/specialize.cpp
   p4/specializeGenericFunctions.cpp
+  p4/specializeGenericTypes.cpp
   p4/strengthReduction.cpp
   p4/structInitializers.cpp
   p4/switchAddDefault.cpp
@@ -119,6 +120,7 @@ set (P4_FRONTEND_HDRS
   p4/simplifyParsers.h
   p4/specialize.h
   p4/specializeGenericFunctions.h
+  p4/specializeGenericTypes.h
   p4/strengthReduction.h
   p4/structInitializers.h
   p4/switchAddDefault.h

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -56,6 +56,7 @@ limitations under the License.
 #include "simplifyParsers.h"
 #include "specialize.h"
 #include "specializeGenericFunctions.h"
+#include "specializeGenericTypes.h"
 #include "strengthReduction.h"
 #include "structInitializers.h"
 #include "switchAddDefault.h"
@@ -152,6 +153,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new TypeInference(&refMap, &typeMap, false),  // insert casts
         new ValidateMatchAnnotations(&typeMap),
         new BindTypeVariables(&refMap, &typeMap),
+        new SpecializeGenericTypes(&refMap, &typeMap),
         new DefaultArguments(&refMap, &typeMap),  // add default argument values to parameters
         new ResolveReferences(&refMap),
         new TypeInference(&refMap, &typeMap, false),  // more casts may be needed

--- a/frontends/p4/methodInstance.cpp
+++ b/frontends/p4/methodInstance.cpp
@@ -51,6 +51,8 @@ MethodInstance::resolve(const IR::MethodCallExpression* mce, DeclarationLookup* 
             else
                 BUG("Could not find type for %1%", mem->expr);
         }
+        if (auto sc = basetype->to<IR::Type_SpecializedCanonical>())
+            basetype = sc->baseType;
         if (basetype->is<IR::Type_HeaderUnion>()) {
             if (mem->member == IR::Type_Header::isValid)
                 return new BuiltInMethod(mce, mem->member, mem->expr, mt->to<IR::Type_Method>());

--- a/frontends/p4/specializeGenericFunctions.cpp
+++ b/frontends/p4/specializeGenericFunctions.cpp
@@ -18,30 +18,6 @@ limitations under the License.
 
 namespace P4 {
 
-namespace {
-
-class TypeSubstitutionVisitor : public TypeVariableSubstitutionVisitor {
-    TypeMap* typeMap;
-
- public:
-    TypeSubstitutionVisitor(TypeMap* typeMap, TypeVariableSubstitution* ts) :
-            TypeVariableSubstitutionVisitor(ts), typeMap(typeMap) {
-        CHECK_NULL(typeMap); setName("TypeSubstitutionVisitor"); }
-    const IR::Node* postorder(IR::PathExpression* path) override {
-        // We want fresh nodes for variables, etc.
-        return new IR::PathExpression(path->path->clone()); }
-    const IR::Node* postorder(IR::Type_Name* type) override {
-        auto actual = typeMap->getTypeType(getOriginal<IR::Type_Name>(), true);
-        if (auto tv = actual->to<IR::ITypeVar>()) {
-            LOG3("Replacing " << tv);
-            return replacement(tv, type);
-        }
-        return type;
-    }
-};
-
-}  // namespace
-
 bool FindFunctionSpecializations::preorder(const IR::MethodCallExpression* mce) {
     if (!mce->typeArguments->size())
         return false;

--- a/frontends/p4/specializeGenericTypes.cpp
+++ b/frontends/p4/specializeGenericTypes.cpp
@@ -1,0 +1,173 @@
+/*
+Copyright 2020 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "specializeGenericTypes.h"
+
+namespace P4 {
+
+bool TypeSpecializationMap::same(
+    const TypeSpecialization* spec, const IR::Type_Specialized* right) const {
+    if (!spec->specialized->baseType->equiv(*right->baseType))
+        return false;
+    BUG_CHECK(spec->argumentTypes->size() == right->arguments->size(),
+              "Type %1% and %2% specialized with different number of arguments?",
+              spec->specialized, right);
+    for (size_t i = 0; i < spec->argumentTypes->size(); i++) {
+        auto argl = spec->argumentTypes->at(i);
+        auto argr = typeMap->getType(right->arguments->at(i), true);
+        if (!typeMap->equivalent(argl, argr))
+            return false;
+    }
+    return true;
+}
+
+void TypeSpecializationMap::add(
+    const IR::Type_Specialized* t, const IR::Type_StructLike* decl, const IR::Node* insertion) {
+    auto it = map.find(t);
+    if (it != map.end())
+        return;
+
+    // First check if we have another specialization with the same
+    // type arguments, in that case reuse it
+    for (auto it : map) {
+        if (same(it.second, t)) {
+            map.emplace(t, it.second);
+            LOG3("Found to specialize: " << t << " as previous " << it.second->name);
+            return;
+        }
+    }
+
+    cstring name = refMap->newName(decl->getName());
+    LOG3("Found to specialize: " << dbp(t) << "(" << t << ") with name "
+         << name << " insert before " << dbp(insertion));
+    auto argTypes = new IR::Vector<IR::Type>();
+    for (auto a : *t->arguments)
+        argTypes->push_back(typeMap->getType(a, true));
+    TypeSpecialization* s = new TypeSpecialization(name, t, decl, insertion, argTypes);
+    map.emplace(t, s);
+}
+
+TypeSpecialization* TypeSpecializationMap::get(const IR::Type_Specialized* type) const {
+    for (auto it : map) {
+        if (same(it.second, type))
+            return it.second;
+    }
+    return nullptr;
+}
+
+namespace {
+
+class ContainsTypeVariable : public Inspector {
+    bool contains = false;
+  public:
+    bool preorder(const IR::TypeParameters*) override { return false; }
+    bool preorder(const IR::Type_Var*) override { contains = true; return false; }
+    bool preorder(const IR::Type_Specialized*) override { contains = true; return false; }
+    static bool inspect(const IR::Node* node) {
+        ContainsTypeVariable ctv;
+        node->apply(ctv);
+        return ctv.contains;
+    }
+};
+
+}  // namespace
+
+void FindTypeSpecializations::postorder(const IR::Type_Specialized* type) {
+    auto baseType = specMap->typeMap->getTypeType(type->baseType, true);
+    auto st = baseType->to<IR::Type_StructLike>();
+    if (st == nullptr || st->typeParameters->size() == 0)
+        // nothing to specialize
+        return;
+    for (auto tp : *type->arguments) {
+        auto argType = specMap->typeMap->getTypeType(tp, true);
+        if (ContainsTypeVariable::inspect(argType))
+            // If type argument contains a type variable, for example, in
+            // the field f:
+            // struct G<T> { T field; }
+            // struct S<T> { G<T> f; }
+            // then we won't specialize this now, but only when encountered in
+            // specialized instances of G, e.g., G<bit<32>>.
+            return;
+    }
+    // Find location where the specialization is to be inserted.
+    // This can be before a Parser, Control, or a toplevel instance declaration
+    const IR::Node* insert = findContext<IR::P4Parser>();
+    if (!insert)
+        insert = findContext<IR::P4Control>();
+    if (!insert)
+        insert = findContext<IR::Type_Declaration>();
+    if (!insert)
+        insert = findContext<IR::Declaration_Constant>();
+    if (!insert)
+        insert = findContext<IR::Declaration_Variable>();
+    CHECK_NULL(insert);
+    specMap->add(type, st, insert);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+
+const IR::Node* CreateSpecializedTypes::postorder(IR::Type_Declaration* type) {
+    for (auto it : specMap->map) {
+        if (it.second->declaration->name == type->name) {
+            auto specialized = it.first;
+            auto genDecl = type->to<IR::IMayBeGenericType>();
+            TypeVariableSubstitution ts;
+            ts.setBindings(type, genDecl->getTypeParameters(), specialized->arguments);
+            TypeSubstitutionVisitor tsv(specMap->typeMap, &ts);
+            auto renamed = type->apply(tsv)->to<IR::Type_StructLike>()->clone();
+            cstring name = it.second->name;
+            auto empty = new IR::TypeParameters();
+            renamed->name = name;
+            renamed->typeParameters = empty;
+            it.second->replacement = postorder(renamed)->to<IR::Type_StructLike>();
+            LOG3("Specializing " << dbp(type) << " with " << ts << " as " << dbp(renamed));
+        }
+    }
+    return insert(type);
+}
+
+const IR::Node* CreateSpecializedTypes::insert(const IR::Node* before) {
+    auto specs = specMap->getSpecializations(getOriginal());
+    if (specs == nullptr)
+        return before;
+    LOG2(specs->size() << " instantiations before " << dbp(before));
+    specs->push_back(before);
+    return specs;
+}
+
+const IR::Node* ReplaceTypeUses::postorder(IR::Type_Specialized* type) {
+    auto t = specMap->get(getOriginal<IR::Type_Specialized>());
+    if (!t)
+        return type;
+    CHECK_NULL(t->replacement);
+    LOG3("Replacing " << dbp(type) << " with " << dbp(t->replacement));
+    return t->replacement->getP4Type();
+}
+
+const IR::Node* ReplaceTypeUses::postorder(IR::StructExpression* expression) {
+    auto spec = getOriginal<IR::StructExpression>()->structType->to<IR::Type_Specialized>();
+    if (spec == nullptr)
+        return expression;
+    auto replacement = specMap->get(spec);
+    if (replacement == nullptr)
+        return expression;
+    auto replType = replacement->replacement;
+    LOG3("Replacing " << dbp(expression->structType) << " with " << dbp(replacement->replacement));
+    expression->structType = replType->getP4Type();
+    return expression;
+}
+
+}  // namespace P4

--- a/frontends/p4/specializeGenericTypes.cpp
+++ b/frontends/p4/specializeGenericTypes.cpp
@@ -73,7 +73,7 @@ namespace {
 
 class ContainsTypeVariable : public Inspector {
     bool contains = false;
-  public:
+ public:
     bool preorder(const IR::TypeParameters*) override { return false; }
     bool preorder(const IR::Type_Var*) override { contains = true; return false; }
     bool preorder(const IR::Type_Specialized*) override { contains = true; return false; }

--- a/frontends/p4/specializeGenericTypes.cpp
+++ b/frontends/p4/specializeGenericTypes.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "specializeGenericTypes.h"
+#include "frontends/p4/typeChecking/typeSubstitutionVisitor.h"
 
 namespace P4 {
 

--- a/frontends/p4/specializeGenericTypes.h
+++ b/frontends/p4/specializeGenericTypes.h
@@ -1,0 +1,176 @@
+/*
+Copyright 2020 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _FRONTENDS_P4_SPECIALIZEGENERICTYPES_H_
+#define _FRONTENDS_P4_SPECIALIZEGENERICTYPES_H_
+
+#include "ir/ir.h"
+#include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/p4/typeChecking/typeChecker.h"
+
+namespace P4 {
+
+struct TypeSpecialization : public IHasDbPrint {
+    /// Name to use for specialized type.
+    cstring name;
+    /// Type that is being specialized
+    const IR::Type_Specialized* specialized;
+    /// Declaration of specialized type, which will be replaced
+    const IR::Type_Declaration* declaration;
+    /// New synthesized type (created later)
+    const IR::Type_StructLike* replacement;
+    /// Insertion point
+    const IR::Node* insertion;
+    /// Save here the canonical types of the type arguments of 'specialized'.
+    /// The typeMap will be cleared, so we cannot look them up later.
+    const IR::Vector<IR::Type> *argumentTypes;
+
+    TypeSpecialization(cstring name, const IR::Type_Specialized* specialized,
+                       const IR::Type_Declaration* decl, const IR::Node* insertion,
+                       const IR::Vector<IR::Type>* argTypes):
+            name(name), specialized(specialized), declaration(decl), replacement(nullptr),
+            insertion(insertion), argumentTypes(argTypes) {
+        CHECK_NULL(specialized); CHECK_NULL(decl); CHECK_NULL(insertion); CHECK_NULL(argTypes);
+    }
+    void dbprint(std::ostream& out) const override
+    { out << "Specializing:" << dbp(specialized) << " from " << dbp(declaration)
+          << " as " << dbp(replacement) << " inserted at " << dbp(insertion); }
+};
+
+struct TypeSpecializationMap : public IHasDbPrint {
+    ReferenceMap* refMap;
+    TypeMap* typeMap;
+    // The map can have multiple keys pointing to the same value
+    ordered_map<const IR::Type_Specialized*, TypeSpecialization*> map;
+    // Keep track of the values in the above map which are already
+    // inserted in the program.
+    std::set<TypeSpecialization*> inserted;
+
+    void add(const IR::Type_Specialized* t, const IR::Type_StructLike* decl,
+             const IR::Node* insertion);
+    TypeSpecialization* get(const IR::Type_Specialized* t) const;
+    bool same(const TypeSpecialization* left, const IR::Type_Specialized* right) const;
+    void dbprint(std::ostream& out) const override {
+        for (auto it : map) { out << dbp(it.first) << " => " << it.second << std::endl; } }
+    IR::Vector<IR::Node>*
+    getSpecializations(const IR::Node* insertionPoint) {
+        IR::Vector<IR::Node>* result = nullptr;
+        for (auto s : map) {
+            if (inserted.find(s.second) != inserted.end())
+                continue;
+            if (s.second->insertion == insertionPoint) {
+                if (result == nullptr)
+                    result = new IR::Vector<IR::Node>();
+                LOG2("Will insert " << dbp(s.second->replacement) <<
+                     " before " << dbp(insertionPoint));
+                result->push_back(s.second->replacement);
+                inserted.emplace(s.second);
+            }
+        }
+        return result;
+    }
+};
+
+/**
+ * Find all generic type instantiations and their type arguments.
+ */
+class FindTypeSpecializations : public Inspector {
+    TypeSpecializationMap* specMap;
+ public:
+    explicit FindTypeSpecializations(TypeSpecializationMap* specMap) :
+            specMap(specMap) {
+        CHECK_NULL(specMap);
+        setName("FindTypeSpecializations");
+    }
+
+    void postorder(const IR::Type_Specialized* type) override;
+};
+
+/**
+ * For each generic type that is specialized with concrete arguments create a
+ * specialized type version and insert it in the program.
+ */
+class CreateSpecializedTypes : public Transform {
+    TypeSpecializationMap* specMap;
+ public:
+    explicit CreateSpecializedTypes(TypeSpecializationMap* specMap) :
+            specMap(specMap) {
+        CHECK_NULL(specMap);
+        setName("CreateSpecializedTypes");
+    }
+
+    const IR::Node* insert(const IR::Node* before);
+    //const IR::Node* postorder(IR::StructExpression* expression) override;
+    const IR::Node* postorder(IR::Type_Declaration* type) override;
+    const IR::Node* postorder(IR::Declaration* decl) override
+    { return insert(decl); }
+};
+
+/**
+ * Replace all uses of a specialized type with concrete arguments
+ * with the specialized version produced in the specialization map
+ */
+class ReplaceTypeUses : public Transform {
+    TypeSpecializationMap* specMap;
+
+ public:
+    explicit ReplaceTypeUses(TypeSpecializationMap* specMap): specMap(specMap) {
+        setName("ReplaceTypeUses"); CHECK_NULL(specMap); }
+    const IR::Node* postorder(IR::Type_Specialized* type) override;
+    const IR::Node* postorder(IR::StructExpression* expresison) override;
+};
+
+/**
+ * @brief Specializes each generic type by substituting type parameters.
+ *
+ * For example:
+ *
+```
+struct S<T> { T data; }
+S<bit<32>> s;
+```
+ *
+ * generates the following code:
+ *
+```
+struct S0 { bit<32> data; }
+S0 s;
+```
+ */
+class SpecializeGenericTypes : public PassRepeated {
+    TypeSpecializationMap specMap;
+ public:
+    SpecializeGenericTypes(ReferenceMap* refMap, TypeMap* typeMap) {
+        passes.emplace_back(new PassRepeated({
+                    new TypeChecking(refMap, typeMap),
+                    new FindTypeSpecializations(&specMap),
+                    new CreateSpecializedTypes(&specMap),
+                    // The previous pass has mutated some struct types
+                    new ClearTypeMap(typeMap, true),
+                }));
+        passes.emplace_back(new TypeChecking(refMap, typeMap));
+        passes.emplace_back(new ReplaceTypeUses(&specMap));
+        // The previous pass has invalidated the types of struct expressions
+        passes.emplace_back(new ClearTypeMap(typeMap, true));
+        specMap.refMap = refMap;
+        specMap.typeMap = typeMap;
+        setName("SpecializeGenericTypes");
+    }
+};
+
+}  // namespace P4
+
+#endif /* _FRONTENDS_P4_SPECIALIZEGENERICTYPES_H_ */

--- a/frontends/p4/specializeGenericTypes.h
+++ b/frontends/p4/specializeGenericTypes.h
@@ -113,7 +113,6 @@ class CreateSpecializedTypes : public Transform {
     }
 
     const IR::Node* insert(const IR::Node* before);
-    //const IR::Node* postorder(IR::StructExpression* expression) override;
     const IR::Node* postorder(IR::Type_Declaration* type) override;
     const IR::Node* postorder(IR::Declaration* decl) override
     { return insert(decl); }

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -493,6 +493,7 @@ bool ToP4::process(const IR::Type_StructLike* t, const char* name) {
         visit(t->annotations);
         builder.appendFormat("%s ", name); }
     builder.append(t->name);
+    visit(t->typeParameters);
     if (!isDeclaration)
         return false;
     builder.spc();
@@ -855,9 +856,9 @@ bool ToP4::preorder(const IR::NamedExpression* e) {
 bool ToP4::preorder(const IR::StructExpression* e) {
     if (expressionPrecedence > DBPrint::Prec_Prefix)
         builder.append("(");
-    if (e->typeName != nullptr) {
+    if (e->structType != nullptr) {
         builder.append("(");
-        visit(e->typeName);
+        visit(e->structType);
         builder.append(")");
     }
     builder.append("{");

--- a/frontends/p4/typeChecking/bindVariables.h
+++ b/frontends/p4/typeChecking/bindVariables.h
@@ -37,7 +37,7 @@ class BindTypeVariables : public PassManager {
         passes.push_back(new ResolveReferences(refMap));
         passes.push_back(new TypeInference(refMap, typeMap, false));  // may insert casts
         passes.push_back(new DoBindTypeVariables(typeMap));
-        passes.push_back(new ClearTypeMap(typeMap));
+        passes.push_back(new ClearTypeMap(typeMap, true));
         setName("BindTypeVariables");
     }
 };

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -186,9 +186,6 @@ void TypeInference::setType(const IR::Node* element, const IR::Type* type) {
 }
 
 void TypeInference::addSubstitutions(const TypeVariableSubstitution* tvs) {
-    if (readOnly)
-        // we only need to do this the first time
-        return;
     typeMap->addSubstitutions(tvs);
 }
 

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1434,7 +1434,9 @@ const IR::Node* TypeInference::postorder(IR::Type_Stack* type) {
     if (etype == nullptr)
         return type;
 
-    if (!etype->is<IR::Type_Header>() && !etype->is<IR::Type_HeaderUnion>())
+    if (!etype->is<IR::Type_Header>() && !etype->is<IR::Type_HeaderUnion>() &&
+        // experimental: generic stacks
+        !etype->is<IR::Type_SpecializedCanonical>())
         typeError("Header stack %1% used with non-header type %2%",
                   type, etype->toString());
     return type;
@@ -1483,7 +1485,9 @@ const IR::Node* TypeInference::postorder(IR::Type_Header* type) {
                // Nested bit-vector struct inside a Header is supported
                // Experimental feature - see Issue 383.
                (t->is<IR::Type_Struct>() && onlyBitsOrBitStructs(t)) ||
-               t->is<IR::Type_SerEnum>() || t->is<IR::Type_Boolean>(); };
+               t->is<IR::Type_SerEnum>() || t->is<IR::Type_Boolean>() ||
+                // experimental: generic headers
+                t->is<IR::Type_Var>() || t->is<IR::Type_SpecializedCanonical>(); };
     validateFields(canon, validator);
     return type;
 }
@@ -1499,6 +1503,7 @@ const IR::Node* TypeInference::postorder(IR::Type_Struct* type) {
         t->is<IR::Type_Boolean>() || t->is<IR::Type_Stack>() ||
         t->is<IR::Type_Varbits>() || t->is<IR::Type_ActionEnum>() ||
         t->is<IR::Type_Tuple>() || t->is<IR::Type_SerEnum>() ||
+                // experimental: generic structs
         t->is<IR::Type_Var>() || t->is<IR::Type_SpecializedCanonical>(); };
     (void)validateFields(canon, validator);
     return type;
@@ -1506,7 +1511,9 @@ const IR::Node* TypeInference::postorder(IR::Type_Struct* type) {
 
 const IR::Node* TypeInference::postorder(IR::Type_HeaderUnion *type) {
     auto canon = setTypeType(type);
-    auto validator = [] (const IR::Type* t) { return t->is<IR::Type_Header>(); };
+    auto validator = [] (const IR::Type* t) { return t->is<IR::Type_Header>() ||
+                // experimental: generic unions
+        t->is<IR::Type_Var>() || t->is<IR::Type_SpecializedCanonical>(); };
     (void)validateFields(canon, validator);
     return type;
 }

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -29,17 +29,22 @@ limitations under the License.
 
 namespace P4 {
 
-// This pass only clears the typeMap if the program has changed.
+// This pass only clears the typeMap if the program has changed
+// or the 'force' flag is set.
 // This is needed if the types of some objects in the program change.
 class ClearTypeMap : public Inspector {
     TypeMap* typeMap;
+    bool     force;
  public:
-    explicit ClearTypeMap(TypeMap* typeMap) :
-            typeMap(typeMap) { CHECK_NULL(typeMap); }
+    explicit ClearTypeMap(TypeMap* typeMap, bool force = false) :
+            typeMap(typeMap), force(force) { CHECK_NULL(typeMap); }
     bool preorder(const IR::P4Program* program) override {
         // Clear map only if program has not changed from last time
-        // otherwise we can reuse it
-        if (!typeMap->checkMap(program))
+        // otherwise we can reuse it.  The 'force' flag is needed
+        // because the program is saved only *after* typechecking,
+        // so if the program changes during type-checking, the
+        // typeMap may not be complete.
+        if (force || !typeMap->checkMap(program))
             typeMap->clear();
         return false;  // prune()
     }

--- a/frontends/p4/typeChecking/typeConstraints.h
+++ b/frontends/p4/typeChecking/typeConstraints.h
@@ -146,6 +146,7 @@ class TypeConstraint : public IHasDbPrint {
             }
             o = constraint->origin;
             constraint = constraint->derivedFrom;
+
         }
         // Indent each string in the message
         std::string s = message.c_str();

--- a/frontends/p4/typeChecking/typeConstraints.h
+++ b/frontends/p4/typeChecking/typeConstraints.h
@@ -146,7 +146,6 @@ class TypeConstraint : public IHasDbPrint {
             }
             o = constraint->origin;
             constraint = constraint->derivedFrom;
-
         }
         // Indent each string in the message
         std::string s = message.c_str();

--- a/frontends/p4/typeChecking/typeSubstitutionVisitor.h
+++ b/frontends/p4/typeChecking/typeSubstitutionVisitor.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "ir/ir.h"
 #include "typeSubstitution.h"
+#include "frontends/p4/typeMap.h"
 
 namespace P4 {
 
@@ -55,6 +56,26 @@ class TypeVariableSubstitutionVisitor : public Transform {
     { return replacement(getOriginal<IR::Type_Var>(), tv); }
     const IR::Node* preorder(IR::Type_InfInt* ti) override
     { return replacement(getOriginal<IR::Type_InfInt>(), ti); }
+};
+
+class TypeSubstitutionVisitor : public TypeVariableSubstitutionVisitor {
+    TypeMap* typeMap;
+
+ public:
+    TypeSubstitutionVisitor(TypeMap* typeMap, TypeVariableSubstitution* ts) :
+            TypeVariableSubstitutionVisitor(ts), typeMap(typeMap) {
+        CHECK_NULL(typeMap); setName("TypeSubstitutionVisitor"); }
+    const IR::Node* postorder(IR::PathExpression* path) override {
+        // We want fresh nodes for variables, etc.
+        return new IR::PathExpression(path->path->clone()); }
+    const IR::Node* postorder(IR::Type_Name* type) override {
+        auto actual = typeMap->getTypeType(getOriginal<IR::Type_Name>(), true);
+        if (auto tv = actual->to<IR::ITypeVar>()) {
+            LOG3("Replacing " << tv);
+            return replacement(tv, type);
+        }
+        return type;
+    }
 };
 
 }  // namespace P4

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -228,7 +228,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %type<IR::Direction>        direction
 %type<IR::Path*>            prefixedNonTypeName prefixedType
 %type<IR::IndexedVector<IR::Type_Var>*>  typeParameterList
-%type<IR::TypeParameters*>  optTypeParameters
+%type<IR::TypeParameters*>  optTypeParameters typeParameters
 %type<IR::Expression*>      expression lvalue keysetExpression selectExpression
                             stateExpression optInitializer initializer
                             simpleKeysetExpression transitionStatement switchLabel
@@ -1001,7 +1001,11 @@ typeOrVoid
 
 optTypeParameters
     : /* empty */               { $$ = new IR::TypeParameters(); }
-    | l_angle typeParameterList r_angle { $$ = new IR::TypeParameters(@1+@3, *$2); }
+    | typeParameters            { $$ = $1; }
+    ;
+
+typeParameters
+    : l_angle typeParameterList r_angle { $$ = new IR::TypeParameters(@1+@3, *$2); }
     ;
 
 typeParameterList
@@ -1056,18 +1060,36 @@ headerTypeDeclaration
     : optAnnotations
         HEADER name { driver.structure->declareType(*$3); }
         "{" structFieldList "}" { $$ = new IR::Type_Header(@3, *$3, $1, *$6); }
+    | optAnnotations  // experimental
+        HEADER name typeParameters { driver.structure->declareType(*$3);
+                                     driver.structure->markAsTemplate(*$3);
+                                     driver.structure->declareTypes(&$4->parameters); }
+        "{" structFieldList "}" { $$ = new IR::Type_Header(@3, *$3, $1, $4, *$7);
+                                  driver.structure->pop(); }
     ;
 
 structTypeDeclaration
     : optAnnotations
         STRUCT name { driver.structure->declareType(*$3); }
         "{" structFieldList "}" { $$ = new IR::Type_Struct(@3, *$3, $1, *$6); }
+    | optAnnotations  // experimental
+        STRUCT name typeParameters { driver.structure->pushContainerType(*$3, true);
+                                     driver.structure->markAsTemplate(*$3);
+                                     driver.structure->declareTypes(&$4->parameters); }
+        "{" structFieldList "}" { $$ = new IR::Type_Struct(@3, *$3, $1, $4, *$7);
+                                  driver.structure->pop(); }
     ;
 
 headerUnionDeclaration
     : optAnnotations
         HEADER_UNION name { driver.structure->declareType(*$3); }
         "{" structFieldList "}" { $$ = new IR::Type_HeaderUnion(@3, *$3, $1, *$6); }
+    | optAnnotations  // experimental
+        HEADER_UNION name typeParameters { driver.structure->declareType(*$3);
+                                     driver.structure->markAsTemplate(*$3);
+                                     driver.structure->declareTypes(&$4->parameters); }
+        "{" structFieldList "}" { $$ = new IR::Type_HeaderUnion(@3, *$3, $1, $4, *$7);
+                                  driver.structure->pop(); }
     ;
 
 structFieldList

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -302,9 +302,9 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %type<IR::Vector<IR::Expression>*> strList
 %type<IR::Expression*> intOrStr
 
-%left COMMA
-%nonassoc QUESTION
-%nonassoc COLON
+// %precedence COMMA
+%precedence QUESTION
+%precedence COLON
 %left OR
 %left AND
 %left EQ NE
@@ -315,9 +315,9 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %left SHL R_ANGLE_SHIFT
 %left PP PLUS MINUS PLUS_SAT MINUS_SAT
 %left MUL DIV MOD
-%right PREFIX
-%nonassoc R_BRACKET L_PAREN L_BRACKET L_ANGLE_ARGS
-%left DOT
+%precedence PREFIX
+%precedence R_BRACKET L_PAREN L_BRACKET L_ANGLE_ARGS
+%precedence DOT
 
 %right THEN ELSE /* THEN is a fake token */
 
@@ -426,7 +426,7 @@ p4rtControllerType
 program : input END { YYACCEPT; };
 
 input
-    : /* epsilon */
+    : %empty
     | input declaration  { if ($2) driver.nodes->push_back($2->getNode()); }
     | input ";"          {}   // empty declaration
     ;
@@ -468,12 +468,12 @@ nonTableKwName
     ;
 
 optCONST
-    : /* empty */ { $$ = OptionalConst{false}; }
+    : %empty      { $$ = OptionalConst{false}; }
     | CONST       { $$ = OptionalConst{true}; }
     ;
 
 optAnnotations
-    : /* empty */ { $$ = IR::Annotations::empty; }
+    : %empty      { $$ = IR::Annotations::empty; }
     | annotations { $$ = new IR::Annotations(@1, *$1); }
     ;
 
@@ -507,8 +507,7 @@ annotation
     ;
 
 annotationBody
-    : /* empty */
-        { $$ = new IR::Vector<IR::AnnotationToken>; }
+    : %empty  { $$ = new IR::Vector<IR::AnnotationToken>; }
     | annotationBody "(" annotationBody ")"
         { $$ = $1;
           $$->push_back(new IR::AnnotationToken(@2, $2.type, $2.text));
@@ -630,8 +629,8 @@ kvPair
     ;
 
 parameterList
-    : /* empty */                        { $$ = new IR::IndexedVector<IR::Parameter>(); }
-    | nonEmptyParameterList              { $$ = $1; }
+    : %empty                          { $$ = new IR::IndexedVector<IR::Parameter>(); }
+    | nonEmptyParameterList           { $$ = $1; }
     ;
 
 nonEmptyParameterList
@@ -649,7 +648,7 @@ direction
     : IN           { $$ = IR::Direction::In; }
     | OUT          { $$ = IR::Direction::Out; }
     | INOUT        { $$ = IR::Direction::InOut; }
-    | /* empty */  { $$ = IR::Direction::None; }
+    | %empty       { $$ = IR::Direction::None; }
     ;
 
 packageTypeDeclaration
@@ -690,7 +689,7 @@ objInitializer
     ;
 
 objDeclarations
-    : /* empty */                    { $$ = new IR::IndexedVector<IR::StatOrDecl>(); }
+    : %empty                         { $$ = new IR::IndexedVector<IR::StatOrDecl>(); }
     | objDeclarations objDeclaration { $$ = $1; $1->push_back($2); }
     ;
 
@@ -700,7 +699,7 @@ objDeclaration
     ;
 
 optConstructorParameters
-    : /* empty */            { $$ = new IR::IndexedVector<IR::Parameter>(); }
+    : %empty                 { $$ = new IR::IndexedVector<IR::Parameter>(); }
     | "(" parameterList ")"  { $$ = $2; }
     ;
 
@@ -720,7 +719,7 @@ parserDeclaration
     ;
 
 parserLocalElements
-    : /* empty */                     { $$ = new IR::IndexedVector<IR::Declaration>(); }
+    : %empty                                 { $$ = new IR::IndexedVector<IR::Declaration>(); }
     | parserLocalElements parserLocalElement { $$ = $1; $$->push_back($2); }
     ;
 
@@ -755,7 +754,7 @@ parserState
     ;
 
 parserStatements
-    : /* empty */                      { $$ = new IR::IndexedVector<IR::StatOrDecl>(); }
+    : %empty                           { $$ = new IR::IndexedVector<IR::StatOrDecl>(); }
     | parserStatements parserStatement { $$ = $1; $1->push_back($2); }
     ;
 
@@ -775,7 +774,7 @@ parserBlockStatement
     ;
 
 transitionStatement
-    : /* empty */                 { $$ = nullptr; }
+    : %empty                      { $$ = nullptr; }
     | TRANSITION stateExpression  { $$ = $2; }
     ;
 
@@ -791,7 +790,7 @@ selectExpression
     ;
 
 selectCaseList
-    : /* empty */                { $$ = new IR::Vector<IR::SelectCase>(); }
+    : %empty                     { $$ = new IR::Vector<IR::SelectCase>(); }
     | selectCaseList selectCase  { $$ = $1; $$->push_back($2); }
     ;
 
@@ -866,7 +865,7 @@ controlTypeDeclaration
     ;
 
 controlLocalDeclarations
-    : /* empty */               { $$ = new IR::IndexedVector<IR::Declaration>(); }
+    : %empty { $$ = new IR::IndexedVector<IR::Declaration>(); }
     | controlLocalDeclarations controlLocalDeclaration { $$ = $1; $$->push_back($2); }
     ;
 
@@ -903,7 +902,7 @@ externDeclaration
     ;
 
 methodPrototypes
-    : /* empty */                      { $$ = new IR::Vector<IR::Method>(); }
+    : %empty                           { $$ = new IR::Vector<IR::Method>(); }
     | methodPrototypes methodPrototype { $$ = $1; $1->push_back($2); }
     ;
 
@@ -964,7 +963,8 @@ tupleType
     ;
 
 headerStackType
-    : typeName "[" expression "]"       { $$ = new IR::Type_Stack(@1+@4, $1, $3); }
+    : typeName "[" expression "]"         { $$ = new IR::Type_Stack(@1+@4, $1, $3); }
+    | specializedType "[" expression "]"  { $$ = new IR::Type_Stack(@1+@4, $1, $3); }
     ;
 
 specializedType
@@ -1000,7 +1000,7 @@ typeOrVoid
     ;
 
 optTypeParameters
-    : /* empty */               { $$ = new IR::TypeParameters(); }
+    : %empty                    { $$ = new IR::TypeParameters(); }
     | typeParameters            { $$ = $1; }
     ;
 
@@ -1023,7 +1023,7 @@ typeArg
     ;
 
 typeArgumentList
-    : /* empty */                    { $$ = new IR::Vector<IR::Type>(); }
+    : %empty                         { $$ = new IR::Vector<IR::Type>(); }
     | typeArg                        { $$ = new IR::Vector<IR::Type>(); $$->push_back($1); }
     | typeArgumentList "," typeArg   { $$ = $1; $$->push_back($3); }
     ;
@@ -1057,43 +1057,34 @@ derivedTypeDeclaration
     ;
 
 headerTypeDeclaration
-    : optAnnotations
-        HEADER name { driver.structure->declareType(*$3); }
-        "{" structFieldList "}" { $$ = new IR::Type_Header(@3, *$3, $1, *$6); }
-    | optAnnotations  // experimental
-        HEADER name typeParameters { driver.structure->declareType(*$3);
-                                     driver.structure->markAsTemplate(*$3);
-                                     driver.structure->declareTypes(&$4->parameters); }
-        "{" structFieldList "}" { $$ = new IR::Type_Header(@3, *$3, $1, $4, *$7);
-                                  driver.structure->pop(); }
+    : optAnnotations HEADER name { driver.structure->pushContainerType(*$3, true); } optTypeParameters {
+        // type parameters are experimental
+        driver.structure->markAsTemplate(*$3);
+        driver.structure->declareTypes(&$5->parameters); }
+      "{" structFieldList "}" { $$ = new IR::Type_Header(@3, *$3, $1, $5, *$8);
+                                driver.structure->pop(); }
     ;
 
 structTypeDeclaration
-    : optAnnotations
-        STRUCT name { driver.structure->declareType(*$3); }
-        "{" structFieldList "}" { $$ = new IR::Type_Struct(@3, *$3, $1, *$6); }
-    | optAnnotations  // experimental
-        STRUCT name typeParameters { driver.structure->pushContainerType(*$3, true);
-                                     driver.structure->markAsTemplate(*$3);
-                                     driver.structure->declareTypes(&$4->parameters); }
-        "{" structFieldList "}" { $$ = new IR::Type_Struct(@3, *$3, $1, $4, *$7);
-                                  driver.structure->pop(); }
+    : optAnnotations STRUCT name  { driver.structure->pushContainerType(*$3, true); } optTypeParameters {
+        // type parameters are experimental
+        driver.structure->markAsTemplate(*$3);
+        driver.structure->declareTypes(&$5->parameters); }
+      "{" structFieldList "}" { $$ = new IR::Type_Struct(@3, *$3, $1, $5, *$8);
+                                driver.structure->pop(); }
     ;
 
 headerUnionDeclaration
-    : optAnnotations
-        HEADER_UNION name { driver.structure->declareType(*$3); }
-        "{" structFieldList "}" { $$ = new IR::Type_HeaderUnion(@3, *$3, $1, *$6); }
-    | optAnnotations  // experimental
-        HEADER_UNION name typeParameters { driver.structure->declareType(*$3);
-                                     driver.structure->markAsTemplate(*$3);
-                                     driver.structure->declareTypes(&$4->parameters); }
-        "{" structFieldList "}" { $$ = new IR::Type_HeaderUnion(@3, *$3, $1, $4, *$7);
-                                  driver.structure->pop(); }
+    : optAnnotations HEADER_UNION name { driver.structure->pushContainerType(*$3, true); } optTypeParameters {
+        // type parameters are experimental
+        driver.structure->markAsTemplate(*$3);
+        driver.structure->declareTypes(&$5->parameters); }
+      "{" structFieldList "}" { $$ = new IR::Type_HeaderUnion(@3, *$3, $1, $5, *$8);
+                                driver.structure->pop(); }
     ;
 
 structFieldList
-    : /* empty */                      { $$ = new IR::IndexedVector<IR::StructField>(); }
+    : %empty                           { $$ = new IR::IndexedVector<IR::StructField>(); }
     | structFieldList structField      { $$ = $1; $1->push_back($2); }
     ;
 
@@ -1214,7 +1205,7 @@ blockStatement
     ;
 
 statOrDeclList
-    : /* empty */                           { $$ = new IR::IndexedVector<IR::StatOrDecl>(); }
+    : %empty                                { $$ = new IR::IndexedVector<IR::StatOrDecl>(); }
     | statOrDeclList statementOrDeclaration { $$ = $1; $$->push_back($2); }
     ;
 
@@ -1224,7 +1215,7 @@ switchStatement
     ;
 
 switchCases
-    : /* empty */              { $$ = new IR::Vector<IR::SwitchCase>(); }
+    : %empty                   { $$ = new IR::Vector<IR::SwitchCase>(); }
     | switchCases switchCase   { $$ = $1; $$->push_back($2); }
     ;
 
@@ -1279,7 +1270,7 @@ tableProperty
     ;
 
 keyElementList
-    : /* empty */                        { $$ = new IR::Vector<IR::KeyElement>(); }
+    : %empty                             { $$ = new IR::Vector<IR::KeyElement>(); }
     | keyElementList keyElement          { $$ = $1; $$->push_back($2); }
     ;
 
@@ -1290,7 +1281,7 @@ keyElement
     ;
 
 actionList
-    : /* empty */                        { $$ = new IR::IndexedVector<IR::ActionListElement>(); }
+    : %empty { $$ = new IR::IndexedVector<IR::ActionListElement>(); }
     | actionList optAnnotations actionRef ";"
         { $$ = $1; $$->push_back(new IR::ActionListElement(@3, $2, $3)); }
     ;
@@ -1347,7 +1338,7 @@ constantDeclaration
     ;
 
 optInitializer
-    : /* empty */                      { $$ = nullptr; }
+    : %empty                           { $$ = nullptr; }
     | "=" initializer                  { $$ = $2; }
     ;
 
@@ -1364,7 +1355,7 @@ functionDeclaration
     ;
 
 argumentList
-    : /* empty */                        { $$ = new IR::Vector<IR::Argument>(); }
+    : %empty                             { $$ = new IR::Vector<IR::Argument>(); }
     | nonEmptyArgList                    { $$ = $1; }
     ;
 
@@ -1381,7 +1372,7 @@ argument
     ;
 
 expressionList
-    : /* empty */                        { $$ = new IR::Vector<IR::Expression>(); }
+    : %empty                             { $$ = new IR::Vector<IR::Expression>(); }
     | expression                         { $$ = new IR::Vector<IR::Expression>();
                                            $$->push_back($1); }
     | expressionList "," expression      { $$ = $1; $$->push_back($3); }
@@ -1417,7 +1408,7 @@ expression
     | expression "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
     | "{" expressionList "}"             { $$ = new IR::ListExpression(@1 + @3, *$2); }
     | "{" kvList "}"                     { $$ = new IR::StructExpression(
-                                                  @1 + @3, IR::Type::Unknown::get(), (IR::Type_Name*)nullptr, *$2); }  // experimental
+                                                  @1 + @3, IR::Type::Unknown::get(), (IR::Type_Name*)nullptr, *$2); }
     | "(" expression ")"                 { $$ = $2; }
     | "!" expression %prec PREFIX        { $$ = new IR::LNot(@1 + @2, $2); }
     | "~" expression %prec PREFIX        { $$ = new IR::Cmpl(@1 + @2, $2); }

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -421,9 +421,14 @@ class ListExpression : Expression {
 class StructExpression : Expression {
     /// The struct or header type that is being intialized.
     /// May only be known after type checking; so it can be nullptr.
-    NullOK optional Type_Name typeName;
+    NullOK Type structType;
     inline IndexedVector<NamedExpression> components;
-    validate { components.check_null(); components.validate(); }
+    validate {
+        components.check_null(); components.validate();
+        BUG_CHECK(structType == nullptr || structType->is<IR::Type_Name>() ||
+                  structType->is<IR::Type_Specialized>(),
+                  "%1%: unexpected struct type", this);
+    }
     size_t size() const { return components.size(); }
 }
 

--- a/ir/node.cpp
+++ b/ir/node.cpp
@@ -62,7 +62,8 @@ cstring IR::dbp(const IR::INode* node) {
                    node->is<IR::TypeNameExpression>() ||
                    node->is<IR::Constant>() ||
                    node->is<IR::Type_Name>() ||
-                   node->is<IR::Type_Base>()) {
+                   node->is<IR::Type_Base>() ||
+                   node->is<IR::Type_Specialized>()) {
             node->getNode()->Node::dbprint(str);
             str << " " << node->toString();
         } else {

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -205,7 +205,12 @@ const Type* Type_SpecializedCanonical::getP4Type() const {
         auto at = a->getP4Type();
         args->push_back(at);
     }
-    return new IR::Type_Specialized(srcInfo, baseType->getP4Type()->to<IR::Type_Name>(), args);
+    auto bt = baseType->getP4Type();
+    if (auto tn = bt->to<IR::Type_Name>())
+        return new IR::Type_Specialized(srcInfo, tn, args);
+    auto st = baseType->to<IR::Type_StructLike>();
+    BUG_CHECK(st != nullptr, "%1%: expected a struct", baseType);
+    return new IR::Type_Specialized(srcInfo, new IR::Type_Name(st->getName()), args);
 }
 
 }  // namespace IR

--- a/ir/type.def
+++ b/ir/type.def
@@ -241,11 +241,14 @@ class StructField : Declaration, IAnnotated {
     Annotations getAnnotations() const override { return annotations; }
 }
 
-abstract Type_StructLike : Type_Declaration, ISimpleNamespace, IAnnotated {
+abstract Type_StructLike : Type_Declaration, INestedNamespace, ISimpleNamespace, IAnnotated, IMayBeGenericType {
     static const cstring minSizeInBits;
     static const cstring minSizeInBytes;
-    optional Annotations                        annotations = Annotations::empty;
+    optional Annotations annotations = Annotations::empty;
+    optional TypeParameters typeParameters = new TypeParameters();
     optional inline IndexedVector<StructField>  fields;
+    TypeParameters getTypeParameters() const override { return typeParameters; }
+    std::vector<INamespace> getNestedNamespaces() const override { return { typeParameters }; }
     Annotations getAnnotations() const override { return annotations; }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
         return fields.getDeclarations(); }

--- a/testdata/p4_16_errors_outputs/generic1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/generic1_e.p4-stderr
@@ -7,7 +7,7 @@ control p2(If<int<32>, int<32>> x) // too many type parameters
 generic1_e.p4(16)
 extern If<T>
        ^^
-generic1_e.p4(36): [--Werror=type-error] error: h<...>: Type header h is not generic and thus it cannot be specialized using type arguments
+generic1_e.p4(36): [--Werror=type-error] error: h<...>: Type header h has 0 type parameter(s), but it is specialized with 1
         h<bit> x; // no type parameter
         ^^^^^^
 generic1_e.p4(31)

--- a/testdata/p4_16_errors_outputs/header2_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header2_e.p4-stderr
@@ -1,15 +1,15 @@
-header2_e.p4(27): [--Werror=type-error] error: Field field of struct s1 cannot have type parser p
+header2_e.p4(27): [--Werror=type-error] error: Field 'field' of 'struct s1' cannot have type 'parser p'
     p field; // no functor-typed fields allowed
       ^^^^^
 header2_e.p4(23)
 parser p();
        ^
-header2_e.p4(32): [--Werror=type-error] error: Field field of header_union u cannot have type struct s
+header2_e.p4(32): [--Werror=type-error] error: Field 'field' of 'header_union u' cannot have type 'struct s'
    s field; // no struct field allowed in header_union
      ^^^^^
 header2_e.p4(16)
 struct s {}
        ^
-header2_e.p4(33): [--Werror=type-error] error: Field field1 of header_union u cannot have type bit<1>
+header2_e.p4(33): [--Werror=type-error] error: Field 'field1' of 'header_union u' cannot have type 'bit<1>'
    bit field1; // no non-header field allowed in header_union
        ^^^^^^

--- a/testdata/p4_16_errors_outputs/header3.p4-stderr
+++ b/testdata/p4_16_errors_outputs/header3.p4-stderr
@@ -1,4 +1,4 @@
-header3.p4(18): [--Werror=type-error] error: Field field1 of header H cannot have type Tuple(2)
+header3.p4(18): [--Werror=type-error] error: Field 'field1' of 'header H' cannot have type 'Tuple(2)'
     tuple<bit, bit> field1; // tuples not allowed in header
                     ^^^^^^
 header3.p4(18)

--- a/testdata/p4_16_errors_outputs/issue2230-1-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2230-1-bmv2.p4-stderr
@@ -19,9 +19,13 @@ issue2230-1-bmv2.p4(82)
   control myCtrl(inout h2_t h2, inout s2_t s2)
                                            ^^
 issue2230-1-bmv2.p4(43)
-struct s2_t {
-       ^^^^
-issue2230-1-bmv2.p4(137): [--Werror=type-error] error: funky_swap: Cannot unify struct s1_t with struct s2_t
+  struct s2_t {
+         ^^^^
+  ---- Originating from:
+issue2230-1-bmv2.p4(115): Function type 'myCtrl' does not match invocation type '<Method call>'
+          c1.apply(hdr.h1, s1);
+          ^^^^^^^^^^^^^^^^^^^^
+issue2230-1-bmv2.p4(137): [--Werror=type-error] error: funky_swap
         s1 = funky_swap(s1);
              ^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2230-1-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2230-1-bmv2.p4-stderr
@@ -19,13 +19,9 @@ issue2230-1-bmv2.p4(82)
   control myCtrl(inout h2_t h2, inout s2_t s2)
                                            ^^
 issue2230-1-bmv2.p4(43)
-  struct s2_t {
-         ^^^^
-  ---- Originating from:
-issue2230-1-bmv2.p4(115): Function type 'myCtrl' does not match invocation type '<Method call>'
-          c1.apply(hdr.h1, s1);
-          ^^^^^^^^^^^^^^^^^^^^
-issue2230-1-bmv2.p4(137): [--Werror=type-error] error: funky_swap
+struct s2_t {
+       ^^^^
+issue2230-1-bmv2.p4(137): [--Werror=type-error] error: funky_swap: Cannot unify struct s1_t with struct s2_t
         s1 = funky_swap(s1);
              ^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2230.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2230.p4-stderr
@@ -1,4 +1,4 @@
-issue2230.p4(70): [--Werror=type-error] error: AssignmentStatement: Cannot unify header h1_t with header h2_t
+issue2230.p4(70): [--Werror=type-error] error: AssignmentStatement
         hdr.h2 = hdr.h1;
                ^
   ---- Actual error:
@@ -16,9 +16,9 @@ issue2230.p4(28)
   header h1_t {
          ^^^^
 issue2230.p4(33)
-header h2_t {
-       ^^^^
-issue2230.p4(74): [--Werror=type-error] error: AssignmentStatement: Cannot unify struct s1_t with header h1_t
+  header h2_t {
+         ^^^^
+issue2230.p4(74): [--Werror=type-error] error: AssignmentStatement
         hdr.h1b = s1;
                 ^
   ---- Actual error:
@@ -36,9 +36,9 @@ issue2230.p4(38)
   struct s1_t {
          ^^^^
 issue2230.p4(28)
-header h1_t {
-       ^^^^
-issue2230.p4(80): [--Werror=type-error] error: AssignmentStatement: Cannot unify header h1_t with struct s1_t
+  header h1_t {
+         ^^^^
+issue2230.p4(80): [--Werror=type-error] error: AssignmentStatement
         s1 = hdr.h1;
            ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2230.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2230.p4-stderr
@@ -1,4 +1,4 @@
-issue2230.p4(70): [--Werror=type-error] error: AssignmentStatement
+issue2230.p4(70): [--Werror=type-error] error: AssignmentStatement: Cannot unify header h1_t with header h2_t
         hdr.h2 = hdr.h1;
                ^
   ---- Actual error:
@@ -16,9 +16,9 @@ issue2230.p4(28)
   header h1_t {
          ^^^^
 issue2230.p4(33)
-  header h2_t {
-         ^^^^
-issue2230.p4(74): [--Werror=type-error] error: AssignmentStatement
+header h2_t {
+       ^^^^
+issue2230.p4(74): [--Werror=type-error] error: AssignmentStatement: Cannot unify struct s1_t with header h1_t
         hdr.h1b = s1;
                 ^
   ---- Actual error:
@@ -36,9 +36,9 @@ issue2230.p4(38)
   struct s1_t {
          ^^^^
 issue2230.p4(28)
-  header h1_t {
-         ^^^^
-issue2230.p4(80): [--Werror=type-error] error: AssignmentStatement
+header h1_t {
+       ^^^^
+issue2230.p4(80): [--Werror=type-error] error: AssignmentStatement: Cannot unify header h1_t with struct s1_t
         s1 = hdr.h1;
            ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2290.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2290.p4-stderr
@@ -1,4 +1,4 @@
-issue2290.p4(16): [--Werror=type-error] error: Field s of header nested_header cannot have type header simple_header
+issue2290.p4(16): [--Werror=type-error] error: Field 's' of 'header nested_header' cannot have type 'header simple_header'
     simple_header s;
                   ^
 issue2290.p4(11)

--- a/testdata/p4_16_errors_outputs/issue407-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue407-1.p4-stderr
@@ -16,7 +16,7 @@ issue407-1.p4(50): [--Werror=type-error] error: Field 'x10' of 'header H' cannot
 issue407-1.p4(38)
 header Ethernet_h {
        ^^^^^^^^^^
-issue407-1.p4(51): [--Werror=type-error] error: Field 'x11' of 'header H' cannot have type 'header Ethernet_h[]'
+issue407-1.p4(51): [--Werror=type-error] error: Field 'x11' of 'header H' cannot have type 'header Ethernet_h[4]'
     Ethernet_h[4] x11;
                   ^^^
 issue407-1.p4(51)

--- a/testdata/p4_16_errors_outputs/issue407-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue407-1.p4-stderr
@@ -1,28 +1,28 @@
-issue407-1.p4(47): [--Werror=type-error] error: Field x7 of header H cannot have type error
+issue407-1.p4(47): [--Werror=type-error] error: Field 'x7' of 'header H' cannot have type 'error'
     error x7;
           ^^
 core.p4(23)
 error {
 ^
-issue407-1.p4(49): [--Werror=type-error] error: Field x9 of header H cannot have type myenum1
+issue407-1.p4(49): [--Werror=type-error] error: Field 'x9' of 'header H' cannot have type 'myenum1'
     myenum1 x9;
             ^^
 issue407-1.p4(32)
 enum myenum1 {
      ^^^^^^^
-issue407-1.p4(50): [--Werror=type-error] error: Field x10 of header H cannot have type header Ethernet_h
+issue407-1.p4(50): [--Werror=type-error] error: Field 'x10' of 'header H' cannot have type 'header Ethernet_h'
     Ethernet_h x10;
                ^^^
 issue407-1.p4(38)
 header Ethernet_h {
        ^^^^^^^^^^
-issue407-1.p4(51): [--Werror=type-error] error: Field x11 of header H cannot have type header Ethernet_h[4]
+issue407-1.p4(51): [--Werror=type-error] error: Field 'x11' of 'header H' cannot have type 'header Ethernet_h[]'
     Ethernet_h[4] x11;
                   ^^^
 issue407-1.p4(51)
     Ethernet_h[4] x11;
     ^^^^^^^^^^^^^
-issue407-1.p4(54): [--Werror=type-error] error: Field x14 of header H cannot have type Tuple(2)
+issue407-1.p4(54): [--Werror=type-error] error: Field 'x14' of 'header H' cannot have type 'Tuple(2)'
     myTuple0 x14;
              ^^^
 issue407-1.p4(44)

--- a/testdata/p4_16_errors_outputs/string-e1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/string-e1.p4-stderr
@@ -1,4 +1,4 @@
-string-e1.p4(2): [--Werror=type-error] error: Field s of struct S cannot have type string
+string-e1.p4(2): [--Werror=type-error] error: Field 's' of 'struct S' cannot have type 'string'
     string s;
            ^
 string-e1.p4(7): [--Werror=type-error] error: v: Cannot declare variables with type string

--- a/testdata/p4_16_samples/generic-struct.p4
+++ b/testdata/p4_16_samples/generic-struct.p4
@@ -1,0 +1,82 @@
+struct Header<St> {
+    St data;
+    bit valid;
+}
+
+#if STACK
+Header<St>[10] stack;
+
+typedef Header<St>[10] Stack;
+#endif
+
+struct S {
+    bit<32> b;
+}
+
+struct U {
+    Header<S> f;
+}
+
+const U u = { f = { data = { b = 10 }, valid = 1 } };
+
+struct H2<G> {
+    Header<G> g;
+    bit invalid;
+}
+
+struct H4<T> {
+    T x;
+}
+
+const Header<S> h2 = (Header<S>){
+    data = { b = 0 },
+    valid = 0
+};
+
+const Header<bit<16>> b = {
+    data = 16,
+    valid = 1
+};
+
+const Header<S> h = {
+    data = { b = 0 },
+    valid = 0
+};
+
+const H2<S> h1 = (H2<S>){
+    g = (Header<S>){ data = { b = 0 }, valid = 1 },
+    invalid = 1
+};
+
+const H2<S> h3 = {
+    g = { data = { b = 0 }, valid = 1 },
+    invalid = 1
+};
+
+typedef H2<S> R;
+
+struct H3<T> {
+    R r;
+    T s;
+    H2<T> h2;
+    H4<H2<T>> h3;
+}
+
+const H3<S> h4 = {
+    r = { g = { data = { b = 10 }, valid = 0 }, invalid = 1 },
+    s = { b = 20 },
+    h2 = { g = { data = { b = 0 }, valid = 1 }, invalid = 1 },
+    h3 = { x = { g = { data = { b = 0 }, valid = 1 }, invalid = 1 } }
+};
+
+control c(out bit x) {
+    apply {
+        H3<S> h5;
+        H4<H2<S>> n;
+        x = u.f.valid & h1.g.valid & h.valid & h2.valid & h1.g.valid & h3.g.valid & n.x.g.valid;
+    }
+}
+
+control ctrl(out bit x);
+package top(ctrl _c);
+top(c()) main;

--- a/testdata/p4_16_samples/generic-struct.p4
+++ b/testdata/p4_16_samples/generic-struct.p4
@@ -3,12 +3,6 @@ struct Header<St> {
     bit valid;
 }
 
-#if STACK
-Header<St>[10] stack;
-
-typedef Header<St>[10] Stack;
-#endif
-
 struct S {
     bit<32> b;
 }
@@ -33,7 +27,7 @@ const Header<S> h2 = (Header<S>){
     valid = 0
 };
 
-const Header<bit<16>> b = {
+const Header<bit<16>> bz = {
     data = 16,
     valid = 1
 };
@@ -62,6 +56,19 @@ struct H3<T> {
     H4<H2<T>> h3;
 }
 
+header GH<T> {
+    T data;
+}
+
+header X {
+    bit<32> b;
+}
+
+const GH<bit<32>> g = { data = 0 };
+const GH<S> g1 = { data = { b = 0 } };
+
+typedef GH<S>[3] Stack;
+
 const H3<S> h4 = {
     r = { g = { data = { b = 10 }, valid = 0 }, invalid = 1 },
     s = { b = 20 },
@@ -69,11 +76,25 @@ const H3<S> h4 = {
     h3 = { x = { g = { data = { b = 0 }, valid = 1 }, invalid = 1 } }
 };
 
+header_union HU<T> {
+    X xu;
+    GH<T> h3u;
+}
+
 control c(out bit x) {
     apply {
         H3<S> h5;
         H4<H2<S>> n;
-        x = u.f.valid & h1.g.valid & h.valid & h2.valid & h1.g.valid & h3.g.valid & n.x.g.valid;
+        GH<S> gh;
+        bool b = gh.isValid();
+        Stack s;
+        s[0] = { data = { b = 1 }};
+        b = b && s[0].isValid();
+        X xinst = { b = 2 };
+        HU<bit<32>> z;
+        z.xu = xinst;
+        z.h3u = { data = 1 };
+        x = u.f.valid & h1.g.valid & h.valid & h2.valid & h1.g.valid & h3.g.valid & n.x.g.valid & (bit)b;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/generic-struct-first.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-first.p4
@@ -1,0 +1,75 @@
+struct Header<St> {
+    St     data;
+    bit<1> valid;
+}
+
+struct S {
+    bit<32> b;
+}
+
+struct Header_0 {
+    S      data;
+    bit<1> valid;
+}
+
+struct U {
+    Header_0 f;
+}
+
+const U u = (U){f = (Header_0){data = (S){b = 32w10},valid = 1w1}};
+struct H2<G> {
+    Header<G> g;
+    bit<1>    invalid;
+}
+
+struct H4<T> {
+    T x;
+}
+
+const Header_0 h2 = (Header_0){data = (S){b = 32w0},valid = 1w0};
+struct Header_1 {
+    bit<16> data;
+    bit<1>  valid;
+}
+
+const Header_1 b = (Header_1){data = 16w16,valid = 1w1};
+const Header_0 h = (Header_0){data = (S){b = 32w0},valid = 1w0};
+struct H2_0 {
+    Header_0 g;
+    bit<1>   invalid;
+}
+
+const H2_0 h1 = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1};
+const H2_0 h3 = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1};
+typedef H2_0 R;
+struct H3<T> {
+    R         r;
+    T         s;
+    H2<T>     h2;
+    H4<H2<T>> h3;
+}
+
+struct H4_0 {
+    H2_0 x;
+}
+
+struct H3_0 {
+    R    r;
+    S    s;
+    H2_0 h2;
+    H4_0 h3;
+}
+
+const H3_0 h4 = (H3_0){r = (H2_0){g = (Header_0){data = (S){b = 32w10},valid = 1w0},invalid = 1w1},s = (S){b = 32w20},h2 = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1},h3 = (H4_0){x = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1}}};
+control c(out bit<1> x) {
+    apply {
+        H3_0 h5;
+        H4_0 n;
+        x = 1w0;
+    }
+}
+
+control ctrl(out bit<1> x);
+package top(ctrl _c);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/generic-struct-first.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-first.p4
@@ -32,7 +32,7 @@ struct Header_1 {
     bit<1>  valid;
 }
 
-const Header_1 b = (Header_1){data = 16w16,valid = 1w1};
+const Header_1 bz = (Header_1){data = 16w16,valid = 1w1};
 const Header_0 h = (Header_0){data = (S){b = 32w0},valid = 1w0};
 struct H2_0 {
     Header_0 g;
@@ -49,6 +49,25 @@ struct H3<T> {
     H4<H2<T>> h3;
 }
 
+header GH<T> {
+    T data;
+}
+
+header X {
+    bit<32> b;
+}
+
+header GH_0 {
+    bit<32> data;
+}
+
+const GH_0 g = (GH_0){data = 32w0};
+header GH_1 {
+    S data;
+}
+
+const GH_1 g1 = (GH_1){data = (S){b = 32w0}};
+typedef GH_1[3] Stack;
 struct H4_0 {
     H2_0 x;
 }
@@ -61,10 +80,29 @@ struct H3_0 {
 }
 
 const H3_0 h4 = (H3_0){r = (H2_0){g = (Header_0){data = (S){b = 32w10},valid = 1w0},invalid = 1w1},s = (S){b = 32w20},h2 = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1},h3 = (H4_0){x = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1}}};
+header_union HU<T> {
+    X     xu;
+    GH<T> h3u;
+}
+
+header_union HU_0 {
+    X    xu;
+    GH_0 h3u;
+}
+
 control c(out bit<1> x) {
     apply {
         H3_0 h5;
         H4_0 n;
+        GH_1 gh;
+        bool b = gh.isValid();
+        Stack s;
+        s[0] = (GH_1){data = (S){b = 32w1}};
+        b = b && s[0].isValid();
+        X xinst = (X){b = 32w2};
+        HU_0 z;
+        z.xu = xinst;
+        z.h3u = (GH_0){data = 32w1};
         x = 1w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/generic-struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-frontend.p4
@@ -1,0 +1,66 @@
+struct Header<St> {
+    St     data;
+    bit<1> valid;
+}
+
+struct S {
+    bit<32> b;
+}
+
+struct Header_0 {
+    S      data;
+    bit<1> valid;
+}
+
+struct U {
+    Header_0 f;
+}
+
+struct H2<G> {
+    Header<G> g;
+    bit<1>    invalid;
+}
+
+struct H4<T> {
+    T x;
+}
+
+struct Header_1 {
+    bit<16> data;
+    bit<1>  valid;
+}
+
+struct H2_0 {
+    Header_0 g;
+    bit<1>   invalid;
+}
+
+typedef H2_0 R;
+struct H3<T> {
+    R         r;
+    T         s;
+    H2<T>     h2;
+    H4<H2<T>> h3;
+}
+
+struct H4_0 {
+    H2_0 x;
+}
+
+struct H3_0 {
+    R    r;
+    S    s;
+    H2_0 h2;
+    H4_0 h3;
+}
+
+control c(out bit<1> x) {
+    apply {
+        x = 1w0;
+    }
+}
+
+control ctrl(out bit<1> x);
+package top(ctrl _c);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/generic-struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-frontend.p4
@@ -43,6 +43,23 @@ struct H3<T> {
     H4<H2<T>> h3;
 }
 
+header GH<T> {
+    T data;
+}
+
+header X {
+    bit<32> b;
+}
+
+header GH_0 {
+    bit<32> data;
+}
+
+header GH_1 {
+    S data;
+}
+
+typedef GH_1[3] Stack;
 struct H4_0 {
     H2_0 x;
 }
@@ -54,8 +71,28 @@ struct H3_0 {
     H4_0 h3;
 }
 
+header_union HU<T> {
+    X     xu;
+    GH<T> h3u;
+}
+
+header_union HU_0 {
+    X    xu;
+    GH_0 h3u;
+}
+
 control c(out bit<1> x) {
+    @name("c.gh") GH_1 gh_0;
+    @name("c.b") bool b_0;
+    @name("c.s") Stack s_0;
+    @name("c.xinst") X xinst_0;
     apply {
+        b_0 = gh_0.isValid();
+        s_0[0].setValid();
+        s_0[0] = (GH_1){data = (S){b = 32w1}};
+        s_0[0].isValid();
+        xinst_0.setValid();
+        xinst_0 = (X){b = 32w2};
         x = 1w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/generic-struct-midend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-midend.p4
@@ -43,6 +43,23 @@ struct H3<T> {
     H4<H2<T>> h3;
 }
 
+header GH<T> {
+    T data;
+}
+
+header X {
+    bit<32> b;
+}
+
+header GH_0 {
+    bit<32> data;
+}
+
+header GH_1 {
+    bit<32> _data_b0;
+}
+
+typedef GH_1[3] Stack;
 struct H4_0 {
     H2_0 x;
 }
@@ -54,18 +71,36 @@ struct H3_0 {
     H4_0 h3;
 }
 
+header_union HU<T> {
+    X     xu;
+    GH<T> h3u;
+}
+
+header_union HU_0 {
+    X    xu;
+    GH_0 h3u;
+}
+
 control c(out bit<1> x) {
-    @hidden action genericstruct76() {
+    @name("c.gh") GH_1 gh_0;
+    @name("c.s") Stack s_0;
+    @name("c.xinst") X xinst_0;
+    @hidden action genericstruct91() {
+        s_0[0].setValid();
+        s_0[0]._data_b0 = 32w1;
+        s_0[0].isValid();
+        xinst_0.setValid();
+        xinst_0.b = 32w2;
         x = 1w0;
     }
-    @hidden table tbl_genericstruct76 {
+    @hidden table tbl_genericstruct91 {
         actions = {
-            genericstruct76();
+            genericstruct91();
         }
-        const default_action = genericstruct76();
+        const default_action = genericstruct91();
     }
     apply {
-        tbl_genericstruct76.apply();
+        tbl_genericstruct91.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/generic-struct-midend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-midend.p4
@@ -1,0 +1,75 @@
+struct Header<St> {
+    St     data;
+    bit<1> valid;
+}
+
+struct S {
+    bit<32> b;
+}
+
+struct Header_0 {
+    S      data;
+    bit<1> valid;
+}
+
+struct U {
+    Header_0 f;
+}
+
+struct H2<G> {
+    Header<G> g;
+    bit<1>    invalid;
+}
+
+struct H4<T> {
+    T x;
+}
+
+struct Header_1 {
+    bit<16> data;
+    bit<1>  valid;
+}
+
+struct H2_0 {
+    Header_0 g;
+    bit<1>   invalid;
+}
+
+typedef H2_0 R;
+struct H3<T> {
+    R         r;
+    T         s;
+    H2<T>     h2;
+    H4<H2<T>> h3;
+}
+
+struct H4_0 {
+    H2_0 x;
+}
+
+struct H3_0 {
+    R    r;
+    S    s;
+    H2_0 h2;
+    H4_0 h3;
+}
+
+control c(out bit<1> x) {
+    @hidden action genericstruct76() {
+        x = 1w0;
+    }
+    @hidden table tbl_genericstruct76 {
+        actions = {
+            genericstruct76();
+        }
+        const default_action = genericstruct76();
+    }
+    apply {
+        tbl_genericstruct76.apply();
+    }
+}
+
+control ctrl(out bit<1> x);
+package top(ctrl _c);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/generic-struct.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct.p4
@@ -22,7 +22,7 @@ struct H4<T> {
 }
 
 const Header<S> h2 = (Header<S>){data = {b = 0},valid = 0};
-const Header<bit<16>> b = {data = 16,valid = 1};
+const Header<bit<16>> bz = {data = 16,valid = 1};
 const Header<S> h = {data = {b = 0},valid = 0};
 const H2<S> h1 = (H2<S>){g = (Header<S>){data = {b = 0},valid = 1},invalid = 1};
 const H2<S> h3 = {g = {data = {b = 0},valid = 1},invalid = 1};
@@ -34,12 +34,37 @@ struct H3<T> {
     H4<H2<T>> h3;
 }
 
+header GH<T> {
+    T data;
+}
+
+header X {
+    bit<32> b;
+}
+
+const GH<bit<32>> g = {data = 0};
+const GH<S> g1 = {data = {b = 0}};
+typedef GH<S>[3] Stack;
 const H3<S> h4 = {r = {g = {data = {b = 10},valid = 0},invalid = 1},s = {b = 20},h2 = {g = {data = {b = 0},valid = 1},invalid = 1},h3 = {x = {g = {data = {b = 0},valid = 1},invalid = 1}}};
+header_union HU<T> {
+    X     xu;
+    GH<T> h3u;
+}
+
 control c(out bit<1> x) {
     apply {
         H3<S> h5;
         H4<H2<S>> n;
-        x = u.f.valid & h1.g.valid & h.valid & h2.valid & h1.g.valid & h3.g.valid & n.x.g.valid;
+        GH<S> gh;
+        bool b = gh.isValid();
+        Stack s;
+        s[0] = {data = {b = 1}};
+        b = b && s[0].isValid();
+        X xinst = {b = 2};
+        HU<bit<32>> z;
+        z.xu = xinst;
+        z.h3u = {data = 1};
+        x = u.f.valid & h1.g.valid & h.valid & h2.valid & h1.g.valid & h3.g.valid & n.x.g.valid & (bit<1>)b;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/generic-struct.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct.p4
@@ -1,0 +1,49 @@
+struct Header<St> {
+    St     data;
+    bit<1> valid;
+}
+
+struct S {
+    bit<32> b;
+}
+
+struct U {
+    Header<S> f;
+}
+
+const U u = {f = {data = {b = 10},valid = 1}};
+struct H2<G> {
+    Header<G> g;
+    bit<1>    invalid;
+}
+
+struct H4<T> {
+    T x;
+}
+
+const Header<S> h2 = (Header<S>){data = {b = 0},valid = 0};
+const Header<bit<16>> b = {data = 16,valid = 1};
+const Header<S> h = {data = {b = 0},valid = 0};
+const H2<S> h1 = (H2<S>){g = (Header<S>){data = {b = 0},valid = 1},invalid = 1};
+const H2<S> h3 = {g = {data = {b = 0},valid = 1},invalid = 1};
+typedef H2<S> R;
+struct H3<T> {
+    R         r;
+    T         s;
+    H2<T>     h2;
+    H4<H2<T>> h3;
+}
+
+const H3<S> h4 = {r = {g = {data = {b = 10},valid = 0},invalid = 1},s = {b = 20},h2 = {g = {data = {b = 0},valid = 1},invalid = 1},h3 = {x = {g = {data = {b = 0},valid = 1},invalid = 1}}};
+control c(out bit<1> x) {
+    apply {
+        H3<S> h5;
+        H4<H2<S>> n;
+        x = u.f.valid & h1.g.valid & h.valid & h2.valid & h1.g.valid & h3.g.valid & n.x.g.valid;
+    }
+}
+
+control ctrl(out bit<1> x);
+package top(ctrl _c);
+top(c()) main;
+


### PR DESCRIPTION
This PR adds support for an experimental features that allows generic structs, headers, and unions (but not yet generic stacks).
A generic struct declaration looks like this:

```
struct S<T> {
    T field;
    bit<32> otherField;
}
```

A generic struct must be instantiated with some type parameters:

```
typedef S<bit<32>> SB;
const SB b = { field = 0, otherField = 1 };
```

This is just syntactic sugar; a new pass in the front-end will actually replace the generic types with concrete types specialized with their arguments, e.g., in this case

```
struct S_0 {
    bit<32> field;
    bit<32> otherField;
}
typedef S_0 SB;
```

