### PR TITLE
Add more flexibility to compiler configuration.

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "lib/gmputil.h"
 #include "constantFolding.h"
-#include "ir/configuration.h"
+#include "frontends/common/options.h"
 #include "frontends/p4/enumInstance.h"
 
 namespace P4 {
@@ -531,9 +531,9 @@ const IR::Node* DoConstantFolding::postorder(IR::LOr* e) {
 }
 
 static bool overflowWidth(const IR::Node* node, int width) {
-    if (width > P4CConfiguration::MaximumWidthSupported) {
+    if (width > P4CContext::getConfig().maximumWidthSupported()) {
         ::error(ErrorType::ERR_UNSUPPORTED, "%1%: Compiler only supports widths up to %2%",
-                node, P4CConfiguration::MaximumWidthSupported);
+                node, P4CContext::getConfig().maximumWidthSupported());
         return true;
     }
     return false;

--- a/frontends/common/constantParsing.cpp
+++ b/frontends/common/constantParsing.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "constantParsing.h"
 
-#include "ir/configuration.h"
+#include "frontends/common/options.h"
 #include "ir/ir.h"
 #include "lib/gmputil.h"
 #include "lib/source_file.h"
@@ -42,7 +42,7 @@ parseConstantWithWidth(Util::SourceInfo srcInfo, const char* text,
     if (size <= 0) {
         ::error(ErrorType::ERR_INVALID, "%1%: invalid width; %2% must be positive", srcInfo, size);
         return nullptr; }
-    if (size > P4CConfiguration::MaximumWidthSupported) {
+    if (size > P4CContext::getConfig().maximumWidthSupported()) {
         ::error(ErrorType::ERR_OVERLIMIT, "%1%: %2% size too large", srcInfo, size);
         return nullptr; }
 

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -446,6 +446,11 @@ DebugHook CompilerOptions::getDebugHook() const {
     return CompileContextStack::top<P4CContext>();
 }
 
+const P4CConfiguration& P4CContext::getConfig() {
+    if (CompileContextStack::isEmpty()) return DefaultP4CConfiguration::get();
+    return get().getConfigImpl();
+}
+
 bool P4CContext::isRecognizedDiagnostic(cstring diagnostic) {
     static const std::unordered_set<cstring> recognizedDiagnostics = {
         "uninitialized_out_param",
@@ -454,4 +459,8 @@ bool P4CContext::isRecognizedDiagnostic(cstring diagnostic) {
     };
 
     return recognizedDiagnostics.count(diagnostic);
+}
+
+const P4CConfiguration& P4CContext::getConfigImpl() {
+    return DefaultP4CConfiguration::get();
 }

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "lib/compile_context.h"
 #include "lib/cstring.h"
 #include "lib/options.h"
+#include "ir/configuration.h"
 #include "ir/ir.h"  // for DebugHook definition
 // for p4::P4RuntimeFormat definition
 #include "control-plane/p4RuntimeSerializer.h"
@@ -149,12 +150,16 @@ class CompilerOptions : public Util::Options {
 };
 
 
-/// A compilation context which exposes compiler options.
+/// A compilation context which exposes compiler options and a compiler configuration.
 class P4CContext : public BaseCompileContext {
  public:
     /// @return the current compilation context, which must inherit from
     /// P4CContext.
     static P4CContext& get();
+
+    /// @return the compiler configuration for the current compilation context. If there is no
+    /// current compilation context, the default configuration is returned.
+    static const P4CConfiguration& getConfig();
 
     P4CContext() {}
 
@@ -188,6 +193,9 @@ class P4CContext : public BaseCompileContext {
     /// intended to help the user find misspelled diagnostics and the like; it
     /// doesn't affect functionality.
     virtual bool isRecognizedDiagnostic(cstring diagnostic);
+
+    /// @return the compiler configuration associated with this type of compilation context.
+    virtual const P4CConfiguration& getConfigImpl();
 };
 
 /// A utility template which can be used to easily make subclasses of P4CContext

--- a/ir/configuration.h
+++ b/ir/configuration.h
@@ -17,13 +17,30 @@ limitations under the License.
 #ifndef IR_CONFIGURATION_H_
 #define IR_CONFIGURATION_H_
 
-namespace P4CConfiguration {
+/// A P4CConfiguration is a set of parameters to the compiler that cannot be changed via user
+/// options. Implementations should be singleton classes.
+class P4CConfiguration {
+ public:
+    /// Maximum width supported for a bit field or integer.
+    virtual int maximumWidthSupported() const = 0;
 
-// Maximum width supported for a bit-field or integer
-const int MaximumWidthSupported = 2048;
-// Maximum size for a header stack array
-const int MaximumArraySize = 256;
+    /// Maximum size for a header stack array.
+    virtual int maximumArraySize() const = 0;
+};
 
-}
+class DefaultP4CConfiguration : public P4CConfiguration {
+ public:
+    int maximumWidthSupported() const { return 2048; }
+    int maximumArraySize() const { return 256; }
+
+    /// @return the singleton instance.
+    static const DefaultP4CConfiguration& get() {
+        static DefaultP4CConfiguration instance;
+        return instance;
+    }
+
+ protected:
+    DefaultP4CConfiguration() {}
+};
 
 #endif /* IR_CONFIGURATION_H_ */

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include <utility>
 #include "ir.h"
-#include "configuration.h"
+#include "frontends/common/options.h"
 
 namespace IR {
 
@@ -65,9 +65,9 @@ const Type_Bits* Type_Bits::get(int width, bool isSigned) {
     auto &result = (*type_map)[std::make_pair(width, isSigned)];
     if (!result)
         result = new Type_Bits(width, isSigned);
-    if (width > P4CConfiguration::MaximumWidthSupported)
+    if (width > P4CContext::getConfig().maximumWidthSupported())
         ::error(ErrorType::ERR_UNSUPPORTED, "%1%: Compiler only supports widths up to %2%",
-                result, P4CConfiguration::MaximumWidthSupported);
+                result, P4CContext::getConfig().maximumWidthSupported());
     return result;
 }
 

--- a/lib/compile_context.h
+++ b/lib/compile_context.h
@@ -49,6 +49,10 @@ struct CompileContextStack final {
         return *current;
     }
 
+    static bool isEmpty() {
+        return getStack().empty();
+    }
+
  private:
     friend struct AutoCompileContext;
 


### PR DESCRIPTION
This turns the `P4CConfiguration` into an abstract class to allow overriding of compiler configuration parameters. The active configuration can be obtained from `P4CContext`.