### PR TITLE
Add INode::checkedTo for checked casts.

### DIFF
--- a/ir/node.h
+++ b/ir/node.h
@@ -56,6 +56,16 @@ class INode : public Util::IHasSourceInfo, public IHasDbPrint {
     template<typename T> bool is() const { return to<T>() != nullptr; }
     template<typename T> const T *to() const { return dynamic_cast<const T*>(this); }
     template<typename T> const T &as() const { return dynamic_cast<const T&>(*this); }
+
+    /// A checked version of INode::to. A BUG occurs if the cast fails.
+    ///
+    /// A similar effect can be achieved with `&as<T>()`, but this method produces a message that
+    /// is easier to debug.
+    template<typename T> const T *checkedTo() const {
+        const auto *result = to<T>();
+        BUG_CHECK(result, "Cast failed: %1% is not a %2%.", this, T::static_type_name());
+        return result;
+    }
 };
 
 class Node : public virtual INode {


### PR DESCRIPTION
Added a convenience method `INode::checkedTo` for checked casts. The effect of `n->checkedTo<N>()` is similar to `&n->as<N>()`, except the former produces an error message that is easier to debug. The former also has clearer intent: the latter could be easily mistaken as being equivalent to `n->to<N>()`.