### PR TITLE
Enable -Werror in CI

### DIFF
--- a/.github/.travis.yml.disabled
+++ b/.github/.travis.yml.disabled
@@ -41,7 +41,7 @@ install:
   # build before continuing with the rest, which produces a unified build.
   # This is done here on MacOS; for Linux, this is done in Dockerfile.
   - if [[ $TRAVIS_OS_NAME == 'linux' ]] ; then docker build --network ccache_network -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=$UNIFIED --build-arg ENABLE_GMP=$ENABLE_GMP . ; fi
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_UNIFIED_COMPILATION=$UNIFIED -DENABLE_GMP=$ENABLE_GMP && cd build && make -j2; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_UNIFIED_COMPILATION=$UNIFIED -DENABLE_GMP=$ENABLE_GMP -DENABLE_WERROR && cd build && make -j2; fi
 
 script:
   # run with sudo (...) --privileged so that we can create network namespaces for the ebpf tests

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -68,7 +68,7 @@ jobs:
   #         # To flush out issues with unified vs. non-unified builds,
   #         # do a non-unified build before continuing with the rest,
   #         # which produces a unified build.
-  #         ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_UNIFIED_COMPILATION=${{matrix.unified}} -DENABLE_GMP=${{ matrix.enable_gmp }} && cd build && make -j2
+  #         ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_UNIFIED_COMPILATION=${{matrix.unified}} -DENABLE_GMP=${{ matrix.enable_gmp }} -DENABLE_WERROR && cd build && make -j2
 
   #   - name: Run tests (MacOS)
   #     run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ OPTION (ENABLE_PROTOBUF_STATIC "Link against Protobuf statically" ON)
 OPTION (ENABLE_GC "Use libgc" ON)
 OPTION (ENABLE_MULTITHREAD "Use multithreading" OFF)
 OPTION (ENABLE_GMP "Use GMP library" ON)
+OPTION (ENABLE_WERROR "Turn GCC warnings into errors (as much as possible)" OFF)
 
 set (P4C_DRIVER_NAME "p4c" CACHE STRING "Customize the name of the driver script")
 
@@ -168,7 +169,6 @@ find_package (BMV2)
 # enable CTest
 enable_testing ()
 
-
 # if we want to manage versions in CMake ...
 # include (cmake/P4CVersion.cmake)
 # set (CPACK_PACKAGE_VERSION_MAJOR ${__P4C_VERSION_MAJOR})
@@ -191,6 +191,13 @@ add_cxx_compiler_option ("-Wall")
 add_cxx_compiler_option ("-Wextra")
 add_cxx_compiler_option ("-Wno-overloaded-virtual")
 add_cxx_compiler_option ("-Wno-deprecated")
+add_cxx_compiler_option ("-Wno-unused-result")
+
+if (ENABLE_WERROR)
+  add_cxx_compiler_option ("-Werror")
+  # For GCC bugs related to boost::optional.
+  add_cxx_compiler_option ("-Wno-error=maybe-uninitialized")
+endif ()
 
 # If we're on GCC, use the gold linker if available.
 if(CMAKE_COMPILER_IS_GNUCC)

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ ARG IMAGE_TYPE=build
 # Whether to do a unified build.
 ARG ENABLE_UNIFIED_COMPILATION=ON
 
+# Whether to turn GCC warnings into errors.
+ARG ENABLE_WERROR=ON
+
 # Whether to enable translation validation
 ARG VALIDATION=OFF
 

--- a/tools/travis-build
+++ b/tools/travis-build
@@ -120,7 +120,9 @@ function build() {
   make
 }
 
-build "-DENABLE_UNIFIED_COMPILATION=${ENABLE_UNIFIED_COMPILATION}"
+build \
+  "-DENABLE_UNIFIED_COMPILATION=${ENABLE_UNIFIED_COMPILATION}" \
+  "-DENABLE_WERROR=${ENABLE_WERROR}"
 
 make install
 /usr/local/bin/ccache -p -s


### PR DESCRIPTION
This ensures that GCC warnings are addressed in PRs before they are merged. Also addressed a couple of uninitialized variables (one seemingly real, one a false positive).