### PR TITLE
add ceil_log2 to gmputil.h

### DIFF
--- a/lib/bitops.h
+++ b/lib/bitops.h
@@ -17,8 +17,30 @@ limitations under the License.
 #ifndef P4C_LIB_BITOPS_H_
 #define P4C_LIB_BITOPS_H_
 
-#include "gmputil.h"
+#include <limits.h>
 #include "bitvec.h"
+
+static inline unsigned bitcount(unsigned v) {
+#if defined(__GNUC__) || defined(__clang__)
+    unsigned rv = __builtin_popcount(v);
+#else
+    unsigned rv = 0;
+    while (v) { v &= v-1; ++rv; }
+#endif
+    return rv; }
+
+static inline int floor_log2(unsigned v) {
+    int rv = -1;
+#if defined(__GNUC__) || defined(__clang__)
+    if (v) rv = CHAR_BIT*sizeof(unsigned) - __builtin_clz(v) - 1;
+#else
+    while (v) { rv++; v >>= 1; }
+#endif
+    return rv; }
+
+static inline int ceil_log2(unsigned v) {
+    return v ? floor_log2(v-1) + 1 : -1;
+}
 
 static inline unsigned bitmask2bytemask(const bitvec &a) {
     int max = a.max().index();

--- a/lib/gmputil.h
+++ b/lib/gmputil.h
@@ -94,8 +94,4 @@ static inline int floor_log2(big_int v) {
     return rv;
 }
 
-static inline int ceil_log2(big_int v) {
-    return v ? floor_log2(v-1) + 1 : -1;
-}
-
 #endif /* _LIB_GMPUTIL_H_ */

--- a/lib/gmputil.h
+++ b/lib/gmputil.h
@@ -94,4 +94,8 @@ static inline int floor_log2(big_int v) {
     return rv;
 }
 
+static inline int ceil_log2(big_int v) {
+    return v ? floor_log2(v-1) + 1 : -1;
+}
+
 #endif /* _LIB_GMPUTIL_H_ */


### PR DESCRIPTION
Revert previous commit to keep the original library function as they are used by other part of the compiler. Only adds ceil_log2 to gmputil.h.