### PR TITLE
Remove redundant slice statements during SimplifyDefUse (#2583)

### DIFF
--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -411,7 +411,6 @@ void ComputeWriteSet::enterScope(const IR::ParameterList* parameters,
     }
     allDefinitions->setDefinitionsAt(entryPoint, defs, false);
     currentDefinitions = defs;
-    LOG3("Definitions at " << entryPoint << ":" << currentDefinitions);
 }
 
 void ComputeWriteSet::exitScope(const IR::ParameterList* parameters,
@@ -465,7 +464,7 @@ bool ComputeWriteSet::setDefinitions(Definitions* defs, const IR::Node* node, bo
     if (findContext<IR::ParserState>())
         overwrite = true;
     allDefinitions->setDefinitionsAt(point, currentDefinitions, overwrite);
-    LOG3("CWS Definitions at " << point << " are " << std::endl << defs);
+    LOG3("CWS Definitions at " << point << " are " << IndentCtl::endl << defs);
     return false;  // always returns false
 }
 
@@ -974,12 +973,12 @@ bool ComputeWriteSet::preorder(const IR::MethodCallStatement* statement) {
 }  // namespace P4
 
 // functions for calling from gdb
-void dump(const P4::StorageLocation *s) { std::cout << *s << std::endl; }
-void dump(const P4::StorageMap *s) { std::cout << *s << std::endl; }
-void dump(const P4::LocationSet *s) { std::cout << *s << std::endl; }
-void dump(const P4::ProgramPoint *p) { std::cout << *p << std::endl; }
-void dump(const P4::ProgramPoint &p) { std::cout << p << std::endl; }
-void dump(const P4::ProgramPoints *p) { std::cout << *p << std::endl; }
-void dump(const P4::ProgramPoints &p) { std::cout << p << std::endl; }
-void dump(const P4::Definitions *d) { std::cout << *d << std::endl; }
-void dump(const P4::AllDefinitions *d) { std::cout << *d << std::endl; }
+void dump(const P4::StorageLocation *s) { std::cout << *s << IndentCtl::endl; }
+void dump(const P4::StorageMap *s) { std::cout << *s << IndentCtl::endl; }
+void dump(const P4::LocationSet *s) { std::cout << *s << IndentCtl::endl; }
+void dump(const P4::ProgramPoint *p) { std::cout << *p << IndentCtl::endl; }
+void dump(const P4::ProgramPoint &p) { std::cout << p << IndentCtl::endl; }
+void dump(const P4::ProgramPoints *p) { std::cout << *p << IndentCtl::endl; }
+void dump(const P4::ProgramPoints &p) { std::cout << p << IndentCtl::endl; }
+void dump(const P4::Definitions *d) { std::cout << *d << IndentCtl::endl; }
+void dump(const P4::AllDefinitions *d) { std::cout << *d << IndentCtl::endl; }

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -227,7 +227,7 @@ class StorageMap {
     }
     virtual void dbprint(std::ostream& out) const {
         for (auto &it : storage)
-            out << it.first << ": " << it.second << std::endl;
+            out << it.first << ": " << it.second << IndentCtl::endl;
     }
 };
 
@@ -351,14 +351,14 @@ class Definitions : public IHasDbPrint {
     bool operator==(const Definitions& other) const;
     void dbprint(std::ostream& out) const {
         if (unreachable) {
-            out << "  Unreachable" << std::endl;
+            out << "  Unreachable" << IndentCtl::endl;
         }
         if (definitions.empty())
             out << "  Empty definitions";
         bool first = true;
         for (auto d : definitions) {
             if (!first)
-                out << std::endl;
+                out << IndentCtl::endl;
             out << "  " << *d.first << "=>" << *d.second;
             first = false;
         }
@@ -404,7 +404,7 @@ class AllDefinitions : public IHasDbPrint {
     }
     void dbprint(std::ostream& out) const {
         for (auto e : atPoint)
-            out << e.first << " => " << e.second << std::endl;
+            out << e.first << " => " << e.second << IndentCtl::endl;
     }
 };
 

--- a/testdata/p4_16_samples/issue2583_simplify_slice.p4
+++ b/testdata/p4_16_samples/issue2583_simplify_slice.p4
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+}
+
+parser p(packet_in pckt, out Header h) {
+    state start {
+
+        h.data = 0;
+        h.data[3:0] = 2;    // skipped
+
+        h.data = 7;
+        h.data[7:0] = 4;    // skipped
+        h.data[7:0] = 3;    // skipped
+        h.data[15:0] = 8;   // stays
+        h.data[31:16] = 5;  // stays
+
+        transition accept;
+    }
+}
+
+parser proto(packet_in pckt, out Header h);
+package top(proto _p);
+
+top(p()) main;

