### PR TITLE
Replace "master" with "main" 

### DIFF
--- a/.github/.travis.yml.disabled
+++ b/.github/.travis.yml.disabled
@@ -2,7 +2,7 @@
 
 branches:
   only:
-  - master
+  - main
   - stable
 
 dist: xenial

--- a/.github/workflows/ci-bazel.yml
+++ b/.github/workflows/ci-bazel.yml
@@ -2,9 +2,9 @@ name: "bazel"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build_direct:  # Build p4c directly.

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,9 +2,9 @@ name: "test-p4c"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   # Build and test p4c on Ubuntu 16.04

--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -2,9 +2,9 @@ name: "validate-p4c"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   # We run validation in parallel with the normal tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/p4lang/p4c.svg?branch=master)](https://travis-ci.com/p4lang/p4c)
+[![Build Status](https://travis-ci.com/p4lang/p4c.svg?branch=main)](https://travis-ci.com/p4lang/p4c)
 
 # p4c
 

--- a/bazel/p4c_deps.bzl
+++ b/bazel/p4c_deps.bzl
@@ -24,7 +24,7 @@ filegroup(
     if not native.existing_rule("com_github_nelhage_rules_boost"):
         git_repository(
             name = "com_github_nelhage_rules_boost",
-            # Newest commit on master branch as of Jan 22, 2021.
+            # Newest commit on main branch as of Jan 22, 2021.
             commit = "77dbe5a5262c71a2fe2c033677f50aaa0e31090d",
             remote = "https://github.com/nelhage/rules_boost",
             shallow_since = "1611019749 -0800",
@@ -43,7 +43,7 @@ filegroup(
         git_repository(
             name = "com_github_p4lang_p4runtime",
             remote = "https://github.com/p4lang/p4runtime",
-            # Newest commit on master branch as of Jan 22, 2021.
+            # Newest commit on main branch as of Jan 22, 2021.
             commit = "0d40261b67283999bf0f03bd6b40b5374c7aebd0",
             shallow_since = "1611340571 -0800",
             # strip_prefix is broken; we use patch_cmds as a workaround,

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,7 @@ Happy writing! Should you have any questions, please don't hesitate to ask.
 
 ```
 git fetch upstream
-git rebase upstream/master
+git rebase upstream/main
 git push -f
 ```
 

--- a/docs/doxygen/doxygen.cfg
+++ b/docs/doxygen/doxygen.cfg
@@ -1233,7 +1233,7 @@ CHM_FILE               =
 HHC_LOCATION           =
 
 # The GENERATE_CHI flag controls if a separate .chi index file is generated (
-# YES) or that it should be included in the master .chm file ( NO).
+# YES) or that it should be included in the main .chm file ( NO).
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 

--- a/p4include/psa.p4
+++ b/p4include/psa.p4
@@ -71,7 +71,7 @@ typedef bit<64> TimestampUint_t;
  * 16 bits of clone/mirror session id are comparable to the type
  * CloneSessionIdUint_t here.  See occurrences of clone_spec in this
  * file for details:
- * https://github.com/p4lang/behavioral-model/blob/master/targets/simple_switch/simple_switch.cpp
+ * https://github.com/p4lang/behavioral-model/blob/main/targets/simple_switch/simple_switch.cpp
  */
 
 @p4runtime_translation("p4.org/psa/v1/PortId_t", 32)

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -19,7 +19,7 @@ limitations under the License.
 /* Note 1: More details about the definition of v1model architecture
  * can be found at the location below.
  *
- * https://github.com/p4lang/behavioral-model/blob/master/docs/simple_switch.md
+ * https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md
  *
  * Note 2: There were several discussions among P4 working group
  * members in early 2019 regarding exactly how resubmit, recirculate,
@@ -27,7 +27,7 @@ limitations under the License.
  * controls, but the values of the fields to be preserved is the value
  * they have when that control is finished executing.  That is how
  * these operations are defined in P4_14.  See
- * https://github.com/p4lang/behavioral-model/blob/master/docs/simple_switch.md#restrictions-on-recirculate-resubmit-and-clone-operations
+ * https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md#restrictions-on-recirculate-resubmit-and-clone-operations
  * for more details on the current state of affairs.
  *
  * Note 3: There are at least some P4_14 implementations where
@@ -425,7 +425,7 @@ extern void mark_to_drop();
  * packet to do something other than drop.
  *
  * See
- * https://github.com/p4lang/behavioral-model/blob/master/docs/simple_switch.md
+ * https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md
  * -- in particular the section "Pseudocode for what happens at the
  * end of ingress and egress processing" -- for the relative priority
  * of the different possible things that can happen to a packet when

--- a/testdata/p4_16_samples/v1model-special-ops-bmv2.p4
+++ b/testdata/p4_16_samples/v1model-special-ops-bmv2.p4
@@ -23,7 +23,7 @@ limitations under the License.
 // named "PktInstanceType" in the p4lang/behavioral-model source file
 // targets/simple_switch/simple_switch.h
 
-// https://github.com/p4lang/behavioral-model/blob/master/targets/simple_switch/simple_switch.h#L126-L134
+// https://github.com/p4lang/behavioral-model/blob/main/targets/simple_switch/simple_switch.h#L126-L134
 
 const bit<32> BMV2_V1MODEL_INSTANCE_TYPE_NORMAL        = 0;
 const bit<32> BMV2_V1MODEL_INSTANCE_TYPE_INGRESS_CLONE = 1;


### PR DESCRIPTION
This is in preparation for renaming p4c's primary branch. 

In particular, update references to "master" in the CI scripts. Also update references to main branch in behavioral-model.

This PR should be merged at the same time as we (manually) rename the branch on GitHub's website.