### PR TITLE
Set idle timeout behavior based on table property in PSA 

### DIFF
--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -991,8 +991,14 @@ class P4RuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
                             const IR::TableBlock* tableBlock) override {
         P4RuntimeArchHandlerCommon<Arch::PSA>::addTableProperties(
             symbols, p4info, table, tableBlock);
-        // TODO(antonin): not supported yet in PSA
-        table->set_idle_timeout_behavior(p4configv1::Table::NOTIFY_CONTROL);
+
+        auto tableDeclaration = tableBlock->container;
+        bool supportsTimeout = getSupportsTimeout(tableDeclaration);
+        if (supportsTimeout) {
+            table->set_idle_timeout_behavior(p4configv1::Table::NOTIFY_CONTROL);
+        } else {
+            table->set_idle_timeout_behavior(p4configv1::Table::NO_TIMEOUT);
+        }
     }
 
     void addExternInstance(const P4RuntimeSymbolTableIface& symbols,
@@ -1023,6 +1029,31 @@ class P4RuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
                   "P4 type %1% could not be converted to P4Info P4DataTypeSpec");
 
         return Digest{decl->controlPlaneName(), typeSpec, decl->to<IR::IAnnotated>()};
+    }
+
+    /// @return true if @table's 'support_timeout' property exists and is true. This
+    /// indicates that @table supports entry ageing.
+    static bool getSupportsTimeout(const IR::P4Table* table) {
+        auto timeout = table->properties->getProperty("psa_idle_timeout");
+
+        if (timeout == nullptr) return false;
+
+        if (auto exprValue = timeout->value->to<IR::ExpressionValue>()) {
+            if (auto expr = exprValue->expression) {
+                if (auto member = expr->to<IR::Member>()) {
+                    if (member->member == "NOTIFY_CONTROL") {
+                        return true;
+                    } else if (member->member == "NO_TIMEOUT") {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        ::error(ErrorType::ERR_UNEXPECTED,
+                "Unexpected value %1% for supports_timeout "
+                "property on table %2%", timeout, table);
+        return false;
     }
 };
 

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -1052,7 +1052,8 @@ class P4RuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
 
         ::error(ErrorType::ERR_UNEXPECTED,
                 "Unexpected value %1% for supports_timeout "
-                "property on table %2%", timeout, table);
+                "property on table %2%. Supported values are "
+                "{ NOTIFY_CONTROL, NO_TIMEOUT }", timeout, table);
         return false;
     }
 };

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -1031,7 +1031,7 @@ class P4RuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
         return Digest{decl->controlPlaneName(), typeSpec, decl->to<IR::IAnnotated>()};
     }
 
-    /// @return true if @table's 'support_timeout' property exists and is true. This
+    /// @return true if @table's 'psa_idle_timeout' property exists and is true. This
     /// indicates that @table supports entry ageing.
     static bool getSupportsTimeout(const IR::P4Table* table) {
         auto timeout = table->properties->getProperty("psa_idle_timeout");
@@ -1046,12 +1046,18 @@ class P4RuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
                     } else if (member->member == "NO_TIMEOUT") {
                         return false;
                     }
+                } else if (auto path = expr->to<IR::PathExpression>()) {
+                    ::error(ErrorType::ERR_UNEXPECTED,
+                        "Unresolved value %1% for psa_idle_timeout "
+                        "property on table %2%. Must be a constant and one of "
+                        "{ NOTIFY_CONTROL, NO_TIMEOUT }", timeout, table);
+                    return false;
                 }
             }
         }
 
         ::error(ErrorType::ERR_UNEXPECTED,
-                "Unexpected value %1% for supports_timeout "
+                "Unexpected value %1% for psa_idle_timeout "
                 "property on table %2%. Supported values are "
                 "{ NOTIFY_CONTROL, NO_TIMEOUT }", timeout, table);
         return false;