--- a/testdata/p4_16_samples/issue2583_simplify_slice2.p4
+++ b/testdata/p4_16_samples/issue2583_simplify_slice2.p4
@@ -1,0 +1,60 @@
+/*
+Copyright 2016 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+}
+
+parser p0(packet_in p, out Header h) {
+    state start {
+        p.extract(h);
+        h.data[7:0] = 8;
+        h.data[7:0] = 8;
+        transition select(h.data[15:8]) {
+            0: next;
+            default: next2;
+        }
+    }
+    state next {
+        h.data = 8;
+        h.data = 8;
+        transition final;
+    }
+
+    state next2 {
+        h.data[7:2] = 9;
+        h.data[7:2] = h.data[7:2];
+        h.data[7:2] = 3;
+
+        transition final;
+    }
+
+    state final {
+        h.data[15:8] = 6;
+        h.data[15:8] = 6;
+        h.data[15:8] = 6;
+
+        transition accept;
+    }
+
+}
+
+parser proto(packet_in p, out Header h);
+package top(proto _p);
+
+top(p0()) main;

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice-first.p4
@@ -1,0 +1,23 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+}
+
+parser p(packet_in pckt, out Header h) {
+    state start {
+        h.data = 32w0;
+        h.data[3:0] = 4w2;
+        h.data = 32w7;
+        h.data[7:0] = 8w4;
+        h.data[7:0] = 8w3;
+        h.data[15:0] = 16w8;
+        h.data[31:16] = 16w5;
+        transition accept;
+    }
+}
+
+parser proto(packet_in pckt, out Header h);
+package top(proto _p);
+top(p()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice-frontend.p4
@@ -1,0 +1,20 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+}
+
+parser p(packet_in pckt, out Header h) {
+    state start {
+        h.data = 32w0;
+        h.data = 32w7;
+        h.data[15:0] = 16w8;
+        h.data[31:16] = 16w5;
+        transition accept;
+    }
+}
+
+parser proto(packet_in pckt, out Header h);
+package top(proto _p);
+top(p()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice-midend.p4
@@ -1,0 +1,20 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+}
+
+parser p(packet_in pckt, out Header h) {
+    state start {
+        h.data = 32w0;
+        h.data = 32w7;
+        h.data[15:0] = 16w8;
+        h.data[31:16] = 16w5;
+        transition accept;
+    }
+}
+
+parser proto(packet_in pckt, out Header h);
+package top(proto _p);
+top(p()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice.p4
@@ -1,0 +1,23 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+}
+
+parser p(packet_in pckt, out Header h) {
+    state start {
+        h.data = 0;
+        h.data[3:0] = 2;
+        h.data = 7;
+        h.data[7:0] = 4;
+        h.data[7:0] = 3;
+        h.data[15:0] = 8;
+        h.data[31:16] = 5;
+        transition accept;
+    }
+}
+
+parser proto(packet_in pckt, out Header h);
+package top(proto _p);
+top(p()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice2-first.p4
@@ -1,0 +1,39 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+}
+
+parser p0(packet_in p, out Header h) {
+    state start {
+        p.extract<Header>(h);
+        h.data[7:0] = 8w8;
+        h.data[7:0] = 8w8;
+        transition select(h.data[15:8]) {
+            8w0: next;
+            default: next2;
+        }
+    }
+    state next {
+        h.data = 32w8;
+        h.data = 32w8;
+        transition final;
+    }
+    state next2 {
+        h.data[7:2] = 6w9;
+        h.data[7:2] = h.data[7:2];
+        h.data[7:2] = 6w3;
+        transition final;
+    }
+    state final {
+        h.data[15:8] = 8w6;
+        h.data[15:8] = 8w6;
+        h.data[15:8] = 8w6;
+        transition accept;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+package top(proto _p);
+top(p0()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice2-frontend.p4
@@ -1,0 +1,34 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+}
+
+parser p0(packet_in p, out Header h) {
+    state start {
+        p.extract<Header>(h);
+        h.data[7:0] = 8w8;
+        transition select(h.data[15:8]) {
+            8w0: next;
+            default: next2;
+        }
+    }
+    state next {
+        h.data = 32w8;
+        transition final;
+    }
+    state next2 {
+        h.data[7:2] = 6w9;
+        h.data[7:2] = 6w3;
+        transition final;
+    }
+    state final {
+        h.data[15:8] = 8w6;
+        transition accept;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+package top(proto _p);
+top(p0()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice2-midend.p4
@@ -1,0 +1,34 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+}
+
+parser p0(packet_in p, out Header h) {
+    state start {
+        p.extract<Header>(h);
+        h.data[7:0] = 8w8;
+        transition select(h.data[15:8]) {
+            8w0: next;
+            default: next2;
+        }
+    }
+    state next {
+        h.data = 32w8;
+        transition final;
+    }
+    state next2 {
+        h.data[7:2] = 6w9;
+        h.data[7:2] = 6w3;
+        transition final;
+    }
+    state final {
+        h.data[15:8] = 8w6;
+        transition accept;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+package top(proto _p);
+top(p0()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice2.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice2.p4
@@ -1,0 +1,39 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+}
+
+parser p0(packet_in p, out Header h) {
+    state start {
+        p.extract(h);
+        h.data[7:0] = 8;
+        h.data[7:0] = 8;
+        transition select(h.data[15:8]) {
+            0: next;
+            default: next2;
+        }
+    }
+    state next {
+        h.data = 8;
+        h.data = 8;
+        transition final;
+    }
+    state next2 {
+        h.data[7:2] = 9;
+        h.data[7:2] = h.data[7:2];
+        h.data[7:2] = 3;
+        transition final;
+    }
+    state final {
+        h.data[15:8] = 6;
+        h.data[15:8] = 6;
+        h.data[15:8] = 6;
+        transition accept;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+package top(proto _p);
+top(p0()) main;
+


### PR DESCRIPTION
* Overwritten slice statements skipped
* Improved logging in FindUninitialized

When FU is registering uses in a lhs slice of an assignment statement, it skips those
which the given slice can overwrite.

To make these changes more comprehensible, I'll start by explaining my view of the problem.

How removing redundant assignment statements works (no-slice lhs assignments):
The issue starts by pointing out that the following
```
h.data = 8;
h.data = 8;
```
gets reduced to
```
h.data = 8;
```
But these snippets are misleading - in reality, the above holds true only when
```
h.data = 8;
h.data = 8;
// a third, certain kind of statement (not necessarily right after the one above) 
```
Why is this third statement required? Because the second `h.data = 8;` would disappear just as well as the first.
This reveals the underlying notion of redundancy the compiler has: 

_Consider all no-slice lhs assignments (with no lvalue on the rhs) as redundant until proven otherwise._

The proof comes from the "third" statement finding use for the second statement (more precisely, it means reading from the same `LocationSet` as `h.data = 8;`). I use the term "floater" to describe a statement that has yet to find its use. Floaters are what is actually getting thrown out during `RemoveUnused` - statements that none other found useful. Similarly, I'll use "anchoring" to describe the moment when floaters find their use. 
 
Every assignment starts out as a floater, but only assignments whose expression(s) can read a `LocationSet`, can anchor a floater (related to the same location). This explains the _assignments with no lvalue on the rhs_ part; lvalues on the rhs read a non-empty location.

Slices are treated differently, in a sense they always read some non-empty `LocationSet` whether they're on the lhs or rhs (why this doesn't apply to no-slice expressions on the lhs is unclear to me).  Consequently, slices always anchor a floater which is why some redundant assignments get to stay.

My solution comes in the form of an additional constraint on the floaters during their time of anchoring done by another slice assignment:

- Is the floater a slice assignment?
- Will the "anchorer" (slice assignment) overwrite the floater?

If both answers are true, the floating slice assignment is not anchored for this particular use (this does **not** mean it won't find its use somewhere else).  

