### PR TITLE
Fix Gauntlet install.

### DIFF
--- a/tools/travis-build
+++ b/tools/travis-build
@@ -80,6 +80,8 @@ rm -rf /tmp/pip
 # ! ------  BEGIN VALIDATION -----------------------------------------------
 
 function build_gauntlet() {
+  # for add-apt-repository
+  apt-get install -y software-properties-common
   # Also pull Gauntlet for translation validation
   git clone -b stable https://github.com/p4gauntlet/gauntlet /gauntlet
   cd /gauntlet


### PR DESCRIPTION
With the changes to the base image, this package was missing for the Gauntlet installation. This just installs 'software-properties-common'. Once we switch to Ubuntu 20.04 all of this will not be necessary anymore. 