### PR TITLE
Convert SimplifyDefUse to a PassRepeated (#2610)

### DIFF
--- a/frontends/p4/simplifyDefUse.h
+++ b/frontends/p4/simplifyDefUse.h
@@ -47,10 +47,10 @@ class DoSimplifyDefUse : public Transform {
     { return process(control); }
 };
 
-class SimplifyDefUse : public PassManager {
+class SimplifyDefUse : public PassRepeated {
  public:
     SimplifyDefUse(ReferenceMap* refMap, TypeMap* typeMap,
-             TypeChecking* typeChecking = nullptr) {
+             TypeChecking* typeChecking = nullptr) : PassRepeated({}) {
         CHECK_NULL(refMap); CHECK_NULL(typeMap);
         if (!typeChecking)
             typeChecking = new TypeChecking(refMap, typeMap);

--- a/testdata/p4_14_samples_outputs/modify_conditionally-frontend.p4
+++ b/testdata/p4_14_samples_outputs/modify_conditionally-frontend.p4
@@ -38,14 +38,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("ingress.tmp") bit<8> tmp;
     @name(".table0_actionlist") action table0_actionlist(bit<1> do_goto_table, bit<8> goto_table_id) {
         meta.metadata_global.do_goto_table = do_goto_table;
-        if (do_goto_table != 1w0) {
-            tmp = goto_table_id;
-        } else {
-            tmp = meta.metadata_global.goto_table_id;
-        }
     }
     @name(".table0") table table0_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/enumCast-frontend.p4
+++ b/testdata/p4_16_samples_outputs/enumCast-frontend.p4
@@ -5,18 +5,6 @@ enum bit<32> X {
     One = 32w1
 }
 
-enum bit<8> E1 {
-    e1 = 8w0,
-    e2 = 8w1,
-    e3 = 8w2
-}
-
-enum bit<8> E2 {
-    e1 = 8w10,
-    e2 = 8w11,
-    e3 = 8w12
-}
-
 header B {
     X x;
 }
@@ -31,14 +19,7 @@ struct O {
 }
 
 parser p(packet_in packet, out O o) {
-    @name("p.bb") bool bb_0;
-    @name("p.a") E1 a_0;
-    @name("p.b") E2 b_0;
     state start {
-        a_0 = E1.e1;
-        b_0 = E2.e2;
-        bb_0 = a_0 == b_0;
-        bb_0 = bb_0 && a_0 == 8w0;
         packet.extract<B>(o.b);
         transition select(o.b.x) {
             X.Zero &&& 32w0x1: accept;

--- a/testdata/p4_16_samples_outputs/generic-struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-frontend.p4
@@ -83,16 +83,12 @@ header_union HU_0 {
 
 control c(out bit<1> x) {
     @name("c.gh") GH_1 gh_0;
-    @name("c.b") bool b_0;
     @name("c.s") Stack s_0;
-    @name("c.xinst") X xinst_0;
     apply {
-        b_0 = gh_0.isValid();
+        gh_0.isValid();
         s_0[0].setValid();
         s_0[0] = (GH_1){data = (S){b = 32w1}};
         s_0[0].isValid();
-        xinst_0.setValid();
-        xinst_0 = (X){b = 32w2};
         x = 1w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/generic-struct-midend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-midend.p4
@@ -84,23 +84,21 @@ header_union HU_0 {
 control c(out bit<1> x) {
     @name("c.gh") GH_1 gh_0;
     @name("c.s") Stack s_0;
-    @name("c.xinst") X xinst_0;
-    @hidden action genericstruct91() {
+    @hidden action genericstruct89() {
+        gh_0.isValid();
         s_0[0].setValid();
         s_0[0]._data_b0 = 32w1;
         s_0[0].isValid();
-        xinst_0.setValid();
-        xinst_0.b = 32w2;
         x = 1w0;
     }
-    @hidden table tbl_genericstruct91 {
+    @hidden table tbl_genericstruct89 {
         actions = {
-            genericstruct91();
+            genericstruct89();
         }
-        const default_action = genericstruct91();
+        const default_action = genericstruct89();
     }
     apply {
-        tbl_genericstruct91.apply();
+        tbl_genericstruct89.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2105-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2105-frontend.p4
@@ -11,9 +11,7 @@ struct Headers {
 }
 
 control c() {
-    @name("c.x") bit<8> x_0;
     apply {
-        x_0 = 8w0;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2221-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2221-bmv2-frontend.p4
@@ -23,17 +23,10 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.tmp") bit<16> tmp;
     @name("ingress.tmp_0") bit<16> tmp_0;
-    @name("ingress.tmp_1") bit<16> tmp_1;
-    @name("ingress.tmp_2") bit<16> tmp_2;
     @name("ingress.tmp_3") bit<16> tmp_3;
-    @name("ingress.tmp_4") bit<16> tmp_4;
-    @name("ingress.tmp_5") bit<16> tmp_5;
-    @name("ingress.tmp_6") bit<16> tmp_6;
-    @name("ingress.tmp_7") bit<16> tmp_7;
+    @name("ingress.tmp_6") bit<16> tmp_4;
     apply {
-        tmp = 16w0;
         {
             @name("ingress.eth_type_0") bit<16> eth_type_0 = h.eth_hdr.eth_type;
             @name("ingress.hasReturned") bool hasReturned = false;
@@ -44,8 +37,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.eth_hdr.eth_type = eth_type_0;
             tmp_0 = retval;
         }
-        tmp_1 = tmp & tmp_0;
-        tmp_2 = 16w0;
         {
             @name("ingress.eth_type_1") bit<16> eth_type_1 = h.eth_hdr.eth_type;
             @name("ingress.hasReturned") bool hasReturned_1 = false;
@@ -56,8 +47,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.eth_hdr.eth_type = eth_type_1;
             tmp_3 = retval_1;
         }
-        tmp_4 = tmp_2 * tmp_3;
-        tmp_5 = 16w0;
         {
             @name("ingress.eth_type_2") bit<16> eth_type_2 = h.eth_hdr.eth_type;
             @name("ingress.hasReturned") bool hasReturned_2 = false;
@@ -66,9 +55,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             hasReturned_2 = true;
             retval_2 = 16w2;
             h.eth_hdr.eth_type = eth_type_2;
-            tmp_6 = retval_2;
+            tmp_4 = retval_2;
         }
-        tmp_7 = tmp_5 >> tmp_6;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2287-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2287-bmv2-frontend.p4
@@ -51,50 +51,23 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.dummy_var") bit<8> dummy_var_0;
-    @name("ingress.tmp") bit<8> tmp;
     @name("ingress.tmp_0") bit<8> tmp_0;
-    @name("ingress.tmp_1") bit<8> tmp_1;
-    @name("ingress.tmp_2") bit<8> tmp_2;
     @name("ingress.tmp_3") bit<8> tmp_3;
-    @name("ingress.tmp_4") bit<8> tmp_4;
-    @name("ingress.tmp_5") bit<8> tmp_5;
     @name("ingress.tmp_6") bit<8> tmp_6;
-    @name("ingress.tmp_7") bit<8> tmp_7;
-    @name("ingress.tmp_8") bit<8> tmp_8;
     @name("ingress.tmp_9") bit<8> tmp_9;
-    @name("ingress.tmp_10") bit<8> tmp_10;
-    @name("ingress.tmp_11") bit<8> tmp_11;
     @name("ingress.tmp_12") bit<8> tmp_12;
-    @name("ingress.tmp_13") bit<8> tmp_13;
-    @name("ingress.tmp_14") bit<8> tmp_14;
     @name("ingress.tmp_15") bit<8> tmp_15;
-    @name("ingress.tmp_16") bit<8> tmp_16;
-    @name("ingress.tmp_17") bit<8> tmp_17;
     @name("ingress.tmp_18") bit<8> tmp_18;
-    @name("ingress.tmp_19") bit<8> tmp_19;
-    @name("ingress.tmp_20") bit<8> tmp_20;
     @name("ingress.tmp_21") bit<8> tmp_21;
-    @name("ingress.tmp_22") bit<8> tmp_22;
-    @name("ingress.tmp_23") bit<8> tmp_23;
-    @name("ingress.tmp_24") bit<8> tmp_24;
-    @name("ingress.tmp_25") bit<8> tmp_25;
-    @name("ingress.tmp_26") bit<8> tmp_26;
-    @name("ingress.tmp_27") bit<8> tmp_27;
-    @name("ingress.tmp_28") bit<8> tmp_28;
-    @name("ingress.tmp_29") bit<8> tmp_29;
-    @name("ingress.tmp_30") bit<16> tmp_30;
-    @name("ingress.tmp_31") bit<8> tmp_31;
-    @name("ingress.tmp_32") bit<24> tmp_32;
-    @name("ingress.tmp_33") bit<8> tmp_33;
-    @name("ingress.tmp_34") bit<8> tmp_34;
-    @name("ingress.tmp_35") bit<8> tmp_35;
-    @name("ingress.tmp_36") bool tmp_36;
-    @name("ingress.tmp_37") bit<8> tmp_37;
-    @name("ingress.tmp_38") bit<8> tmp_38;
-    @name("ingress.tmp_39") bit<8> tmp_39;
-    @name("ingress.tmp_40") bool tmp_40;
+    @name("ingress.tmp_24") bit<8> tmp_23;
+    @name("ingress.tmp_27") bit<8> tmp_24;
+    @name("ingress.tmp_29") bit<8> tmp_25;
+    @name("ingress.tmp_31") bit<8> tmp_26;
+    @name("ingress.tmp_34") bit<8> tmp_27;
+    @name("ingress.tmp_35") bit<8> tmp_28;
+    @name("ingress.tmp_38") bit<8> tmp_29;
+    @name("ingress.tmp_39") bit<8> tmp_30;
     apply {
-        tmp = 8w0;
         {
             @name("ingress.val_0") bit<8> val_0 = h.h.a;
             @name("ingress.hasReturned") bool hasReturned = false;
@@ -105,8 +78,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.h.a = val_0;
             tmp_0 = retval;
         }
-        tmp_1 = tmp & tmp_0;
-        tmp_2 = 8w0;
         {
             @name("ingress.val_1") bit<8> val_1 = h.h.b;
             @name("ingress.hasReturned") bool hasReturned_1 = false;
@@ -117,8 +88,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.h.b = val_1;
             tmp_3 = retval_1;
         }
-        tmp_4 = tmp_2 * tmp_3;
-        tmp_5 = 8w0;
         {
             @name("ingress.val_2") bit<8> val_2 = h.h.c;
             @name("ingress.hasReturned") bool hasReturned_2 = false;
@@ -129,8 +98,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.h.c = val_2;
             tmp_6 = retval_2;
         }
-        tmp_7 = tmp_5 / tmp_6;
-        tmp_8 = 8w0;
         {
             @name("ingress.val_3") bit<8> val_3 = h.h.d;
             @name("ingress.hasReturned") bool hasReturned_3 = false;
@@ -141,8 +108,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.h.d = val_3;
             tmp_9 = retval_3;
         }
-        tmp_10 = tmp_8 >> tmp_9;
-        tmp_11 = 8w0;
         {
             @name("ingress.val_4") bit<8> val_4 = h.h.e;
             @name("ingress.hasReturned") bool hasReturned_4 = false;
@@ -153,8 +118,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.h.e = val_4;
             tmp_12 = retval_4;
         }
-        tmp_13 = tmp_11 << tmp_12;
-        tmp_14 = 8w0;
         {
             @name("ingress.val_5") bit<8> val_5 = h.h.f;
             @name("ingress.hasReturned") bool hasReturned_5 = false;
@@ -165,7 +128,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.h.f = val_5;
             tmp_15 = retval_5;
         }
-        tmp_16 = tmp_14 % tmp_15;
         {
             @name("ingress.val_6") bit<8> val_6 = h.h.g;
             @name("ingress.hasReturned") bool hasReturned_6 = false;
@@ -176,7 +138,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.h.g = val_6;
             dummy_var_0 = retval_6;
         }
-        tmp_17 = 8w0;
         {
             @name("ingress.val_7") bit<8> val_7 = h.h.h;
             @name("ingress.hasReturned") bool hasReturned_7 = false;
@@ -187,8 +148,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.h.h = val_7;
             tmp_18 = retval_7;
         }
-        tmp_19 = tmp_17 |-| tmp_18;
-        tmp_20 = 8w255;
         {
             @name("ingress.val_8") bit<8> val_8 = h.h.i;
             @name("ingress.hasReturned") bool hasReturned_8 = false;
@@ -199,8 +158,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             h.h.i = val_8;
             tmp_21 = retval_8;
         }
-        tmp_22 = tmp_20 |+| tmp_21;
-        tmp_23 = 8w255;
         {
             @name("ingress.val_9") bit<8> val_9 = h.h.j;
             @name("ingress.hasReturned") bool hasReturned_9 = false;
@@ -209,10 +166,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             hasReturned_9 = true;
             retval_9 = 8w2;
             h.h.j = val_9;
-            tmp_24 = retval_9;
+            tmp_23 = retval_9;
         }
-        tmp_25 = tmp_23 + tmp_24;
-        tmp_26 = 8w255;
         {
             @name("ingress.val_10") bit<8> val_10 = h.h.k;
             @name("ingress.hasReturned") bool hasReturned_10 = false;
@@ -221,9 +176,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             hasReturned_10 = true;
             retval_10 = 8w2;
             h.h.k = val_10;
-            tmp_27 = retval_10;
+            tmp_24 = retval_10;
         }
-        tmp_28 = tmp_26 | tmp_27;
         {
             @name("ingress.val_11") bit<8> val_11 = h.h.l;
             @name("ingress.hasReturned") bool hasReturned_11 = false;
@@ -232,9 +186,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             hasReturned_11 = true;
             retval_11 = 8w2;
             h.h.l = val_11;
-            tmp_29 = retval_11;
+            tmp_25 = retval_11;
         }
-        tmp_30 = 16w1;
         {
             @name("ingress.val_12") bit<8> val_12 = h.h.m;
             @name("ingress.hasReturned") bool hasReturned_12 = false;
@@ -243,9 +196,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             hasReturned_12 = true;
             retval_12 = 8w2;
             h.h.m = val_12;
-            tmp_31 = retval_12;
+            tmp_26 = retval_12;
         }
-        tmp_32 = tmp_30 ++ tmp_31;
         {
             @name("ingress.val_13") bit<8> val_13 = h.b.c;
             @name("ingress.hasReturned") bool hasReturned_13 = false;
@@ -254,9 +206,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             hasReturned_13 = true;
             retval_13 = 8w2;
             h.b.c = val_13;
-            tmp_34 = retval_13;
+            tmp_27 = retval_13;
         }
-        tmp_33 = tmp_34;
         {
             @name("ingress.val_14") bit<8> val_14 = h.b.c;
             @name("ingress.hasReturned") bool hasReturned_14 = false;
@@ -265,9 +216,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             hasReturned_14 = true;
             retval_14 = 8w2;
             h.b.c = val_14;
-            tmp_35 = retval_14;
+            tmp_28 = retval_14;
         }
-        tmp_36 = tmp_33 != tmp_35;
         {
             @name("ingress.val_15") bit<8> val_15 = h.b.d;
             @name("ingress.hasReturned") bool hasReturned_15 = false;
@@ -276,9 +226,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             hasReturned_15 = true;
             retval_15 = 8w2;
             h.b.d = val_15;
-            tmp_38 = retval_15;
+            tmp_29 = retval_15;
         }
-        tmp_37 = tmp_38;
         {
             @name("ingress.val_16") bit<8> val_16 = h.b.d;
             @name("ingress.hasReturned") bool hasReturned_16 = false;
@@ -287,9 +236,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             hasReturned_16 = true;
             retval_16 = 8w2;
             h.b.d = val_16;
-            tmp_39 = retval_16;
+            tmp_30 = retval_16;
         }
-        tmp_40 = tmp_37 == tmp_39;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2356-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2356-frontend.p4
@@ -23,17 +23,13 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.tmp") bit<16> tmp;
-    @name("ingress.tmp_1") bit<16> tmp_1;
     apply {
         {
             @name("ingress.hasReturned") bool hasReturned = false;
             @name("ingress.retval") bit<16> retval;
             hasReturned = true;
             retval = 16w1;
-            tmp = retval;
         }
-        tmp_1 = tmp << 8w8;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2488-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2488-bmv2-frontend.p4
@@ -33,9 +33,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp_2") bit<48> tmp_2;
     @name("ingress.tmp_3") bit<48> tmp_3;
     @name("ingress.tmp_4") bit<16> tmp_4;
-    @name("ingress.tmp_5") bit<48> tmp_5;
-    @name("ingress.tmp_6") bit<48> tmp_6;
-    @name("ingress.tmp_7") bit<48> tmp_7;
     apply {
         tmp_1 = h.eth_hdr.dst_addr;
         {
@@ -53,7 +50,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         tmp_0.setValid();
         tmp_0 = (ethernet_t){dst_addr = tmp_1,src_addr = tmp_2,eth_type = tmp_4};
         tmp = (Headers){eth_hdr = tmp_0};
-        tmp_5 = h.eth_hdr.dst_addr;
         {
             @name("ingress.s_1") bit<48> s_1 = h.eth_hdr.dst_addr;
             @name("ingress.hasReturned") bool hasReturned_1 = false;
@@ -62,9 +58,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             hasReturned_1 = true;
             retval_1 = 48w2;
             h.eth_hdr.dst_addr = s_1;
-            tmp_7 = retval_1;
         }
-        tmp_6 = tmp_7;
         h = tmp;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue2543-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2543-1-frontend.p4
@@ -11,26 +11,13 @@ struct Headers {
 }
 
 control ingress(inout Headers h) {
-    @name("ingress.foo") Headers foo_0;
-    @name("ingress.tmp") ethernet_t tmp;
-    @name("ingress.tmp_0") bit<48> tmp_0;
-    @name("ingress.tmp_1") bit<48> tmp_1;
-    @name("ingress.tmp_2") bit<16> tmp_2;
-    @name("ingress.tmp_3") bit<16> tmp_3;
     apply {
-        tmp_0 = 48w1;
-        tmp_1 = 48w1;
         {
             @name("ingress.hasReturned") bool hasReturned = false;
             @name("ingress.retval") bit<16> retval;
             hasReturned = true;
             retval = 16w1;
-            tmp_3 = retval;
         }
-        tmp_2 = tmp_3;
-        tmp.setValid();
-        tmp = (ethernet_t){dst_addr = tmp_0,src_addr = tmp_1,eth_type = tmp_2};
-        foo_0 = (Headers){eth_hdr = tmp};
         {
             @name("ingress.hasReturned_0") bool hasReturned_0 = false;
             @name("ingress.retval_0") ethernet_t retval_0;

--- a/testdata/p4_16_samples_outputs/issue2543-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2543-1-midend.p4
@@ -11,13 +11,8 @@ struct Headers {
 }
 
 control ingress(inout Headers h) {
-    @name("ingress.tmp") ethernet_t tmp;
     @name("ingress.retval_0") ethernet_t retval_0;
     @hidden action issue25431l17() {
-        tmp.setValid();
-        tmp.dst_addr = 48w1;
-        tmp.src_addr = 48w1;
-        tmp.eth_type = 16w1;
         retval_0.setValid();
         retval_0.dst_addr = 48w1;
         retval_0.src_addr = 48w1;

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice-frontend.p4
@@ -6,7 +6,6 @@ header Header {
 
 parser p(packet_in pckt, out Header h) {
     state start {
-        h.data = 32w0;
         h.data = 32w7;
         h.data[15:0] = 16w8;
         h.data[31:16] = 16w5;

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice-midend.p4
@@ -6,7 +6,6 @@ header Header {
 
 parser p(packet_in pckt, out Header h) {
     state start {
-        h.data = 32w0;
         h.data = 32w7;
         h.data[15:0] = 16w8;
         h.data[31:16] = 16w5;

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice2-frontend.p4
@@ -18,7 +18,6 @@ parser p0(packet_in p, out Header h) {
         transition final;
     }
     state next2 {
-        h.data[7:2] = 6w9;
         h.data[7:2] = 6w3;
         transition final;
     }

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice2-midend.p4
@@ -18,7 +18,6 @@ parser p0(packet_in p, out Header h) {
         transition final;
     }
     state next2 {
-        h.data[7:2] = 6w9;
         h.data[7:2] = 6w3;
         transition final;
     }

--- a/testdata/p4_16_samples_outputs/issue561-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-frontend.p4
@@ -16,9 +16,8 @@ package top(ct _ct);
 control c(out bit<32> x) {
     @name("c.u") U u_0;
     @name("c.u2") U[2] u2_0;
-    @name("c.b") bool b_0;
     apply {
-        b_0 = u_0.isValid();
+        u_0.isValid();
         u_0.h1.isValid();
         x = u_0.h1.f + u_0.h2.g;
         u_0.h1.setValid();

--- a/testdata/p4_16_samples_outputs/issue561-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-midend.p4
@@ -16,7 +16,8 @@ package top(ct _ct);
 control c(out bit<32> x) {
     @name("c.u") U u_0;
     @name("c.u2") U[2] u2_0;
-    @hidden action issue561l33() {
+    @hidden action issue561l32() {
+        u_0.isValid();
         u_0.h1.isValid();
         x = u_0.h1.f + u_0.h2.g;
         u_0.h1.setValid();
@@ -28,14 +29,14 @@ control c(out bit<32> x) {
         u2_0[0].h1.f = 32w2;
         x = x + u2_0[1].h2.g + 32w2;
     }
-    @hidden table tbl_issue561l33 {
+    @hidden table tbl_issue561l32 {
         actions = {
-            issue561l33();
+            issue561l32();
         }
-        const default_action = issue561l33();
+        const default_action = issue561l32();
     }
     apply {
-        tbl_issue561l33.apply();
+        tbl_issue561l32.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/pred2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pred2-frontend.p4
@@ -5,9 +5,7 @@
 control empty();
 package top(empty e);
 control Ing() {
-    @name("Ing.tmp_1") bool tmp;
     @name("Ing.cond") action cond_0() {
-        tmp = tmp;
     }
     @name("Ing.tbl_cond") table tbl_cond_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/pred2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pred2-midend.p4
@@ -5,7 +5,6 @@
 control empty();
 package top(empty e);
 control Ing() {
-    @name("Ing.tmp_1") bool tmp;
     @name("Ing.cond") action cond_0() {
     }
     @name("Ing.tbl_cond") table tbl_cond_0 {

--- a/testdata/p4_16_samples_outputs/side_effects-frontend.p4
+++ b/testdata/p4_16_samples_outputs/side_effects-frontend.p4
@@ -29,7 +29,6 @@ control my() {
         tmp_4 = tmp_3;
         tmp_5 = s_0[tmp_4].z;
         tmp_6 = f(tmp_5, a_0);
-        s_0[tmp_4].z = tmp_5;
         a_0 = tmp_6;
         a_0 = g(a_0);
         a_0 = g(a_0);

--- a/testdata/p4_16_samples_outputs/side_effects-midend.p4
+++ b/testdata/p4_16_samples_outputs/side_effects-midend.p4
@@ -23,7 +23,6 @@ control my() {
         tmp_3 = g(a_0);
         tmp_5 = s_0[tmp_3].z;
         tmp_6 = f(tmp_5, a_0);
-        s_0[tmp_3].z = tmp_5;
         a_0 = tmp_6;
         a_0 = g(a_0);
         a_0 = g(a_0);

--- a/testdata/p4_16_samples_outputs/simplify_slice-frontend.p4
+++ b/testdata/p4_16_samples_outputs/simplify_slice-frontend.p4
@@ -41,13 +41,9 @@ parser P(packet_in b, out Headers p, inout Metadata meta, inout standard_metadat
 
 control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_t standard_meta) {
     @name("Ing.n") bit<8> n_0;
-    @name("Ing.m") bit<8> m_0;
-    @name("Ing.x") bit<8> x_0;
     @name("Ing.debug") register<bit<8>>(32w2) debug_0;
     apply {
         n_0 = 8w0b11111111;
-        m_0 = 8w0b11111111;
-        x_0 = 8w0b11111111;
         n_0[7:4] = 4w0;
         debug_0.write(32w1, n_0);
         standard_meta.egress_spec = 9w0;

--- a/testdata/p4_16_samples_outputs/stack-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack-frontend.p4
@@ -5,26 +5,23 @@ header h {
 
 parser p() {
     @name("p.stack") h[4] stack_0;
-    @name("p.b") h b_0;
     state start {
         stack_0[0].setInvalid();
         stack_0[1].setInvalid();
         stack_0[2].setInvalid();
         stack_0[3].setInvalid();
         stack_0[3].setValid();
-        b_0 = stack_0.last;
-        stack_0[2] = b_0;
         transition accept;
     }
 }
 
 control c() {
     @name("c.stack") h[4] stack_1;
-    @name("c.b") h b_1;
+    @name("c.b") h b_0;
     apply {
         stack_1[3].setValid();
-        b_1 = stack_1[3];
-        stack_1[2] = b_1;
+        b_0 = stack_1[3];
+        stack_1[2] = b_0;
         stack_1.push_front(2);
         stack_1.pop_front(2);
     }

--- a/testdata/p4_16_samples_outputs/stack-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-midend.p4
@@ -11,7 +11,6 @@ parser p() {
         stack_0[2].setInvalid();
         stack_0[3].setInvalid();
         stack_0[3].setValid();
-        stack_0[2] = stack_0.last;
         transition accept;
     }
 }

--- a/testdata/p4_16_samples_outputs/tuple-frontend.p4
+++ b/testdata/p4_16_samples_outputs/tuple-frontend.p4
@@ -6,9 +6,7 @@ struct S {
 control proto();
 package top(proto _p);
 control c() {
-    @name("c.x") tuple<bit<32>, bool> x_0;
     apply {
-        x_0 = { 32w10, false };
     }
 }
 

--- a/testdata/p4_16_samples_outputs/tuple-midend.p4
+++ b/testdata/p4_16_samples_outputs/tuple-midend.p4
@@ -5,11 +5,6 @@ struct S {
 
 control proto();
 package top(proto _p);
-struct tuple_0 {
-    bit<32> f0;
-    bool    f1;
-}
-
 control c() {
     apply {
     }

--- a/testdata/p4_16_samples_outputs/uninit-frontend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-frontend.p4
@@ -10,8 +10,6 @@ extern void func(in Header h);
 extern bit<32> g(inout bit<32> v, in bit<32> w);
 parser p1(packet_in p, out Header h) {
     @name("p1.stack") Header[2] stack_0;
-    @name("p1.c") bool c_0;
-    @name("p1.d") bool d_0;
     @name("p1.tmp") bit<32> tmp;
     @name("p1.tmp_0") bit<32> tmp_0;
     @name("p1.tmp_1") bit<32> tmp_1;
@@ -33,12 +31,9 @@ parser p1(packet_in p, out Header h) {
         }
     }
     state next1 {
-        d_0 = false;
         transition next3;
     }
     state next2 {
-        c_0 = true;
-        d_0 = c_0;
         transition next3;
     }
     state next3 {
@@ -47,18 +42,12 @@ parser p1(packet_in p, out Header h) {
 }
 
 control c(out bit<32> v) {
-    @name("c.d") bit<32> d_1;
-    @name("c.setByAction") bit<32> setByAction_0;
     @name("c.e") bit<32> e_0;
-    @name("c.touched") bool touched_0;
     @name("c.a1") action a1() {
-        setByAction_0 = 32w1;
     }
     @name("c.a1") action a1_2() {
-        setByAction_0 = 32w1;
     }
     @name("c.a2") action a2() {
-        setByAction_0 = 32w1;
     }
     @name("c.t") table t_0 {
         actions = {
@@ -68,7 +57,6 @@ control c(out bit<32> v) {
         default_action = a1();
     }
     apply {
-        d_1 = 32w1;
         if (e_0 > 32w0) {
             e_0 = 32w1;
         } else {
@@ -77,12 +65,10 @@ control c(out bit<32> v) {
         e_0 = e_0 + 32w1;
         switch (t_0.apply().action_run) {
             a1: {
-                touched_0 = true;
             }
             default: {
             }
         }
-
         if (e_0 > 32w0) {
             t_0.apply();
         } else {


### PR DESCRIPTION
This (second) PR is a continuation of the discussion in https://github.com/p4lang/p4c/pull/2610.
Originally suggested as part of the solution, it was decided to become a separate concern.
As a result, the SimplifyDefUse pass runs until convergence, instead of only once.