### PR TITLE
Fix Dpdk regression failure: Duplicates declaration

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -1,5 +1,5 @@
 p4c_add_xfail_reason("dpdk"
-  "Duplicates declaration"
+  "declaration not found"
   testdata/p4_16_samples/psa-action-profile1.p4
   testdata/p4_16_samples/psa-action-profile2.p4
   testdata/p4_16_samples/psa-action-profile3.p4
@@ -18,10 +18,6 @@ p4c_add_xfail_reason("dpdk"
   testdata/p4_16_samples/psa-meter6.p4
   testdata/p4_16_samples/psa-test.p4
   testdata/p4_16_samples/psa-register1.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
-  "declaration not found"
   testdata/p4_16_samples/psa-action-selector1.p4
   testdata/p4_16_samples/psa-action-selector2.p4
   testdata/p4_16_samples/psa-action-selector3.p4

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -319,10 +319,13 @@ const IR::Node *ReplaceMetadataHeaderName::preorder(IR::Member *m) {
 
 const IR::Node *ReplaceMetadataHeaderName::preorder(IR::Parameter *p) {
     if (auto type = p->type->to<IR::Type_Name>()) {
-        if (type->path->name == info->header_type) {
-            return new IR::Parameter(IR::ID("h"), p->direction, p->type);
+       cstring newName;
+       if (type->path->name == info->header_type) {
+           newName = "h." + p->name;
+           return new IR::Parameter(IR::ID(newName), p->direction, p->type);
         } else if (type->path->name == info->local_metadata_type) {
-            return new IR::Parameter(IR::ID("m"), p->direction, p->type);
+            newName = "m." + p->name;
+            return new IR::Parameter(IR::ID(newName), p->direction, p->type);
         }
     }
     return p;


### PR DESCRIPTION
This commit fixes the "Duplicates declaration error with p4c-dpdk.
The changes are made as per the comment specified in backends/dpdk/dpdkArch.h.
All header and metadata references should be prefixed with "h." and "m." respectively.
