### PR TITLE
Add -o option to p4test backend

### DIFF
--- a/backends/bmv2/common/options.h
+++ b/backends/bmv2/common/options.h
@@ -26,8 +26,6 @@ class BMV2Options : public CompilerOptions {
  public:
     // Externs generation
     bool emitExterns = false;
-    // file to output to
-    cstring outputFile = nullptr;
     // read from json
     bool loadIRFromJson = false;
 
@@ -36,9 +34,6 @@ class BMV2Options : public CompilerOptions {
                 [this](const char*) { emitExterns = true; return true; },
                 "[BMv2 back-end] Force externs be emitted by the backend.\n"
                 "The generated code follows the BMv2 JSON specification.");
-        registerOption("-o", "outfile",
-                [this](const char* arg) { outputFile = arg; return true; },
-                "Write output to outfile");
         registerOption("--fromJSON", "file",
                 [this](const char* arg) { loadIRFromJson = true; file = arg; return true; },
                 "Use IR representation from JsonFile dumped previously,"\

--- a/backends/ebpf/ebpfOptions.cpp
+++ b/backends/ebpf/ebpfOptions.cpp
@@ -4,9 +4,6 @@
 
 EbpfOptions::EbpfOptions() {
         langVersion = CompilerOptions::FrontendVersion::P4_16;
-        registerOption("-o", "outfile",
-                [this](const char* arg) { outputFile = arg; return true; },
-                "Write output to outfile");
         registerOption("--listMidendPasses", nullptr,
                 [this](const char*) {
                     loadIRFromJson = false;

--- a/backends/ebpf/ebpfOptions.h
+++ b/backends/ebpf/ebpfOptions.h
@@ -23,8 +23,6 @@ limitations under the License.
 
 class EbpfOptions : public CompilerOptions {
  public:
-    // file to output to
-    cstring outputFile = nullptr;
     // read from json
     bool loadIRFromJson = false;
     // Externs generation

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -40,6 +40,7 @@ class P4TestOptions : public CompilerOptions {
     bool validateOnly = false;
     bool loadIRFromJson = false;
     P4TestOptions() {
+        unRegisterOption("-o");
         registerOption("--listMidendPasses", nullptr,
                 [this](const char*) {
                     listMidendPasses = true;

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -100,6 +100,11 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
     registerOption("--toJSON", "file",
                    [this](const char* arg) { dumpJsonFile = arg; return true; },
                    "Dump the compiler IR after the midend as JSON in the specified file.");
+
+    registerOption("-o", "outfile",
+                   [this](const char* arg) { outputFile = arg; return true; },
+                   "Write output to outfile");
+
     registerOption("--p4runtime-files", "filelist",
                    [this](const char* arg) { p4RuntimeFiles = arg; return true; },
                    "Write the P4Runtime control plane API description to the specified\n"

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -90,6 +90,9 @@ class CompilerOptions : public Util::Options {
     // Dump a JSON representation of the IR in the file
     cstring dumpJsonFile = nullptr;
 
+    // Use to dump output from backends.
+    cstring outputFile = nullptr;
+
     // Dump and undump the IR tree
     bool debugJson = false;
 

--- a/lib/options.cpp
+++ b/lib/options.cpp
@@ -40,14 +40,15 @@ void Util::Options::registerOption(const char* option, const char* argName,
 
 void Util::Options::unRegisterOption(const char* option) {
     auto it = options.find(option);
-    auto itv = find (optionOrder.begin(), optionOrder.end(), option);
-    if (it != options.end()) {
-        auto o = it->second;
-        options.erase(it);
-        if (itv != optionOrder.end())
-            optionOrder.erase(itv);
-        delete o;
-    }
+    auto itv = find(optionOrder.begin(), optionOrder.end(), option);
+    BUG_CHECK(it != options.end(),
+              "Failed to find option data to unregister: %1%", option);
+    auto o = it->second;
+    options.erase(it);
+    BUG_CHECK(itv != optionOrder.end(),
+              "Failed to find option internal data to unregister: %1%", option);
+    optionOrder.erase(itv);
+    delete o;
 }
 
 // Process options; return list of remaining options.

--- a/lib/options.cpp
+++ b/lib/options.cpp
@@ -38,6 +38,18 @@ void Util::Options::registerOption(const char* option, const char* argName,
     optionOrder.push_back(option);
 }
 
+void Util::Options::unRegisterOption(const char* option) {
+    auto it = options.find(option);
+    auto itv = find (optionOrder.begin(), optionOrder.end(), option);
+    if (it != options.end()) {
+        auto o = it->second;
+        options.erase(it);
+        if (itv != optionOrder.end())
+            optionOrder.erase(itv);
+        delete o;
+    }
+}
+
 // Process options; return list of remaining options.
 // Returns 'nullptr' if an error is signalled
 std::vector<const char*>* Util::Options::process(int argc, char* const argv[]) {

--- a/lib/options.h
+++ b/lib/options.h
@@ -77,6 +77,7 @@ class Options {
                         OptionProcessor processor,  // function to execute when option matches
                         const char* description,  // option help message
                         OptionFlags flags = OptionFlags::Default);  // additional flags
+    void unRegisterOption(const char* option);
 
     explicit Options(cstring message) : binaryName(nullptr), message(message) {}
 


### PR DESCRIPTION
p4c backends in bmv2, ebpf, and ubpf support the `-o` option.  It's only the p4test backend that does not.  P4 modularity is one example of an app which would use the `-o` option to dump the merged P4 program.   This PR moves the option to `frontend/common/options.h[.cpp]`.