### PR TITLE
Remove generic types after specialization

### DIFF
--- a/frontends/p4/specializeGenericTypes.cpp
+++ b/frontends/p4/specializeGenericTypes.cpp
@@ -134,7 +134,7 @@ const IR::Node* CreateSpecializedTypes::postorder(IR::Type_Declaration* type) {
             renamed->name = name;
             renamed->typeParameters = empty;
             it.second->replacement = postorder(renamed)->to<IR::Type_StructLike>();
-            LOG3("Specializing " << dbp(type) << " with " << ts << " as " << dbp(renamed));
+            LOG3("CST Specializing " << dbp(type) << " with " << ts << " as " << dbp(renamed));
         }
     }
     return insert(type);
@@ -154,19 +154,22 @@ const IR::Node* ReplaceTypeUses::postorder(IR::Type_Specialized* type) {
     if (!t)
         return type;
     CHECK_NULL(t->replacement);
-    LOG3("Replacing " << dbp(type) << " with " << dbp(t->replacement));
+    LOG3("RTU Replacing " << dbp(type) << " with " << dbp(t->replacement));
     return t->replacement->getP4Type();
 }
 
 const IR::Node* ReplaceTypeUses::postorder(IR::StructExpression* expression) {
-    auto spec = getOriginal<IR::StructExpression>()->structType->to<IR::Type_Specialized>();
+    auto st = getOriginal<IR::StructExpression>()->structType;
+    CHECK_NULL(st);
+    auto spec = st->to<IR::Type_Specialized>();
     if (spec == nullptr)
         return expression;
     auto replacement = specMap->get(spec);
     if (replacement == nullptr)
         return expression;
     auto replType = replacement->replacement;
-    LOG3("Replacing " << dbp(expression->structType) << " with " << dbp(replacement->replacement));
+    LOG3("RTU Replacing " << dbp(expression->structType) << " with " <<
+         dbp(replacement->replacement));
     expression->structType = replType->getP4Type();
     return expression;
 }

--- a/testdata/p4_16_samples/generic-struct-tuple.p4
+++ b/testdata/p4_16_samples/generic-struct-tuple.p4
@@ -1,0 +1,5 @@
+struct S<T> {
+    tuple<T, T> t;
+}
+
+const S<bit<32>> x = { t = { 0, 0 } };

