### PR TITLE
Make v1model immutable

### DIFF
--- a/backends/bmv2/common/helpers.h
+++ b/backends/bmv2/common/helpers.h
@@ -64,7 +64,9 @@ namespace Standard {
 /// "traits" for each extern type, templatized by the architecture name (using
 /// the Arch enum class defined below), as a convenient way to access
 /// architecture-specific names in the unified code.
-enum class Arch { V1MODEL, PSA };
+/// The V1MODEL2020 is the modified v1model.p4 file with a version
+/// >= 20200408
+enum class Arch { V1MODEL, PSA, V1MODEL2020 };
 
 /// Traits for the action profile extern, must be specialized for v1model and
 /// PSA.
@@ -80,6 +82,9 @@ template<> struct ActionProfileTraits<Arch::V1MODEL> {
     }
     static const cstring sizeParamName() { return "size"; }
 };
+
+template<> struct ActionProfileTraits<Arch::V1MODEL2020> :
+            public ActionProfileTraits<Arch::V1MODEL> {};
 
 template<> struct ActionProfileTraits<Arch::PSA> {
     static const cstring name() { return "action profile"; }
@@ -103,6 +108,9 @@ template<> struct ActionSelectorTraits<Arch::V1MODEL> : public ActionProfileTrai
     }
 };
 
