### PR TITLE
Separate Gauntlet from the normal P4C tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,9 @@ script:
 # We only test the front end and some mid end passes for now.
 jobs:
   include:
-    - install:
-        - docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=$UNIFIED --build-arg ENABLE_GMP=$ENABLE_GMP --build-arg VALIDATION=ON .
     - name: "Validation"
       os: linux
+      install:
+        - docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=$UNIFIED --build-arg ENABLE_GMP=$ENABLE_GMP --build-arg VALIDATION=ON .
       script:
         - docker run -w /gauntlet p4c python3.6 -m pytest test.py -vrf -k "test_p4c" -n $CTEST_PARALLEL_LEVEL --suppress-crashes

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
     - name: "Validation"
       os: linux
       install:
+        - tools/start_ccache
         - docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=$UNIFIED --build-arg ENABLE_GMP=$ENABLE_GMP --build-arg VALIDATION=ON .
       script:
         - docker run -w /gauntlet p4c python3.6 -m pytest test.py -vrf -k "test_p4c" -n $CTEST_PARALLEL_LEVEL --suppress-crashes

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,6 @@ jobs:
       os: linux
       install:
         - tools/start_ccache
-        - docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=$UNIFIED --build-arg ENABLE_GMP=$ENABLE_GMP --build-arg VALIDATION=ON . || travis_terminate 0
+        - docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=$UNIFIED --build-arg ENABLE_GMP=$ENABLE_GMP --build-arg VALIDATION=ON . || { echo "Building Gauntlet failed." ; travis_terminate 0; }
       script:
         - docker run -w /gauntlet p4c python3.6 -m pytest test.py -vrf -k "test_p4c" -n $CTEST_PARALLEL_LEVEL --suppress-crashes

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ script:
 # We only test the front end and some mid end passes for now.
 jobs:
   include:
+    - install:
+        - docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=$UNIFIED --build-arg ENABLE_GMP=$ENABLE_GMP --build-arg VALIDATION=ON .
     - name: "Validation"
       os: linux
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,6 @@ jobs:
       os: linux
       install:
         - tools/start_ccache
-        - docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=$UNIFIED --build-arg ENABLE_GMP=$ENABLE_GMP --build-arg VALIDATION=ON .
+        - docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=$UNIFIED --build-arg ENABLE_GMP=$ENABLE_GMP --build-arg VALIDATION=ON . || travis_terminate 0
       script:
         - docker run -w /gauntlet p4c python3.6 -m pytest test.py -vrf -k "test_p4c" -n $CTEST_PARALLEL_LEVEL --suppress-crashes

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ ARG IMAGE_TYPE=build
 # Whether to do a unified build.
 ARG ENABLE_UNIFIED_COMPILATION=ON
 
+# Whether to enable translation validation
+ARG VALIDATION=OFF
+
 # Delegate the build to tools/travis-build.
 COPY . /p4c/
 WORKDIR /p4c/

--- a/tools/travis-build
+++ b/tools/travis-build
@@ -104,7 +104,9 @@ function build_gauntlet() {
 
 # These steps are necessary to validate the correct compilation of the P4C test
 # suite programs. See also https://github.com/p4gauntlet/gauntlet.
-build_gauntlet
+if [ "$VALIDATION" == "ON" ]; then
+  build_gauntlet
+fi
 # ! ------  END VALIDATION -----------------------------------------------
 
 


### PR DESCRIPTION
When the toz3 extension does not build only the validation test should fail. Now the question is what to do when the build for Gauntlet fails. Just ignore or try to issue some sort of warning? 
There is also the possibility of using [allow_failures](https://docs.travis-ci.com/user/build-matrix/#rows-that-are-allowed-to-fail) in Travis but I am not exactly sure if that has the intended effect.