### PR TITLE
Fixes #2613 predication issue

### DIFF
--- a/midend/predication.cpp
+++ b/midend/predication.cpp
@@ -189,16 +189,11 @@ const IR::Node* Predication::preorder(IR::AssignmentStatement* statement) {
         auto foundedAssignment = liveAssignments.find(statementName);
         if (foundedAssignment != liveAssignments.end()) {
             statement->right = foundedAssignment->second->right;
-            // Remove statement for 'then' if there is an else branch
-            if (!travesalPath[ifNestingLevel - 1]) {
-                liveAssigns.erase(std::remove(liveAssigns.begin(), liveAssigns.end(),
-                    foundedAssignment->second), liveAssigns.end());
-            }
         } else if (!statement->right->is<IR::Mux>()) {
             auto clonedLeft = clone(statement->left);
             statement->right = new IR::Mux(conditions.back(), clonedLeft, clonedLeft);
         }
-        // Remove statement for 'then' if there is an a statement
+        // Remove statement for 'then' if there is a statement
         // with the same statement name in the else branch.
         if (liveAssigns.size() > 0 && !isStatementDependent[statementName] &&
             lvalue_name(liveAssigns.back()->left) == lvalue_name(statement->left)) {

--- a/testdata/p4_16_samples/predication_issue.p4
+++ b/testdata/p4_16_samples/predication_issue.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+
+action assign_addrs(inout Headers h, bool check_1, bool check_2) {
+    h.eth_hdr.dst_addr = 4;
+	if (check_1) {
+        h.eth_hdr.dst_addr = 2;
+        if (check_2) {
+            // note that this is not dst_addr
+            h.eth_hdr.src_addr = 3;
+        } else {
+            h.eth_hdr.dst_addr = 1;
+        }
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+        assign_addrs(h, true, true);
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {b.emit(h);} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/predication_issue-first.p4
+++ b/testdata/p4_16_samples_outputs/predication_issue-first.p4
@@ -1,0 +1,67 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+action assign_addrs(inout Headers h, bool check_1, bool check_2) {
+    h.eth_hdr.dst_addr = 48w4;
+    if (check_1) {
+        h.eth_hdr.dst_addr = 48w2;
+        if (check_2) {
+            h.eth_hdr.src_addr = 48w3;
+        } else {
+            h.eth_hdr.dst_addr = 48w1;
+        }
+    }
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+        assign_addrs(h, true, true);
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<Headers>(h);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/predication_issue-frontend.p4
+++ b/testdata/p4_16_samples_outputs/predication_issue-frontend.p4
@@ -1,0 +1,64 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @name(".assign_addrs") action assign_addrs(inout Headers h_1, bool check_1, bool check_2) {
+        h_1.eth_hdr.dst_addr = 48w4;
+        if (check_1) {
+            h_1.eth_hdr.dst_addr = 48w2;
+            if (check_2) {
+                h_1.eth_hdr.src_addr = 48w3;
+            } else {
+                h_1.eth_hdr.dst_addr = 48w1;
+            }
+        }
+    }
+    apply {
+        assign_addrs(h, true, true);
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<Headers>(h);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/predication_issue-midend.p4
+++ b/testdata/p4_16_samples_outputs/predication_issue-midend.p4
@@ -1,0 +1,68 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    ethernet_t h_1_eth_hdr;
+    @name(".assign_addrs") action assign_addrs() {
+        h_1_eth_hdr = h.eth_hdr;
+        h_1_eth_hdr.dst_addr = 48w4;
+        h_1_eth_hdr.dst_addr = 48w2;
+        h_1_eth_hdr.src_addr = 48w3;
+        h_1_eth_hdr.dst_addr = 48w2;
+        h.eth_hdr = h_1_eth_hdr;
+    }
+    @hidden table tbl_assign_addrs {
+        actions = {
+            assign_addrs();
+        }
+        const default_action = assign_addrs();
+    }
+    apply {
+        tbl_assign_addrs.apply();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit<ethernet_t>(h.eth_hdr);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/predication_issue.p4
+++ b/testdata/p4_16_samples_outputs/predication_issue.p4
@@ -1,0 +1,67 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+action assign_addrs(inout Headers h, bool check_1, bool check_2) {
+    h.eth_hdr.dst_addr = 4;
+    if (check_1) {
+        h.eth_hdr.dst_addr = 2;
+        if (check_2) {
+            h.eth_hdr.src_addr = 3;
+        } else {
+            h.eth_hdr.dst_addr = 1;
+        }
+    }
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+        assign_addrs(h, true, true);
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+        b.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+


### PR DESCRIPTION
The removal of the condition on the line 192 leads to the correct predication output. The mentioned condition was not correct, it only tests if the travesalPath is false, which is true when there is any else branch in a p4 test. The assignment in 'then' should be erased only when there is a statement with the same statementName in the else branch inside a p4 test.

Then-else handling is correctly managed in if block on line 201 (new line 196), so no other test outputs are changed by this commit.