### PR TITLE
Revert "Add -o option to p4test backend (#2634)"

### DIFF
--- a/backends/bmv2/common/options.h
+++ b/backends/bmv2/common/options.h
@@ -26,6 +26,8 @@ class BMV2Options : public CompilerOptions {
  public:
     // Externs generation
     bool emitExterns = false;
+    // file to output to
+    cstring outputFile = nullptr;
     // read from json
     bool loadIRFromJson = false;
 
@@ -34,6 +36,9 @@ class BMV2Options : public CompilerOptions {
                 [this](const char*) { emitExterns = true; return true; },
                 "[BMv2 back-end] Force externs be emitted by the backend.\n"
                 "The generated code follows the BMv2 JSON specification.");
+        registerOption("-o", "outfile",
+                [this](const char* arg) { outputFile = arg; return true; },
+                "Write output to outfile");
         registerOption("--fromJSON", "file",
                 [this](const char* arg) { loadIRFromJson = true; file = arg; return true; },
                 "Use IR representation from JsonFile dumped previously,"\

--- a/backends/ebpf/ebpfOptions.cpp
+++ b/backends/ebpf/ebpfOptions.cpp
@@ -4,6 +4,9 @@
 
 EbpfOptions::EbpfOptions() {
         langVersion = CompilerOptions::FrontendVersion::P4_16;
+        registerOption("-o", "outfile",
+                [this](const char* arg) { outputFile = arg; return true; },
+                "Write output to outfile");
         registerOption("--listMidendPasses", nullptr,
                 [this](const char*) {
                     loadIRFromJson = false;

--- a/backends/ebpf/ebpfOptions.h
+++ b/backends/ebpf/ebpfOptions.h
@@ -23,6 +23,8 @@ limitations under the License.
 
 class EbpfOptions : public CompilerOptions {
  public:
+    // file to output to
+    cstring outputFile = nullptr;
     // read from json
     bool loadIRFromJson = false;
     // Externs generation

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -40,7 +40,6 @@ class P4TestOptions : public CompilerOptions {
     bool validateOnly = false;
     bool loadIRFromJson = false;
     P4TestOptions() {
-        unRegisterOption("-o");
         registerOption("--listMidendPasses", nullptr,
                 [this](const char*) {
                     listMidendPasses = true;

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -100,11 +100,6 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
     registerOption("--toJSON", "file",
                    [this](const char* arg) { dumpJsonFile = arg; return true; },
                    "Dump the compiler IR after the midend as JSON in the specified file.");
-
-    registerOption("-o", "outfile",
-                   [this](const char* arg) { outputFile = arg; return true; },
-                   "Write output to outfile");
-
     registerOption("--p4runtime-files", "filelist",
                    [this](const char* arg) { p4RuntimeFiles = arg; return true; },
                    "Write the P4Runtime control plane API description to the specified\n"

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -90,9 +90,6 @@ class CompilerOptions : public Util::Options {
     // Dump a JSON representation of the IR in the file
     cstring dumpJsonFile = nullptr;
 
-    // Use to dump output from backends.
-    cstring outputFile = nullptr;
-
     // Dump and undump the IR tree
     bool debugJson = false;
 

--- a/lib/options.cpp
+++ b/lib/options.cpp
@@ -38,19 +38,6 @@ void Util::Options::registerOption(const char* option, const char* argName,
     optionOrder.push_back(option);
 }
 
-void Util::Options::unRegisterOption(const char* option) {
-    auto it = options.find(option);
-    auto itv = find(optionOrder.begin(), optionOrder.end(), option);
-    BUG_CHECK(it != options.end(),
-              "Failed to find option data to unregister: %1%", option);
-    auto o = it->second;
-    options.erase(it);
-    BUG_CHECK(itv != optionOrder.end(),
-              "Failed to find option internal data to unregister: %1%", option);
-    optionOrder.erase(itv);
-    delete o;
-}
-
 // Process options; return list of remaining options.
 // Returns 'nullptr' if an error is signalled
 std::vector<const char*>* Util::Options::process(int argc, char* const argv[]) {

--- a/lib/options.h
+++ b/lib/options.h
@@ -77,7 +77,6 @@ class Options {
                         OptionProcessor processor,  // function to execute when option matches
                         const char* description,  // option help message
                         OptionFlags flags = OptionFlags::Default);  // additional flags
-    void unRegisterOption(const char* option);
 
     explicit Options(cstring message) : binaryName(nullptr), message(message) {}
 


### PR DESCRIPTION
This reverts commit ecba24ad591e719268860f66202530830d2a914e.

Not all targets outputs to a single file, moving '-o' to top level creates unnecessary work.