+template<> struct ActionSelectorTraits<Arch::V1MODEL2020> :
+            public ActionProfileTraits<Arch::V1MODEL2020> {};
+
 template<> struct ActionSelectorTraits<Arch::PSA> : public ActionProfileTraits<Arch::PSA> {
     static const cstring name() { return "action selector"; }
     static const cstring typeName() {
@@ -122,9 +130,11 @@ template<> struct RegisterTraits<Arch::V1MODEL> {
     // the index of the type parameter for the data stored in the register, in
     // the type parameter list of the extern type declaration
     static size_t dataTypeParamIdx() { return 0; }
-    static boost::optional<size_t> indexTypeParamIdx() {
-        if (P4V1::V1Model::instance.haveIndexTypeParam()) return 1;
-        return boost::none; }
+    static boost::optional<size_t> indexTypeParamIdx() { return boost::none; }
+};
+
+template<> struct RegisterTraits<Arch::V1MODEL2020> : public RegisterTraits<Arch::V1MODEL> {
+    static boost::optional<size_t> indexTypeParamIdx() { return 1; }
 };
 
 template<> struct RegisterTraits<Arch::PSA> {
@@ -177,9 +187,24 @@ template<> struct CounterlikeTraits<Standard::CounterExtern<Standard::Arch::V1MO
     static const cstring sizeParamName() {
         return "size";
     }
-    static boost::optional<size_t> indexTypeParamIdx() {
-        if (P4V1::V1Model::instance.haveIndexTypeParam()) return 0;
-        return boost::none; }
+    static boost::optional<size_t> indexTypeParamIdx() { return boost::none; }
+};
+
+template<> struct CounterlikeTraits<Standard::CounterExtern<Standard::Arch::V1MODEL2020> > {
+    static const cstring name() { return "counter"; }
+    static const cstring directPropertyName() {
+        return P4V1::V1Model::instance.tableAttributes.counters.name;
+    }
+    static const cstring typeName() {
+        return P4V1::V1Model::instance.counter.name;
+    }
+    static const cstring directTypeName() {
+        return P4V1::V1Model::instance.directCounter.name;
+    }
+    static const cstring sizeParamName() {
+        return "size";
+    }
+    static boost::optional<size_t> indexTypeParamIdx() { return 0; }
 };
 
 /// @ref CounterlikeTraits<> specialization for @ref CounterExtern for PSA
@@ -217,10 +242,26 @@ template<> struct CounterlikeTraits<Standard::MeterExtern<Standard::Arch::V1MODE
     static const cstring sizeParamName() {
         return "size";
     }
-    static boost::optional<size_t> indexTypeParamIdx() {
-        if (P4V1::V1Model::instance.haveIndexTypeParam()) return 0;
-        return boost::none; }
+    static boost::optional<size_t> indexTypeParamIdx() { return boost::none; }
 };
+
+template<> struct CounterlikeTraits<Standard::MeterExtern<Standard::Arch::V1MODEL2020> > {
+    static const cstring name() { return "meter"; }
+    static const cstring directPropertyName() {
+        return P4V1::V1Model::instance.tableAttributes.meters.name;
+    }
+    static const cstring typeName() {
+        return P4V1::V1Model::instance.meter.name;
+    }
+    static const cstring directTypeName() {
+        return P4V1::V1Model::instance.directMeter.name;
+    }
+    static const cstring sizeParamName() {
+        return "size";
+    }
+    static boost::optional<size_t> indexTypeParamIdx() { return 0; }
+};
+
 
 /// @ref CounterlikeTraits<> specialization for @ref MeterExtern for PSA
 template<> struct CounterlikeTraits<Standard::MeterExtern<Standard::Arch::PSA> > {

--- a/backends/ebpf/ebpfModel.h
+++ b/backends/ebpf/ebpfModel.h
@@ -51,8 +51,7 @@ struct Filter_Model : public ::Model::Elem {
 // Keep this in sync with ebpf_model.p4
 class EBPFModel : public ::Model::Model {
  protected:
-    EBPFModel() : Model("0.1"),
-                  counterArray(),
+    EBPFModel() : counterArray(),
                   array_table("array_table"),
                   hash_table("hash_table"),
                   tableImplProperty("implementation"),

--- a/backends/ubpf/ubpfModel.h
+++ b/backends/ubpf/ubpfModel.h
@@ -61,8 +61,7 @@ namespace UBPF {
 
     class UBPFModel : public ::Model::Model {
     protected:
-        UBPFModel() : Model("0.1"),
-                      CPacketName("pkt"),
+        UBPFModel() : CPacketName("pkt"),
                       packet("packet", P4::P4CoreLibrary::instance.packetIn, 0),
                       pipeline(),
                       registerModel(),

--- a/frontends/common/model.h
+++ b/frontends/common/model.h
@@ -52,17 +52,13 @@ struct Extern_Model : public Type_Model {
 
 /// Param_Model : Elem
 struct Param_Model : public Elem {
-    Type_Model type;
-    unsigned   index;
+    const Type_Model type;
+    const unsigned   index;
     Param_Model(cstring name, Type_Model type, unsigned index) :
             Elem(name), type(type), index(index) {}
 };
 
-class Model {
- public:
-    cstring version;
-    explicit Model(cstring version) : version(version) {}
-};
+class Model {};
 
 }  // namespace Model
 

--- a/frontends/p4/coreLibrary.h
+++ b/frontends/p4/coreLibrary.h
@@ -98,7 +98,7 @@ class P4Exception_Model : public ::Model::Elem {
 class P4CoreLibrary : public ::Model::Model {
  protected:
     P4CoreLibrary() :
-            Model("0.2"), noAction("NoAction"), exactMatch("exact"),
+            noAction("NoAction"), exactMatch("exact"),
             ternaryMatch("ternary"), lpmMatch("lpm"), packetIn(PacketIn()),
             packetOut(PacketOut()), noError(StandardExceptions::NoError),
             packetTooShort(StandardExceptions::PacketTooShort),

--- a/frontends/p4/evaluator/evaluator.cpp
+++ b/frontends/p4/evaluator/evaluator.cpp
@@ -100,7 +100,7 @@ bool Evaluator::preorder(const IR::P4Program* program) {
 bool Evaluator::preorder(const IR::Declaration_Constant* decl) {
     LOG2("Evaluating " << dbp(decl));
     visit(decl->initializer);
-    auto value = getValue(decl);
+    auto value = getValue(decl->initializer);
     setValue(decl, value);
     return false;
 }

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -609,7 +609,7 @@ void ProgramStructure::include(cstring filename, cstring ppoptions) {
 void ProgramStructure::loadModel() {
     // This includes in turn core.p4
     std::stringstream versionArg;
-    versionArg << "-DV1MODEL_VERSION=" << V1Model::instance.version;
+    versionArg << "-DV1MODEL_VERSION=20200408";
     include(V1Model::instance.file.name, versionArg.str());
 
     metadataInstances.insert(v1model.standardMetadataType.name);

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -238,7 +238,7 @@ struct TableAttributes_Model {
 class V1Model : public ::Model::Model {
  protected:
     V1Model() :
-            Model::Model("0.1"), file("v1model.p4"),
+            file("v1model.p4"),
             standardMetadata("standard_metadata"),
             // The following 2 are not really docmented in the P4-14 spec.
             intrinsicMetadata("intrinsic_metadata"),
@@ -265,60 +265,62 @@ class V1Model : public ::Model::Model {
     {}
 
  public:
-    unsigned      version = 20200408;
-    ::Model::Elem       file;
-    ::Model::Elem       standardMetadata;
-    ::Model::Elem       intrinsicMetadata;
-    ::Model::Elem       queueingMetadata;
-    ::Model::Type_Model headersType;
-    ::Model::Type_Model metadataType;
-    StandardMetadataType_Model standardMetadataType;
-    Parser_Model        parser;
-    Deparser_Model      deparser;
-    Control_Model       egress;
-    Control_Model       ingress;
-    Switch_Model        sw;
-    Truncate            truncate;
-    CounterOrMeter_Model counterOrMeter;
-    Counter_Model       counter;
-    Meter_Model         meter;
-    Random_Model        random;
-    ActionProfile_Model action_profile;
-    ActionSelector_Model action_selector;
-    Cloner_Model        clone;
-    ::Model::Elem       resubmit;
-    TableAttributes_Model tableAttributes;
-    ::Model::Elem       rangeMatchType;
-    ::Model::Elem       optionalMatchType;
-    ::Model::Elem       selectorMatchType;
-    VerifyUpdate_Model  verify;
-    VerifyUpdate_Model  compute;
-    DigestReceiver_Model digest_receiver;
-    Hash_Model          hash;
-    Algorithm_Model     algorithm;
-    Register_Model      registers;
-    ::Model::Elem       drop;
-    ::Model::Elem       recirculate;
-    ::Model::Elem       verify_checksum;
-    ::Model::Elem       update_checksum;
-    ::Model::Elem       verify_checksum_with_payload;
-    ::Model::Elem       update_checksum_with_payload;
-    ::Model::Elem       log_msg;
-    DirectMeter_Model   directMeter;
-    DirectCounter_Model directCounter;
-
-    bool haveIndexTypeParam() const { return version >= 20200408; }  // depends on version
+    const ::Model::Elem       file;
+    const ::Model::Elem       standardMetadata;
+    const ::Model::Elem       intrinsicMetadata;
+    const ::Model::Elem       queueingMetadata;
+    const ::Model::Type_Model headersType;
+    const ::Model::Type_Model metadataType;
+    const StandardMetadataType_Model standardMetadataType;
+    const Parser_Model        parser;
+    const Deparser_Model      deparser;
+    const Control_Model       egress;
+    const Control_Model       ingress;
+    const Switch_Model        sw;
+    const Truncate            truncate;
+    const CounterOrMeter_Model counterOrMeter;
+    const Counter_Model       counter;
+    const Meter_Model         meter;
+    const Random_Model        random;
+    const ActionProfile_Model action_profile;
+    const ActionSelector_Model action_selector;
+    const Cloner_Model        clone;
+    const ::Model::Elem       resubmit;
+    const TableAttributes_Model tableAttributes;
+    const ::Model::Elem       rangeMatchType;
+    const ::Model::Elem       optionalMatchType;
+    const ::Model::Elem       selectorMatchType;
+    const VerifyUpdate_Model  verify;
+    const VerifyUpdate_Model  compute;
+    const DigestReceiver_Model digest_receiver;
+    const Hash_Model          hash;
+    const Algorithm_Model     algorithm;
+    const Register_Model      registers;
+    const ::Model::Elem       drop;
+    const ::Model::Elem       recirculate;
+    const ::Model::Elem       verify_checksum;
+    const ::Model::Elem       update_checksum;
+    const ::Model::Elem       verify_checksum_with_payload;
+    const ::Model::Elem       update_checksum_with_payload;
+    const ::Model::Elem       log_msg;
+    const DirectMeter_Model   directMeter;
+    const DirectCounter_Model directCounter;
 
     static V1Model instance;
 };
 
+/// Stores the version of the global constant __v1model_version used
+/// in the 'version' public instance variable.
 class getV1ModelVersion : public Inspector {
     bool preorder(const IR::Declaration_Constant *dc) override {
         if (dc->name == "__v1model_version") {
             auto val = dc->initializer->to<IR::Constant>();
-            V1Model::instance.version = static_cast<unsigned>(val->value); }
+            version = static_cast<unsigned>(val->value); }
         return false; }
     bool preorder(const IR::Declaration *) override { return false; }
+
+ public:
+    unsigned version = 0;
 };
 
 }  // namespace P4V1

--- a/frontends/p4/modelInstances.cpp
+++ b/frontends/p4/modelInstances.cpp
@@ -23,11 +23,10 @@ P4CoreLibrary P4CoreLibrary::instance;
 
 }  // namespace P4
 
-/* These must be in the same compiliation unit to ensure that P4CoreLibrary::instance
+/* These must be in the same compilation unit to ensure that P4CoreLibrary::instance
  * is initialized before V1Model::instance */
 namespace P4V1 {
 
 V1Model V1Model::instance;
 
 }  // namespace P4V1
-

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -706,7 +706,6 @@ class FindUninitialized : public Inspector {
 };
 
 class RemoveUnused : public Transform {
-    // TODO: remove transitively unused
     const HasUses* hasUses;
     ReferenceMap*   refMap;
     TypeMap*        typeMap;

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -170,9 +170,12 @@ bool ToP4::preorder(const IR::P4Program* program) {
                     const char *p = sourceFile.c_str() + strlen(p4includePath);
                     if (*p == '/') p++;
                     if (P4V1::V1Model::instance.file.name == p) {
-                        std::stringstream buf;
-                        buf << "#define V1MODEL_VERSION " << P4V1::V1Model::instance.version;
-                        builder.appendLine(buf.str()); }
+                        P4V1::getV1ModelVersion g;
+                        program->apply(g);
+                        builder.append("#define V1MODEL_VERSION ");
+                        builder.append(g.version);
+                        builder.appendLine("");
+                    }
                     builder.append("#include <");
                     builder.append(p);
                     builder.appendLine(">");
@@ -1417,4 +1420,17 @@ bool ToP4::preorder(const IR::Path* p) {
     builder.append(p->asString());
     return false;
 }
+
+std::string toP4(const IR::INode* node) {
+    std::stringstream stream;
+    P4::ToP4 toP4(&stream, false);
+    node->getNode()->apply(toP4);
+    return stream.str();
+}
+
+void dumpP4(const IR::INode* node) {
+    auto s = toP4(node);
+    std::cout << s;
+}
+
 }  // namespace P4

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -247,6 +247,9 @@ class ToP4 : public Inspector {
     bool preorder(const IR::V1Program*) override { return false; }
 };
 
+std::string toP4(const IR::INode* node);
+void dumpP4(const IR::INode* node);
+
 }  // namespace P4
 
 #endif /* _P4_TOP4_TOP4_H_ */

--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -80,8 +80,14 @@ class FindSymbols : public Inspector {
     }
     void postorder(const IR::Declaration_Variable* decl) override
     { doDecl(decl); }
-    void postorder(const IR::Declaration_Constant* decl) override
-    { doDecl(decl); }
+    void postorder(const IR::Declaration_Constant* decl) override {
+        // Skip toplevel constants with names like __
+        // We assume that these do not clash and no new symbols with
+        // these names will be added.
+        if (decl->getName().name.startsWith("__") && getParent<IR::P4Program>())
+            return;
+        doDecl(decl);
+    }
     void postorder(const IR::Declaration_Instance* decl) override
     { if (!isTopLevel()) doDecl(decl); }
     void postorder(const IR::P4Table* decl) override

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -104,6 +104,9 @@ const IR::Node* RemoveUnusedDeclarations::process(const IR::IDeclaration* decl) 
     LOG3("Visiting " << decl);
     if (decl->getName().name == IR::ParserState::verify && getParent<IR::P4Program>())
         return decl->getNode();
+    if (decl->getName().name.startsWith("__"))
+        // Internal identifiers, e.g., __v1model_version
+        return decl->getNode();
     if (refMap->isUsed(getOriginal<IR::IDeclaration>()))
         return decl->getNode();
     LOG3("Removing " << getOriginal());

--- a/ir/dump.cpp
+++ b/ir/dump.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright 2013-present Barefoot Networks, Inc. 
+Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -79,7 +79,7 @@ bool SymbolicValueFactory::isFixedWidth(const IR::Type* type) const {
 }
 
 unsigned SymbolicValueFactory::getWidth(const IR::Type* type) const {
-    type = typeMap->getType(type, true);
+    type = typeMap->getTypeType(type, true);
     if (type->is<IR::Type_Bits>())
         return type->to<IR::Type_Bits>()->size;
     if (type->is<IR::Type_Boolean>())
@@ -739,7 +739,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation* expression) {
 
 void ExpressionEvaluator::postorder(const IR::Member* expression) {
     auto type = typeMap->getType(expression, true);
-    if (type->is<IR::Type_MethodBase>()) {
+    if (type->is<IR::Type_MethodBase>() || type->is<IR::Type_Error>()) {
         // not really void, but we can't do anything with this anyway
         set(expression, SymbolicVoid::get());
         return;
@@ -783,7 +783,7 @@ bool ExpressionEvaluator::preorder(const IR::ArrayIndex* expression) {
     visit(expression->left);
     evaluatingLeftValue = lv;
     visit(expression->right);
-    return false;  // prune
+    return true;  // don't prune
 }
 
 void ExpressionEvaluator::postorder(const IR::ArrayIndex* expression) {
@@ -971,7 +971,7 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression* expression) 
         mi->actualMethodType->returnType->is<IR::Type_Void>()) {
         set(expression, SymbolicVoid::get());
     } else {
-        auto type = typeMap->getType(mi->actualMethodType->returnType, true);
+        auto type = typeMap->getTypeType(mi->actualMethodType->returnType, true);
         auto res = factory->create(type, false);
         set(expression, res);
     }

--- a/test/gtest/helpers.cpp
+++ b/test/gtest/helpers.cpp
@@ -128,7 +128,7 @@ P4CTestEnvironment::P4CTestEnvironment() {
     // XXX(seth): We should find a more robust way to locate these headers.
     _coreP4 = readHeader("p4include/core.p4");
     _v1Model = readHeader("p4include/v1model.p4", true,
-                          "V1MODEL_VERSION", P4V1::V1Model::instance.version);
+                          "V1MODEL_VERSION", 20200408);
     _psaP4 = readHeader("p4include/psa.p4", true);
 }
 


### PR DESCRIPTION
In particular, v1model::instance::version was a global static variable. That's bad.
The weird thing is that some of the classes I have introduced to represent the two versions of v1model are currently not used.
@antoninbas some of these are in the control-plane API generation code.
In particular, V1MODEL2020 is never used, but all tests pass.