--- a/testdata/p4_16_samples/generic-struct.p4
+++ b/testdata/p4_16_samples/generic-struct.p4
@@ -54,6 +54,7 @@ struct H3<T> {
     T s;
     H2<T> h2;
     H4<H2<T>> h3;
+    tuple<T, T> t;
 }
 
 header GH<T> {
@@ -73,7 +74,8 @@ const H3<S> h4 = {
     r = { g = { data = { b = 10 }, valid = 0 }, invalid = 1 },
     s = { b = 20 },
     h2 = { g = { data = { b = 0 }, valid = 1 }, invalid = 1 },
-    h3 = { x = { g = { data = { b = 0 }, valid = 1 }, invalid = 1 } }
+    h3 = { x = { g = { data = { b = 0 }, valid = 1 }, invalid = 1 } },
+    t = { { b = 0 }, { b = 1 } }
 };
 
 header_union HU<T> {

--- a/testdata/p4_16_samples/issue2627.p4
+++ b/testdata/p4_16_samples/issue2627.p4
@@ -1,0 +1,11 @@
+struct H3<T> {
+    tuple<T> t;
+}
+
+struct S {
+    bit<32> b;
+}
+
+const H3<S> h4 = {
+    t = { { b = 0 } }
+};

--- a/testdata/p4_16_samples_outputs/generic-struct-first.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-first.p4
@@ -55,7 +55,7 @@ struct H3_0 {
     tuple<S, S> t;
 }
 
-const H3_0 h4 = (H3_0){r = (H2_0){g = (Header_0){data = (S){b = 32w10},valid = 1w0},invalid = 1w1},s = (S){b = 32w20},h2 = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1},h3 = (H4_0){x = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1}},t = { {b = 32w0}, {b = 32w1} }};
+const H3_0 h4 = (H3_0){r = (H2_0){g = (Header_0){data = (S){b = 32w10},valid = 1w0},invalid = 1w1},s = (S){b = 32w20},h2 = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1},h3 = (H4_0){x = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1}},t = { (S){b = 32w0}, (S){b = 32w1} }};
 header_union HU_0 {
     X    xu;
     GH_0 h3u;

--- a/testdata/p4_16_samples_outputs/generic-struct-first.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-first.p4
@@ -1,8 +1,3 @@
-struct Header<St> {
-    St     data;
-    bit<1> valid;
-}
-
 struct S {
     bit<32> b;
 }
@@ -17,15 +12,6 @@ struct U {
 }
 
 const U u = (U){f = (Header_0){data = (S){b = 32w10},valid = 1w1}};
-struct H2<G> {
-    Header<G> g;
-    bit<1>    invalid;
-}
-
-struct H4<T> {
-    T x;
-}
-
 const Header_0 h2 = (Header_0){data = (S){b = 32w0},valid = 1w0};
 struct Header_1 {
     bit<16> data;
@@ -42,17 +28,6 @@ struct H2_0 {
 const H2_0 h1 = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1};
 const H2_0 h3 = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1};
 typedef H2_0 R;
-struct H3<T> {
-    R         r;
-    T         s;
-    H2<T>     h2;
-    H4<H2<T>> h3;
-}
-
-header GH<T> {
-    T data;
-}
-
 header X {
     bit<32> b;
 }
@@ -73,18 +48,14 @@ struct H4_0 {
 }
 
 struct H3_0 {
-    R    r;
-    S    s;
-    H2_0 h2;
-    H4_0 h3;
+    R           r;
+    S           s;
+    H2_0        h2;
+    H4_0        h3;
+    tuple<S, S> t;
 }
 
-const H3_0 h4 = (H3_0){r = (H2_0){g = (Header_0){data = (S){b = 32w10},valid = 1w0},invalid = 1w1},s = (S){b = 32w20},h2 = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1},h3 = (H4_0){x = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1}}};
-header_union HU<T> {
-    X     xu;
-    GH<T> h3u;
-}
-
+const H3_0 h4 = (H3_0){r = (H2_0){g = (Header_0){data = (S){b = 32w10},valid = 1w0},invalid = 1w1},s = (S){b = 32w20},h2 = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1},h3 = (H4_0){x = (H2_0){g = (Header_0){data = (S){b = 32w0},valid = 1w1},invalid = 1w1}},t = { {b = 32w0}, {b = 32w1} }};
 header_union HU_0 {
     X    xu;
     GH_0 h3u;

--- a/testdata/p4_16_samples_outputs/generic-struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-frontend.p4
@@ -1,8 +1,3 @@
-struct Header<St> {
-    St     data;
-    bit<1> valid;
-}
-
 struct S {
     bit<32> b;
 }
@@ -16,15 +11,6 @@ struct U {
     Header_0 f;
 }
 
-struct H2<G> {
-    Header<G> g;
-    bit<1>    invalid;
-}
-
-struct H4<T> {
-    T x;
-}
-
 struct Header_1 {
     bit<16> data;
     bit<1>  valid;
@@ -36,17 +22,6 @@ struct H2_0 {
 }
 
 typedef H2_0 R;
-struct H3<T> {
-    R         r;
-    T         s;
-    H2<T>     h2;
-    H4<H2<T>> h3;
-}
-
-header GH<T> {
-    T data;
-}
-
 header X {
     bit<32> b;
 }
@@ -64,15 +39,11 @@ struct H4_0 {
 }
 
 struct H3_0 {
-    R    r;
-    S    s;
-    H2_0 h2;
-    H4_0 h3;
-}
-
-header_union HU<T> {
-    X     xu;
-    GH<T> h3u;
+    R           r;
+    S           s;
+    H2_0        h2;
+    H4_0        h3;
+    tuple<S, S> t;
 }
 
 header_union HU_0 {

--- a/testdata/p4_16_samples_outputs/generic-struct-midend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-midend.p4
@@ -1,8 +1,3 @@
-struct Header<St> {
-    St     data;
-    bit<1> valid;
-}
-
 struct S {
     bit<32> b;
 }
@@ -16,15 +11,6 @@ struct U {
     Header_0 f;
 }
 
-struct H2<G> {
-    Header<G> g;
-    bit<1>    invalid;
-}
-
-struct H4<T> {
-    T x;
-}
-
 struct Header_1 {
     bit<16> data;
     bit<1>  valid;
@@ -36,17 +22,6 @@ struct H2_0 {
 }
 
 typedef H2_0 R;
-struct H3<T> {
-    R         r;
-    T         s;
-    H2<T>     h2;
-    H4<H2<T>> h3;
-}
-
-header GH<T> {
-    T data;
-}
-
 header X {
     bit<32> b;
 }
@@ -63,16 +38,17 @@ struct H4_0 {
     H2_0 x;
 }
 
-struct H3_0 {
-    R    r;
-    S    s;
-    H2_0 h2;
-    H4_0 h3;
+struct tuple_0 {
+    S f0;
+    S f1;
 }
 
-header_union HU<T> {
-    X     xu;
-    GH<T> h3u;
+struct H3_0 {
+    R       r;
+    S       s;
+    H2_0    h2;
+    H4_0    h3;
+    tuple_0 t;
 }
 
 header_union HU_0 {
@@ -81,21 +57,28 @@ header_union HU_0 {
 }
 
 control c(out bit<1> x) {
-    @hidden action genericstruct97() {
+    @name("c.gh") GH_1 gh_0;
+    @name("c.s") Stack s_0;
+    @name("c.xinst") X xinst_0;
+    @hidden action genericstruct93() {
+        s_0[0].setValid();
+        s_0[0]._data_b0 = 32w1;
+        s_0[0].isValid();
+        xinst_0.setValid();
+        xinst_0.b = 32w2;
         x = 1w0;
     }
-    @hidden table tbl_genericstruct97 {
+    @hidden table tbl_genericstruct93 {
         actions = {
-            genericstruct97();
+            genericstruct93();
         }
-        const default_action = genericstruct97();
+        const default_action = genericstruct93();
     }
     apply {
-        tbl_genericstruct97.apply();
+        tbl_genericstruct93.apply();
     }
 }
 
 control ctrl(out bit<1> x);
 package top(ctrl _c);
 top(c()) main;
-

--- a/testdata/p4_16_samples_outputs/generic-struct-midend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-midend.p4
@@ -57,28 +57,21 @@ header_union HU_0 {
 }
 
 control c(out bit<1> x) {
-    @name("c.gh") GH_1 gh_0;
-    @name("c.s") Stack s_0;
-    @name("c.xinst") X xinst_0;
-    @hidden action genericstruct93() {
-        s_0[0].setValid();
-        s_0[0]._data_b0 = 32w1;
-        s_0[0].isValid();
-        xinst_0.setValid();
-        xinst_0.b = 32w2;
+    @hidden action genericstruct99() {
         x = 1w0;
     }
-    @hidden table tbl_genericstruct93 {
+    @hidden table tbl_genericstruct99 {
         actions = {
-            genericstruct93();
+            genericstruct99();
         }
-        const default_action = genericstruct93();
+        const default_action = genericstruct99();
     }
     apply {
-        tbl_genericstruct93.apply();
+        tbl_genericstruct99.apply();
     }
 }
 
 control ctrl(out bit<1> x);
 package top(ctrl _c);
 top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/generic-struct-tuple-first.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-tuple-first.p4
@@ -1,0 +1,5 @@
+struct S_0 {
+    tuple<bit<32>, bit<32>> t;
+}
+
+const S_0 x = (S_0){t = { 32w0, 32w0 }};

--- a/testdata/p4_16_samples_outputs/generic-struct-tuple-frontend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-tuple-frontend.p4
@@ -1,0 +1,4 @@
+struct S_0 {
+    tuple<bit<32>, bit<32>> t;
+}
+

--- a/testdata/p4_16_samples_outputs/generic-struct-tuple.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-tuple.p4
@@ -1,0 +1,5 @@
+struct S<T> {
+    tuple<T, T> t;
+}
+
+const S<bit<32>> x = {t = { 0, 0 }};

--- a/testdata/p4_16_samples_outputs/generic-struct-tuple.p4-stderr
+++ b/testdata/p4_16_samples_outputs/generic-struct-tuple.p4-stderr
@@ -1,0 +1,1 @@
+[--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/generic-struct.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct.p4
@@ -28,10 +28,11 @@ const H2<S> h1 = (H2<S>){g = (Header<S>){data = {b = 0},valid = 1},invalid = 1};
 const H2<S> h3 = {g = {data = {b = 0},valid = 1},invalid = 1};
 typedef H2<S> R;
 struct H3<T> {
-    R         r;
-    T         s;
-    H2<T>     h2;
-    H4<H2<T>> h3;
+    R           r;
+    T           s;
+    H2<T>       h2;
+    H4<H2<T>>   h3;
+    tuple<T, T> t;
 }
 
 header GH<T> {
@@ -45,7 +46,7 @@ header X {
 const GH<bit<32>> g = {data = 0};
 const GH<S> g1 = {data = {b = 0}};
 typedef GH<S>[3] Stack;
-const H3<S> h4 = {r = {g = {data = {b = 10},valid = 0},invalid = 1},s = {b = 20},h2 = {g = {data = {b = 0},valid = 1},invalid = 1},h3 = {x = {g = {data = {b = 0},valid = 1},invalid = 1}}};
+const H3<S> h4 = {r = {g = {data = {b = 10},valid = 0},invalid = 1},s = {b = 20},h2 = {g = {data = {b = 0},valid = 1},invalid = 1},h3 = {x = {g = {data = {b = 0},valid = 1},invalid = 1}},t = { {b = 0}, {b = 1} }};
 header_union HU<T> {
     X     xu;
     GH<T> h3u;

--- a/testdata/p4_16_samples_outputs/issue2627-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2627-first.p4
@@ -1,0 +1,9 @@
+struct S {
+    bit<32> b;
+}
+
+struct H3_0 {
+    tuple<S> t;
+}
+
+const H3_0 h4 = (H3_0){t = { (S){b = 32w0} }};

--- a/testdata/p4_16_samples_outputs/issue2627-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2627-frontend.p4
@@ -1,0 +1,8 @@
+struct S {
+    bit<32> b;
+}
+
+struct H3_0 {
+    tuple<S> t;
+}
+

--- a/testdata/p4_16_samples_outputs/issue2627.p4
+++ b/testdata/p4_16_samples_outputs/issue2627.p4
@@ -1,0 +1,9 @@
+struct H3<T> {
+    tuple<T> t;
+}
+
+struct S {
+    bit<32> b;
+}
+
+const H3<S> h4 = {t = { {b = 0} }};

--- a/testdata/p4_16_samples_outputs/issue2627.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2627.p4-stderr
@@ -1,0 +1,1 @@
+[--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
This fixes a bug found as a result of reviewing this design in the language design working group.
After specializing generic structs the original type definitions are removed from the program so not further passes have to worry about them. Without these passes the tuple elimination pass generates incorrect code.
