### PR TITLE
Add don't cares to the list of type variable bindings

### DIFF
--- a/testdata/p4_16_samples/issue2492.p4
+++ b/testdata/p4_16_samples/issue2492.p4
@@ -17,4 +17,4 @@ control ingress(inout headers hdr) {
 control ctr<H>(inout H hdr);
 package top<H1, H2, H3>(ctr<H1> ctrl1, @optional ctr<H2> ctrl2, @optional ctr<H3> ctrl3);
 
-top<headers, _, _>(ingress()) main;
+top(ingress()) main;

--- a/testdata/p4_16_samples/issue2630.p4
+++ b/testdata/p4_16_samples/issue2630.p4
@@ -1,0 +1,13 @@
+control C<H>(inout H h);
+package Pipeline<H>(C<H> c);
+package Switch<H0, H1>(Pipeline<H0> p0, @optional Pipeline<H1> p1);
+
+
+struct header_t {
+}
+control MyC(inout header_t h) {
+    apply {}
+}
+
+Pipeline(MyC()) pipe;
+Switch(pipe) main;

--- a/testdata/p4_16_samples_outputs/issue2492.p4
+++ b/testdata/p4_16_samples_outputs/issue2492.p4
@@ -16,5 +16,5 @@ control ingress(inout headers hdr) {
 
 control ctr<H>(inout H hdr);
 package top<H1, H2, H3>(ctr<H1> ctrl1, @optional ctr<H2> ctrl2, @optional ctr<H3> ctrl3);
-top<headers, _, _>(ingress()) main;
+top(ingress()) main;
 

--- a/testdata/p4_16_samples_outputs/issue2630-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2630-first.p4
@@ -1,0 +1,15 @@
+control C<H>(inout H h);
+package Pipeline<H>(C<H> c);
+package Switch<H0, H1>(Pipeline<H0> p0, @optional Pipeline<H1> p1);
+struct header_t {
+}
+
+control MyC(inout header_t h) {
+    apply {
+    }
+}
+
+Pipeline<header_t>(MyC()) pipe;
+
+Switch<header_t, _>(pipe) main;
+

--- a/testdata/p4_16_samples_outputs/issue2630-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2630-frontend.p4
@@ -1,0 +1,15 @@
+control C<H>(inout H h);
+package Pipeline<H>(C<H> c);
+package Switch<H0, H1>(Pipeline<H0> p0, @optional Pipeline<H1> p1);
+struct header_t {
+}
+
+control MyC(inout header_t h) {
+    apply {
+    }
+}
+
+Pipeline<header_t>(MyC()) pipe;
+
+Switch<header_t, _>(pipe) main;
+

--- a/testdata/p4_16_samples_outputs/issue2630-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2630-midend.p4
@@ -1,0 +1,15 @@
+control C<H>(inout H h);
+package Pipeline<H>(C<H> c);
+package Switch<H0, H1>(Pipeline<H0> p0, @optional Pipeline<H1> p1);
+struct header_t {
+}
+
+control MyC(inout header_t h) {
+    apply {
+    }
+}
+
+Pipeline<header_t>(MyC()) pipe;
+
+Switch<header_t, _>(pipe) main;
+

--- a/testdata/p4_16_samples_outputs/issue2630.p4
+++ b/testdata/p4_16_samples_outputs/issue2630.p4
@@ -1,0 +1,15 @@
+control C<H>(inout H h);
+package Pipeline<H>(C<H> c);
+package Switch<H0, H1>(Pipeline<H0> p0, @optional Pipeline<H1> p1);
+struct header_t {
+}
+
+control MyC(inout header_t h) {
+    apply {
+    }
+}
+
+Pipeline(MyC()) pipe;
+
+Switch(pipe) main;
+


### PR DESCRIPTION
This update was lost when the statement to save the values of the type variables was moved in #2603.
Fixes #2630