### PR TITLE
Seperate parser options from frontend options

### DIFF
--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -151,6 +151,7 @@ set (COMMON_FRONTEND_SRCS
   common/constantFolding.cpp
   common/constantParsing.cpp
   common/options.cpp
+  common/parser_options.cpp
   common/parseInput.cpp
   common/resolveReferences/referenceMap.cpp
   common/resolveReferences/resolveReferences.cpp
@@ -163,6 +164,7 @@ set (COMMON_FRONTEND_HDRS
   common/model.h
   common/name_gateways.h
   common/options.h
+  common/parser_options.h
   common/parseInput.h
   common/programMap.h
   common/resolveReferences/referenceMap.h

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -1,54 +1,41 @@
-/*
-Copyright 2013-present Barefoot Networks, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-#include <getopt.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <unordered_set>
-#include <regex>
-
 #include "options.h"
-#include "lib/log.h"
-#include "lib/exceptions.h"
-#include "lib/exename.h"
-#include "lib/nullstream.h"
-#include "lib/path.h"
-#include "frontends/p4/toP4/toP4.h"
-#include "ir/json_generator.h"
 #include "frontends/p4/frontend.h"
 
-const char* p4includePath = CONFIG_PKGDATADIR "/p4include";
-const char* p4_14includePath = CONFIG_PKGDATADIR "/p4_14include";
 
 CompilerOptions::CompilerOptions() : ParserOptions() {
+    registerOption("--excludeFrontendPasses", "pass1[,pass2]",
+                   [this](const char* arg) {
+                      excludeFrontendPasses = true;
+                      auto copy = strdup(arg);
+                      while (auto pass = strsep(&copy, ","))
+                          passesToExcludeFrontend.push_back(pass);
+                      return true;
+                   },
+                   "Exclude passes from frontend passes whose name is equal\n"
+                   "to one of `passX' strings.\n");
+    registerOption("--listFrontendPasses", nullptr,
+                   [this](const char*) {
+                      listFrontendPasses = true;
+                      P4::FrontEnd frontend;
+                      frontend.run(*this, nullptr, false, outStream);
+                      exit(0);
+                      return false;
+                   },
+                   "List exact names of all frontend passes\n");
+    registerOption("--pp", "file",
+                   [this](const char* arg) { prettyPrintFile = arg; return true; },
+                   "Pretty-print the program in the specified file.");
+    registerOption("--target", "target",
+                   [this](const char* arg) { target = arg; return true; },
+                    "Compile for the specified target device.");
+    registerOption("--arch", "arch",
+                   [this](const char* arg) { arch = arg; return true; },
+                   "Compile for the specified architecture.");
     registerOption("--p4runtime-files", "filelist",
                    [this](const char* arg) { p4RuntimeFiles = arg; return true; },
                    "Write the P4Runtime control plane API description to the specified\n"
                    "files (comma-separated list). The format is inferred from the file\n"
                    "suffix: .txt, .json, .bin");
-    registerOption("--p4runtime-file", "file",
-                   [this](const char* arg) { p4RuntimeFile = arg; return true; },
-                   "Write a P4Runtime control plane API description to the specified file.\n"
-                   "[Deprecated; use '--p4runtime-files' instead].");
-    registerOption("--p4runtime-entries-file", "file",
-                   [this](const char* arg) { p4RuntimeEntriesFile = arg; return true; },
-                   "Write static table entries as a P4Runtime WriteRequest message"
-                   "to the specified file.\n"
-                   "[Deprecated; use '--p4runtime-entries-files' instead].");
     registerOption("--p4runtime-entries-files", "files",
                    [this](const char* arg) { p4RuntimeEntriesFiles = arg; return true; },
                    "Write static table entries as a P4Runtime WriteRequest message\n"
@@ -70,320 +57,4 @@ CompilerOptions::CompilerOptions() : ParserOptions() {
                    "Choose output format for the P4Runtime API description (default is binary).\n"
                    "[Deprecated; use '--p4runtime-files' instead].");
 
-    registerOption("--excludeFrontendPasses", "pass1[,pass2]",
-                   [this](const char* arg) {
-                      excludeFrontendPasses = true;
-                      auto copy = strdup(arg);
-                      while (auto pass = strsep(&copy, ","))
-                          passesToExcludeFrontend.push_back(pass);
-                      return true;
-                   },
-                   "Exclude passes from frontend passes whose name is equal\n"
-                   "to one of `passX' strings.\n");
-    registerOption("--excludeMidendPasses", "pass1[,pass2]",
-                   [this](const char* arg) {
-                      excludeMidendPasses = true;
-                      auto copy = strdup(arg);
-                      while (auto pass = strsep(&copy, ","))
-                          passesToExcludeMidend.push_back(pass);
-                      return true;
-                   },
-                   "Exclude passes from midend passes whose name is equal\n"
-                   "to one of `passX' strings.\n");
-    registerOption("--listFrontendPasses", nullptr,
-                   [this](const char*) {
-                      listFrontendPasses = true;
-                      P4::FrontEnd frontend;
-                      frontend.run(*this, nullptr, false, outStream);
-                      exit(0);
-                      return false;
-                   },
-                   "List exact names of all frontend passes\n");
-
-    registerOption("--Wdisable", "diagnostic",
-        [](const char *diagnostic) {
-            if (diagnostic) {
-                P4CContext::get().setDiagnosticAction(diagnostic,
-                                                      DiagnosticAction::Ignore);
-            } else {
-                auto action = DiagnosticAction::Ignore;
-                P4CContext::get().setDefaultWarningDiagnosticAction(action);
-            }
-            return true;
-        }, "Disable a compiler diagnostic, or disable all warnings if no "
-           "diagnostic is specified.",
-        OptionFlags::OptionalArgument);
-    registerOption("--Wwarn", "diagnostic",
-        [](const char *diagnostic) {
-            if (diagnostic) {
-                P4CContext::get().setDiagnosticAction(diagnostic,
-                                                      DiagnosticAction::Warn);
-            } else {
-                auto action = DiagnosticAction::Warn;
-                P4CContext::get().setDefaultWarningDiagnosticAction(action);
-            }
-            return true;
-        }, "Report a warning for a compiler diagnostic, or treat all warnings "
-           "as warnings (the default) if no diagnostic is specified.",
-        OptionFlags::OptionalArgument);
-    registerOption("--Werror", "diagnostic",
-        [](const char *diagnostic) {
-            if (diagnostic) {
-                P4CContext::get().setDiagnosticAction(diagnostic,
-                                                      DiagnosticAction::Error);
-            } else {
-                auto action = DiagnosticAction::Error;
-                P4CContext::get().setDefaultWarningDiagnosticAction(action);
-            }
-            return true;
-        }, "Report an error for a compiler diagnostic, or treat all warnings as "
-           "errors if no diagnostic is specified.",
-        OptionFlags::OptionalArgument);
-    registerOption("--maxErrorCount", "errorCount",
-                   [](const char *arg) {
-                       auto maxError = strtoul(arg, nullptr, 10);
-                       P4CContext::get().errorReporter().setMaxErrorCount(maxError);
-                       return true; },
-                       "Set the maximum number of errors to display before failing.");
-    registerOption("--p4v", "{14|16}",
-                   [this](const char* arg) {
-                       if (!strcmp(arg, "1.0") || !strcmp(arg, "14")) {
-                           langVersion = CompilerOptions::FrontendVersion::P4_14;
-                       } else if (!strcmp(arg, "1.2") || !strcmp(arg, "16")) {
-                           langVersion = CompilerOptions::FrontendVersion::P4_16;
-                       } else {
-                           ::error(ErrorType::ERR_INVALID, "Illegal language version %1%", arg);
-                           return false;
-                       }
-                       return true; },
-                    "[Deprecated; use --std instead] Specify language version to compile.",
-                    OptionFlags::Hide);
-    registerOption("--std", "{p4-14|p4-16}",
-                   [this](const char* arg) {
-                       if (!strcmp(arg, "14") || !strcmp(arg, "p4-14")) {
-                           langVersion = CompilerOptions::FrontendVersion::P4_14;
-                       } else if (!strcmp(arg, "16") || !strcmp(arg, "p4-16")) {
-                           langVersion = CompilerOptions::FrontendVersion::P4_16;
-                       } else {
-                           ::error(ErrorType::ERR_INVALID, "Illegal language version %1%", arg);
-                           return false;
-                       }
-                       return true; },
-                    "Specify language version to compile.");
-}
-
-void CompilerOptions::setInputFile() {
-    if (remainingOptions.size() > 1) {
-        ::error(ErrorType::ERR_OVERLIMIT, "Only one input file must be specified: %s",
-                cstring::join(remainingOptions.begin(), remainingOptions.end(), ","));
-        usage();
-        exit(1);
-    } else if (remainingOptions.size() == 0) {
-        ::error(ErrorType::ERR_EXPECTED, "No input files specified");
-        usage();
-        exit(1);
-    } else {
-        file = remainingOptions.at(0);
-    }
-}
-
-namespace {
-
-bool setIncludePathIfExists(const char*& includePathOut,
-                            const char* possiblePath) {
-    struct stat st;
-    if (!(stat(possiblePath, &st) >= 0 && S_ISDIR(st.st_mode))) return false;
-    if (auto path = realpath(possiblePath, NULL))
-        includePathOut = path;
-    else
-        includePathOut = strdup(possiblePath);
-    return true;
-}
-
-}  // namespace
-
-std::vector<const char*>* CompilerOptions::process(int argc, char* const argv[]) {
-    char buffer[PATH_MAX];
-
-    snprintf(buffer, sizeof(buffer), "%s", exename(argv[0]));
-    if (char *p = strrchr(buffer, '/')) {
-        ++p;
-        exe_name = p;
-        snprintf(p, buffer + sizeof(buffer) - p, "p4include");
-        if (!setIncludePathIfExists(p4includePath, buffer)) {
-            snprintf(p, buffer + sizeof(buffer) - p, "../p4include");
-            setIncludePathIfExists(p4includePath, buffer); }
-        snprintf(p, buffer + sizeof(buffer) - p, "p4_14include");
-        if (!setIncludePathIfExists(p4_14includePath, buffer)) {
-            snprintf(p, buffer + sizeof(buffer) - p, "../p4_14include");
-            setIncludePathIfExists(p4_14includePath, buffer); }
-    }
-
-    auto remainingOptions = Util::Options::process(argc, argv);
-    validateOptions();
-    return remainingOptions;
-}
-
-void CompilerOptions::validateOptions() const {
-    if (!p4RuntimeFile.isNullOrEmpty()) {
-        ::warning(ErrorType::WARN_DEPRECATED,
-                  "'--p4runtime-file' and '--p4runtime-format' are deprecated, "
-                  "consider using '--p4runtime-files' instead");
-    }
-    if (!p4RuntimeEntriesFile.isNullOrEmpty()) {
-        ::warning(ErrorType::WARN_DEPRECATED,
-                  "'--p4runtime-entries-file' is deprecated, "
-                  "consider using '--p4runtime-entries-files' instead");
-    }
-}
-
-FILE* CompilerOptions::preprocess() {
-    FILE* in = nullptr;
-
-    if (file == "-") {
-        file = "<stdin>";
-        in = stdin;
-    } else {
-#ifdef __clang__
-        std::string cmd("cc -E -x c -Wno-comment");
-#else
-        std::string cmd("cpp");
-#endif
-        // the p4c driver sets environment variables for include
-        // paths.  check the environment and add these to the command
-        // line for the preprocessor
-        char * driverP4IncludePath =
-          isv1() ? getenv("P4C_14_INCLUDE_PATH") : getenv("P4C_16_INCLUDE_PATH");
-        cmd += cstring(" -C -undef -nostdinc -x assembler-with-cpp") + " " + preprocessor_options
-            + (driverP4IncludePath ? " -I" + cstring(driverP4IncludePath) : "")
-            + " -I" + (isv1() ? p4_14includePath : p4includePath) + " " + file;
-
-        if (Log::verbose())
-            std::cerr << "Invoking preprocessor " << std::endl << cmd << std::endl;
-        in = popen(cmd.c_str(), "r");
-        if (in == nullptr) {
-            ::error(ErrorType::ERR_IO, "Error invoking preprocessor");
-            perror("");
-            return nullptr;
-        }
-        close_input = true;
-    }
-
-    if (doNotCompile) {
-        char *line = NULL;
-        size_t len = 0;
-        ssize_t read;
-
-        while ((read = getline(&line, &len, in)) != -1)
-            printf("%s", line);
-        closeInput(in);
-        return nullptr;
-    }
-    return in;
-}
-
-void CompilerOptions::closeInput(FILE* inputStream) const {
-    if (close_input) {
-        int exitCode = pclose(inputStream);
-        if (WIFEXITED(exitCode) && WEXITSTATUS(exitCode) == 4)
-            ::error(ErrorType::ERR_IO, "input file %s does not exist", file);
-        else if (exitCode != 0)
-            ::error(ErrorType::ERR_IO,
-                    "Preprocessor returned exit code %d; aborting compilation", exitCode);
-    }
-}
-
-// From (folder, file.ext, suffix)  returns
-// folder/file-suffix.ext
-static cstring makeFileName(cstring folder, cstring name, cstring baseSuffix) {
-    Util::PathName filename(name);
-    Util::PathName newName(filename.getBasename() + baseSuffix + "." + filename.getExtension());
-    auto result = Util::PathName(folder).join(newName.toString());
-    return result.toString();
-}
-
-bool CompilerOptions::isv1() const {
-    return langVersion == CompilerOptions::FrontendVersion::P4_14;
-}
-
-bool CompilerOptions::enable_intrinsic_metadata_fix() {
-    return true;
-}
-
-void CompilerOptions::dumpPass(const char* manager, unsigned seq, const char* pass,
-                               const IR::Node* node) const {
-    if (strncmp(pass, "P4::", 4) == 0) pass += 4;
-    cstring name = cstring(manager) + "_" + Util::toString(seq) + "_" + pass;
-    if (Log::verbose())
-        std::cerr << name << std::endl;
-
-    for (auto s : top4) {
-        bool match = false;
-        try {
-           auto s_regex = std::regex(s, std::regex_constants::ECMAScript);
-            // we use regex_search instead of regex_match
-            // regex_match compares the regex against the entire string
-            // regex_search checks if the regex is contained as substring
-            match = std::regex_search(name.begin(), name.end(), s_regex);
-        } catch (const std::regex_error &e) {
-            ::error(ErrorType::ERR_INVALID, "Malformed toP4 regex string \"%s\".\n"
-                    "The regex matcher follows ECMAScript syntax.", s);
-            exit(1);
-        }
-        if (match) {
-            cstring suffix = cstring("-") + name;
-            cstring filename = file;
-            if (filename == "-")
-                filename = "tmp.p4";
-
-            cstring fileName = makeFileName(dumpFolder, filename, suffix);
-            auto stream = openFile(fileName, true);
-            if (stream != nullptr) {
-                if (Log::verbose())
-                    std::cerr << "Writing program to " << fileName << std::endl;
-                P4::ToP4 toP4(stream, Log::verbose(), file);
-                node->apply(toP4);
-                delete stream;  // close the file
-            }
-            break;
-        }
-    }
-}
-
-bool CompilerOptions::isAnnotationDisabled(const IR::Annotation *a) const {
-    if (disabledAnnotations.count(a->name.name) > 0) {
-        ::warning(ErrorType::WARN_IGNORE,
-                  "%1% is ignored because it was explicitly disabled", a);
-        return true;
-    }
-    return false;
-}
-
-DebugHook CompilerOptions::getDebugHook() const {
-    using namespace std::placeholders;
-    auto dp = std::bind(&CompilerOptions::dumpPass, this, _1, _2, _3, _4);
-    return dp;
-}
-
-/* static */ P4CContext& P4CContext::get() {
-    return CompileContextStack::top<P4CContext>();
-}
-
-const P4CConfiguration& P4CContext::getConfig() {
-    if (CompileContextStack::isEmpty()) return DefaultP4CConfiguration::get();
-    return get().getConfigImpl();
-}
-
-bool P4CContext::isRecognizedDiagnostic(cstring diagnostic) {
-    static const std::unordered_set<cstring> recognizedDiagnostics = {
-        "uninitialized_out_param",
-        "uninitialized_use",
-        "unknown_diagnostic"
-    };
-
-    return recognizedDiagnostics.count(diagnostic);
-}
-
-const P4CConfiguration& P4CContext::getConfigImpl() {
-    return DefaultP4CConfiguration::get();
 }

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -56,5 +56,4 @@ CompilerOptions::CompilerOptions() : ParserOptions() {
                        return true; },
                    "Choose output format for the P4Runtime API description (default is binary).\n"
                    "[Deprecated; use '--p4runtime-files' instead].");
-
 }

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -36,7 +36,8 @@ const char* p4_14includePath = CONFIG_PKGDATADIR "/p4_14include";
 
 const char* CompilerOptions::defaultMessage = "Compile a P4 program";
 
-CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
+
+ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
     registerOption("--help", nullptr,
                    [this](const char*) { usage(); exit(0); return false; },
                    "Print this help message");
@@ -49,6 +50,16 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                    [this](const char* arg) {
                        preprocessor_options += std::string(" -I") + arg; return true; },
                    "Specify include path (passed to preprocessor)");
+    registerOption("--target", "target",
+                   [this](const char* arg) { target = arg; return true; },
+                    "Compile for the specified target device.");
+    registerOption("--arch", "arch",
+                   [this](const char* arg) { arch = arg; return true; },
+                   "Compile for the specified architecture.");
+}
+
+
+CompilerOptions::CompilerOptions() : ParserOptions() {
     registerOption("-D", "arg=value",
                    [this](const char* arg) {
                        preprocessor_options += std::string(" -D") + arg; return true; },
@@ -88,12 +99,6 @@ CompilerOptions::CompilerOptions() : Util::Options(defaultMessage) {
                        }
                        return true; },
                     "Specify language version to compile.");
-    registerOption("--target", "target",
-                   [this](const char* arg) { target = arg; return true; },
-                    "Compile for the specified target device.");
-    registerOption("--arch", "arch",
-                   [this](const char* arg) { arch = arg; return true; },
-                   "Compile for the specified architecture.");
     registerOption("--pp", "file",
                    [this](const char* arg) { prettyPrintFile = arg; return true; },
                    "Pretty-print the program in the specified file.");

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -35,7 +35,6 @@ const char* p4includePath = CONFIG_PKGDATADIR "/p4include";
 const char* p4_14includePath = CONFIG_PKGDATADIR "/p4_14include";
 
 CompilerOptions::CompilerOptions() : ParserOptions() {
-
     registerOption("--p4runtime-files", "filelist",
                    [this](const char* arg) { p4RuntimeFiles = arg; return true; },
                    "Write the P4Runtime control plane API description to the specified\n"
@@ -170,7 +169,7 @@ CompilerOptions::CompilerOptions() : ParserOptions() {
                            return false;
                        }
                        return true; },
-                    "Specify language version to compile.");                       
+                    "Specify language version to compile.");
 }
 
 void CompilerOptions::setInputFile() {

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -1,3 +1,19 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #include "options.h"
 #include "frontends/p4/frontend.h"
 

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -34,7 +34,7 @@ limitations under the License.
 const char* p4includePath = CONFIG_PKGDATADIR "/p4include";
 const char* p4_14includePath = CONFIG_PKGDATADIR "/p4_14include";
 
-const char* CompilerOptions::defaultMessage = "Compile a P4 program";
+const char* ParserOptions::defaultMessage = "Compile a P4 program";
 
 
 ParserOptions::ParserOptions() : Util::Options(defaultMessage) {

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -39,14 +39,25 @@ extern const char* p4_14includePath;
 // Each back-end should subclass this file.
 
 class ParserOptions : public Util::Options {
+    static const char* defaultMessage;
+
  public:
     ParserOptions();
+    // Target
+    cstring target = nullptr;
+    // Architecture
+    cstring arch = nullptr;
+    // Compiler version.
+    cstring compilerVersion;
+    // options to pass to preprocessor
+    cstring preprocessor_options = "";
+
+
 };
 
 
 class CompilerOptions : public ParserOptions {
     bool close_input = false;
-    static const char* defaultMessage;
 
     // annotation names that are to be ignored by the compiler
     std::set<cstring> disabledAnnotations;
@@ -71,8 +82,6 @@ class CompilerOptions : public ParserOptions {
     cstring exe_name;
     // Which language to compile
     FrontendVersion langVersion = FrontendVersion::P4_14;
-    // options to pass to preprocessor
-    cstring preprocessor_options = "";
     // file to compile (- for stdin)
     cstring file = nullptr;
     // if true preprocess only
@@ -83,8 +92,6 @@ class CompilerOptions : public ParserOptions {
     cstring dumpFolder = ".";
     // Pretty-print the program in the specified file
     cstring prettyPrintFile = nullptr;
-    // Compiler version.
-    cstring compilerVersion;
     // if true, skip frontend passes whose names are contained in passesToExcludeFrontend vector
     bool excludeFrontendPasses = false;
     bool listFrontendPasses = false;
@@ -116,11 +123,6 @@ class CompilerOptions : public ParserOptions {
     // Choose format for P4Runtime API description.
     P4::P4RuntimeFormat p4RuntimeFormat = P4::P4RuntimeFormat::BINARY;
 
-    // Target
-    cstring target = nullptr;
-
-    // Architecture
-    cstring arch = nullptr;
 
     // substrings matched agains pass names
     std::vector<cstring> top4;

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -37,7 +37,14 @@ extern const char* p4_14includePath;
 // Base class for compiler options.
 // This class contains the options for the front-ends.
 // Each back-end should subclass this file.
-class CompilerOptions : public Util::Options {
+
+class ParserOptions : public Util::Options {
+ public:
+    ParserOptions();
+};
+
+
+class CompilerOptions : public ParserOptions {
     bool close_input = false;
     static const char* defaultMessage;
 

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "lib/compile_context.h"
 #include "lib/cstring.h"
 #include "lib/options.h"
+#include "parser_options.h"
 #include "ir/configuration.h"
 #include "ir/ir.h"  // for DebugHook definition
 // for p4::P4RuntimeFormat definition
@@ -38,27 +39,9 @@ extern const char* p4_14includePath;
 // This class contains the options for the front-ends.
 // Each back-end should subclass this file.
 
-class ParserOptions : public Util::Options {
-    static const char* defaultMessage;
-
- public:
-    ParserOptions();
-    // Target
-    cstring target = nullptr;
-    // Architecture
-    cstring arch = nullptr;
-    // Compiler version.
-    cstring compilerVersion;
-    // options to pass to preprocessor
-    cstring preprocessor_options = "";
-};
-
-
 class CompilerOptions : public ParserOptions {
     bool close_input = false;
 
-    // annotation names that are to be ignored by the compiler
-    std::set<cstring> disabledAnnotations;
 
     // Checks if parsed options make sense with respect to each-other.
     void validateOptions() const;
@@ -71,25 +54,12 @@ class CompilerOptions : public ParserOptions {
     CompilerOptions();
     std::vector<const char*>* process(int argc, char* const argv[]) override;
 
-    enum class FrontendVersion {
-        P4_14,
-        P4_16
-    };
+
 
     // Name of executable that is being run.
     cstring exe_name;
-    // Which language to compile
-    FrontendVersion langVersion = FrontendVersion::P4_14;
     // file to compile (- for stdin)
     cstring file = nullptr;
-    // if true preprocess only
-    bool doNotCompile = false;
-    // if true skip preprocess
-    bool doNotPreprocess = false;
-    // debugging dumps of programs written in this folder
-    cstring dumpFolder = ".";
-    // Pretty-print the program in the specified file
-    cstring prettyPrintFile = nullptr;
     // if true, skip frontend passes whose names are contained in passesToExcludeFrontend vector
     bool excludeFrontendPasses = false;
     bool listFrontendPasses = false;
@@ -99,13 +69,8 @@ class CompilerOptions : public ParserOptions {
     bool listMidendPasses = false;
     // if true, skip backend passes whose names are contained in passesToExcludeBackend vector
     bool excludeBackendPasses = false;
-
-    // Dump a JSON representation of the IR in the file
-    cstring dumpJsonFile = nullptr;
-
-    // Dump and undump the IR tree
-    bool debugJson = false;
-
+    // Which language to compile
+    FrontendVersion langVersion = FrontendVersion::P4_14;
     // Write a P4Runtime control plane API description to the specified file.
     cstring p4RuntimeFile = nullptr;
 
@@ -120,13 +85,6 @@ class CompilerOptions : public ParserOptions {
 
     // Choose format for P4Runtime API description.
     P4::P4RuntimeFormat p4RuntimeFormat = P4::P4RuntimeFormat::BINARY;
-
-
-    // substrings matched agains pass names
-    std::vector<cstring> top4;
-
-    // if this flag is true, compile program in non-debug mode
-    bool ndebug = false;
 
     // strings matched against pass names that should be excluded from Frontend passes
     std::vector<cstring> passesToExcludeFrontend;

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -1,3 +1,21 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* -*-C++-*- */
+
 #ifndef FRONTENDS_COMMON_OPTIONS_H_
 #define FRONTENDS_COMMON_OPTIONS_H_
 

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -1,193 +1,29 @@
-/*
-Copyright 2013-present Barefoot Networks, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-/* -*-C++-*- */
-
 #ifndef FRONTENDS_COMMON_OPTIONS_H_
 #define FRONTENDS_COMMON_OPTIONS_H_
 
-#include <set>
-#include <unordered_map>
-#include "lib/compile_context.h"
-#include "lib/cstring.h"
-#include "lib/options.h"
 #include "parser_options.h"
-#include "ir/configuration.h"
-#include "ir/ir.h"  // for DebugHook definition
 // for p4::P4RuntimeFormat definition
 #include "control-plane/p4RuntimeSerializer.h"
 
-// Standard include paths for .p4 header files. The values are determined by
-// `configure`.
-extern const char* p4includePath;
-extern const char* p4_14includePath;
-
-// Base class for compiler options.
-// This class contains the options for the front-ends.
-// Each back-end should subclass this file.
 
 class CompilerOptions : public ParserOptions {
-    bool close_input = false;
-
-
-    // Checks if parsed options make sense with respect to each-other.
-    void validateOptions() const;
-
- protected:
-    // Function that is returned by getDebugHook.
-    void dumpPass(const char* manager, unsigned seq, const char* pass, const IR::Node* node) const;
-
  public:
     CompilerOptions();
-    std::vector<const char*>* process(int argc, char* const argv[]) override;
 
-
-
-    // Name of executable that is being run.
-    cstring exe_name;
-    // file to compile (- for stdin)
-    cstring file = nullptr;
     // if true, skip frontend passes whose names are contained in passesToExcludeFrontend vector
     bool excludeFrontendPasses = false;
     bool listFrontendPasses = false;
-
-    // if true, skip midend passes whose names are contained in passesToExcludeMidend vector
-    bool excludeMidendPasses = false;
-    bool listMidendPasses = false;
-    // if true, skip backend passes whose names are contained in passesToExcludeBackend vector
-    bool excludeBackendPasses = false;
-    // Which language to compile
-    FrontendVersion langVersion = FrontendVersion::P4_14;
-    // Write a P4Runtime control plane API description to the specified file.
-    cstring p4RuntimeFile = nullptr;
-
-    // Write static table entries as a P4Runtime WriteRequest message to the specified file.
-    cstring p4RuntimeEntriesFile = nullptr;
-
-    // Write P4Runtime control plane API description to the specified files.
-    cstring p4RuntimeFiles = nullptr;
-
-    // Write static table entries as a P4Runtime WriteRequest message to the specified files.
-    cstring p4RuntimeEntriesFiles = nullptr;
-
-    // Choose format for P4Runtime API description.
-    P4::P4RuntimeFormat p4RuntimeFormat = P4::P4RuntimeFormat::BINARY;
-
     // strings matched against pass names that should be excluded from Frontend passes
     std::vector<cstring> passesToExcludeFrontend;
-
-    // strings matched against pass names that should be excluded from Midend passes
-    std::vector<cstring> passesToExcludeMidend;
-
-    // strings matched against pass names that should be excluded from Backend passes
-    std::vector<cstring> passesToExcludeBackend;
-
-    // Expect that the only remaining argument is the input file.
-    void setInputFile();
-
-    // Returns the output of the preprocessor.
-    FILE* preprocess();
-    // Closes the input stream returned by preprocess.
-    void closeInput(FILE* input) const;
-
-    // True if we are compiling a P4 v1.0 or v1.1 program
-    bool isv1() const;
-    // Get a debug hook function suitable for insertion
-    // in the pass managers that are executed.
-    DebugHook getDebugHook() const;
-
-    bool isAnnotationDisabled(const IR::Annotation *) const;
-
-    virtual bool enable_intrinsic_metadata_fix();
+    // Target
+    cstring target = nullptr;
+    // Architecture
+    cstring arch = nullptr;
+    // Write P4Runtime control plane API description to the specified files.
+    cstring p4RuntimeFiles = nullptr;
+    // Write static table entries as a P4Runtime WriteRequest message to the specified files.
+    cstring p4RuntimeEntriesFiles = nullptr;
+    // Choose format for P4Runtime API description.
+    P4::P4RuntimeFormat p4RuntimeFormat = P4::P4RuntimeFormat::BINARY;
 };
-
-
-/// A compilation context which exposes compiler options and a compiler configuration.
-class P4CContext : public BaseCompileContext {
- public:
-    /// @return the current compilation context, which must inherit from
-    /// P4CContext.
-    static P4CContext& get();
-
-    /// @return the compiler configuration for the current compilation context. If there is no
-    /// current compilation context, the default configuration is returned.
-    static const P4CConfiguration& getConfig();
-
-    P4CContext() {}
-
-    /// @return the compiler options for this compilation context.
-    virtual CompilerOptions& options() = 0;
-
-    /// @return the default diagnostic action for calls to `::warning()`.
-    DiagnosticAction getDefaultWarningDiagnosticAction() final {
-        return errorReporter().getDefaultWarningDiagnosticAction();
-    }
-
-    /// set the default diagnostic action for calls to `::warning()`.
-    void setDefaultWarningDiagnosticAction(DiagnosticAction action) {
-        errorReporter().setDefaultWarningDiagnosticAction(action);
-    }
-
-    /// @return the action to take for the given diagnostic, falling back to the
-    /// default action if it wasn't overridden via the command line or a pragma.
-    DiagnosticAction
-    getDiagnosticAction(cstring diagnostic, DiagnosticAction defaultAction) final {
-        return errorReporter().getDiagnosticAction(diagnostic, defaultAction);
-    }
-
-    /// Set the action to take for the given diagnostic.
-    void setDiagnosticAction(cstring diagnostic, DiagnosticAction action) {
-        errorReporter().setDiagnosticAction(diagnostic, action);
-    }
-
- protected:
-    /// @return true if the given diagnostic is known to be valid. This is
-    /// intended to help the user find misspelled diagnostics and the like; it
-    /// doesn't affect functionality.
-    virtual bool isRecognizedDiagnostic(cstring diagnostic);
-
-    /// @return the compiler configuration associated with this type of compilation context.
-    virtual const P4CConfiguration& getConfigImpl();
-};
-
-/// A utility template which can be used to easily make subclasses of P4CContext
-/// which expose a particular subclass of CompilerOptions. This is provided as a
-/// convenience since this is all many backends need.
-template <typename OptionsType>
-class P4CContextWithOptions final : public P4CContext {
- public:
-    /// @return the current compilation context, which must be of type
-    /// P4CContextWithOptions<OptionsType>.
-    static P4CContextWithOptions& get() {
-        return CompileContextStack::top<P4CContextWithOptions>();
-    }
-
-    P4CContextWithOptions() {}
-
-    template <typename OptionsDerivedType>
-    P4CContextWithOptions(P4CContextWithOptions<OptionsDerivedType>& context) {
-        optionsInstance = context.options();
-    }
-
-    /// @return the compiler options for this compilation context.
-    OptionsType& options() override { return optionsInstance; }
-
- private:
-    /// Compiler options for this compilation context.
-    OptionsType optionsInstance;
-};
-
-#endif /* FRONTENDS_COMMON_OPTIONS_H_ */
+#endif /* FRONTENDS_COMMON_PARSER_OPTIONS_H_ */

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -26,4 +26,4 @@ class CompilerOptions : public ParserOptions {
     // Choose format for P4Runtime API description.
     P4::P4RuntimeFormat p4RuntimeFormat = P4::P4RuntimeFormat::BINARY;
 };
-#endif /* FRONTENDS_COMMON_PARSER_OPTIONS_H_ */
+#endif  /* FRONTENDS_COMMON_OPTIONS_H_ */

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -51,8 +51,6 @@ class ParserOptions : public Util::Options {
     cstring compilerVersion;
     // options to pass to preprocessor
     cstring preprocessor_options = "";
-
-
 };
 
 

--- a/frontends/common/parseInput.h
+++ b/frontends/common/parseInput.h
@@ -65,7 +65,7 @@ parseV1Program(Input& stream, const char* sourceFile, unsigned sourceLine,
  * on failure. If failure occurs, an error will also be reported.
  */
 template <typename C = P4V1::Converter>
-const IR::P4Program* parseP4File(CompilerOptions& options) {
+const IR::P4Program* parseP4File(ParserOptions& options) {
     BUG_CHECK(&options == &P4CContext::get().options(),
               "Parsing using options that don't match the current "
               "compiler context");

--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -1,0 +1,91 @@
+#include "parser_options.h"
+#include "lib/compile_context.h"
+
+const char* ParserOptions::defaultMessage = "Compile a P4 program";
+
+
+ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
+    registerOption("--help", nullptr,
+                   [this](const char*) { usage(); exit(0); return false; },
+                   "Print this help message");
+    registerOption("--version", nullptr,
+                   [this](const char*) {
+                       std::cerr << binaryName << std::endl;
+                       std::cerr << "Version " << compilerVersion << std::endl;
+                       exit(0); return false; }, "Print compiler version");
+    registerOption("-I", "path",
+                   [this](const char* arg) {
+                       preprocessor_options += std::string(" -I") + arg; return true; },
+                   "Specify include path (passed to preprocessor)");
+    registerOption("--target", "target",
+                   [this](const char* arg) { target = arg; return true; },
+                    "Compile for the specified target device.");
+    registerOption("--arch", "arch",
+                   [this](const char* arg) { arch = arg; return true; },
+                   "Compile for the specified architecture.");
+    registerOption("-D", "arg=value",
+                   [this](const char* arg) {
+                       preprocessor_options += std::string(" -D") + arg; return true; },
+                   "Define macro (passed to preprocessor)");
+    registerOption("-U", "arg",
+                   [this](const char* arg) {
+                       preprocessor_options += std::string(" -U") + arg; return true; },
+                   "Undefine macro (passed to preprocessor)");
+    registerOption("-E", nullptr,
+                   [this](const char*) { doNotCompile = true; return true; },
+                   "Preprocess only, do not compile (prints program on stdout)");
+    registerOption("--nocpp", nullptr,
+                   [this](const char*) { doNotPreprocess = true; return true; },
+                   "Skip preprocess, assume input file is already preprocessed.");
+    registerOption("--disable-annotations", "annotations",
+                   [this](const char *arg) {
+                      auto copy = strdup(arg);
+                      while (auto name = strsep(&copy, ","))
+                          disabledAnnotations.insert(name);
+                      return true;
+                   },
+                   "Specify a (comma separated) list of annotations that should be ignored by\n"
+                   "the compiler. A warning will be printed that the annotation is ignored",
+                   OptionFlags::OptionalArgument);
+    registerOption("--testJson", nullptr,
+                    [this](const char*) { debugJson = true; return true; },
+                    "[Compiler debugging] Dump and undump the IR");
+    registerOption("-T", "loglevel",
+                   [](const char* arg) { Log::addDebugSpec(arg); return true; },
+                   "[Compiler debugging] Adjust logging level per file (see below)");
+    registerOption("-v", nullptr,
+                   [](const char*) { Log::increaseVerbosity(); return true; },
+                   "[Compiler debugging] Increase verbosity level (can be repeated)");
+    registerOption("--top4", "pass1[,pass2]",
+                   [this](const char* arg) {
+                       auto copy = strdup(arg);
+                       while (auto pass = strsep(&copy, ","))
+                           top4.push_back(pass);
+                       return true;
+                   },
+                   "[Compiler debugging] Dump the P4 representation after\n"
+                   "passes whose name contains one of `passX' substrings.\n"
+                   "When '-v' is used this will include the compiler IR.\n");
+    registerOption("--dump", "folder",
+                   [this](const char* arg) { dumpFolder = arg; return true; },
+                   "[Compiler debugging] Folder where P4 programs are dumped\n");
+    registerUsage("loglevel format is:\n"
+                  "  sourceFile:level,...,sourceFile:level\n"
+                  "where 'sourceFile' is a compiler source file and\n"
+                  "'level' is the verbosity level for LOG messages in that file");
+    registerOption("--ndebug", nullptr,
+                   [this](const char*) { ndebug = true; return true; },
+                  "Compile program in non-debug mode.\n");
+    registerOption("--pp", "file",
+                   [this](const char* arg) { prettyPrintFile = arg; return true; },
+                   "Pretty-print the program in the specified file.");
+    registerOption("--toJSON", "file",
+                   [this](const char* arg) { dumpJsonFile = arg; return true; },
+                   "Dump the compiler IR after the midend as JSON in the specified file.");
+
+
+
+
+}
+
+

--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -1,8 +1,39 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <getopt.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <unordered_set>
+#include <regex>
+
 #include "parser_options.h"
-#include "lib/compile_context.h"
+#include "lib/log.h"
+#include "lib/exceptions.h"
+#include "lib/exename.h"
+#include "lib/nullstream.h"
+#include "lib/path.h"
+#include "frontends/p4/toP4/toP4.h"
+#include "ir/json_generator.h"
+
+const char* p4includePath = CONFIG_PKGDATADIR "/p4include";
+const char* p4_14includePath = CONFIG_PKGDATADIR "/p4_14include";
 
 const char* ParserOptions::defaultMessage = "Compile a P4 program";
-
 
 ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
     registerOption("--help", nullptr,
@@ -17,12 +48,6 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
                    [this](const char* arg) {
                        preprocessor_options += std::string(" -I") + arg; return true; },
                    "Specify include path (passed to preprocessor)");
-    registerOption("--target", "target",
-                   [this](const char* arg) { target = arg; return true; },
-                    "Compile for the specified target device.");
-    registerOption("--arch", "arch",
-                   [this](const char* arg) { arch = arg; return true; },
-                   "Compile for the specified architecture.");
     registerOption("-D", "arg=value",
                    [this](const char* arg) {
                        preprocessor_options += std::string(" -D") + arg; return true; },
@@ -34,9 +59,38 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
     registerOption("-E", nullptr,
                    [this](const char*) { doNotCompile = true; return true; },
                    "Preprocess only, do not compile (prints program on stdout)");
+    registerOption("--p4v", "{14|16}",
+                   [this](const char* arg) {
+                       if (!strcmp(arg, "1.0") || !strcmp(arg, "14")) {
+                           langVersion = ParserOptions::FrontendVersion::P4_14;
+                       } else if (!strcmp(arg, "1.2") || !strcmp(arg, "16")) {
+                           langVersion = ParserOptions::FrontendVersion::P4_16;
+                       } else {
+                           ::error(ErrorType::ERR_INVALID, "Illegal language version %1%", arg);
+                           return false;
+                       }
+                       return true; },
+                    "[Deprecated; use --std instead] Specify language version to compile.",
+                    OptionFlags::Hide);
+    registerOption("--std", "{p4-14|p4-16}",
+                   [this](const char* arg) {
+                       if (!strcmp(arg, "14") || !strcmp(arg, "p4-14")) {
+                           langVersion = ParserOptions::FrontendVersion::P4_14;
+                       } else if (!strcmp(arg, "16") || !strcmp(arg, "p4-16")) {
+                           langVersion = ParserOptions::FrontendVersion::P4_16;
+                       } else {
+                           ::error(ErrorType::ERR_INVALID, "Illegal language version %1%", arg);
+                           return false;
+                       }
+                       return true; },
+                    "Specify language version to compile.");
     registerOption("--nocpp", nullptr,
                    [this](const char*) { doNotPreprocess = true; return true; },
                    "Skip preprocess, assume input file is already preprocessed.");
+    registerOption("--toJSON", "file",
+                   [this](const char* arg) { dumpJsonFile = arg; return true; },
+                   "Dump the compiler IR after the midend as JSON in the specified file.");
+
     registerOption("--disable-annotations", "annotations",
                    [this](const char *arg) {
                       auto copy = strdup(arg);
@@ -47,6 +101,51 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
                    "Specify a (comma separated) list of annotations that should be ignored by\n"
                    "the compiler. A warning will be printed that the annotation is ignored",
                    OptionFlags::OptionalArgument);
+    registerOption("--Wdisable", "diagnostic",
+        [](const char *diagnostic) {
+            if (diagnostic) {
+                P4CContext::get().setDiagnosticAction(diagnostic,
+                                                      DiagnosticAction::Ignore);
+            } else {
+                auto action = DiagnosticAction::Ignore;
+                P4CContext::get().setDefaultWarningDiagnosticAction(action);
+            }
+            return true;
+        }, "Disable a compiler diagnostic, or disable all warnings if no "
+           "diagnostic is specified.",
+        OptionFlags::OptionalArgument);
+    registerOption("--Wwarn", "diagnostic",
+        [](const char *diagnostic) {
+            if (diagnostic) {
+                P4CContext::get().setDiagnosticAction(diagnostic,
+                                                      DiagnosticAction::Warn);
+            } else {
+                auto action = DiagnosticAction::Warn;
+                P4CContext::get().setDefaultWarningDiagnosticAction(action);
+            }
+            return true;
+        }, "Report a warning for a compiler diagnostic, or treat all warnings "
+           "as warnings (the default) if no diagnostic is specified.",
+        OptionFlags::OptionalArgument);
+    registerOption("--Werror", "diagnostic",
+        [](const char *diagnostic) {
+            if (diagnostic) {
+                P4CContext::get().setDiagnosticAction(diagnostic,
+                                                      DiagnosticAction::Error);
+            } else {
+                auto action = DiagnosticAction::Error;
+                P4CContext::get().setDefaultWarningDiagnosticAction(action);
+            }
+            return true;
+        }, "Report an error for a compiler diagnostic, or treat all warnings as "
+           "errors if no diagnostic is specified.",
+        OptionFlags::OptionalArgument);
+    registerOption("--maxErrorCount", "errorCount",
+                   [](const char *arg) {
+                       auto maxError = strtoul(arg, nullptr, 10);
+                       P4CContext::get().errorReporter().setMaxErrorCount(maxError);
+                       return true; },
+                   "Set the maximum number of errors to display before failing.");
     registerOption("--testJson", nullptr,
                     [this](const char*) { debugJson = true; return true; },
                     "[Compiler debugging] Dump and undump the IR");
@@ -56,6 +155,33 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
     registerOption("-v", nullptr,
                    [](const char*) { Log::increaseVerbosity(); return true; },
                    "[Compiler debugging] Increase verbosity level (can be repeated)");
+
+    registerUsage("loglevel format is:\n"
+                  "  sourceFile:level,...,sourceFile:level\n"
+                  "where 'sourceFile' is a compiler source file and\n"
+                  "'level' is the verbosity level for LOG messages in that file");
+    registerOption("--ndebug", nullptr,
+                   [this](const char*) { ndebug = true; return true; },
+                  "Compile program in non-debug mode.\n");
+    registerOption("--excludeMidendPasses", "pass1[,pass2]",
+                   [this](const char* arg) {
+                      excludeMidendPasses = true;
+                      auto copy = strdup(arg);
+                      while (auto pass = strsep(&copy, ","))
+                          passesToExcludeMidend.push_back(pass);
+                      return true;
+                   },
+                   "Exclude passes from midend passes whose name is equal\n"
+                   "to one of `passX' strings.\n");
+    registerOption("--p4runtime-file", "file",
+                   [this](const char* arg) { p4RuntimeFile = arg; return true; },
+                   "Write a P4Runtime control plane API description to the specified file.\n"
+                   "[Deprecated; use '--p4runtime-files' instead].");
+    registerOption("--p4runtime-entries-file", "file",
+                   [this](const char* arg) { p4RuntimeEntriesFile = arg; return true; },
+                   "Write static table entries as a P4Runtime WriteRequest message"
+                   "to the specified file.\n"
+                   "[Deprecated; use '--p4runtime-entries-files' instead].");
     registerOption("--top4", "pass1[,pass2]",
                    [this](const char* arg) {
                        auto copy = strdup(arg);
@@ -69,23 +195,221 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
     registerOption("--dump", "folder",
                    [this](const char* arg) { dumpFolder = arg; return true; },
                    "[Compiler debugging] Folder where P4 programs are dumped\n");
-    registerUsage("loglevel format is:\n"
-                  "  sourceFile:level,...,sourceFile:level\n"
-                  "where 'sourceFile' is a compiler source file and\n"
-                  "'level' is the verbosity level for LOG messages in that file");
-    registerOption("--ndebug", nullptr,
-                   [this](const char*) { ndebug = true; return true; },
-                  "Compile program in non-debug mode.\n");
-    registerOption("--pp", "file",
-                   [this](const char* arg) { prettyPrintFile = arg; return true; },
-                   "Pretty-print the program in the specified file.");
-    registerOption("--toJSON", "file",
-                   [this](const char* arg) { dumpJsonFile = arg; return true; },
-                   "Dump the compiler IR after the midend as JSON in the specified file.");
-
-
-
 
 }
 
+void ParserOptions::setInputFile() {
+    if (remainingOptions.size() > 1) {
+        ::error(ErrorType::ERR_OVERLIMIT, "Only one input file must be specified: %s",
+                cstring::join(remainingOptions.begin(), remainingOptions.end(), ","));
+        usage();
+        exit(1);
+    } else if (remainingOptions.size() == 0) {
+        ::error(ErrorType::ERR_EXPECTED, "No input files specified");
+        usage();
+        exit(1);
+    } else {
+        file = remainingOptions.at(0);
+    }
+}
 
+namespace {
+
+bool setIncludePathIfExists(const char*& includePathOut,
+                            const char* possiblePath) {
+    struct stat st;
+    if (!(stat(possiblePath, &st) >= 0 && S_ISDIR(st.st_mode))) return false;
+    if (auto path = realpath(possiblePath, NULL))
+        includePathOut = path;
+    else
+        includePathOut = strdup(possiblePath);
+    return true;
+}
+
+}  // namespace
+
+std::vector<const char*>* ParserOptions::process(int argc, char* const argv[]) {
+    char buffer[PATH_MAX];
+
+    snprintf(buffer, sizeof(buffer), "%s", exename(argv[0]));
+    if (char *p = strrchr(buffer, '/')) {
+        ++p;
+        exe_name = p;
+        snprintf(p, buffer + sizeof(buffer) - p, "p4include");
+        if (!setIncludePathIfExists(p4includePath, buffer)) {
+            snprintf(p, buffer + sizeof(buffer) - p, "../p4include");
+            setIncludePathIfExists(p4includePath, buffer); }
+        snprintf(p, buffer + sizeof(buffer) - p, "p4_14include");
+        if (!setIncludePathIfExists(p4_14includePath, buffer)) {
+            snprintf(p, buffer + sizeof(buffer) - p, "../p4_14include");
+            setIncludePathIfExists(p4_14includePath, buffer); }
+    }
+
+    auto remainingOptions = Util::Options::process(argc, argv);
+    validateOptions();
+    return remainingOptions;
+}
+
+void ParserOptions::validateOptions() const {
+    if (!p4RuntimeFile.isNullOrEmpty()) {
+        ::warning(ErrorType::WARN_DEPRECATED,
+                  "'--p4runtime-file' and '--p4runtime-format' are deprecated, "
+                  "consider using '--p4runtime-files' instead");
+    }
+    if (!p4RuntimeEntriesFile.isNullOrEmpty()) {
+        ::warning(ErrorType::WARN_DEPRECATED,
+                  "'--p4runtime-entries-file' is deprecated, "
+                  "consider using '--p4runtime-entries-files' instead");
+    }
+}
+
+FILE* ParserOptions::preprocess() {
+    FILE* in = nullptr;
+
+    if (file == "-") {
+        file = "<stdin>";
+        in = stdin;
+    } else {
+#ifdef __clang__
+        std::string cmd("cc -E -x c -Wno-comment");
+#else
+        std::string cmd("cpp");
+#endif
+        // the p4c driver sets environment variables for include
+        // paths.  check the environment and add these to the command
+        // line for the preprocessor
+        char * driverP4IncludePath =
+          isv1() ? getenv("P4C_14_INCLUDE_PATH") : getenv("P4C_16_INCLUDE_PATH");
+        cmd += cstring(" -C -undef -nostdinc -x assembler-with-cpp") + " " + preprocessor_options
+            + (driverP4IncludePath ? " -I" + cstring(driverP4IncludePath) : "")
+            + " -I" + (isv1() ? p4_14includePath : p4includePath) + " " + file;
+
+        if (Log::verbose())
+            std::cerr << "Invoking preprocessor " << std::endl << cmd << std::endl;
+        in = popen(cmd.c_str(), "r");
+        if (in == nullptr) {
+            ::error(ErrorType::ERR_IO, "Error invoking preprocessor");
+            perror("");
+            return nullptr;
+        }
+        close_input = true;
+    }
+
+    if (doNotCompile) {
+        char *line = NULL;
+        size_t len = 0;
+        ssize_t read;
+
+        while ((read = getline(&line, &len, in)) != -1)
+            printf("%s", line);
+        closeInput(in);
+        return nullptr;
+    }
+    return in;
+}
+
+void ParserOptions::closeInput(FILE* inputStream) const {
+    if (close_input) {
+        int exitCode = pclose(inputStream);
+        if (WIFEXITED(exitCode) && WEXITSTATUS(exitCode) == 4)
+            ::error(ErrorType::ERR_IO, "input file %s does not exist", file);
+        else if (exitCode != 0)
+            ::error(ErrorType::ERR_IO,
+                    "Preprocessor returned exit code %d; aborting compilation", exitCode);
+    }
+}
+
+// From (folder, file.ext, suffix)  returns
+// folder/file-suffix.ext
+static cstring makeFileName(cstring folder, cstring name, cstring baseSuffix) {
+    Util::PathName filename(name);
+    Util::PathName newName(filename.getBasename() + baseSuffix + "." + filename.getExtension());
+    auto result = Util::PathName(folder).join(newName.toString());
+    return result.toString();
+}
+
+bool ParserOptions::isv1() const {
+    return langVersion == ParserOptions::FrontendVersion::P4_14;
+}
+
+bool ParserOptions::enable_intrinsic_metadata_fix() {
+    return true;
+}
+
+void ParserOptions::dumpPass(const char* manager, unsigned seq, const char* pass,
+                               const IR::Node* node) const {
+    if (strncmp(pass, "P4::", 4) == 0) pass += 4;
+    cstring name = cstring(manager) + "_" + Util::toString(seq) + "_" + pass;
+    if (Log::verbose())
+        std::cerr << name << std::endl;
+
+    for (auto s : top4) {
+        bool match = false;
+        try {
+           auto s_regex = std::regex(s, std::regex_constants::ECMAScript);
+            // we use regex_search instead of regex_match
+            // regex_match compares the regex against the entire string
+            // regex_search checks if the regex is contained as substring
+            match = std::regex_search(name.begin(), name.end(), s_regex);
+        } catch (const std::regex_error &e) {
+            ::error(ErrorType::ERR_INVALID, "Malformed toP4 regex string \"%s\".\n"
+                    "The regex matcher follows ECMAScript syntax.", s);
+            exit(1);
+        }
+        if (match) {
+            cstring suffix = cstring("-") + name;
+            cstring filename = file;
+            if (filename == "-")
+                filename = "tmp.p4";
+
+            cstring fileName = makeFileName(dumpFolder, filename, suffix);
+            auto stream = openFile(fileName, true);
+            if (stream != nullptr) {
+                if (Log::verbose())
+                    std::cerr << "Writing program to " << fileName << std::endl;
+                P4::ToP4 toP4(stream, Log::verbose(), file);
+                node->apply(toP4);
+                delete stream;  // close the file
+            }
+            break;
+        }
+    }
+}
+
+bool ParserOptions::isAnnotationDisabled(const IR::Annotation *a) const {
+    if (disabledAnnotations.count(a->name.name) > 0) {
+        ::warning(ErrorType::WARN_IGNORE,
+                  "%1% is ignored because it was explicitly disabled", a);
+        return true;
+    }
+    return false;
+}
+
+DebugHook ParserOptions::getDebugHook() const {
+    using namespace std::placeholders;
+    auto dp = std::bind(&ParserOptions::dumpPass, this, _1, _2, _3, _4);
+    return dp;
+}
+
+/* static */ P4CContext& P4CContext::get() {
+    return CompileContextStack::top<P4CContext>();
+}
+
+const P4CConfiguration& P4CContext::getConfig() {
+    if (CompileContextStack::isEmpty()) return DefaultP4CConfiguration::get();
+    return get().getConfigImpl();
+}
+
+bool P4CContext::isRecognizedDiagnostic(cstring diagnostic) {
+    static const std::unordered_set<cstring> recognizedDiagnostics = {
+        "uninitialized_out_param",
+        "uninitialized_use",
+        "unknown_diagnostic"
+    };
+
+    return recognizedDiagnostics.count(diagnostic);
+}
+
+const P4CConfiguration& P4CContext::getConfigImpl() {
+    return DefaultP4CConfiguration::get();
+}

--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -195,7 +195,6 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
     registerOption("--dump", "folder",
                    [this](const char* arg) { dumpFolder = arg; return true; },
                    "[Compiler debugging] Folder where P4 programs are dumped\n");
-
 }
 
 void ParserOptions::setInputFile() {

--- a/frontends/common/parser_options.h
+++ b/frontends/common/parser_options.h
@@ -1,0 +1,71 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* -*-C++-*- */
+
+#ifndef FRONTENDS_COMMON_PARSER_OPTIONS_H_
+#define FRONTENDS_COMMON_PARSER_OPTIONS_H_
+#include <set>
+#include "lib/options.h"
+#include "ir/configuration.h"
+
+
+// Base class for parser options.
+// This class contains the options for the parser.
+
+class ParserOptions : public Util::Options {
+    static const char* defaultMessage;
+
+ public:
+    ParserOptions();
+
+
+    enum class FrontendVersion {
+        P4_14,
+        P4_16
+    };
+
+    // Target
+    cstring target = nullptr;
+    // Architecture
+    cstring arch = nullptr;
+    // Compiler version.
+    cstring compilerVersion;
+    // options to pass to preprocessor
+    cstring preprocessor_options = "";
+
+    // if true preprocess only
+    bool doNotCompile = false;
+    // if true skip preprocess
+    bool doNotPreprocess = false;
+    // Dump and undump the IR tree
+    bool debugJson = false;
+    // substrings matched agains pass names
+    std::vector<cstring> top4;
+    // debugging dumps of programs written in this folder
+    cstring dumpFolder = ".";
+    // if this flag is true, compile program in non-debug mode
+    bool ndebug = false;
+    // Pretty-print the program in the specified file
+    cstring prettyPrintFile = nullptr;
+    // Dump a JSON representation of the IR in the file
+    cstring dumpJsonFile = nullptr;
+    // annotation names that are to be ignored by the compiler
+    std::set<cstring> disabledAnnotations;
+
+
+};
+#endif /* FRONTENDS_COMMON_PARSER_OPTIONS_H_ */

--- a/frontends/common/parser_options.h
+++ b/frontends/common/parser_options.h
@@ -18,54 +18,181 @@ limitations under the License.
 
 #ifndef FRONTENDS_COMMON_PARSER_OPTIONS_H_
 #define FRONTENDS_COMMON_PARSER_OPTIONS_H_
+
 #include <set>
+#include <unordered_map>
+#include "lib/compile_context.h"
+#include "lib/cstring.h"
 #include "lib/options.h"
 #include "ir/configuration.h"
+#include "ir/ir.h"  // for DebugHook definition
 
+// Standard include paths for .p4 header files. The values are determined by
+// `configure`.
+extern const char* p4includePath;
+extern const char* p4_14includePath;
 
-// Base class for parser options.
-// This class contains the options for the parser.
-
+// Base class for compiler options.
+// This class contains the options for the front-ends.
+// Each back-end should subclass this file.
 class ParserOptions : public Util::Options {
+    bool close_input = false;
     static const char* defaultMessage;
+
+    // annotation names that are to be ignored by the compiler
+    std::set<cstring> disabledAnnotations;
+
+    // Checks if parsed options make sense with respect to each-other.
+    void validateOptions() const;
+
+ protected:
+    // Function that is returned by getDebugHook.
+    void dumpPass(const char* manager, unsigned seq, const char* pass, const IR::Node* node) const;
 
  public:
     ParserOptions();
-
+    std::vector<const char*>* process(int argc, char* const argv[]) override;
 
     enum class FrontendVersion {
         P4_14,
         P4_16
     };
 
-    // Target
-    cstring target = nullptr;
-    // Architecture
-    cstring arch = nullptr;
-    // Compiler version.
-    cstring compilerVersion;
+    // Name of executable that is being run.
+    cstring exe_name;
+    // Which language to compile
+    FrontendVersion langVersion = FrontendVersion::P4_14;
     // options to pass to preprocessor
     cstring preprocessor_options = "";
-
+    // file to compile (- for stdin)
+    cstring file = nullptr;
     // if true preprocess only
     bool doNotCompile = false;
+    // Pretty-print the program in the specified file
+    cstring prettyPrintFile = nullptr;
+    // Compiler version.
+    cstring compilerVersion;
     // if true skip preprocess
     bool doNotPreprocess = false;
+    // if true, skip midend passes whose names are contained in passesToExcludeMidend vector
+    bool excludeMidendPasses = false;
+    bool listMidendPasses = false;
+    // if true, skip backend passes whose names are contained in passesToExcludeBackend vector
+    bool excludeBackendPasses = false;
+    // strings matched against pass names that should be excluded from Midend passes
+    std::vector<cstring> passesToExcludeMidend;
+    // strings matched against pass names that should be excluded from Backend passes
+    std::vector<cstring> passesToExcludeBackend;
+    // Write a P4Runtime control plane API description to the specified file.
+    cstring p4RuntimeFile = nullptr;
+    // Write static table entries as a P4Runtime WriteRequest message to the specified file.
+    cstring p4RuntimeEntriesFile = nullptr;
+
+    // Dump a JSON representation of the IR in the file
+    cstring dumpJsonFile = nullptr;
+
     // Dump and undump the IR tree
     bool debugJson = false;
+
+    // if this flag is true, compile program in non-debug mode
+    bool ndebug = false;
     // substrings matched agains pass names
     std::vector<cstring> top4;
     // debugging dumps of programs written in this folder
     cstring dumpFolder = ".";
-    // if this flag is true, compile program in non-debug mode
-    bool ndebug = false;
-    // Pretty-print the program in the specified file
-    cstring prettyPrintFile = nullptr;
-    // Dump a JSON representation of the IR in the file
-    cstring dumpJsonFile = nullptr;
-    // annotation names that are to be ignored by the compiler
-    std::set<cstring> disabledAnnotations;
+    // Expect that the only remaining argument is the input file.
+    void setInputFile();
 
+    // Returns the output of the preprocessor.
+    FILE* preprocess();
+    // Closes the input stream returned by preprocess.
+    void closeInput(FILE* input) const;
 
+    // True if we are compiling a P4 v1.0 or v1.1 program
+    bool isv1() const;
+    // Get a debug hook function suitable for insertion
+    // in the pass managers that are executed.
+    DebugHook getDebugHook() const;
+
+    bool isAnnotationDisabled(const IR::Annotation *) const;
+
+    virtual bool enable_intrinsic_metadata_fix();
 };
+
+
+/// A compilation context which exposes compiler options and a compiler configuration.
+class P4CContext : public BaseCompileContext {
+ public:
+    /// @return the current compilation context, which must inherit from
+    /// P4CContext.
+    static P4CContext& get();
+
+    /// @return the compiler configuration for the current compilation context. If there is no
+    /// current compilation context, the default configuration is returned.
+    static const P4CConfiguration& getConfig();
+
+    P4CContext() {}
+
+    /// @return the compiler options for this compilation context.
+    virtual ParserOptions& options() = 0;
+
+    /// @return the default diagnostic action for calls to `::warning()`.
+    DiagnosticAction getDefaultWarningDiagnosticAction() final {
+        return errorReporter().getDefaultWarningDiagnosticAction();
+    }
+
+    /// set the default diagnostic action for calls to `::warning()`.
+    void setDefaultWarningDiagnosticAction(DiagnosticAction action) {
+        errorReporter().setDefaultWarningDiagnosticAction(action);
+    }
+
+    /// @return the action to take for the given diagnostic, falling back to the
+    /// default action if it wasn't overridden via the command line or a pragma.
+    DiagnosticAction
+    getDiagnosticAction(cstring diagnostic, DiagnosticAction defaultAction) final {
+        return errorReporter().getDiagnosticAction(diagnostic, defaultAction);
+    }
+
+    /// Set the action to take for the given diagnostic.
+    void setDiagnosticAction(cstring diagnostic, DiagnosticAction action) {
+        errorReporter().setDiagnosticAction(diagnostic, action);
+    }
+
+ protected:
+    /// @return true if the given diagnostic is known to be valid. This is
+    /// intended to help the user find misspelled diagnostics and the like; it
+    /// doesn't affect functionality.
+    virtual bool isRecognizedDiagnostic(cstring diagnostic);
+
+    /// @return the compiler configuration associated with this type of compilation context.
+    virtual const P4CConfiguration& getConfigImpl();
+};
+
+/// A utility template which can be used to easily make subclasses of P4CContext
+/// which expose a particular subclass of CompilerOptions. This is provided as a
+/// convenience since this is all many backends need.
+template <typename OptionsType>
+class P4CContextWithOptions final : public P4CContext {
+ public:
+    /// @return the current compilation context, which must be of type
+    /// P4CContextWithOptions<OptionsType>.
+    static P4CContextWithOptions& get() {
+        return CompileContextStack::top<P4CContextWithOptions>();
+    }
+
+    P4CContextWithOptions() {}
+
+    template <typename OptionsDerivedType>
+    P4CContextWithOptions(P4CContextWithOptions<OptionsDerivedType>& context) {
+        optionsInstance = context.options();
+    }
+
+    /// @return the compiler options for this compilation context.
+    OptionsType& options() override { return optionsInstance; }
+
+ private:
+    /// Compiler options for this compilation context.
+    OptionsType optionsInstance;
+};
+
 #endif /* FRONTENDS_COMMON_PARSER_OPTIONS_H_ */


### PR DESCRIPTION
Implements issue #2679. The CompilerOptions class now inherits from a new class called ParserOptions that is defined in the parser_options file, which sits between Util::Options and CompilerOptions. This change should be invisible to other users, and all changes are local to the frontends folder. Note we also changed the signature of the parseP4File function in parseInput which will now take in a ParserOptions object instead of a CompilerOptions object as an argument. 
This would allow for an added level of granularity for extensions like ours in regards to the number of options that we have at hand, which would tidy up our usage message. 
@fruffy 