### PR TITLE
Update run-p4-sample.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG ENABLE_UNIFIED_COMPILATION=ON
 # Whether to enable translation validation
 ARG VALIDATION=OFF
 
-# Delegate the build to tools/travis-build.
+# Delegate the build to tools/ci-build.
 COPY . /p4c/
 WORKDIR /p4c/
-RUN chmod u+x tools/travis-build && tools/travis-build
+RUN chmod u+x tools/ci-build.sh && tools/ci-build.sh

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ dot -Tpdf ParserImpl.dot > ParserImpl.pdf
 2.  Install [dependencies](#dependencies). You can find specific instructions
     for Ubuntu 16.04 [here](#ubuntu-dependencies) and for macOS 10.12
     [here](#macos-dependencies).  You can also look at the
-    [travis installation script](tools/travis-build).
+    [CI installation script](tools/ci-build.sh).
 
 3.  Build. Building should also take place in a subdirectory named `build`.
     ```

--- a/backends/bmv2/run-bmv2-test.py
+++ b/backends/bmv2/run-bmv2-test.py
@@ -254,9 +254,9 @@ def process_file(options, argv):
 
     if result != SUCCESS:
         print("Error compiling")
-        print("".join(open(stderr).readlines()))
+        print(open(stderr).read())
         # If the compiler crashed fail the test
-        if 'Compiler Bug' in open(stderr).readlines():
+        if 'Compiler Bug' in open(stderr).read():
             return FAILURE
 
     expected_error = isError(options.p4filename)

--- a/backends/p4test/run-p4-sample.py
+++ b/backends/p4test/run-p4-sample.py
@@ -264,9 +264,9 @@ def process_file(options, argv):
 
     if result != SUCCESS:
         print("Error compiling")
-        print("".join(open(stderr).readlines()))
+        print(open(stderr).read())
         # If the compiler crashed fail the test
-        if 'Compiler Bug' in open(stderr).readlines():
+        if 'Compiler Bug' in open(stderr).read():
             return FAILURE
 
     expected_error = isError(options.p4filename)


### PR DESCRIPTION
This pull request adds `-fsanitize=null` to the CI build process (only the CI build process) and also fixes an issue, where compiler bugs were incorrectly classified in the Python test scripts. The sanitize options by GCC and Clang seem fairly useful to find obscure bugs like these. However, they also increase compilation time substantially and, considering that the tests already run very slow, it makes sense to stick with only `-fsanitize=null`for now.  

This should be merged once #2681 and #2684 are resolved. 