### PR TITLE
Add correct Bazel cc toolchain dependency

### DIFF
--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -117,4 +117,6 @@ p4_library = rule(
         ),
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
+    incompatible_use_toolchain_transition = True,
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )


### PR DESCRIPTION
In upcoming versions of Bazel, cc toolchains will be resolved via toolchain resolution, which requires the `toolchains` argument to the `rule` function.

The `incompatible_use_toolchain_transition` flag is set due to a migration, we will remove this when it is no longer needed (on the order of a half year, I suspect).