### PR TITLE
Fixed unitialized variable in frontend typeChecking

### DIFF
--- a/frontends/p4/typeChecking/typeConstraints.h
+++ b/frontends/p4/typeChecking/typeConstraints.h
@@ -228,7 +228,8 @@ class TypeConstraints final {
 
     explicit TypeConstraints(const TypeVariableSubstitution* definedVariables) :
             unification(new TypeUnification(this)), definedVariables(definedVariables),
-            replaceVariables(definedVariables) {}
+            replaceVariables(definedVariables),
+            currentSubstitution(new TypeVariableSubstitution()) {}
 
     // Mark this variable as being free.
     void addUnifiableTypeVariable(const IR::ITypeVar* typeVariable)


### PR DESCRIPTION
* Unitialized variable added to constructor (introduced by 6b9da239267529aeea6946cb0aa984c4487b07d9)