### PR TITLE
Handle Type_Dontcare args when creating Counterlike instances

### DIFF
--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -414,11 +414,13 @@ struct Counterlike {
             BUG_CHECK(type->arguments->size() > *indexTypeParamIdx,
                       "%1%: expected at least %2% type arguments",
                       instance, *indexTypeParamIdx + 1);
-            auto typeArg = type->arguments->at(*indexTypeParamIdx);
-            // We ignore the return type on purpose, but the call is required to update p4RtTypeInfo
-            // if the index has a user-defined type.
-            TypeSpecConverter::convert(refMap, typeMap, typeArg, p4RtTypeInfo);
-            index_type_name = getTypeName(typeArg, typeMap);
+            const IR::Type* typeArg = type->arguments->at(*indexTypeParamIdx);
+            if (!typeArg->is<IR::Type_Dontcare>()) {
+                // We ignore the return type on purpose, but the call is required to update p4RtTypeInfo
+                // if the index has a user-defined type.
+                TypeSpecConverter::convert(refMap, typeMap, typeArg, p4RtTypeInfo);
+                index_type_name = getTypeName(typeArg, typeMap);
+            }
         }
 
         return Counterlike<Kind>{declaration->controlPlaneName(),

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -416,8 +416,8 @@ struct Counterlike {
                       instance, *indexTypeParamIdx + 1);
             const IR::Type* typeArg = type->arguments->at(*indexTypeParamIdx);
             if (!typeArg->is<IR::Type_Dontcare>()) {
-                // We ignore the return type on purpose, but the call is required to update p4RtTypeInfo
-                // if the index has a user-defined type.
+                // We ignore the return type on purpose, but the call is required to
+                // update p4RtTypeInfo if the index has a user-defined type.
                 TypeSpecConverter::convert(refMap, typeMap, typeArg, p4RtTypeInfo);
                 index_type_name = getTypeName(typeArg, typeMap);
             }


### PR DESCRIPTION
The added gtest P4Runtime.ArgTypeDontCare demonstrates the problem viz:
```
meter<_>(1024, MeterType.bytes) mtr;  // Use `result` argument to infer type.
```
without the fix fails with:
```
error: Unexpected type _
            meter<_>(1024, MeterType.bytes) mtr;
```
Please advise as to the correctness of the fix, and the location of the gtest.
Thank you.