--- a/testdata/p4_16_samples/psa-idle-timeout.p4
+++ b/testdata/p4_16_samples/psa-idle-timeout.p4
@@ -1,0 +1,120 @@
+#include <core.p4>
+#include <psa.p4>
+
+struct EMPTY { };
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    EthernetAddress srcAddr2;
+    EthernetAddress srcAddr3;
+    bit<16>         etherType;
+}
+
+parser MyIP(
+    packet_in buffer,
+    out ethernet_t eth,
+    inout EMPTY b,
+    in psa_ingress_parser_input_metadata_t c,
+    in EMPTY d,
+    in EMPTY e) {
+
+    state start {
+        buffer.extract(eth);
+        transition accept;
+    }
+}
+
+parser MyEP(
+    packet_in buffer,
+    out EMPTY a,
+    inout EMPTY b,
+    in psa_egress_parser_input_metadata_t c,
+    in EMPTY d,
+    in EMPTY e,
+    in EMPTY f) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(
+    inout ethernet_t a,
+    inout EMPTY b,
+    in psa_ingress_input_metadata_t c,
+    inout psa_ingress_output_metadata_t d) {
+
+    action a1(bit<48> param) { a.dstAddr = param; }
+    action a2(bit<16> param) { a.etherType = param; }
+    table tbl_idle_timeout {
+        key = {
+            a.srcAddr : exact;
+        }
+        actions = { NoAction; a1; a2; }
+        psa_idle_timeout = PSA_IdleTimeout_t.NOTIFY_CONTROL; 
+    }
+
+    table tbl_no_idle_timeout {
+        key = {
+            a.srcAddr2: exact;
+        }
+        actions = { NoAction; a1; a2; }
+        psa_idle_timeout = PSA_IdleTimeout_t.NO_TIMEOUT; 
+    }
+
+    table tbl_no_idle_timeout_prop {
+        key = {
+            a.srcAddr2: exact;
+        }
+        actions = { NoAction; a1; a2; }
+    }
+
+    apply {
+        tbl_idle_timeout.apply();
+        tbl_no_idle_timeout.apply();
+        tbl_no_idle_timeout_prop.apply();
+    }
+}
+
+control MyEC(
+    inout EMPTY a,
+    inout EMPTY b,
+    in psa_egress_input_metadata_t c,
+    inout psa_egress_output_metadata_t d) {
+    apply { }
+}
+
+control MyID(
+    packet_out buffer,
+    out EMPTY a,
+    out EMPTY b,
+    out EMPTY c,
+    inout ethernet_t d,
+    in EMPTY e,
+    in psa_ingress_output_metadata_t f) {
+    apply {
+        buffer.emit(d);
+    }
+}
+
+control MyED(
+    packet_out buffer,
+    out EMPTY a,
+    out EMPTY b,
+    inout EMPTY c,
+    in EMPTY d,
+    in psa_egress_output_metadata_t e,
+    in psa_egress_deparser_input_metadata_t f) {
+    apply { }
+}
+
+IngressPipeline(MyIP(), MyIC(), MyID()) ip;
+EgressPipeline(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch(
+    ip,
+    PacketReplicationEngine(),
+    ep,
+    BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-action-profile1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1.p4.p4info.txt
@@ -23,7 +23,6 @@ tables {
     id: 23466264
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-action-profile2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile2.p4.p4info.txt
@@ -23,7 +23,6 @@ tables {
     id: 23466264
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-action-profile4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4.p4.p4info.txt
@@ -20,7 +20,6 @@ tables {
     id: 23466264
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 tables {
   preamble {
@@ -41,7 +40,6 @@ tables {
     id: 21832421
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-action-selector1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1.p4.p4info.txt
@@ -23,7 +23,6 @@ tables {
     id: 23466264
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4.p4info.txt
@@ -23,7 +23,6 @@ tables {
     id: 23466264
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4.p4info.txt
@@ -23,7 +23,6 @@ tables {
     id: 23466264
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.p4info.txt
@@ -11,7 +11,6 @@ tables {
     id: 17064084
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4.p4info.txt
@@ -20,7 +20,6 @@ tables {
     id: 22078320
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4.p4info.txt
@@ -20,7 +20,6 @@ tables {
     id: 22078320
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4.p4info.txt
@@ -18,7 +18,6 @@ tables {
   }
   direct_resource_ids: 319980461
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.p4info.txt
@@ -20,7 +20,6 @@ tables {
     id: 22078320
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-example-counters-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-counters-bmv2.p4.p4info.txt
@@ -21,7 +21,6 @@ tables {
   }
   direct_resource_ids: 332805598
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-example-digest-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-digest-bmv2.p4.p4info.txt
@@ -20,7 +20,6 @@ tables {
     id: 26564927
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 tables {
   preamble {
@@ -41,7 +40,6 @@ tables {
     id: 21257015
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 tables {
   preamble {
@@ -65,7 +63,6 @@ tables {
     id: 21257015
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum-first.p4
@@ -111,7 +111,6 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
                         error.BadIPv4HeaderChecksum : set_error_idx(8w7);
                         error.UnhandledIPv4Options : set_error_idx(8w8);
         }
-
         psa_direct_counter = parser_error_counts;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum-frontend.p4
@@ -117,7 +117,6 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
                         error.BadIPv4HeaderChecksum : set_error_idx(8w7);
                         error.UnhandledIPv4Options : set_error_idx(8w8);
         }
-
         psa_direct_counter = parser_error_counts_0;
     }
     apply {
@@ -165,3 +164,4 @@ IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_met
 EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum-midend.p4
@@ -125,7 +125,6 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
                         error.BadIPv4HeaderChecksum : set_error_idx(8w7);
                         error.UnhandledIPv4Options : set_error_idx(8w8);
         }
-
         psa_direct_counter = parser_error_counts_0;
     }
     @hidden action psaexampleparserchecksum184() {

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum.p4
@@ -111,7 +111,6 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
                         error.BadIPv4HeaderChecksum : set_error_idx(7);
                         error.UnhandledIPv4Options : set_error_idx(8);
         }
-
         psa_direct_counter = parser_error_counts;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/psa-hash.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-hash.p4.p4info.txt
@@ -20,7 +20,6 @@ tables {
     id: 21832421
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout-first.p4
@@ -1,0 +1,99 @@
+#include <core.p4>
+#include <psa.p4>
+
+struct EMPTY {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    EthernetAddress srcAddr2;
+    EthernetAddress srcAddr3;
+    bit<16>         etherType;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+    state start {
+        buffer.extract<ethernet_t>(eth);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_input_metadata_t c, in EMPTY d, in EMPTY e, in EMPTY f) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    action a1(bit<48> param) {
+        a.dstAddr = param;
+    }
+    action a2(bit<16> param) {
+        a.etherType = param;
+    }
+    table tbl_idle_timeout {
+        key = {
+            a.srcAddr: exact @name("a.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            a1();
+            a2();
+        }
+        psa_idle_timeout = PSA_IdleTimeout_t.NOTIFY_CONTROL;
+        default_action = NoAction();
+    }
+    table tbl_no_idle_timeout {
+        key = {
+            a.srcAddr2: exact @name("a.srcAddr2") ;
+        }
+        actions = {
+            NoAction();
+            a1();
+            a2();
+        }
+        psa_idle_timeout = PSA_IdleTimeout_t.NO_TIMEOUT;
+        default_action = NoAction();
+    }
+    table tbl_no_idle_timeout_prop {
+        key = {
+            a.srcAddr2: exact @name("a.srcAddr2") ;
+        }
+        actions = {
+            NoAction();
+            a1();
+            a2();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl_idle_timeout.apply();
+        tbl_no_idle_timeout.apply();
+        tbl_no_idle_timeout_prop.apply();
+    }
+}
+
+control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    apply {
+        buffer.emit<ethernet_t>(d);
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPTY d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout-frontend.p4
@@ -1,0 +1,117 @@
+#include <core.p4>
+#include <psa.p4>
+
+struct EMPTY {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    EthernetAddress srcAddr2;
+    EthernetAddress srcAddr3;
+    bit<16>         etherType;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+    state start {
+        buffer.extract<ethernet_t>(eth);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_input_metadata_t c, in EMPTY d, in EMPTY e, in EMPTY f) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_4() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_5() {
+    }
+    @name("MyIC.a1") action a1(bit<48> param) {
+        a.dstAddr = param;
+    }
+    @name("MyIC.a1") action a1_3(bit<48> param) {
+        a.dstAddr = param;
+    }
+    @name("MyIC.a1") action a1_4(bit<48> param) {
+        a.dstAddr = param;
+    }
+    @name("MyIC.a2") action a2(bit<16> param) {
+        a.etherType = param;
+    }
+    @name("MyIC.a2") action a2_3(bit<16> param) {
+        a.etherType = param;
+    }
+    @name("MyIC.a2") action a2_4(bit<16> param) {
+        a.etherType = param;
+    }
+    @name("MyIC.tbl_idle_timeout") table tbl_idle_timeout_0 {
+        key = {
+            a.srcAddr: exact @name("a.srcAddr") ;
+        }
+        actions = {
+            NoAction_0();
+            a1();
+            a2();
+        }
+        psa_idle_timeout = PSA_IdleTimeout_t.NOTIFY_CONTROL;
+        default_action = NoAction_0();
+    }
+    @name("MyIC.tbl_no_idle_timeout") table tbl_no_idle_timeout_0 {
+        key = {
+            a.srcAddr2: exact @name("a.srcAddr2") ;
+        }
+        actions = {
+            NoAction_4();
+            a1_3();
+            a2_3();
+        }
+        psa_idle_timeout = PSA_IdleTimeout_t.NO_TIMEOUT;
+        default_action = NoAction_4();
+    }
+    @name("MyIC.tbl_no_idle_timeout_prop") table tbl_no_idle_timeout_prop_0 {
+        key = {
+            a.srcAddr2: exact @name("a.srcAddr2") ;
+        }
+        actions = {
+            NoAction_5();
+            a1_4();
+            a2_4();
+        }
+        default_action = NoAction_5();
+    }
+    apply {
+        tbl_idle_timeout_0.apply();
+        tbl_no_idle_timeout_0.apply();
+        tbl_no_idle_timeout_prop_0.apply();
+    }
+}
+
+control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    apply {
+        buffer.emit<ethernet_t>(d);
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPTY d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout-midend.p4
@@ -1,0 +1,126 @@
+#include <core.p4>
+#include <psa.p4>
+
+struct EMPTY {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    EthernetAddress srcAddr2;
+    EthernetAddress srcAddr3;
+    bit<16>         etherType;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+    state start {
+        buffer.extract<ethernet_t>(eth);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_input_metadata_t c, in EMPTY d, in EMPTY e, in EMPTY f) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_4() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_5() {
+    }
+    @name("MyIC.a1") action a1(bit<48> param) {
+        a.dstAddr = param;
+    }
+    @name("MyIC.a1") action a1_3(bit<48> param) {
+        a.dstAddr = param;
+    }
+    @name("MyIC.a1") action a1_4(bit<48> param) {
+        a.dstAddr = param;
+    }
+    @name("MyIC.a2") action a2(bit<16> param) {
+        a.etherType = param;
+    }
+    @name("MyIC.a2") action a2_3(bit<16> param) {
+        a.etherType = param;
+    }
+    @name("MyIC.a2") action a2_4(bit<16> param) {
+        a.etherType = param;
+    }
+    @name("MyIC.tbl_idle_timeout") table tbl_idle_timeout_0 {
+        key = {
+            a.srcAddr: exact @name("a.srcAddr") ;
+        }
+        actions = {
+            NoAction_0();
+            a1();
+            a2();
+        }
+        psa_idle_timeout = PSA_IdleTimeout_t.NOTIFY_CONTROL;
+        default_action = NoAction_0();
+    }
+    @name("MyIC.tbl_no_idle_timeout") table tbl_no_idle_timeout_0 {
+        key = {
+            a.srcAddr2: exact @name("a.srcAddr2") ;
+        }
+        actions = {
+            NoAction_4();
+            a1_3();
+            a2_3();
+        }
+        psa_idle_timeout = PSA_IdleTimeout_t.NO_TIMEOUT;
+        default_action = NoAction_4();
+    }
+    @name("MyIC.tbl_no_idle_timeout_prop") table tbl_no_idle_timeout_prop_0 {
+        key = {
+            a.srcAddr2: exact @name("a.srcAddr2") ;
+        }
+        actions = {
+            NoAction_5();
+            a1_4();
+            a2_4();
+        }
+        default_action = NoAction_5();
+    }
+    apply {
+        tbl_idle_timeout_0.apply();
+        tbl_no_idle_timeout_0.apply();
+        tbl_no_idle_timeout_prop_0.apply();
+    }
+}
+
+control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    @hidden action psaidletimeout98() {
+        buffer.emit<ethernet_t>(d);
+    }
+    @hidden table tbl_psaidletimeout98 {
+        actions = {
+            psaidletimeout98();
+        }
+        const default_action = psaidletimeout98();
+    }
+    apply {
+        tbl_psaidletimeout98.apply();
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPTY d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout.p4
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout.p4
@@ -1,0 +1,96 @@
+#include <core.p4>
+#include <psa.p4>
+
+struct EMPTY {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    EthernetAddress srcAddr2;
+    EthernetAddress srcAddr3;
+    bit<16>         etherType;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+    state start {
+        buffer.extract(eth);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_input_metadata_t c, in EMPTY d, in EMPTY e, in EMPTY f) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    action a1(bit<48> param) {
+        a.dstAddr = param;
+    }
+    action a2(bit<16> param) {
+        a.etherType = param;
+    }
+    table tbl_idle_timeout {
+        key = {
+            a.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            a1;
+            a2;
+        }
+        psa_idle_timeout = PSA_IdleTimeout_t.NOTIFY_CONTROL;
+    }
+    table tbl_no_idle_timeout {
+        key = {
+            a.srcAddr2: exact;
+        }
+        actions = {
+            NoAction;
+            a1;
+            a2;
+        }
+        psa_idle_timeout = PSA_IdleTimeout_t.NO_TIMEOUT;
+    }
+    table tbl_no_idle_timeout_prop {
+        key = {
+            a.srcAddr2: exact;
+        }
+        actions = {
+            NoAction;
+            a1;
+            a2;
+        }
+    }
+    apply {
+        tbl_idle_timeout.apply();
+        tbl_no_idle_timeout.apply();
+        tbl_no_idle_timeout_prop.apply();
+    }
+}
+
+control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    apply {
+        buffer.emit(d);
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPTY d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.p4info.txt
@@ -3,9 +3,9 @@ pkg_info {
 }
 tables {
   preamble {
-    id: 39967501
-    name: "MyIC.tbl"
-    alias: "tbl"
+    id: 38763260
+    name: "MyIC.tbl_idle_timeout"
+    alias: "tbl_idle_timeout"
   }
   match_fields {
     id: 1
@@ -23,16 +23,40 @@ tables {
     id: 23466264
   }
   size: 1024
+  idle_timeout_behavior: NOTIFY_CONTROL
 }
 tables {
   preamble {
-    id: 47318070
-    name: "MyIC.tbl2"
-    alias: "tbl2"
+    id: 46250950
+    name: "MyIC.tbl_no_idle_timeout"
+    alias: "tbl_no_idle_timeout"
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "a.srcAddr2"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 21832421
+  }
+  action_refs {
+    id: 23466264
+  }
+  size: 1024
+}
+tables {
+  preamble {
+    id: 43498864
+    name: "MyIC.tbl_no_idle_timeout_prop"
+    alias: "tbl_no_idle_timeout_prop"
+  }
+  match_fields {
+    id: 1
+    name: "a.srcAddr2"
     bitwidth: 48
     match_type: EXACT
   }
@@ -78,14 +102,6 @@ actions {
     name: "param"
     bitwidth: 16
   }
-}
-action_profiles {
-  preamble {
-    id: 298015716
-    name: "MyIC.ap"
-    alias: "ap"
-  }
-  size: 1024
 }
 type_info {
 }

--- a/testdata/p4_16_samples_outputs/psa-meter3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter3.p4.p4info.txt
@@ -17,7 +17,6 @@ tables {
     id: 21257015
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4.p4info.txt
@@ -18,7 +18,6 @@ tables {
   }
   direct_resource_ids: 368068636
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4.p4info.txt
@@ -18,7 +18,6 @@ tables {
   }
   direct_resource_ids: 368068636
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-meter6.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter6.p4.p4info.txt
@@ -18,7 +18,6 @@ tables {
   }
   direct_resource_ids: 368068636
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 tables {
   preamble {
@@ -39,7 +38,6 @@ tables {
     id: 18579058
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-random.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-random.p4.p4info.txt
@@ -20,7 +20,6 @@ tables {
     id: 18493089
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txt
@@ -11,7 +11,6 @@ tables {
     id: 25218586
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.p4info.txt
@@ -20,7 +20,6 @@ tables {
     id: 23115527
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.p4info.txt
@@ -20,7 +20,6 @@ tables {
     id: 23115527
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.p4info.txt
@@ -20,7 +20,6 @@ tables {
     id: 23115527
   }
   size: 1024
-  idle_timeout_behavior: NOTIFY_CONTROL
 }
 actions {
   preamble {


### PR DESCRIPTION
For p4info generation on PSA, the idle timeout is always set to `NOTIFY_CONTROL` which shows up for tables which dont have any 'psa_idle_timeout' property on the table. PR checks for the property and sets the value accordingly.
