### PR TITLE
Give unique names to action directionless parameters

### DIFF
--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -183,7 +183,7 @@ ActionConverter::convertActionParams(const IR::ParameterList *parameters,
             ::warning(ErrorType::WARN_UNUSED, "Unused action parameter %1%", p);
 
         auto param = new Util::JsonObject();
-        param->emplace("name", p->name);
+        param->emplace("name", p->externalName());
         auto type = ctxt->typeMap->getType(p, true);
         // TODO: added IR::Type_Enum here to support PSA_MeterColor_t
         // should re-consider how to support action parameters that is neither bit<> nor int<>

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -140,7 +140,7 @@ void EBPFTable::emitActionArguments(CodeBuilder* builder,
     for (auto p : *action->parameters->getEnumerator()) {
         builder->emitIndent();
         auto type = EBPFTypeFactory::instance->create(p->type);
-        type->declare(builder, p->name.name, false);
+        type->declare(builder, p->externalName(), false);
         builder->endOfStatement(true);
     }
 

--- a/backends/p4test/run-p4-sample.py
+++ b/backends/p4test/run-p4-sample.py
@@ -119,7 +119,8 @@ def run_timeout(options, args, timeout, stderr):
 timeout = 10 * 60
 
 def compare_files(options, produced, expected, ignore_case):
-    if options.replace:
+    # p4info files should not change
+    if options.replace and "p4info" not in produced:
         if options.verbose:
             print("Saving new version of ", expected)
         shutil.copy2(produced, expected)

--- a/backends/ubpf/ubpfTable.cpp
+++ b/backends/ubpf/ubpfTable.cpp
@@ -311,7 +311,7 @@ void UBPFTable::emitActionArguments(EBPF::CodeBuilder *builder,
     for (auto p : *action->parameters->getEnumerator()) {
         builder->emitIndent();
         auto type = UBPFTypeFactory::instance->create(p->type);
-        type->declare(builder, p->name.name, false);
+        type->declare(builder, p->externalName(), false);
         builder->endOfStatement(true);
     }
 

--- a/frontends/p4/hierarchicalNames.h
+++ b/frontends/p4/hierarchicalNames.h
@@ -74,6 +74,9 @@ class HierarchicalNames : public Transform {
     { visit(table->annotations); prune(); return table; }
 
     const IR::Node* postorder(IR::Annotation* annotation) override;
+    // Do not change name annotations on parameters
+    const IR::Node* preorder(IR::Parameter* parameter) override
+    { prune(); return parameter; }
 };
 
 }  // namespace P4

--- a/frontends/p4/uniqueNames.cpp
+++ b/frontends/p4/uniqueNames.cpp
@@ -39,10 +39,6 @@ void RenameMap::markActionCall(const IR::P4Action* action, const IR::MethodCallE
     actionCall.emplace(call, action);
 }
 
-void RenameMap::foundInTable(const IR::P4Action* action) {
-    inTable.emplace(action);
-}
-
 namespace {
 
 class FindActionCalls : public Inspector {
@@ -60,10 +56,6 @@ class FindActionCalls : public Inspector {
             return;
         auto ac = mi->to<P4::ActionCall>();
         renameMap->markActionCall(ac->action, getOriginal<IR::MethodCallExpression>());
-
-        auto table = findContext<IR::P4Table>();
-        if (table != nullptr)
-            renameMap->foundInTable(ac->action);
     }
 };
 
@@ -129,8 +121,10 @@ const IR::Node* RenameSymbols::postorder(IR::Declaration_Constant* decl) {
 
 const IR::Node* RenameSymbols::postorder(IR::Parameter* param) {
     auto name = getName();
-    if (name != nullptr && *name != param->name.name)
+    if (name != nullptr && *name != param->name.name) {
+        param->annotations = addNameAnnotation(param->name, param->annotations);
         param->name = IR::ID(param->name.srcInfo, *name, param->name.originalName);
+    }
     return param;
 }
 

--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -26,8 +26,6 @@ namespace P4 {
 class RenameMap {
     /// Internal declaration name
     std::map<const IR::IDeclaration*, cstring> newName;
-    /// all actions that appear in tables
-    std::set<const IR::P4Action*> inTable;
     /// Map from method call to action that is being called
     std::map<const IR::MethodCallExpression*, const IR::P4Action*> actionCall;
 
@@ -45,8 +43,6 @@ class RenameMap {
     }
     void foundInTable(const IR::P4Action* action);
     void markActionCall(const IR::P4Action* action, const IR::MethodCallExpression* call);
-    bool isInTable(const IR::P4Action* action)
-    { return inTable.find(action) != inTable.end(); }
     const IR::P4Action* actionCalled(const IR::MethodCallExpression* expression) const;
 };
 
@@ -125,12 +121,8 @@ class FindParameters : public Inspector {
     ReferenceMap* refMap;  // used to generate new names
     RenameMap*    renameMap;
 
-    // If all is true then rename all parameters, else rename only
-    // directional parameters
-    void doParameters(const IR::ParameterList* pl, bool all) {
+    void doParameters(const IR::ParameterList* pl) {
         for (auto p : pl->parameters) {
-            if (!all && p->direction == IR::Direction::None)
-                continue;
             cstring newName = refMap->newName(p->name);
             renameMap->setNewName(p, newName);
         }
@@ -140,8 +132,7 @@ class FindParameters : public Inspector {
             refMap(refMap), renameMap(renameMap)
     { CHECK_NULL(refMap); CHECK_NULL(renameMap); setName("FindParameters"); }
     void postorder(const IR::P4Action* action) override {
-        bool inTable = renameMap->isInTable(action);
-        doParameters(action->parameters, !inTable);
+        doParameters(action->parameters);
     }
 };
 

--- a/testdata/p4_14_samples_outputs/01-BigMatch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-frontend.p4
@@ -80,17 +80,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_8() {
     }
-    @name(".set_f1") action set_f1(bit<1024> f1) {
-        meta.ing_metadata.f1 = f1;
+    @name(".set_f1") action set_f1(@name("f1") bit<1024> f1_1) {
+        meta.ing_metadata.f1 = f1_1;
     }
-    @name(".set_f2") action set_f2(bit<512> f2) {
-        meta.ing_metadata.f2 = f2;
+    @name(".set_f2") action set_f2(@name("f2") bit<512> f2_1) {
+        meta.ing_metadata.f2 = f2_1;
     }
-    @name(".set_f3") action set_f3(bit<256> f3) {
-        meta.ing_metadata.f3 = f3;
+    @name(".set_f3") action set_f3(@name("f3") bit<256> f3_1) {
+        meta.ing_metadata.f3 = f3_1;
     }
-    @name(".set_f4") action set_f4(bit<128> f4) {
-        meta.ing_metadata.f4 = f4;
+    @name(".set_f4") action set_f4(@name("f4") bit<128> f4_1) {
+        meta.ing_metadata.f4 = f4_1;
     }
     @name(".i_t1") table i_t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/01-BigMatch-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-BigMatch-midend.p4
@@ -84,17 +84,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_8() {
     }
-    @name(".set_f1") action set_f1(bit<1024> f1) {
-        meta._ing_metadata_f12 = f1;
+    @name(".set_f1") action set_f1(@name("f1") bit<1024> f1_1) {
+        meta._ing_metadata_f12 = f1_1;
     }
-    @name(".set_f2") action set_f2(bit<512> f2) {
-        meta._ing_metadata_f23 = f2;
+    @name(".set_f2") action set_f2(@name("f2") bit<512> f2_1) {
+        meta._ing_metadata_f23 = f2_1;
     }
-    @name(".set_f3") action set_f3(bit<256> f3) {
-        meta._ing_metadata_f34 = f3;
+    @name(".set_f3") action set_f3(@name("f3") bit<256> f3_1) {
+        meta._ing_metadata_f34 = f3_1;
     }
-    @name(".set_f4") action set_f4(bit<128> f4) {
-        meta._ing_metadata_f45 = f4;
+    @name(".set_f4") action set_f4(@name("f4") bit<128> f4_1) {
+        meta._ing_metadata_f45 = f4_1;
     }
     @name(".i_t1") table i_t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/01-NoDeps-frontend.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-frontend.p4
@@ -59,8 +59,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_4() {
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta.ing_metadata.egress_port = egress_port_1;
     }
     @name(".ing_drop") action ing_drop() {
         meta.ing_metadata.drop = 1w1;

--- a/testdata/p4_14_samples_outputs/01-NoDeps-midend.p4
+++ b/testdata/p4_14_samples_outputs/01-NoDeps-midend.p4
@@ -59,8 +59,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_4() {
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta._ing_metadata_egress_port1 = egress_port_1;
     }
     @name(".ing_drop") action ing_drop() {
         meta._ing_metadata_drop0 = 1w1;

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-frontend.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-frontend.p4
@@ -63,8 +63,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_2() {
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta.ing_metadata.egress_port = egress_port_1;
     }
     @name(".i_t1") table i_t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/02-BadSizeField-midend.p4
+++ b/testdata/p4_14_samples_outputs/02-BadSizeField-midend.p4
@@ -63,8 +63,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_2() {
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta._ing_metadata_egress_port1 = egress_port_1;
     }
     @name(".i_t1") table i_t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/03-Gateway-frontend.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-frontend.p4
@@ -84,20 +84,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".ing_drop") action ing_drop() {
         meta.ing_metadata.drop = 1w1;
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta.ing_metadata.egress_port = egress_port_1;
     }
-    @name(".set_f1") action set_f1(bit<8> f1) {
-        meta.ing_metadata.f1 = f1;
+    @name(".set_f1") action set_f1(@name("f1") bit<8> f1_1) {
+        meta.ing_metadata.f1 = f1_1;
     }
-    @name(".set_f2") action set_f2(bit<16> f2) {
-        meta.ing_metadata.f2 = f2;
+    @name(".set_f2") action set_f2(@name("f2") bit<16> f2_1) {
+        meta.ing_metadata.f2 = f2_1;
     }
-    @name(".set_f3") action set_f3(bit<32> f3) {
-        meta.ing_metadata.f3 = f3;
+    @name(".set_f3") action set_f3(@name("f3") bit<32> f3_1) {
+        meta.ing_metadata.f3 = f3_1;
     }
-    @name(".set_f4") action set_f4(bit<64> f4) {
-        meta.ing_metadata.f4 = f4;
+    @name(".set_f4") action set_f4(@name("f4") bit<64> f4_1) {
+        meta.ing_metadata.f4 = f4_1;
     }
     @name(".i_t1") table i_t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/03-Gateway-midend.p4
+++ b/testdata/p4_14_samples_outputs/03-Gateway-midend.p4
@@ -88,20 +88,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".ing_drop") action ing_drop() {
         meta._ing_metadata_drop0 = 1w1;
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta._ing_metadata_egress_port1 = egress_port_1;
     }
-    @name(".set_f1") action set_f1(bit<8> f1) {
-        meta._ing_metadata_f12 = f1;
+    @name(".set_f1") action set_f1(@name("f1") bit<8> f1_1) {
+        meta._ing_metadata_f12 = f1_1;
     }
-    @name(".set_f2") action set_f2(bit<16> f2) {
-        meta._ing_metadata_f23 = f2;
+    @name(".set_f2") action set_f2(@name("f2") bit<16> f2_1) {
+        meta._ing_metadata_f23 = f2_1;
     }
-    @name(".set_f3") action set_f3(bit<32> f3) {
-        meta._ing_metadata_f34 = f3;
+    @name(".set_f3") action set_f3(@name("f3") bit<32> f3_1) {
+        meta._ing_metadata_f34 = f3_1;
     }
-    @name(".set_f4") action set_f4(bit<64> f4) {
-        meta._ing_metadata_f45 = f4;
+    @name(".set_f4") action set_f4(@name("f4") bit<64> f4_1) {
+        meta._ing_metadata_f45 = f4_1;
     }
     @name(".i_t1") table i_t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-first.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-first.p4
@@ -133,7 +133,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 i_t4.apply();
             }
         }
-
     }
 }
 

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-frontend.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-frontend.p4
@@ -74,26 +74,26 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".ing_drop") action ing_drop() {
         meta.ing_metadata.drop = 8w1;
     }
-    @name(".set_f1") action set_f1(bit<8> f1) {
-        meta.ing_metadata.f1 = f1;
+    @name(".set_f1") action set_f1(@name("f1") bit<8> f1_1) {
+        meta.ing_metadata.f1 = f1_1;
     }
-    @name(".set_f2") action set_f2(bit<16> f2) {
-        meta.ing_metadata.f2 = f2;
+    @name(".set_f2") action set_f2(@name("f2") bit<16> f2_1) {
+        meta.ing_metadata.f2 = f2_1;
     }
-    @name(".set_f2") action set_f2_2(bit<16> f2) {
-        meta.ing_metadata.f2 = f2;
+    @name(".set_f2") action set_f2_2(@name("f2") bit<16> f2_2) {
+        meta.ing_metadata.f2 = f2_2;
     }
-    @name(".set_f3") action set_f3(bit<32> f3) {
-        meta.ing_metadata.f3 = f3;
+    @name(".set_f3") action set_f3(@name("f3") bit<32> f3_1) {
+        meta.ing_metadata.f3 = f3_1;
     }
-    @name(".set_f3") action set_f3_2(bit<32> f3) {
-        meta.ing_metadata.f3 = f3;
+    @name(".set_f3") action set_f3_2(@name("f3") bit<32> f3_2) {
+        meta.ing_metadata.f3 = f3_2;
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta.ing_metadata.egress_port = egress_port_1;
     }
-    @name(".set_f4") action set_f4(bit<64> f4) {
-        meta.ing_metadata.f4 = f4;
+    @name(".set_f4") action set_f4(@name("f4") bit<64> f4_1) {
+        meta.ing_metadata.f4 = f4_1;
     }
     @name(".i_t1") table i_t1_0 {
         actions = {
@@ -155,7 +155,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 i_t4_0.apply();
             }
         }
-
     }
 }
 

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault-midend.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault-midend.p4
@@ -78,26 +78,26 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".ing_drop") action ing_drop() {
         meta._ing_metadata_drop0 = 8w1;
     }
-    @name(".set_f1") action set_f1(bit<8> f1) {
-        meta._ing_metadata_f12 = f1;
+    @name(".set_f1") action set_f1(@name("f1") bit<8> f1_1) {
+        meta._ing_metadata_f12 = f1_1;
     }
-    @name(".set_f2") action set_f2(bit<16> f2) {
-        meta._ing_metadata_f23 = f2;
+    @name(".set_f2") action set_f2(@name("f2") bit<16> f2_1) {
+        meta._ing_metadata_f23 = f2_1;
     }
-    @name(".set_f2") action set_f2_2(bit<16> f2) {
-        meta._ing_metadata_f23 = f2;
+    @name(".set_f2") action set_f2_2(@name("f2") bit<16> f2_2) {
+        meta._ing_metadata_f23 = f2_2;
     }
-    @name(".set_f3") action set_f3(bit<32> f3) {
-        meta._ing_metadata_f34 = f3;
+    @name(".set_f3") action set_f3(@name("f3") bit<32> f3_1) {
+        meta._ing_metadata_f34 = f3_1;
     }
-    @name(".set_f3") action set_f3_2(bit<32> f3) {
-        meta._ing_metadata_f34 = f3;
+    @name(".set_f3") action set_f3_2(@name("f3") bit<32> f3_2) {
+        meta._ing_metadata_f34 = f3_2;
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta._ing_metadata_egress_port1 = egress_port_1;
     }
-    @name(".set_f4") action set_f4(bit<64> f4) {
-        meta._ing_metadata_f45 = f4;
+    @name(".set_f4") action set_f4(@name("f4") bit<64> f4_1) {
+        meta._ing_metadata_f45 = f4_1;
     }
     @name(".i_t1") table i_t1_0 {
         actions = {
@@ -159,7 +159,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 i_t4_0.apply();
             }
         }
-
     }
 }
 

--- a/testdata/p4_14_samples_outputs/04-GatewayDefault.p4
+++ b/testdata/p4_14_samples_outputs/04-GatewayDefault.p4
@@ -123,7 +123,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 i_t4.apply();
             }
         }
-
     }
 }
 

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-frontend.p4
@@ -56,8 +56,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_2() {
     }
-    @name(".set_f1") action set_f1(bit<8> f1) {
-        meta.ing_metadata.f1 = f1;
+    @name(".set_f1") action set_f1(@name("f1") bit<8> f1_1) {
+        meta.ing_metadata.f1 = f1_1;
     }
     @name(".i_t1") table i_t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/05-FieldProblem-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-FieldProblem-midend.p4
@@ -57,8 +57,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_2() {
     }
-    @name(".set_f1") action set_f1(bit<8> f1) {
-        meta._ing_metadata_f10 = f1;
+    @name(".set_f1") action set_f1(@name("f1") bit<8> f1_1) {
+        meta._ing_metadata_f10 = f1_1;
     }
     @name(".i_t1") table i_t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-frontend.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-frontend.p4
@@ -549,20 +549,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.m.field_32_63 = 32w63;
         hdr.h.setInvalid();
     }
-    @name(".set_egress_spec") action set_egress_spec(bit<9> port) {
+    @name(".set_egress_spec") action set_egress_spec(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".set_egress_spec") action set_egress_spec_5(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_5(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
-    @name(".set_egress_spec") action set_egress_spec_6(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_6(@name("port") bit<9> port_2) {
+        standard_metadata.egress_spec = port_2;
     }
-    @name(".set_egress_spec") action set_egress_spec_7(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_7(@name("port") bit<9> port_3) {
+        standard_metadata.egress_spec = port_3;
     }
-    @name(".set_egress_spec") action set_egress_spec_8(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_8(@name("port") bit<9> port_4) {
+        standard_metadata.egress_spec = port_4;
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/05-FullTPHV-midend.p4
+++ b/testdata/p4_14_samples_outputs/05-FullTPHV-midend.p4
@@ -771,20 +771,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._m_field_32_63222 = 32w63;
         hdr.h.setInvalid();
     }
-    @name(".set_egress_spec") action set_egress_spec(bit<9> port) {
+    @name(".set_egress_spec") action set_egress_spec(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".set_egress_spec") action set_egress_spec_5(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_5(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
-    @name(".set_egress_spec") action set_egress_spec_6(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_6(@name("port") bit<9> port_2) {
+        standard_metadata.egress_spec = port_2;
     }
-    @name(".set_egress_spec") action set_egress_spec_7(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_7(@name("port") bit<9> port_3) {
+        standard_metadata.egress_spec = port_3;
     }
-    @name(".set_egress_spec") action set_egress_spec_8(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_8(@name("port") bit<9> port_4) {
+        standard_metadata.egress_spec = port_4;
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-frontend.p4
@@ -532,20 +532,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.m.field_32_62 = 32w62;
         meta.m.field_32_63 = 32w63;
     }
-    @name(".set_egress_spec") action set_egress_spec(bit<9> port) {
+    @name(".set_egress_spec") action set_egress_spec(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".set_egress_spec") action set_egress_spec_5(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_5(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
-    @name(".set_egress_spec") action set_egress_spec_6(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_6(@name("port") bit<9> port_2) {
+        standard_metadata.egress_spec = port_2;
     }
-    @name(".set_egress_spec") action set_egress_spec_7(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_7(@name("port") bit<9> port_3) {
+        standard_metadata.egress_spec = port_3;
     }
-    @name(".set_egress_spec") action set_egress_spec_8(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_8(@name("port") bit<9> port_4) {
+        standard_metadata.egress_spec = port_4;
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/06-FullTPHV1-midend.p4
+++ b/testdata/p4_14_samples_outputs/06-FullTPHV1-midend.p4
@@ -754,20 +754,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._m_field_32_62221 = 32w62;
         meta._m_field_32_63222 = 32w63;
     }
-    @name(".set_egress_spec") action set_egress_spec(bit<9> port) {
+    @name(".set_egress_spec") action set_egress_spec(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".set_egress_spec") action set_egress_spec_5(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_5(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
-    @name(".set_egress_spec") action set_egress_spec_6(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_6(@name("port") bit<9> port_2) {
+        standard_metadata.egress_spec = port_2;
     }
-    @name(".set_egress_spec") action set_egress_spec_7(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_7(@name("port") bit<9> port_3) {
+        standard_metadata.egress_spec = port_3;
     }
-    @name(".set_egress_spec") action set_egress_spec_8(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_8(@name("port") bit<9> port_4) {
+        standard_metadata.egress_spec = port_4;
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-frontend.p4
@@ -565,20 +565,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.m.field_32_63 = 32w63;
         meta.m.field_32_64 = 32w64;
     }
-    @name(".set_egress_spec") action set_egress_spec(bit<9> port) {
+    @name(".set_egress_spec") action set_egress_spec(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".set_egress_spec") action set_egress_spec_5(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_5(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
-    @name(".set_egress_spec") action set_egress_spec_6(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_6(@name("port") bit<9> port_2) {
+        standard_metadata.egress_spec = port_2;
     }
-    @name(".set_egress_spec") action set_egress_spec_7(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_7(@name("port") bit<9> port_3) {
+        standard_metadata.egress_spec = port_3;
     }
-    @name(".set_egress_spec") action set_egress_spec_8(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_8(@name("port") bit<9> port_4) {
+        standard_metadata.egress_spec = port_4;
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/07-FullTPHV2-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-FullTPHV2-midend.p4
@@ -787,20 +787,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._m_field_32_63222 = 32w63;
         meta._m_field_32_64223 = 32w64;
     }
-    @name(".set_egress_spec") action set_egress_spec(bit<9> port) {
+    @name(".set_egress_spec") action set_egress_spec(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".set_egress_spec") action set_egress_spec_5(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_5(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
-    @name(".set_egress_spec") action set_egress_spec_6(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_6(@name("port") bit<9> port_2) {
+        standard_metadata.egress_spec = port_2;
     }
-    @name(".set_egress_spec") action set_egress_spec_7(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_7(@name("port") bit<9> port_3) {
+        standard_metadata.egress_spec = port_3;
     }
-    @name(".set_egress_spec") action set_egress_spec_8(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_8(@name("port") bit<9> port_4) {
+        standard_metadata.egress_spec = port_4;
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-first.p4
@@ -284,7 +284,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 l2_match.apply();
             }
         }
-
         if (hdr.tcp.isValid()) {
             tcp_check.apply();
         } else if (hdr.udp.isValid()) {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-frontend.p4
@@ -203,14 +203,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_4() {
         meta.ing_metadata.drop = 1w1;
     }
-    @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<9> egress_port_1) {
+        meta.ing_metadata.egress_port = egress_port_1;
     }
-    @name(".set_egress_port") action set_egress_port_3(bit<9> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port_3(@name("egress_port") bit<9> egress_port_2) {
+        meta.ing_metadata.egress_port = egress_port_2;
     }
-    @name(".set_egress_port") action set_egress_port_4(bit<9> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port_4(@name("egress_port") bit<9> egress_port_3) {
+        meta.ing_metadata.egress_port = egress_port_3;
     }
     @name(".discard") action discard() {
         mark_to_drop(standard_metadata);
@@ -322,7 +322,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 l2_match_0.apply();
             }
         }
-
         if (hdr.tcp.isValid()) {
             tcp_check_0.apply();
         } else if (hdr.udp.isValid()) {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol-midend.p4
@@ -204,14 +204,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_4() {
         meta._ing_metadata_drop0 = 1w1;
     }
-    @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<9> egress_port_1) {
+        meta._ing_metadata_egress_port1 = egress_port_1;
     }
-    @name(".set_egress_port") action set_egress_port_3(bit<9> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port_3(@name("egress_port") bit<9> egress_port_2) {
+        meta._ing_metadata_egress_port1 = egress_port_2;
     }
-    @name(".set_egress_port") action set_egress_port_4(bit<9> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port_4(@name("egress_port") bit<9> egress_port_3) {
+        meta._ing_metadata_egress_port1 = egress_port_3;
     }
     @name(".discard") action discard() {
         mark_to_drop(standard_metadata);
@@ -323,7 +323,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 l2_match_0.apply();
             }
         }
-
         if (hdr.tcp.isValid()) {
             tcp_check_0.apply();
         } else if (hdr.udp.isValid()) {

--- a/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
+++ b/testdata/p4_14_samples_outputs/07-MultiProtocol.p4
@@ -268,7 +268,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 l2_match.apply();
             }
         }
-
         if (hdr.tcp.isValid()) {
             tcp_check.apply();
         } else {

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-frontend.p4
@@ -735,20 +735,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.h_8_2.setInvalid();
         hdr.h_32_15.setInvalid();
     }
-    @name(".set_egress_spec") action set_egress_spec(bit<9> port) {
+    @name(".set_egress_spec") action set_egress_spec(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".set_egress_spec") action set_egress_spec_5(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_5(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
-    @name(".set_egress_spec") action set_egress_spec_6(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_6(@name("port") bit<9> port_2) {
+        standard_metadata.egress_spec = port_2;
     }
-    @name(".set_egress_spec") action set_egress_spec_7(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_7(@name("port") bit<9> port_3) {
+        standard_metadata.egress_spec = port_3;
     }
-    @name(".set_egress_spec") action set_egress_spec_8(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_8(@name("port") bit<9> port_4) {
+        standard_metadata.egress_spec = port_4;
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/08-FullTPHV3-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-FullTPHV3-midend.p4
@@ -957,20 +957,20 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         hdr.h_8_2.setInvalid();
         hdr.h_32_15.setInvalid();
     }
-    @name(".set_egress_spec") action set_egress_spec(bit<9> port) {
+    @name(".set_egress_spec") action set_egress_spec(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".set_egress_spec") action set_egress_spec_5(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_5(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
-    @name(".set_egress_spec") action set_egress_spec_6(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_6(@name("port") bit<9> port_2) {
+        standard_metadata.egress_spec = port_2;
     }
-    @name(".set_egress_spec") action set_egress_spec_7(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_7(@name("port") bit<9> port_3) {
+        standard_metadata.egress_spec = port_3;
     }
-    @name(".set_egress_spec") action set_egress_spec_8(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_egress_spec") action set_egress_spec_8(@name("port") bit<9> port_4) {
+        standard_metadata.egress_spec = port_4;
     }
     @name(".t1") table t1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-frontend.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-frontend.p4
@@ -163,14 +163,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_4() {
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta.ing_metadata.egress_port = egress_port_1;
     }
-    @name(".set_egress_port") action set_egress_port_3(bit<8> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port_3(@name("egress_port") bit<8> egress_port_2) {
+        meta.ing_metadata.egress_port = egress_port_2;
     }
-    @name(".set_egress_port") action set_egress_port_4(bit<8> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port_4(@name("egress_port") bit<8> egress_port_3) {
+        meta.ing_metadata.egress_port = egress_port_3;
     }
     @name(".ipv4_match") table ipv4_match_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-midend.p4
+++ b/testdata/p4_14_samples_outputs/08-MultiProtocolIfElse-midend.p4
@@ -164,14 +164,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_4() {
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta._ing_metadata_egress_port1 = egress_port_1;
     }
-    @name(".set_egress_port") action set_egress_port_3(bit<8> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port_3(@name("egress_port") bit<8> egress_port_2) {
+        meta._ing_metadata_egress_port1 = egress_port_2;
     }
-    @name(".set_egress_port") action set_egress_port_4(bit<8> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port_4(@name("egress_port") bit<8> egress_port_3) {
+        meta._ing_metadata_egress_port1 = egress_port_3;
     }
     @name(".ipv4_match") table ipv4_match_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-frontend.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-frontend.p4
@@ -87,11 +87,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_2() {
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta.ing_metadata.egress_port = egress_port_1;
     }
-    @name(".set_egress_port") action set_egress_port_2(bit<8> egress_port) {
-        meta.ing_metadata.egress_port = egress_port;
+    @name(".set_egress_port") action set_egress_port_2(@name("egress_port") bit<8> egress_port_2) {
+        meta.ing_metadata.egress_port = egress_port_2;
     }
     @name(".ipv4_match") table ipv4_match_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-midend.p4
+++ b/testdata/p4_14_samples_outputs/15-MultiProtocolIfElseMinimal-midend.p4
@@ -88,11 +88,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop_2() {
     }
-    @name(".set_egress_port") action set_egress_port(bit<8> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<8> egress_port_1) {
+        meta._ing_metadata_egress_port1 = egress_port_1;
     }
-    @name(".set_egress_port") action set_egress_port_2(bit<8> egress_port) {
-        meta._ing_metadata_egress_port1 = egress_port;
+    @name(".set_egress_port") action set_egress_port_2(@name("egress_port") bit<8> egress_port_2) {
+        meta._ing_metadata_egress_port1 = egress_port_2;
     }
     @name(".ipv4_match") table ipv4_match_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-first.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-first.p4
@@ -100,7 +100,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             default: {
             }
         }
-
         F.apply();
     }
 }

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-frontend.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-frontend.p4
@@ -120,7 +120,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             default: {
             }
         }
-
         F_0.apply();
     }
 }

--- a/testdata/p4_14_samples_outputs/16-TwoReferences-midend.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences-midend.p4
@@ -120,7 +120,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             default: {
             }
         }
-
         F_0.apply();
     }
 }

--- a/testdata/p4_14_samples_outputs/16-TwoReferences.p4
+++ b/testdata/p4_14_samples_outputs/16-TwoReferences.p4
@@ -90,7 +90,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 E.apply();
             }
         }
-
         F.apply();
     }
 }

--- a/testdata/p4_14_samples_outputs/acl1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-frontend.p4
@@ -180,18 +180,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop() {
     }
-    @name(".copy_to_cpu") action copy_to_cpu(bit<16> reason_code) {
-        meta.fabric_metadata.reason_code = reason_code;
+    @name(".copy_to_cpu") action copy_to_cpu(@name("reason_code") bit<16> reason_code_2) {
+        meta.fabric_metadata.reason_code = reason_code_2;
     }
-    @name(".redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
-        meta.fabric_metadata.reason_code = reason_code;
+    @name(".redirect_to_cpu") action redirect_to_cpu(@name("reason_code") bit<16> reason_code_3) {
+        meta.fabric_metadata.reason_code = reason_code_3;
     }
     @name(".drop_packet") action drop_packet() {
     }
-    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<8> drop_reason) {
-        drop_stats.count(drop_reason);
+    @name(".drop_packet_with_reason") action drop_packet_with_reason(@name("drop_reason") bit<8> drop_reason_1) {
+        drop_stats.count(drop_reason_1);
     }
-    @name(".negative_mirror") action negative_mirror(bit<8> session_id) {
+    @name(".negative_mirror") action negative_mirror(@name("session_id") bit<8> session_id) {
     }
     @name(".congestion_mirror_set") action congestion_mirror_set() {
     }

--- a/testdata/p4_14_samples_outputs/acl1-midend.p4
+++ b/testdata/p4_14_samples_outputs/acl1-midend.p4
@@ -254,18 +254,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action nop() {
     }
-    @name(".copy_to_cpu") action copy_to_cpu(bit<16> reason_code) {
-        meta._fabric_metadata_reason_code13 = reason_code;
+    @name(".copy_to_cpu") action copy_to_cpu(@name("reason_code") bit<16> reason_code_2) {
+        meta._fabric_metadata_reason_code13 = reason_code_2;
     }
-    @name(".redirect_to_cpu") action redirect_to_cpu(bit<16> reason_code) {
-        meta._fabric_metadata_reason_code13 = reason_code;
+    @name(".redirect_to_cpu") action redirect_to_cpu(@name("reason_code") bit<16> reason_code_3) {
+        meta._fabric_metadata_reason_code13 = reason_code_3;
     }
     @name(".drop_packet") action drop_packet() {
     }
-    @name(".drop_packet_with_reason") action drop_packet_with_reason(bit<8> drop_reason) {
-        drop_stats.count(drop_reason);
+    @name(".drop_packet_with_reason") action drop_packet_with_reason(@name("drop_reason") bit<8> drop_reason_1) {
+        drop_stats.count(drop_reason_1);
     }
-    @name(".negative_mirror") action negative_mirror(bit<8> session_id) {
+    @name(".negative_mirror") action negative_mirror(@name("session_id") bit<8> session_id) {
     }
     @name(".congestion_mirror_set") action congestion_mirror_set() {
     }

--- a/testdata/p4_14_samples_outputs/action_bus1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-frontend.p4
@@ -77,7 +77,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_15() {
     }
-    @name(".set1") action set1(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
+    @name(".set1") action set1(@name("v1") bit<32> v1, @name("v2") bit<32> v2, @name("v3") bit<32> v3, @name("v4") bit<32> v4, @name("v5") bit<32> v5) {
         hdr.data.f1_1 = v1;
         hdr.data.f1_2 = v2;
         hdr.data.f1_3 = v3;
@@ -100,54 +100,54 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_14() {
     }
-    @name(".set2") action set2(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f2_1 = v1;
-        hdr.data.f2_2 = v2;
-        hdr.data.f2_3 = v3;
-        hdr.data.f2_4 = v4;
-        hdr.data.f2_5 = v5;
+    @name(".set2") action set2(@name("v1") bit<32> v1_8, @name("v2") bit<32> v2_8, @name("v3") bit<32> v3_8, @name("v4") bit<32> v4_8, @name("v5") bit<32> v5_8) {
+        hdr.data.f2_1 = v1_8;
+        hdr.data.f2_2 = v2_8;
+        hdr.data.f2_3 = v3_8;
+        hdr.data.f2_4 = v4_8;
+        hdr.data.f2_5 = v5_8;
     }
-    @name(".set3") action set3(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f3_1 = v1;
-        hdr.data.f3_2 = v2;
-        hdr.data.f3_3 = v3;
-        hdr.data.f3_4 = v4;
-        hdr.data.f3_5 = v5;
+    @name(".set3") action set3(@name("v1") bit<32> v1_9, @name("v2") bit<32> v2_9, @name("v3") bit<32> v3_9, @name("v4") bit<32> v4_9, @name("v5") bit<32> v5_9) {
+        hdr.data.f3_1 = v1_9;
+        hdr.data.f3_2 = v2_9;
+        hdr.data.f3_3 = v3_9;
+        hdr.data.f3_4 = v4_9;
+        hdr.data.f3_5 = v5_9;
     }
-    @name(".set4") action set4(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f4_1 = v1;
-        hdr.data.f4_2 = v2;
-        hdr.data.f4_3 = v3;
-        hdr.data.f4_4 = v4;
-        hdr.data.f4_5 = v5;
+    @name(".set4") action set4(@name("v1") bit<32> v1_10, @name("v2") bit<32> v2_10, @name("v3") bit<32> v3_10, @name("v4") bit<32> v4_10, @name("v5") bit<32> v5_10) {
+        hdr.data.f4_1 = v1_10;
+        hdr.data.f4_2 = v2_10;
+        hdr.data.f4_3 = v3_10;
+        hdr.data.f4_4 = v4_10;
+        hdr.data.f4_5 = v5_10;
     }
-    @name(".set5") action set5(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f5_1 = v1;
-        hdr.data.f5_2 = v2;
-        hdr.data.f5_3 = v3;
-        hdr.data.f5_4 = v4;
-        hdr.data.f5_5 = v5;
+    @name(".set5") action set5(@name("v1") bit<32> v1_11, @name("v2") bit<32> v2_11, @name("v3") bit<32> v3_11, @name("v4") bit<32> v4_11, @name("v5") bit<32> v5_11) {
+        hdr.data.f5_1 = v1_11;
+        hdr.data.f5_2 = v2_11;
+        hdr.data.f5_3 = v3_11;
+        hdr.data.f5_4 = v4_11;
+        hdr.data.f5_5 = v5_11;
     }
-    @name(".set6") action set6(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f6_1 = v1;
-        hdr.data.f6_2 = v2;
-        hdr.data.f6_3 = v3;
-        hdr.data.f6_4 = v4;
-        hdr.data.f6_5 = v5;
+    @name(".set6") action set6(@name("v1") bit<32> v1_12, @name("v2") bit<32> v2_12, @name("v3") bit<32> v3_12, @name("v4") bit<32> v4_12, @name("v5") bit<32> v5_12) {
+        hdr.data.f6_1 = v1_12;
+        hdr.data.f6_2 = v2_12;
+        hdr.data.f6_3 = v3_12;
+        hdr.data.f6_4 = v4_12;
+        hdr.data.f6_5 = v5_12;
     }
-    @name(".set7") action set7(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f7_1 = v1;
-        hdr.data.f7_2 = v2;
-        hdr.data.f7_3 = v3;
-        hdr.data.f7_4 = v4;
-        hdr.data.f7_5 = v5;
+    @name(".set7") action set7(@name("v1") bit<32> v1_13, @name("v2") bit<32> v2_13, @name("v3") bit<32> v3_13, @name("v4") bit<32> v4_13, @name("v5") bit<32> v5_13) {
+        hdr.data.f7_1 = v1_13;
+        hdr.data.f7_2 = v2_13;
+        hdr.data.f7_3 = v3_13;
+        hdr.data.f7_4 = v4_13;
+        hdr.data.f7_5 = v5_13;
     }
-    @name(".set8") action set8(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f8_1 = v1;
-        hdr.data.f8_2 = v2;
-        hdr.data.f8_3 = v3;
-        hdr.data.f8_4 = v4;
-        hdr.data.f8_5 = v5;
+    @name(".set8") action set8(@name("v1") bit<32> v1_14, @name("v2") bit<32> v2_14, @name("v3") bit<32> v3_14, @name("v4") bit<32> v4_14, @name("v5") bit<32> v5_14) {
+        hdr.data.f8_1 = v1_14;
+        hdr.data.f8_2 = v2_14;
+        hdr.data.f8_3 = v3_14;
+        hdr.data.f8_4 = v4_14;
+        hdr.data.f8_5 = v5_14;
     }
     @name(".tbl1") table tbl1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/action_bus1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_bus1-midend.p4
@@ -77,7 +77,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_15() {
     }
-    @name(".set1") action set1(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
+    @name(".set1") action set1(@name("v1") bit<32> v1, @name("v2") bit<32> v2, @name("v3") bit<32> v3, @name("v4") bit<32> v4, @name("v5") bit<32> v5) {
         hdr.data.f1_1 = v1;
         hdr.data.f1_2 = v2;
         hdr.data.f1_3 = v3;
@@ -100,54 +100,54 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_14() {
     }
-    @name(".set2") action set2(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f2_1 = v1;
-        hdr.data.f2_2 = v2;
-        hdr.data.f2_3 = v3;
-        hdr.data.f2_4 = v4;
-        hdr.data.f2_5 = v5;
+    @name(".set2") action set2(@name("v1") bit<32> v1_8, @name("v2") bit<32> v2_8, @name("v3") bit<32> v3_8, @name("v4") bit<32> v4_8, @name("v5") bit<32> v5_8) {
+        hdr.data.f2_1 = v1_8;
+        hdr.data.f2_2 = v2_8;
+        hdr.data.f2_3 = v3_8;
+        hdr.data.f2_4 = v4_8;
+        hdr.data.f2_5 = v5_8;
     }
-    @name(".set3") action set3(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f3_1 = v1;
-        hdr.data.f3_2 = v2;
-        hdr.data.f3_3 = v3;
-        hdr.data.f3_4 = v4;
-        hdr.data.f3_5 = v5;
+    @name(".set3") action set3(@name("v1") bit<32> v1_9, @name("v2") bit<32> v2_9, @name("v3") bit<32> v3_9, @name("v4") bit<32> v4_9, @name("v5") bit<32> v5_9) {
+        hdr.data.f3_1 = v1_9;
+        hdr.data.f3_2 = v2_9;
+        hdr.data.f3_3 = v3_9;
+        hdr.data.f3_4 = v4_9;
+        hdr.data.f3_5 = v5_9;
     }
-    @name(".set4") action set4(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f4_1 = v1;
-        hdr.data.f4_2 = v2;
-        hdr.data.f4_3 = v3;
-        hdr.data.f4_4 = v4;
-        hdr.data.f4_5 = v5;
+    @name(".set4") action set4(@name("v1") bit<32> v1_10, @name("v2") bit<32> v2_10, @name("v3") bit<32> v3_10, @name("v4") bit<32> v4_10, @name("v5") bit<32> v5_10) {
+        hdr.data.f4_1 = v1_10;
+        hdr.data.f4_2 = v2_10;
+        hdr.data.f4_3 = v3_10;
+        hdr.data.f4_4 = v4_10;
+        hdr.data.f4_5 = v5_10;
     }
-    @name(".set5") action set5(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f5_1 = v1;
-        hdr.data.f5_2 = v2;
-        hdr.data.f5_3 = v3;
-        hdr.data.f5_4 = v4;
-        hdr.data.f5_5 = v5;
+    @name(".set5") action set5(@name("v1") bit<32> v1_11, @name("v2") bit<32> v2_11, @name("v3") bit<32> v3_11, @name("v4") bit<32> v4_11, @name("v5") bit<32> v5_11) {
+        hdr.data.f5_1 = v1_11;
+        hdr.data.f5_2 = v2_11;
+        hdr.data.f5_3 = v3_11;
+        hdr.data.f5_4 = v4_11;
+        hdr.data.f5_5 = v5_11;
     }
-    @name(".set6") action set6(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f6_1 = v1;
-        hdr.data.f6_2 = v2;
-        hdr.data.f6_3 = v3;
-        hdr.data.f6_4 = v4;
-        hdr.data.f6_5 = v5;
+    @name(".set6") action set6(@name("v1") bit<32> v1_12, @name("v2") bit<32> v2_12, @name("v3") bit<32> v3_12, @name("v4") bit<32> v4_12, @name("v5") bit<32> v5_12) {
+        hdr.data.f6_1 = v1_12;
+        hdr.data.f6_2 = v2_12;
+        hdr.data.f6_3 = v3_12;
+        hdr.data.f6_4 = v4_12;
+        hdr.data.f6_5 = v5_12;
     }
-    @name(".set7") action set7(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f7_1 = v1;
-        hdr.data.f7_2 = v2;
-        hdr.data.f7_3 = v3;
-        hdr.data.f7_4 = v4;
-        hdr.data.f7_5 = v5;
+    @name(".set7") action set7(@name("v1") bit<32> v1_13, @name("v2") bit<32> v2_13, @name("v3") bit<32> v3_13, @name("v4") bit<32> v4_13, @name("v5") bit<32> v5_13) {
+        hdr.data.f7_1 = v1_13;
+        hdr.data.f7_2 = v2_13;
+        hdr.data.f7_3 = v3_13;
+        hdr.data.f7_4 = v4_13;
+        hdr.data.f7_5 = v5_13;
     }
-    @name(".set8") action set8(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<32> v5) {
-        hdr.data.f8_1 = v1;
-        hdr.data.f8_2 = v2;
-        hdr.data.f8_3 = v3;
-        hdr.data.f8_4 = v4;
-        hdr.data.f8_5 = v5;
+    @name(".set8") action set8(@name("v1") bit<32> v1_14, @name("v2") bit<32> v2_14, @name("v3") bit<32> v3_14, @name("v4") bit<32> v4_14, @name("v5") bit<32> v5_14) {
+        hdr.data.f8_1 = v1_14;
+        hdr.data.f8_2 = v2_14;
+        hdr.data.f8_3 = v3_14;
+        hdr.data.f8_4 = v4_14;
+        hdr.data.f8_5 = v5_14;
     }
     @name(".tbl1") table tbl1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/action_chain1-first.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-first.p4
@@ -141,7 +141,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             default: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_14_samples_outputs/action_chain1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-frontend.p4
@@ -51,17 +51,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_9() {
     }
-    @name(".set0b1") action set0b1(bit<8> val) {
+    @name(".set0b1") action set0b1(@name("val") bit<8> val) {
         hdr.extra[0].b1 = val;
     }
-    @name(".act1") action act1(bit<8> val) {
-        hdr.extra[0].b1 = val;
+    @name(".act1") action act1(@name("val") bit<8> val_8) {
+        hdr.extra[0].b1 = val_8;
     }
-    @name(".act2") action act2(bit<8> val) {
-        hdr.extra[0].b1 = val;
+    @name(".act2") action act2(@name("val") bit<8> val_9) {
+        hdr.extra[0].b1 = val_9;
     }
-    @name(".act3") action act3(bit<8> val) {
-        hdr.extra[0].b1 = val;
+    @name(".act3") action act3(@name("val") bit<8> val_10) {
+        hdr.extra[0].b1 = val_10;
     }
     @name(".noop") action noop() {
     }
@@ -73,17 +73,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_8() {
     }
-    @name(".setb2") action setb2(bit<8> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<8> val_11) {
+        hdr.data.b2 = val_11;
     }
-    @name(".set1b1") action set1b1(bit<8> val) {
-        hdr.extra[1].b1 = val;
+    @name(".set1b1") action set1b1(@name("val") bit<8> val_12) {
+        hdr.extra[1].b1 = val_12;
     }
-    @name(".set2b2") action set2b2(bit<8> val) {
-        hdr.extra[2].b2 = val;
+    @name(".set2b2") action set2b2(@name("val") bit<8> val_13) {
+        hdr.extra[2].b2 = val_13;
     }
-    @name(".setb1") action setb1(bit<9> port, bit<8> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1(@name("port") bit<9> port, @name("val") bit<8> val_14) {
+        hdr.data.b1 = val_14;
         standard_metadata.egress_spec = port;
     }
     @name(".ex1") table ex1_0 {
@@ -159,7 +159,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             default: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_14_samples_outputs/action_chain1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1-midend.p4
@@ -51,17 +51,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_9() {
     }
-    @name(".set0b1") action set0b1(bit<8> val) {
+    @name(".set0b1") action set0b1(@name("val") bit<8> val) {
         hdr.extra[0].b1 = val;
     }
-    @name(".act1") action act1(bit<8> val) {
-        hdr.extra[0].b1 = val;
+    @name(".act1") action act1(@name("val") bit<8> val_8) {
+        hdr.extra[0].b1 = val_8;
     }
-    @name(".act2") action act2(bit<8> val) {
-        hdr.extra[0].b1 = val;
+    @name(".act2") action act2(@name("val") bit<8> val_9) {
+        hdr.extra[0].b1 = val_9;
     }
-    @name(".act3") action act3(bit<8> val) {
-        hdr.extra[0].b1 = val;
+    @name(".act3") action act3(@name("val") bit<8> val_10) {
+        hdr.extra[0].b1 = val_10;
     }
     @name(".noop") action noop() {
     }
@@ -73,17 +73,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_8() {
     }
-    @name(".setb2") action setb2(bit<8> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<8> val_11) {
+        hdr.data.b2 = val_11;
     }
-    @name(".set1b1") action set1b1(bit<8> val) {
-        hdr.extra[1].b1 = val;
+    @name(".set1b1") action set1b1(@name("val") bit<8> val_12) {
+        hdr.extra[1].b1 = val_12;
     }
-    @name(".set2b2") action set2b2(bit<8> val) {
-        hdr.extra[2].b2 = val;
+    @name(".set2b2") action set2b2(@name("val") bit<8> val_13) {
+        hdr.extra[2].b2 = val_13;
     }
-    @name(".setb1") action setb1(bit<9> port, bit<8> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1(@name("port") bit<9> port, @name("val") bit<8> val_14) {
+        hdr.data.b1 = val_14;
         standard_metadata.egress_spec = port;
     }
     @name(".ex1") table ex1_0 {
@@ -159,7 +159,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             default: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_14_samples_outputs/action_chain1.p4
+++ b/testdata/p4_14_samples_outputs/action_chain1.p4
@@ -129,7 +129,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 tbl3.apply();
             }
         }
-
     }
 }
 

--- a/testdata/p4_14_samples_outputs/action_inline-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline-frontend.p4
@@ -30,7 +30,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
             meta.md.b = y0;
         }
         {
-            @name("ingress.y0_1") bit<1> y0_1 = meta.md.b;
+            @name("ingress.y0") bit<1> y0_1 = meta.md.b;
             y0_1 = y0_1 + 1w1;
             meta.md.b = y0_1;
         }

--- a/testdata/p4_14_samples_outputs/action_inline1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-frontend.p4
@@ -30,7 +30,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         {
             @name("ingress.dest") bit<8> dest = hdr.data.b1;
             dest = val;

--- a/testdata/p4_14_samples_outputs/action_inline1-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline1-midend.p4
@@ -30,7 +30,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-frontend.p4
@@ -30,11 +30,11 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<9> port) {
+    @name(".setb1") action setb1(@name("port") bit<9> port) {
         {
-            @name("ingress.dest_4") bit<8> dest = hdr.data.b1;
+            @name("ingress.dest") bit<8> dest = hdr.data.b1;
             {
-                @name("ingress.dest_3") bit<8> dest_3 = dest;
+                @name("ingress.dest") bit<8> dest_3 = dest;
                 {
                     @name("ingress.dest") bit<8> dest_4 = dest_3;
                     dest_4 = hdr.data.b2;

--- a/testdata/p4_14_samples_outputs/action_inline2-midend.p4
+++ b/testdata/p4_14_samples_outputs/action_inline2-midend.p4
@@ -30,7 +30,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<9> port) {
+    @name(".setb1") action setb1(@name("port") bit<9> port) {
         hdr.data.b1 = hdr.data.b2;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/basic_conditionals-frontend.p4
+++ b/testdata/p4_14_samples_outputs/basic_conditionals-frontend.p4
@@ -29,7 +29,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_port") action set_port(bit<9> port) {
+    @name(".set_port") action set_port(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     @name(".test1") table test1_0 {

--- a/testdata/p4_14_samples_outputs/basic_conditionals-midend.p4
+++ b/testdata/p4_14_samples_outputs/basic_conditionals-midend.p4
@@ -29,7 +29,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_port") action set_port(bit<9> port) {
+    @name(".set_port") action set_port(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     @name(".test1") table test1_0 {

--- a/testdata/p4_14_samples_outputs/basic_routing-first.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-first.p4
@@ -169,7 +169,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
             nexthop.apply();
         }
     }

--- a/testdata/p4_14_samples_outputs/basic_routing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-frontend.p4
@@ -63,7 +63,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".on_miss") action on_miss() {
     }
-    @name(".rewrite_src_dst_mac") action rewrite_src_dst_mac(bit<48> smac, bit<48> dmac) {
+    @name(".rewrite_src_dst_mac") action rewrite_src_dst_mac(@name("smac") bit<48> smac, @name("dmac") bit<48> dmac) {
         hdr.ethernet.srcAddr = smac;
         hdr.ethernet.dstAddr = dmac;
     }
@@ -95,8 +95,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name(".set_vrf") action set_vrf(bit<12> vrf) {
-        meta.ingress_metadata.vrf = vrf;
+    @name(".set_vrf") action set_vrf(@name("vrf") bit<12> vrf_1) {
+        meta.ingress_metadata.vrf = vrf_1;
     }
     @name(".on_miss") action on_miss_2() {
     }
@@ -104,19 +104,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action on_miss_6() {
     }
-    @name(".fib_hit_nexthop") action fib_hit_nexthop(bit<16> nexthop_index) {
-        meta.ingress_metadata.nexthop_index = nexthop_index;
+    @name(".fib_hit_nexthop") action fib_hit_nexthop(@name("nexthop_index") bit<16> nexthop_index_1) {
+        meta.ingress_metadata.nexthop_index = nexthop_index_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".fib_hit_nexthop") action fib_hit_nexthop_2(bit<16> nexthop_index) {
-        meta.ingress_metadata.nexthop_index = nexthop_index;
+    @name(".fib_hit_nexthop") action fib_hit_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_2) {
+        meta.ingress_metadata.nexthop_index = nexthop_index_2;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".set_egress_details") action set_egress_details(bit<9> egress_spec) {
-        standard_metadata.egress_spec = egress_spec;
+    @name(".set_egress_details") action set_egress_details(@name("egress_spec") bit<9> egress_spec_1) {
+        standard_metadata.egress_spec = egress_spec_1;
     }
-    @name(".set_bd") action set_bd(bit<16> bd) {
-        meta.ingress_metadata.bd = bd;
+    @name(".set_bd") action set_bd(@name("bd") bit<16> bd_2) {
+        meta.ingress_metadata.bd = bd_2;
     }
     @name(".bd") table bd_0 {
         actions = {
@@ -189,7 +189,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
             nexthop_0.apply();
         }
     }

--- a/testdata/p4_14_samples_outputs/basic_routing-midend.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing-midend.p4
@@ -64,7 +64,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".on_miss") action on_miss() {
     }
-    @name(".rewrite_src_dst_mac") action rewrite_src_dst_mac(bit<48> smac, bit<48> dmac) {
+    @name(".rewrite_src_dst_mac") action rewrite_src_dst_mac(@name("smac") bit<48> smac, @name("dmac") bit<48> dmac) {
         hdr.ethernet.srcAddr = smac;
         hdr.ethernet.dstAddr = dmac;
     }
@@ -96,8 +96,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name(".set_vrf") action set_vrf(bit<12> vrf) {
-        meta._ingress_metadata_vrf0 = vrf;
+    @name(".set_vrf") action set_vrf(@name("vrf") bit<12> vrf_1) {
+        meta._ingress_metadata_vrf0 = vrf_1;
     }
     @name(".on_miss") action on_miss_2() {
     }
@@ -105,19 +105,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action on_miss_6() {
     }
-    @name(".fib_hit_nexthop") action fib_hit_nexthop(bit<16> nexthop_index) {
-        meta._ingress_metadata_nexthop_index2 = nexthop_index;
+    @name(".fib_hit_nexthop") action fib_hit_nexthop(@name("nexthop_index") bit<16> nexthop_index_1) {
+        meta._ingress_metadata_nexthop_index2 = nexthop_index_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".fib_hit_nexthop") action fib_hit_nexthop_2(bit<16> nexthop_index) {
-        meta._ingress_metadata_nexthop_index2 = nexthop_index;
+    @name(".fib_hit_nexthop") action fib_hit_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_2) {
+        meta._ingress_metadata_nexthop_index2 = nexthop_index_2;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".set_egress_details") action set_egress_details(bit<9> egress_spec) {
-        standard_metadata.egress_spec = egress_spec;
+    @name(".set_egress_details") action set_egress_details(@name("egress_spec") bit<9> egress_spec_1) {
+        standard_metadata.egress_spec = egress_spec_1;
     }
-    @name(".set_bd") action set_bd(bit<16> bd) {
-        meta._ingress_metadata_bd1 = bd;
+    @name(".set_bd") action set_bd(@name("bd") bit<16> bd_2) {
+        meta._ingress_metadata_bd1 = bd_2;
     }
     @name(".bd") table bd_0 {
         actions = {
@@ -190,7 +190,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
             nexthop_0.apply();
         }
     }

--- a/testdata/p4_14_samples_outputs/basic_routing.p4
+++ b/testdata/p4_14_samples_outputs/basic_routing.p4
@@ -155,7 +155,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                     ipv4_fib_lpm.apply();
                 }
             }
-
             nexthop.apply();
         }
     }

--- a/testdata/p4_14_samples_outputs/bigfield1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1-frontend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setx1") action setx1(bit<48> val, bit<9> port) {
+    @name(".setx1") action setx1(@name("val") bit<48> val, @name("port") bit<9> port) {
         hdr.data.x1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/bigfield1-midend.p4
+++ b/testdata/p4_14_samples_outputs/bigfield1-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setx1") action setx1(bit<48> val, bit<9> port) {
+    @name(".setx1") action setx1(@name("val") bit<48> val, @name("port") bit<9> port) {
         hdr.data.x1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/bridge1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-frontend.p4
@@ -51,8 +51,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
-        meta.meta.val = val;
+    @name(".setb1") action setb1(@name("val") bit<8> val_1, @name("port") bit<9> port) {
+        meta.meta.val = val_1;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {

--- a/testdata/p4_14_samples_outputs/bridge1-midend.p4
+++ b/testdata/p4_14_samples_outputs/bridge1-midend.p4
@@ -50,8 +50,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
-        meta._meta_val0 = val;
+    @name(".setb1") action setb1(@name("val") bit<8> val_1, @name("port") bit<9> port) {
+        meta._meta_val0 = val_1;
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {

--- a/testdata/p4_14_samples_outputs/checksum1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-frontend.p4
@@ -75,7 +75,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".drop") action drop() {
     }
-    @name(".forward") action forward(bit<48> to) {
+    @name(".forward") action forward(@name("to") bit<48> to) {
         hdr.ethernet.dstAddr = to;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }

--- a/testdata/p4_14_samples_outputs/checksum1-midend.p4
+++ b/testdata/p4_14_samples_outputs/checksum1-midend.p4
@@ -75,7 +75,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".drop") action drop() {
     }
-    @name(".forward") action forward(bit<48> to) {
+    @name(".forward") action forward(@name("to") bit<48> to) {
         hdr.ethernet.dstAddr = to;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }

--- a/testdata/p4_14_samples_outputs/const_default_action-frontend.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action-frontend.p4
@@ -61,13 +61,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".no_op") action _no_op_2() {
     }
-    @name(".set_bd_properties") action _set_bd_properties_0(bit<14> bd, bit<14> ingress_rid) {
-        meta.ingress_metadata.bd = bd;
+    @name(".set_bd_properties") action _set_bd_properties_0(@name("bd") bit<14> bd_1, @name("ingress_rid") bit<14> ingress_rid) {
+        meta.ingress_metadata.bd = bd_1;
         meta.ingress_metadata.rid = ingress_rid;
     }
-    @name(".set_bd_properties") action _set_bd_properties_2(bit<14> bd, bit<14> ingress_rid) {
-        meta.ingress_metadata.bd = bd;
-        meta.ingress_metadata.rid = ingress_rid;
+    @name(".set_bd_properties") action _set_bd_properties_2(@name("bd") bit<14> bd_2, @name("ingress_rid") bit<14> ingress_rid_1) {
+        meta.ingress_metadata.bd = bd_2;
+        meta.ingress_metadata.rid = ingress_rid_1;
     }
     @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss_0() {
         meta.ingress_metadata.drop_flag = 1w1;

--- a/testdata/p4_14_samples_outputs/const_default_action-midend.p4
+++ b/testdata/p4_14_samples_outputs/const_default_action-midend.p4
@@ -68,13 +68,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".no_op") action _no_op_2() {
     }
-    @name(".set_bd_properties") action _set_bd_properties_0(bit<14> bd, bit<14> ingress_rid) {
-        meta._ingress_metadata_bd1 = bd;
+    @name(".set_bd_properties") action _set_bd_properties_0(@name("bd") bit<14> bd_1, @name("ingress_rid") bit<14> ingress_rid) {
+        meta._ingress_metadata_bd1 = bd_1;
         meta._ingress_metadata_rid2 = ingress_rid;
     }
-    @name(".set_bd_properties") action _set_bd_properties_2(bit<14> bd, bit<14> ingress_rid) {
-        meta._ingress_metadata_bd1 = bd;
-        meta._ingress_metadata_rid2 = ingress_rid;
+    @name(".set_bd_properties") action _set_bd_properties_2(@name("bd") bit<14> bd_2, @name("ingress_rid") bit<14> ingress_rid_1) {
+        meta._ingress_metadata_bd1 = bd_2;
+        meta._ingress_metadata_rid2 = ingress_rid_1;
     }
     @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss_0() {
         meta._ingress_metadata_drop_flag3 = 1w1;

--- a/testdata/p4_14_samples_outputs/counter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter-frontend.p4
@@ -48,7 +48,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".my_direct_counter") direct_counter(CounterType.bytes) my_direct_counter_0;
-    @name(".m_action") action m_action_0(bit<14> idx) {
+    @name(".m_action") action m_action_0(@name("idx") bit<14> idx) {
         my_direct_counter_0.count();
         my_indirect_counter.count(idx);
         mark_to_drop(standard_metadata);

--- a/testdata/p4_14_samples_outputs/counter-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter-midend.p4
@@ -47,7 +47,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".my_direct_counter") direct_counter(CounterType.bytes) my_direct_counter_0;
-    @name(".m_action") action m_action_0(bit<14> idx) {
+    @name(".m_action") action m_action_0(@name("idx") bit<14> idx) {
         my_direct_counter_0.count();
         my_indirect_counter.count(idx);
         mark_to_drop(standard_metadata);

--- a/testdata/p4_14_samples_outputs/counter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter1-frontend.p4
@@ -33,7 +33,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".cnt") direct_counter(CounterType.packets) cnt_0;
-    @name(".act") action act_0(bit<9> port) {
+    @name(".act") action act_0(@name("port") bit<9> port) {
         cnt_0.count();
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/counter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter1-midend.p4
@@ -33,7 +33,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".cnt") direct_counter(CounterType.packets) cnt_0;
-    @name(".act") action act_0(bit<9> port) {
+    @name(".act") action act_0(@name("port") bit<9> port) {
         cnt_0.count();
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/counter2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter2-frontend.p4
@@ -33,7 +33,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".cnt") direct_counter(CounterType.packets) cnt_0;
-    @name(".act") action act_0(bit<9> port) {
+    @name(".act") action act_0(@name("port") bit<9> port) {
         cnt_0.count();
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/counter2-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter2-midend.p4
@@ -33,7 +33,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".cnt") direct_counter(CounterType.packets) cnt_0;
-    @name(".act") action act_0(bit<9> port) {
+    @name(".act") action act_0(@name("port") bit<9> port) {
         cnt_0.count();
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/counter3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter3-frontend.p4
@@ -33,7 +33,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".cnt") direct_counter(CounterType.bytes) cnt_0;
-    @name(".act") action act_0(bit<9> port) {
+    @name(".act") action act_0(@name("port") bit<9> port) {
         cnt_0.count();
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/counter3-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter3-midend.p4
@@ -33,7 +33,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".cnt") direct_counter(CounterType.bytes) cnt_0;
-    @name(".act") action act_0(bit<9> port) {
+    @name(".act") action act_0(@name("port") bit<9> port) {
         cnt_0.count();
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/counter4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-frontend.p4
@@ -34,7 +34,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".act") action act(bit<9> port, bit<8> idx) {
+    @name(".act") action act(@name("port") bit<9> port, @name("idx") bit<8> idx) {
         standard_metadata.egress_spec = port;
         cntDum.count(idx);
     }

--- a/testdata/p4_14_samples_outputs/counter4-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter4-midend.p4
@@ -34,7 +34,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".act") action act(bit<9> port, bit<8> idx) {
+    @name(".act") action act(@name("port") bit<9> port, @name("idx") bit<8> idx) {
         standard_metadata.egress_spec = port;
         cntDum.count(idx);
     }

--- a/testdata/p4_14_samples_outputs/counter5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-frontend.p4
@@ -34,7 +34,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".act") action act(bit<9> port, bit<17> idx) {
+    @name(".act") action act(@name("port") bit<9> port, @name("idx") bit<17> idx) {
         standard_metadata.egress_spec = port;
         cntDum.count(idx);
     }

--- a/testdata/p4_14_samples_outputs/counter5-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter5-midend.p4
@@ -34,7 +34,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".act") action act(bit<9> port, bit<17> idx) {
+    @name(".act") action act(@name("port") bit<9> port, @name("idx") bit<17> idx) {
         standard_metadata.egress_spec = port;
         cntDum.count(idx);
     }

--- a/testdata/p4_14_samples_outputs/counter6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/counter6-frontend.p4
@@ -64,7 +64,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".act") action _act_1(bit<9> port, bit<12> idx) {
+    @name(".act") action _act_1(@name("port") bit<9> port, @name("idx") bit<12> idx) {
         standard_metadata.egress_spec = port;
         cntDum.count(idx);
     }
@@ -78,9 +78,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = NoAction_0();
     }
-    @name(".act") action _act_2(bit<9> port, bit<12> idx) {
-        standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+    @name(".act") action _act_2(@name("port") bit<9> port_2, @name("idx") bit<12> idx_2) {
+        standard_metadata.egress_spec = port_2;
+        cntDum.count(idx_2);
     }
     @name(".tabB") table _tabB {
         actions = {

--- a/testdata/p4_14_samples_outputs/counter6-midend.p4
+++ b/testdata/p4_14_samples_outputs/counter6-midend.p4
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".act") action _act_1(bit<9> port, bit<12> idx) {
+    @name(".act") action _act_1(@name("port") bit<9> port, @name("idx") bit<12> idx) {
         standard_metadata.egress_spec = port;
         cntDum.count(idx);
     }
@@ -83,9 +83,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = NoAction_0();
     }
-    @name(".act") action _act_2(bit<9> port, bit<12> idx) {
-        standard_metadata.egress_spec = port;
-        cntDum.count(idx);
+    @name(".act") action _act_2(@name("port") bit<9> port_2, @name("idx") bit<12> idx_2) {
+        standard_metadata.egress_spec = port_2;
+        cntDum.count(idx_2);
     }
     @name(".tabB") table _tabB {
         actions = {

--- a/testdata/p4_14_samples_outputs/exact_match1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-frontend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match1-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-frontend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match2-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match2-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-frontend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match3-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match3-midend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-frontend.p4
@@ -56,7 +56,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match4-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match4-midend.p4
@@ -56,7 +56,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-frontend.p4
@@ -56,7 +56,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match5-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match5-midend.p4
@@ -56,7 +56,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match7-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-frontend.p4
@@ -35,7 +35,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val) {
+    @name(".setb1") action setb1(@name("val") bit<8> val) {
         hdr.data.b1 = val;
     }
     @name(".noop") action noop() {

--- a/testdata/p4_14_samples_outputs/exact_match7-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match7-midend.p4
@@ -35,7 +35,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val) {
+    @name(".setb1") action setb1(@name("val") bit<8> val) {
         hdr.data.b1 = val;
     }
     @name(".noop") action noop() {

--- a/testdata/p4_14_samples_outputs/exact_match8-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-frontend.p4
@@ -33,41 +33,41 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop() {
     }
-    @name(".setb1") action setb1(bit<8> val) {
+    @name(".setb1") action setb1(@name("val") bit<8> val) {
         hdr.data.b1 = val;
     }
-    @name(".setb2") action setb2(bit<8> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<8> val_4) {
+        hdr.data.b2 = val_4;
     }
-    @name(".setb3") action setb3(bit<8> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<8> val_5) {
+        hdr.data.b3 = val_5;
     }
-    @name(".setb4") action setb4(bit<8> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<8> val_6) {
+        hdr.data.b4 = val_6;
     }
-    @name(".setb12") action setb12(bit<8> v1, bit<8> v2) {
+    @name(".setb12") action setb12(@name("v1") bit<8> v1, @name("v2") bit<8> v2) {
         hdr.data.b1 = v1;
         hdr.data.b2 = v2;
     }
-    @name(".setb13") action setb13(bit<8> v1, bit<8> v2) {
-        hdr.data.b1 = v1;
-        hdr.data.b3 = v2;
+    @name(".setb13") action setb13(@name("v1") bit<8> v1_6, @name("v2") bit<8> v2_6) {
+        hdr.data.b1 = v1_6;
+        hdr.data.b3 = v2_6;
     }
-    @name(".setb14") action setb14(bit<8> v1, bit<8> v2) {
-        hdr.data.b1 = v1;
-        hdr.data.b4 = v2;
+    @name(".setb14") action setb14(@name("v1") bit<8> v1_7, @name("v2") bit<8> v2_7) {
+        hdr.data.b1 = v1_7;
+        hdr.data.b4 = v2_7;
     }
-    @name(".setb23") action setb23(bit<8> v1, bit<8> v2) {
-        hdr.data.b2 = v1;
-        hdr.data.b3 = v2;
+    @name(".setb23") action setb23(@name("v1") bit<8> v1_8, @name("v2") bit<8> v2_8) {
+        hdr.data.b2 = v1_8;
+        hdr.data.b3 = v2_8;
     }
-    @name(".setb24") action setb24(bit<8> v1, bit<8> v2) {
-        hdr.data.b2 = v1;
-        hdr.data.b4 = v2;
+    @name(".setb24") action setb24(@name("v1") bit<8> v1_9, @name("v2") bit<8> v2_9) {
+        hdr.data.b2 = v1_9;
+        hdr.data.b4 = v2_9;
     }
-    @name(".setb34") action setb34(bit<8> v1, bit<8> v2) {
-        hdr.data.b3 = v1;
-        hdr.data.b4 = v2;
+    @name(".setb34") action setb34(@name("v1") bit<8> v1_10, @name("v2") bit<8> v2_10) {
+        hdr.data.b3 = v1_10;
+        hdr.data.b4 = v2_10;
     }
     @name(".test1") table test1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/exact_match8-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match8-midend.p4
@@ -33,41 +33,41 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop() {
     }
-    @name(".setb1") action setb1(bit<8> val) {
+    @name(".setb1") action setb1(@name("val") bit<8> val) {
         hdr.data.b1 = val;
     }
-    @name(".setb2") action setb2(bit<8> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<8> val_4) {
+        hdr.data.b2 = val_4;
     }
-    @name(".setb3") action setb3(bit<8> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<8> val_5) {
+        hdr.data.b3 = val_5;
     }
-    @name(".setb4") action setb4(bit<8> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<8> val_6) {
+        hdr.data.b4 = val_6;
     }
-    @name(".setb12") action setb12(bit<8> v1, bit<8> v2) {
+    @name(".setb12") action setb12(@name("v1") bit<8> v1, @name("v2") bit<8> v2) {
         hdr.data.b1 = v1;
         hdr.data.b2 = v2;
     }
-    @name(".setb13") action setb13(bit<8> v1, bit<8> v2) {
-        hdr.data.b1 = v1;
-        hdr.data.b3 = v2;
+    @name(".setb13") action setb13(@name("v1") bit<8> v1_6, @name("v2") bit<8> v2_6) {
+        hdr.data.b1 = v1_6;
+        hdr.data.b3 = v2_6;
     }
-    @name(".setb14") action setb14(bit<8> v1, bit<8> v2) {
-        hdr.data.b1 = v1;
-        hdr.data.b4 = v2;
+    @name(".setb14") action setb14(@name("v1") bit<8> v1_7, @name("v2") bit<8> v2_7) {
+        hdr.data.b1 = v1_7;
+        hdr.data.b4 = v2_7;
     }
-    @name(".setb23") action setb23(bit<8> v1, bit<8> v2) {
-        hdr.data.b2 = v1;
-        hdr.data.b3 = v2;
+    @name(".setb23") action setb23(@name("v1") bit<8> v1_8, @name("v2") bit<8> v2_8) {
+        hdr.data.b2 = v1_8;
+        hdr.data.b3 = v2_8;
     }
-    @name(".setb24") action setb24(bit<8> v1, bit<8> v2) {
-        hdr.data.b2 = v1;
-        hdr.data.b4 = v2;
+    @name(".setb24") action setb24(@name("v1") bit<8> v1_9, @name("v2") bit<8> v2_9) {
+        hdr.data.b2 = v1_9;
+        hdr.data.b4 = v2_9;
     }
-    @name(".setb34") action setb34(bit<8> v1, bit<8> v2) {
-        hdr.data.b3 = v1;
-        hdr.data.b4 = v2;
+    @name(".setb34") action setb34(@name("v1") bit<8> v1_10, @name("v2") bit<8> v2_10) {
+        hdr.data.b3 = v1_10;
+        hdr.data.b4 = v2_10;
     }
     @name(".test1") table test1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/exact_match9-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-frontend.p4
@@ -33,17 +33,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop() {
     }
-    @name(".setb1") action setb1(bit<8> val) {
+    @name(".setb1") action setb1(@name("val") bit<8> val) {
         hdr.data.b1 = val;
     }
-    @name(".setb2") action setb2(bit<8> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<8> val_4) {
+        hdr.data.b2 = val_4;
     }
-    @name(".setb3") action setb3(bit<8> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<8> val_5) {
+        hdr.data.b3 = val_5;
     }
-    @name(".setb4") action setb4(bit<8> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<8> val_6) {
+        hdr.data.b4 = val_6;
     }
     @name(".test1") table test1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/exact_match9-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match9-midend.p4
@@ -33,17 +33,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop() {
     }
-    @name(".setb1") action setb1(bit<8> val) {
+    @name(".setb1") action setb1(@name("val") bit<8> val) {
         hdr.data.b1 = val;
     }
-    @name(".setb2") action setb2(bit<8> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<8> val_4) {
+        hdr.data.b2 = val_4;
     }
-    @name(".setb3") action setb3(bit<8> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<8> val_5) {
+        hdr.data.b3 = val_5;
     }
-    @name(".setb4") action setb4(bit<8> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<8> val_6) {
+        hdr.data.b4 = val_6;
     }
     @name(".test1") table test1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-frontend.p4
@@ -28,7 +28,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match_mask1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_mask1-midend.p4
@@ -29,7 +29,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     bit<32> key_0;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-frontend.p4
@@ -40,7 +40,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/exact_match_valid1-midend.p4
+++ b/testdata/p4_14_samples_outputs/exact_match_valid1-midend.p4
@@ -40,7 +40,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-frontend.p4
@@ -93,7 +93,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name(".rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
@@ -140,11 +140,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_6() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
+    @name(".set_ecmp_select") action set_ecmp_select(@name("ecmp_base") bit<8> ecmp_base, @name("ecmp_count") bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);
     }
-    @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;
+    @name(".set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta.ingress_metadata.nhop_ipv4 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
@@ -156,7 +156,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime.write(meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
-    @name(".set_dmac") action set_dmac(bit<48> dmac) {
+    @name(".set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name(".update_flowlet_id") action update_flowlet_id() {

--- a/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
+++ b/testdata/p4_14_samples_outputs/flowlet_switching-midend.p4
@@ -97,7 +97,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name(".rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
@@ -161,11 +161,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_6() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
+    @name(".set_ecmp_select") action set_ecmp_select(@name("ecmp_base") bit<8> ecmp_base, @name("ecmp_count") bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple_0, bit<20>>(meta._ingress_metadata_ecmp_offset4, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta._ingress_metadata_flowlet_id2 }, (bit<20>)ecmp_count);
     }
-    @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta._ingress_metadata_nhop_ipv45 = nhop_ipv4;
+    @name(".set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta._ingress_metadata_nhop_ipv45 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
@@ -177,7 +177,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._ingress_metadata_flow_ipg0 = (bit<32>)standard_metadata.ingress_global_timestamp - meta._ingress_metadata_flowlet_lasttime3;
         flowlet_lasttime.write(meta._ingress_metadata_flowlet_map_index1, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
-    @name(".set_dmac") action set_dmac(bit<48> dmac) {
+    @name(".set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name(".update_flowlet_id") action update_flowlet_id() {

--- a/testdata/p4_14_samples_outputs/gateway1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-frontend.p4
@@ -32,13 +32,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway1-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway1-midend.p4
@@ -32,13 +32,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-frontend.p4
@@ -34,13 +34,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway2-midend.p4
@@ -34,13 +34,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-frontend.p4
@@ -34,13 +34,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway3-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway3-midend.p4
@@ -34,13 +34,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-frontend.p4
@@ -48,13 +48,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway4-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway4-midend.p4
@@ -48,13 +48,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop() {
         mark_to_drop(standard_metadata);
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-frontend.p4
@@ -37,11 +37,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".output") action output(bit<9> port) {
+    @name(".output") action output(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".output") action output_2(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".output") action output_2(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway5-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway5-midend.p4
@@ -37,11 +37,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".output") action output(bit<9> port) {
+    @name(".output") action output(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".output") action output_2(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".output") action output_2(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-frontend.p4
@@ -31,11 +31,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".output") action output(bit<9> port) {
+    @name(".output") action output(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".output") action output_2(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".output") action output_2(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway6-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-midend.p4
@@ -31,11 +31,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".output") action output(bit<9> port) {
+    @name(".output") action output(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".output") action output_2(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".output") action output_2(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway7-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-frontend.p4
@@ -31,11 +31,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".output") action output(bit<9> port) {
+    @name(".output") action output(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".output") action output_2(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".output") action output_2(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway7-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway7-midend.p4
@@ -31,11 +31,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".output") action output(bit<9> port) {
+    @name(".output") action output(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".output") action output_2(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".output") action output_2(@name("port") bit<9> port_1) {
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway8-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway8-frontend.p4
@@ -29,13 +29,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/gateway8-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway8-midend.p4
@@ -29,13 +29,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/hash_action_basic-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-frontend.p4
@@ -37,8 +37,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_index") action set_index(bit<16> index, bit<9> port) {
-        meta.counter_metadata.counter_index = index;
+    @name(".set_index") action set_index(@name("index") bit<16> index_1, @name("port") bit<9> port) {
+        meta.counter_metadata.counter_index = index_1;
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {

--- a/testdata/p4_14_samples_outputs/hash_action_basic-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_basic-midend.p4
@@ -36,8 +36,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_index") action set_index(bit<16> index, bit<9> port) {
-        meta._counter_metadata_counter_index0 = index;
+    @name(".set_index") action set_index(@name("index") bit<16> index_1, @name("port") bit<9> port) {
+        meta._counter_metadata_counter_index0 = index_1;
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-frontend.p4
@@ -38,8 +38,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_index") action set_index(bit<16> index, bit<9> port) {
-        meta.counter_metadata.counter_index = index;
+    @name(".set_index") action set_index(@name("index") bit<16> index_1, @name("port") bit<9> port) {
+        meta.counter_metadata.counter_index = index_1;
         standard_metadata.egress_spec = port;
         meta.counter_metadata.counter_run = 4w1;
     }

--- a/testdata/p4_14_samples_outputs/hash_action_gateway-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway-midend.p4
@@ -38,8 +38,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_index") action set_index(bit<16> index, bit<9> port) {
-        meta._counter_metadata_counter_index0 = index;
+    @name(".set_index") action set_index(@name("index") bit<16> index_1, @name("port") bit<9> port) {
+        meta._counter_metadata_counter_index0 = index_1;
         standard_metadata.egress_spec = port;
         meta._counter_metadata_counter_run1 = 4w1;
     }

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-frontend.p4
@@ -42,19 +42,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name(".set_index") action set_index(bit<16> index, bit<9> port) {
-        meta.counter_metadata.counter_index = index;
+    @name(".set_index") action set_index(@name("index") bit<16> index_1, @name("port") bit<9> port) {
+        meta.counter_metadata.counter_index = index_1;
         standard_metadata.egress_spec = port;
         meta.counter_metadata.counter_run = 4w1;
     }
     @name(".count_entries") action count_entries() {
         count1.count((bit<14>)meta.counter_metadata.counter_index);
     }
-    @name(".seth2") action seth2(bit<16> val) {
+    @name(".seth2") action seth2(@name("val") bit<16> val) {
         hdr.data.h2 = val;
     }
-    @name(".seth4") action seth4(bit<16> val) {
-        hdr.data.h4 = val;
+    @name(".seth4") action seth4(@name("val") bit<16> val_2) {
+        hdr.data.h4 = val_2;
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_gateway2-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_gateway2-midend.p4
@@ -42,19 +42,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name(".set_index") action set_index(bit<16> index, bit<9> port) {
-        meta._counter_metadata_counter_index0 = index;
+    @name(".set_index") action set_index(@name("index") bit<16> index_1, @name("port") bit<9> port) {
+        meta._counter_metadata_counter_index0 = index_1;
         standard_metadata.egress_spec = port;
         meta._counter_metadata_counter_run1 = 4w1;
     }
     @name(".count_entries") action count_entries() {
         count1.count((bit<14>)meta._counter_metadata_counter_index0);
     }
-    @name(".seth2") action seth2(bit<16> val) {
+    @name(".seth2") action seth2(@name("val") bit<16> val) {
         hdr.data.h2 = val;
     }
-    @name(".seth4") action seth4(bit<16> val) {
-        hdr.data.h4 = val;
+    @name(".seth4") action seth4(@name("val") bit<16> val_2) {
+        hdr.data.h4 = val_2;
     }
     @name(".index_setter") table index_setter_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-frontend.p4
@@ -50,9 +50,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".set_index") action set_index(bit<16> index, bit<9> port) {
-        meta.counter_metadata.counter_index = index;
-        meta.meter_metadata.meter_index = index;
+    @name(".set_index") action set_index(@name("index") bit<16> index_1, @name("port") bit<9> port) {
+        meta.counter_metadata.counter_index = index_1;
+        meta.meter_metadata.meter_index = index_1;
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {

--- a/testdata/p4_14_samples_outputs/hash_action_two_same-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_same-midend.p4
@@ -48,9 +48,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".set_index") action set_index(bit<16> index, bit<9> port) {
-        meta._counter_metadata_counter_index0 = index;
-        meta._meter_metadata_meter_index1 = index;
+    @name(".set_index") action set_index(@name("index") bit<16> index_1, @name("port") bit<9> port) {
+        meta._counter_metadata_counter_index0 = index_1;
+        meta._meter_metadata_meter_index1 = index_1;
         standard_metadata.egress_spec = port;
     }
     @name(".count_entries") action count_entries() {

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-frontend.p4
@@ -40,7 +40,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_index") action set_index(bit<16> index1, bit<16> index2, bit<9> port) {
+    @name(".set_index") action set_index(@name("index1") bit<16> index1, @name("index2") bit<16> index2, @name("port") bit<9> port) {
         meta.counter_metadata.counter_index_first = index1;
         meta.counter_metadata.counter_index_second = index2;
         standard_metadata.egress_spec = port;

--- a/testdata/p4_14_samples_outputs/hash_action_two_separate-midend.p4
+++ b/testdata/p4_14_samples_outputs/hash_action_two_separate-midend.p4
@@ -40,7 +40,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_index") action set_index(bit<16> index1, bit<16> index2, bit<9> port) {
+    @name(".set_index") action set_index(@name("index1") bit<16> index1, @name("index2") bit<16> index2, @name("port") bit<9> port) {
         meta._counter_metadata_counter_index_first0 = index1;
         meta._counter_metadata_counter_index_second1 = index2;
         standard_metadata.egress_spec = port;

--- a/testdata/p4_14_samples_outputs/hit-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hit-frontend.p4
@@ -34,13 +34,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/hit-midend.p4
+++ b/testdata/p4_14_samples_outputs/hit-midend.p4
@@ -34,13 +34,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/hitmiss-frontend.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-frontend.p4
@@ -34,17 +34,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_3(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_3(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
-    @name(".setb1") action setb1_4(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_4(@name("val") bit<8> val_2, @name("port") bit<9> port_2) {
+        hdr.data.b1 = val_2;
+        standard_metadata.egress_spec = port_2;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/hitmiss-midend.p4
+++ b/testdata/p4_14_samples_outputs/hitmiss-midend.p4
@@ -34,17 +34,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_3(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_3(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
-    @name(".setb1") action setb1_4(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_4(@name("val") bit<8> val_2, @name("port") bit<9> port_2) {
+        hdr.data.b1 = val_2;
+        standard_metadata.egress_spec = port_2;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/instruct5-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-frontend.p4
@@ -46,23 +46,23 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".output") action output(bit<9> port) {
+    @name(".output") action output(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {
     }
-    @name(".push1") action push1(bit<24> x1) {
+    @name(".push1") action push1(@name("x1") bit<24> x1_2) {
         hdr.extra.push_front(1);
         hdr.extra[0].setValid();
-        hdr.extra[0].x1 = x1;
+        hdr.extra[0].x1 = x1_2;
         hdr.extra[0].more = hdr.data.more;
         hdr.data.more = 8w1;
     }
-    @name(".push2") action push2(bit<24> x1, bit<24> x2) {
+    @name(".push2") action push2(@name("x1") bit<24> x1_3, @name("x2") bit<24> x2) {
         hdr.extra.push_front(2);
         hdr.extra[0].setValid();
         hdr.extra[1].setValid();
-        hdr.extra[0].x1 = x1;
+        hdr.extra[0].x1 = x1_3;
         hdr.extra[0].more = 8w1;
         hdr.extra[1].x1 = x2;
         hdr.extra[1].more = hdr.data.more;

--- a/testdata/p4_14_samples_outputs/instruct5-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct5-midend.p4
@@ -46,23 +46,23 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".output") action output(bit<9> port) {
+    @name(".output") action output(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     @name(".noop") action noop() {
     }
-    @name(".push1") action push1(bit<24> x1) {
+    @name(".push1") action push1(@name("x1") bit<24> x1_2) {
         hdr.extra.push_front(1);
         hdr.extra[0].setValid();
-        hdr.extra[0].x1 = x1;
+        hdr.extra[0].x1 = x1_2;
         hdr.extra[0].more = hdr.data.more;
         hdr.data.more = 8w1;
     }
-    @name(".push2") action push2(bit<24> x1, bit<24> x2) {
+    @name(".push2") action push2(@name("x1") bit<24> x1_3, @name("x2") bit<24> x2) {
         hdr.extra.push_front(2);
         hdr.extra[0].setValid();
         hdr.extra[1].setValid();
-        hdr.extra[0].x1 = x1;
+        hdr.extra[0].x1 = x1_3;
         hdr.extra[0].more = 8w1;
         hdr.extra[1].x1 = x2;
         hdr.extra[1].more = hdr.data.more;

--- a/testdata/p4_14_samples_outputs/instruct6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/instruct6-frontend.p4
@@ -29,13 +29,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".op1") action op1(bit<9> port) {
+    @name(".op1") action op1(@name("port") bit<9> port) {
         hdr.data.h1[7:0] = hdr.data.h2[15:8];
         standard_metadata.egress_spec = port;
     }
-    @name(".op2") action op2(bit<9> port) {
+    @name(".op2") action op2(@name("port") bit<9> port_2) {
         hdr.data.h1[7:4] = hdr.data.h2[11:8];
-        standard_metadata.egress_spec = port;
+        standard_metadata.egress_spec = port_2;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/instruct6-midend.p4
+++ b/testdata/p4_14_samples_outputs/instruct6-midend.p4
@@ -29,13 +29,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".op1") action op1(bit<9> port) {
+    @name(".op1") action op1(@name("port") bit<9> port) {
         hdr.data.h1[7:0] = hdr.data.h2[15:8];
         standard_metadata.egress_spec = port;
     }
-    @name(".op2") action op2(bit<9> port) {
+    @name(".op2") action op2(@name("port") bit<9> port_2) {
         hdr.data.h1[7:4] = hdr.data.h2[11:8];
-        standard_metadata.egress_spec = port;
+        standard_metadata.egress_spec = port_2;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-frontend.p4
@@ -37,11 +37,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_7() {
     }
-    @name(".send") action send(bit<9> port) {
+    @name(".send") action send(@name("port") bit<9> port) {
         standard_metadata.egress_port = port;
     }
-    @name(".send") action send_2(bit<9> port) {
-        standard_metadata.egress_port = port;
+    @name(".send") action send_2(@name("port") bit<9> port_2) {
+        standard_metadata.egress_port = port_2;
     }
     @name(".discard") action discard() {
         mark_to_drop(standard_metadata);
@@ -73,11 +73,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1024;
         default_action = NoAction_5();
     }
-    @name(".send") action _send_0(bit<9> port) {
-        standard_metadata.egress_port = port;
+    @name(".send") action _send_0(@name("port") bit<9> port_3) {
+        standard_metadata.egress_port = port_3;
     }
-    @name(".send") action _send_2(bit<9> port) {
-        standard_metadata.egress_port = port;
+    @name(".send") action _send_2(@name("port") bit<9> port_4) {
+        standard_metadata.egress_port = port_4;
     }
     @name(".discard") action _discard_0() {
         mark_to_drop(standard_metadata);

--- a/testdata/p4_14_samples_outputs/issue-1426-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue-1426-midend.p4
@@ -37,11 +37,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_7() {
     }
-    @name(".send") action send(bit<9> port) {
+    @name(".send") action send(@name("port") bit<9> port) {
         standard_metadata.egress_port = port;
     }
-    @name(".send") action send_2(bit<9> port) {
-        standard_metadata.egress_port = port;
+    @name(".send") action send_2(@name("port") bit<9> port_2) {
+        standard_metadata.egress_port = port_2;
     }
     @name(".discard") action discard() {
         mark_to_drop(standard_metadata);
@@ -73,11 +73,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1024;
         default_action = NoAction_5();
     }
-    @name(".send") action _send_0(bit<9> port) {
-        standard_metadata.egress_port = port;
+    @name(".send") action _send_0(@name("port") bit<9> port_3) {
+        standard_metadata.egress_port = port_3;
     }
-    @name(".send") action _send_2(bit<9> port) {
-        standard_metadata.egress_port = port;
+    @name(".send") action _send_2(@name("port") bit<9> port_4) {
+        standard_metadata.egress_port = port_4;
     }
     @name(".discard") action _discard_0() {
         mark_to_drop(standard_metadata);

--- a/testdata/p4_14_samples_outputs/issue2196-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue2196-frontend.p4
@@ -60,9 +60,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".route_eth") action route_eth(bit<9> egress_spec, bit<48> src_addr) {
-        standard_metadata.egress_spec = egress_spec;
-        hdr.ethernet.src_addr = src_addr;
+    @name(".route_eth") action route_eth(@name("egress_spec") bit<9> egress_spec_1, @name("src_addr") bit<48> src_addr_1) {
+        standard_metadata.egress_spec = egress_spec_1;
+        hdr.ethernet.src_addr = src_addr_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/issue2196-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue2196-midend.p4
@@ -60,9 +60,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".route_eth") action route_eth(bit<9> egress_spec, bit<48> src_addr) {
-        standard_metadata.egress_spec = egress_spec;
-        hdr.ethernet.src_addr = src_addr;
+    @name(".route_eth") action route_eth(@name("egress_spec") bit<9> egress_spec_1, @name("src_addr") bit<48> src_addr_1) {
+        standard_metadata.egress_spec = egress_spec_1;
+        hdr.ethernet.src_addr = src_addr_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/issue583-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-frontend.p4
@@ -193,11 +193,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".drop_pkt") action drop_pkt() {
         mark_to_drop(standard_metadata);
     }
-    @name(".hop_ipv4") action hop_ipv4(bit<9> egress_spec) {
+    @name(".hop_ipv4") action hop_ipv4(@name("egress_spec") bit<9> egress_spec_0) {
         {
-            @name("ingress.ttl_1") bit<8> ttl_1 = hdr.ipv4.ttl;
+            @name("ingress.ttl") bit<8> ttl_1 = hdr.ipv4.ttl;
             ttl_1 = ttl_1 + 8w255;
-            standard_metadata.egress_spec = egress_spec;
+            standard_metadata.egress_spec = egress_spec_0;
             hdr.ipv4.ttl = ttl_1;
         }
     }

--- a/testdata/p4_14_samples_outputs/issue583-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue583-midend.p4
@@ -200,8 +200,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".drop_pkt") action drop_pkt() {
         mark_to_drop(standard_metadata);
     }
-    @name(".hop_ipv4") action hop_ipv4(bit<9> egress_spec) {
-        standard_metadata.egress_spec = egress_spec;
+    @name(".hop_ipv4") action hop_ipv4(@name("egress_spec") bit<9> egress_spec_0) {
+        standard_metadata.egress_spec = egress_spec_0;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
     @name(".act") action act() {

--- a/testdata/p4_14_samples_outputs/issue60-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue60-frontend.p4
@@ -31,7 +31,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_egress_port") action set_egress_port(bit<9> port) {
+    @name(".set_egress_port") action set_egress_port(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     @name(".t1") table t1_0 {

--- a/testdata/p4_14_samples_outputs/issue60-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue60-midend.p4
@@ -31,7 +31,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_egress_port") action set_egress_port(bit<9> port) {
+    @name(".set_egress_port") action set_egress_port(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     @name(".t1") table t1_0 {

--- a/testdata/p4_14_samples_outputs/issue846-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue846-frontend.p4
@@ -56,17 +56,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".do_nothing") action do_nothing_6() {
     }
-    @name(".action_0") action action_0(bit<8> p) {
+    @name(".action_0") action action_0(@name("p") bit<8> p_3) {
         meta.meta.x = 16w1;
         meta.meta.y = 16w2;
     }
-    @name(".action_1") action action_1(bit<8> p) {
+    @name(".action_1") action action_1(@name("p") bit<8> p_4) {
         meta.meta.z = meta.meta.y + meta.meta.x;
     }
-    @name(".action_1") action action_2(bit<8> p) {
+    @name(".action_1") action action_2(@name("p") bit<8> p_5) {
         meta.meta.z = meta.meta.y + meta.meta.x;
     }
-    @name(".action_2") action action_7(bit<8> p) {
+    @name(".action_2") action action_7(@name("p") bit<8> p_6) {
         hdr.hdr0.a = meta.meta.z;
     }
     @name(".t0") table t0_0 {

--- a/testdata/p4_14_samples_outputs/issue846-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue846-midend.p4
@@ -57,17 +57,17 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".do_nothing") action do_nothing_6() {
     }
-    @name(".action_0") action action_0(bit<8> p) {
+    @name(".action_0") action action_0(@name("p") bit<8> p_3) {
         meta._meta_x0 = 16w1;
         meta._meta_y1 = 16w2;
     }
-    @name(".action_1") action action_1(bit<8> p) {
+    @name(".action_1") action action_1(@name("p") bit<8> p_4) {
         meta._meta_z2 = meta._meta_y1 + meta._meta_x0;
     }
-    @name(".action_1") action action_2(bit<8> p) {
+    @name(".action_1") action action_2(@name("p") bit<8> p_5) {
         meta._meta_z2 = meta._meta_y1 + meta._meta_x0;
     }
-    @name(".action_2") action action_7(bit<8> p) {
+    @name(".action_2") action action_7(@name("p") bit<8> p_6) {
         hdr.hdr0.a = meta._meta_z2;
     }
     @name(".t0") table t0_0 {

--- a/testdata/p4_14_samples_outputs/issue894-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-frontend.p4
@@ -86,7 +86,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name(".rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
@@ -131,11 +131,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_6() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_dmac") action set_dmac(bit<48> dmac) {
+    @name(".set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
-    @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta.custom_metadata.nhop_ipv4 = nhop_ipv4;
+    @name(".set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta.custom_metadata.nhop_ipv4 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }

--- a/testdata/p4_14_samples_outputs/issue894-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue894-midend.p4
@@ -89,7 +89,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name(".rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
@@ -142,11 +142,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_6() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_dmac") action set_dmac(bit<48> dmac) {
+    @name(".set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
-    @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta._custom_metadata_nhop_ipv40 = nhop_ipv4;
+    @name(".set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta._custom_metadata_nhop_ipv40 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }

--- a/testdata/p4_14_samples_outputs/mac_rewrite-frontend.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-frontend.p4
@@ -90,10 +90,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".do_setup") action do_setup(bit<9> idx, bit<1> routed) {
+    @name(".do_setup") action do_setup(@name("idx") bit<9> idx, @name("routed") bit<1> routed_1) {
         meta.egress_metadata.mac_da = hdr.ethernet.dstAddr;
         meta.egress_metadata.smac_idx = idx;
-        meta.egress_metadata.routed = routed;
+        meta.egress_metadata.routed = routed_1;
     }
     @name(".setup") table setup_0 {
         actions = {
@@ -107,23 +107,23 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_0() {
     }
-    @name(".rewrite_ipv4_unicast_mac") action _rewrite_ipv4_unicast_mac_0(bit<48> smac) {
+    @name(".rewrite_ipv4_unicast_mac") action _rewrite_ipv4_unicast_mac_0(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
         hdr.ethernet.dstAddr = meta.egress_metadata.mac_da;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".rewrite_ipv4_multicast_mac") action _rewrite_ipv4_multicast_mac_0(bit<48> smac) {
-        hdr.ethernet.srcAddr = smac;
+    @name(".rewrite_ipv4_multicast_mac") action _rewrite_ipv4_multicast_mac_0(@name("smac") bit<48> smac_4) {
+        hdr.ethernet.srcAddr = smac_4;
         hdr.ethernet.dstAddr[47:23] = 25w0x200bc;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".rewrite_ipv6_unicast_mac") action _rewrite_ipv6_unicast_mac_0(bit<48> smac) {
-        hdr.ethernet.srcAddr = smac;
+    @name(".rewrite_ipv6_unicast_mac") action _rewrite_ipv6_unicast_mac_0(@name("smac") bit<48> smac_5) {
+        hdr.ethernet.srcAddr = smac_5;
         hdr.ethernet.dstAddr = meta.egress_metadata.mac_da;
         hdr.ipv6.hopLimit = hdr.ipv6.hopLimit + 8w255;
     }
-    @name(".rewrite_ipv6_multicast_mac") action _rewrite_ipv6_multicast_mac_0(bit<48> smac) {
-        hdr.ethernet.srcAddr = smac;
+    @name(".rewrite_ipv6_multicast_mac") action _rewrite_ipv6_multicast_mac_0(@name("smac") bit<48> smac_6) {
+        hdr.ethernet.srcAddr = smac_6;
         hdr.ethernet.dstAddr[47:32] = 16w0x3333;
         hdr.ipv6.hopLimit = hdr.ipv6.hopLimit + 8w255;
     }

--- a/testdata/p4_14_samples_outputs/mac_rewrite-midend.p4
+++ b/testdata/p4_14_samples_outputs/mac_rewrite-midend.p4
@@ -100,10 +100,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name(".do_setup") action do_setup(bit<9> idx, bit<1> routed) {
+    @name(".do_setup") action do_setup(@name("idx") bit<9> idx, @name("routed") bit<1> routed_1) {
         meta._egress_metadata_mac_da5 = hdr.ethernet.dstAddr;
         meta._egress_metadata_smac_idx1 = idx;
-        meta._egress_metadata_routed6 = routed;
+        meta._egress_metadata_routed6 = routed_1;
     }
     @name(".setup") table setup_0 {
         actions = {
@@ -117,23 +117,23 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_0() {
     }
-    @name(".rewrite_ipv4_unicast_mac") action _rewrite_ipv4_unicast_mac_0(bit<48> smac) {
+    @name(".rewrite_ipv4_unicast_mac") action _rewrite_ipv4_unicast_mac_0(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
         hdr.ethernet.dstAddr = meta._egress_metadata_mac_da5;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".rewrite_ipv4_multicast_mac") action _rewrite_ipv4_multicast_mac_0(bit<48> smac) {
-        hdr.ethernet.srcAddr = smac;
+    @name(".rewrite_ipv4_multicast_mac") action _rewrite_ipv4_multicast_mac_0(@name("smac") bit<48> smac_4) {
+        hdr.ethernet.srcAddr = smac_4;
         hdr.ethernet.dstAddr[47:23] = 25w0x200bc;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".rewrite_ipv6_unicast_mac") action _rewrite_ipv6_unicast_mac_0(bit<48> smac) {
-        hdr.ethernet.srcAddr = smac;
+    @name(".rewrite_ipv6_unicast_mac") action _rewrite_ipv6_unicast_mac_0(@name("smac") bit<48> smac_5) {
+        hdr.ethernet.srcAddr = smac_5;
         hdr.ethernet.dstAddr = meta._egress_metadata_mac_da5;
         hdr.ipv6.hopLimit = hdr.ipv6.hopLimit + 8w255;
     }
-    @name(".rewrite_ipv6_multicast_mac") action _rewrite_ipv6_multicast_mac_0(bit<48> smac) {
-        hdr.ethernet.srcAddr = smac;
+    @name(".rewrite_ipv6_multicast_mac") action _rewrite_ipv6_multicast_mac_0(@name("smac") bit<48> smac_6) {
+        hdr.ethernet.srcAddr = smac_6;
         hdr.ethernet.dstAddr[47:32] = 16w0x3333;
         hdr.ipv6.hopLimit = hdr.ipv6.hopLimit + 8w255;
     }

--- a/testdata/p4_14_samples_outputs/meter-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter-frontend.p4
@@ -56,7 +56,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop_2() {
     }
-    @name(".m_action") action m_action(bit<14> meter_idx) {
+    @name(".m_action") action m_action(@name("meter_idx") bit<14> meter_idx) {
         my_meter.execute_meter<bit<32>>(meter_idx, meta.meta.meter_tag);
         standard_metadata.egress_spec = 9w1;
     }

--- a/testdata/p4_14_samples_outputs/meter-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter-midend.p4
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop_2() {
     }
-    @name(".m_action") action m_action(bit<14> meter_idx) {
+    @name(".m_action") action m_action(@name("meter_idx") bit<14> meter_idx) {
         my_meter.execute_meter<bit<32>>(meter_idx, meta._meta_meter_tag0);
         standard_metadata.egress_spec = 9w1;
     }

--- a/testdata/p4_14_samples_outputs/meter1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-frontend.p4
@@ -65,7 +65,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 16;
         default_action = NoAction_0();
     }
-    @name(".m_action") action m_action_0(bit<9> meter_idx) {
+    @name(".m_action") action m_action_0(@name("meter_idx") bit<9> meter_idx) {
         my_meter_0.read(meta.meta.meter_tag);
         standard_metadata.egress_spec = 9w1;
     }

--- a/testdata/p4_14_samples_outputs/meter1-midend.p4
+++ b/testdata/p4_14_samples_outputs/meter1-midend.p4
@@ -64,7 +64,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 16;
         default_action = NoAction_0();
     }
-    @name(".m_action") action m_action_0(bit<9> meter_idx) {
+    @name(".m_action") action m_action_0(@name("meter_idx") bit<9> meter_idx) {
         my_meter_0.read(meta._meta_meter_tag0);
         standard_metadata.egress_spec = 9w1;
     }

--- a/testdata/p4_14_samples_outputs/misc_prim-frontend.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim-frontend.p4
@@ -47,26 +47,26 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".action_0") action action_0() {
         hdr.pkt.field_a_32 = ~((bit<32>)hdr.pkt.field_b_32 | hdr.pkt.field_c_32);
     }
-    @name(".action_1") action action_1(bit<32> param0) {
+    @name(".action_1") action action_1(@name("param0") bit<32> param0) {
         hdr.pkt.field_a_32 = ~(param0 & hdr.pkt.field_c_32);
     }
-    @name(".action_2") action action_2(bit<32> param0) {
-        hdr.pkt.field_a_32 = ~((bit<32>)hdr.pkt.field_b_32 ^ param0);
+    @name(".action_2") action action_2(@name("param0") bit<32> param0_10) {
+        hdr.pkt.field_a_32 = ~((bit<32>)hdr.pkt.field_b_32 ^ param0_10);
     }
     @name(".action_3") action action_3() {
         hdr.pkt.field_a_32 = ~hdr.pkt.field_d_32;
     }
-    @name(".action_4") action action_4(bit<32> param0) {
-        if (hdr.pkt.field_d_32 <= param0) {
+    @name(".action_4") action action_4(@name("param0") bit<32> param0_11) {
+        if (hdr.pkt.field_d_32 <= param0_11) {
             tmp = hdr.pkt.field_d_32;
         } else {
-            tmp = param0;
+            tmp = param0_11;
         }
         hdr.pkt.field_a_32 = tmp;
     }
-    @name(".action_5") action action_5(bit<32> param0) {
-        if (param0 >= hdr.pkt.field_d_32) {
-            tmp_0 = param0;
+    @name(".action_5") action action_5(@name("param0") bit<32> param0_12) {
+        if (param0_12 >= hdr.pkt.field_d_32) {
+            tmp_0 = param0_12;
         } else {
             tmp_0 = hdr.pkt.field_d_32;
         }
@@ -80,36 +80,36 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         hdr.pkt.field_b_32 = tmp_1;
     }
-    @name(".action_7") action action_7(int<32> param0) {
-        if (param0 >= (int<32>)hdr.pkt.field_d_32) {
-            tmp_2 = param0;
+    @name(".action_7") action action_7(@name("param0") int<32> param0_13) {
+        if (param0_13 >= (int<32>)hdr.pkt.field_d_32) {
+            tmp_2 = param0_13;
         } else {
             tmp_2 = (int<32>)hdr.pkt.field_d_32;
         }
         hdr.pkt.field_b_32 = tmp_2;
     }
-    @name(".action_8") action action_8(int<32> param0) {
-        if (hdr.pkt.field_x_32 >= param0) {
+    @name(".action_8") action action_8(@name("param0") int<32> param0_14) {
+        if (hdr.pkt.field_x_32 >= param0_14) {
             tmp_3 = hdr.pkt.field_x_32;
         } else {
-            tmp_3 = param0;
+            tmp_3 = param0_14;
         }
         hdr.pkt.field_x_32 = tmp_3;
     }
     @name(".action_9") action action_9() {
         hdr.pkt.field_x_32 = hdr.pkt.field_x_32 >> 7;
     }
-    @name(".action_10") action action_10(bit<32> param0) {
-        hdr.pkt.field_a_32 = ~param0 & hdr.pkt.field_a_32;
+    @name(".action_10") action action_10(@name("param0") bit<32> param0_15) {
+        hdr.pkt.field_a_32 = ~param0_15 & hdr.pkt.field_a_32;
     }
-    @name(".action_11") action action_11(bit<32> param0) {
-        hdr.pkt.field_a_32 = param0 & ~hdr.pkt.field_a_32;
+    @name(".action_11") action action_11(@name("param0") bit<32> param0_16) {
+        hdr.pkt.field_a_32 = param0_16 & ~hdr.pkt.field_a_32;
     }
-    @name(".action_12") action action_12(bit<32> param0) {
-        hdr.pkt.field_a_32 = ~param0 | hdr.pkt.field_a_32;
+    @name(".action_12") action action_12(@name("param0") bit<32> param0_17) {
+        hdr.pkt.field_a_32 = ~param0_17 | hdr.pkt.field_a_32;
     }
-    @name(".action_13") action action_13(bit<32> param0) {
-        hdr.pkt.field_a_32 = param0 | ~hdr.pkt.field_a_32;
+    @name(".action_13") action action_13(@name("param0") bit<32> param0_18) {
+        hdr.pkt.field_a_32 = param0_18 | ~hdr.pkt.field_a_32;
     }
     @name(".do_nothing") action do_nothing() {
     }

--- a/testdata/p4_14_samples_outputs/misc_prim-midend.p4
+++ b/testdata/p4_14_samples_outputs/misc_prim-midend.p4
@@ -42,44 +42,44 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".action_0") action action_0() {
         hdr.pkt.field_a_32 = ~((bit<32>)hdr.pkt.field_b_32 | hdr.pkt.field_c_32);
     }
-    @name(".action_1") action action_1(bit<32> param0) {
+    @name(".action_1") action action_1(@name("param0") bit<32> param0) {
         hdr.pkt.field_a_32 = ~(param0 & hdr.pkt.field_c_32);
     }
-    @name(".action_2") action action_2(bit<32> param0) {
-        hdr.pkt.field_a_32 = ~((bit<32>)hdr.pkt.field_b_32 ^ param0);
+    @name(".action_2") action action_2(@name("param0") bit<32> param0_10) {
+        hdr.pkt.field_a_32 = ~((bit<32>)hdr.pkt.field_b_32 ^ param0_10);
     }
     @name(".action_3") action action_3() {
         hdr.pkt.field_a_32 = ~hdr.pkt.field_d_32;
     }
-    @name(".action_4") action action_4(bit<32> param0) {
-        hdr.pkt.field_a_32 = (hdr.pkt.field_d_32 <= param0 ? hdr.pkt.field_d_32 : param0);
+    @name(".action_4") action action_4(@name("param0") bit<32> param0_11) {
+        hdr.pkt.field_a_32 = (hdr.pkt.field_d_32 <= param0_11 ? hdr.pkt.field_d_32 : param0_11);
     }
-    @name(".action_5") action action_5(bit<32> param0) {
-        hdr.pkt.field_a_32 = (param0 >= hdr.pkt.field_d_32 ? param0 : hdr.pkt.field_d_32);
+    @name(".action_5") action action_5(@name("param0") bit<32> param0_12) {
+        hdr.pkt.field_a_32 = (param0_12 >= hdr.pkt.field_d_32 ? param0_12 : hdr.pkt.field_d_32);
     }
     @name(".action_6") action action_6() {
         hdr.pkt.field_b_32 = ((int<32>)hdr.pkt.field_d_32 <= 32s7 ? (int<32>)hdr.pkt.field_d_32 : 32s7);
     }
-    @name(".action_7") action action_7(int<32> param0) {
-        hdr.pkt.field_b_32 = (param0 >= (int<32>)hdr.pkt.field_d_32 ? param0 : (int<32>)hdr.pkt.field_d_32);
+    @name(".action_7") action action_7(@name("param0") int<32> param0_13) {
+        hdr.pkt.field_b_32 = (param0_13 >= (int<32>)hdr.pkt.field_d_32 ? param0_13 : (int<32>)hdr.pkt.field_d_32);
     }
-    @name(".action_8") action action_8(int<32> param0) {
-        hdr.pkt.field_x_32 = (hdr.pkt.field_x_32 >= param0 ? hdr.pkt.field_x_32 : param0);
+    @name(".action_8") action action_8(@name("param0") int<32> param0_14) {
+        hdr.pkt.field_x_32 = (hdr.pkt.field_x_32 >= param0_14 ? hdr.pkt.field_x_32 : param0_14);
     }
     @name(".action_9") action action_9() {
         hdr.pkt.field_x_32 = hdr.pkt.field_x_32 >> 7;
     }
-    @name(".action_10") action action_10(bit<32> param0) {
-        hdr.pkt.field_a_32 = ~param0 & hdr.pkt.field_a_32;
+    @name(".action_10") action action_10(@name("param0") bit<32> param0_15) {
+        hdr.pkt.field_a_32 = ~param0_15 & hdr.pkt.field_a_32;
     }
-    @name(".action_11") action action_11(bit<32> param0) {
-        hdr.pkt.field_a_32 = param0 & ~hdr.pkt.field_a_32;
+    @name(".action_11") action action_11(@name("param0") bit<32> param0_16) {
+        hdr.pkt.field_a_32 = param0_16 & ~hdr.pkt.field_a_32;
     }
-    @name(".action_12") action action_12(bit<32> param0) {
-        hdr.pkt.field_a_32 = ~param0 | hdr.pkt.field_a_32;
+    @name(".action_12") action action_12(@name("param0") bit<32> param0_17) {
+        hdr.pkt.field_a_32 = ~param0_17 | hdr.pkt.field_a_32;
     }
-    @name(".action_13") action action_13(bit<32> param0) {
-        hdr.pkt.field_a_32 = param0 | ~hdr.pkt.field_a_32;
+    @name(".action_13") action action_13(@name("param0") bit<32> param0_18) {
+        hdr.pkt.field_a_32 = param0_18 | ~hdr.pkt.field_a_32;
     }
     @name(".do_nothing") action do_nothing() {
     }

--- a/testdata/p4_14_samples_outputs/miss-frontend.p4
+++ b/testdata/p4_14_samples_outputs/miss-frontend.p4
@@ -34,13 +34,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/miss-midend.p4
+++ b/testdata/p4_14_samples_outputs/miss-midend.p4
@@ -34,13 +34,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }
-    @name(".setb1") action setb1_2(bit<8> val, bit<9> port) {
-        hdr.data.b1 = val;
-        standard_metadata.egress_spec = port;
+    @name(".setb1") action setb1_2(@name("val") bit<8> val_1, @name("port") bit<9> port_1) {
+        hdr.data.b1 = val_1;
+        standard_metadata.egress_spec = port_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/modify_conditionally-frontend.p4
+++ b/testdata/p4_14_samples_outputs/modify_conditionally-frontend.p4
@@ -38,8 +38,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".table0_actionlist") action table0_actionlist(bit<1> do_goto_table, bit<8> goto_table_id) {
-        meta.metadata_global.do_goto_table = do_goto_table;
+    @name(".table0_actionlist") action table0_actionlist(@name("do_goto_table") bit<1> do_goto_table_1, @name("goto_table_id") bit<8> goto_table_id_1) {
+        meta.metadata_global.do_goto_table = do_goto_table_1;
     }
     @name(".table0") table table0_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/modify_conditionally-midend.p4
+++ b/testdata/p4_14_samples_outputs/modify_conditionally-midend.p4
@@ -38,8 +38,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".table0_actionlist") action table0_actionlist(bit<1> do_goto_table, bit<8> goto_table_id) {
-        meta._metadata_global_do_goto_table0 = do_goto_table;
+    @name(".table0_actionlist") action table0_actionlist(@name("do_goto_table") bit<1> do_goto_table_1, @name("goto_table_id") bit<8> goto_table_id_1) {
+        meta._metadata_global_do_goto_table0 = do_goto_table_1;
     }
     @name(".table0") table table0_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/name_collision-frontend.p4
+++ b/testdata/p4_14_samples_outputs/name_collision-frontend.p4
@@ -40,7 +40,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".A") action A_2(bit<8> val, bit<9> port, bit<10> idx) {
+    @name(".A") action A_2(@name("val") bit<8> val, @name("port") bit<9> port, @name("idx") bit<10> idx) {
         hdr.A.b1 = val;
         standard_metadata.egress_spec = port;
         meta.meta.B = idx;

--- a/testdata/p4_14_samples_outputs/name_collision-midend.p4
+++ b/testdata/p4_14_samples_outputs/name_collision-midend.p4
@@ -40,7 +40,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".A") action A_2(bit<8> val, bit<9> port, bit<10> idx) {
+    @name(".A") action A_2(@name("val") bit<8> val, @name("port") bit<9> port, @name("idx") bit<10> idx) {
         hdr.A.b1 = val;
         standard_metadata.egress_spec = port;
         meta._meta_B1 = idx;

--- a/testdata/p4_14_samples_outputs/overflow-frontend.p4
+++ b/testdata/p4_14_samples_outputs/overflow-frontend.p4
@@ -29,8 +29,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".action_1_1") action action_0(bit<1> value) {
-        meta.md.field_1_1_1 = value;
+    @name(".action_1_1") action action_0(@name("value") bit<1> value_1) {
+        meta.md.field_1_1_1 = value_1;
         meta.md.field_2_1_1 = 1w1;
     }
     @name(".dmac") table dmac_0 {

--- a/testdata/p4_14_samples_outputs/overflow-midend.p4
+++ b/testdata/p4_14_samples_outputs/overflow-midend.p4
@@ -29,8 +29,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".action_1_1") action action_0(bit<1> value) {
-        meta._md_field_1_1_10 = value;
+    @name(".action_1_1") action action_0(@name("value") bit<1> value_1) {
+        meta._md_field_1_1_10 = value_1;
         meta._md_field_2_1_11 = 1w1;
     }
     @name(".dmac") table dmac_0 {

--- a/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-frontend.p4
@@ -50,7 +50,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name("._recirculate") action _recirculate() {
         recirculate<tuple<standard_metadata_t, metaA_t>>({ standard_metadata, meta.metaA });
     }
-    @name("._clone_e2e") action _clone_e2e(bit<32> mirror_id) {
+    @name("._clone_e2e") action _clone_e2e(@name("mirror_id") bit<32> mirror_id) {
         clone3<tuple<standard_metadata_t, metaA_t>>(CloneType.E2E, mirror_id, { standard_metadata, meta.metaA });
     }
     @name(".t_egress") table t_egress_0 {
@@ -81,18 +81,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop_4() {
     }
-    @name("._set_port") action _set_port(bit<9> port) {
+    @name("._set_port") action _set_port(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
         meta.metaA.f1 = 8w1;
     }
-    @name("._multicast") action _multicast(bit<16> mgrp) {
+    @name("._multicast") action _multicast(@name("mgrp") bit<16> mgrp) {
         standard_metadata.mcast_grp = mgrp;
     }
     @name("._resubmit") action _resubmit() {
         resubmit<tuple<standard_metadata_t, metaA_t>>({ standard_metadata, meta.metaA });
     }
-    @name("._clone_i2e") action _clone_i2e(bit<32> mirror_id) {
-        clone3<tuple<standard_metadata_t, metaA_t>>(CloneType.I2E, mirror_id, { standard_metadata, meta.metaA });
+    @name("._clone_i2e") action _clone_i2e(@name("mirror_id") bit<32> mirror_id_2) {
+        clone3<tuple<standard_metadata_t, metaA_t>>(CloneType.I2E, mirror_id_2, { standard_metadata, meta.metaA });
     }
     @name(".t_ingress_1") table t_ingress {
         actions = {

--- a/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
+++ b/testdata/p4_14_samples_outputs/packet_redirect-midend.p4
@@ -55,7 +55,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name("._recirculate") action _recirculate() {
         recirculate<tuple_0>({ standard_metadata, (metaA_t){f1 = meta._metaA_f10,f2 = meta._metaA_f21} });
     }
-    @name("._clone_e2e") action _clone_e2e(bit<32> mirror_id) {
+    @name("._clone_e2e") action _clone_e2e(@name("mirror_id") bit<32> mirror_id) {
         clone3<tuple_0>(CloneType.E2E, mirror_id, { standard_metadata, (metaA_t){f1 = meta._metaA_f10,f2 = meta._metaA_f21} });
     }
     @name(".t_egress") table t_egress_0 {
@@ -86,18 +86,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop_4() {
     }
-    @name("._set_port") action _set_port(bit<9> port) {
+    @name("._set_port") action _set_port(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
         meta._metaA_f10 = 8w1;
     }
-    @name("._multicast") action _multicast(bit<16> mgrp) {
+    @name("._multicast") action _multicast(@name("mgrp") bit<16> mgrp) {
         standard_metadata.mcast_grp = mgrp;
     }
     @name("._resubmit") action _resubmit() {
         resubmit<tuple_0>({ standard_metadata, (metaA_t){f1 = meta._metaA_f10,f2 = meta._metaA_f21} });
     }
-    @name("._clone_i2e") action _clone_i2e(bit<32> mirror_id) {
-        clone3<tuple_0>(CloneType.I2E, mirror_id, { standard_metadata, (metaA_t){f1 = meta._metaA_f10,f2 = meta._metaA_f21} });
+    @name("._clone_i2e") action _clone_i2e(@name("mirror_id") bit<32> mirror_id_2) {
+        clone3<tuple_0>(CloneType.I2E, mirror_id_2, { standard_metadata, (metaA_t){f1 = meta._metaA_f10,f2 = meta._metaA_f21} });
     }
     @name(".t_ingress_1") table t_ingress {
         actions = {

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-frontend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-frontend.p4
@@ -734,113 +734,113 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_bd") action set_bd(bit<16> outer_vlan_bd, bit<12> vrf, bit<10> rmac_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> igmp_snooping_enabled, bit<10> stp_group) {
-        meta.ingress_metadata.vrf = vrf;
-        meta.ingress_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled;
-        meta.ingress_metadata.igmp_snooping_enabled = igmp_snooping_enabled;
-        meta.ingress_metadata.rmac_group = rmac_group;
-        meta.ingress_metadata.uuc_mc_index = uuc_mc_index;
-        meta.ingress_metadata.umc_mc_index = umc_mc_index;
-        meta.ingress_metadata.bcast_mc_index = bcast_mc_index;
-        meta.ingress_metadata.bd_label = bd_label;
+    @name(".set_bd") action set_bd(@name("outer_vlan_bd") bit<16> outer_vlan_bd, @name("vrf") bit<12> vrf_5, @name("rmac_group") bit<10> rmac_group_5, @name("bd_label") bit<16> bd_label_5, @name("uuc_mc_index") bit<16> uuc_mc_index_5, @name("bcast_mc_index") bit<16> bcast_mc_index_5, @name("umc_mc_index") bit<16> umc_mc_index_5, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_5, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_5, @name("stp_group") bit<10> stp_group_5) {
+        meta.ingress_metadata.vrf = vrf_5;
+        meta.ingress_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled_5;
+        meta.ingress_metadata.igmp_snooping_enabled = igmp_snooping_enabled_5;
+        meta.ingress_metadata.rmac_group = rmac_group_5;
+        meta.ingress_metadata.uuc_mc_index = uuc_mc_index_5;
+        meta.ingress_metadata.umc_mc_index = umc_mc_index_5;
+        meta.ingress_metadata.bcast_mc_index = bcast_mc_index_5;
+        meta.ingress_metadata.bd_label = bd_label_5;
         meta.ingress_metadata.bd = outer_vlan_bd;
-        meta.ingress_metadata.stp_group = stp_group;
+        meta.ingress_metadata.stp_group = stp_group_5;
     }
-    @name(".set_outer_bd_ipv4_mcast_switch_ipv6_mcast_switch_flags") action set_outer_bd_ipv4_mcast_switch_ipv6_mcast_switch_flags(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<16> mrpf_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_multicast_mode, bit<2> ipv6_multicast_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<10> stp_group) {
-        meta.ingress_metadata.vrf = vrf;
-        meta.ingress_metadata.bd = bd;
-        meta.ingress_metadata.outer_bd = (bit<8>)bd;
+    @name(".set_outer_bd_ipv4_mcast_switch_ipv6_mcast_switch_flags") action set_outer_bd_ipv4_mcast_switch_ipv6_mcast_switch_flags(@name("bd") bit<16> bd_4, @name("vrf") bit<12> vrf_6, @name("rmac_group") bit<10> rmac_group_6, @name("mrpf_group") bit<16> mrpf_group, @name("bd_label") bit<16> bd_label_6, @name("uuc_mc_index") bit<16> uuc_mc_index_6, @name("bcast_mc_index") bit<16> bcast_mc_index_6, @name("umc_mc_index") bit<16> umc_mc_index_6, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_6, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_4, @name("ipv4_multicast_mode") bit<2> ipv4_multicast_mode_4, @name("ipv6_multicast_mode") bit<2> ipv6_multicast_mode_4, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_6, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_4, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_4, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_4, @name("stp_group") bit<10> stp_group_6) {
+        meta.ingress_metadata.vrf = vrf_6;
+        meta.ingress_metadata.bd = bd_4;
+        meta.ingress_metadata.outer_bd = (bit<8>)bd_4;
         meta.ingress_metadata.outer_ipv4_mcast_key_type = 1w0;
-        meta.ingress_metadata.outer_ipv4_mcast_key = (bit<8>)bd;
+        meta.ingress_metadata.outer_ipv4_mcast_key = (bit<8>)bd_4;
         meta.ingress_metadata.outer_ipv6_mcast_key_type = 1w0;
-        meta.ingress_metadata.outer_ipv6_mcast_key = (bit<8>)bd;
-        meta.ingress_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled;
-        meta.ingress_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled;
-        meta.ingress_metadata.ipv4_multicast_mode = ipv4_multicast_mode;
-        meta.ingress_metadata.ipv6_multicast_mode = ipv6_multicast_mode;
-        meta.ingress_metadata.igmp_snooping_enabled = igmp_snooping_enabled;
-        meta.ingress_metadata.mld_snooping_enabled = mld_snooping_enabled;
-        meta.ingress_metadata.ipv4_urpf_mode = ipv4_urpf_mode;
-        meta.ingress_metadata.ipv6_urpf_mode = ipv6_urpf_mode;
-        meta.ingress_metadata.rmac_group = rmac_group;
+        meta.ingress_metadata.outer_ipv6_mcast_key = (bit<8>)bd_4;
+        meta.ingress_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled_6;
+        meta.ingress_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled_4;
+        meta.ingress_metadata.ipv4_multicast_mode = ipv4_multicast_mode_4;
+        meta.ingress_metadata.ipv6_multicast_mode = ipv6_multicast_mode_4;
+        meta.ingress_metadata.igmp_snooping_enabled = igmp_snooping_enabled_6;
+        meta.ingress_metadata.mld_snooping_enabled = mld_snooping_enabled_4;
+        meta.ingress_metadata.ipv4_urpf_mode = ipv4_urpf_mode_4;
+        meta.ingress_metadata.ipv6_urpf_mode = ipv6_urpf_mode_4;
+        meta.ingress_metadata.rmac_group = rmac_group_6;
         meta.ingress_metadata.bd_mrpf_group = mrpf_group;
-        meta.ingress_metadata.uuc_mc_index = uuc_mc_index;
-        meta.ingress_metadata.umc_mc_index = umc_mc_index;
-        meta.ingress_metadata.bcast_mc_index = bcast_mc_index;
-        meta.ingress_metadata.bd_label = bd_label;
-        meta.ingress_metadata.stp_group = stp_group;
+        meta.ingress_metadata.uuc_mc_index = uuc_mc_index_6;
+        meta.ingress_metadata.umc_mc_index = umc_mc_index_6;
+        meta.ingress_metadata.bcast_mc_index = bcast_mc_index_6;
+        meta.ingress_metadata.bd_label = bd_label_6;
+        meta.ingress_metadata.stp_group = stp_group_6;
     }
-    @name(".set_outer_bd_ipv4_mcast_switch_ipv6_mcast_route_flags") action set_outer_bd_ipv4_mcast_switch_ipv6_mcast_route_flags(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<16> mrpf_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_multicast_mode, bit<2> ipv6_multicast_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<10> stp_group) {
-        meta.ingress_metadata.vrf = vrf;
-        meta.ingress_metadata.bd = bd;
-        meta.ingress_metadata.outer_bd = (bit<8>)bd;
+    @name(".set_outer_bd_ipv4_mcast_switch_ipv6_mcast_route_flags") action set_outer_bd_ipv4_mcast_switch_ipv6_mcast_route_flags(@name("bd") bit<16> bd_5, @name("vrf") bit<12> vrf_7, @name("rmac_group") bit<10> rmac_group_7, @name("mrpf_group") bit<16> mrpf_group_4, @name("bd_label") bit<16> bd_label_7, @name("uuc_mc_index") bit<16> uuc_mc_index_7, @name("bcast_mc_index") bit<16> bcast_mc_index_7, @name("umc_mc_index") bit<16> umc_mc_index_7, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_7, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_5, @name("ipv4_multicast_mode") bit<2> ipv4_multicast_mode_5, @name("ipv6_multicast_mode") bit<2> ipv6_multicast_mode_5, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_7, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_5, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_5, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_5, @name("stp_group") bit<10> stp_group_7) {
+        meta.ingress_metadata.vrf = vrf_7;
+        meta.ingress_metadata.bd = bd_5;
+        meta.ingress_metadata.outer_bd = (bit<8>)bd_5;
         meta.ingress_metadata.outer_ipv4_mcast_key_type = 1w0;
-        meta.ingress_metadata.outer_ipv4_mcast_key = (bit<8>)bd;
+        meta.ingress_metadata.outer_ipv4_mcast_key = (bit<8>)bd_5;
         meta.ingress_metadata.outer_ipv6_mcast_key_type = 1w1;
-        meta.ingress_metadata.outer_ipv6_mcast_key = (bit<8>)vrf;
-        meta.ingress_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled;
-        meta.ingress_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled;
-        meta.ingress_metadata.ipv4_multicast_mode = ipv4_multicast_mode;
-        meta.ingress_metadata.ipv6_multicast_mode = ipv6_multicast_mode;
-        meta.ingress_metadata.igmp_snooping_enabled = igmp_snooping_enabled;
-        meta.ingress_metadata.mld_snooping_enabled = mld_snooping_enabled;
-        meta.ingress_metadata.ipv4_urpf_mode = ipv4_urpf_mode;
-        meta.ingress_metadata.ipv6_urpf_mode = ipv6_urpf_mode;
-        meta.ingress_metadata.rmac_group = rmac_group;
-        meta.ingress_metadata.bd_mrpf_group = mrpf_group;
-        meta.ingress_metadata.uuc_mc_index = uuc_mc_index;
-        meta.ingress_metadata.umc_mc_index = umc_mc_index;
-        meta.ingress_metadata.bcast_mc_index = bcast_mc_index;
-        meta.ingress_metadata.bd_label = bd_label;
-        meta.ingress_metadata.stp_group = stp_group;
+        meta.ingress_metadata.outer_ipv6_mcast_key = (bit<8>)vrf_7;
+        meta.ingress_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled_7;
+        meta.ingress_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled_5;
+        meta.ingress_metadata.ipv4_multicast_mode = ipv4_multicast_mode_5;
+        meta.ingress_metadata.ipv6_multicast_mode = ipv6_multicast_mode_5;
+        meta.ingress_metadata.igmp_snooping_enabled = igmp_snooping_enabled_7;
+        meta.ingress_metadata.mld_snooping_enabled = mld_snooping_enabled_5;
+        meta.ingress_metadata.ipv4_urpf_mode = ipv4_urpf_mode_5;
+        meta.ingress_metadata.ipv6_urpf_mode = ipv6_urpf_mode_5;
+        meta.ingress_metadata.rmac_group = rmac_group_7;
+        meta.ingress_metadata.bd_mrpf_group = mrpf_group_4;
+        meta.ingress_metadata.uuc_mc_index = uuc_mc_index_7;
+        meta.ingress_metadata.umc_mc_index = umc_mc_index_7;
+        meta.ingress_metadata.bcast_mc_index = bcast_mc_index_7;
+        meta.ingress_metadata.bd_label = bd_label_7;
+        meta.ingress_metadata.stp_group = stp_group_7;
     }
-    @name(".set_outer_bd_ipv4_mcast_route_ipv6_mcast_switch_flags") action set_outer_bd_ipv4_mcast_route_ipv6_mcast_switch_flags(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<16> mrpf_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_multicast_mode, bit<2> ipv6_multicast_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<10> stp_group) {
-        meta.ingress_metadata.vrf = vrf;
-        meta.ingress_metadata.bd = bd;
-        meta.ingress_metadata.outer_bd = (bit<8>)bd;
+    @name(".set_outer_bd_ipv4_mcast_route_ipv6_mcast_switch_flags") action set_outer_bd_ipv4_mcast_route_ipv6_mcast_switch_flags(@name("bd") bit<16> bd_6, @name("vrf") bit<12> vrf_8, @name("rmac_group") bit<10> rmac_group_8, @name("mrpf_group") bit<16> mrpf_group_5, @name("bd_label") bit<16> bd_label_8, @name("uuc_mc_index") bit<16> uuc_mc_index_8, @name("bcast_mc_index") bit<16> bcast_mc_index_8, @name("umc_mc_index") bit<16> umc_mc_index_8, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_8, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_6, @name("ipv4_multicast_mode") bit<2> ipv4_multicast_mode_6, @name("ipv6_multicast_mode") bit<2> ipv6_multicast_mode_6, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_8, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_6, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_6, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_6, @name("stp_group") bit<10> stp_group_8) {
+        meta.ingress_metadata.vrf = vrf_8;
+        meta.ingress_metadata.bd = bd_6;
+        meta.ingress_metadata.outer_bd = (bit<8>)bd_6;
         meta.ingress_metadata.outer_ipv4_mcast_key_type = 1w1;
-        meta.ingress_metadata.outer_ipv4_mcast_key = (bit<8>)vrf;
+        meta.ingress_metadata.outer_ipv4_mcast_key = (bit<8>)vrf_8;
         meta.ingress_metadata.outer_ipv6_mcast_key_type = 1w0;
-        meta.ingress_metadata.outer_ipv6_mcast_key = (bit<8>)bd;
-        meta.ingress_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled;
-        meta.ingress_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled;
-        meta.ingress_metadata.ipv4_multicast_mode = ipv4_multicast_mode;
-        meta.ingress_metadata.ipv6_multicast_mode = ipv6_multicast_mode;
-        meta.ingress_metadata.igmp_snooping_enabled = igmp_snooping_enabled;
-        meta.ingress_metadata.mld_snooping_enabled = mld_snooping_enabled;
-        meta.ingress_metadata.ipv4_urpf_mode = ipv4_urpf_mode;
-        meta.ingress_metadata.ipv6_urpf_mode = ipv6_urpf_mode;
-        meta.ingress_metadata.rmac_group = rmac_group;
-        meta.ingress_metadata.bd_mrpf_group = mrpf_group;
-        meta.ingress_metadata.uuc_mc_index = uuc_mc_index;
-        meta.ingress_metadata.umc_mc_index = umc_mc_index;
-        meta.ingress_metadata.bcast_mc_index = bcast_mc_index;
-        meta.ingress_metadata.bd_label = bd_label;
-        meta.ingress_metadata.stp_group = stp_group;
+        meta.ingress_metadata.outer_ipv6_mcast_key = (bit<8>)bd_6;
+        meta.ingress_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled_8;
+        meta.ingress_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled_6;
+        meta.ingress_metadata.ipv4_multicast_mode = ipv4_multicast_mode_6;
+        meta.ingress_metadata.ipv6_multicast_mode = ipv6_multicast_mode_6;
+        meta.ingress_metadata.igmp_snooping_enabled = igmp_snooping_enabled_8;
+        meta.ingress_metadata.mld_snooping_enabled = mld_snooping_enabled_6;
+        meta.ingress_metadata.ipv4_urpf_mode = ipv4_urpf_mode_6;
+        meta.ingress_metadata.ipv6_urpf_mode = ipv6_urpf_mode_6;
+        meta.ingress_metadata.rmac_group = rmac_group_8;
+        meta.ingress_metadata.bd_mrpf_group = mrpf_group_5;
+        meta.ingress_metadata.uuc_mc_index = uuc_mc_index_8;
+        meta.ingress_metadata.umc_mc_index = umc_mc_index_8;
+        meta.ingress_metadata.bcast_mc_index = bcast_mc_index_8;
+        meta.ingress_metadata.bd_label = bd_label_8;
+        meta.ingress_metadata.stp_group = stp_group_8;
     }
-    @name(".set_outer_bd_ipv4_mcast_route_ipv6_mcast_route_flags") action set_outer_bd_ipv4_mcast_route_ipv6_mcast_route_flags(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<16> mrpf_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_multicast_mode, bit<2> ipv6_multicast_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<10> stp_group) {
-        meta.ingress_metadata.vrf = vrf;
-        meta.ingress_metadata.bd = bd;
-        meta.ingress_metadata.outer_bd = (bit<8>)bd;
+    @name(".set_outer_bd_ipv4_mcast_route_ipv6_mcast_route_flags") action set_outer_bd_ipv4_mcast_route_ipv6_mcast_route_flags(@name("bd") bit<16> bd_7, @name("vrf") bit<12> vrf_9, @name("rmac_group") bit<10> rmac_group_9, @name("mrpf_group") bit<16> mrpf_group_6, @name("bd_label") bit<16> bd_label_9, @name("uuc_mc_index") bit<16> uuc_mc_index_9, @name("bcast_mc_index") bit<16> bcast_mc_index_9, @name("umc_mc_index") bit<16> umc_mc_index_9, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_9, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_7, @name("ipv4_multicast_mode") bit<2> ipv4_multicast_mode_7, @name("ipv6_multicast_mode") bit<2> ipv6_multicast_mode_7, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_9, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_7, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_7, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_7, @name("stp_group") bit<10> stp_group_9) {
+        meta.ingress_metadata.vrf = vrf_9;
+        meta.ingress_metadata.bd = bd_7;
+        meta.ingress_metadata.outer_bd = (bit<8>)bd_7;
         meta.ingress_metadata.outer_ipv4_mcast_key_type = 1w1;
-        meta.ingress_metadata.outer_ipv4_mcast_key = (bit<8>)vrf;
+        meta.ingress_metadata.outer_ipv4_mcast_key = (bit<8>)vrf_9;
         meta.ingress_metadata.outer_ipv6_mcast_key_type = 1w1;
-        meta.ingress_metadata.outer_ipv6_mcast_key = (bit<8>)vrf;
-        meta.ingress_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled;
-        meta.ingress_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled;
-        meta.ingress_metadata.ipv4_multicast_mode = ipv4_multicast_mode;
-        meta.ingress_metadata.ipv6_multicast_mode = ipv6_multicast_mode;
-        meta.ingress_metadata.igmp_snooping_enabled = igmp_snooping_enabled;
-        meta.ingress_metadata.mld_snooping_enabled = mld_snooping_enabled;
-        meta.ingress_metadata.ipv4_urpf_mode = ipv4_urpf_mode;
-        meta.ingress_metadata.ipv6_urpf_mode = ipv6_urpf_mode;
-        meta.ingress_metadata.rmac_group = rmac_group;
-        meta.ingress_metadata.bd_mrpf_group = mrpf_group;
-        meta.ingress_metadata.uuc_mc_index = uuc_mc_index;
-        meta.ingress_metadata.umc_mc_index = umc_mc_index;
-        meta.ingress_metadata.bcast_mc_index = bcast_mc_index;
-        meta.ingress_metadata.bd_label = bd_label;
-        meta.ingress_metadata.stp_group = stp_group;
+        meta.ingress_metadata.outer_ipv6_mcast_key = (bit<8>)vrf_9;
+        meta.ingress_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled_9;
+        meta.ingress_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled_7;
+        meta.ingress_metadata.ipv4_multicast_mode = ipv4_multicast_mode_7;
+        meta.ingress_metadata.ipv6_multicast_mode = ipv6_multicast_mode_7;
+        meta.ingress_metadata.igmp_snooping_enabled = igmp_snooping_enabled_9;
+        meta.ingress_metadata.mld_snooping_enabled = mld_snooping_enabled_7;
+        meta.ingress_metadata.ipv4_urpf_mode = ipv4_urpf_mode_7;
+        meta.ingress_metadata.ipv6_urpf_mode = ipv6_urpf_mode_7;
+        meta.ingress_metadata.rmac_group = rmac_group_9;
+        meta.ingress_metadata.bd_mrpf_group = mrpf_group_6;
+        meta.ingress_metadata.uuc_mc_index = uuc_mc_index_9;
+        meta.ingress_metadata.umc_mc_index = umc_mc_index_9;
+        meta.ingress_metadata.bcast_mc_index = bcast_mc_index_9;
+        meta.ingress_metadata.bd_label = bd_label_9;
+        meta.ingress_metadata.stp_group = stp_group_9;
     }
     @name(".port_vlan_mapping") table port_vlan_mapping_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
+++ b/testdata/p4_14_samples_outputs/port_vlan_mapping-midend.p4
@@ -841,113 +841,113 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".set_bd") action set_bd(bit<16> outer_vlan_bd, bit<12> vrf, bit<10> rmac_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> igmp_snooping_enabled, bit<10> stp_group) {
-        meta._ingress_metadata_vrf22 = vrf;
-        meta._ingress_metadata_ipv4_unicast_enabled42 = ipv4_unicast_enabled;
-        meta._ingress_metadata_igmp_snooping_enabled46 = igmp_snooping_enabled;
-        meta._ingress_metadata_rmac_group56 = rmac_group;
-        meta._ingress_metadata_uuc_mc_index63 = uuc_mc_index;
-        meta._ingress_metadata_umc_mc_index64 = umc_mc_index;
-        meta._ingress_metadata_bcast_mc_index65 = bcast_mc_index;
-        meta._ingress_metadata_bd_label74 = bd_label;
+    @name(".set_bd") action set_bd(@name("outer_vlan_bd") bit<16> outer_vlan_bd, @name("vrf") bit<12> vrf_5, @name("rmac_group") bit<10> rmac_group_5, @name("bd_label") bit<16> bd_label_5, @name("uuc_mc_index") bit<16> uuc_mc_index_5, @name("bcast_mc_index") bit<16> bcast_mc_index_5, @name("umc_mc_index") bit<16> umc_mc_index_5, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_5, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_5, @name("stp_group") bit<10> stp_group_5) {
+        meta._ingress_metadata_vrf22 = vrf_5;
+        meta._ingress_metadata_ipv4_unicast_enabled42 = ipv4_unicast_enabled_5;
+        meta._ingress_metadata_igmp_snooping_enabled46 = igmp_snooping_enabled_5;
+        meta._ingress_metadata_rmac_group56 = rmac_group_5;
+        meta._ingress_metadata_uuc_mc_index63 = uuc_mc_index_5;
+        meta._ingress_metadata_umc_mc_index64 = umc_mc_index_5;
+        meta._ingress_metadata_bcast_mc_index65 = bcast_mc_index_5;
+        meta._ingress_metadata_bd_label74 = bd_label_5;
         meta._ingress_metadata_bd40 = outer_vlan_bd;
-        meta._ingress_metadata_stp_group109 = stp_group;
+        meta._ingress_metadata_stp_group109 = stp_group_5;
     }
-    @name(".set_outer_bd_ipv4_mcast_switch_ipv6_mcast_switch_flags") action set_outer_bd_ipv4_mcast_switch_ipv6_mcast_switch_flags(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<16> mrpf_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_multicast_mode, bit<2> ipv6_multicast_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<10> stp_group) {
-        meta._ingress_metadata_vrf22 = vrf;
-        meta._ingress_metadata_bd40 = bd;
-        meta._ingress_metadata_outer_bd27 = (bit<8>)bd;
+    @name(".set_outer_bd_ipv4_mcast_switch_ipv6_mcast_switch_flags") action set_outer_bd_ipv4_mcast_switch_ipv6_mcast_switch_flags(@name("bd") bit<16> bd_4, @name("vrf") bit<12> vrf_6, @name("rmac_group") bit<10> rmac_group_6, @name("mrpf_group") bit<16> mrpf_group, @name("bd_label") bit<16> bd_label_6, @name("uuc_mc_index") bit<16> uuc_mc_index_6, @name("bcast_mc_index") bit<16> bcast_mc_index_6, @name("umc_mc_index") bit<16> umc_mc_index_6, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_6, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_4, @name("ipv4_multicast_mode") bit<2> ipv4_multicast_mode_4, @name("ipv6_multicast_mode") bit<2> ipv6_multicast_mode_4, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_6, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_4, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_4, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_4, @name("stp_group") bit<10> stp_group_6) {
+        meta._ingress_metadata_vrf22 = vrf_6;
+        meta._ingress_metadata_bd40 = bd_4;
+        meta._ingress_metadata_outer_bd27 = (bit<8>)bd_4;
         meta._ingress_metadata_outer_ipv4_mcast_key_type28 = 1w0;
-        meta._ingress_metadata_outer_ipv4_mcast_key29 = (bit<8>)bd;
+        meta._ingress_metadata_outer_ipv4_mcast_key29 = (bit<8>)bd_4;
         meta._ingress_metadata_outer_ipv6_mcast_key_type30 = 1w0;
-        meta._ingress_metadata_outer_ipv6_mcast_key31 = (bit<8>)bd;
-        meta._ingress_metadata_ipv4_unicast_enabled42 = ipv4_unicast_enabled;
-        meta._ingress_metadata_ipv6_unicast_enabled43 = ipv6_unicast_enabled;
-        meta._ingress_metadata_ipv4_multicast_mode44 = ipv4_multicast_mode;
-        meta._ingress_metadata_ipv6_multicast_mode45 = ipv6_multicast_mode;
-        meta._ingress_metadata_igmp_snooping_enabled46 = igmp_snooping_enabled;
-        meta._ingress_metadata_mld_snooping_enabled47 = mld_snooping_enabled;
-        meta._ingress_metadata_ipv4_urpf_mode52 = ipv4_urpf_mode;
-        meta._ingress_metadata_ipv6_urpf_mode53 = ipv6_urpf_mode;
-        meta._ingress_metadata_rmac_group56 = rmac_group;
+        meta._ingress_metadata_outer_ipv6_mcast_key31 = (bit<8>)bd_4;
+        meta._ingress_metadata_ipv4_unicast_enabled42 = ipv4_unicast_enabled_6;
+        meta._ingress_metadata_ipv6_unicast_enabled43 = ipv6_unicast_enabled_4;
+        meta._ingress_metadata_ipv4_multicast_mode44 = ipv4_multicast_mode_4;
+        meta._ingress_metadata_ipv6_multicast_mode45 = ipv6_multicast_mode_4;
+        meta._ingress_metadata_igmp_snooping_enabled46 = igmp_snooping_enabled_6;
+        meta._ingress_metadata_mld_snooping_enabled47 = mld_snooping_enabled_4;
+        meta._ingress_metadata_ipv4_urpf_mode52 = ipv4_urpf_mode_4;
+        meta._ingress_metadata_ipv6_urpf_mode53 = ipv6_urpf_mode_4;
+        meta._ingress_metadata_rmac_group56 = rmac_group_6;
         meta._ingress_metadata_bd_mrpf_group60 = mrpf_group;
-        meta._ingress_metadata_uuc_mc_index63 = uuc_mc_index;
-        meta._ingress_metadata_umc_mc_index64 = umc_mc_index;
-        meta._ingress_metadata_bcast_mc_index65 = bcast_mc_index;
-        meta._ingress_metadata_bd_label74 = bd_label;
-        meta._ingress_metadata_stp_group109 = stp_group;
+        meta._ingress_metadata_uuc_mc_index63 = uuc_mc_index_6;
+        meta._ingress_metadata_umc_mc_index64 = umc_mc_index_6;
+        meta._ingress_metadata_bcast_mc_index65 = bcast_mc_index_6;
+        meta._ingress_metadata_bd_label74 = bd_label_6;
+        meta._ingress_metadata_stp_group109 = stp_group_6;
     }
-    @name(".set_outer_bd_ipv4_mcast_switch_ipv6_mcast_route_flags") action set_outer_bd_ipv4_mcast_switch_ipv6_mcast_route_flags(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<16> mrpf_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_multicast_mode, bit<2> ipv6_multicast_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<10> stp_group) {
-        meta._ingress_metadata_vrf22 = vrf;
-        meta._ingress_metadata_bd40 = bd;
-        meta._ingress_metadata_outer_bd27 = (bit<8>)bd;
+    @name(".set_outer_bd_ipv4_mcast_switch_ipv6_mcast_route_flags") action set_outer_bd_ipv4_mcast_switch_ipv6_mcast_route_flags(@name("bd") bit<16> bd_5, @name("vrf") bit<12> vrf_7, @name("rmac_group") bit<10> rmac_group_7, @name("mrpf_group") bit<16> mrpf_group_4, @name("bd_label") bit<16> bd_label_7, @name("uuc_mc_index") bit<16> uuc_mc_index_7, @name("bcast_mc_index") bit<16> bcast_mc_index_7, @name("umc_mc_index") bit<16> umc_mc_index_7, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_7, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_5, @name("ipv4_multicast_mode") bit<2> ipv4_multicast_mode_5, @name("ipv6_multicast_mode") bit<2> ipv6_multicast_mode_5, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_7, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_5, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_5, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_5, @name("stp_group") bit<10> stp_group_7) {
+        meta._ingress_metadata_vrf22 = vrf_7;
+        meta._ingress_metadata_bd40 = bd_5;
+        meta._ingress_metadata_outer_bd27 = (bit<8>)bd_5;
         meta._ingress_metadata_outer_ipv4_mcast_key_type28 = 1w0;
-        meta._ingress_metadata_outer_ipv4_mcast_key29 = (bit<8>)bd;
+        meta._ingress_metadata_outer_ipv4_mcast_key29 = (bit<8>)bd_5;
         meta._ingress_metadata_outer_ipv6_mcast_key_type30 = 1w1;
-        meta._ingress_metadata_outer_ipv6_mcast_key31 = (bit<8>)vrf;
-        meta._ingress_metadata_ipv4_unicast_enabled42 = ipv4_unicast_enabled;
-        meta._ingress_metadata_ipv6_unicast_enabled43 = ipv6_unicast_enabled;
-        meta._ingress_metadata_ipv4_multicast_mode44 = ipv4_multicast_mode;
-        meta._ingress_metadata_ipv6_multicast_mode45 = ipv6_multicast_mode;
-        meta._ingress_metadata_igmp_snooping_enabled46 = igmp_snooping_enabled;
-        meta._ingress_metadata_mld_snooping_enabled47 = mld_snooping_enabled;
-        meta._ingress_metadata_ipv4_urpf_mode52 = ipv4_urpf_mode;
-        meta._ingress_metadata_ipv6_urpf_mode53 = ipv6_urpf_mode;
-        meta._ingress_metadata_rmac_group56 = rmac_group;
-        meta._ingress_metadata_bd_mrpf_group60 = mrpf_group;
-        meta._ingress_metadata_uuc_mc_index63 = uuc_mc_index;
-        meta._ingress_metadata_umc_mc_index64 = umc_mc_index;
-        meta._ingress_metadata_bcast_mc_index65 = bcast_mc_index;
-        meta._ingress_metadata_bd_label74 = bd_label;
-        meta._ingress_metadata_stp_group109 = stp_group;
+        meta._ingress_metadata_outer_ipv6_mcast_key31 = (bit<8>)vrf_7;
+        meta._ingress_metadata_ipv4_unicast_enabled42 = ipv4_unicast_enabled_7;
+        meta._ingress_metadata_ipv6_unicast_enabled43 = ipv6_unicast_enabled_5;
+        meta._ingress_metadata_ipv4_multicast_mode44 = ipv4_multicast_mode_5;
+        meta._ingress_metadata_ipv6_multicast_mode45 = ipv6_multicast_mode_5;
+        meta._ingress_metadata_igmp_snooping_enabled46 = igmp_snooping_enabled_7;
+        meta._ingress_metadata_mld_snooping_enabled47 = mld_snooping_enabled_5;
+        meta._ingress_metadata_ipv4_urpf_mode52 = ipv4_urpf_mode_5;
+        meta._ingress_metadata_ipv6_urpf_mode53 = ipv6_urpf_mode_5;
+        meta._ingress_metadata_rmac_group56 = rmac_group_7;
+        meta._ingress_metadata_bd_mrpf_group60 = mrpf_group_4;
+        meta._ingress_metadata_uuc_mc_index63 = uuc_mc_index_7;
+        meta._ingress_metadata_umc_mc_index64 = umc_mc_index_7;
+        meta._ingress_metadata_bcast_mc_index65 = bcast_mc_index_7;
+        meta._ingress_metadata_bd_label74 = bd_label_7;
+        meta._ingress_metadata_stp_group109 = stp_group_7;
     }
-    @name(".set_outer_bd_ipv4_mcast_route_ipv6_mcast_switch_flags") action set_outer_bd_ipv4_mcast_route_ipv6_mcast_switch_flags(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<16> mrpf_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_multicast_mode, bit<2> ipv6_multicast_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<10> stp_group) {
-        meta._ingress_metadata_vrf22 = vrf;
-        meta._ingress_metadata_bd40 = bd;
-        meta._ingress_metadata_outer_bd27 = (bit<8>)bd;
+    @name(".set_outer_bd_ipv4_mcast_route_ipv6_mcast_switch_flags") action set_outer_bd_ipv4_mcast_route_ipv6_mcast_switch_flags(@name("bd") bit<16> bd_6, @name("vrf") bit<12> vrf_8, @name("rmac_group") bit<10> rmac_group_8, @name("mrpf_group") bit<16> mrpf_group_5, @name("bd_label") bit<16> bd_label_8, @name("uuc_mc_index") bit<16> uuc_mc_index_8, @name("bcast_mc_index") bit<16> bcast_mc_index_8, @name("umc_mc_index") bit<16> umc_mc_index_8, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_8, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_6, @name("ipv4_multicast_mode") bit<2> ipv4_multicast_mode_6, @name("ipv6_multicast_mode") bit<2> ipv6_multicast_mode_6, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_8, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_6, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_6, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_6, @name("stp_group") bit<10> stp_group_8) {
+        meta._ingress_metadata_vrf22 = vrf_8;
+        meta._ingress_metadata_bd40 = bd_6;
+        meta._ingress_metadata_outer_bd27 = (bit<8>)bd_6;
         meta._ingress_metadata_outer_ipv4_mcast_key_type28 = 1w1;
-        meta._ingress_metadata_outer_ipv4_mcast_key29 = (bit<8>)vrf;
+        meta._ingress_metadata_outer_ipv4_mcast_key29 = (bit<8>)vrf_8;
         meta._ingress_metadata_outer_ipv6_mcast_key_type30 = 1w0;
-        meta._ingress_metadata_outer_ipv6_mcast_key31 = (bit<8>)bd;
-        meta._ingress_metadata_ipv4_unicast_enabled42 = ipv4_unicast_enabled;
-        meta._ingress_metadata_ipv6_unicast_enabled43 = ipv6_unicast_enabled;
-        meta._ingress_metadata_ipv4_multicast_mode44 = ipv4_multicast_mode;
-        meta._ingress_metadata_ipv6_multicast_mode45 = ipv6_multicast_mode;
-        meta._ingress_metadata_igmp_snooping_enabled46 = igmp_snooping_enabled;
-        meta._ingress_metadata_mld_snooping_enabled47 = mld_snooping_enabled;
-        meta._ingress_metadata_ipv4_urpf_mode52 = ipv4_urpf_mode;
-        meta._ingress_metadata_ipv6_urpf_mode53 = ipv6_urpf_mode;
-        meta._ingress_metadata_rmac_group56 = rmac_group;
-        meta._ingress_metadata_bd_mrpf_group60 = mrpf_group;
-        meta._ingress_metadata_uuc_mc_index63 = uuc_mc_index;
-        meta._ingress_metadata_umc_mc_index64 = umc_mc_index;
-        meta._ingress_metadata_bcast_mc_index65 = bcast_mc_index;
-        meta._ingress_metadata_bd_label74 = bd_label;
-        meta._ingress_metadata_stp_group109 = stp_group;
+        meta._ingress_metadata_outer_ipv6_mcast_key31 = (bit<8>)bd_6;
+        meta._ingress_metadata_ipv4_unicast_enabled42 = ipv4_unicast_enabled_8;
+        meta._ingress_metadata_ipv6_unicast_enabled43 = ipv6_unicast_enabled_6;
+        meta._ingress_metadata_ipv4_multicast_mode44 = ipv4_multicast_mode_6;
+        meta._ingress_metadata_ipv6_multicast_mode45 = ipv6_multicast_mode_6;
+        meta._ingress_metadata_igmp_snooping_enabled46 = igmp_snooping_enabled_8;
+        meta._ingress_metadata_mld_snooping_enabled47 = mld_snooping_enabled_6;
+        meta._ingress_metadata_ipv4_urpf_mode52 = ipv4_urpf_mode_6;
+        meta._ingress_metadata_ipv6_urpf_mode53 = ipv6_urpf_mode_6;
+        meta._ingress_metadata_rmac_group56 = rmac_group_8;
+        meta._ingress_metadata_bd_mrpf_group60 = mrpf_group_5;
+        meta._ingress_metadata_uuc_mc_index63 = uuc_mc_index_8;
+        meta._ingress_metadata_umc_mc_index64 = umc_mc_index_8;
+        meta._ingress_metadata_bcast_mc_index65 = bcast_mc_index_8;
+        meta._ingress_metadata_bd_label74 = bd_label_8;
+        meta._ingress_metadata_stp_group109 = stp_group_8;
     }
-    @name(".set_outer_bd_ipv4_mcast_route_ipv6_mcast_route_flags") action set_outer_bd_ipv4_mcast_route_ipv6_mcast_route_flags(bit<16> bd, bit<12> vrf, bit<10> rmac_group, bit<16> mrpf_group, bit<16> bd_label, bit<16> uuc_mc_index, bit<16> bcast_mc_index, bit<16> umc_mc_index, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_multicast_mode, bit<2> ipv6_multicast_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<10> stp_group) {
-        meta._ingress_metadata_vrf22 = vrf;
-        meta._ingress_metadata_bd40 = bd;
-        meta._ingress_metadata_outer_bd27 = (bit<8>)bd;
+    @name(".set_outer_bd_ipv4_mcast_route_ipv6_mcast_route_flags") action set_outer_bd_ipv4_mcast_route_ipv6_mcast_route_flags(@name("bd") bit<16> bd_7, @name("vrf") bit<12> vrf_9, @name("rmac_group") bit<10> rmac_group_9, @name("mrpf_group") bit<16> mrpf_group_6, @name("bd_label") bit<16> bd_label_9, @name("uuc_mc_index") bit<16> uuc_mc_index_9, @name("bcast_mc_index") bit<16> bcast_mc_index_9, @name("umc_mc_index") bit<16> umc_mc_index_9, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_9, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_7, @name("ipv4_multicast_mode") bit<2> ipv4_multicast_mode_7, @name("ipv6_multicast_mode") bit<2> ipv6_multicast_mode_7, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_9, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_7, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_7, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_7, @name("stp_group") bit<10> stp_group_9) {
+        meta._ingress_metadata_vrf22 = vrf_9;
+        meta._ingress_metadata_bd40 = bd_7;
+        meta._ingress_metadata_outer_bd27 = (bit<8>)bd_7;
         meta._ingress_metadata_outer_ipv4_mcast_key_type28 = 1w1;
-        meta._ingress_metadata_outer_ipv4_mcast_key29 = (bit<8>)vrf;
+        meta._ingress_metadata_outer_ipv4_mcast_key29 = (bit<8>)vrf_9;
         meta._ingress_metadata_outer_ipv6_mcast_key_type30 = 1w1;
-        meta._ingress_metadata_outer_ipv6_mcast_key31 = (bit<8>)vrf;
-        meta._ingress_metadata_ipv4_unicast_enabled42 = ipv4_unicast_enabled;
-        meta._ingress_metadata_ipv6_unicast_enabled43 = ipv6_unicast_enabled;
-        meta._ingress_metadata_ipv4_multicast_mode44 = ipv4_multicast_mode;
-        meta._ingress_metadata_ipv6_multicast_mode45 = ipv6_multicast_mode;
-        meta._ingress_metadata_igmp_snooping_enabled46 = igmp_snooping_enabled;
-        meta._ingress_metadata_mld_snooping_enabled47 = mld_snooping_enabled;
-        meta._ingress_metadata_ipv4_urpf_mode52 = ipv4_urpf_mode;
-        meta._ingress_metadata_ipv6_urpf_mode53 = ipv6_urpf_mode;
-        meta._ingress_metadata_rmac_group56 = rmac_group;
-        meta._ingress_metadata_bd_mrpf_group60 = mrpf_group;
-        meta._ingress_metadata_uuc_mc_index63 = uuc_mc_index;
-        meta._ingress_metadata_umc_mc_index64 = umc_mc_index;
-        meta._ingress_metadata_bcast_mc_index65 = bcast_mc_index;
-        meta._ingress_metadata_bd_label74 = bd_label;
-        meta._ingress_metadata_stp_group109 = stp_group;
+        meta._ingress_metadata_outer_ipv6_mcast_key31 = (bit<8>)vrf_9;
+        meta._ingress_metadata_ipv4_unicast_enabled42 = ipv4_unicast_enabled_9;
+        meta._ingress_metadata_ipv6_unicast_enabled43 = ipv6_unicast_enabled_7;
+        meta._ingress_metadata_ipv4_multicast_mode44 = ipv4_multicast_mode_7;
+        meta._ingress_metadata_ipv6_multicast_mode45 = ipv6_multicast_mode_7;
+        meta._ingress_metadata_igmp_snooping_enabled46 = igmp_snooping_enabled_9;
+        meta._ingress_metadata_mld_snooping_enabled47 = mld_snooping_enabled_7;
+        meta._ingress_metadata_ipv4_urpf_mode52 = ipv4_urpf_mode_7;
+        meta._ingress_metadata_ipv6_urpf_mode53 = ipv6_urpf_mode_7;
+        meta._ingress_metadata_rmac_group56 = rmac_group_9;
+        meta._ingress_metadata_bd_mrpf_group60 = mrpf_group_6;
+        meta._ingress_metadata_uuc_mc_index63 = uuc_mc_index_9;
+        meta._ingress_metadata_umc_mc_index64 = umc_mc_index_9;
+        meta._ingress_metadata_bcast_mc_index65 = bcast_mc_index_9;
+        meta._ingress_metadata_bd_label74 = bd_label_9;
+        meta._ingress_metadata_stp_group109 = stp_group_9;
     }
     @name(".port_vlan_mapping") table port_vlan_mapping_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/queueing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-frontend.p4
@@ -72,7 +72,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name(".set_port") action set_port(bit<9> port) {
+    @name(".set_port") action set_port(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     @name("._drop") action _drop() {

--- a/testdata/p4_14_samples_outputs/queueing-midend.p4
+++ b/testdata/p4_14_samples_outputs/queueing-midend.p4
@@ -72,7 +72,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name(".set_port") action set_port(bit<9> port) {
+    @name(".set_port") action set_port(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     @name("._drop") action _drop() {

--- a/testdata/p4_14_samples_outputs/register-frontend.p4
+++ b/testdata/p4_14_samples_outputs/register-frontend.p4
@@ -47,7 +47,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".m_action") action m_action(bit<14> register_idx) {
+    @name(".m_action") action m_action(@name("register_idx") bit<14> register_idx) {
         my_register.read(meta.meta.register_tmp, register_idx);
     }
     @name("._nop") action _nop() {

--- a/testdata/p4_14_samples_outputs/register-midend.p4
+++ b/testdata/p4_14_samples_outputs/register-midend.p4
@@ -46,7 +46,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".m_action") action m_action(bit<14> register_idx) {
+    @name(".m_action") action m_action(@name("register_idx") bit<14> register_idx) {
         my_register.read(meta._meta_register_tmp0, register_idx);
     }
     @name("._nop") action _nop() {

--- a/testdata/p4_14_samples_outputs/repeater-frontend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-frontend.p4
@@ -32,8 +32,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".my_drop") action my_drop() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
-        standard_metadata.egress_spec = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<9> egress_port_1) {
+        standard_metadata.egress_spec = egress_port_1;
     }
     @name(".repeater") table repeater_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/repeater-midend.p4
+++ b/testdata/p4_14_samples_outputs/repeater-midend.p4
@@ -32,8 +32,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".my_drop") action my_drop() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_egress_port") action set_egress_port(bit<9> egress_port) {
-        standard_metadata.egress_spec = egress_port;
+    @name(".set_egress_port") action set_egress_port(@name("egress_port") bit<9> egress_port_1) {
+        standard_metadata.egress_spec = egress_port_1;
     }
     @name(".repeater") table repeater_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/resubmit-frontend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-frontend.p4
@@ -51,7 +51,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop_2() {
     }
-    @name(".set_port") action set_port(bit<9> port) {
+    @name(".set_port") action set_port(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     @name("._resubmit") action _resubmit() {

--- a/testdata/p4_14_samples_outputs/resubmit-midend.p4
+++ b/testdata/p4_14_samples_outputs/resubmit-midend.p4
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop_2() {
     }
-    @name(".set_port") action set_port(bit<9> port) {
+    @name(".set_port") action set_port(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     @name("._resubmit") action _resubmit() {

--- a/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-frontend.p4
@@ -155,8 +155,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_17() {
     }
     @name(".port_counters") direct_counter(CounterType.packets) port_counters_0;
-    @name(".fdb_set") action fdb_set(bit<1> type_, bit<9> port_id) {
-        meta.ingress_metadata.mac_type = type_;
+    @name(".fdb_set") action fdb_set(@name("type_") bit<1> type_4, @name("port_id") bit<9> port_id) {
+        meta.ingress_metadata.mac_type = type_4;
         standard_metadata.egress_spec = port_id;
         meta.ingress_metadata.routed = 1w0;
     }
@@ -165,57 +165,57 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".generate_learn_notify") action generate_learn_notify() {
         digest<mac_learn_digest>(32w1024, (mac_learn_digest){vlan_id = meta.ingress_metadata.vlan_id,srcAddr = hdr.eth.srcAddr,ingress_port = standard_metadata.ingress_port,learning = meta.ingress_metadata.learning});
     }
-    @name(".set_dmac") action set_dmac(bit<48> dst_mac_address, bit<9> port_id) {
+    @name(".set_dmac") action set_dmac(@name("dst_mac_address") bit<48> dst_mac_address, @name("port_id") bit<9> port_id_3) {
         hdr.eth.dstAddr = dst_mac_address;
         hdr.eth.srcAddr = meta.ingress_metadata.def_smac;
-        standard_metadata.egress_spec = port_id;
+        standard_metadata.egress_spec = port_id_3;
     }
-    @name(".set_next_hop") action set_next_hop(bit<8> type_, bit<8> ip, bit<16> router_interface_id) {
+    @name(".set_next_hop") action set_next_hop(@name("type_") bit<8> type_5, @name("ip") bit<8> ip, @name("router_interface_id") bit<16> router_interface_id) {
         meta.ingress_metadata.router_intf = router_interface_id;
     }
-    @name(".route_set_trap") action route_set_trap(bit<3> trap_priority) {
+    @name(".route_set_trap") action route_set_trap(@name("trap_priority") bit<3> trap_priority) {
         meta.ingress_metadata.pri = trap_priority;
         meta.ingress_metadata.copy_to_cpu = 1w1;
     }
-    @name(".route_set_nexthop") action route_set_nexthop(bit<16> next_hop_id) {
+    @name(".route_set_nexthop") action route_set_nexthop(@name("next_hop_id") bit<16> next_hop_id) {
         meta.ingress_metadata.nhop = next_hop_id;
         meta.ingress_metadata.routed = 1w1;
         meta.ingress_metadata.ip_dest = hdr.ipv4.dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".route_set_nexthop_group") action route_set_nexthop_group(bit<16> next_hop_group_id) {
+    @name(".route_set_nexthop_group") action route_set_nexthop_group(@name("next_hop_group_id") bit<16> next_hop_group_id) {
         meta.ingress_metadata.ecmp_nhop = next_hop_group_id;
         meta.ingress_metadata.routed = 1w1;
         meta.ingress_metadata.ip_dest = hdr.ipv4.dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".set_router_interface") action set_router_interface(bit<16> virtual_router_id, bit<1> type_, bit<9> port_id, bit<12> vlan_id, bit<48> src_mac_address, bit<1> admin_v4_state, bit<1> admin_v6_state, bit<14> mtu) {
+    @name(".set_router_interface") action set_router_interface(@name("virtual_router_id") bit<16> virtual_router_id, @name("type_") bit<1> type_6, @name("port_id") bit<9> port_id_4, @name("vlan_id") bit<12> vlan_id_1, @name("src_mac_address") bit<48> src_mac_address, @name("admin_v4_state") bit<1> admin_v4_state, @name("admin_v6_state") bit<1> admin_v6_state, @name("mtu") bit<14> mtu_2) {
         meta.ingress_metadata.vrf = virtual_router_id;
-        meta.ingress_metadata.interface_type = type_;
-        standard_metadata.egress_spec = port_id;
-        meta.ingress_metadata.vlan_id = vlan_id;
+        meta.ingress_metadata.interface_type = type_6;
+        standard_metadata.egress_spec = port_id_4;
+        meta.ingress_metadata.vlan_id = vlan_id_1;
         meta.ingress_metadata.def_smac = src_mac_address;
         meta.ingress_metadata.v4_enable = admin_v4_state;
         meta.ingress_metadata.v6_enable = admin_v6_state;
-        meta.ingress_metadata.mtu = mtu;
+        meta.ingress_metadata.mtu = mtu_2;
         meta.ingress_metadata.router_mac = 1w1;
     }
     @name(".router_interface_miss") action router_interface_miss() {
         meta.ingress_metadata.router_mac = 1w0;
     }
-    @name(".set_switch") action set_switch(bit<8> port_number, bit<16> cpu_port, bit<8> max_virtual_routers, bit<8> fdb_table_size, bit<8> on_link_route_supported, bit<2> oper_status, bit<8> max_temp, bit<8> switching_mode, bit<8> cpu_flood_enable, bit<8> ttl1_action, bit<12> port_vlan_id, bit<48> src_mac_address, bit<8> fdb_aging_time, bit<8> fdb_unicast_miss_action, bit<8> fdb_broadcast_miss_action, bit<8> fdb_multicast_miss_action, bit<8> ecmp_hash_seed, bit<8> ecmp_hash_type, bit<8> ecmp_hash_fields, bit<8> ecmp_max_paths, bit<16> vr_id) {
+    @name(".set_switch") action set_switch(@name("port_number") bit<8> port_number, @name("cpu_port") bit<16> cpu_port_1, @name("max_virtual_routers") bit<8> max_virtual_routers, @name("fdb_table_size") bit<8> fdb_table_size, @name("on_link_route_supported") bit<8> on_link_route_supported, @name("oper_status") bit<2> oper_status_2, @name("max_temp") bit<8> max_temp, @name("switching_mode") bit<8> switching_mode, @name("cpu_flood_enable") bit<8> cpu_flood_enable, @name("ttl1_action") bit<8> ttl1_action, @name("port_vlan_id") bit<12> port_vlan_id, @name("src_mac_address") bit<48> src_mac_address_3, @name("fdb_aging_time") bit<8> fdb_aging_time, @name("fdb_unicast_miss_action") bit<8> fdb_unicast_miss_action, @name("fdb_broadcast_miss_action") bit<8> fdb_broadcast_miss_action, @name("fdb_multicast_miss_action") bit<8> fdb_multicast_miss_action, @name("ecmp_hash_seed") bit<8> ecmp_hash_seed, @name("ecmp_hash_type") bit<8> ecmp_hash_type, @name("ecmp_hash_fields") bit<8> ecmp_hash_fields, @name("ecmp_max_paths") bit<8> ecmp_max_paths, @name("vr_id") bit<16> vr_id) {
         meta.ingress_metadata.def_vlan = port_vlan_id;
         meta.ingress_metadata.vrf = vr_id;
-        meta.ingress_metadata.def_smac = src_mac_address;
-        meta.ingress_metadata.cpu_port = cpu_port;
+        meta.ingress_metadata.def_smac = src_mac_address_3;
+        meta.ingress_metadata.cpu_port = cpu_port_1;
         meta.ingress_metadata.max_ports = port_number;
-        meta.ingress_metadata.oper_status = oper_status;
+        meta.ingress_metadata.oper_status = oper_status_2;
         standard_metadata.ingress_port = standard_metadata.ingress_port;
     }
-    @name(".set_router") action set_router(bit<1> admin_v4_state, bit<1> admin_v6_state, bit<48> src_mac_address, bit<8> violation_ttl1_action, bit<8> violation_ip_options) {
-        meta.ingress_metadata.def_smac = src_mac_address;
-        meta.ingress_metadata.v4_enable = admin_v4_state;
-        meta.ingress_metadata.v6_enable = admin_v6_state;
+    @name(".set_router") action set_router(@name("admin_v4_state") bit<1> admin_v4_state_2, @name("admin_v6_state") bit<1> admin_v6_state_2, @name("src_mac_address") bit<48> src_mac_address_4, @name("violation_ttl1_action") bit<8> violation_ttl1_action, @name("violation_ip_options") bit<8> violation_ip_options) {
+        meta.ingress_metadata.def_smac = src_mac_address_4;
+        meta.ingress_metadata.v4_enable = admin_v4_state_2;
+        meta.ingress_metadata.v6_enable = admin_v6_state_2;
     }
     @name(".fdb") table fdb_0 {
         actions = {
@@ -263,22 +263,22 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = NoAction_12();
     }
-    @name(".set_in_port") action set_in_port_0(bit<10> port, bit<2> type_, bit<2> oper_status, bit<4> speed, bit<8> admin_state, bit<12> default_vlan, bit<8> default_vlan_priority, bit<1> ingress_filtering, bit<1> drop_untagged, bit<1> drop_tagged, bit<2> port_loopback_mode, bit<2> fdb_learning, bit<3> stp_state, bit<1> update_dscp, bit<14> mtu, bit<8> sflow, bit<8> flood_storm_control, bit<8> broadcast_storm_control, bit<8> multicast_storm_control, bit<2> global_flow_control, bit<16> max_learned_address, bit<8> fdb_learning_limit_violation) {
+    @name(".set_in_port") action set_in_port_0(@name("port") bit<10> port, @name("type_") bit<2> type_7, @name("oper_status") bit<2> oper_status_3, @name("speed") bit<4> speed, @name("admin_state") bit<8> admin_state, @name("default_vlan") bit<12> default_vlan, @name("default_vlan_priority") bit<8> default_vlan_priority, @name("ingress_filtering") bit<1> ingress_filtering, @name("drop_untagged") bit<1> drop_untagged_1, @name("drop_tagged") bit<1> drop_tagged_1, @name("port_loopback_mode") bit<2> port_loopback_mode, @name("fdb_learning") bit<2> fdb_learning, @name("stp_state") bit<3> stp_state_1, @name("update_dscp") bit<1> update_dscp_1, @name("mtu") bit<14> mtu_3, @name("sflow") bit<8> sflow, @name("flood_storm_control") bit<8> flood_storm_control, @name("broadcast_storm_control") bit<8> broadcast_storm_control, @name("multicast_storm_control") bit<8> multicast_storm_control, @name("global_flow_control") bit<2> global_flow_control, @name("max_learned_address") bit<16> max_learned_address, @name("fdb_learning_limit_violation") bit<8> fdb_learning_limit_violation) {
         port_counters_0.count();
         meta.ingress_metadata.port_lag = port;
         meta.ingress_metadata.mac_limit = max_learned_address;
-        meta.ingress_metadata.port_type = type_;
-        meta.ingress_metadata.oper_status = oper_status;
+        meta.ingress_metadata.port_type = type_7;
+        meta.ingress_metadata.oper_status = oper_status_3;
         meta.ingress_metadata.flow_ctrl = global_flow_control;
         meta.ingress_metadata.port_speed = speed;
         meta.ingress_metadata.drop_vlan = ingress_filtering;
-        meta.ingress_metadata.drop_tagged = drop_tagged;
-        meta.ingress_metadata.drop_untagged = drop_untagged;
+        meta.ingress_metadata.drop_tagged = drop_tagged_1;
+        meta.ingress_metadata.drop_untagged = drop_untagged_1;
         meta.ingress_metadata.port_mode = port_loopback_mode;
         meta.ingress_metadata.learning = fdb_learning;
-        meta.ingress_metadata.stp_state = stp_state;
-        meta.ingress_metadata.update_dscp = update_dscp;
-        meta.ingress_metadata.mtu = mtu;
+        meta.ingress_metadata.stp_state = stp_state_1;
+        meta.ingress_metadata.update_dscp = update_dscp_1;
+        meta.ingress_metadata.mtu = mtu_3;
         meta.ingress_metadata.vlan_id = default_vlan;
     }
     @name(".port") table port_0 {

--- a/testdata/p4_14_samples_outputs/sai_p4-midend.p4
+++ b/testdata/p4_14_samples_outputs/sai_p4-midend.p4
@@ -192,8 +192,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @noWarn("unused") @name(".NoAction") action NoAction_17() {
     }
     @name(".port_counters") direct_counter(CounterType.packets) port_counters_0;
-    @name(".fdb_set") action fdb_set(bit<1> type_, bit<9> port_id) {
-        meta._ingress_metadata_mac_type21 = type_;
+    @name(".fdb_set") action fdb_set(@name("type_") bit<1> type_4, @name("port_id") bit<9> port_id) {
+        meta._ingress_metadata_mac_type21 = type_4;
         standard_metadata.egress_spec = port_id;
         meta._ingress_metadata_routed5 = 1w0;
     }
@@ -202,56 +202,56 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".generate_learn_notify") action generate_learn_notify() {
         digest<mac_learn_digest>(32w1024, (mac_learn_digest){vlan_id = meta._ingress_metadata_vlan_id37,srcAddr = hdr.eth.srcAddr,ingress_port = standard_metadata.ingress_port,learning = meta._ingress_metadata_learning33});
     }
-    @name(".set_dmac") action set_dmac(bit<48> dst_mac_address, bit<9> port_id) {
+    @name(".set_dmac") action set_dmac(@name("dst_mac_address") bit<48> dst_mac_address, @name("port_id") bit<9> port_id_3) {
         hdr.eth.dstAddr = dst_mac_address;
         hdr.eth.srcAddr = meta._ingress_metadata_def_smac18;
-        standard_metadata.egress_spec = port_id;
+        standard_metadata.egress_spec = port_id_3;
     }
-    @name(".set_next_hop") action set_next_hop(bit<8> type_, bit<8> ip, bit<16> router_interface_id) {
+    @name(".set_next_hop") action set_next_hop(@name("type_") bit<8> type_5, @name("ip") bit<8> ip, @name("router_interface_id") bit<16> router_interface_id) {
         meta._ingress_metadata_router_intf9 = router_interface_id;
     }
-    @name(".route_set_trap") action route_set_trap(bit<3> trap_priority) {
+    @name(".route_set_trap") action route_set_trap(@name("trap_priority") bit<3> trap_priority) {
         meta._ingress_metadata_pri12 = trap_priority;
         meta._ingress_metadata_copy_to_cpu11 = 1w1;
     }
-    @name(".route_set_nexthop") action route_set_nexthop(bit<16> next_hop_id) {
+    @name(".route_set_nexthop") action route_set_nexthop(@name("next_hop_id") bit<16> next_hop_id) {
         meta._ingress_metadata_nhop7 = next_hop_id;
         meta._ingress_metadata_routed5 = 1w1;
         meta._ingress_metadata_ip_dest3 = hdr.ipv4.dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".route_set_nexthop_group") action route_set_nexthop_group(bit<16> next_hop_group_id) {
+    @name(".route_set_nexthop_group") action route_set_nexthop_group(@name("next_hop_group_id") bit<16> next_hop_group_id) {
         meta._ingress_metadata_ecmp_nhop8 = next_hop_group_id;
         meta._ingress_metadata_routed5 = 1w1;
         meta._ingress_metadata_ip_dest3 = hdr.ipv4.dstAddr;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name(".set_router_interface") action set_router_interface(bit<16> virtual_router_id, bit<1> type_, bit<9> port_id, bit<12> vlan_id, bit<48> src_mac_address, bit<1> admin_v4_state, bit<1> admin_v6_state, bit<14> mtu) {
+    @name(".set_router_interface") action set_router_interface(@name("virtual_router_id") bit<16> virtual_router_id, @name("type_") bit<1> type_6, @name("port_id") bit<9> port_id_4, @name("vlan_id") bit<12> vlan_id_1, @name("src_mac_address") bit<48> src_mac_address, @name("admin_v4_state") bit<1> admin_v4_state, @name("admin_v6_state") bit<1> admin_v6_state, @name("mtu") bit<14> mtu_2) {
         meta._ingress_metadata_vrf6 = virtual_router_id;
-        meta._ingress_metadata_interface_type34 = type_;
-        standard_metadata.egress_spec = port_id;
-        meta._ingress_metadata_vlan_id37 = vlan_id;
+        meta._ingress_metadata_interface_type34 = type_6;
+        standard_metadata.egress_spec = port_id_4;
+        meta._ingress_metadata_vlan_id37 = vlan_id_1;
         meta._ingress_metadata_def_smac18 = src_mac_address;
         meta._ingress_metadata_v4_enable35 = admin_v4_state;
         meta._ingress_metadata_v6_enable36 = admin_v6_state;
-        meta._ingress_metadata_mtu32 = mtu;
+        meta._ingress_metadata_mtu32 = mtu_2;
         meta._ingress_metadata_router_mac40 = 1w1;
     }
     @name(".router_interface_miss") action router_interface_miss() {
         meta._ingress_metadata_router_mac40 = 1w0;
     }
-    @name(".set_switch") action set_switch(bit<8> port_number, bit<16> cpu_port, bit<8> max_virtual_routers, bit<8> fdb_table_size, bit<8> on_link_route_supported, bit<2> oper_status, bit<8> max_temp, bit<8> switching_mode, bit<8> cpu_flood_enable, bit<8> ttl1_action, bit<12> port_vlan_id, bit<48> src_mac_address, bit<8> fdb_aging_time, bit<8> fdb_unicast_miss_action, bit<8> fdb_broadcast_miss_action, bit<8> fdb_multicast_miss_action, bit<8> ecmp_hash_seed, bit<8> ecmp_hash_type, bit<8> ecmp_hash_fields, bit<8> ecmp_max_paths, bit<16> vr_id) {
+    @name(".set_switch") action set_switch(@name("port_number") bit<8> port_number, @name("cpu_port") bit<16> cpu_port_1, @name("max_virtual_routers") bit<8> max_virtual_routers, @name("fdb_table_size") bit<8> fdb_table_size, @name("on_link_route_supported") bit<8> on_link_route_supported, @name("oper_status") bit<2> oper_status_2, @name("max_temp") bit<8> max_temp, @name("switching_mode") bit<8> switching_mode, @name("cpu_flood_enable") bit<8> cpu_flood_enable, @name("ttl1_action") bit<8> ttl1_action, @name("port_vlan_id") bit<12> port_vlan_id, @name("src_mac_address") bit<48> src_mac_address_3, @name("fdb_aging_time") bit<8> fdb_aging_time, @name("fdb_unicast_miss_action") bit<8> fdb_unicast_miss_action, @name("fdb_broadcast_miss_action") bit<8> fdb_broadcast_miss_action, @name("fdb_multicast_miss_action") bit<8> fdb_multicast_miss_action, @name("ecmp_hash_seed") bit<8> ecmp_hash_seed, @name("ecmp_hash_type") bit<8> ecmp_hash_type, @name("ecmp_hash_fields") bit<8> ecmp_hash_fields, @name("ecmp_max_paths") bit<8> ecmp_max_paths, @name("vr_id") bit<16> vr_id) {
         meta._ingress_metadata_def_vlan17 = port_vlan_id;
         meta._ingress_metadata_vrf6 = vr_id;
-        meta._ingress_metadata_def_smac18 = src_mac_address;
-        meta._ingress_metadata_cpu_port19 = cpu_port;
+        meta._ingress_metadata_def_smac18 = src_mac_address_3;
+        meta._ingress_metadata_cpu_port19 = cpu_port_1;
         meta._ingress_metadata_max_ports20 = port_number;
-        meta._ingress_metadata_oper_status22 = oper_status;
+        meta._ingress_metadata_oper_status22 = oper_status_2;
     }
-    @name(".set_router") action set_router(bit<1> admin_v4_state, bit<1> admin_v6_state, bit<48> src_mac_address, bit<8> violation_ttl1_action, bit<8> violation_ip_options) {
-        meta._ingress_metadata_def_smac18 = src_mac_address;
-        meta._ingress_metadata_v4_enable35 = admin_v4_state;
-        meta._ingress_metadata_v6_enable36 = admin_v6_state;
+    @name(".set_router") action set_router(@name("admin_v4_state") bit<1> admin_v4_state_2, @name("admin_v6_state") bit<1> admin_v6_state_2, @name("src_mac_address") bit<48> src_mac_address_4, @name("violation_ttl1_action") bit<8> violation_ttl1_action, @name("violation_ip_options") bit<8> violation_ip_options) {
+        meta._ingress_metadata_def_smac18 = src_mac_address_4;
+        meta._ingress_metadata_v4_enable35 = admin_v4_state_2;
+        meta._ingress_metadata_v6_enable36 = admin_v6_state_2;
     }
     @name(".fdb") table fdb_0 {
         actions = {
@@ -299,22 +299,22 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = NoAction_12();
     }
-    @name(".set_in_port") action set_in_port_0(bit<10> port, bit<2> type_, bit<2> oper_status, bit<4> speed, bit<8> admin_state, bit<12> default_vlan, bit<8> default_vlan_priority, bit<1> ingress_filtering, bit<1> drop_untagged, bit<1> drop_tagged, bit<2> port_loopback_mode, bit<2> fdb_learning, bit<3> stp_state, bit<1> update_dscp, bit<14> mtu, bit<8> sflow, bit<8> flood_storm_control, bit<8> broadcast_storm_control, bit<8> multicast_storm_control, bit<2> global_flow_control, bit<16> max_learned_address, bit<8> fdb_learning_limit_violation) {
+    @name(".set_in_port") action set_in_port_0(@name("port") bit<10> port, @name("type_") bit<2> type_7, @name("oper_status") bit<2> oper_status_3, @name("speed") bit<4> speed, @name("admin_state") bit<8> admin_state, @name("default_vlan") bit<12> default_vlan, @name("default_vlan_priority") bit<8> default_vlan_priority, @name("ingress_filtering") bit<1> ingress_filtering, @name("drop_untagged") bit<1> drop_untagged_1, @name("drop_tagged") bit<1> drop_tagged_1, @name("port_loopback_mode") bit<2> port_loopback_mode, @name("fdb_learning") bit<2> fdb_learning, @name("stp_state") bit<3> stp_state_1, @name("update_dscp") bit<1> update_dscp_1, @name("mtu") bit<14> mtu_3, @name("sflow") bit<8> sflow, @name("flood_storm_control") bit<8> flood_storm_control, @name("broadcast_storm_control") bit<8> broadcast_storm_control, @name("multicast_storm_control") bit<8> multicast_storm_control, @name("global_flow_control") bit<2> global_flow_control, @name("max_learned_address") bit<16> max_learned_address, @name("fdb_learning_limit_violation") bit<8> fdb_learning_limit_violation) {
         port_counters_0.count();
         meta._ingress_metadata_port_lag1 = port;
         meta._ingress_metadata_mac_limit16 = max_learned_address;
-        meta._ingress_metadata_port_type23 = type_;
-        meta._ingress_metadata_oper_status22 = oper_status;
+        meta._ingress_metadata_port_type23 = type_7;
+        meta._ingress_metadata_oper_status22 = oper_status_3;
         meta._ingress_metadata_flow_ctrl25 = global_flow_control;
         meta._ingress_metadata_port_speed27 = speed;
         meta._ingress_metadata_drop_vlan28 = ingress_filtering;
-        meta._ingress_metadata_drop_tagged29 = drop_tagged;
-        meta._ingress_metadata_drop_untagged30 = drop_untagged;
+        meta._ingress_metadata_drop_tagged29 = drop_tagged_1;
+        meta._ingress_metadata_drop_untagged30 = drop_untagged_1;
         meta._ingress_metadata_port_mode26 = port_loopback_mode;
         meta._ingress_metadata_learning33 = fdb_learning;
-        meta._ingress_metadata_stp_state24 = stp_state;
-        meta._ingress_metadata_update_dscp31 = update_dscp;
-        meta._ingress_metadata_mtu32 = mtu;
+        meta._ingress_metadata_stp_state24 = stp_state_1;
+        meta._ingress_metadata_update_dscp31 = update_dscp_1;
+        meta._ingress_metadata_mtu32 = mtu_3;
         meta._ingress_metadata_vlan_id37 = default_vlan;
     }
     @name(".port") table port_0 {

--- a/testdata/p4_14_samples_outputs/selector1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector1-frontend.p4
@@ -35,7 +35,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop() {
     }
-    @name(".setf1") action setf1(bit<32> val) {
+    @name(".setf1") action setf1(@name("val") bit<32> val) {
         hdr.data.f1 = val;
     }
     @name(".test1") table test1_0 {

--- a/testdata/p4_14_samples_outputs/selector1-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector1-midend.p4
@@ -35,7 +35,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop() {
     }
-    @name(".setf1") action setf1(bit<32> val) {
+    @name(".setf1") action setf1(@name("val") bit<32> val) {
         hdr.data.f1 = val;
     }
     @name(".test1") table test1_0 {

--- a/testdata/p4_14_samples_outputs/selector2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector2-frontend.p4
@@ -35,7 +35,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop() {
     }
-    @name(".setf1") action setf1(bit<32> val) {
+    @name(".setf1") action setf1(@name("val") bit<32> val) {
         hdr.data.f1 = val;
     }
     @name(".test1") table test1_0 {

--- a/testdata/p4_14_samples_outputs/selector2-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector2-midend.p4
@@ -35,7 +35,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop() {
     }
-    @name(".setf1") action setf1(bit<32> val) {
+    @name(".setf1") action setf1(@name("val") bit<32> val) {
         hdr.data.f1 = val;
     }
     @name(".test1") table test1_0 {

--- a/testdata/p4_14_samples_outputs/selector3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/selector3-frontend.p4
@@ -35,10 +35,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop() {
     }
-    @name(".setf1") action setf1(bit<32> val) {
+    @name(".setf1") action setf1(@name("val") bit<32> val) {
         hdr.data.f1 = val;
     }
-    @name(".setall") action setall(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4) {
+    @name(".setall") action setall(@name("v1") bit<32> v1, @name("v2") bit<32> v2, @name("v3") bit<32> v3, @name("v4") bit<32> v4) {
         hdr.data.f1 = v1;
         hdr.data.f2 = v2;
         hdr.data.f3 = v3;

--- a/testdata/p4_14_samples_outputs/selector3-midend.p4
+++ b/testdata/p4_14_samples_outputs/selector3-midend.p4
@@ -35,10 +35,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop() {
     }
-    @name(".setf1") action setf1(bit<32> val) {
+    @name(".setf1") action setf1(@name("val") bit<32> val) {
         hdr.data.f1 = val;
     }
-    @name(".setall") action setall(bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4) {
+    @name(".setall") action setall(@name("v1") bit<32> v1, @name("v2") bit<32> v2, @name("v3") bit<32> v3, @name("v4") bit<32> v4) {
         hdr.data.f1 = v1;
         hdr.data.f2 = v2;
         hdr.data.f3 = v3;

--- a/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-frontend.p4
@@ -125,7 +125,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name(".do_rewrites") action do_rewrites(bit<48> smac) {
+    @name(".do_rewrites") action do_rewrites(@name("smac") bit<48> smac) {
         hdr.cpu_header.setInvalid();
         hdr.ethernet.srcAddr = smac;
         hdr.ipv4.srcAddr = meta.meta.ipv4_sa;
@@ -180,7 +180,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name(".set_dmac") action set_dmac(bit<48> dmac) {
+    @name(".set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
@@ -195,13 +195,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_8() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
+    @name(".set_if_info") action set_if_info(@name("ipv4_addr") bit<32> ipv4_addr, @name("mac_addr") bit<48> mac_addr, @name("is_ext") bit<1> is_ext) {
         meta.meta.if_ipv4_addr = ipv4_addr;
         meta.meta.if_mac_addr = mac_addr;
         meta.meta.is_ext_if = is_ext;
     }
-    @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta.meta.nhop_ipv4 = nhop_ipv4;
+    @name(".set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta.meta.nhop_ipv4 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
@@ -212,15 +212,15 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.meta.do_forward = 1w0;
         mark_to_drop(standard_metadata);
     }
-    @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
+    @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(@name("srcAddr") bit<32> srcAddr_1, @name("srcPort") bit<16> srcPort_1) {
         meta.meta.do_forward = 1w1;
-        meta.meta.ipv4_sa = srcAddr;
-        meta.meta.tcp_sp = srcPort;
+        meta.meta.ipv4_sa = srcAddr_1;
+        meta.meta.tcp_sp = srcPort_1;
     }
-    @name(".nat_hit_ext_to_int") action nat_hit_ext_to_int(bit<32> dstAddr, bit<16> dstPort) {
+    @name(".nat_hit_ext_to_int") action nat_hit_ext_to_int(@name("dstAddr") bit<32> dstAddr_1, @name("dstPort") bit<16> dstPort_1) {
         meta.meta.do_forward = 1w1;
-        meta.meta.ipv4_da = dstAddr;
-        meta.meta.tcp_dp = dstPort;
+        meta.meta.ipv4_da = dstAddr_1;
+        meta.meta.tcp_dp = dstPort_1;
     }
     @name(".nat_no_nat") action nat_no_nat() {
         meta.meta.do_forward = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_nat-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_nat-midend.p4
@@ -132,7 +132,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name(".do_rewrites") action do_rewrites(bit<48> smac) {
+    @name(".do_rewrites") action do_rewrites(@name("smac") bit<48> smac) {
         hdr.cpu_header.setInvalid();
         hdr.ethernet.srcAddr = smac;
         hdr.ipv4.srcAddr = meta._meta_ipv4_sa1;
@@ -191,7 +191,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name(".set_dmac") action set_dmac(bit<48> dmac) {
+    @name(".set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
@@ -206,13 +206,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_8() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_if_info") action set_if_info(bit<32> ipv4_addr, bit<48> mac_addr, bit<1> is_ext) {
+    @name(".set_if_info") action set_if_info(@name("ipv4_addr") bit<32> ipv4_addr, @name("mac_addr") bit<48> mac_addr, @name("is_ext") bit<1> is_ext) {
         meta._meta_if_ipv4_addr6 = ipv4_addr;
         meta._meta_if_mac_addr7 = mac_addr;
         meta._meta_is_ext_if8 = is_ext;
     }
-    @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta._meta_nhop_ipv45 = nhop_ipv4;
+    @name(".set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta._meta_nhop_ipv45 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
@@ -223,15 +223,15 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._meta_do_forward0 = 1w0;
         mark_to_drop(standard_metadata);
     }
-    @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(bit<32> srcAddr, bit<16> srcPort) {
+    @name(".nat_hit_int_to_ext") action nat_hit_int_to_ext(@name("srcAddr") bit<32> srcAddr_1, @name("srcPort") bit<16> srcPort_1) {
         meta._meta_do_forward0 = 1w1;
-        meta._meta_ipv4_sa1 = srcAddr;
-        meta._meta_tcp_sp3 = srcPort;
+        meta._meta_ipv4_sa1 = srcAddr_1;
+        meta._meta_tcp_sp3 = srcPort_1;
     }
-    @name(".nat_hit_ext_to_int") action nat_hit_ext_to_int(bit<32> dstAddr, bit<16> dstPort) {
+    @name(".nat_hit_ext_to_int") action nat_hit_ext_to_int(@name("dstAddr") bit<32> dstAddr_1, @name("dstPort") bit<16> dstPort_1) {
         meta._meta_do_forward0 = 1w1;
-        meta._meta_ipv4_da2 = dstAddr;
-        meta._meta_tcp_dp4 = dstPort;
+        meta._meta_ipv4_da2 = dstAddr_1;
+        meta._meta_tcp_dp4 = dstPort_1;
     }
     @name(".nat_no_nat") action nat_no_nat() {
         meta._meta_do_forward0 = 1w1;

--- a/testdata/p4_14_samples_outputs/simple_router-frontend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-frontend.p4
@@ -59,7 +59,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name(".rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
@@ -94,11 +94,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_6() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_dmac") action set_dmac(bit<48> dmac) {
+    @name(".set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
-    @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta.routing_metadata.nhop_ipv4 = nhop_ipv4;
+    @name(".set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta.routing_metadata.nhop_ipv4 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }

--- a/testdata/p4_14_samples_outputs/simple_router-midend.p4
+++ b/testdata/p4_14_samples_outputs/simple_router-midend.p4
@@ -58,7 +58,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name(".rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
@@ -93,11 +93,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_6() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_dmac") action set_dmac(bit<48> dmac) {
+    @name(".set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
-    @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta._routing_metadata_nhop_ipv40 = nhop_ipv4;
+    @name(".set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta._routing_metadata_nhop_ipv40 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-first.p4
@@ -2270,7 +2270,6 @@ control process_int_insertion(inout headers hdr, inout metadata meta, inout stan
             default: {
             }
         }
-
     }
 }
 
@@ -3091,7 +3090,6 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
                 default: {
                 }
             }
-
             process_tunnel_encap_0.apply(hdr, meta, standard_metadata);
             process_int_outer_encap_0.apply(hdr, meta, standard_metadata);
             if (meta.egress_metadata.port_type == 2w0) {
@@ -3332,7 +3330,6 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
                 }
             }
         }
-
     }
 }
 
@@ -3474,7 +3471,6 @@ control process_ip_sourceguard(inout headers hdr, inout metadata meta, inout sta
                 default: {
                 }
             }
-
         }
     }
 }
@@ -3791,7 +3787,6 @@ control process_outer_ipv4_multicast(inout headers hdr, inout metadata meta, ino
             default: {
             }
         }
-
     }
 }
 
@@ -3871,7 +3866,6 @@ control process_outer_ipv6_multicast(inout headers hdr, inout metadata meta, ino
             default: {
             }
         }
-
     }
 }
 
@@ -3946,7 +3940,6 @@ control process_ipv4_vtep(inout headers hdr, inout metadata meta, inout standard
             default: {
             }
         }
-
     }
 }
 
@@ -4002,7 +3995,6 @@ control process_ipv6_vtep(inout headers hdr, inout metadata meta, inout standard
             default: {
             }
         }
-
     }
 }
 
@@ -4270,7 +4262,6 @@ control process_tunnel(inout headers hdr, inout metadata meta, inout standard_me
                     }
                 }
             }
-
         }
         if (meta.tunnel_metadata.tunnel_terminate == 1w1 || meta.multicast_metadata.outer_mcast_route_hit == 1w1 && (meta.multicast_metadata.outer_mcast_mode == 2w1 && meta.multicast_metadata.mcast_rpf_group == 16w0 || meta.multicast_metadata.outer_mcast_mode == 2w2 && meta.multicast_metadata.mcast_rpf_group != 16w0)) {
             switch (tunnel.apply().action_run) {
@@ -4280,7 +4271,6 @@ control process_tunnel(inout headers hdr, inout metadata meta, inout standard_me
                 default: {
                 }
             }
-
         } else {
             tunnel_miss.apply();
         }
@@ -4841,7 +4831,6 @@ control process_ipv4_multicast(inout headers hdr, inout metadata meta, inout sta
                 default: {
                 }
             }
-
         }
         if (meta.ingress_metadata.bypass_lookups & 16w0x2 == 16w0 && meta.multicast_metadata.ipv4_multicast_enabled == 1w1) {
             switch (ipv4_multicast_route.apply().action_run) {
@@ -4851,7 +4840,6 @@ control process_ipv4_multicast(inout headers hdr, inout metadata meta, inout sta
                 default: {
                 }
             }
-
         }
     }
 }
@@ -4986,7 +4974,6 @@ control process_ipv6_multicast(inout headers hdr, inout metadata meta, inout sta
                 default: {
                 }
             }
-
         }
         if (meta.ingress_metadata.bypass_lookups & 16w0x2 == 16w0 && meta.multicast_metadata.ipv6_multicast_enabled == 1w1) {
             switch (ipv6_multicast_route.apply().action_run) {
@@ -4996,7 +4983,6 @@ control process_ipv6_multicast(inout headers hdr, inout metadata meta, inout sta
                 default: {
                 }
             }
-
         }
     }
 }
@@ -5121,7 +5107,6 @@ control process_ipv4_urpf(inout headers hdr, inout metadata meta, inout standard
                 default: {
                 }
             }
-
         }
     }
 }
@@ -5175,7 +5160,6 @@ control process_ipv4_fib(inout headers hdr, inout metadata meta, inout standard_
             default: {
             }
         }
-
     }
 }
 
@@ -5280,7 +5264,6 @@ control process_ipv6_urpf(inout headers hdr, inout metadata meta, inout standard
                 default: {
                 }
             }
-
         }
     }
 }
@@ -5334,7 +5317,6 @@ control process_ipv6_fib(inout headers hdr, inout metadata meta, inout standard_
             default: {
             }
         }
-
     }
 }
 
@@ -6030,7 +6012,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                         }
                     }
                 }
-
             }
         }
         process_meter_index_0.apply(hdr, meta, standard_metadata);

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-frontend.p4
@@ -1282,27 +1282,27 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @noWarn("unused") @name(".NoAction") action NoAction_147() {
     }
-    @name(".egress_port_type_normal") action egress_port_type_normal(bit<16> ifindex) {
+    @name(".egress_port_type_normal") action egress_port_type_normal(@name("ifindex") bit<16> ifindex_11) {
         meta.egress_metadata.port_type = 2w0;
-        meta.egress_metadata.ifindex = ifindex;
+        meta.egress_metadata.ifindex = ifindex_11;
     }
-    @name(".egress_port_type_fabric") action egress_port_type_fabric(bit<16> ifindex) {
+    @name(".egress_port_type_fabric") action egress_port_type_fabric(@name("ifindex") bit<16> ifindex_12) {
         meta.egress_metadata.port_type = 2w1;
         meta.tunnel_metadata.egress_tunnel_type = 5w15;
-        meta.egress_metadata.ifindex = ifindex;
+        meta.egress_metadata.ifindex = ifindex_12;
     }
-    @name(".egress_port_type_cpu") action egress_port_type_cpu(bit<16> ifindex) {
+    @name(".egress_port_type_cpu") action egress_port_type_cpu(@name("ifindex") bit<16> ifindex_13) {
         meta.egress_metadata.port_type = 2w2;
         meta.tunnel_metadata.egress_tunnel_type = 5w16;
-        meta.egress_metadata.ifindex = ifindex;
+        meta.egress_metadata.ifindex = ifindex_13;
     }
     @name(".nop") action nop() {
     }
-    @name(".set_mirror_nhop") action set_mirror_nhop(bit<16> nhop_idx) {
+    @name(".set_mirror_nhop") action set_mirror_nhop(@name("nhop_idx") bit<16> nhop_idx) {
         meta.l3_metadata.nexthop_index = nhop_idx;
     }
-    @name(".set_mirror_bd") action set_mirror_bd(bit<16> bd) {
-        meta.egress_metadata.bd = bd;
+    @name(".set_mirror_bd") action set_mirror_bd(@name("bd") bit<16> bd_17) {
+        meta.egress_metadata.bd = bd_17;
     }
     @name(".sflow_pkt_to_cpu") action sflow_pkt_to_cpu() {
         hdr.fabric_header_sflow.setValid();
@@ -1342,25 +1342,25 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".set_replica_copy_bridged") action _set_replica_copy_bridged_0() {
         meta.egress_metadata.routed = 1w0;
     }
-    @name(".outer_replica_from_rid") action _outer_replica_from_rid_0(bit<16> bd, bit<14> tunnel_index, bit<5> tunnel_type, bit<4> header_count) {
-        meta.egress_metadata.bd = bd;
+    @name(".outer_replica_from_rid") action _outer_replica_from_rid_0(@name("bd") bit<16> bd_18, @name("tunnel_index") bit<14> tunnel_index_9, @name("tunnel_type") bit<5> tunnel_type, @name("header_count") bit<4> header_count) {
+        meta.egress_metadata.bd = bd_18;
         meta.multicast_metadata.replica = 1w1;
         meta.multicast_metadata.inner_replica = 1w0;
         meta.egress_metadata.routed = meta.l3_metadata.outer_routed;
-        meta.egress_metadata.same_bd_check = bd ^ meta.ingress_metadata.outer_bd;
-        meta.tunnel_metadata.tunnel_index = tunnel_index;
+        meta.egress_metadata.same_bd_check = bd_18 ^ meta.ingress_metadata.outer_bd;
+        meta.tunnel_metadata.tunnel_index = tunnel_index_9;
         meta.tunnel_metadata.egress_tunnel_type = tunnel_type;
         meta.tunnel_metadata.egress_header_count = header_count;
     }
-    @name(".inner_replica_from_rid") action _inner_replica_from_rid_0(bit<16> bd, bit<14> tunnel_index, bit<5> tunnel_type, bit<4> header_count) {
-        meta.egress_metadata.bd = bd;
+    @name(".inner_replica_from_rid") action _inner_replica_from_rid_0(@name("bd") bit<16> bd_19, @name("tunnel_index") bit<14> tunnel_index_10, @name("tunnel_type") bit<5> tunnel_type_8, @name("header_count") bit<4> header_count_6) {
+        meta.egress_metadata.bd = bd_19;
         meta.multicast_metadata.replica = 1w1;
         meta.multicast_metadata.inner_replica = 1w1;
         meta.egress_metadata.routed = meta.l3_metadata.routed;
-        meta.egress_metadata.same_bd_check = bd ^ meta.ingress_metadata.bd;
-        meta.tunnel_metadata.tunnel_index = tunnel_index;
-        meta.tunnel_metadata.egress_tunnel_type = tunnel_type;
-        meta.tunnel_metadata.egress_header_count = header_count;
+        meta.egress_metadata.same_bd_check = bd_19 ^ meta.ingress_metadata.bd;
+        meta.tunnel_metadata.tunnel_index = tunnel_index_10;
+        meta.tunnel_metadata.egress_tunnel_type = tunnel_type_8;
+        meta.tunnel_metadata.egress_header_count = header_count_6;
     }
     @name(".replica_type") table _replica_type {
         actions = {
@@ -1705,58 +1705,58 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta.egress_metadata.bd = meta.ingress_metadata.bd;
         meta.egress_metadata.outer_bd = meta.ingress_metadata.bd;
     }
-    @name(".set_l2_rewrite_with_tunnel") action _set_l2_rewrite_with_tunnel_0(bit<14> tunnel_index, bit<5> tunnel_type) {
+    @name(".set_l2_rewrite_with_tunnel") action _set_l2_rewrite_with_tunnel_0(@name("tunnel_index") bit<14> tunnel_index_11, @name("tunnel_type") bit<5> tunnel_type_9) {
         meta.egress_metadata.routed = 1w0;
         meta.egress_metadata.bd = meta.ingress_metadata.bd;
         meta.egress_metadata.outer_bd = meta.ingress_metadata.bd;
-        meta.tunnel_metadata.tunnel_index = tunnel_index;
-        meta.tunnel_metadata.egress_tunnel_type = tunnel_type;
+        meta.tunnel_metadata.tunnel_index = tunnel_index_11;
+        meta.tunnel_metadata.egress_tunnel_type = tunnel_type_9;
     }
-    @name(".set_l3_rewrite") action _set_l3_rewrite_0(bit<16> bd, bit<8> mtu_index, bit<48> dmac) {
+    @name(".set_l3_rewrite") action _set_l3_rewrite_0(@name("bd") bit<16> bd_20, @name("mtu_index") bit<8> mtu_index_1, @name("dmac") bit<48> dmac) {
         meta.egress_metadata.routed = 1w1;
         meta.egress_metadata.mac_da = dmac;
-        meta.egress_metadata.bd = bd;
-        meta.egress_metadata.outer_bd = bd;
-        meta.l3_metadata.mtu_index = mtu_index;
+        meta.egress_metadata.bd = bd_20;
+        meta.egress_metadata.outer_bd = bd_20;
+        meta.l3_metadata.mtu_index = mtu_index_1;
     }
-    @name(".set_l3_rewrite_with_tunnel") action _set_l3_rewrite_with_tunnel_0(bit<16> bd, bit<48> dmac, bit<14> tunnel_index, bit<5> tunnel_type) {
+    @name(".set_l3_rewrite_with_tunnel") action _set_l3_rewrite_with_tunnel_0(@name("bd") bit<16> bd_21, @name("dmac") bit<48> dmac_0, @name("tunnel_index") bit<14> tunnel_index_12, @name("tunnel_type") bit<5> tunnel_type_10) {
         meta.egress_metadata.routed = 1w1;
-        meta.egress_metadata.mac_da = dmac;
-        meta.egress_metadata.bd = bd;
-        meta.egress_metadata.outer_bd = bd;
-        meta.tunnel_metadata.tunnel_index = tunnel_index;
-        meta.tunnel_metadata.egress_tunnel_type = tunnel_type;
+        meta.egress_metadata.mac_da = dmac_0;
+        meta.egress_metadata.bd = bd_21;
+        meta.egress_metadata.outer_bd = bd_21;
+        meta.tunnel_metadata.tunnel_index = tunnel_index_12;
+        meta.tunnel_metadata.egress_tunnel_type = tunnel_type_10;
     }
-    @name(".set_mpls_swap_push_rewrite_l2") action _set_mpls_swap_push_rewrite_l2_0(bit<20> label, bit<14> tunnel_index, bit<4> header_count) {
+    @name(".set_mpls_swap_push_rewrite_l2") action _set_mpls_swap_push_rewrite_l2_0(@name("label") bit<20> label_2, @name("tunnel_index") bit<14> tunnel_index_13, @name("header_count") bit<4> header_count_7) {
         meta.egress_metadata.routed = meta.l3_metadata.routed;
         meta.egress_metadata.bd = meta.ingress_metadata.bd;
-        hdr.mpls[0].label = label;
-        meta.tunnel_metadata.tunnel_index = tunnel_index;
-        meta.tunnel_metadata.egress_header_count = header_count;
+        hdr.mpls[0].label = label_2;
+        meta.tunnel_metadata.tunnel_index = tunnel_index_13;
+        meta.tunnel_metadata.egress_header_count = header_count_7;
         meta.tunnel_metadata.egress_tunnel_type = 5w13;
     }
-    @name(".set_mpls_push_rewrite_l2") action _set_mpls_push_rewrite_l2_0(bit<14> tunnel_index, bit<4> header_count) {
+    @name(".set_mpls_push_rewrite_l2") action _set_mpls_push_rewrite_l2_0(@name("tunnel_index") bit<14> tunnel_index_14, @name("header_count") bit<4> header_count_8) {
         meta.egress_metadata.routed = meta.l3_metadata.routed;
         meta.egress_metadata.bd = meta.ingress_metadata.bd;
-        meta.tunnel_metadata.tunnel_index = tunnel_index;
-        meta.tunnel_metadata.egress_header_count = header_count;
+        meta.tunnel_metadata.tunnel_index = tunnel_index_14;
+        meta.tunnel_metadata.egress_header_count = header_count_8;
         meta.tunnel_metadata.egress_tunnel_type = 5w13;
     }
-    @name(".set_mpls_swap_push_rewrite_l3") action _set_mpls_swap_push_rewrite_l3_0(bit<16> bd, bit<48> dmac, bit<20> label, bit<14> tunnel_index, bit<4> header_count) {
+    @name(".set_mpls_swap_push_rewrite_l3") action _set_mpls_swap_push_rewrite_l3_0(@name("bd") bit<16> bd_22, @name("dmac") bit<48> dmac_6, @name("label") bit<20> label_3, @name("tunnel_index") bit<14> tunnel_index_15, @name("header_count") bit<4> header_count_9) {
         meta.egress_metadata.routed = meta.l3_metadata.routed;
-        meta.egress_metadata.bd = bd;
-        hdr.mpls[0].label = label;
-        meta.egress_metadata.mac_da = dmac;
-        meta.tunnel_metadata.tunnel_index = tunnel_index;
-        meta.tunnel_metadata.egress_header_count = header_count;
+        meta.egress_metadata.bd = bd_22;
+        hdr.mpls[0].label = label_3;
+        meta.egress_metadata.mac_da = dmac_6;
+        meta.tunnel_metadata.tunnel_index = tunnel_index_15;
+        meta.tunnel_metadata.egress_header_count = header_count_9;
         meta.tunnel_metadata.egress_tunnel_type = 5w14;
     }
-    @name(".set_mpls_push_rewrite_l3") action _set_mpls_push_rewrite_l3_0(bit<16> bd, bit<48> dmac, bit<14> tunnel_index, bit<4> header_count) {
+    @name(".set_mpls_push_rewrite_l3") action _set_mpls_push_rewrite_l3_0(@name("bd") bit<16> bd_23, @name("dmac") bit<48> dmac_7, @name("tunnel_index") bit<14> tunnel_index_16, @name("header_count") bit<4> header_count_10) {
         meta.egress_metadata.routed = meta.l3_metadata.routed;
-        meta.egress_metadata.bd = bd;
-        meta.egress_metadata.mac_da = dmac;
-        meta.tunnel_metadata.tunnel_index = tunnel_index;
-        meta.tunnel_metadata.egress_header_count = header_count;
+        meta.egress_metadata.bd = bd_23;
+        meta.egress_metadata.mac_da = dmac_7;
+        meta.tunnel_metadata.tunnel_index = tunnel_index_16;
+        meta.tunnel_metadata.egress_header_count = header_count_10;
         meta.tunnel_metadata.egress_tunnel_type = 5w14;
     }
     @name(".rewrite_ipv4_multicast") action _rewrite_ipv4_multicast_0() {
@@ -1800,8 +1800,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".nop") action _nop_4() {
     }
-    @name(".set_egress_bd_properties") action _set_egress_bd_properties_0(bit<9> smac_idx) {
-        meta.egress_metadata.smac_idx = smac_idx;
+    @name(".set_egress_bd_properties") action _set_egress_bd_properties_0(@name("smac_idx") bit<9> smac_idx_5) {
+        meta.egress_metadata.smac_idx = smac_idx_5;
     }
     @name(".egress_bd_map") table _egress_bd_map {
         actions = {
@@ -1837,7 +1837,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.dstAddr = meta.egress_metadata.mac_da;
         hdr.mpls[0].ttl = hdr.mpls[0].ttl + 8w255;
     }
-    @name(".rewrite_smac") action _rewrite_smac_0(bit<48> smac) {
+    @name(".rewrite_smac") action _rewrite_smac_0(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name(".l3_rewrite") table _l3_rewrite {
@@ -1873,11 +1873,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".mtu_miss") action _mtu_miss_0() {
         meta.l3_metadata.l3_mtu_check = 16w0xffff;
     }
-    @name(".ipv4_mtu_check") action _ipv4_mtu_check_0(bit<16> l3_mtu) {
+    @name(".ipv4_mtu_check") action _ipv4_mtu_check_0(@name("l3_mtu") bit<16> l3_mtu) {
         meta.l3_metadata.l3_mtu_check = l3_mtu |-| hdr.ipv4.totalLen;
     }
-    @name(".ipv6_mtu_check") action _ipv6_mtu_check_0(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu |-| hdr.ipv6.payloadLen;
+    @name(".ipv6_mtu_check") action _ipv6_mtu_check_0(@name("l3_mtu") bit<16> l3_mtu_3) {
+        meta.l3_metadata.l3_mtu_check = l3_mtu_3 |-| hdr.ipv6.payloadLen;
     }
     @name(".mtu") table _mtu {
         actions = {
@@ -1926,15 +1926,15 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".nop") action _nop_47() {
     }
-    @name(".int_transit") action _int_transit_0(bit<32> switch_id) {
+    @name(".int_transit") action _int_transit_0(@name("switch_id") bit<32> switch_id_2) {
         meta.int_metadata.insert_cnt = hdr.int_header.max_hop_cnt - hdr.int_header.total_hop_cnt;
-        meta.int_metadata.switch_id = switch_id;
+        meta.int_metadata.switch_id = switch_id_2;
         meta.int_metadata.insert_byte_cnt = meta.int_metadata.instruction_cnt << 2;
         meta.int_metadata.gpe_int_hdr_len8 = (bit<8>)hdr.int_header.ins_cnt;
     }
-    @name(".int_src") action _int_src_0(bit<32> switch_id, bit<8> hop_cnt, bit<5> ins_cnt, bit<4> ins_mask0003, bit<4> ins_mask0407, bit<16> ins_byte_cnt, bit<8> total_words) {
+    @name(".int_src") action _int_src_0(@name("switch_id") bit<32> switch_id_3, @name("hop_cnt") bit<8> hop_cnt, @name("ins_cnt") bit<5> ins_cnt_1, @name("ins_mask0003") bit<4> ins_mask0003, @name("ins_mask0407") bit<4> ins_mask0407, @name("ins_byte_cnt") bit<16> ins_byte_cnt, @name("total_words") bit<8> total_words) {
         meta.int_metadata.insert_cnt = hop_cnt;
-        meta.int_metadata.switch_id = switch_id;
+        meta.int_metadata.switch_id = switch_id_3;
         meta.int_metadata.insert_byte_cnt = ins_byte_cnt;
         meta.int_metadata.gpe_int_hdr_len8 = total_words;
         hdr.int_header.setValid();
@@ -1943,7 +1943,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.int_header.c = 1w0;
         hdr.int_header.e = 1w0;
         hdr.int_header.rsvd1 = 5w0;
-        hdr.int_header.ins_cnt = ins_cnt;
+        hdr.int_header.ins_cnt = ins_cnt_1;
         hdr.int_header.max_hop_cnt = hop_cnt;
         hdr.int_header.total_hop_cnt = 8w0;
         hdr.int_header.instruction_mask_0003 = ins_mask0003;
@@ -2330,17 +2330,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".nop") action _nop_55() {
     }
-    @name(".set_egress_tunnel_vni") action _set_egress_tunnel_vni_0(bit<24> vnid) {
-        meta.tunnel_metadata.vnid = vnid;
+    @name(".set_egress_tunnel_vni") action _set_egress_tunnel_vni_0(@name("vnid") bit<24> vnid_1) {
+        meta.tunnel_metadata.vnid = vnid_1;
     }
-    @name(".rewrite_tunnel_dmac") action _rewrite_tunnel_dmac_0(bit<48> dmac) {
-        hdr.ethernet.dstAddr = dmac;
+    @name(".rewrite_tunnel_dmac") action _rewrite_tunnel_dmac_0(@name("dmac") bit<48> dmac_8) {
+        hdr.ethernet.dstAddr = dmac_8;
     }
-    @name(".rewrite_tunnel_ipv4_dst") action _rewrite_tunnel_ipv4_dst_0(bit<32> ip) {
+    @name(".rewrite_tunnel_ipv4_dst") action _rewrite_tunnel_ipv4_dst_0(@name("ip") bit<32> ip) {
         hdr.ipv4.dstAddr = ip;
     }
-    @name(".rewrite_tunnel_ipv6_dst") action _rewrite_tunnel_ipv6_dst_0(bit<128> ip) {
-        hdr.ipv6.dstAddr = ip;
+    @name(".rewrite_tunnel_ipv6_dst") action _rewrite_tunnel_ipv6_dst_0(@name("ip") bit<128> ip_4) {
+        hdr.ipv6.dstAddr = ip_4;
     }
     @name(".inner_ipv4_udp_rewrite") action _inner_ipv4_udp_rewrite_0() {
         hdr.inner_ipv4 = hdr.ipv4;
@@ -2677,57 +2677,57 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.mpls[2].setValid();
         hdr.ethernet.etherType = 16w0x8847;
     }
-    @name(".fabric_rewrite") action _fabric_rewrite_0(bit<14> tunnel_index) {
-        meta.tunnel_metadata.tunnel_index = tunnel_index;
+    @name(".fabric_rewrite") action _fabric_rewrite_0(@name("tunnel_index") bit<14> tunnel_index_17) {
+        meta.tunnel_metadata.tunnel_index = tunnel_index_17;
     }
-    @name(".tunnel_mtu_check") action _tunnel_mtu_check_0(bit<16> l3_mtu) {
-        meta.l3_metadata.l3_mtu_check = l3_mtu |-| meta.egress_metadata.payload_length;
+    @name(".tunnel_mtu_check") action _tunnel_mtu_check_0(@name("l3_mtu") bit<16> l3_mtu_4) {
+        meta.l3_metadata.l3_mtu_check = l3_mtu_4 |-| meta.egress_metadata.payload_length;
     }
     @name(".tunnel_mtu_miss") action _tunnel_mtu_miss_0() {
         meta.l3_metadata.l3_mtu_check = 16w0xffff;
     }
-    @name(".set_tunnel_rewrite_details") action _set_tunnel_rewrite_details_0(bit<16> outer_bd, bit<9> smac_idx, bit<14> dmac_idx, bit<9> sip_index, bit<14> dip_index) {
-        meta.egress_metadata.outer_bd = outer_bd;
-        meta.tunnel_metadata.tunnel_smac_index = smac_idx;
+    @name(".set_tunnel_rewrite_details") action _set_tunnel_rewrite_details_0(@name("outer_bd") bit<16> outer_bd_1, @name("smac_idx") bit<9> smac_idx_6, @name("dmac_idx") bit<14> dmac_idx, @name("sip_index") bit<9> sip_index, @name("dip_index") bit<14> dip_index) {
+        meta.egress_metadata.outer_bd = outer_bd_1;
+        meta.tunnel_metadata.tunnel_smac_index = smac_idx_6;
         meta.tunnel_metadata.tunnel_dmac_index = dmac_idx;
         meta.tunnel_metadata.tunnel_src_index = sip_index;
         meta.tunnel_metadata.tunnel_dst_index = dip_index;
     }
-    @name(".set_mpls_rewrite_push1") action _set_mpls_rewrite_push1_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<9> smac_idx, bit<14> dmac_idx) {
+    @name(".set_mpls_rewrite_push1") action _set_mpls_rewrite_push1_0(@name("label1") bit<20> label1, @name("exp1") bit<3> exp1, @name("ttl1") bit<8> ttl1, @name("smac_idx") bit<9> smac_idx_7, @name("dmac_idx") bit<14> dmac_idx_4) {
         hdr.mpls[0].label = label1;
         hdr.mpls[0].exp = exp1;
         hdr.mpls[0].bos = 1w0x1;
         hdr.mpls[0].ttl = ttl1;
-        meta.tunnel_metadata.tunnel_smac_index = smac_idx;
-        meta.tunnel_metadata.tunnel_dmac_index = dmac_idx;
+        meta.tunnel_metadata.tunnel_smac_index = smac_idx_7;
+        meta.tunnel_metadata.tunnel_dmac_index = dmac_idx_4;
     }
-    @name(".set_mpls_rewrite_push2") action _set_mpls_rewrite_push2_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<20> label2, bit<3> exp2, bit<8> ttl2, bit<9> smac_idx, bit<14> dmac_idx) {
-        hdr.mpls[0].label = label1;
-        hdr.mpls[0].exp = exp1;
-        hdr.mpls[0].ttl = ttl1;
+    @name(".set_mpls_rewrite_push2") action _set_mpls_rewrite_push2_0(@name("label1") bit<20> label1_3, @name("exp1") bit<3> exp1_3, @name("ttl1") bit<8> ttl1_3, @name("label2") bit<20> label2, @name("exp2") bit<3> exp2, @name("ttl2") bit<8> ttl2, @name("smac_idx") bit<9> smac_idx_8, @name("dmac_idx") bit<14> dmac_idx_5) {
+        hdr.mpls[0].label = label1_3;
+        hdr.mpls[0].exp = exp1_3;
+        hdr.mpls[0].ttl = ttl1_3;
         hdr.mpls[0].bos = 1w0x0;
         hdr.mpls[1].label = label2;
         hdr.mpls[1].exp = exp2;
         hdr.mpls[1].ttl = ttl2;
         hdr.mpls[1].bos = 1w0x1;
-        meta.tunnel_metadata.tunnel_smac_index = smac_idx;
-        meta.tunnel_metadata.tunnel_dmac_index = dmac_idx;
+        meta.tunnel_metadata.tunnel_smac_index = smac_idx_8;
+        meta.tunnel_metadata.tunnel_dmac_index = dmac_idx_5;
     }
-    @name(".set_mpls_rewrite_push3") action _set_mpls_rewrite_push3_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<20> label2, bit<3> exp2, bit<8> ttl2, bit<20> label3, bit<3> exp3, bit<8> ttl3, bit<9> smac_idx, bit<14> dmac_idx) {
-        hdr.mpls[0].label = label1;
-        hdr.mpls[0].exp = exp1;
-        hdr.mpls[0].ttl = ttl1;
+    @name(".set_mpls_rewrite_push3") action _set_mpls_rewrite_push3_0(@name("label1") bit<20> label1_4, @name("exp1") bit<3> exp1_4, @name("ttl1") bit<8> ttl1_4, @name("label2") bit<20> label2_2, @name("exp2") bit<3> exp2_2, @name("ttl2") bit<8> ttl2_2, @name("label3") bit<20> label3, @name("exp3") bit<3> exp3, @name("ttl3") bit<8> ttl3, @name("smac_idx") bit<9> smac_idx_9, @name("dmac_idx") bit<14> dmac_idx_6) {
+        hdr.mpls[0].label = label1_4;
+        hdr.mpls[0].exp = exp1_4;
+        hdr.mpls[0].ttl = ttl1_4;
         hdr.mpls[0].bos = 1w0x0;
-        hdr.mpls[1].label = label2;
-        hdr.mpls[1].exp = exp2;
-        hdr.mpls[1].ttl = ttl2;
+        hdr.mpls[1].label = label2_2;
+        hdr.mpls[1].exp = exp2_2;
+        hdr.mpls[1].ttl = ttl2_2;
         hdr.mpls[1].bos = 1w0x0;
         hdr.mpls[2].label = label3;
         hdr.mpls[2].exp = exp3;
         hdr.mpls[2].ttl = ttl3;
         hdr.mpls[2].bos = 1w0x1;
-        meta.tunnel_metadata.tunnel_smac_index = smac_idx;
-        meta.tunnel_metadata.tunnel_dmac_index = dmac_idx;
+        meta.tunnel_metadata.tunnel_smac_index = smac_idx_9;
+        meta.tunnel_metadata.tunnel_dmac_index = dmac_idx_6;
     }
     @name(".cpu_rx_rewrite") action _cpu_rx_rewrite_0() {
         hdr.fabric_header.setValid();
@@ -2762,7 +2762,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.fabric_payload_header.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = 16w0x9000;
     }
-    @name(".fabric_multicast_rewrite") action _fabric_multicast_rewrite_0(bit<16> fabric_mgid) {
+    @name(".fabric_multicast_rewrite") action _fabric_multicast_rewrite_0(@name("fabric_mgid") bit<16> fabric_mgid) {
         hdr.fabric_header.setValid();
         hdr.fabric_header.headerVersion = 2w0;
         hdr.fabric_header.packetVersion = 2w0;
@@ -2782,14 +2782,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.fabric_payload_header.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = 16w0x9000;
     }
-    @name(".rewrite_tunnel_smac") action _rewrite_tunnel_smac_0(bit<48> smac) {
-        hdr.ethernet.srcAddr = smac;
+    @name(".rewrite_tunnel_smac") action _rewrite_tunnel_smac_0(@name("smac") bit<48> smac_0) {
+        hdr.ethernet.srcAddr = smac_0;
     }
-    @name(".rewrite_tunnel_ipv4_src") action _rewrite_tunnel_ipv4_src_0(bit<32> ip) {
-        hdr.ipv4.srcAddr = ip;
+    @name(".rewrite_tunnel_ipv4_src") action _rewrite_tunnel_ipv4_src_0(@name("ip") bit<32> ip_5) {
+        hdr.ipv4.srcAddr = ip_5;
     }
-    @name(".rewrite_tunnel_ipv6_src") action _rewrite_tunnel_ipv6_src_0(bit<128> ip) {
-        hdr.ipv6.srcAddr = ip;
+    @name(".rewrite_tunnel_ipv6_src") action _rewrite_tunnel_ipv6_src_0(@name("ip") bit<128> ip_6) {
+        hdr.ipv6.srcAddr = ip_6;
     }
     @name(".egress_vni") table _egress_vni {
         actions = {
@@ -2973,13 +2973,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".set_egress_packet_vlan_untagged") action _set_egress_packet_vlan_untagged_0() {
     }
-    @name(".set_egress_packet_vlan_tagged") action _set_egress_packet_vlan_tagged_0(bit<12> vlan_id) {
+    @name(".set_egress_packet_vlan_tagged") action _set_egress_packet_vlan_tagged_0(@name("vlan_id") bit<12> vlan_id) {
         hdr.vlan_tag_[0].setValid();
         hdr.vlan_tag_[0].etherType = hdr.ethernet.etherType;
         hdr.vlan_tag_[0].vid = vlan_id;
         hdr.ethernet.etherType = 16w0x8100;
     }
-    @name(".set_egress_packet_vlan_double_tagged") action _set_egress_packet_vlan_double_tagged_0(bit<12> s_tag, bit<12> c_tag) {
+    @name(".set_egress_packet_vlan_double_tagged") action _set_egress_packet_vlan_double_tagged_0(@name("s_tag") bit<12> s_tag, @name("c_tag") bit<12> c_tag) {
         hdr.vlan_tag_[1].setValid();
         hdr.vlan_tag_[0].setValid();
         hdr.vlan_tag_[1].etherType = hdr.ethernet.etherType;
@@ -3026,17 +3026,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".nop") action _nop_57() {
     }
-    @name(".egress_mirror") action _egress_mirror_0(bit<32> session_id) {
+    @name(".egress_mirror") action _egress_mirror_0(@name("session_id") bit<32> session_id) {
         meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
         clone3<tuple<bit<32>, bit<16>>>(CloneType.E2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
     }
-    @name(".egress_mirror_drop") action _egress_mirror_drop_0(bit<32> session_id) {
-        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
-        clone3<tuple<bit<32>, bit<16>>>(CloneType.E2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
+    @name(".egress_mirror_drop") action _egress_mirror_drop_0(@name("session_id") bit<32> session_id_6) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id_6;
+        clone3<tuple<bit<32>, bit<16>>>(CloneType.E2E, session_id_6, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
         mark_to_drop(standard_metadata);
     }
-    @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(bit<16> reason_code) {
-        meta.fabric_metadata.reason_code = reason_code;
+    @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(@name("reason_code") bit<16> reason_code_0) {
+        meta.fabric_metadata.reason_code = reason_code_0;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.E2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
         mark_to_drop(standard_metadata);
     }
@@ -3099,13 +3099,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
                         default: {
                         }
                     }
-
                     _egress_bd_stats_0.apply();
                 }
                 default: {
                 }
             }
-
             if (meta.fabric_metadata.fabric_header_present == 1w0 && meta.tunnel_metadata.egress_tunnel_type != 5w0) {
                 _egress_vni.apply();
                 if (meta.tunnel_metadata.egress_tunnel_type != 5w15 && meta.tunnel_metadata.egress_tunnel_type != 5w16) {
@@ -3330,12 +3328,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1024;
         default_action = NoAction_148();
     }
-    @name(".set_ifindex") action _set_ifindex_0(bit<16> ifindex, bit<2> port_type) {
-        meta.ingress_metadata.ifindex = ifindex;
-        meta.ingress_metadata.port_type = port_type;
+    @name(".set_ifindex") action _set_ifindex_0(@name("ifindex") bit<16> ifindex_14, @name("port_type") bit<2> port_type_1) {
+        meta.ingress_metadata.ifindex = ifindex_14;
+        meta.ingress_metadata.port_type = port_type_1;
     }
-    @name(".set_ingress_port_properties") action _set_ingress_port_properties_0(bit<16> if_label) {
-        meta.acl_metadata.if_label = if_label;
+    @name(".set_ingress_port_properties") action _set_ingress_port_properties_0(@name("if_label") bit<16> if_label_1) {
+        meta.acl_metadata.if_label = if_label_1;
     }
     @name(".ingress_port_mapping") table _ingress_port_mapping {
         actions = {
@@ -3359,9 +3357,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 288;
         default_action = NoAction_150();
     }
-    @name(".malformed_outer_ethernet_packet") action _malformed_outer_ethernet_packet_0(bit<8> drop_reason) {
+    @name(".malformed_outer_ethernet_packet") action _malformed_outer_ethernet_packet_0(@name("drop_reason") bit<8> drop_reason_5) {
         meta.ingress_metadata.drop_flag = 1w1;
-        meta.ingress_metadata.drop_reason = drop_reason;
+        meta.ingress_metadata.drop_reason = drop_reason_5;
     }
     @name(".set_valid_outer_unicast_packet_untagged") action _set_valid_outer_unicast_packet_untagged_0() {
         meta.l2_metadata.lkp_pkt_type = 3w1;
@@ -3442,9 +3440,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l3_metadata.lkp_ip_tc = hdr.ipv4.diffserv;
         meta.l3_metadata.lkp_ip_version = hdr.ipv4.version;
     }
-    @name(".set_malformed_outer_ipv4_packet") action _set_malformed_outer_ipv4_packet(bit<8> drop_reason) {
+    @name(".set_malformed_outer_ipv4_packet") action _set_malformed_outer_ipv4_packet(@name("drop_reason") bit<8> drop_reason_6) {
         meta.ingress_metadata.drop_flag = 1w1;
-        meta.ingress_metadata.drop_reason = drop_reason;
+        meta.ingress_metadata.drop_reason = drop_reason_6;
     }
     @name(".validate_outer_ipv4_packet") table _validate_outer_ipv4_packet_0 {
         actions = {
@@ -3465,9 +3463,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l3_metadata.lkp_ip_tc = hdr.ipv6.trafficClass;
         meta.l3_metadata.lkp_ip_version = hdr.ipv6.version;
     }
-    @name(".set_malformed_outer_ipv6_packet") action _set_malformed_outer_ipv6_packet(bit<8> drop_reason) {
+    @name(".set_malformed_outer_ipv6_packet") action _set_malformed_outer_ipv6_packet(@name("drop_reason") bit<8> drop_reason_7) {
         meta.ingress_metadata.drop_flag = 1w1;
-        meta.ingress_metadata.drop_reason = drop_reason;
+        meta.ingress_metadata.drop_reason = drop_reason_7;
     }
     @name(".validate_outer_ipv6_packet") table _validate_outer_ipv6_packet_0 {
         actions = {
@@ -3516,7 +3514,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 512;
         default_action = NoAction_154();
     }
-    @name(".set_config_parameters") action _set_config_parameters_0(bit<8> enable_dod) {
+    @name(".set_config_parameters") action _set_config_parameters_0(@name("enable_dod") bit<8> enable_dod_0) {
         meta.i2e_metadata.ingress_tstamp = (bit<32>)standard_metadata.ingress_global_timestamp;
         meta.ingress_metadata.ingress_port = standard_metadata.ingress_port;
         meta.l2_metadata.same_if_check = meta.ingress_metadata.ifindex;
@@ -3531,28 +3529,28 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1;
         default_action = NoAction_155();
     }
-    @name(".set_bd_properties") action _set_bd_properties_0(bit<16> bd, bit<16> vrf, bit<10> stp_group, bit<1> learning_enabled, bit<16> bd_label, bit<16> stats_idx, bit<10> rmac_group, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<1> ipv4_multicast_enabled, bit<1> ipv6_multicast_enabled, bit<16> mrpf_group, bit<16> ipv4_mcast_key, bit<1> ipv4_mcast_key_type, bit<16> ipv6_mcast_key, bit<1> ipv6_mcast_key_type) {
-        meta.ingress_metadata.bd = bd;
-        meta.ingress_metadata.outer_bd = bd;
-        meta.acl_metadata.bd_label = bd_label;
-        meta.l2_metadata.stp_group = stp_group;
+    @name(".set_bd_properties") action _set_bd_properties_0(@name("bd") bit<16> bd_24, @name("vrf") bit<16> vrf_7, @name("stp_group") bit<10> stp_group_1, @name("learning_enabled") bit<1> learning_enabled_1, @name("bd_label") bit<16> bd_label_4, @name("stats_idx") bit<16> stats_idx, @name("rmac_group") bit<10> rmac_group_5, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_3, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_3, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_3, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_3, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_2, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_2, @name("ipv4_multicast_enabled") bit<1> ipv4_multicast_enabled_3, @name("ipv6_multicast_enabled") bit<1> ipv6_multicast_enabled_3, @name("mrpf_group") bit<16> mrpf_group, @name("ipv4_mcast_key") bit<16> ipv4_mcast_key_1, @name("ipv4_mcast_key_type") bit<1> ipv4_mcast_key_type_1, @name("ipv6_mcast_key") bit<16> ipv6_mcast_key_1, @name("ipv6_mcast_key_type") bit<1> ipv6_mcast_key_type_1) {
+        meta.ingress_metadata.bd = bd_24;
+        meta.ingress_metadata.outer_bd = bd_24;
+        meta.acl_metadata.bd_label = bd_label_4;
+        meta.l2_metadata.stp_group = stp_group_1;
         meta.l2_metadata.bd_stats_idx = stats_idx;
-        meta.l2_metadata.learning_enabled = learning_enabled;
-        meta.l3_metadata.vrf = vrf;
-        meta.ipv4_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled;
-        meta.ipv6_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled;
-        meta.ipv4_metadata.ipv4_urpf_mode = ipv4_urpf_mode;
-        meta.ipv6_metadata.ipv6_urpf_mode = ipv6_urpf_mode;
-        meta.l3_metadata.rmac_group = rmac_group;
-        meta.multicast_metadata.igmp_snooping_enabled = igmp_snooping_enabled;
-        meta.multicast_metadata.mld_snooping_enabled = mld_snooping_enabled;
-        meta.multicast_metadata.ipv4_multicast_enabled = ipv4_multicast_enabled;
-        meta.multicast_metadata.ipv6_multicast_enabled = ipv6_multicast_enabled;
+        meta.l2_metadata.learning_enabled = learning_enabled_1;
+        meta.l3_metadata.vrf = vrf_7;
+        meta.ipv4_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled_3;
+        meta.ipv6_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled_3;
+        meta.ipv4_metadata.ipv4_urpf_mode = ipv4_urpf_mode_3;
+        meta.ipv6_metadata.ipv6_urpf_mode = ipv6_urpf_mode_3;
+        meta.l3_metadata.rmac_group = rmac_group_5;
+        meta.multicast_metadata.igmp_snooping_enabled = igmp_snooping_enabled_2;
+        meta.multicast_metadata.mld_snooping_enabled = mld_snooping_enabled_2;
+        meta.multicast_metadata.ipv4_multicast_enabled = ipv4_multicast_enabled_3;
+        meta.multicast_metadata.ipv6_multicast_enabled = ipv6_multicast_enabled_3;
         meta.multicast_metadata.bd_mrpf_group = mrpf_group;
-        meta.multicast_metadata.ipv4_mcast_key_type = ipv4_mcast_key_type;
-        meta.multicast_metadata.ipv4_mcast_key = ipv4_mcast_key;
-        meta.multicast_metadata.ipv6_mcast_key_type = ipv6_mcast_key_type;
-        meta.multicast_metadata.ipv6_mcast_key = ipv6_mcast_key;
+        meta.multicast_metadata.ipv4_mcast_key_type = ipv4_mcast_key_type_1;
+        meta.multicast_metadata.ipv4_mcast_key = ipv4_mcast_key_1;
+        meta.multicast_metadata.ipv6_mcast_key_type = ipv6_mcast_key_type_1;
+        meta.multicast_metadata.ipv6_mcast_key = ipv6_mcast_key_1;
     }
     @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss_0() {
         meta.l2_metadata.port_vlan_mapping_miss = 1w1;
@@ -3574,8 +3572,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         implementation = bd_action_profile;
         default_action = NoAction_156();
     }
-    @name(".set_stp_state") action _set_stp_state_0(bit<3> stp_state) {
-        meta.l2_metadata.stp_state = stp_state;
+    @name(".set_stp_state") action _set_stp_state_0(@name("stp_state") bit<3> stp_state_1) {
+        meta.l2_metadata.stp_state = stp_state_1;
     }
     @name(".spanning_tree") table _spanning_tree {
         actions = {
@@ -3635,7 +3633,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".int_set_no_src") action _int_set_no_src_0() {
         meta.int_metadata_i2e.source = 1w0;
     }
-    @name(".int_sink_gpe") action _int_sink_gpe_0(bit<32> mirror_id) {
+    @name(".int_sink_gpe") action _int_sink_gpe_0(@name("mirror_id") bit<32> mirror_id) {
         meta.int_metadata.insert_byte_cnt = meta.int_metadata.gpe_int_hdr_len << 2;
         meta.int_metadata_i2e.sink = 1w1;
         meta.i2e_metadata.mirror_session_id = (bit<16>)mirror_id;
@@ -3727,72 +3725,72 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".tunnel_lookup_miss") action _tunnel_lookup_miss_0() {
     }
-    @name(".terminate_tunnel_inner_non_ip") action _terminate_tunnel_inner_non_ip_0(bit<16> bd, bit<16> bd_label, bit<16> stats_idx) {
+    @name(".terminate_tunnel_inner_non_ip") action _terminate_tunnel_inner_non_ip_0(@name("bd") bit<16> bd_25, @name("bd_label") bit<16> bd_label_5, @name("stats_idx") bit<16> stats_idx_4) {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
-        meta.ingress_metadata.bd = bd;
-        meta.acl_metadata.bd_label = bd_label;
-        meta.l2_metadata.bd_stats_idx = stats_idx;
+        meta.ingress_metadata.bd = bd_25;
+        meta.acl_metadata.bd_label = bd_label_5;
+        meta.l2_metadata.bd_stats_idx = stats_idx_4;
         meta.l3_metadata.lkp_ip_type = 2w0;
         meta.l2_metadata.lkp_mac_type = hdr.inner_ethernet.etherType;
     }
-    @name(".terminate_tunnel_inner_ethernet_ipv4") action _terminate_tunnel_inner_ethernet_ipv4_0(bit<16> bd, bit<16> vrf, bit<10> rmac_group, bit<16> bd_label, bit<1> ipv4_unicast_enabled, bit<2> ipv4_urpf_mode, bit<1> igmp_snooping_enabled, bit<16> stats_idx, bit<1> ipv4_multicast_enabled, bit<16> mrpf_group) {
+    @name(".terminate_tunnel_inner_ethernet_ipv4") action _terminate_tunnel_inner_ethernet_ipv4_0(@name("bd") bit<16> bd_26, @name("vrf") bit<16> vrf_8, @name("rmac_group") bit<10> rmac_group_6, @name("bd_label") bit<16> bd_label_6, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_4, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_4, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_3, @name("stats_idx") bit<16> stats_idx_5, @name("ipv4_multicast_enabled") bit<1> ipv4_multicast_enabled_4, @name("mrpf_group") bit<16> mrpf_group_5) {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
-        meta.ingress_metadata.bd = bd;
-        meta.l3_metadata.vrf = vrf;
+        meta.ingress_metadata.bd = bd_26;
+        meta.l3_metadata.vrf = vrf_8;
         meta.qos_metadata.outer_dscp = meta.l3_metadata.lkp_ip_tc;
-        meta.ipv4_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled;
-        meta.ipv4_metadata.ipv4_urpf_mode = ipv4_urpf_mode;
-        meta.l3_metadata.rmac_group = rmac_group;
-        meta.acl_metadata.bd_label = bd_label;
-        meta.l2_metadata.bd_stats_idx = stats_idx;
+        meta.ipv4_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled_4;
+        meta.ipv4_metadata.ipv4_urpf_mode = ipv4_urpf_mode_4;
+        meta.l3_metadata.rmac_group = rmac_group_6;
+        meta.acl_metadata.bd_label = bd_label_6;
+        meta.l2_metadata.bd_stats_idx = stats_idx_5;
         meta.l3_metadata.lkp_ip_type = 2w1;
         meta.l2_metadata.lkp_mac_type = hdr.inner_ethernet.etherType;
         meta.l3_metadata.lkp_ip_version = hdr.inner_ipv4.version;
         meta.l3_metadata.lkp_ip_tc = hdr.inner_ipv4.diffserv;
-        meta.multicast_metadata.igmp_snooping_enabled = igmp_snooping_enabled;
-        meta.multicast_metadata.ipv4_multicast_enabled = ipv4_multicast_enabled;
-        meta.multicast_metadata.bd_mrpf_group = mrpf_group;
+        meta.multicast_metadata.igmp_snooping_enabled = igmp_snooping_enabled_3;
+        meta.multicast_metadata.ipv4_multicast_enabled = ipv4_multicast_enabled_4;
+        meta.multicast_metadata.bd_mrpf_group = mrpf_group_5;
     }
-    @name(".terminate_tunnel_inner_ipv4") action _terminate_tunnel_inner_ipv4_0(bit<16> vrf, bit<10> rmac_group, bit<2> ipv4_urpf_mode, bit<1> ipv4_unicast_enabled, bit<1> ipv4_multicast_enabled, bit<16> mrpf_group) {
+    @name(".terminate_tunnel_inner_ipv4") action _terminate_tunnel_inner_ipv4_0(@name("vrf") bit<16> vrf_9, @name("rmac_group") bit<10> rmac_group_7, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_5, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_5, @name("ipv4_multicast_enabled") bit<1> ipv4_multicast_enabled_5, @name("mrpf_group") bit<16> mrpf_group_6) {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
-        meta.l3_metadata.vrf = vrf;
+        meta.l3_metadata.vrf = vrf_9;
         meta.qos_metadata.outer_dscp = meta.l3_metadata.lkp_ip_tc;
-        meta.ipv4_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled;
-        meta.ipv4_metadata.ipv4_urpf_mode = ipv4_urpf_mode;
-        meta.l3_metadata.rmac_group = rmac_group;
+        meta.ipv4_metadata.ipv4_unicast_enabled = ipv4_unicast_enabled_5;
+        meta.ipv4_metadata.ipv4_urpf_mode = ipv4_urpf_mode_5;
+        meta.l3_metadata.rmac_group = rmac_group_7;
         meta.l2_metadata.lkp_mac_sa = hdr.ethernet.srcAddr;
         meta.l2_metadata.lkp_mac_da = hdr.ethernet.dstAddr;
         meta.l3_metadata.lkp_ip_type = 2w1;
         meta.l3_metadata.lkp_ip_version = hdr.inner_ipv4.version;
         meta.l3_metadata.lkp_ip_tc = hdr.inner_ipv4.diffserv;
-        meta.multicast_metadata.bd_mrpf_group = mrpf_group;
-        meta.multicast_metadata.ipv4_multicast_enabled = ipv4_multicast_enabled;
+        meta.multicast_metadata.bd_mrpf_group = mrpf_group_6;
+        meta.multicast_metadata.ipv4_multicast_enabled = ipv4_multicast_enabled_5;
     }
-    @name(".terminate_tunnel_inner_ethernet_ipv6") action _terminate_tunnel_inner_ethernet_ipv6_0(bit<16> bd, bit<16> vrf, bit<10> rmac_group, bit<16> bd_label, bit<1> ipv6_unicast_enabled, bit<2> ipv6_urpf_mode, bit<1> mld_snooping_enabled, bit<16> stats_idx, bit<1> ipv6_multicast_enabled, bit<16> mrpf_group) {
+    @name(".terminate_tunnel_inner_ethernet_ipv6") action _terminate_tunnel_inner_ethernet_ipv6_0(@name("bd") bit<16> bd_27, @name("vrf") bit<16> vrf_10, @name("rmac_group") bit<10> rmac_group_8, @name("bd_label") bit<16> bd_label_7, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_4, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_4, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_3, @name("stats_idx") bit<16> stats_idx_6, @name("ipv6_multicast_enabled") bit<1> ipv6_multicast_enabled_4, @name("mrpf_group") bit<16> mrpf_group_7) {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
-        meta.ingress_metadata.bd = bd;
-        meta.l3_metadata.vrf = vrf;
+        meta.ingress_metadata.bd = bd_27;
+        meta.l3_metadata.vrf = vrf_10;
         meta.qos_metadata.outer_dscp = meta.l3_metadata.lkp_ip_tc;
-        meta.ipv6_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled;
-        meta.ipv6_metadata.ipv6_urpf_mode = ipv6_urpf_mode;
-        meta.l3_metadata.rmac_group = rmac_group;
-        meta.acl_metadata.bd_label = bd_label;
-        meta.l2_metadata.bd_stats_idx = stats_idx;
+        meta.ipv6_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled_4;
+        meta.ipv6_metadata.ipv6_urpf_mode = ipv6_urpf_mode_4;
+        meta.l3_metadata.rmac_group = rmac_group_8;
+        meta.acl_metadata.bd_label = bd_label_7;
+        meta.l2_metadata.bd_stats_idx = stats_idx_6;
         meta.l3_metadata.lkp_ip_type = 2w2;
         meta.l2_metadata.lkp_mac_type = hdr.inner_ethernet.etherType;
         meta.l3_metadata.lkp_ip_version = hdr.inner_ipv6.version;
         meta.l3_metadata.lkp_ip_tc = hdr.inner_ipv6.trafficClass;
-        meta.multicast_metadata.bd_mrpf_group = mrpf_group;
-        meta.multicast_metadata.ipv6_multicast_enabled = ipv6_multicast_enabled;
-        meta.multicast_metadata.mld_snooping_enabled = mld_snooping_enabled;
+        meta.multicast_metadata.bd_mrpf_group = mrpf_group_7;
+        meta.multicast_metadata.ipv6_multicast_enabled = ipv6_multicast_enabled_4;
+        meta.multicast_metadata.mld_snooping_enabled = mld_snooping_enabled_3;
     }
-    @name(".terminate_tunnel_inner_ipv6") action _terminate_tunnel_inner_ipv6_0(bit<16> vrf, bit<10> rmac_group, bit<1> ipv6_unicast_enabled, bit<2> ipv6_urpf_mode, bit<1> ipv6_multicast_enabled, bit<16> mrpf_group) {
+    @name(".terminate_tunnel_inner_ipv6") action _terminate_tunnel_inner_ipv6_0(@name("vrf") bit<16> vrf_11, @name("rmac_group") bit<10> rmac_group_9, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_5, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_5, @name("ipv6_multicast_enabled") bit<1> ipv6_multicast_enabled_5, @name("mrpf_group") bit<16> mrpf_group_8) {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
-        meta.l3_metadata.vrf = vrf;
+        meta.l3_metadata.vrf = vrf_11;
         meta.qos_metadata.outer_dscp = meta.l3_metadata.lkp_ip_tc;
-        meta.ipv6_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled;
-        meta.ipv6_metadata.ipv6_urpf_mode = ipv6_urpf_mode;
-        meta.l3_metadata.rmac_group = rmac_group;
+        meta.ipv6_metadata.ipv6_unicast_enabled = ipv6_unicast_enabled_5;
+        meta.ipv6_metadata.ipv6_urpf_mode = ipv6_urpf_mode_5;
+        meta.l3_metadata.rmac_group = rmac_group_9;
         meta.l2_metadata.lkp_mac_sa = hdr.ethernet.srcAddr;
         meta.l2_metadata.lkp_mac_da = hdr.ethernet.dstAddr;
         meta.l3_metadata.lkp_ip_type = 2w2;
@@ -3800,8 +3798,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ipv6_metadata.lkp_ipv6_da = hdr.inner_ipv6.dstAddr;
         meta.l3_metadata.lkp_ip_version = hdr.inner_ipv6.version;
         meta.l3_metadata.lkp_ip_tc = hdr.inner_ipv6.trafficClass;
-        meta.multicast_metadata.bd_mrpf_group = mrpf_group;
-        meta.multicast_metadata.ipv6_multicast_enabled = ipv6_multicast_enabled;
+        meta.multicast_metadata.bd_mrpf_group = mrpf_group_8;
+        meta.multicast_metadata.ipv6_multicast_enabled = ipv6_multicast_enabled_5;
     }
     @name(".non_ip_tunnel_lookup_miss") action _non_ip_tunnel_lookup_miss_0() {
         meta.l2_metadata.lkp_mac_sa = hdr.ethernet.srcAddr;
@@ -4033,33 +4031,33 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_1() {
     }
-    @name(".outer_multicast_route_s_g_hit") action _outer_multicast_route_s_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".outer_multicast_route_s_g_hit") action _outer_multicast_route_s_g_hit(@name("mc_index") bit<16> mc_index, @name("mcast_rpf_group") bit<16> mcast_rpf_group_12) {
         standard_metadata.mcast_grp = mc_index;
         meta.multicast_metadata.outer_mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group ^ meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_12 ^ meta.multicast_metadata.bd_mrpf_group;
         meta.fabric_metadata.dst_device = 8w127;
     }
-    @name(".outer_multicast_bridge_s_g_hit") action _outer_multicast_bridge_s_g_hit(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".outer_multicast_bridge_s_g_hit") action _outer_multicast_bridge_s_g_hit(@name("mc_index") bit<16> mc_index_22) {
+        standard_metadata.mcast_grp = mc_index_22;
         meta.tunnel_metadata.tunnel_terminate = 1w1;
         meta.fabric_metadata.dst_device = 8w127;
     }
-    @name(".outer_multicast_route_sm_star_g_hit") action _outer_multicast_route_sm_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".outer_multicast_route_sm_star_g_hit") action _outer_multicast_route_sm_star_g_hit(@name("mc_index") bit<16> mc_index_23, @name("mcast_rpf_group") bit<16> mcast_rpf_group_13) {
         meta.multicast_metadata.outer_mcast_mode = 2w1;
-        standard_metadata.mcast_grp = mc_index;
+        standard_metadata.mcast_grp = mc_index_23;
         meta.multicast_metadata.outer_mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group ^ meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_13 ^ meta.multicast_metadata.bd_mrpf_group;
         meta.fabric_metadata.dst_device = 8w127;
     }
-    @name(".outer_multicast_route_bidir_star_g_hit") action _outer_multicast_route_bidir_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".outer_multicast_route_bidir_star_g_hit") action _outer_multicast_route_bidir_star_g_hit(@name("mc_index") bit<16> mc_index_24, @name("mcast_rpf_group") bit<16> mcast_rpf_group_14) {
         meta.multicast_metadata.outer_mcast_mode = 2w2;
-        standard_metadata.mcast_grp = mc_index;
+        standard_metadata.mcast_grp = mc_index_24;
         meta.multicast_metadata.outer_mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group | meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_14 | meta.multicast_metadata.bd_mrpf_group;
         meta.fabric_metadata.dst_device = 8w127;
     }
-    @name(".outer_multicast_bridge_star_g_hit") action _outer_multicast_bridge_star_g_hit(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".outer_multicast_bridge_star_g_hit") action _outer_multicast_bridge_star_g_hit(@name("mc_index") bit<16> mc_index_25) {
+        standard_metadata.mcast_grp = mc_index_25;
         meta.tunnel_metadata.tunnel_terminate = 1w1;
         meta.fabric_metadata.dst_device = 8w127;
     }
@@ -4102,33 +4100,33 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_2() {
     }
-    @name(".outer_multicast_route_s_g_hit") action _outer_multicast_route_s_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".outer_multicast_route_s_g_hit") action _outer_multicast_route_s_g_hit_0(@name("mc_index") bit<16> mc_index_26, @name("mcast_rpf_group") bit<16> mcast_rpf_group_15) {
+        standard_metadata.mcast_grp = mc_index_26;
         meta.multicast_metadata.outer_mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group ^ meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_15 ^ meta.multicast_metadata.bd_mrpf_group;
         meta.fabric_metadata.dst_device = 8w127;
     }
-    @name(".outer_multicast_bridge_s_g_hit") action _outer_multicast_bridge_s_g_hit_0(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".outer_multicast_bridge_s_g_hit") action _outer_multicast_bridge_s_g_hit_0(@name("mc_index") bit<16> mc_index_27) {
+        standard_metadata.mcast_grp = mc_index_27;
         meta.tunnel_metadata.tunnel_terminate = 1w1;
         meta.fabric_metadata.dst_device = 8w127;
     }
-    @name(".outer_multicast_route_sm_star_g_hit") action _outer_multicast_route_sm_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".outer_multicast_route_sm_star_g_hit") action _outer_multicast_route_sm_star_g_hit_0(@name("mc_index") bit<16> mc_index_28, @name("mcast_rpf_group") bit<16> mcast_rpf_group_16) {
         meta.multicast_metadata.outer_mcast_mode = 2w1;
-        standard_metadata.mcast_grp = mc_index;
+        standard_metadata.mcast_grp = mc_index_28;
         meta.multicast_metadata.outer_mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group ^ meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_16 ^ meta.multicast_metadata.bd_mrpf_group;
         meta.fabric_metadata.dst_device = 8w127;
     }
-    @name(".outer_multicast_route_bidir_star_g_hit") action _outer_multicast_route_bidir_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".outer_multicast_route_bidir_star_g_hit") action _outer_multicast_route_bidir_star_g_hit_0(@name("mc_index") bit<16> mc_index_29, @name("mcast_rpf_group") bit<16> mcast_rpf_group_17) {
         meta.multicast_metadata.outer_mcast_mode = 2w2;
-        standard_metadata.mcast_grp = mc_index;
+        standard_metadata.mcast_grp = mc_index_29;
         meta.multicast_metadata.outer_mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group | meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_17 | meta.multicast_metadata.bd_mrpf_group;
         meta.fabric_metadata.dst_device = 8w127;
     }
-    @name(".outer_multicast_bridge_star_g_hit") action _outer_multicast_bridge_star_g_hit_0(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".outer_multicast_bridge_star_g_hit") action _outer_multicast_bridge_star_g_hit_0(@name("mc_index") bit<16> mc_index_30) {
+        standard_metadata.mcast_grp = mc_index_30;
         meta.tunnel_metadata.tunnel_terminate = 1w1;
         meta.fabric_metadata.dst_device = 8w127;
     }
@@ -4170,14 +4168,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_tunnel_termination_flag") action _set_tunnel_termination_flag() {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
     }
-    @name(".set_tunnel_vni_and_termination_flag") action _set_tunnel_vni_and_termination_flag(bit<24> tunnel_vni) {
-        meta.tunnel_metadata.tunnel_vni = tunnel_vni;
+    @name(".set_tunnel_vni_and_termination_flag") action _set_tunnel_vni_and_termination_flag(@name("tunnel_vni") bit<24> tunnel_vni_2) {
+        meta.tunnel_metadata.tunnel_vni = tunnel_vni_2;
         meta.tunnel_metadata.tunnel_terminate = 1w1;
     }
     @name(".on_miss") action _on_miss_3() {
     }
-    @name(".src_vtep_hit") action _src_vtep_hit(bit<16> ifindex) {
-        meta.ingress_metadata.ifindex = ifindex;
+    @name(".src_vtep_hit") action _src_vtep_hit(@name("ifindex") bit<16> ifindex_15) {
+        meta.ingress_metadata.ifindex = ifindex_15;
     }
     @name(".ipv4_dest_vtep") table _ipv4_dest_vtep_0 {
         actions = {
@@ -4213,14 +4211,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_tunnel_termination_flag") action _set_tunnel_termination_flag_0() {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
     }
-    @name(".set_tunnel_vni_and_termination_flag") action _set_tunnel_vni_and_termination_flag_0(bit<24> tunnel_vni) {
-        meta.tunnel_metadata.tunnel_vni = tunnel_vni;
+    @name(".set_tunnel_vni_and_termination_flag") action _set_tunnel_vni_and_termination_flag_0(@name("tunnel_vni") bit<24> tunnel_vni_3) {
+        meta.tunnel_metadata.tunnel_vni = tunnel_vni_3;
         meta.tunnel_metadata.tunnel_terminate = 1w1;
     }
     @name(".on_miss") action _on_miss_4() {
     }
-    @name(".src_vtep_hit") action _src_vtep_hit_0(bit<16> ifindex) {
-        meta.ingress_metadata.ifindex = ifindex;
+    @name(".src_vtep_hit") action _src_vtep_hit_0(@name("ifindex") bit<16> ifindex_16) {
+        meta.ingress_metadata.ifindex = ifindex_16;
     }
     @name(".ipv6_dest_vtep") table _ipv6_dest_vtep_0 {
         actions = {
@@ -4251,22 +4249,22 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1024;
         default_action = NoAction_177();
     }
-    @name(".terminate_eompls") action _terminate_eompls(bit<16> bd, bit<5> tunnel_type) {
+    @name(".terminate_eompls") action _terminate_eompls(@name("bd") bit<16> bd_28, @name("tunnel_type") bit<5> tunnel_type_11) {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
-        meta.tunnel_metadata.ingress_tunnel_type = tunnel_type;
-        meta.ingress_metadata.bd = bd;
+        meta.tunnel_metadata.ingress_tunnel_type = tunnel_type_11;
+        meta.ingress_metadata.bd = bd_28;
         meta.l2_metadata.lkp_mac_type = hdr.inner_ethernet.etherType;
     }
-    @name(".terminate_vpls") action _terminate_vpls(bit<16> bd, bit<5> tunnel_type) {
+    @name(".terminate_vpls") action _terminate_vpls(@name("bd") bit<16> bd_29, @name("tunnel_type") bit<5> tunnel_type_12) {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
-        meta.tunnel_metadata.ingress_tunnel_type = tunnel_type;
-        meta.ingress_metadata.bd = bd;
+        meta.tunnel_metadata.ingress_tunnel_type = tunnel_type_12;
+        meta.ingress_metadata.bd = bd_29;
         meta.l2_metadata.lkp_mac_type = hdr.inner_ethernet.etherType;
     }
-    @name(".terminate_ipv4_over_mpls") action _terminate_ipv4_over_mpls(bit<16> vrf, bit<5> tunnel_type) {
+    @name(".terminate_ipv4_over_mpls") action _terminate_ipv4_over_mpls(@name("vrf") bit<16> vrf_12, @name("tunnel_type") bit<5> tunnel_type_13) {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
-        meta.tunnel_metadata.ingress_tunnel_type = tunnel_type;
-        meta.l3_metadata.vrf = vrf;
+        meta.tunnel_metadata.ingress_tunnel_type = tunnel_type_13;
+        meta.l3_metadata.vrf = vrf_12;
         meta.l2_metadata.lkp_mac_sa = hdr.ethernet.srcAddr;
         meta.l2_metadata.lkp_mac_da = hdr.ethernet.dstAddr;
         meta.l3_metadata.lkp_ip_type = 2w1;
@@ -4274,10 +4272,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l3_metadata.lkp_ip_version = hdr.inner_ipv4.version;
         meta.l3_metadata.lkp_ip_tc = hdr.inner_ipv4.diffserv;
     }
-    @name(".terminate_ipv6_over_mpls") action _terminate_ipv6_over_mpls(bit<16> vrf, bit<5> tunnel_type) {
+    @name(".terminate_ipv6_over_mpls") action _terminate_ipv6_over_mpls(@name("vrf") bit<16> vrf_13, @name("tunnel_type") bit<5> tunnel_type_14) {
         meta.tunnel_metadata.tunnel_terminate = 1w1;
-        meta.tunnel_metadata.ingress_tunnel_type = tunnel_type;
-        meta.l3_metadata.vrf = vrf;
+        meta.tunnel_metadata.ingress_tunnel_type = tunnel_type_14;
+        meta.l3_metadata.vrf = vrf_13;
         meta.l2_metadata.lkp_mac_sa = hdr.ethernet.srcAddr;
         meta.l2_metadata.lkp_mac_da = hdr.ethernet.dstAddr;
         meta.l3_metadata.lkp_ip_type = 2w2;
@@ -4285,13 +4283,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l3_metadata.lkp_ip_version = hdr.inner_ipv6.version;
         meta.l3_metadata.lkp_ip_tc = hdr.inner_ipv6.trafficClass;
     }
-    @name(".terminate_pw") action _terminate_pw(bit<16> ifindex) {
-        meta.ingress_metadata.egress_ifindex = ifindex;
+    @name(".terminate_pw") action _terminate_pw(@name("ifindex") bit<16> ifindex_17) {
+        meta.ingress_metadata.egress_ifindex = ifindex_17;
         meta.l2_metadata.lkp_mac_sa = hdr.ethernet.srcAddr;
         meta.l2_metadata.lkp_mac_da = hdr.ethernet.dstAddr;
     }
-    @name(".forward_mpls") action _forward_mpls(bit<16> nexthop_index) {
-        meta.l3_metadata.fib_nexthop = nexthop_index;
+    @name(".forward_mpls") action _forward_mpls(@name("nexthop_index") bit<16> nexthop_index_8) {
+        meta.l3_metadata.fib_nexthop = nexthop_index_8;
         meta.l3_metadata.fib_nexthop_type = 1w0;
         meta.l3_metadata.fib_hit = 1w1;
         meta.l2_metadata.lkp_mac_sa = hdr.ethernet.srcAddr;
@@ -4318,16 +4316,16 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".sflow_ingress_session_pkt_counter") direct_counter(CounterType.packets) _sflow_ingress_session_pkt_counter;
     @name(".nop") action _nop_68() {
     }
-    @name(".sflow_ing_session_enable") action _sflow_ing_session_enable_0(bit<32> rate_thr, bit<16> session_id) {
+    @name(".sflow_ing_session_enable") action _sflow_ing_session_enable_0(@name("rate_thr") bit<32> rate_thr, @name("session_id") bit<16> session_id_7) {
         meta.ingress_metadata.sflow_take_sample = rate_thr |+| meta.ingress_metadata.sflow_take_sample;
-        meta.sflow_metadata.sflow_session_id = session_id;
+        meta.sflow_metadata.sflow_session_id = session_id_7;
     }
     @name(".nop") action _nop_69() {
         _sflow_ingress_session_pkt_counter.count();
     }
-    @name(".sflow_ing_pkt_to_cpu") action _sflow_ing_pkt_to_cpu_0(bit<32> sflow_i2e_mirror_id, bit<16> reason_code) {
+    @name(".sflow_ing_pkt_to_cpu") action _sflow_ing_pkt_to_cpu_0(@name("sflow_i2e_mirror_id") bit<32> sflow_i2e_mirror_id, @name("reason_code") bit<16> reason_code_5) {
         _sflow_ingress_session_pkt_counter.count();
-        meta.fabric_metadata.reason_code = reason_code;
+        meta.fabric_metadata.reason_code = reason_code_5;
         meta.i2e_metadata.mirror_session_id = (bit<16>)sflow_i2e_mirror_id;
         clone3<tuple<tuple<bit<16>, bit<16>, bit<16>, bit<9>>, bit<16>, bit<16>>>(CloneType.I2E, sflow_i2e_mirror_id, { { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port }, meta.sflow_metadata.sflow_session_id, meta.i2e_metadata.mirror_session_id });
     }
@@ -4361,7 +4359,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_70() {
     }
-    @name(".set_storm_control_meter") action _set_storm_control_meter_0(bit<16> meter_idx) {
+    @name(".set_storm_control_meter") action _set_storm_control_meter_0(@name("meter_idx") bit<16> meter_idx) {
         storm_control_meter.execute_meter<bit<2>>((bit<10>)meter_idx, meta.meter_metadata.meter_color);
         meta.meter_metadata.meter_index = meter_idx;
     }
@@ -4400,9 +4398,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.l2_metadata.lkp_pkt_type = 3w4;
         meta.l2_metadata.bd_stats_idx = meta.l2_metadata.bd_stats_idx + 16w2;
     }
-    @name(".set_malformed_packet") action _set_malformed_packet_0(bit<8> drop_reason) {
+    @name(".set_malformed_packet") action _set_malformed_packet_0(@name("drop_reason") bit<8> drop_reason_8) {
         meta.ingress_metadata.drop_flag = 1w1;
-        meta.ingress_metadata.drop_reason = drop_reason;
+        meta.ingress_metadata.drop_reason = drop_reason_8;
     }
     @name(".validate_packet") table _validate_packet {
         actions = {
@@ -4431,24 +4429,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_73() {
     }
-    @name(".dmac_hit") action _dmac_hit_0(bit<16> ifindex) {
-        meta.ingress_metadata.egress_ifindex = ifindex;
-        meta.l2_metadata.same_if_check = meta.l2_metadata.same_if_check ^ ifindex;
+    @name(".dmac_hit") action _dmac_hit_0(@name("ifindex") bit<16> ifindex_18) {
+        meta.ingress_metadata.egress_ifindex = ifindex_18;
+        meta.l2_metadata.same_if_check = meta.l2_metadata.same_if_check ^ ifindex_18;
     }
-    @name(".dmac_multicast_hit") action _dmac_multicast_hit_0(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".dmac_multicast_hit") action _dmac_multicast_hit_0(@name("mc_index") bit<16> mc_index_31) {
+        standard_metadata.mcast_grp = mc_index_31;
         meta.fabric_metadata.dst_device = 8w127;
     }
     @name(".dmac_miss") action _dmac_miss_0() {
         meta.ingress_metadata.egress_ifindex = 16w65535;
         meta.fabric_metadata.dst_device = 8w127;
     }
-    @name(".dmac_redirect_nexthop") action _dmac_redirect_nexthop_0(bit<16> nexthop_index) {
+    @name(".dmac_redirect_nexthop") action _dmac_redirect_nexthop_0(@name("nexthop_index") bit<16> nexthop_index_9) {
         meta.l2_metadata.l2_redirect = 1w1;
-        meta.l2_metadata.l2_nexthop = nexthop_index;
+        meta.l2_metadata.l2_nexthop = nexthop_index_9;
         meta.l2_metadata.l2_nexthop_type = 1w0;
     }
-    @name(".dmac_redirect_ecmp") action _dmac_redirect_ecmp_0(bit<16> ecmp_index) {
+    @name(".dmac_redirect_ecmp") action _dmac_redirect_ecmp_0(@name("ecmp_index") bit<16> ecmp_index) {
         meta.l2_metadata.l2_redirect = 1w1;
         meta.l2_metadata.l2_nexthop = ecmp_index;
         meta.l2_metadata.l2_nexthop_type = 1w1;
@@ -4459,8 +4457,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".smac_miss") action _smac_miss_0() {
         meta.l2_metadata.l2_src_miss = 1w1;
     }
-    @name(".smac_hit") action _smac_hit_0(bit<16> ifindex) {
-        meta.l2_metadata.l2_src_move = meta.ingress_metadata.ifindex ^ ifindex;
+    @name(".smac_hit") action _smac_hit_0(@name("ifindex") bit<16> ifindex_19) {
+        meta.l2_metadata.l2_src_move = meta.ingress_metadata.ifindex ^ ifindex_19;
     }
     @name(".dmac") table _dmac {
         support_timeout = true;
@@ -4497,43 +4495,43 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_74() {
     }
-    @name(".acl_deny") action _acl_deny_1(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_deny") action _acl_deny_1(@name("acl_stats_index") bit<14> acl_stats_index_18, @name("acl_meter_index") bit<16> acl_meter_index, @name("acl_copy") bit<1> acl_copy_16, @name("acl_copy_reason") bit<16> acl_copy_reason) {
         meta.acl_metadata.acl_deny = 1w1;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_18;
         meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
+        meta.acl_metadata.acl_copy = acl_copy_16;
         meta.fabric_metadata.reason_code = acl_copy_reason;
     }
-    @name(".acl_permit") action _acl_permit_1(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+    @name(".acl_permit") action _acl_permit_1(@name("acl_stats_index") bit<14> acl_stats_index_19, @name("acl_meter_index") bit<16> acl_meter_index_10, @name("acl_copy") bit<1> acl_copy_17, @name("acl_copy_reason") bit<16> acl_copy_reason_16) {
+        meta.acl_metadata.acl_stats_index = acl_stats_index_19;
+        meta.meter_metadata.meter_index = acl_meter_index_10;
+        meta.acl_metadata.acl_copy = acl_copy_17;
+        meta.fabric_metadata.reason_code = acl_copy_reason_16;
     }
-    @name(".acl_mirror") action _acl_mirror_1(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
+    @name(".acl_mirror") action _acl_mirror_1(@name("session_id") bit<32> session_id_8, @name("acl_stats_index") bit<14> acl_stats_index_20, @name("acl_meter_index") bit<16> acl_meter_index_11) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id_8;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)standard_metadata.ingress_global_timestamp;
-        clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
+        clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id_8, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
+        meta.acl_metadata.acl_stats_index = acl_stats_index_20;
+        meta.meter_metadata.meter_index = acl_meter_index_11;
     }
-    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_1(bit<16> nexthop_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_1(@name("nexthop_index") bit<16> nexthop_index_10, @name("acl_stats_index") bit<14> acl_stats_index_21, @name("acl_meter_index") bit<16> acl_meter_index_12, @name("acl_copy") bit<1> acl_copy_18, @name("acl_copy_reason") bit<16> acl_copy_reason_17) {
         meta.acl_metadata.acl_redirect = 1w1;
-        meta.acl_metadata.acl_nexthop = nexthop_index;
+        meta.acl_metadata.acl_nexthop = nexthop_index_10;
         meta.acl_metadata.acl_nexthop_type = 1w0;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_21;
+        meta.meter_metadata.meter_index = acl_meter_index_12;
+        meta.acl_metadata.acl_copy = acl_copy_18;
+        meta.fabric_metadata.reason_code = acl_copy_reason_17;
     }
-    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_1(bit<16> ecmp_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_1(@name("ecmp_index") bit<16> ecmp_index_7, @name("acl_stats_index") bit<14> acl_stats_index_22, @name("acl_meter_index") bit<16> acl_meter_index_13, @name("acl_copy") bit<1> acl_copy_19, @name("acl_copy_reason") bit<16> acl_copy_reason_18) {
         meta.acl_metadata.acl_redirect = 1w1;
-        meta.acl_metadata.acl_nexthop = ecmp_index;
+        meta.acl_metadata.acl_nexthop = ecmp_index_7;
         meta.acl_metadata.acl_nexthop_type = 1w1;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_22;
+        meta.meter_metadata.meter_index = acl_meter_index_13;
+        meta.acl_metadata.acl_copy = acl_copy_19;
+        meta.fabric_metadata.reason_code = acl_copy_reason_18;
     }
     @name(".mac_acl") table _mac_acl {
         actions = {
@@ -4559,81 +4557,81 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_93() {
     }
-    @name(".acl_deny") action _acl_deny_2(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_deny") action _acl_deny_2(@name("acl_stats_index") bit<14> acl_stats_index_23, @name("acl_meter_index") bit<16> acl_meter_index_14, @name("acl_copy") bit<1> acl_copy_20, @name("acl_copy_reason") bit<16> acl_copy_reason_19) {
         meta.acl_metadata.acl_deny = 1w1;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_23;
+        meta.meter_metadata.meter_index = acl_meter_index_14;
+        meta.acl_metadata.acl_copy = acl_copy_20;
+        meta.fabric_metadata.reason_code = acl_copy_reason_19;
     }
-    @name(".acl_deny") action _acl_deny_4(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_deny") action _acl_deny_4(@name("acl_stats_index") bit<14> acl_stats_index_24, @name("acl_meter_index") bit<16> acl_meter_index_15, @name("acl_copy") bit<1> acl_copy_21, @name("acl_copy_reason") bit<16> acl_copy_reason_20) {
         meta.acl_metadata.acl_deny = 1w1;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_24;
+        meta.meter_metadata.meter_index = acl_meter_index_15;
+        meta.acl_metadata.acl_copy = acl_copy_21;
+        meta.fabric_metadata.reason_code = acl_copy_reason_20;
     }
-    @name(".acl_permit") action _acl_permit_2(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+    @name(".acl_permit") action _acl_permit_2(@name("acl_stats_index") bit<14> acl_stats_index_25, @name("acl_meter_index") bit<16> acl_meter_index_16, @name("acl_copy") bit<1> acl_copy_22, @name("acl_copy_reason") bit<16> acl_copy_reason_21) {
+        meta.acl_metadata.acl_stats_index = acl_stats_index_25;
+        meta.meter_metadata.meter_index = acl_meter_index_16;
+        meta.acl_metadata.acl_copy = acl_copy_22;
+        meta.fabric_metadata.reason_code = acl_copy_reason_21;
     }
-    @name(".acl_permit") action _acl_permit_4(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+    @name(".acl_permit") action _acl_permit_4(@name("acl_stats_index") bit<14> acl_stats_index_26, @name("acl_meter_index") bit<16> acl_meter_index_17, @name("acl_copy") bit<1> acl_copy_23, @name("acl_copy_reason") bit<16> acl_copy_reason_22) {
+        meta.acl_metadata.acl_stats_index = acl_stats_index_26;
+        meta.meter_metadata.meter_index = acl_meter_index_17;
+        meta.acl_metadata.acl_copy = acl_copy_23;
+        meta.fabric_metadata.reason_code = acl_copy_reason_22;
     }
-    @name(".acl_mirror") action _acl_mirror_2(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
+    @name(".acl_mirror") action _acl_mirror_2(@name("session_id") bit<32> session_id_9, @name("acl_stats_index") bit<14> acl_stats_index_27, @name("acl_meter_index") bit<16> acl_meter_index_18) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id_9;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)standard_metadata.ingress_global_timestamp;
-        clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
+        clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id_9, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
+        meta.acl_metadata.acl_stats_index = acl_stats_index_27;
+        meta.meter_metadata.meter_index = acl_meter_index_18;
     }
-    @name(".acl_mirror") action _acl_mirror_4(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id;
+    @name(".acl_mirror") action _acl_mirror_4(@name("session_id") bit<32> session_id_10, @name("acl_stats_index") bit<14> acl_stats_index_28, @name("acl_meter_index") bit<16> acl_meter_index_19) {
+        meta.i2e_metadata.mirror_session_id = (bit<16>)session_id_10;
         meta.i2e_metadata.ingress_tstamp = (bit<32>)standard_metadata.ingress_global_timestamp;
-        clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
+        clone3<tuple<bit<32>, bit<16>>>(CloneType.I2E, session_id_10, { meta.i2e_metadata.ingress_tstamp, meta.i2e_metadata.mirror_session_id });
+        meta.acl_metadata.acl_stats_index = acl_stats_index_28;
+        meta.meter_metadata.meter_index = acl_meter_index_19;
     }
-    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_2(bit<16> nexthop_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_11, @name("acl_stats_index") bit<14> acl_stats_index_29, @name("acl_meter_index") bit<16> acl_meter_index_20, @name("acl_copy") bit<1> acl_copy_24, @name("acl_copy_reason") bit<16> acl_copy_reason_23) {
         meta.acl_metadata.acl_redirect = 1w1;
-        meta.acl_metadata.acl_nexthop = nexthop_index;
+        meta.acl_metadata.acl_nexthop = nexthop_index_11;
         meta.acl_metadata.acl_nexthop_type = 1w0;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_29;
+        meta.meter_metadata.meter_index = acl_meter_index_20;
+        meta.acl_metadata.acl_copy = acl_copy_24;
+        meta.fabric_metadata.reason_code = acl_copy_reason_23;
     }
-    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_4(bit<16> nexthop_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_4(@name("nexthop_index") bit<16> nexthop_index_12, @name("acl_stats_index") bit<14> acl_stats_index_30, @name("acl_meter_index") bit<16> acl_meter_index_21, @name("acl_copy") bit<1> acl_copy_25, @name("acl_copy_reason") bit<16> acl_copy_reason_24) {
         meta.acl_metadata.acl_redirect = 1w1;
-        meta.acl_metadata.acl_nexthop = nexthop_index;
+        meta.acl_metadata.acl_nexthop = nexthop_index_12;
         meta.acl_metadata.acl_nexthop_type = 1w0;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_30;
+        meta.meter_metadata.meter_index = acl_meter_index_21;
+        meta.acl_metadata.acl_copy = acl_copy_25;
+        meta.fabric_metadata.reason_code = acl_copy_reason_24;
     }
-    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_2(bit<16> ecmp_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_2(@name("ecmp_index") bit<16> ecmp_index_8, @name("acl_stats_index") bit<14> acl_stats_index_31, @name("acl_meter_index") bit<16> acl_meter_index_22, @name("acl_copy") bit<1> acl_copy_26, @name("acl_copy_reason") bit<16> acl_copy_reason_25) {
         meta.acl_metadata.acl_redirect = 1w1;
-        meta.acl_metadata.acl_nexthop = ecmp_index;
+        meta.acl_metadata.acl_nexthop = ecmp_index_8;
         meta.acl_metadata.acl_nexthop_type = 1w1;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_31;
+        meta.meter_metadata.meter_index = acl_meter_index_22;
+        meta.acl_metadata.acl_copy = acl_copy_26;
+        meta.fabric_metadata.reason_code = acl_copy_reason_25;
     }
-    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_4(bit<16> ecmp_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_4(@name("ecmp_index") bit<16> ecmp_index_9, @name("acl_stats_index") bit<14> acl_stats_index_32, @name("acl_meter_index") bit<16> acl_meter_index_23, @name("acl_copy") bit<1> acl_copy_27, @name("acl_copy_reason") bit<16> acl_copy_reason_26) {
         meta.acl_metadata.acl_redirect = 1w1;
-        meta.acl_metadata.acl_nexthop = ecmp_index;
+        meta.acl_metadata.acl_nexthop = ecmp_index_9;
         meta.acl_metadata.acl_nexthop_type = 1w1;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.meter_metadata.meter_index = acl_meter_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_32;
+        meta.meter_metadata.meter_index = acl_meter_index_23;
+        meta.acl_metadata.acl_copy = acl_copy_27;
+        meta.fabric_metadata.reason_code = acl_copy_reason_26;
     }
     @name(".ip_acl") table _ip_acl {
         actions = {
@@ -4685,13 +4683,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_94() {
     }
-    @name(".apply_cos_marking") action _apply_cos_marking_0(bit<3> cos) {
+    @name(".apply_cos_marking") action _apply_cos_marking_0(@name("cos") bit<3> cos) {
         meta.qos_metadata.marked_cos = cos;
     }
-    @name(".apply_dscp_marking") action _apply_dscp_marking_0(bit<8> dscp) {
+    @name(".apply_dscp_marking") action _apply_dscp_marking_0(@name("dscp") bit<8> dscp) {
         meta.qos_metadata.marked_dscp = dscp;
     }
-    @name(".apply_tc_marking") action _apply_tc_marking_0(bit<3> tc) {
+    @name(".apply_tc_marking") action _apply_tc_marking_0(@name("tc") bit<3> tc) {
         meta.qos_metadata.marked_exp = tc;
     }
     @name(".qos") table _qos {
@@ -4718,14 +4716,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".ipv4_multicast_route_star_g_stats") direct_counter(CounterType.packets) _ipv4_multicast_route_star_g_stats_0;
     @name(".on_miss") action _on_miss_5() {
     }
-    @name(".multicast_bridge_s_g_hit") action _multicast_bridge_s_g_hit(bit<16> mc_index) {
-        meta.multicast_metadata.multicast_bridge_mc_index = mc_index;
+    @name(".multicast_bridge_s_g_hit") action _multicast_bridge_s_g_hit(@name("mc_index") bit<16> mc_index_32) {
+        meta.multicast_metadata.multicast_bridge_mc_index = mc_index_32;
         meta.multicast_metadata.mcast_bridge_hit = 1w1;
     }
     @name(".nop") action _nop_95() {
     }
-    @name(".multicast_bridge_star_g_hit") action _multicast_bridge_star_g_hit(bit<16> mc_index) {
-        meta.multicast_metadata.multicast_bridge_mc_index = mc_index;
+    @name(".multicast_bridge_star_g_hit") action _multicast_bridge_star_g_hit(@name("mc_index") bit<16> mc_index_33) {
+        meta.multicast_metadata.multicast_bridge_mc_index = mc_index_33;
         meta.multicast_metadata.mcast_bridge_hit = 1w1;
     }
     @name(".ipv4_multicast_bridge") table _ipv4_multicast_bridge_0 {
@@ -4758,12 +4756,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_6() {
         _ipv4_multicast_route_s_g_stats_0.count();
     }
-    @name(".multicast_route_s_g_hit") action _multicast_route_s_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_s_g_hit") action _multicast_route_s_g_hit(@name("mc_index") bit<16> mc_index_34, @name("mcast_rpf_group") bit<16> mcast_rpf_group_18) {
         _ipv4_multicast_route_s_g_stats_0.count();
-        meta.multicast_metadata.multicast_route_mc_index = mc_index;
+        meta.multicast_metadata.multicast_route_mc_index = mc_index_34;
         meta.multicast_metadata.mcast_mode = 2w1;
         meta.multicast_metadata.mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group ^ meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_18 ^ meta.multicast_metadata.bd_mrpf_group;
     }
     @name(".ipv4_multicast_route") table _ipv4_multicast_route_0 {
         actions = {
@@ -4784,19 +4782,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         _ipv4_multicast_route_star_g_stats_0.count();
         meta.l3_metadata.l3_copy = 1w1;
     }
-    @name(".multicast_route_sm_star_g_hit") action _multicast_route_sm_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_sm_star_g_hit") action _multicast_route_sm_star_g_hit(@name("mc_index") bit<16> mc_index_35, @name("mcast_rpf_group") bit<16> mcast_rpf_group_19) {
         _ipv4_multicast_route_star_g_stats_0.count();
         meta.multicast_metadata.mcast_mode = 2w1;
-        meta.multicast_metadata.multicast_route_mc_index = mc_index;
+        meta.multicast_metadata.multicast_route_mc_index = mc_index_35;
         meta.multicast_metadata.mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group ^ meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_19 ^ meta.multicast_metadata.bd_mrpf_group;
     }
-    @name(".multicast_route_bidir_star_g_hit") action _multicast_route_bidir_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_bidir_star_g_hit") action _multicast_route_bidir_star_g_hit(@name("mc_index") bit<16> mc_index_36, @name("mcast_rpf_group") bit<16> mcast_rpf_group_20) {
         _ipv4_multicast_route_star_g_stats_0.count();
         meta.multicast_metadata.mcast_mode = 2w2;
-        meta.multicast_metadata.multicast_route_mc_index = mc_index;
+        meta.multicast_metadata.multicast_route_mc_index = mc_index_36;
         meta.multicast_metadata.mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group | meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_20 | meta.multicast_metadata.bd_mrpf_group;
     }
     @name(".ipv4_multicast_route_star_g") table _ipv4_multicast_route_star_g_0 {
         actions = {
@@ -4817,14 +4815,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".ipv6_multicast_route_star_g_stats") direct_counter(CounterType.packets) _ipv6_multicast_route_star_g_stats_0;
     @name(".on_miss") action _on_miss_7() {
     }
-    @name(".multicast_bridge_s_g_hit") action _multicast_bridge_s_g_hit_0(bit<16> mc_index) {
-        meta.multicast_metadata.multicast_bridge_mc_index = mc_index;
+    @name(".multicast_bridge_s_g_hit") action _multicast_bridge_s_g_hit_0(@name("mc_index") bit<16> mc_index_37) {
+        meta.multicast_metadata.multicast_bridge_mc_index = mc_index_37;
         meta.multicast_metadata.mcast_bridge_hit = 1w1;
     }
     @name(".nop") action _nop_96() {
     }
-    @name(".multicast_bridge_star_g_hit") action _multicast_bridge_star_g_hit_0(bit<16> mc_index) {
-        meta.multicast_metadata.multicast_bridge_mc_index = mc_index;
+    @name(".multicast_bridge_star_g_hit") action _multicast_bridge_star_g_hit_0(@name("mc_index") bit<16> mc_index_38) {
+        meta.multicast_metadata.multicast_bridge_mc_index = mc_index_38;
         meta.multicast_metadata.mcast_bridge_hit = 1w1;
     }
     @name(".ipv6_multicast_bridge") table _ipv6_multicast_bridge_0 {
@@ -4857,12 +4855,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_8() {
         _ipv6_multicast_route_s_g_stats_0.count();
     }
-    @name(".multicast_route_s_g_hit") action _multicast_route_s_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_s_g_hit") action _multicast_route_s_g_hit_0(@name("mc_index") bit<16> mc_index_39, @name("mcast_rpf_group") bit<16> mcast_rpf_group_21) {
         _ipv6_multicast_route_s_g_stats_0.count();
-        meta.multicast_metadata.multicast_route_mc_index = mc_index;
+        meta.multicast_metadata.multicast_route_mc_index = mc_index_39;
         meta.multicast_metadata.mcast_mode = 2w1;
         meta.multicast_metadata.mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group ^ meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_21 ^ meta.multicast_metadata.bd_mrpf_group;
     }
     @name(".ipv6_multicast_route") table _ipv6_multicast_route_0 {
         actions = {
@@ -4883,19 +4881,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         _ipv6_multicast_route_star_g_stats_0.count();
         meta.l3_metadata.l3_copy = 1w1;
     }
-    @name(".multicast_route_sm_star_g_hit") action _multicast_route_sm_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_sm_star_g_hit") action _multicast_route_sm_star_g_hit_0(@name("mc_index") bit<16> mc_index_40, @name("mcast_rpf_group") bit<16> mcast_rpf_group_22) {
         _ipv6_multicast_route_star_g_stats_0.count();
         meta.multicast_metadata.mcast_mode = 2w1;
-        meta.multicast_metadata.multicast_route_mc_index = mc_index;
+        meta.multicast_metadata.multicast_route_mc_index = mc_index_40;
         meta.multicast_metadata.mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group ^ meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_22 ^ meta.multicast_metadata.bd_mrpf_group;
     }
-    @name(".multicast_route_bidir_star_g_hit") action _multicast_route_bidir_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_bidir_star_g_hit") action _multicast_route_bidir_star_g_hit_0(@name("mc_index") bit<16> mc_index_41, @name("mcast_rpf_group") bit<16> mcast_rpf_group_23) {
         _ipv6_multicast_route_star_g_stats_0.count();
         meta.multicast_metadata.mcast_mode = 2w2;
-        meta.multicast_metadata.multicast_route_mc_index = mc_index;
+        meta.multicast_metadata.multicast_route_mc_index = mc_index_41;
         meta.multicast_metadata.mcast_route_hit = 1w1;
-        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group | meta.multicast_metadata.bd_mrpf_group;
+        meta.multicast_metadata.mcast_rpf_group = mcast_rpf_group_23 | meta.multicast_metadata.bd_mrpf_group;
     }
     @name(".ipv6_multicast_route_star_g") table _ipv6_multicast_route_star_g_0 {
         actions = {
@@ -4914,32 +4912,32 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_97() {
     }
-    @name(".racl_deny") action _racl_deny_1(bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_deny") action _racl_deny_1(@name("acl_stats_index") bit<14> acl_stats_index_33, @name("acl_copy") bit<1> acl_copy_28, @name("acl_copy_reason") bit<16> acl_copy_reason_27) {
         meta.acl_metadata.racl_deny = 1w1;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_33;
+        meta.acl_metadata.acl_copy = acl_copy_28;
+        meta.fabric_metadata.reason_code = acl_copy_reason_27;
     }
-    @name(".racl_permit") action _racl_permit_1(bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+    @name(".racl_permit") action _racl_permit_1(@name("acl_stats_index") bit<14> acl_stats_index_34, @name("acl_copy") bit<1> acl_copy_29, @name("acl_copy_reason") bit<16> acl_copy_reason_28) {
+        meta.acl_metadata.acl_stats_index = acl_stats_index_34;
+        meta.acl_metadata.acl_copy = acl_copy_29;
+        meta.fabric_metadata.reason_code = acl_copy_reason_28;
     }
-    @name(".racl_redirect_nexthop") action _racl_redirect_nexthop_1(bit<16> nexthop_index, bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_redirect_nexthop") action _racl_redirect_nexthop_1(@name("nexthop_index") bit<16> nexthop_index_13, @name("acl_stats_index") bit<14> acl_stats_index_35, @name("acl_copy") bit<1> acl_copy_30, @name("acl_copy_reason") bit<16> acl_copy_reason_29) {
         meta.acl_metadata.racl_redirect = 1w1;
-        meta.acl_metadata.racl_nexthop = nexthop_index;
+        meta.acl_metadata.racl_nexthop = nexthop_index_13;
         meta.acl_metadata.racl_nexthop_type = 1w0;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_35;
+        meta.acl_metadata.acl_copy = acl_copy_30;
+        meta.fabric_metadata.reason_code = acl_copy_reason_29;
     }
-    @name(".racl_redirect_ecmp") action _racl_redirect_ecmp_1(bit<16> ecmp_index, bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_redirect_ecmp") action _racl_redirect_ecmp_1(@name("ecmp_index") bit<16> ecmp_index_10, @name("acl_stats_index") bit<14> acl_stats_index_36, @name("acl_copy") bit<1> acl_copy_31, @name("acl_copy_reason") bit<16> acl_copy_reason_30) {
         meta.acl_metadata.racl_redirect = 1w1;
-        meta.acl_metadata.racl_nexthop = ecmp_index;
+        meta.acl_metadata.racl_nexthop = ecmp_index_10;
         meta.acl_metadata.racl_nexthop_type = 1w1;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_36;
+        meta.acl_metadata.acl_copy = acl_copy_31;
+        meta.fabric_metadata.reason_code = acl_copy_reason_30;
     }
     @name(".ipv4_racl") table _ipv4_racl {
         actions = {
@@ -4963,14 +4961,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_23() {
     }
-    @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_0(bit<16> urpf_bd_group) {
+    @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_0(@name("urpf_bd_group") bit<16> urpf_bd_group_2) {
         meta.l3_metadata.urpf_hit = 1w1;
-        meta.l3_metadata.urpf_bd_group = urpf_bd_group;
+        meta.l3_metadata.urpf_bd_group = urpf_bd_group_2;
         meta.l3_metadata.urpf_mode = meta.ipv4_metadata.ipv4_urpf_mode;
     }
-    @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_2(bit<16> urpf_bd_group) {
+    @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_2(@name("urpf_bd_group") bit<16> urpf_bd_group_3) {
         meta.l3_metadata.urpf_hit = 1w1;
-        meta.l3_metadata.urpf_bd_group = urpf_bd_group;
+        meta.l3_metadata.urpf_bd_group = urpf_bd_group_3;
         meta.l3_metadata.urpf_mode = meta.ipv4_metadata.ipv4_urpf_mode;
     }
     @name(".urpf_miss") action _urpf_miss_1() {
@@ -5006,24 +5004,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_25() {
     }
-    @name(".fib_hit_nexthop") action _fib_hit_nexthop_1(bit<16> nexthop_index) {
+    @name(".fib_hit_nexthop") action _fib_hit_nexthop_1(@name("nexthop_index") bit<16> nexthop_index_14) {
         meta.l3_metadata.fib_hit = 1w1;
-        meta.l3_metadata.fib_nexthop = nexthop_index;
+        meta.l3_metadata.fib_nexthop = nexthop_index_14;
         meta.l3_metadata.fib_nexthop_type = 1w0;
     }
-    @name(".fib_hit_nexthop") action _fib_hit_nexthop_2(bit<16> nexthop_index) {
+    @name(".fib_hit_nexthop") action _fib_hit_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_15) {
         meta.l3_metadata.fib_hit = 1w1;
-        meta.l3_metadata.fib_nexthop = nexthop_index;
+        meta.l3_metadata.fib_nexthop = nexthop_index_15;
         meta.l3_metadata.fib_nexthop_type = 1w0;
     }
-    @name(".fib_hit_ecmp") action _fib_hit_ecmp_1(bit<16> ecmp_index) {
+    @name(".fib_hit_ecmp") action _fib_hit_ecmp_1(@name("ecmp_index") bit<16> ecmp_index_11) {
         meta.l3_metadata.fib_hit = 1w1;
-        meta.l3_metadata.fib_nexthop = ecmp_index;
+        meta.l3_metadata.fib_nexthop = ecmp_index_11;
         meta.l3_metadata.fib_nexthop_type = 1w1;
     }
-    @name(".fib_hit_ecmp") action _fib_hit_ecmp_2(bit<16> ecmp_index) {
+    @name(".fib_hit_ecmp") action _fib_hit_ecmp_2(@name("ecmp_index") bit<16> ecmp_index_12) {
         meta.l3_metadata.fib_hit = 1w1;
-        meta.l3_metadata.fib_nexthop = ecmp_index;
+        meta.l3_metadata.fib_nexthop = ecmp_index_12;
         meta.l3_metadata.fib_nexthop_type = 1w1;
     }
     @name(".ipv4_fib") table _ipv4_fib {
@@ -5056,32 +5054,32 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_98() {
     }
-    @name(".racl_deny") action _racl_deny_2(bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_deny") action _racl_deny_2(@name("acl_stats_index") bit<14> acl_stats_index_37, @name("acl_copy") bit<1> acl_copy_32, @name("acl_copy_reason") bit<16> acl_copy_reason_31) {
         meta.acl_metadata.racl_deny = 1w1;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_37;
+        meta.acl_metadata.acl_copy = acl_copy_32;
+        meta.fabric_metadata.reason_code = acl_copy_reason_31;
     }
-    @name(".racl_permit") action _racl_permit_2(bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+    @name(".racl_permit") action _racl_permit_2(@name("acl_stats_index") bit<14> acl_stats_index_38, @name("acl_copy") bit<1> acl_copy_33, @name("acl_copy_reason") bit<16> acl_copy_reason_32) {
+        meta.acl_metadata.acl_stats_index = acl_stats_index_38;
+        meta.acl_metadata.acl_copy = acl_copy_33;
+        meta.fabric_metadata.reason_code = acl_copy_reason_32;
     }
-    @name(".racl_redirect_nexthop") action _racl_redirect_nexthop_2(bit<16> nexthop_index, bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_redirect_nexthop") action _racl_redirect_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_16, @name("acl_stats_index") bit<14> acl_stats_index_39, @name("acl_copy") bit<1> acl_copy_34, @name("acl_copy_reason") bit<16> acl_copy_reason_33) {
         meta.acl_metadata.racl_redirect = 1w1;
-        meta.acl_metadata.racl_nexthop = nexthop_index;
+        meta.acl_metadata.racl_nexthop = nexthop_index_16;
         meta.acl_metadata.racl_nexthop_type = 1w0;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_39;
+        meta.acl_metadata.acl_copy = acl_copy_34;
+        meta.fabric_metadata.reason_code = acl_copy_reason_33;
     }
-    @name(".racl_redirect_ecmp") action _racl_redirect_ecmp_2(bit<16> ecmp_index, bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_redirect_ecmp") action _racl_redirect_ecmp_2(@name("ecmp_index") bit<16> ecmp_index_13, @name("acl_stats_index") bit<14> acl_stats_index_40, @name("acl_copy") bit<1> acl_copy_35, @name("acl_copy_reason") bit<16> acl_copy_reason_34) {
         meta.acl_metadata.racl_redirect = 1w1;
-        meta.acl_metadata.racl_nexthop = ecmp_index;
+        meta.acl_metadata.racl_nexthop = ecmp_index_13;
         meta.acl_metadata.racl_nexthop_type = 1w1;
-        meta.acl_metadata.acl_stats_index = acl_stats_index;
-        meta.acl_metadata.acl_copy = acl_copy;
-        meta.fabric_metadata.reason_code = acl_copy_reason;
+        meta.acl_metadata.acl_stats_index = acl_stats_index_40;
+        meta.acl_metadata.acl_copy = acl_copy_35;
+        meta.fabric_metadata.reason_code = acl_copy_reason_34;
     }
     @name(".ipv6_racl") table _ipv6_racl {
         actions = {
@@ -5105,14 +5103,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_26() {
     }
-    @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_0(bit<16> urpf_bd_group) {
+    @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_0(@name("urpf_bd_group") bit<16> urpf_bd_group_4) {
         meta.l3_metadata.urpf_hit = 1w1;
-        meta.l3_metadata.urpf_bd_group = urpf_bd_group;
+        meta.l3_metadata.urpf_bd_group = urpf_bd_group_4;
         meta.l3_metadata.urpf_mode = meta.ipv6_metadata.ipv6_urpf_mode;
     }
-    @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_2(bit<16> urpf_bd_group) {
+    @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_2(@name("urpf_bd_group") bit<16> urpf_bd_group_5) {
         meta.l3_metadata.urpf_hit = 1w1;
-        meta.l3_metadata.urpf_bd_group = urpf_bd_group;
+        meta.l3_metadata.urpf_bd_group = urpf_bd_group_5;
         meta.l3_metadata.urpf_mode = meta.ipv6_metadata.ipv6_urpf_mode;
     }
     @name(".urpf_miss") action _urpf_miss_2() {
@@ -5148,24 +5146,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_30() {
     }
-    @name(".fib_hit_nexthop") action _fib_hit_nexthop_5(bit<16> nexthop_index) {
+    @name(".fib_hit_nexthop") action _fib_hit_nexthop_5(@name("nexthop_index") bit<16> nexthop_index_17) {
         meta.l3_metadata.fib_hit = 1w1;
-        meta.l3_metadata.fib_nexthop = nexthop_index;
+        meta.l3_metadata.fib_nexthop = nexthop_index_17;
         meta.l3_metadata.fib_nexthop_type = 1w0;
     }
-    @name(".fib_hit_nexthop") action _fib_hit_nexthop_6(bit<16> nexthop_index) {
+    @name(".fib_hit_nexthop") action _fib_hit_nexthop_6(@name("nexthop_index") bit<16> nexthop_index_18) {
         meta.l3_metadata.fib_hit = 1w1;
-        meta.l3_metadata.fib_nexthop = nexthop_index;
+        meta.l3_metadata.fib_nexthop = nexthop_index_18;
         meta.l3_metadata.fib_nexthop_type = 1w0;
     }
-    @name(".fib_hit_ecmp") action _fib_hit_ecmp_5(bit<16> ecmp_index) {
+    @name(".fib_hit_ecmp") action _fib_hit_ecmp_5(@name("ecmp_index") bit<16> ecmp_index_14) {
         meta.l3_metadata.fib_hit = 1w1;
-        meta.l3_metadata.fib_nexthop = ecmp_index;
+        meta.l3_metadata.fib_nexthop = ecmp_index_14;
         meta.l3_metadata.fib_nexthop_type = 1w1;
     }
-    @name(".fib_hit_ecmp") action _fib_hit_ecmp_6(bit<16> ecmp_index) {
+    @name(".fib_hit_ecmp") action _fib_hit_ecmp_6(@name("ecmp_index") bit<16> ecmp_index_15) {
         meta.l3_metadata.fib_hit = 1w1;
-        meta.l3_metadata.fib_nexthop = ecmp_index;
+        meta.l3_metadata.fib_nexthop = ecmp_index_15;
         meta.l3_metadata.fib_nexthop_type = 1w1;
     }
     @name(".ipv6_fib") table _ipv6_fib {
@@ -5445,30 +5443,30 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_104() {
     }
-    @name(".set_ecmp_nexthop_details") action _set_ecmp_nexthop_details_0(bit<16> ifindex, bit<16> bd, bit<16> nhop_index, bit<1> tunnel) {
-        meta.ingress_metadata.egress_ifindex = ifindex;
+    @name(".set_ecmp_nexthop_details") action _set_ecmp_nexthop_details_0(@name("ifindex") bit<16> ifindex_20, @name("bd") bit<16> bd_30, @name("nhop_index") bit<16> nhop_index, @name("tunnel") bit<1> tunnel) {
+        meta.ingress_metadata.egress_ifindex = ifindex_20;
         meta.l3_metadata.nexthop_index = nhop_index;
-        meta.l3_metadata.same_bd_check = meta.ingress_metadata.bd ^ bd;
-        meta.l2_metadata.same_if_check = meta.l2_metadata.same_if_check ^ ifindex;
+        meta.l3_metadata.same_bd_check = meta.ingress_metadata.bd ^ bd_30;
+        meta.l2_metadata.same_if_check = meta.l2_metadata.same_if_check ^ ifindex_20;
         meta.tunnel_metadata.tunnel_if_check = meta.tunnel_metadata.tunnel_terminate ^ tunnel;
     }
-    @name(".set_ecmp_nexthop_details_for_post_routed_flood") action _set_ecmp_nexthop_details_for_post_routed_flood_0(bit<16> bd, bit<16> uuc_mc_index, bit<16> nhop_index) {
+    @name(".set_ecmp_nexthop_details_for_post_routed_flood") action _set_ecmp_nexthop_details_for_post_routed_flood_0(@name("bd") bit<16> bd_31, @name("uuc_mc_index") bit<16> uuc_mc_index, @name("nhop_index") bit<16> nhop_index_2) {
         standard_metadata.mcast_grp = uuc_mc_index;
-        meta.l3_metadata.nexthop_index = nhop_index;
+        meta.l3_metadata.nexthop_index = nhop_index_2;
         meta.ingress_metadata.egress_ifindex = 16w0;
-        meta.l3_metadata.same_bd_check = meta.ingress_metadata.bd ^ bd;
+        meta.l3_metadata.same_bd_check = meta.ingress_metadata.bd ^ bd_31;
         meta.fabric_metadata.dst_device = 8w127;
     }
-    @name(".set_nexthop_details") action _set_nexthop_details_0(bit<16> ifindex, bit<16> bd, bit<1> tunnel) {
-        meta.ingress_metadata.egress_ifindex = ifindex;
-        meta.l3_metadata.same_bd_check = meta.ingress_metadata.bd ^ bd;
-        meta.l2_metadata.same_if_check = meta.l2_metadata.same_if_check ^ ifindex;
-        meta.tunnel_metadata.tunnel_if_check = meta.tunnel_metadata.tunnel_terminate ^ tunnel;
+    @name(".set_nexthop_details") action _set_nexthop_details_0(@name("ifindex") bit<16> ifindex_21, @name("bd") bit<16> bd_32, @name("tunnel") bit<1> tunnel_0) {
+        meta.ingress_metadata.egress_ifindex = ifindex_21;
+        meta.l3_metadata.same_bd_check = meta.ingress_metadata.bd ^ bd_32;
+        meta.l2_metadata.same_if_check = meta.l2_metadata.same_if_check ^ ifindex_21;
+        meta.tunnel_metadata.tunnel_if_check = meta.tunnel_metadata.tunnel_terminate ^ tunnel_0;
     }
-    @name(".set_nexthop_details_for_post_routed_flood") action _set_nexthop_details_for_post_routed_flood_0(bit<16> bd, bit<16> uuc_mc_index) {
-        standard_metadata.mcast_grp = uuc_mc_index;
+    @name(".set_nexthop_details_for_post_routed_flood") action _set_nexthop_details_for_post_routed_flood_0(@name("bd") bit<16> bd_33, @name("uuc_mc_index") bit<16> uuc_mc_index_2) {
+        standard_metadata.mcast_grp = uuc_mc_index_2;
         meta.ingress_metadata.egress_ifindex = 16w0;
-        meta.l3_metadata.same_bd_check = meta.ingress_metadata.bd ^ bd;
+        meta.l3_metadata.same_bd_check = meta.ingress_metadata.bd ^ bd_33;
         meta.fabric_metadata.dst_device = 8w127;
     }
     @name(".ecmp_group") table _ecmp_group {
@@ -5501,8 +5499,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_105() {
     }
-    @name(".set_bd_flood_mc_index") action _set_bd_flood_mc_index_0(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".set_bd_flood_mc_index") action _set_bd_flood_mc_index_0(@name("mc_index") bit<16> mc_index_42) {
+        standard_metadata.mcast_grp = mc_index_42;
     }
     @name(".bd_flood") table _bd_flood {
         actions = {
@@ -5519,12 +5517,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_lag_miss") action _set_lag_miss_0() {
     }
-    @name(".set_lag_port") action _set_lag_port_0(bit<9> port) {
+    @name(".set_lag_port") action _set_lag_port_0(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".set_lag_remote_port") action _set_lag_remote_port_0(bit<8> device, bit<16> port) {
+    @name(".set_lag_remote_port") action _set_lag_remote_port_0(@name("device") bit<8> device, @name("port") bit<16> port_3) {
         meta.fabric_metadata.dst_device = device;
-        meta.fabric_metadata.dst_port = port;
+        meta.fabric_metadata.dst_port = port_3;
     }
     @name(".lag_group") table _lag_group {
         actions = {
@@ -5562,10 +5560,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_107() {
     }
-    @name(".set_fabric_lag_port") action _set_fabric_lag_port_0(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_fabric_lag_port") action _set_fabric_lag_port_0(@name("port") bit<9> port_4) {
+        standard_metadata.egress_spec = port_4;
     }
-    @name(".set_fabric_multicast") action _set_fabric_multicast_0(bit<8> fabric_mgid) {
+    @name(".set_fabric_multicast") action _set_fabric_multicast_0(@name("fabric_mgid") bit<8> fabric_mgid_2) {
         meta.multicast_metadata.mcast_grp = standard_metadata.mcast_grp;
     }
     @name(".fabric_lag") table _fabric_lag {
@@ -5587,12 +5585,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_108() {
     }
-    @name(".copy_to_cpu_with_reason") action _copy_to_cpu_with_reason_0(bit<16> reason_code) {
-        meta.fabric_metadata.reason_code = reason_code;
+    @name(".copy_to_cpu_with_reason") action _copy_to_cpu_with_reason_0(@name("reason_code") bit<16> reason_code_6) {
+        meta.fabric_metadata.reason_code = reason_code_6;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.I2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
     }
-    @name(".redirect_to_cpu") action _redirect_to_cpu_0(bit<16> reason_code) {
-        meta.fabric_metadata.reason_code = reason_code;
+    @name(".redirect_to_cpu") action _redirect_to_cpu_0(@name("reason_code") bit<16> reason_code_7) {
+        meta.fabric_metadata.reason_code = reason_code_7;
         clone3<tuple<bit<16>, bit<16>, bit<16>, bit<9>>>(CloneType.I2E, 32w250, { meta.ingress_metadata.bd, meta.ingress_metadata.ifindex, meta.fabric_metadata.reason_code, meta.ingress_metadata.ingress_port });
         mark_to_drop(standard_metadata);
         meta.fabric_metadata.dst_device = 8w0;
@@ -5603,12 +5601,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".drop_packet") action _drop_packet_0() {
         mark_to_drop(standard_metadata);
     }
-    @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<10> drop_reason) {
-        drop_stats.count(drop_reason);
+    @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(@name("drop_reason") bit<10> drop_reason_9) {
+        drop_stats.count(drop_reason_9);
         mark_to_drop(standard_metadata);
     }
-    @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {
-        clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, session_id, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
+    @name(".negative_mirror") action _negative_mirror_0(@name("session_id") bit<32> session_id_11) {
+        clone3<tuple<bit<16>, bit<8>>>(CloneType.I2E, session_id_11, { meta.ingress_metadata.ifindex, meta.ingress_metadata.drop_reason });
         mark_to_drop(standard_metadata);
     }
     @name(".drop_stats") table _drop_stats {
@@ -5678,7 +5676,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 }
             }
         }
-
         _switch_config_params.apply();
         _port_vlan_mapping.apply();
         if (meta.ingress_metadata.port_type == 2w0 && meta.l2_metadata.stp_group != 10w0) {
@@ -5692,7 +5689,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
         }
         if (!hdr.int_header.isValid()) {
             _int_source.apply();
@@ -5722,7 +5718,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                             default: {
                             }
                         }
-
                     } else if (hdr.ipv6.isValid()) {
                         switch (_outer_ipv6_multicast_0.apply().action_run) {
                             _on_miss_2: {
@@ -5731,7 +5726,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                             default: {
                             }
                         }
-
                     }
                 }
                 default: {
@@ -5743,7 +5737,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                             default: {
                             }
                         }
-
                     } else if (hdr.ipv6.isValid()) {
                         switch (_ipv6_src_vtep_0.apply().action_run) {
                             _src_vtep_hit_0: {
@@ -5752,13 +5745,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                             default: {
                             }
                         }
-
                     } else if (hdr.mpls[0].isValid()) {
                         _mpls_0.apply();
                     }
                 }
             }
-
         }
         if (meta.tunnel_metadata.tunnel_terminate == 1w1 || meta.multicast_metadata.outer_mcast_route_hit == 1w1 && (meta.multicast_metadata.outer_mcast_mode == 2w1 && meta.multicast_metadata.mcast_rpf_group == 16w0 || meta.multicast_metadata.outer_mcast_mode == 2w2 && meta.multicast_metadata.mcast_rpf_group != 16w0)) {
             switch (_tunnel.apply().action_run) {
@@ -5768,7 +5759,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
         } else {
             _tunnel_miss.apply();
         }
@@ -5811,7 +5801,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             }
                             if (meta.ingress_metadata.bypass_lookups & 16w0x2 == 16w0 && meta.multicast_metadata.ipv4_multicast_enabled == 1w1) {
                                 switch (_ipv4_multicast_route_0.apply().action_run) {
@@ -5821,7 +5810,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             }
                         } else if (meta.l3_metadata.lkp_ip_type == 2w2) {
                             if (meta.ingress_metadata.bypass_lookups & 16w0x1 == 16w0) {
@@ -5832,7 +5820,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             }
                             if (meta.ingress_metadata.bypass_lookups & 16w0x2 == 16w0 && meta.multicast_metadata.ipv6_multicast_enabled == 1w1) {
                                 switch (_ipv6_multicast_route_0.apply().action_run) {
@@ -5842,7 +5829,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             }
                         }
                     }
@@ -5858,7 +5844,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                         default: {
                                         }
                                     }
-
                                 }
                                 switch (_ipv4_fib.apply().action_run) {
                                     _on_miss_24: {
@@ -5867,7 +5852,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             } else if (meta.l3_metadata.lkp_ip_type == 2w2 && meta.ipv6_metadata.ipv6_unicast_enabled == 1w1) {
                                 _ipv6_racl.apply();
                                 if (meta.ipv6_metadata.ipv6_urpf_mode != 2w0) {
@@ -5878,7 +5862,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                         default: {
                                         }
                                     }
-
                                 }
                                 switch (_ipv6_fib.apply().action_run) {
                                     _on_miss_29: {
@@ -5887,7 +5870,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             }
                             if (meta.l3_metadata.urpf_mode == 2w2 && meta.l3_metadata.urpf_hit == 1w1) {
                                 _urpf_bd.apply();
@@ -5895,7 +5877,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                         }
                     }
                 }
-
             }
         }
         if (meta.ingress_metadata.bypass_lookups & 16w0x10 == 16w0) {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch-midend.p4
@@ -1397,27 +1397,27 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @noWarn("unused") @name(".NoAction") action NoAction_147() {
     }
-    @name(".egress_port_type_normal") action egress_port_type_normal(bit<16> ifindex) {
+    @name(".egress_port_type_normal") action egress_port_type_normal(@name("ifindex") bit<16> ifindex_11) {
         meta._egress_metadata_port_type16 = 2w0;
-        meta._egress_metadata_ifindex25 = ifindex;
+        meta._egress_metadata_ifindex25 = ifindex_11;
     }
-    @name(".egress_port_type_fabric") action egress_port_type_fabric(bit<16> ifindex) {
+    @name(".egress_port_type_fabric") action egress_port_type_fabric(@name("ifindex") bit<16> ifindex_12) {
         meta._egress_metadata_port_type16 = 2w1;
         meta._tunnel_metadata_egress_tunnel_type143 = 5w15;
-        meta._egress_metadata_ifindex25 = ifindex;
+        meta._egress_metadata_ifindex25 = ifindex_12;
     }
-    @name(".egress_port_type_cpu") action egress_port_type_cpu(bit<16> ifindex) {
+    @name(".egress_port_type_cpu") action egress_port_type_cpu(@name("ifindex") bit<16> ifindex_13) {
         meta._egress_metadata_port_type16 = 2w2;
         meta._tunnel_metadata_egress_tunnel_type143 = 5w16;
-        meta._egress_metadata_ifindex25 = ifindex;
+        meta._egress_metadata_ifindex25 = ifindex_13;
     }
     @name(".nop") action nop() {
     }
-    @name(".set_mirror_nhop") action set_mirror_nhop(bit<16> nhop_idx) {
+    @name(".set_mirror_nhop") action set_mirror_nhop(@name("nhop_idx") bit<16> nhop_idx) {
         meta._l3_metadata_nexthop_index100 = nhop_idx;
     }
-    @name(".set_mirror_bd") action set_mirror_bd(bit<16> bd) {
-        meta._egress_metadata_bd19 = bd;
+    @name(".set_mirror_bd") action set_mirror_bd(@name("bd") bit<16> bd_17) {
+        meta._egress_metadata_bd19 = bd_17;
     }
     @name(".sflow_pkt_to_cpu") action sflow_pkt_to_cpu() {
         hdr.fabric_header_sflow.setValid();
@@ -1457,25 +1457,25 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".set_replica_copy_bridged") action _set_replica_copy_bridged_0() {
         meta._egress_metadata_routed22 = 1w0;
     }
-    @name(".outer_replica_from_rid") action _outer_replica_from_rid_0(bit<16> bd, bit<14> tunnel_index, bit<5> tunnel_type, bit<4> header_count) {
-        meta._egress_metadata_bd19 = bd;
+    @name(".outer_replica_from_rid") action _outer_replica_from_rid_0(@name("bd") bit<16> bd_18, @name("tunnel_index") bit<14> tunnel_index_9, @name("tunnel_type") bit<5> tunnel_type, @name("header_count") bit<4> header_count) {
+        meta._egress_metadata_bd19 = bd_18;
         meta._multicast_metadata_replica126 = 1w1;
         meta._multicast_metadata_inner_replica125 = 1w0;
         meta._egress_metadata_routed22 = meta._l3_metadata_outer_routed102;
-        meta._egress_metadata_same_bd_check23 = bd ^ meta._ingress_metadata_outer_bd41;
-        meta._tunnel_metadata_tunnel_index144 = tunnel_index;
+        meta._egress_metadata_same_bd_check23 = bd_18 ^ meta._ingress_metadata_outer_bd41;
+        meta._tunnel_metadata_tunnel_index144 = tunnel_index_9;
         meta._tunnel_metadata_egress_tunnel_type143 = tunnel_type;
         meta._tunnel_metadata_egress_header_count152 = header_count;
     }
-    @name(".inner_replica_from_rid") action _inner_replica_from_rid_0(bit<16> bd, bit<14> tunnel_index, bit<5> tunnel_type, bit<4> header_count) {
-        meta._egress_metadata_bd19 = bd;
+    @name(".inner_replica_from_rid") action _inner_replica_from_rid_0(@name("bd") bit<16> bd_19, @name("tunnel_index") bit<14> tunnel_index_10, @name("tunnel_type") bit<5> tunnel_type_8, @name("header_count") bit<4> header_count_6) {
+        meta._egress_metadata_bd19 = bd_19;
         meta._multicast_metadata_replica126 = 1w1;
         meta._multicast_metadata_inner_replica125 = 1w1;
         meta._egress_metadata_routed22 = meta._l3_metadata_routed101;
-        meta._egress_metadata_same_bd_check23 = bd ^ meta._ingress_metadata_bd42;
-        meta._tunnel_metadata_tunnel_index144 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type143 = tunnel_type;
-        meta._tunnel_metadata_egress_header_count152 = header_count;
+        meta._egress_metadata_same_bd_check23 = bd_19 ^ meta._ingress_metadata_bd42;
+        meta._tunnel_metadata_tunnel_index144 = tunnel_index_10;
+        meta._tunnel_metadata_egress_tunnel_type143 = tunnel_type_8;
+        meta._tunnel_metadata_egress_header_count152 = header_count_6;
     }
     @name(".replica_type") table _replica_type {
         actions = {
@@ -1820,58 +1820,58 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         meta._egress_metadata_bd19 = meta._ingress_metadata_bd42;
         meta._egress_metadata_outer_bd20 = meta._ingress_metadata_bd42;
     }
-    @name(".set_l2_rewrite_with_tunnel") action _set_l2_rewrite_with_tunnel_0(bit<14> tunnel_index, bit<5> tunnel_type) {
+    @name(".set_l2_rewrite_with_tunnel") action _set_l2_rewrite_with_tunnel_0(@name("tunnel_index") bit<14> tunnel_index_11, @name("tunnel_type") bit<5> tunnel_type_9) {
         meta._egress_metadata_routed22 = 1w0;
         meta._egress_metadata_bd19 = meta._ingress_metadata_bd42;
         meta._egress_metadata_outer_bd20 = meta._ingress_metadata_bd42;
-        meta._tunnel_metadata_tunnel_index144 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type143 = tunnel_type;
+        meta._tunnel_metadata_tunnel_index144 = tunnel_index_11;
+        meta._tunnel_metadata_egress_tunnel_type143 = tunnel_type_9;
     }
-    @name(".set_l3_rewrite") action _set_l3_rewrite_0(bit<16> bd, bit<8> mtu_index, bit<48> dmac) {
+    @name(".set_l3_rewrite") action _set_l3_rewrite_0(@name("bd") bit<16> bd_20, @name("mtu_index") bit<8> mtu_index_1, @name("dmac") bit<48> dmac) {
         meta._egress_metadata_routed22 = 1w1;
         meta._egress_metadata_mac_da21 = dmac;
-        meta._egress_metadata_bd19 = bd;
-        meta._egress_metadata_outer_bd20 = bd;
-        meta._l3_metadata_mtu_index103 = mtu_index;
+        meta._egress_metadata_bd19 = bd_20;
+        meta._egress_metadata_outer_bd20 = bd_20;
+        meta._l3_metadata_mtu_index103 = mtu_index_1;
     }
-    @name(".set_l3_rewrite_with_tunnel") action _set_l3_rewrite_with_tunnel_0(bit<16> bd, bit<48> dmac, bit<14> tunnel_index, bit<5> tunnel_type) {
+    @name(".set_l3_rewrite_with_tunnel") action _set_l3_rewrite_with_tunnel_0(@name("bd") bit<16> bd_21, @name("dmac") bit<48> dmac_0, @name("tunnel_index") bit<14> tunnel_index_12, @name("tunnel_type") bit<5> tunnel_type_10) {
         meta._egress_metadata_routed22 = 1w1;
-        meta._egress_metadata_mac_da21 = dmac;
-        meta._egress_metadata_bd19 = bd;
-        meta._egress_metadata_outer_bd20 = bd;
-        meta._tunnel_metadata_tunnel_index144 = tunnel_index;
-        meta._tunnel_metadata_egress_tunnel_type143 = tunnel_type;
+        meta._egress_metadata_mac_da21 = dmac_0;
+        meta._egress_metadata_bd19 = bd_21;
+        meta._egress_metadata_outer_bd20 = bd_21;
+        meta._tunnel_metadata_tunnel_index144 = tunnel_index_12;
+        meta._tunnel_metadata_egress_tunnel_type143 = tunnel_type_10;
     }
-    @name(".set_mpls_swap_push_rewrite_l2") action _set_mpls_swap_push_rewrite_l2_0(bit<20> label, bit<14> tunnel_index, bit<4> header_count) {
+    @name(".set_mpls_swap_push_rewrite_l2") action _set_mpls_swap_push_rewrite_l2_0(@name("label") bit<20> label_2, @name("tunnel_index") bit<14> tunnel_index_13, @name("header_count") bit<4> header_count_7) {
         meta._egress_metadata_routed22 = meta._l3_metadata_routed101;
         meta._egress_metadata_bd19 = meta._ingress_metadata_bd42;
-        hdr.mpls[0].label = label;
-        meta._tunnel_metadata_tunnel_index144 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count152 = header_count;
+        hdr.mpls[0].label = label_2;
+        meta._tunnel_metadata_tunnel_index144 = tunnel_index_13;
+        meta._tunnel_metadata_egress_header_count152 = header_count_7;
         meta._tunnel_metadata_egress_tunnel_type143 = 5w13;
     }
-    @name(".set_mpls_push_rewrite_l2") action _set_mpls_push_rewrite_l2_0(bit<14> tunnel_index, bit<4> header_count) {
+    @name(".set_mpls_push_rewrite_l2") action _set_mpls_push_rewrite_l2_0(@name("tunnel_index") bit<14> tunnel_index_14, @name("header_count") bit<4> header_count_8) {
         meta._egress_metadata_routed22 = meta._l3_metadata_routed101;
         meta._egress_metadata_bd19 = meta._ingress_metadata_bd42;
-        meta._tunnel_metadata_tunnel_index144 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count152 = header_count;
+        meta._tunnel_metadata_tunnel_index144 = tunnel_index_14;
+        meta._tunnel_metadata_egress_header_count152 = header_count_8;
         meta._tunnel_metadata_egress_tunnel_type143 = 5w13;
     }
-    @name(".set_mpls_swap_push_rewrite_l3") action _set_mpls_swap_push_rewrite_l3_0(bit<16> bd, bit<48> dmac, bit<20> label, bit<14> tunnel_index, bit<4> header_count) {
+    @name(".set_mpls_swap_push_rewrite_l3") action _set_mpls_swap_push_rewrite_l3_0(@name("bd") bit<16> bd_22, @name("dmac") bit<48> dmac_6, @name("label") bit<20> label_3, @name("tunnel_index") bit<14> tunnel_index_15, @name("header_count") bit<4> header_count_9) {
         meta._egress_metadata_routed22 = meta._l3_metadata_routed101;
-        meta._egress_metadata_bd19 = bd;
-        hdr.mpls[0].label = label;
-        meta._egress_metadata_mac_da21 = dmac;
-        meta._tunnel_metadata_tunnel_index144 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count152 = header_count;
+        meta._egress_metadata_bd19 = bd_22;
+        hdr.mpls[0].label = label_3;
+        meta._egress_metadata_mac_da21 = dmac_6;
+        meta._tunnel_metadata_tunnel_index144 = tunnel_index_15;
+        meta._tunnel_metadata_egress_header_count152 = header_count_9;
         meta._tunnel_metadata_egress_tunnel_type143 = 5w14;
     }
-    @name(".set_mpls_push_rewrite_l3") action _set_mpls_push_rewrite_l3_0(bit<16> bd, bit<48> dmac, bit<14> tunnel_index, bit<4> header_count) {
+    @name(".set_mpls_push_rewrite_l3") action _set_mpls_push_rewrite_l3_0(@name("bd") bit<16> bd_23, @name("dmac") bit<48> dmac_7, @name("tunnel_index") bit<14> tunnel_index_16, @name("header_count") bit<4> header_count_10) {
         meta._egress_metadata_routed22 = meta._l3_metadata_routed101;
-        meta._egress_metadata_bd19 = bd;
-        meta._egress_metadata_mac_da21 = dmac;
-        meta._tunnel_metadata_tunnel_index144 = tunnel_index;
-        meta._tunnel_metadata_egress_header_count152 = header_count;
+        meta._egress_metadata_bd19 = bd_23;
+        meta._egress_metadata_mac_da21 = dmac_7;
+        meta._tunnel_metadata_tunnel_index144 = tunnel_index_16;
+        meta._tunnel_metadata_egress_header_count152 = header_count_10;
         meta._tunnel_metadata_egress_tunnel_type143 = 5w14;
     }
     @name(".rewrite_ipv4_multicast") action _rewrite_ipv4_multicast_0() {
@@ -1915,8 +1915,8 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".nop") action _nop_4() {
     }
-    @name(".set_egress_bd_properties") action _set_egress_bd_properties_0(bit<9> smac_idx) {
-        meta._egress_metadata_smac_idx18 = smac_idx;
+    @name(".set_egress_bd_properties") action _set_egress_bd_properties_0(@name("smac_idx") bit<9> smac_idx_5) {
+        meta._egress_metadata_smac_idx18 = smac_idx_5;
     }
     @name(".egress_bd_map") table _egress_bd_map {
         actions = {
@@ -1952,7 +1952,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ethernet.dstAddr = meta._egress_metadata_mac_da21;
         hdr.mpls[0].ttl = hdr.mpls[0].ttl + 8w255;
     }
-    @name(".rewrite_smac") action _rewrite_smac_0(bit<48> smac) {
+    @name(".rewrite_smac") action _rewrite_smac_0(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name(".l3_rewrite") table _l3_rewrite {
@@ -1988,11 +1988,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".mtu_miss") action _mtu_miss_0() {
         meta._l3_metadata_l3_mtu_check105 = 16w0xffff;
     }
-    @name(".ipv4_mtu_check") action _ipv4_mtu_check_0(bit<16> l3_mtu) {
+    @name(".ipv4_mtu_check") action _ipv4_mtu_check_0(@name("l3_mtu") bit<16> l3_mtu) {
         meta._l3_metadata_l3_mtu_check105 = l3_mtu |-| hdr.ipv4.totalLen;
     }
-    @name(".ipv6_mtu_check") action _ipv6_mtu_check_0(bit<16> l3_mtu) {
-        meta._l3_metadata_l3_mtu_check105 = l3_mtu |-| hdr.ipv6.payloadLen;
+    @name(".ipv6_mtu_check") action _ipv6_mtu_check_0(@name("l3_mtu") bit<16> l3_mtu_3) {
+        meta._l3_metadata_l3_mtu_check105 = l3_mtu_3 |-| hdr.ipv6.payloadLen;
     }
     @name(".mtu") table _mtu {
         actions = {
@@ -2041,15 +2041,15 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".nop") action _nop_47() {
     }
-    @name(".int_transit") action _int_transit_0(bit<32> switch_id) {
+    @name(".int_transit") action _int_transit_0(@name("switch_id") bit<32> switch_id_2) {
         meta._int_metadata_insert_cnt49 = hdr.int_header.max_hop_cnt - hdr.int_header.total_hop_cnt;
-        meta._int_metadata_switch_id48 = switch_id;
+        meta._int_metadata_switch_id48 = switch_id_2;
         meta._int_metadata_insert_byte_cnt50 = meta._int_metadata_instruction_cnt53 << 2;
         meta._int_metadata_gpe_int_hdr_len852 = (bit<8>)hdr.int_header.ins_cnt;
     }
-    @name(".int_src") action _int_src_0(bit<32> switch_id, bit<8> hop_cnt, bit<5> ins_cnt, bit<4> ins_mask0003, bit<4> ins_mask0407, bit<16> ins_byte_cnt, bit<8> total_words) {
+    @name(".int_src") action _int_src_0(@name("switch_id") bit<32> switch_id_3, @name("hop_cnt") bit<8> hop_cnt, @name("ins_cnt") bit<5> ins_cnt_1, @name("ins_mask0003") bit<4> ins_mask0003, @name("ins_mask0407") bit<4> ins_mask0407, @name("ins_byte_cnt") bit<16> ins_byte_cnt, @name("total_words") bit<8> total_words) {
         meta._int_metadata_insert_cnt49 = hop_cnt;
-        meta._int_metadata_switch_id48 = switch_id;
+        meta._int_metadata_switch_id48 = switch_id_3;
         meta._int_metadata_insert_byte_cnt50 = ins_byte_cnt;
         meta._int_metadata_gpe_int_hdr_len852 = total_words;
         hdr.int_header.setValid();
@@ -2058,7 +2058,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.int_header.c = 1w0;
         hdr.int_header.e = 1w0;
         hdr.int_header.rsvd1 = 5w0;
-        hdr.int_header.ins_cnt = ins_cnt;
+        hdr.int_header.ins_cnt = ins_cnt_1;
         hdr.int_header.max_hop_cnt = hop_cnt;
         hdr.int_header.total_hop_cnt = 8w0;
         hdr.int_header.instruction_mask_0003 = ins_mask0003;
@@ -2445,17 +2445,17 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".nop") action _nop_55() {
     }
-    @name(".set_egress_tunnel_vni") action _set_egress_tunnel_vni_0(bit<24> vnid) {
-        meta._tunnel_metadata_vnid149 = vnid;
+    @name(".set_egress_tunnel_vni") action _set_egress_tunnel_vni_0(@name("vnid") bit<24> vnid_1) {
+        meta._tunnel_metadata_vnid149 = vnid_1;
     }
-    @name(".rewrite_tunnel_dmac") action _rewrite_tunnel_dmac_0(bit<48> dmac) {
-        hdr.ethernet.dstAddr = dmac;
+    @name(".rewrite_tunnel_dmac") action _rewrite_tunnel_dmac_0(@name("dmac") bit<48> dmac_8) {
+        hdr.ethernet.dstAddr = dmac_8;
     }
-    @name(".rewrite_tunnel_ipv4_dst") action _rewrite_tunnel_ipv4_dst_0(bit<32> ip) {
+    @name(".rewrite_tunnel_ipv4_dst") action _rewrite_tunnel_ipv4_dst_0(@name("ip") bit<32> ip) {
         hdr.ipv4.dstAddr = ip;
     }
-    @name(".rewrite_tunnel_ipv6_dst") action _rewrite_tunnel_ipv6_dst_0(bit<128> ip) {
-        hdr.ipv6.dstAddr = ip;
+    @name(".rewrite_tunnel_ipv6_dst") action _rewrite_tunnel_ipv6_dst_0(@name("ip") bit<128> ip_4) {
+        hdr.ipv6.dstAddr = ip_4;
     }
     @name(".inner_ipv4_udp_rewrite") action _inner_ipv4_udp_rewrite_0() {
         hdr.inner_ipv4 = hdr.ipv4;
@@ -2792,57 +2792,57 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.mpls[2].setValid();
         hdr.ethernet.etherType = 16w0x8847;
     }
-    @name(".fabric_rewrite") action _fabric_rewrite_0(bit<14> tunnel_index) {
-        meta._tunnel_metadata_tunnel_index144 = tunnel_index;
+    @name(".fabric_rewrite") action _fabric_rewrite_0(@name("tunnel_index") bit<14> tunnel_index_17) {
+        meta._tunnel_metadata_tunnel_index144 = tunnel_index_17;
     }
-    @name(".tunnel_mtu_check") action _tunnel_mtu_check_0(bit<16> l3_mtu) {
-        meta._l3_metadata_l3_mtu_check105 = l3_mtu |-| meta._egress_metadata_payload_length17;
+    @name(".tunnel_mtu_check") action _tunnel_mtu_check_0(@name("l3_mtu") bit<16> l3_mtu_4) {
+        meta._l3_metadata_l3_mtu_check105 = l3_mtu_4 |-| meta._egress_metadata_payload_length17;
     }
     @name(".tunnel_mtu_miss") action _tunnel_mtu_miss_0() {
         meta._l3_metadata_l3_mtu_check105 = 16w0xffff;
     }
-    @name(".set_tunnel_rewrite_details") action _set_tunnel_rewrite_details_0(bit<16> outer_bd, bit<9> smac_idx, bit<14> dmac_idx, bit<9> sip_index, bit<14> dip_index) {
-        meta._egress_metadata_outer_bd20 = outer_bd;
-        meta._tunnel_metadata_tunnel_smac_index146 = smac_idx;
+    @name(".set_tunnel_rewrite_details") action _set_tunnel_rewrite_details_0(@name("outer_bd") bit<16> outer_bd_1, @name("smac_idx") bit<9> smac_idx_6, @name("dmac_idx") bit<14> dmac_idx, @name("sip_index") bit<9> sip_index, @name("dip_index") bit<14> dip_index) {
+        meta._egress_metadata_outer_bd20 = outer_bd_1;
+        meta._tunnel_metadata_tunnel_smac_index146 = smac_idx_6;
         meta._tunnel_metadata_tunnel_dmac_index148 = dmac_idx;
         meta._tunnel_metadata_tunnel_src_index145 = sip_index;
         meta._tunnel_metadata_tunnel_dst_index147 = dip_index;
     }
-    @name(".set_mpls_rewrite_push1") action _set_mpls_rewrite_push1_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<9> smac_idx, bit<14> dmac_idx) {
+    @name(".set_mpls_rewrite_push1") action _set_mpls_rewrite_push1_0(@name("label1") bit<20> label1, @name("exp1") bit<3> exp1, @name("ttl1") bit<8> ttl1, @name("smac_idx") bit<9> smac_idx_7, @name("dmac_idx") bit<14> dmac_idx_4) {
         hdr.mpls[0].label = label1;
         hdr.mpls[0].exp = exp1;
         hdr.mpls[0].bos = 1w0x1;
         hdr.mpls[0].ttl = ttl1;
-        meta._tunnel_metadata_tunnel_smac_index146 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index148 = dmac_idx;
+        meta._tunnel_metadata_tunnel_smac_index146 = smac_idx_7;
+        meta._tunnel_metadata_tunnel_dmac_index148 = dmac_idx_4;
     }
-    @name(".set_mpls_rewrite_push2") action _set_mpls_rewrite_push2_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<20> label2, bit<3> exp2, bit<8> ttl2, bit<9> smac_idx, bit<14> dmac_idx) {
-        hdr.mpls[0].label = label1;
-        hdr.mpls[0].exp = exp1;
-        hdr.mpls[0].ttl = ttl1;
+    @name(".set_mpls_rewrite_push2") action _set_mpls_rewrite_push2_0(@name("label1") bit<20> label1_3, @name("exp1") bit<3> exp1_3, @name("ttl1") bit<8> ttl1_3, @name("label2") bit<20> label2, @name("exp2") bit<3> exp2, @name("ttl2") bit<8> ttl2, @name("smac_idx") bit<9> smac_idx_8, @name("dmac_idx") bit<14> dmac_idx_5) {
+        hdr.mpls[0].label = label1_3;
+        hdr.mpls[0].exp = exp1_3;
+        hdr.mpls[0].ttl = ttl1_3;
         hdr.mpls[0].bos = 1w0x0;
         hdr.mpls[1].label = label2;
         hdr.mpls[1].exp = exp2;
         hdr.mpls[1].ttl = ttl2;
         hdr.mpls[1].bos = 1w0x1;
-        meta._tunnel_metadata_tunnel_smac_index146 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index148 = dmac_idx;
+        meta._tunnel_metadata_tunnel_smac_index146 = smac_idx_8;
+        meta._tunnel_metadata_tunnel_dmac_index148 = dmac_idx_5;
     }
-    @name(".set_mpls_rewrite_push3") action _set_mpls_rewrite_push3_0(bit<20> label1, bit<3> exp1, bit<8> ttl1, bit<20> label2, bit<3> exp2, bit<8> ttl2, bit<20> label3, bit<3> exp3, bit<8> ttl3, bit<9> smac_idx, bit<14> dmac_idx) {
-        hdr.mpls[0].label = label1;
-        hdr.mpls[0].exp = exp1;
-        hdr.mpls[0].ttl = ttl1;
+    @name(".set_mpls_rewrite_push3") action _set_mpls_rewrite_push3_0(@name("label1") bit<20> label1_4, @name("exp1") bit<3> exp1_4, @name("ttl1") bit<8> ttl1_4, @name("label2") bit<20> label2_2, @name("exp2") bit<3> exp2_2, @name("ttl2") bit<8> ttl2_2, @name("label3") bit<20> label3, @name("exp3") bit<3> exp3, @name("ttl3") bit<8> ttl3, @name("smac_idx") bit<9> smac_idx_9, @name("dmac_idx") bit<14> dmac_idx_6) {
+        hdr.mpls[0].label = label1_4;
+        hdr.mpls[0].exp = exp1_4;
+        hdr.mpls[0].ttl = ttl1_4;
         hdr.mpls[0].bos = 1w0x0;
-        hdr.mpls[1].label = label2;
-        hdr.mpls[1].exp = exp2;
-        hdr.mpls[1].ttl = ttl2;
+        hdr.mpls[1].label = label2_2;
+        hdr.mpls[1].exp = exp2_2;
+        hdr.mpls[1].ttl = ttl2_2;
         hdr.mpls[1].bos = 1w0x0;
         hdr.mpls[2].label = label3;
         hdr.mpls[2].exp = exp3;
         hdr.mpls[2].ttl = ttl3;
         hdr.mpls[2].bos = 1w0x1;
-        meta._tunnel_metadata_tunnel_smac_index146 = smac_idx;
-        meta._tunnel_metadata_tunnel_dmac_index148 = dmac_idx;
+        meta._tunnel_metadata_tunnel_smac_index146 = smac_idx_9;
+        meta._tunnel_metadata_tunnel_dmac_index148 = dmac_idx_6;
     }
     @name(".cpu_rx_rewrite") action _cpu_rx_rewrite_0() {
         hdr.fabric_header.setValid();
@@ -2877,7 +2877,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.fabric_payload_header.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = 16w0x9000;
     }
-    @name(".fabric_multicast_rewrite") action _fabric_multicast_rewrite_0(bit<16> fabric_mgid) {
+    @name(".fabric_multicast_rewrite") action _fabric_multicast_rewrite_0(@name("fabric_mgid") bit<16> fabric_mgid) {
         hdr.fabric_header.setValid();
         hdr.fabric_header.headerVersion = 2w0;
         hdr.fabric_header.packetVersion = 2w0;
@@ -2897,14 +2897,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.fabric_payload_header.etherType = hdr.ethernet.etherType;
         hdr.ethernet.etherType = 16w0x9000;
     }
-    @name(".rewrite_tunnel_smac") action _rewrite_tunnel_smac_0(bit<48> smac) {
-        hdr.ethernet.srcAddr = smac;
+    @name(".rewrite_tunnel_smac") action _rewrite_tunnel_smac_0(@name("smac") bit<48> smac_0) {
+        hdr.ethernet.srcAddr = smac_0;
     }
-    @name(".rewrite_tunnel_ipv4_src") action _rewrite_tunnel_ipv4_src_0(bit<32> ip) {
-        hdr.ipv4.srcAddr = ip;
+    @name(".rewrite_tunnel_ipv4_src") action _rewrite_tunnel_ipv4_src_0(@name("ip") bit<32> ip_5) {
+        hdr.ipv4.srcAddr = ip_5;
     }
-    @name(".rewrite_tunnel_ipv6_src") action _rewrite_tunnel_ipv6_src_0(bit<128> ip) {
-        hdr.ipv6.srcAddr = ip;
+    @name(".rewrite_tunnel_ipv6_src") action _rewrite_tunnel_ipv6_src_0(@name("ip") bit<128> ip_6) {
+        hdr.ipv6.srcAddr = ip_6;
     }
     @name(".egress_vni") table _egress_vni {
         actions = {
@@ -3088,13 +3088,13 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".set_egress_packet_vlan_untagged") action _set_egress_packet_vlan_untagged_0() {
     }
-    @name(".set_egress_packet_vlan_tagged") action _set_egress_packet_vlan_tagged_0(bit<12> vlan_id) {
+    @name(".set_egress_packet_vlan_tagged") action _set_egress_packet_vlan_tagged_0(@name("vlan_id") bit<12> vlan_id) {
         hdr.vlan_tag_[0].setValid();
         hdr.vlan_tag_[0].etherType = hdr.ethernet.etherType;
         hdr.vlan_tag_[0].vid = vlan_id;
         hdr.ethernet.etherType = 16w0x8100;
     }
-    @name(".set_egress_packet_vlan_double_tagged") action _set_egress_packet_vlan_double_tagged_0(bit<12> s_tag, bit<12> c_tag) {
+    @name(".set_egress_packet_vlan_double_tagged") action _set_egress_packet_vlan_double_tagged_0(@name("s_tag") bit<12> s_tag, @name("c_tag") bit<12> c_tag) {
         hdr.vlan_tag_[1].setValid();
         hdr.vlan_tag_[0].setValid();
         hdr.vlan_tag_[1].etherType = hdr.ethernet.etherType;
@@ -3141,18 +3141,18 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".nop") action _nop_57() {
     }
-    @name(".egress_mirror") action _egress_mirror_0(bit<32> session_id) {
+    @name(".egress_mirror") action _egress_mirror_0(@name("session_id") bit<32> session_id) {
         meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id;
         clone3<tuple_0>(CloneType.E2E, session_id, { meta._i2e_metadata_ingress_tstamp35, (bit<16>)session_id });
     }
-    @name(".egress_mirror_drop") action _egress_mirror_drop_0(bit<32> session_id) {
-        meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id;
-        clone3<tuple_0>(CloneType.E2E, session_id, { meta._i2e_metadata_ingress_tstamp35, (bit<16>)session_id });
+    @name(".egress_mirror_drop") action _egress_mirror_drop_0(@name("session_id") bit<32> session_id_6) {
+        meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id_6;
+        clone3<tuple_0>(CloneType.E2E, session_id_6, { meta._i2e_metadata_ingress_tstamp35, (bit<16>)session_id_6 });
         mark_to_drop(standard_metadata);
     }
-    @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(bit<16> reason_code) {
-        meta._fabric_metadata_reason_code28 = reason_code;
-        clone3<tuple_1>(CloneType.E2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code, meta._ingress_metadata_ingress_port37 });
+    @name(".egress_redirect_to_cpu") action _egress_redirect_to_cpu_0(@name("reason_code") bit<16> reason_code_0) {
+        meta._fabric_metadata_reason_code28 = reason_code_0;
+        clone3<tuple_1>(CloneType.E2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code_0, meta._ingress_metadata_ingress_port37 });
         mark_to_drop(standard_metadata);
     }
     @name(".egress_acl") table _egress_acl {
@@ -3214,13 +3214,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
                         default: {
                         }
                     }
-
                     _egress_bd_stats_0.apply();
                 }
                 default: {
                 }
             }
-
             if (meta._fabric_metadata_fabric_header_present27 == 1w0 && meta._tunnel_metadata_egress_tunnel_type143 != 5w0) {
                 _egress_vni.apply();
                 if (meta._tunnel_metadata_egress_tunnel_type143 != 5w15 && meta._tunnel_metadata_egress_tunnel_type143 != 5w16) {
@@ -3504,12 +3502,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1024;
         default_action = NoAction_148();
     }
-    @name(".set_ifindex") action _set_ifindex_0(bit<16> ifindex, bit<2> port_type) {
-        meta._ingress_metadata_ifindex38 = ifindex;
-        meta._ingress_metadata_port_type40 = port_type;
+    @name(".set_ifindex") action _set_ifindex_0(@name("ifindex") bit<16> ifindex_14, @name("port_type") bit<2> port_type_1) {
+        meta._ingress_metadata_ifindex38 = ifindex_14;
+        meta._ingress_metadata_port_type40 = port_type_1;
     }
-    @name(".set_ingress_port_properties") action _set_ingress_port_properties_0(bit<16> if_label) {
-        meta._acl_metadata_if_label9 = if_label;
+    @name(".set_ingress_port_properties") action _set_ingress_port_properties_0(@name("if_label") bit<16> if_label_1) {
+        meta._acl_metadata_if_label9 = if_label_1;
     }
     @name(".ingress_port_mapping") table _ingress_port_mapping {
         actions = {
@@ -3533,9 +3531,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 288;
         default_action = NoAction_150();
     }
-    @name(".malformed_outer_ethernet_packet") action _malformed_outer_ethernet_packet_0(bit<8> drop_reason) {
+    @name(".malformed_outer_ethernet_packet") action _malformed_outer_ethernet_packet_0(@name("drop_reason") bit<8> drop_reason_5) {
         meta._ingress_metadata_drop_flag43 = 1w1;
-        meta._ingress_metadata_drop_reason44 = drop_reason;
+        meta._ingress_metadata_drop_reason44 = drop_reason_5;
     }
     @name(".set_valid_outer_unicast_packet_untagged") action _set_valid_outer_unicast_packet_untagged_0() {
         meta._l2_metadata_lkp_pkt_type67 = 3w1;
@@ -3616,9 +3614,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._l3_metadata_lkp_ip_tc83 = hdr.ipv4.diffserv;
         meta._l3_metadata_lkp_ip_version81 = hdr.ipv4.version;
     }
-    @name(".set_malformed_outer_ipv4_packet") action _set_malformed_outer_ipv4_packet(bit<8> drop_reason) {
+    @name(".set_malformed_outer_ipv4_packet") action _set_malformed_outer_ipv4_packet(@name("drop_reason") bit<8> drop_reason_6) {
         meta._ingress_metadata_drop_flag43 = 1w1;
-        meta._ingress_metadata_drop_reason44 = drop_reason;
+        meta._ingress_metadata_drop_reason44 = drop_reason_6;
     }
     @name(".validate_outer_ipv4_packet") table _validate_outer_ipv4_packet_0 {
         actions = {
@@ -3639,9 +3637,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._l3_metadata_lkp_ip_tc83 = hdr.ipv6.trafficClass;
         meta._l3_metadata_lkp_ip_version81 = hdr.ipv6.version;
     }
-    @name(".set_malformed_outer_ipv6_packet") action _set_malformed_outer_ipv6_packet(bit<8> drop_reason) {
+    @name(".set_malformed_outer_ipv6_packet") action _set_malformed_outer_ipv6_packet(@name("drop_reason") bit<8> drop_reason_7) {
         meta._ingress_metadata_drop_flag43 = 1w1;
-        meta._ingress_metadata_drop_reason44 = drop_reason;
+        meta._ingress_metadata_drop_reason44 = drop_reason_7;
     }
     @name(".validate_outer_ipv6_packet") table _validate_outer_ipv6_packet_0 {
         actions = {
@@ -3690,7 +3688,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 512;
         default_action = NoAction_154();
     }
-    @name(".set_config_parameters") action _set_config_parameters_0(bit<8> enable_dod) {
+    @name(".set_config_parameters") action _set_config_parameters_0(@name("enable_dod") bit<8> enable_dod_0) {
         meta._i2e_metadata_ingress_tstamp35 = (bit<32>)standard_metadata.ingress_global_timestamp;
         meta._ingress_metadata_ingress_port37 = standard_metadata.ingress_port;
         meta._l2_metadata_same_if_check79 = meta._ingress_metadata_ifindex38;
@@ -3705,28 +3703,28 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1;
         default_action = NoAction_155();
     }
-    @name(".set_bd_properties") action _set_bd_properties_0(bit<16> bd, bit<16> vrf, bit<10> stp_group, bit<1> learning_enabled, bit<16> bd_label, bit<16> stats_idx, bit<10> rmac_group, bit<1> ipv4_unicast_enabled, bit<1> ipv6_unicast_enabled, bit<2> ipv4_urpf_mode, bit<2> ipv6_urpf_mode, bit<1> igmp_snooping_enabled, bit<1> mld_snooping_enabled, bit<1> ipv4_multicast_enabled, bit<1> ipv6_multicast_enabled, bit<16> mrpf_group, bit<16> ipv4_mcast_key, bit<1> ipv4_mcast_key_type, bit<16> ipv6_mcast_key, bit<1> ipv6_mcast_key_type) {
-        meta._ingress_metadata_bd42 = bd;
-        meta._ingress_metadata_outer_bd41 = bd;
-        meta._acl_metadata_bd_label10 = bd_label;
-        meta._l2_metadata_stp_group74 = stp_group;
+    @name(".set_bd_properties") action _set_bd_properties_0(@name("bd") bit<16> bd_24, @name("vrf") bit<16> vrf_7, @name("stp_group") bit<10> stp_group_1, @name("learning_enabled") bit<1> learning_enabled_1, @name("bd_label") bit<16> bd_label_4, @name("stats_idx") bit<16> stats_idx, @name("rmac_group") bit<10> rmac_group_5, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_3, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_3, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_3, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_3, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_2, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_2, @name("ipv4_multicast_enabled") bit<1> ipv4_multicast_enabled_3, @name("ipv6_multicast_enabled") bit<1> ipv6_multicast_enabled_3, @name("mrpf_group") bit<16> mrpf_group, @name("ipv4_mcast_key") bit<16> ipv4_mcast_key_1, @name("ipv4_mcast_key_type") bit<1> ipv4_mcast_key_type_1, @name("ipv6_mcast_key") bit<16> ipv6_mcast_key_1, @name("ipv6_mcast_key_type") bit<1> ipv6_mcast_key_type_1) {
+        meta._ingress_metadata_bd42 = bd_24;
+        meta._ingress_metadata_outer_bd41 = bd_24;
+        meta._acl_metadata_bd_label10 = bd_label_4;
+        meta._l2_metadata_stp_group74 = stp_group_1;
         meta._l2_metadata_bd_stats_idx76 = stats_idx;
-        meta._l2_metadata_learning_enabled77 = learning_enabled;
-        meta._l3_metadata_vrf89 = vrf;
-        meta._ipv4_metadata_ipv4_unicast_enabled58 = ipv4_unicast_enabled;
-        meta._ipv6_metadata_ipv6_unicast_enabled62 = ipv6_unicast_enabled;
-        meta._ipv4_metadata_ipv4_urpf_mode59 = ipv4_urpf_mode;
-        meta._ipv6_metadata_ipv6_urpf_mode64 = ipv6_urpf_mode;
-        meta._l3_metadata_rmac_group90 = rmac_group;
-        meta._multicast_metadata_igmp_snooping_enabled118 = igmp_snooping_enabled;
-        meta._multicast_metadata_mld_snooping_enabled119 = mld_snooping_enabled;
-        meta._multicast_metadata_ipv4_multicast_enabled116 = ipv4_multicast_enabled;
-        meta._multicast_metadata_ipv6_multicast_enabled117 = ipv6_multicast_enabled;
+        meta._l2_metadata_learning_enabled77 = learning_enabled_1;
+        meta._l3_metadata_vrf89 = vrf_7;
+        meta._ipv4_metadata_ipv4_unicast_enabled58 = ipv4_unicast_enabled_3;
+        meta._ipv6_metadata_ipv6_unicast_enabled62 = ipv6_unicast_enabled_3;
+        meta._ipv4_metadata_ipv4_urpf_mode59 = ipv4_urpf_mode_3;
+        meta._ipv6_metadata_ipv6_urpf_mode64 = ipv6_urpf_mode_3;
+        meta._l3_metadata_rmac_group90 = rmac_group_5;
+        meta._multicast_metadata_igmp_snooping_enabled118 = igmp_snooping_enabled_2;
+        meta._multicast_metadata_mld_snooping_enabled119 = mld_snooping_enabled_2;
+        meta._multicast_metadata_ipv4_multicast_enabled116 = ipv4_multicast_enabled_3;
+        meta._multicast_metadata_ipv6_multicast_enabled117 = ipv6_multicast_enabled_3;
         meta._multicast_metadata_bd_mrpf_group120 = mrpf_group;
-        meta._multicast_metadata_ipv4_mcast_key_type108 = ipv4_mcast_key_type;
-        meta._multicast_metadata_ipv4_mcast_key109 = ipv4_mcast_key;
-        meta._multicast_metadata_ipv6_mcast_key_type110 = ipv6_mcast_key_type;
-        meta._multicast_metadata_ipv6_mcast_key111 = ipv6_mcast_key;
+        meta._multicast_metadata_ipv4_mcast_key_type108 = ipv4_mcast_key_type_1;
+        meta._multicast_metadata_ipv4_mcast_key109 = ipv4_mcast_key_1;
+        meta._multicast_metadata_ipv6_mcast_key_type110 = ipv6_mcast_key_type_1;
+        meta._multicast_metadata_ipv6_mcast_key111 = ipv6_mcast_key_1;
     }
     @name(".port_vlan_mapping_miss") action _port_vlan_mapping_miss_0() {
         meta._l2_metadata_port_vlan_mapping_miss78 = 1w1;
@@ -3748,8 +3746,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         implementation = bd_action_profile;
         default_action = NoAction_156();
     }
-    @name(".set_stp_state") action _set_stp_state_0(bit<3> stp_state) {
-        meta._l2_metadata_stp_state75 = stp_state;
+    @name(".set_stp_state") action _set_stp_state_0(@name("stp_state") bit<3> stp_state_1) {
+        meta._l2_metadata_stp_state75 = stp_state_1;
     }
     @name(".spanning_tree") table _spanning_tree {
         actions = {
@@ -3809,7 +3807,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".int_set_no_src") action _int_set_no_src_0() {
         meta._int_metadata_i2e_source55 = 1w0;
     }
-    @name(".int_sink_gpe") action _int_sink_gpe_0(bit<32> mirror_id) {
+    @name(".int_sink_gpe") action _int_sink_gpe_0(@name("mirror_id") bit<32> mirror_id) {
         meta._int_metadata_insert_byte_cnt50 = meta._int_metadata_gpe_int_hdr_len51 << 2;
         meta._int_metadata_i2e_sink54 = 1w1;
         meta._i2e_metadata_mirror_session_id36 = (bit<16>)mirror_id;
@@ -3901,72 +3899,72 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".tunnel_lookup_miss") action _tunnel_lookup_miss_0() {
     }
-    @name(".terminate_tunnel_inner_non_ip") action _terminate_tunnel_inner_non_ip_0(bit<16> bd, bit<16> bd_label, bit<16> stats_idx) {
+    @name(".terminate_tunnel_inner_non_ip") action _terminate_tunnel_inner_non_ip_0(@name("bd") bit<16> bd_25, @name("bd_label") bit<16> bd_label_5, @name("stats_idx") bit<16> stats_idx_4) {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
-        meta._ingress_metadata_bd42 = bd;
-        meta._acl_metadata_bd_label10 = bd_label;
-        meta._l2_metadata_bd_stats_idx76 = stats_idx;
+        meta._ingress_metadata_bd42 = bd_25;
+        meta._acl_metadata_bd_label10 = bd_label_5;
+        meta._l2_metadata_bd_stats_idx76 = stats_idx_4;
         meta._l3_metadata_lkp_ip_type80 = 2w0;
         meta._l2_metadata_lkp_mac_type68 = hdr.inner_ethernet.etherType;
     }
-    @name(".terminate_tunnel_inner_ethernet_ipv4") action _terminate_tunnel_inner_ethernet_ipv4_0(bit<16> bd, bit<16> vrf, bit<10> rmac_group, bit<16> bd_label, bit<1> ipv4_unicast_enabled, bit<2> ipv4_urpf_mode, bit<1> igmp_snooping_enabled, bit<16> stats_idx, bit<1> ipv4_multicast_enabled, bit<16> mrpf_group) {
+    @name(".terminate_tunnel_inner_ethernet_ipv4") action _terminate_tunnel_inner_ethernet_ipv4_0(@name("bd") bit<16> bd_26, @name("vrf") bit<16> vrf_8, @name("rmac_group") bit<10> rmac_group_6, @name("bd_label") bit<16> bd_label_6, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_4, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_4, @name("igmp_snooping_enabled") bit<1> igmp_snooping_enabled_3, @name("stats_idx") bit<16> stats_idx_5, @name("ipv4_multicast_enabled") bit<1> ipv4_multicast_enabled_4, @name("mrpf_group") bit<16> mrpf_group_5) {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
-        meta._ingress_metadata_bd42 = bd;
-        meta._l3_metadata_vrf89 = vrf;
+        meta._ingress_metadata_bd42 = bd_26;
+        meta._l3_metadata_vrf89 = vrf_8;
         meta._qos_metadata_outer_dscp129 = meta._l3_metadata_lkp_ip_tc83;
-        meta._ipv4_metadata_ipv4_unicast_enabled58 = ipv4_unicast_enabled;
-        meta._ipv4_metadata_ipv4_urpf_mode59 = ipv4_urpf_mode;
-        meta._l3_metadata_rmac_group90 = rmac_group;
-        meta._acl_metadata_bd_label10 = bd_label;
-        meta._l2_metadata_bd_stats_idx76 = stats_idx;
+        meta._ipv4_metadata_ipv4_unicast_enabled58 = ipv4_unicast_enabled_4;
+        meta._ipv4_metadata_ipv4_urpf_mode59 = ipv4_urpf_mode_4;
+        meta._l3_metadata_rmac_group90 = rmac_group_6;
+        meta._acl_metadata_bd_label10 = bd_label_6;
+        meta._l2_metadata_bd_stats_idx76 = stats_idx_5;
         meta._l3_metadata_lkp_ip_type80 = 2w1;
         meta._l2_metadata_lkp_mac_type68 = hdr.inner_ethernet.etherType;
         meta._l3_metadata_lkp_ip_version81 = hdr.inner_ipv4.version;
         meta._l3_metadata_lkp_ip_tc83 = hdr.inner_ipv4.diffserv;
-        meta._multicast_metadata_igmp_snooping_enabled118 = igmp_snooping_enabled;
-        meta._multicast_metadata_ipv4_multicast_enabled116 = ipv4_multicast_enabled;
-        meta._multicast_metadata_bd_mrpf_group120 = mrpf_group;
+        meta._multicast_metadata_igmp_snooping_enabled118 = igmp_snooping_enabled_3;
+        meta._multicast_metadata_ipv4_multicast_enabled116 = ipv4_multicast_enabled_4;
+        meta._multicast_metadata_bd_mrpf_group120 = mrpf_group_5;
     }
-    @name(".terminate_tunnel_inner_ipv4") action _terminate_tunnel_inner_ipv4_0(bit<16> vrf, bit<10> rmac_group, bit<2> ipv4_urpf_mode, bit<1> ipv4_unicast_enabled, bit<1> ipv4_multicast_enabled, bit<16> mrpf_group) {
+    @name(".terminate_tunnel_inner_ipv4") action _terminate_tunnel_inner_ipv4_0(@name("vrf") bit<16> vrf_9, @name("rmac_group") bit<10> rmac_group_7, @name("ipv4_urpf_mode") bit<2> ipv4_urpf_mode_5, @name("ipv4_unicast_enabled") bit<1> ipv4_unicast_enabled_5, @name("ipv4_multicast_enabled") bit<1> ipv4_multicast_enabled_5, @name("mrpf_group") bit<16> mrpf_group_6) {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
-        meta._l3_metadata_vrf89 = vrf;
+        meta._l3_metadata_vrf89 = vrf_9;
         meta._qos_metadata_outer_dscp129 = meta._l3_metadata_lkp_ip_tc83;
-        meta._ipv4_metadata_ipv4_unicast_enabled58 = ipv4_unicast_enabled;
-        meta._ipv4_metadata_ipv4_urpf_mode59 = ipv4_urpf_mode;
-        meta._l3_metadata_rmac_group90 = rmac_group;
+        meta._ipv4_metadata_ipv4_unicast_enabled58 = ipv4_unicast_enabled_5;
+        meta._ipv4_metadata_ipv4_urpf_mode59 = ipv4_urpf_mode_5;
+        meta._l3_metadata_rmac_group90 = rmac_group_7;
         meta._l2_metadata_lkp_mac_sa65 = hdr.ethernet.srcAddr;
         meta._l2_metadata_lkp_mac_da66 = hdr.ethernet.dstAddr;
         meta._l3_metadata_lkp_ip_type80 = 2w1;
         meta._l3_metadata_lkp_ip_version81 = hdr.inner_ipv4.version;
         meta._l3_metadata_lkp_ip_tc83 = hdr.inner_ipv4.diffserv;
-        meta._multicast_metadata_bd_mrpf_group120 = mrpf_group;
-        meta._multicast_metadata_ipv4_multicast_enabled116 = ipv4_multicast_enabled;
+        meta._multicast_metadata_bd_mrpf_group120 = mrpf_group_6;
+        meta._multicast_metadata_ipv4_multicast_enabled116 = ipv4_multicast_enabled_5;
     }
-    @name(".terminate_tunnel_inner_ethernet_ipv6") action _terminate_tunnel_inner_ethernet_ipv6_0(bit<16> bd, bit<16> vrf, bit<10> rmac_group, bit<16> bd_label, bit<1> ipv6_unicast_enabled, bit<2> ipv6_urpf_mode, bit<1> mld_snooping_enabled, bit<16> stats_idx, bit<1> ipv6_multicast_enabled, bit<16> mrpf_group) {
+    @name(".terminate_tunnel_inner_ethernet_ipv6") action _terminate_tunnel_inner_ethernet_ipv6_0(@name("bd") bit<16> bd_27, @name("vrf") bit<16> vrf_10, @name("rmac_group") bit<10> rmac_group_8, @name("bd_label") bit<16> bd_label_7, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_4, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_4, @name("mld_snooping_enabled") bit<1> mld_snooping_enabled_3, @name("stats_idx") bit<16> stats_idx_6, @name("ipv6_multicast_enabled") bit<1> ipv6_multicast_enabled_4, @name("mrpf_group") bit<16> mrpf_group_7) {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
-        meta._ingress_metadata_bd42 = bd;
-        meta._l3_metadata_vrf89 = vrf;
+        meta._ingress_metadata_bd42 = bd_27;
+        meta._l3_metadata_vrf89 = vrf_10;
         meta._qos_metadata_outer_dscp129 = meta._l3_metadata_lkp_ip_tc83;
-        meta._ipv6_metadata_ipv6_unicast_enabled62 = ipv6_unicast_enabled;
-        meta._ipv6_metadata_ipv6_urpf_mode64 = ipv6_urpf_mode;
-        meta._l3_metadata_rmac_group90 = rmac_group;
-        meta._acl_metadata_bd_label10 = bd_label;
-        meta._l2_metadata_bd_stats_idx76 = stats_idx;
+        meta._ipv6_metadata_ipv6_unicast_enabled62 = ipv6_unicast_enabled_4;
+        meta._ipv6_metadata_ipv6_urpf_mode64 = ipv6_urpf_mode_4;
+        meta._l3_metadata_rmac_group90 = rmac_group_8;
+        meta._acl_metadata_bd_label10 = bd_label_7;
+        meta._l2_metadata_bd_stats_idx76 = stats_idx_6;
         meta._l3_metadata_lkp_ip_type80 = 2w2;
         meta._l2_metadata_lkp_mac_type68 = hdr.inner_ethernet.etherType;
         meta._l3_metadata_lkp_ip_version81 = hdr.inner_ipv6.version;
         meta._l3_metadata_lkp_ip_tc83 = hdr.inner_ipv6.trafficClass;
-        meta._multicast_metadata_bd_mrpf_group120 = mrpf_group;
-        meta._multicast_metadata_ipv6_multicast_enabled117 = ipv6_multicast_enabled;
-        meta._multicast_metadata_mld_snooping_enabled119 = mld_snooping_enabled;
+        meta._multicast_metadata_bd_mrpf_group120 = mrpf_group_7;
+        meta._multicast_metadata_ipv6_multicast_enabled117 = ipv6_multicast_enabled_4;
+        meta._multicast_metadata_mld_snooping_enabled119 = mld_snooping_enabled_3;
     }
-    @name(".terminate_tunnel_inner_ipv6") action _terminate_tunnel_inner_ipv6_0(bit<16> vrf, bit<10> rmac_group, bit<1> ipv6_unicast_enabled, bit<2> ipv6_urpf_mode, bit<1> ipv6_multicast_enabled, bit<16> mrpf_group) {
+    @name(".terminate_tunnel_inner_ipv6") action _terminate_tunnel_inner_ipv6_0(@name("vrf") bit<16> vrf_11, @name("rmac_group") bit<10> rmac_group_9, @name("ipv6_unicast_enabled") bit<1> ipv6_unicast_enabled_5, @name("ipv6_urpf_mode") bit<2> ipv6_urpf_mode_5, @name("ipv6_multicast_enabled") bit<1> ipv6_multicast_enabled_5, @name("mrpf_group") bit<16> mrpf_group_8) {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
-        meta._l3_metadata_vrf89 = vrf;
+        meta._l3_metadata_vrf89 = vrf_11;
         meta._qos_metadata_outer_dscp129 = meta._l3_metadata_lkp_ip_tc83;
-        meta._ipv6_metadata_ipv6_unicast_enabled62 = ipv6_unicast_enabled;
-        meta._ipv6_metadata_ipv6_urpf_mode64 = ipv6_urpf_mode;
-        meta._l3_metadata_rmac_group90 = rmac_group;
+        meta._ipv6_metadata_ipv6_unicast_enabled62 = ipv6_unicast_enabled_5;
+        meta._ipv6_metadata_ipv6_urpf_mode64 = ipv6_urpf_mode_5;
+        meta._l3_metadata_rmac_group90 = rmac_group_9;
         meta._l2_metadata_lkp_mac_sa65 = hdr.ethernet.srcAddr;
         meta._l2_metadata_lkp_mac_da66 = hdr.ethernet.dstAddr;
         meta._l3_metadata_lkp_ip_type80 = 2w2;
@@ -3974,8 +3972,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._ipv6_metadata_lkp_ipv6_da61 = hdr.inner_ipv6.dstAddr;
         meta._l3_metadata_lkp_ip_version81 = hdr.inner_ipv6.version;
         meta._l3_metadata_lkp_ip_tc83 = hdr.inner_ipv6.trafficClass;
-        meta._multicast_metadata_bd_mrpf_group120 = mrpf_group;
-        meta._multicast_metadata_ipv6_multicast_enabled117 = ipv6_multicast_enabled;
+        meta._multicast_metadata_bd_mrpf_group120 = mrpf_group_8;
+        meta._multicast_metadata_ipv6_multicast_enabled117 = ipv6_multicast_enabled_5;
     }
     @name(".non_ip_tunnel_lookup_miss") action _non_ip_tunnel_lookup_miss_0() {
         meta._l2_metadata_lkp_mac_sa65 = hdr.ethernet.srcAddr;
@@ -4207,33 +4205,33 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_1() {
     }
-    @name(".outer_multicast_route_s_g_hit") action _outer_multicast_route_s_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".outer_multicast_route_s_g_hit") action _outer_multicast_route_s_g_hit(@name("mc_index") bit<16> mc_index, @name("mcast_rpf_group") bit<16> mcast_rpf_group_12) {
         standard_metadata.mcast_grp = mc_index;
         meta._multicast_metadata_outer_mcast_route_hit112 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_12 ^ meta._multicast_metadata_bd_mrpf_group120;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
-    @name(".outer_multicast_bridge_s_g_hit") action _outer_multicast_bridge_s_g_hit(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".outer_multicast_bridge_s_g_hit") action _outer_multicast_bridge_s_g_hit(@name("mc_index") bit<16> mc_index_22) {
+        standard_metadata.mcast_grp = mc_index_22;
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
-    @name(".outer_multicast_route_sm_star_g_hit") action _outer_multicast_route_sm_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".outer_multicast_route_sm_star_g_hit") action _outer_multicast_route_sm_star_g_hit(@name("mc_index") bit<16> mc_index_23, @name("mcast_rpf_group") bit<16> mcast_rpf_group_13) {
         meta._multicast_metadata_outer_mcast_mode113 = 2w1;
-        standard_metadata.mcast_grp = mc_index;
+        standard_metadata.mcast_grp = mc_index_23;
         meta._multicast_metadata_outer_mcast_route_hit112 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_13 ^ meta._multicast_metadata_bd_mrpf_group120;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
-    @name(".outer_multicast_route_bidir_star_g_hit") action _outer_multicast_route_bidir_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".outer_multicast_route_bidir_star_g_hit") action _outer_multicast_route_bidir_star_g_hit(@name("mc_index") bit<16> mc_index_24, @name("mcast_rpf_group") bit<16> mcast_rpf_group_14) {
         meta._multicast_metadata_outer_mcast_mode113 = 2w2;
-        standard_metadata.mcast_grp = mc_index;
+        standard_metadata.mcast_grp = mc_index_24;
         meta._multicast_metadata_outer_mcast_route_hit112 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_14 | meta._multicast_metadata_bd_mrpf_group120;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
-    @name(".outer_multicast_bridge_star_g_hit") action _outer_multicast_bridge_star_g_hit(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".outer_multicast_bridge_star_g_hit") action _outer_multicast_bridge_star_g_hit(@name("mc_index") bit<16> mc_index_25) {
+        standard_metadata.mcast_grp = mc_index_25;
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
@@ -4276,33 +4274,33 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_2() {
     }
-    @name(".outer_multicast_route_s_g_hit") action _outer_multicast_route_s_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".outer_multicast_route_s_g_hit") action _outer_multicast_route_s_g_hit_0(@name("mc_index") bit<16> mc_index_26, @name("mcast_rpf_group") bit<16> mcast_rpf_group_15) {
+        standard_metadata.mcast_grp = mc_index_26;
         meta._multicast_metadata_outer_mcast_route_hit112 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_15 ^ meta._multicast_metadata_bd_mrpf_group120;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
-    @name(".outer_multicast_bridge_s_g_hit") action _outer_multicast_bridge_s_g_hit_0(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".outer_multicast_bridge_s_g_hit") action _outer_multicast_bridge_s_g_hit_0(@name("mc_index") bit<16> mc_index_27) {
+        standard_metadata.mcast_grp = mc_index_27;
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
-    @name(".outer_multicast_route_sm_star_g_hit") action _outer_multicast_route_sm_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".outer_multicast_route_sm_star_g_hit") action _outer_multicast_route_sm_star_g_hit_0(@name("mc_index") bit<16> mc_index_28, @name("mcast_rpf_group") bit<16> mcast_rpf_group_16) {
         meta._multicast_metadata_outer_mcast_mode113 = 2w1;
-        standard_metadata.mcast_grp = mc_index;
+        standard_metadata.mcast_grp = mc_index_28;
         meta._multicast_metadata_outer_mcast_route_hit112 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_16 ^ meta._multicast_metadata_bd_mrpf_group120;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
-    @name(".outer_multicast_route_bidir_star_g_hit") action _outer_multicast_route_bidir_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".outer_multicast_route_bidir_star_g_hit") action _outer_multicast_route_bidir_star_g_hit_0(@name("mc_index") bit<16> mc_index_29, @name("mcast_rpf_group") bit<16> mcast_rpf_group_17) {
         meta._multicast_metadata_outer_mcast_mode113 = 2w2;
-        standard_metadata.mcast_grp = mc_index;
+        standard_metadata.mcast_grp = mc_index_29;
         meta._multicast_metadata_outer_mcast_route_hit112 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_17 | meta._multicast_metadata_bd_mrpf_group120;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
-    @name(".outer_multicast_bridge_star_g_hit") action _outer_multicast_bridge_star_g_hit_0(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".outer_multicast_bridge_star_g_hit") action _outer_multicast_bridge_star_g_hit_0(@name("mc_index") bit<16> mc_index_30) {
+        standard_metadata.mcast_grp = mc_index_30;
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
@@ -4344,14 +4342,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_tunnel_termination_flag") action _set_tunnel_termination_flag() {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
     }
-    @name(".set_tunnel_vni_and_termination_flag") action _set_tunnel_vni_and_termination_flag(bit<24> tunnel_vni) {
-        meta._tunnel_metadata_tunnel_vni138 = tunnel_vni;
+    @name(".set_tunnel_vni_and_termination_flag") action _set_tunnel_vni_and_termination_flag(@name("tunnel_vni") bit<24> tunnel_vni_2) {
+        meta._tunnel_metadata_tunnel_vni138 = tunnel_vni_2;
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
     }
     @name(".on_miss") action _on_miss_3() {
     }
-    @name(".src_vtep_hit") action _src_vtep_hit(bit<16> ifindex) {
-        meta._ingress_metadata_ifindex38 = ifindex;
+    @name(".src_vtep_hit") action _src_vtep_hit(@name("ifindex") bit<16> ifindex_15) {
+        meta._ingress_metadata_ifindex38 = ifindex_15;
     }
     @name(".ipv4_dest_vtep") table _ipv4_dest_vtep_0 {
         actions = {
@@ -4387,14 +4385,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".set_tunnel_termination_flag") action _set_tunnel_termination_flag_0() {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
     }
-    @name(".set_tunnel_vni_and_termination_flag") action _set_tunnel_vni_and_termination_flag_0(bit<24> tunnel_vni) {
-        meta._tunnel_metadata_tunnel_vni138 = tunnel_vni;
+    @name(".set_tunnel_vni_and_termination_flag") action _set_tunnel_vni_and_termination_flag_0(@name("tunnel_vni") bit<24> tunnel_vni_3) {
+        meta._tunnel_metadata_tunnel_vni138 = tunnel_vni_3;
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
     }
     @name(".on_miss") action _on_miss_4() {
     }
-    @name(".src_vtep_hit") action _src_vtep_hit_0(bit<16> ifindex) {
-        meta._ingress_metadata_ifindex38 = ifindex;
+    @name(".src_vtep_hit") action _src_vtep_hit_0(@name("ifindex") bit<16> ifindex_16) {
+        meta._ingress_metadata_ifindex38 = ifindex_16;
     }
     @name(".ipv6_dest_vtep") table _ipv6_dest_vtep_0 {
         actions = {
@@ -4425,22 +4423,22 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 1024;
         default_action = NoAction_177();
     }
-    @name(".terminate_eompls") action _terminate_eompls(bit<16> bd, bit<5> tunnel_type) {
+    @name(".terminate_eompls") action _terminate_eompls(@name("bd") bit<16> bd_28, @name("tunnel_type") bit<5> tunnel_type_11) {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type137 = tunnel_type;
-        meta._ingress_metadata_bd42 = bd;
+        meta._tunnel_metadata_ingress_tunnel_type137 = tunnel_type_11;
+        meta._ingress_metadata_bd42 = bd_28;
         meta._l2_metadata_lkp_mac_type68 = hdr.inner_ethernet.etherType;
     }
-    @name(".terminate_vpls") action _terminate_vpls(bit<16> bd, bit<5> tunnel_type) {
+    @name(".terminate_vpls") action _terminate_vpls(@name("bd") bit<16> bd_29, @name("tunnel_type") bit<5> tunnel_type_12) {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type137 = tunnel_type;
-        meta._ingress_metadata_bd42 = bd;
+        meta._tunnel_metadata_ingress_tunnel_type137 = tunnel_type_12;
+        meta._ingress_metadata_bd42 = bd_29;
         meta._l2_metadata_lkp_mac_type68 = hdr.inner_ethernet.etherType;
     }
-    @name(".terminate_ipv4_over_mpls") action _terminate_ipv4_over_mpls(bit<16> vrf, bit<5> tunnel_type) {
+    @name(".terminate_ipv4_over_mpls") action _terminate_ipv4_over_mpls(@name("vrf") bit<16> vrf_12, @name("tunnel_type") bit<5> tunnel_type_13) {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type137 = tunnel_type;
-        meta._l3_metadata_vrf89 = vrf;
+        meta._tunnel_metadata_ingress_tunnel_type137 = tunnel_type_13;
+        meta._l3_metadata_vrf89 = vrf_12;
         meta._l2_metadata_lkp_mac_sa65 = hdr.ethernet.srcAddr;
         meta._l2_metadata_lkp_mac_da66 = hdr.ethernet.dstAddr;
         meta._l3_metadata_lkp_ip_type80 = 2w1;
@@ -4448,10 +4446,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._l3_metadata_lkp_ip_version81 = hdr.inner_ipv4.version;
         meta._l3_metadata_lkp_ip_tc83 = hdr.inner_ipv4.diffserv;
     }
-    @name(".terminate_ipv6_over_mpls") action _terminate_ipv6_over_mpls(bit<16> vrf, bit<5> tunnel_type) {
+    @name(".terminate_ipv6_over_mpls") action _terminate_ipv6_over_mpls(@name("vrf") bit<16> vrf_13, @name("tunnel_type") bit<5> tunnel_type_14) {
         meta._tunnel_metadata_tunnel_terminate150 = 1w1;
-        meta._tunnel_metadata_ingress_tunnel_type137 = tunnel_type;
-        meta._l3_metadata_vrf89 = vrf;
+        meta._tunnel_metadata_ingress_tunnel_type137 = tunnel_type_14;
+        meta._l3_metadata_vrf89 = vrf_13;
         meta._l2_metadata_lkp_mac_sa65 = hdr.ethernet.srcAddr;
         meta._l2_metadata_lkp_mac_da66 = hdr.ethernet.dstAddr;
         meta._l3_metadata_lkp_ip_type80 = 2w2;
@@ -4459,13 +4457,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._l3_metadata_lkp_ip_version81 = hdr.inner_ipv6.version;
         meta._l3_metadata_lkp_ip_tc83 = hdr.inner_ipv6.trafficClass;
     }
-    @name(".terminate_pw") action _terminate_pw(bit<16> ifindex) {
-        meta._ingress_metadata_egress_ifindex39 = ifindex;
+    @name(".terminate_pw") action _terminate_pw(@name("ifindex") bit<16> ifindex_17) {
+        meta._ingress_metadata_egress_ifindex39 = ifindex_17;
         meta._l2_metadata_lkp_mac_sa65 = hdr.ethernet.srcAddr;
         meta._l2_metadata_lkp_mac_da66 = hdr.ethernet.dstAddr;
     }
-    @name(".forward_mpls") action _forward_mpls(bit<16> nexthop_index) {
-        meta._l3_metadata_fib_nexthop97 = nexthop_index;
+    @name(".forward_mpls") action _forward_mpls(@name("nexthop_index") bit<16> nexthop_index_8) {
+        meta._l3_metadata_fib_nexthop97 = nexthop_index_8;
         meta._l3_metadata_fib_nexthop_type98 = 1w0;
         meta._l3_metadata_fib_hit96 = 1w1;
         meta._l2_metadata_lkp_mac_sa65 = hdr.ethernet.srcAddr;
@@ -4492,18 +4490,18 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".sflow_ingress_session_pkt_counter") direct_counter(CounterType.packets) _sflow_ingress_session_pkt_counter;
     @name(".nop") action _nop_68() {
     }
-    @name(".sflow_ing_session_enable") action _sflow_ing_session_enable_0(bit<32> rate_thr, bit<16> session_id) {
+    @name(".sflow_ing_session_enable") action _sflow_ing_session_enable_0(@name("rate_thr") bit<32> rate_thr, @name("session_id") bit<16> session_id_7) {
         meta._ingress_metadata_sflow_take_sample47 = rate_thr |+| meta._ingress_metadata_sflow_take_sample47;
-        meta._sflow_metadata_sflow_session_id136 = session_id;
+        meta._sflow_metadata_sflow_session_id136 = session_id_7;
     }
     @name(".nop") action _nop_69() {
         _sflow_ingress_session_pkt_counter.count();
     }
-    @name(".sflow_ing_pkt_to_cpu") action _sflow_ing_pkt_to_cpu_0(bit<32> sflow_i2e_mirror_id, bit<16> reason_code) {
+    @name(".sflow_ing_pkt_to_cpu") action _sflow_ing_pkt_to_cpu_0(@name("sflow_i2e_mirror_id") bit<32> sflow_i2e_mirror_id, @name("reason_code") bit<16> reason_code_5) {
         _sflow_ingress_session_pkt_counter.count();
-        meta._fabric_metadata_reason_code28 = reason_code;
+        meta._fabric_metadata_reason_code28 = reason_code_5;
         meta._i2e_metadata_mirror_session_id36 = (bit<16>)sflow_i2e_mirror_id;
-        clone3<tuple_3>(CloneType.I2E, sflow_i2e_mirror_id, { { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code, meta._ingress_metadata_ingress_port37 }, meta._sflow_metadata_sflow_session_id136, (bit<16>)sflow_i2e_mirror_id });
+        clone3<tuple_3>(CloneType.I2E, sflow_i2e_mirror_id, { { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code_5, meta._ingress_metadata_ingress_port37 }, meta._sflow_metadata_sflow_session_id136, (bit<16>)sflow_i2e_mirror_id });
     }
     @name(".sflow_ing_take_sample") table _sflow_ing_take_sample {
         actions = {
@@ -4535,7 +4533,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_70() {
     }
-    @name(".set_storm_control_meter") action _set_storm_control_meter_0(bit<16> meter_idx) {
+    @name(".set_storm_control_meter") action _set_storm_control_meter_0(@name("meter_idx") bit<16> meter_idx) {
         storm_control_meter.execute_meter<bit<2>>((bit<10>)meter_idx, meta._meter_metadata_meter_color106);
         meta._meter_metadata_meter_index107 = meter_idx;
     }
@@ -4574,9 +4572,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._l2_metadata_lkp_pkt_type67 = 3w4;
         meta._l2_metadata_bd_stats_idx76 = meta._l2_metadata_bd_stats_idx76 + 16w2;
     }
-    @name(".set_malformed_packet") action _set_malformed_packet_0(bit<8> drop_reason) {
+    @name(".set_malformed_packet") action _set_malformed_packet_0(@name("drop_reason") bit<8> drop_reason_8) {
         meta._ingress_metadata_drop_flag43 = 1w1;
-        meta._ingress_metadata_drop_reason44 = drop_reason;
+        meta._ingress_metadata_drop_reason44 = drop_reason_8;
     }
     @name(".validate_packet") table _validate_packet {
         actions = {
@@ -4605,24 +4603,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_73() {
     }
-    @name(".dmac_hit") action _dmac_hit_0(bit<16> ifindex) {
-        meta._ingress_metadata_egress_ifindex39 = ifindex;
-        meta._l2_metadata_same_if_check79 = meta._l2_metadata_same_if_check79 ^ ifindex;
+    @name(".dmac_hit") action _dmac_hit_0(@name("ifindex") bit<16> ifindex_18) {
+        meta._ingress_metadata_egress_ifindex39 = ifindex_18;
+        meta._l2_metadata_same_if_check79 = meta._l2_metadata_same_if_check79 ^ ifindex_18;
     }
-    @name(".dmac_multicast_hit") action _dmac_multicast_hit_0(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".dmac_multicast_hit") action _dmac_multicast_hit_0(@name("mc_index") bit<16> mc_index_31) {
+        standard_metadata.mcast_grp = mc_index_31;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".dmac_miss") action _dmac_miss_0() {
         meta._ingress_metadata_egress_ifindex39 = 16w65535;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
-    @name(".dmac_redirect_nexthop") action _dmac_redirect_nexthop_0(bit<16> nexthop_index) {
+    @name(".dmac_redirect_nexthop") action _dmac_redirect_nexthop_0(@name("nexthop_index") bit<16> nexthop_index_9) {
         meta._l2_metadata_l2_redirect71 = 1w1;
-        meta._l2_metadata_l2_nexthop69 = nexthop_index;
+        meta._l2_metadata_l2_nexthop69 = nexthop_index_9;
         meta._l2_metadata_l2_nexthop_type70 = 1w0;
     }
-    @name(".dmac_redirect_ecmp") action _dmac_redirect_ecmp_0(bit<16> ecmp_index) {
+    @name(".dmac_redirect_ecmp") action _dmac_redirect_ecmp_0(@name("ecmp_index") bit<16> ecmp_index) {
         meta._l2_metadata_l2_redirect71 = 1w1;
         meta._l2_metadata_l2_nexthop69 = ecmp_index;
         meta._l2_metadata_l2_nexthop_type70 = 1w1;
@@ -4633,8 +4631,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".smac_miss") action _smac_miss_0() {
         meta._l2_metadata_l2_src_miss72 = 1w1;
     }
-    @name(".smac_hit") action _smac_hit_0(bit<16> ifindex) {
-        meta._l2_metadata_l2_src_move73 = meta._ingress_metadata_ifindex38 ^ ifindex;
+    @name(".smac_hit") action _smac_hit_0(@name("ifindex") bit<16> ifindex_19) {
+        meta._l2_metadata_l2_src_move73 = meta._ingress_metadata_ifindex38 ^ ifindex_19;
     }
     @name(".dmac") table _dmac {
         support_timeout = true;
@@ -4671,43 +4669,43 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_74() {
     }
-    @name(".acl_deny") action _acl_deny_1(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_deny") action _acl_deny_1(@name("acl_stats_index") bit<14> acl_stats_index_18, @name("acl_meter_index") bit<16> acl_meter_index, @name("acl_copy") bit<1> acl_copy_16, @name("acl_copy_reason") bit<16> acl_copy_reason) {
         meta._acl_metadata_acl_deny0 = 1w1;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_18;
         meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
+        meta._acl_metadata_acl_copy1 = acl_copy_16;
         meta._fabric_metadata_reason_code28 = acl_copy_reason;
     }
-    @name(".acl_permit") action _acl_permit_1(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+    @name(".acl_permit") action _acl_permit_1(@name("acl_stats_index") bit<14> acl_stats_index_19, @name("acl_meter_index") bit<16> acl_meter_index_10, @name("acl_copy") bit<1> acl_copy_17, @name("acl_copy_reason") bit<16> acl_copy_reason_16) {
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_19;
+        meta._meter_metadata_meter_index107 = acl_meter_index_10;
+        meta._acl_metadata_acl_copy1 = acl_copy_17;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_16;
     }
-    @name(".acl_mirror") action _acl_mirror_1(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id;
+    @name(".acl_mirror") action _acl_mirror_1(@name("session_id") bit<32> session_id_8, @name("acl_stats_index") bit<14> acl_stats_index_20, @name("acl_meter_index") bit<16> acl_meter_index_11) {
+        meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id_8;
         meta._i2e_metadata_ingress_tstamp35 = (bit<32>)standard_metadata.ingress_global_timestamp;
-        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)standard_metadata.ingress_global_timestamp, (bit<16>)session_id });
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
+        clone3<tuple_0>(CloneType.I2E, session_id_8, { (bit<32>)standard_metadata.ingress_global_timestamp, (bit<16>)session_id_8 });
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_20;
+        meta._meter_metadata_meter_index107 = acl_meter_index_11;
     }
-    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_1(bit<16> nexthop_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_1(@name("nexthop_index") bit<16> nexthop_index_10, @name("acl_stats_index") bit<14> acl_stats_index_21, @name("acl_meter_index") bit<16> acl_meter_index_12, @name("acl_copy") bit<1> acl_copy_18, @name("acl_copy_reason") bit<16> acl_copy_reason_17) {
         meta._acl_metadata_acl_redirect7 = 1w1;
-        meta._acl_metadata_acl_nexthop3 = nexthop_index;
+        meta._acl_metadata_acl_nexthop3 = nexthop_index_10;
         meta._acl_metadata_acl_nexthop_type5 = 1w0;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_21;
+        meta._meter_metadata_meter_index107 = acl_meter_index_12;
+        meta._acl_metadata_acl_copy1 = acl_copy_18;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_17;
     }
-    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_1(bit<16> ecmp_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_1(@name("ecmp_index") bit<16> ecmp_index_7, @name("acl_stats_index") bit<14> acl_stats_index_22, @name("acl_meter_index") bit<16> acl_meter_index_13, @name("acl_copy") bit<1> acl_copy_19, @name("acl_copy_reason") bit<16> acl_copy_reason_18) {
         meta._acl_metadata_acl_redirect7 = 1w1;
-        meta._acl_metadata_acl_nexthop3 = ecmp_index;
+        meta._acl_metadata_acl_nexthop3 = ecmp_index_7;
         meta._acl_metadata_acl_nexthop_type5 = 1w1;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_22;
+        meta._meter_metadata_meter_index107 = acl_meter_index_13;
+        meta._acl_metadata_acl_copy1 = acl_copy_19;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_18;
     }
     @name(".mac_acl") table _mac_acl {
         actions = {
@@ -4733,81 +4731,81 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_93() {
     }
-    @name(".acl_deny") action _acl_deny_2(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_deny") action _acl_deny_2(@name("acl_stats_index") bit<14> acl_stats_index_23, @name("acl_meter_index") bit<16> acl_meter_index_14, @name("acl_copy") bit<1> acl_copy_20, @name("acl_copy_reason") bit<16> acl_copy_reason_19) {
         meta._acl_metadata_acl_deny0 = 1w1;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_23;
+        meta._meter_metadata_meter_index107 = acl_meter_index_14;
+        meta._acl_metadata_acl_copy1 = acl_copy_20;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_19;
     }
-    @name(".acl_deny") action _acl_deny_4(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_deny") action _acl_deny_4(@name("acl_stats_index") bit<14> acl_stats_index_24, @name("acl_meter_index") bit<16> acl_meter_index_15, @name("acl_copy") bit<1> acl_copy_21, @name("acl_copy_reason") bit<16> acl_copy_reason_20) {
         meta._acl_metadata_acl_deny0 = 1w1;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_24;
+        meta._meter_metadata_meter_index107 = acl_meter_index_15;
+        meta._acl_metadata_acl_copy1 = acl_copy_21;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_20;
     }
-    @name(".acl_permit") action _acl_permit_2(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+    @name(".acl_permit") action _acl_permit_2(@name("acl_stats_index") bit<14> acl_stats_index_25, @name("acl_meter_index") bit<16> acl_meter_index_16, @name("acl_copy") bit<1> acl_copy_22, @name("acl_copy_reason") bit<16> acl_copy_reason_21) {
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_25;
+        meta._meter_metadata_meter_index107 = acl_meter_index_16;
+        meta._acl_metadata_acl_copy1 = acl_copy_22;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_21;
     }
-    @name(".acl_permit") action _acl_permit_4(bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+    @name(".acl_permit") action _acl_permit_4(@name("acl_stats_index") bit<14> acl_stats_index_26, @name("acl_meter_index") bit<16> acl_meter_index_17, @name("acl_copy") bit<1> acl_copy_23, @name("acl_copy_reason") bit<16> acl_copy_reason_22) {
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_26;
+        meta._meter_metadata_meter_index107 = acl_meter_index_17;
+        meta._acl_metadata_acl_copy1 = acl_copy_23;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_22;
     }
-    @name(".acl_mirror") action _acl_mirror_2(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id;
+    @name(".acl_mirror") action _acl_mirror_2(@name("session_id") bit<32> session_id_9, @name("acl_stats_index") bit<14> acl_stats_index_27, @name("acl_meter_index") bit<16> acl_meter_index_18) {
+        meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id_9;
         meta._i2e_metadata_ingress_tstamp35 = (bit<32>)standard_metadata.ingress_global_timestamp;
-        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)standard_metadata.ingress_global_timestamp, (bit<16>)session_id });
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
+        clone3<tuple_0>(CloneType.I2E, session_id_9, { (bit<32>)standard_metadata.ingress_global_timestamp, (bit<16>)session_id_9 });
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_27;
+        meta._meter_metadata_meter_index107 = acl_meter_index_18;
     }
-    @name(".acl_mirror") action _acl_mirror_4(bit<32> session_id, bit<14> acl_stats_index, bit<16> acl_meter_index) {
-        meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id;
+    @name(".acl_mirror") action _acl_mirror_4(@name("session_id") bit<32> session_id_10, @name("acl_stats_index") bit<14> acl_stats_index_28, @name("acl_meter_index") bit<16> acl_meter_index_19) {
+        meta._i2e_metadata_mirror_session_id36 = (bit<16>)session_id_10;
         meta._i2e_metadata_ingress_tstamp35 = (bit<32>)standard_metadata.ingress_global_timestamp;
-        clone3<tuple_0>(CloneType.I2E, session_id, { (bit<32>)standard_metadata.ingress_global_timestamp, (bit<16>)session_id });
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
+        clone3<tuple_0>(CloneType.I2E, session_id_10, { (bit<32>)standard_metadata.ingress_global_timestamp, (bit<16>)session_id_10 });
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_28;
+        meta._meter_metadata_meter_index107 = acl_meter_index_19;
     }
-    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_2(bit<16> nexthop_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_11, @name("acl_stats_index") bit<14> acl_stats_index_29, @name("acl_meter_index") bit<16> acl_meter_index_20, @name("acl_copy") bit<1> acl_copy_24, @name("acl_copy_reason") bit<16> acl_copy_reason_23) {
         meta._acl_metadata_acl_redirect7 = 1w1;
-        meta._acl_metadata_acl_nexthop3 = nexthop_index;
+        meta._acl_metadata_acl_nexthop3 = nexthop_index_11;
         meta._acl_metadata_acl_nexthop_type5 = 1w0;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_29;
+        meta._meter_metadata_meter_index107 = acl_meter_index_20;
+        meta._acl_metadata_acl_copy1 = acl_copy_24;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_23;
     }
-    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_4(bit<16> nexthop_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_nexthop") action _acl_redirect_nexthop_4(@name("nexthop_index") bit<16> nexthop_index_12, @name("acl_stats_index") bit<14> acl_stats_index_30, @name("acl_meter_index") bit<16> acl_meter_index_21, @name("acl_copy") bit<1> acl_copy_25, @name("acl_copy_reason") bit<16> acl_copy_reason_24) {
         meta._acl_metadata_acl_redirect7 = 1w1;
-        meta._acl_metadata_acl_nexthop3 = nexthop_index;
+        meta._acl_metadata_acl_nexthop3 = nexthop_index_12;
         meta._acl_metadata_acl_nexthop_type5 = 1w0;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_30;
+        meta._meter_metadata_meter_index107 = acl_meter_index_21;
+        meta._acl_metadata_acl_copy1 = acl_copy_25;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_24;
     }
-    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_2(bit<16> ecmp_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_2(@name("ecmp_index") bit<16> ecmp_index_8, @name("acl_stats_index") bit<14> acl_stats_index_31, @name("acl_meter_index") bit<16> acl_meter_index_22, @name("acl_copy") bit<1> acl_copy_26, @name("acl_copy_reason") bit<16> acl_copy_reason_25) {
         meta._acl_metadata_acl_redirect7 = 1w1;
-        meta._acl_metadata_acl_nexthop3 = ecmp_index;
+        meta._acl_metadata_acl_nexthop3 = ecmp_index_8;
         meta._acl_metadata_acl_nexthop_type5 = 1w1;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_31;
+        meta._meter_metadata_meter_index107 = acl_meter_index_22;
+        meta._acl_metadata_acl_copy1 = acl_copy_26;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_25;
     }
-    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_4(bit<16> ecmp_index, bit<14> acl_stats_index, bit<16> acl_meter_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".acl_redirect_ecmp") action _acl_redirect_ecmp_4(@name("ecmp_index") bit<16> ecmp_index_9, @name("acl_stats_index") bit<14> acl_stats_index_32, @name("acl_meter_index") bit<16> acl_meter_index_23, @name("acl_copy") bit<1> acl_copy_27, @name("acl_copy_reason") bit<16> acl_copy_reason_26) {
         meta._acl_metadata_acl_redirect7 = 1w1;
-        meta._acl_metadata_acl_nexthop3 = ecmp_index;
+        meta._acl_metadata_acl_nexthop3 = ecmp_index_9;
         meta._acl_metadata_acl_nexthop_type5 = 1w1;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._meter_metadata_meter_index107 = acl_meter_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_32;
+        meta._meter_metadata_meter_index107 = acl_meter_index_23;
+        meta._acl_metadata_acl_copy1 = acl_copy_27;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_26;
     }
     @name(".ip_acl") table _ip_acl {
         actions = {
@@ -4859,13 +4857,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_94() {
     }
-    @name(".apply_cos_marking") action _apply_cos_marking_0(bit<3> cos) {
+    @name(".apply_cos_marking") action _apply_cos_marking_0(@name("cos") bit<3> cos) {
         meta._qos_metadata_marked_cos130 = cos;
     }
-    @name(".apply_dscp_marking") action _apply_dscp_marking_0(bit<8> dscp) {
+    @name(".apply_dscp_marking") action _apply_dscp_marking_0(@name("dscp") bit<8> dscp) {
         meta._qos_metadata_marked_dscp131 = dscp;
     }
-    @name(".apply_tc_marking") action _apply_tc_marking_0(bit<3> tc) {
+    @name(".apply_tc_marking") action _apply_tc_marking_0(@name("tc") bit<3> tc) {
         meta._qos_metadata_marked_exp132 = tc;
     }
     @name(".qos") table _qos {
@@ -4892,14 +4890,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".ipv4_multicast_route_star_g_stats") direct_counter(CounterType.packets) _ipv4_multicast_route_star_g_stats_0;
     @name(".on_miss") action _on_miss_5() {
     }
-    @name(".multicast_bridge_s_g_hit") action _multicast_bridge_s_g_hit(bit<16> mc_index) {
-        meta._multicast_metadata_multicast_bridge_mc_index124 = mc_index;
+    @name(".multicast_bridge_s_g_hit") action _multicast_bridge_s_g_hit(@name("mc_index") bit<16> mc_index_32) {
+        meta._multicast_metadata_multicast_bridge_mc_index124 = mc_index_32;
         meta._multicast_metadata_mcast_bridge_hit115 = 1w1;
     }
     @name(".nop") action _nop_95() {
     }
-    @name(".multicast_bridge_star_g_hit") action _multicast_bridge_star_g_hit(bit<16> mc_index) {
-        meta._multicast_metadata_multicast_bridge_mc_index124 = mc_index;
+    @name(".multicast_bridge_star_g_hit") action _multicast_bridge_star_g_hit(@name("mc_index") bit<16> mc_index_33) {
+        meta._multicast_metadata_multicast_bridge_mc_index124 = mc_index_33;
         meta._multicast_metadata_mcast_bridge_hit115 = 1w1;
     }
     @name(".ipv4_multicast_bridge") table _ipv4_multicast_bridge_0 {
@@ -4932,12 +4930,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_6() {
         _ipv4_multicast_route_s_g_stats_0.count();
     }
-    @name(".multicast_route_s_g_hit") action _multicast_route_s_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_s_g_hit") action _multicast_route_s_g_hit(@name("mc_index") bit<16> mc_index_34, @name("mcast_rpf_group") bit<16> mcast_rpf_group_18) {
         _ipv4_multicast_route_s_g_stats_0.count();
-        meta._multicast_metadata_multicast_route_mc_index123 = mc_index;
+        meta._multicast_metadata_multicast_route_mc_index123 = mc_index_34;
         meta._multicast_metadata_mcast_mode122 = 2w1;
         meta._multicast_metadata_mcast_route_hit114 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_18 ^ meta._multicast_metadata_bd_mrpf_group120;
     }
     @name(".ipv4_multicast_route") table _ipv4_multicast_route_0 {
         actions = {
@@ -4958,19 +4956,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         _ipv4_multicast_route_star_g_stats_0.count();
         meta._l3_metadata_l3_copy104 = 1w1;
     }
-    @name(".multicast_route_sm_star_g_hit") action _multicast_route_sm_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_sm_star_g_hit") action _multicast_route_sm_star_g_hit(@name("mc_index") bit<16> mc_index_35, @name("mcast_rpf_group") bit<16> mcast_rpf_group_19) {
         _ipv4_multicast_route_star_g_stats_0.count();
         meta._multicast_metadata_mcast_mode122 = 2w1;
-        meta._multicast_metadata_multicast_route_mc_index123 = mc_index;
+        meta._multicast_metadata_multicast_route_mc_index123 = mc_index_35;
         meta._multicast_metadata_mcast_route_hit114 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_19 ^ meta._multicast_metadata_bd_mrpf_group120;
     }
-    @name(".multicast_route_bidir_star_g_hit") action _multicast_route_bidir_star_g_hit(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_bidir_star_g_hit") action _multicast_route_bidir_star_g_hit(@name("mc_index") bit<16> mc_index_36, @name("mcast_rpf_group") bit<16> mcast_rpf_group_20) {
         _ipv4_multicast_route_star_g_stats_0.count();
         meta._multicast_metadata_mcast_mode122 = 2w2;
-        meta._multicast_metadata_multicast_route_mc_index123 = mc_index;
+        meta._multicast_metadata_multicast_route_mc_index123 = mc_index_36;
         meta._multicast_metadata_mcast_route_hit114 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_20 | meta._multicast_metadata_bd_mrpf_group120;
     }
     @name(".ipv4_multicast_route_star_g") table _ipv4_multicast_route_star_g_0 {
         actions = {
@@ -4991,14 +4989,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".ipv6_multicast_route_star_g_stats") direct_counter(CounterType.packets) _ipv6_multicast_route_star_g_stats_0;
     @name(".on_miss") action _on_miss_7() {
     }
-    @name(".multicast_bridge_s_g_hit") action _multicast_bridge_s_g_hit_0(bit<16> mc_index) {
-        meta._multicast_metadata_multicast_bridge_mc_index124 = mc_index;
+    @name(".multicast_bridge_s_g_hit") action _multicast_bridge_s_g_hit_0(@name("mc_index") bit<16> mc_index_37) {
+        meta._multicast_metadata_multicast_bridge_mc_index124 = mc_index_37;
         meta._multicast_metadata_mcast_bridge_hit115 = 1w1;
     }
     @name(".nop") action _nop_96() {
     }
-    @name(".multicast_bridge_star_g_hit") action _multicast_bridge_star_g_hit_0(bit<16> mc_index) {
-        meta._multicast_metadata_multicast_bridge_mc_index124 = mc_index;
+    @name(".multicast_bridge_star_g_hit") action _multicast_bridge_star_g_hit_0(@name("mc_index") bit<16> mc_index_38) {
+        meta._multicast_metadata_multicast_bridge_mc_index124 = mc_index_38;
         meta._multicast_metadata_mcast_bridge_hit115 = 1w1;
     }
     @name(".ipv6_multicast_bridge") table _ipv6_multicast_bridge_0 {
@@ -5031,12 +5029,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".on_miss") action _on_miss_8() {
         _ipv6_multicast_route_s_g_stats_0.count();
     }
-    @name(".multicast_route_s_g_hit") action _multicast_route_s_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_s_g_hit") action _multicast_route_s_g_hit_0(@name("mc_index") bit<16> mc_index_39, @name("mcast_rpf_group") bit<16> mcast_rpf_group_21) {
         _ipv6_multicast_route_s_g_stats_0.count();
-        meta._multicast_metadata_multicast_route_mc_index123 = mc_index;
+        meta._multicast_metadata_multicast_route_mc_index123 = mc_index_39;
         meta._multicast_metadata_mcast_mode122 = 2w1;
         meta._multicast_metadata_mcast_route_hit114 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_21 ^ meta._multicast_metadata_bd_mrpf_group120;
     }
     @name(".ipv6_multicast_route") table _ipv6_multicast_route_0 {
         actions = {
@@ -5057,19 +5055,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         _ipv6_multicast_route_star_g_stats_0.count();
         meta._l3_metadata_l3_copy104 = 1w1;
     }
-    @name(".multicast_route_sm_star_g_hit") action _multicast_route_sm_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_sm_star_g_hit") action _multicast_route_sm_star_g_hit_0(@name("mc_index") bit<16> mc_index_40, @name("mcast_rpf_group") bit<16> mcast_rpf_group_22) {
         _ipv6_multicast_route_star_g_stats_0.count();
         meta._multicast_metadata_mcast_mode122 = 2w1;
-        meta._multicast_metadata_multicast_route_mc_index123 = mc_index;
+        meta._multicast_metadata_multicast_route_mc_index123 = mc_index_40;
         meta._multicast_metadata_mcast_route_hit114 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group ^ meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_22 ^ meta._multicast_metadata_bd_mrpf_group120;
     }
-    @name(".multicast_route_bidir_star_g_hit") action _multicast_route_bidir_star_g_hit_0(bit<16> mc_index, bit<16> mcast_rpf_group) {
+    @name(".multicast_route_bidir_star_g_hit") action _multicast_route_bidir_star_g_hit_0(@name("mc_index") bit<16> mc_index_41, @name("mcast_rpf_group") bit<16> mcast_rpf_group_23) {
         _ipv6_multicast_route_star_g_stats_0.count();
         meta._multicast_metadata_mcast_mode122 = 2w2;
-        meta._multicast_metadata_multicast_route_mc_index123 = mc_index;
+        meta._multicast_metadata_multicast_route_mc_index123 = mc_index_41;
         meta._multicast_metadata_mcast_route_hit114 = 1w1;
-        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group | meta._multicast_metadata_bd_mrpf_group120;
+        meta._multicast_metadata_mcast_rpf_group121 = mcast_rpf_group_23 | meta._multicast_metadata_bd_mrpf_group120;
     }
     @name(".ipv6_multicast_route_star_g") table _ipv6_multicast_route_star_g_0 {
         actions = {
@@ -5088,32 +5086,32 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_97() {
     }
-    @name(".racl_deny") action _racl_deny_1(bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_deny") action _racl_deny_1(@name("acl_stats_index") bit<14> acl_stats_index_33, @name("acl_copy") bit<1> acl_copy_28, @name("acl_copy_reason") bit<16> acl_copy_reason_27) {
         meta._acl_metadata_racl_deny2 = 1w1;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_33;
+        meta._acl_metadata_acl_copy1 = acl_copy_28;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_27;
     }
-    @name(".racl_permit") action _racl_permit_1(bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+    @name(".racl_permit") action _racl_permit_1(@name("acl_stats_index") bit<14> acl_stats_index_34, @name("acl_copy") bit<1> acl_copy_29, @name("acl_copy_reason") bit<16> acl_copy_reason_28) {
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_34;
+        meta._acl_metadata_acl_copy1 = acl_copy_29;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_28;
     }
-    @name(".racl_redirect_nexthop") action _racl_redirect_nexthop_1(bit<16> nexthop_index, bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_redirect_nexthop") action _racl_redirect_nexthop_1(@name("nexthop_index") bit<16> nexthop_index_13, @name("acl_stats_index") bit<14> acl_stats_index_35, @name("acl_copy") bit<1> acl_copy_30, @name("acl_copy_reason") bit<16> acl_copy_reason_29) {
         meta._acl_metadata_racl_redirect8 = 1w1;
-        meta._acl_metadata_racl_nexthop4 = nexthop_index;
+        meta._acl_metadata_racl_nexthop4 = nexthop_index_13;
         meta._acl_metadata_racl_nexthop_type6 = 1w0;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_35;
+        meta._acl_metadata_acl_copy1 = acl_copy_30;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_29;
     }
-    @name(".racl_redirect_ecmp") action _racl_redirect_ecmp_1(bit<16> ecmp_index, bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_redirect_ecmp") action _racl_redirect_ecmp_1(@name("ecmp_index") bit<16> ecmp_index_10, @name("acl_stats_index") bit<14> acl_stats_index_36, @name("acl_copy") bit<1> acl_copy_31, @name("acl_copy_reason") bit<16> acl_copy_reason_30) {
         meta._acl_metadata_racl_redirect8 = 1w1;
-        meta._acl_metadata_racl_nexthop4 = ecmp_index;
+        meta._acl_metadata_racl_nexthop4 = ecmp_index_10;
         meta._acl_metadata_racl_nexthop_type6 = 1w1;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_36;
+        meta._acl_metadata_acl_copy1 = acl_copy_31;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_30;
     }
     @name(".ipv4_racl") table _ipv4_racl {
         actions = {
@@ -5137,14 +5135,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_23() {
     }
-    @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_0(bit<16> urpf_bd_group) {
+    @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_0(@name("urpf_bd_group") bit<16> urpf_bd_group_2) {
         meta._l3_metadata_urpf_hit93 = 1w1;
-        meta._l3_metadata_urpf_bd_group95 = urpf_bd_group;
+        meta._l3_metadata_urpf_bd_group95 = urpf_bd_group_2;
         meta._l3_metadata_urpf_mode92 = meta._ipv4_metadata_ipv4_urpf_mode59;
     }
-    @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_2(bit<16> urpf_bd_group) {
+    @name(".ipv4_urpf_hit") action _ipv4_urpf_hit_2(@name("urpf_bd_group") bit<16> urpf_bd_group_3) {
         meta._l3_metadata_urpf_hit93 = 1w1;
-        meta._l3_metadata_urpf_bd_group95 = urpf_bd_group;
+        meta._l3_metadata_urpf_bd_group95 = urpf_bd_group_3;
         meta._l3_metadata_urpf_mode92 = meta._ipv4_metadata_ipv4_urpf_mode59;
     }
     @name(".urpf_miss") action _urpf_miss_1() {
@@ -5180,24 +5178,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_25() {
     }
-    @name(".fib_hit_nexthop") action _fib_hit_nexthop_1(bit<16> nexthop_index) {
+    @name(".fib_hit_nexthop") action _fib_hit_nexthop_1(@name("nexthop_index") bit<16> nexthop_index_14) {
         meta._l3_metadata_fib_hit96 = 1w1;
-        meta._l3_metadata_fib_nexthop97 = nexthop_index;
+        meta._l3_metadata_fib_nexthop97 = nexthop_index_14;
         meta._l3_metadata_fib_nexthop_type98 = 1w0;
     }
-    @name(".fib_hit_nexthop") action _fib_hit_nexthop_2(bit<16> nexthop_index) {
+    @name(".fib_hit_nexthop") action _fib_hit_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_15) {
         meta._l3_metadata_fib_hit96 = 1w1;
-        meta._l3_metadata_fib_nexthop97 = nexthop_index;
+        meta._l3_metadata_fib_nexthop97 = nexthop_index_15;
         meta._l3_metadata_fib_nexthop_type98 = 1w0;
     }
-    @name(".fib_hit_ecmp") action _fib_hit_ecmp_1(bit<16> ecmp_index) {
+    @name(".fib_hit_ecmp") action _fib_hit_ecmp_1(@name("ecmp_index") bit<16> ecmp_index_11) {
         meta._l3_metadata_fib_hit96 = 1w1;
-        meta._l3_metadata_fib_nexthop97 = ecmp_index;
+        meta._l3_metadata_fib_nexthop97 = ecmp_index_11;
         meta._l3_metadata_fib_nexthop_type98 = 1w1;
     }
-    @name(".fib_hit_ecmp") action _fib_hit_ecmp_2(bit<16> ecmp_index) {
+    @name(".fib_hit_ecmp") action _fib_hit_ecmp_2(@name("ecmp_index") bit<16> ecmp_index_12) {
         meta._l3_metadata_fib_hit96 = 1w1;
-        meta._l3_metadata_fib_nexthop97 = ecmp_index;
+        meta._l3_metadata_fib_nexthop97 = ecmp_index_12;
         meta._l3_metadata_fib_nexthop_type98 = 1w1;
     }
     @name(".ipv4_fib") table _ipv4_fib {
@@ -5230,32 +5228,32 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_98() {
     }
-    @name(".racl_deny") action _racl_deny_2(bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_deny") action _racl_deny_2(@name("acl_stats_index") bit<14> acl_stats_index_37, @name("acl_copy") bit<1> acl_copy_32, @name("acl_copy_reason") bit<16> acl_copy_reason_31) {
         meta._acl_metadata_racl_deny2 = 1w1;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_37;
+        meta._acl_metadata_acl_copy1 = acl_copy_32;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_31;
     }
-    @name(".racl_permit") action _racl_permit_2(bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+    @name(".racl_permit") action _racl_permit_2(@name("acl_stats_index") bit<14> acl_stats_index_38, @name("acl_copy") bit<1> acl_copy_33, @name("acl_copy_reason") bit<16> acl_copy_reason_32) {
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_38;
+        meta._acl_metadata_acl_copy1 = acl_copy_33;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_32;
     }
-    @name(".racl_redirect_nexthop") action _racl_redirect_nexthop_2(bit<16> nexthop_index, bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_redirect_nexthop") action _racl_redirect_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_16, @name("acl_stats_index") bit<14> acl_stats_index_39, @name("acl_copy") bit<1> acl_copy_34, @name("acl_copy_reason") bit<16> acl_copy_reason_33) {
         meta._acl_metadata_racl_redirect8 = 1w1;
-        meta._acl_metadata_racl_nexthop4 = nexthop_index;
+        meta._acl_metadata_racl_nexthop4 = nexthop_index_16;
         meta._acl_metadata_racl_nexthop_type6 = 1w0;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_39;
+        meta._acl_metadata_acl_copy1 = acl_copy_34;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_33;
     }
-    @name(".racl_redirect_ecmp") action _racl_redirect_ecmp_2(bit<16> ecmp_index, bit<14> acl_stats_index, bit<1> acl_copy, bit<16> acl_copy_reason) {
+    @name(".racl_redirect_ecmp") action _racl_redirect_ecmp_2(@name("ecmp_index") bit<16> ecmp_index_13, @name("acl_stats_index") bit<14> acl_stats_index_40, @name("acl_copy") bit<1> acl_copy_35, @name("acl_copy_reason") bit<16> acl_copy_reason_34) {
         meta._acl_metadata_racl_redirect8 = 1w1;
-        meta._acl_metadata_racl_nexthop4 = ecmp_index;
+        meta._acl_metadata_racl_nexthop4 = ecmp_index_13;
         meta._acl_metadata_racl_nexthop_type6 = 1w1;
-        meta._acl_metadata_acl_stats_index11 = acl_stats_index;
-        meta._acl_metadata_acl_copy1 = acl_copy;
-        meta._fabric_metadata_reason_code28 = acl_copy_reason;
+        meta._acl_metadata_acl_stats_index11 = acl_stats_index_40;
+        meta._acl_metadata_acl_copy1 = acl_copy_35;
+        meta._fabric_metadata_reason_code28 = acl_copy_reason_34;
     }
     @name(".ipv6_racl") table _ipv6_racl {
         actions = {
@@ -5279,14 +5277,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_26() {
     }
-    @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_0(bit<16> urpf_bd_group) {
+    @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_0(@name("urpf_bd_group") bit<16> urpf_bd_group_4) {
         meta._l3_metadata_urpf_hit93 = 1w1;
-        meta._l3_metadata_urpf_bd_group95 = urpf_bd_group;
+        meta._l3_metadata_urpf_bd_group95 = urpf_bd_group_4;
         meta._l3_metadata_urpf_mode92 = meta._ipv6_metadata_ipv6_urpf_mode64;
     }
-    @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_2(bit<16> urpf_bd_group) {
+    @name(".ipv6_urpf_hit") action _ipv6_urpf_hit_2(@name("urpf_bd_group") bit<16> urpf_bd_group_5) {
         meta._l3_metadata_urpf_hit93 = 1w1;
-        meta._l3_metadata_urpf_bd_group95 = urpf_bd_group;
+        meta._l3_metadata_urpf_bd_group95 = urpf_bd_group_5;
         meta._l3_metadata_urpf_mode92 = meta._ipv6_metadata_ipv6_urpf_mode64;
     }
     @name(".urpf_miss") action _urpf_miss_2() {
@@ -5322,24 +5320,24 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action _on_miss_30() {
     }
-    @name(".fib_hit_nexthop") action _fib_hit_nexthop_5(bit<16> nexthop_index) {
+    @name(".fib_hit_nexthop") action _fib_hit_nexthop_5(@name("nexthop_index") bit<16> nexthop_index_17) {
         meta._l3_metadata_fib_hit96 = 1w1;
-        meta._l3_metadata_fib_nexthop97 = nexthop_index;
+        meta._l3_metadata_fib_nexthop97 = nexthop_index_17;
         meta._l3_metadata_fib_nexthop_type98 = 1w0;
     }
-    @name(".fib_hit_nexthop") action _fib_hit_nexthop_6(bit<16> nexthop_index) {
+    @name(".fib_hit_nexthop") action _fib_hit_nexthop_6(@name("nexthop_index") bit<16> nexthop_index_18) {
         meta._l3_metadata_fib_hit96 = 1w1;
-        meta._l3_metadata_fib_nexthop97 = nexthop_index;
+        meta._l3_metadata_fib_nexthop97 = nexthop_index_18;
         meta._l3_metadata_fib_nexthop_type98 = 1w0;
     }
-    @name(".fib_hit_ecmp") action _fib_hit_ecmp_5(bit<16> ecmp_index) {
+    @name(".fib_hit_ecmp") action _fib_hit_ecmp_5(@name("ecmp_index") bit<16> ecmp_index_14) {
         meta._l3_metadata_fib_hit96 = 1w1;
-        meta._l3_metadata_fib_nexthop97 = ecmp_index;
+        meta._l3_metadata_fib_nexthop97 = ecmp_index_14;
         meta._l3_metadata_fib_nexthop_type98 = 1w1;
     }
-    @name(".fib_hit_ecmp") action _fib_hit_ecmp_6(bit<16> ecmp_index) {
+    @name(".fib_hit_ecmp") action _fib_hit_ecmp_6(@name("ecmp_index") bit<16> ecmp_index_15) {
         meta._l3_metadata_fib_hit96 = 1w1;
-        meta._l3_metadata_fib_nexthop97 = ecmp_index;
+        meta._l3_metadata_fib_nexthop97 = ecmp_index_15;
         meta._l3_metadata_fib_nexthop_type98 = 1w1;
     }
     @name(".ipv6_fib") table _ipv6_fib {
@@ -5619,30 +5617,30 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_104() {
     }
-    @name(".set_ecmp_nexthop_details") action _set_ecmp_nexthop_details_0(bit<16> ifindex, bit<16> bd, bit<16> nhop_index, bit<1> tunnel) {
-        meta._ingress_metadata_egress_ifindex39 = ifindex;
+    @name(".set_ecmp_nexthop_details") action _set_ecmp_nexthop_details_0(@name("ifindex") bit<16> ifindex_20, @name("bd") bit<16> bd_30, @name("nhop_index") bit<16> nhop_index, @name("tunnel") bit<1> tunnel) {
+        meta._ingress_metadata_egress_ifindex39 = ifindex_20;
         meta._l3_metadata_nexthop_index100 = nhop_index;
-        meta._l3_metadata_same_bd_check99 = meta._ingress_metadata_bd42 ^ bd;
-        meta._l2_metadata_same_if_check79 = meta._l2_metadata_same_if_check79 ^ ifindex;
+        meta._l3_metadata_same_bd_check99 = meta._ingress_metadata_bd42 ^ bd_30;
+        meta._l2_metadata_same_if_check79 = meta._l2_metadata_same_if_check79 ^ ifindex_20;
         meta._tunnel_metadata_tunnel_if_check151 = meta._tunnel_metadata_tunnel_terminate150 ^ tunnel;
     }
-    @name(".set_ecmp_nexthop_details_for_post_routed_flood") action _set_ecmp_nexthop_details_for_post_routed_flood_0(bit<16> bd, bit<16> uuc_mc_index, bit<16> nhop_index) {
+    @name(".set_ecmp_nexthop_details_for_post_routed_flood") action _set_ecmp_nexthop_details_for_post_routed_flood_0(@name("bd") bit<16> bd_31, @name("uuc_mc_index") bit<16> uuc_mc_index, @name("nhop_index") bit<16> nhop_index_2) {
         standard_metadata.mcast_grp = uuc_mc_index;
-        meta._l3_metadata_nexthop_index100 = nhop_index;
+        meta._l3_metadata_nexthop_index100 = nhop_index_2;
         meta._ingress_metadata_egress_ifindex39 = 16w0;
-        meta._l3_metadata_same_bd_check99 = meta._ingress_metadata_bd42 ^ bd;
+        meta._l3_metadata_same_bd_check99 = meta._ingress_metadata_bd42 ^ bd_31;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
-    @name(".set_nexthop_details") action _set_nexthop_details_0(bit<16> ifindex, bit<16> bd, bit<1> tunnel) {
-        meta._ingress_metadata_egress_ifindex39 = ifindex;
-        meta._l3_metadata_same_bd_check99 = meta._ingress_metadata_bd42 ^ bd;
-        meta._l2_metadata_same_if_check79 = meta._l2_metadata_same_if_check79 ^ ifindex;
-        meta._tunnel_metadata_tunnel_if_check151 = meta._tunnel_metadata_tunnel_terminate150 ^ tunnel;
+    @name(".set_nexthop_details") action _set_nexthop_details_0(@name("ifindex") bit<16> ifindex_21, @name("bd") bit<16> bd_32, @name("tunnel") bit<1> tunnel_0) {
+        meta._ingress_metadata_egress_ifindex39 = ifindex_21;
+        meta._l3_metadata_same_bd_check99 = meta._ingress_metadata_bd42 ^ bd_32;
+        meta._l2_metadata_same_if_check79 = meta._l2_metadata_same_if_check79 ^ ifindex_21;
+        meta._tunnel_metadata_tunnel_if_check151 = meta._tunnel_metadata_tunnel_terminate150 ^ tunnel_0;
     }
-    @name(".set_nexthop_details_for_post_routed_flood") action _set_nexthop_details_for_post_routed_flood_0(bit<16> bd, bit<16> uuc_mc_index) {
-        standard_metadata.mcast_grp = uuc_mc_index;
+    @name(".set_nexthop_details_for_post_routed_flood") action _set_nexthop_details_for_post_routed_flood_0(@name("bd") bit<16> bd_33, @name("uuc_mc_index") bit<16> uuc_mc_index_2) {
+        standard_metadata.mcast_grp = uuc_mc_index_2;
         meta._ingress_metadata_egress_ifindex39 = 16w0;
-        meta._l3_metadata_same_bd_check99 = meta._ingress_metadata_bd42 ^ bd;
+        meta._l3_metadata_same_bd_check99 = meta._ingress_metadata_bd42 ^ bd_33;
         meta._fabric_metadata_dst_device29 = 8w127;
     }
     @name(".ecmp_group") table _ecmp_group {
@@ -5675,8 +5673,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_105() {
     }
-    @name(".set_bd_flood_mc_index") action _set_bd_flood_mc_index_0(bit<16> mc_index) {
-        standard_metadata.mcast_grp = mc_index;
+    @name(".set_bd_flood_mc_index") action _set_bd_flood_mc_index_0(@name("mc_index") bit<16> mc_index_42) {
+        standard_metadata.mcast_grp = mc_index_42;
     }
     @name(".bd_flood") table _bd_flood {
         actions = {
@@ -5693,12 +5691,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".set_lag_miss") action _set_lag_miss_0() {
     }
-    @name(".set_lag_port") action _set_lag_port_0(bit<9> port) {
+    @name(".set_lag_port") action _set_lag_port_0(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
-    @name(".set_lag_remote_port") action _set_lag_remote_port_0(bit<8> device, bit<16> port) {
+    @name(".set_lag_remote_port") action _set_lag_remote_port_0(@name("device") bit<8> device, @name("port") bit<16> port_3) {
         meta._fabric_metadata_dst_device29 = device;
-        meta._fabric_metadata_dst_port30 = port;
+        meta._fabric_metadata_dst_port30 = port_3;
     }
     @name(".lag_group") table _lag_group {
         actions = {
@@ -5736,10 +5734,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_107() {
     }
-    @name(".set_fabric_lag_port") action _set_fabric_lag_port_0(bit<9> port) {
-        standard_metadata.egress_spec = port;
+    @name(".set_fabric_lag_port") action _set_fabric_lag_port_0(@name("port") bit<9> port_4) {
+        standard_metadata.egress_spec = port_4;
     }
-    @name(".set_fabric_multicast") action _set_fabric_multicast_0(bit<8> fabric_mgid) {
+    @name(".set_fabric_multicast") action _set_fabric_multicast_0(@name("fabric_mgid") bit<8> fabric_mgid_2) {
         meta._multicast_metadata_mcast_grp127 = standard_metadata.mcast_grp;
     }
     @name(".fabric_lag") table _fabric_lag {
@@ -5761,13 +5759,13 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".nop") action _nop_108() {
     }
-    @name(".copy_to_cpu_with_reason") action _copy_to_cpu_with_reason_0(bit<16> reason_code) {
-        meta._fabric_metadata_reason_code28 = reason_code;
-        clone3<tuple_1>(CloneType.I2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code, meta._ingress_metadata_ingress_port37 });
+    @name(".copy_to_cpu_with_reason") action _copy_to_cpu_with_reason_0(@name("reason_code") bit<16> reason_code_6) {
+        meta._fabric_metadata_reason_code28 = reason_code_6;
+        clone3<tuple_1>(CloneType.I2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code_6, meta._ingress_metadata_ingress_port37 });
     }
-    @name(".redirect_to_cpu") action _redirect_to_cpu_0(bit<16> reason_code) {
-        meta._fabric_metadata_reason_code28 = reason_code;
-        clone3<tuple_1>(CloneType.I2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code, meta._ingress_metadata_ingress_port37 });
+    @name(".redirect_to_cpu") action _redirect_to_cpu_0(@name("reason_code") bit<16> reason_code_7) {
+        meta._fabric_metadata_reason_code28 = reason_code_7;
+        clone3<tuple_1>(CloneType.I2E, 32w250, { meta._ingress_metadata_bd42, meta._ingress_metadata_ifindex38, reason_code_7, meta._ingress_metadata_ingress_port37 });
         mark_to_drop(standard_metadata);
         meta._fabric_metadata_dst_device29 = 8w0;
     }
@@ -5777,12 +5775,12 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".drop_packet") action _drop_packet_0() {
         mark_to_drop(standard_metadata);
     }
-    @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(bit<10> drop_reason) {
-        drop_stats.count(drop_reason);
+    @name(".drop_packet_with_reason") action _drop_packet_with_reason_0(@name("drop_reason") bit<10> drop_reason_9) {
+        drop_stats.count(drop_reason_9);
         mark_to_drop(standard_metadata);
     }
-    @name(".negative_mirror") action _negative_mirror_0(bit<32> session_id) {
-        clone3<tuple_9>(CloneType.I2E, session_id, { meta._ingress_metadata_ifindex38, meta._ingress_metadata_drop_reason44 });
+    @name(".negative_mirror") action _negative_mirror_0(@name("session_id") bit<32> session_id_11) {
+        clone3<tuple_9>(CloneType.I2E, session_id_11, { meta._ingress_metadata_ifindex38, meta._ingress_metadata_drop_reason44 });
         mark_to_drop(standard_metadata);
     }
     @name(".drop_stats") table _drop_stats {
@@ -5852,7 +5850,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 }
             }
         }
-
         _switch_config_params.apply();
         _port_vlan_mapping.apply();
         if (meta._ingress_metadata_port_type40 == 2w0 && meta._l2_metadata_stp_group74 != 10w0) {
@@ -5866,7 +5863,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
         }
         if (!hdr.int_header.isValid()) {
             _int_source.apply();
@@ -5896,7 +5892,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                             default: {
                             }
                         }
-
                     } else if (hdr.ipv6.isValid()) {
                         switch (_outer_ipv6_multicast_0.apply().action_run) {
                             _on_miss_2: {
@@ -5905,7 +5900,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                             default: {
                             }
                         }
-
                     }
                 }
                 default: {
@@ -5917,7 +5911,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                             default: {
                             }
                         }
-
                     } else if (hdr.ipv6.isValid()) {
                         switch (_ipv6_src_vtep_0.apply().action_run) {
                             _src_vtep_hit_0: {
@@ -5926,13 +5919,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                             default: {
                             }
                         }
-
                     } else if (hdr.mpls[0].isValid()) {
                         _mpls_0.apply();
                     }
                 }
             }
-
         }
         if (meta._tunnel_metadata_tunnel_terminate150 == 1w1 || meta._multicast_metadata_outer_mcast_route_hit112 == 1w1 && (meta._multicast_metadata_outer_mcast_mode113 == 2w1 && meta._multicast_metadata_mcast_rpf_group121 == 16w0 || meta._multicast_metadata_outer_mcast_mode113 == 2w2 && meta._multicast_metadata_mcast_rpf_group121 != 16w0)) {
             switch (_tunnel.apply().action_run) {
@@ -5942,7 +5933,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
         } else {
             _tunnel_miss.apply();
         }
@@ -5985,7 +5975,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             }
                             if (meta._ingress_metadata_bypass_lookups46 & 16w0x2 == 16w0 && meta._multicast_metadata_ipv4_multicast_enabled116 == 1w1) {
                                 switch (_ipv4_multicast_route_0.apply().action_run) {
@@ -5995,7 +5984,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             }
                         } else if (meta._l3_metadata_lkp_ip_type80 == 2w2) {
                             if (meta._ingress_metadata_bypass_lookups46 & 16w0x1 == 16w0) {
@@ -6006,7 +5994,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             }
                             if (meta._ingress_metadata_bypass_lookups46 & 16w0x2 == 16w0 && meta._multicast_metadata_ipv6_multicast_enabled117 == 1w1) {
                                 switch (_ipv6_multicast_route_0.apply().action_run) {
@@ -6016,7 +6003,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             }
                         }
                     }
@@ -6032,7 +6018,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                         default: {
                                         }
                                     }
-
                                 }
                                 switch (_ipv4_fib.apply().action_run) {
                                     _on_miss_24: {
@@ -6041,7 +6026,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             } else if (meta._l3_metadata_lkp_ip_type80 == 2w2 && meta._ipv6_metadata_ipv6_unicast_enabled62 == 1w1) {
                                 _ipv6_racl.apply();
                                 if (meta._ipv6_metadata_ipv6_urpf_mode64 != 2w0) {
@@ -6052,7 +6036,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                         default: {
                                         }
                                     }
-
                                 }
                                 switch (_ipv6_fib.apply().action_run) {
                                     _on_miss_29: {
@@ -6061,7 +6044,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                                     default: {
                                     }
                                 }
-
                             }
                             if (meta._l3_metadata_urpf_mode92 == 2w2 && meta._l3_metadata_urpf_hit93 == 1w1) {
                                 _urpf_bd.apply();
@@ -6069,7 +6051,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                         }
                     }
                 }
-
             }
         }
         if (meta._ingress_metadata_bypass_lookups46 & 16w0x10 == 16w0) {

--- a/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
+++ b/testdata/p4_14_samples_outputs/switch_20160512/switch.p4
@@ -2232,7 +2232,6 @@ control process_int_insertion(inout headers hdr, inout metadata meta, inout stan
                 int_meta_header_update.apply();
             }
         }
-
     }
 }
 
@@ -3029,7 +3028,6 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
                     process_egress_bd_stats_0.apply(hdr, meta, standard_metadata);
                 }
             }
-
             process_tunnel_encap_0.apply(hdr, meta, standard_metadata);
             process_int_outer_encap_0.apply(hdr, meta, standard_metadata);
             if (meta.egress_metadata.port_type == 2w0) {
@@ -3262,7 +3260,6 @@ control process_validate_outer_header(inout headers hdr, inout metadata meta, in
                 }
             }
         }
-
     }
 }
 
@@ -3392,7 +3389,6 @@ control process_ip_sourceguard(inout headers hdr, inout metadata meta, inout sta
                     ipsg_permit_special.apply();
                 }
             }
-
         }
     }
 }
@@ -3691,7 +3687,6 @@ control process_outer_ipv4_multicast(inout headers hdr, inout metadata meta, ino
                 outer_ipv4_multicast_star_g.apply();
             }
         }
-
     }
 }
 
@@ -3765,7 +3760,6 @@ control process_outer_ipv6_multicast(inout headers hdr, inout metadata meta, ino
                 outer_ipv6_multicast_star_g.apply();
             }
         }
-
     }
 }
 
@@ -3836,7 +3830,6 @@ control process_ipv4_vtep(inout headers hdr, inout metadata meta, inout standard
                 ipv4_dest_vtep.apply();
             }
         }
-
     }
 }
 
@@ -3886,7 +3879,6 @@ control process_ipv6_vtep(inout headers hdr, inout metadata meta, inout standard
                 ipv6_dest_vtep.apply();
             }
         }
-
     }
 }
 
@@ -4148,7 +4140,6 @@ control process_tunnel(inout headers hdr, inout metadata meta, inout standard_me
                     }
                 }
             }
-
         }
         if (meta.tunnel_metadata.tunnel_terminate == 1w1 || meta.multicast_metadata.outer_mcast_route_hit == 1w1 && (meta.multicast_metadata.outer_mcast_mode == 2w1 && meta.multicast_metadata.mcast_rpf_group == 16w0 || meta.multicast_metadata.outer_mcast_mode == 2w2 && meta.multicast_metadata.mcast_rpf_group != 16w0)) {
             switch (tunnel.apply().action_run) {
@@ -4156,7 +4147,6 @@ control process_tunnel(inout headers hdr, inout metadata meta, inout standard_me
                     tunnel_lookup_miss_0.apply();
                 }
             }
-
         } else {
             tunnel_miss.apply();
         }
@@ -4689,7 +4679,6 @@ control process_ipv4_multicast(inout headers hdr, inout metadata meta, inout sta
                     ipv4_multicast_bridge_star_g.apply();
                 }
             }
-
         }
         if (meta.ingress_metadata.bypass_lookups & 16w0x2 == 16w0 && meta.multicast_metadata.ipv4_multicast_enabled == 1w1) {
             switch (ipv4_multicast_route.apply().action_run) {
@@ -4697,7 +4686,6 @@ control process_ipv4_multicast(inout headers hdr, inout metadata meta, inout sta
                     ipv4_multicast_route_star_g.apply();
                 }
             }
-
         }
     }
 }
@@ -4822,7 +4810,6 @@ control process_ipv6_multicast(inout headers hdr, inout metadata meta, inout sta
                     ipv6_multicast_bridge_star_g.apply();
                 }
             }
-
         }
         if (meta.ingress_metadata.bypass_lookups & 16w0x2 == 16w0 && meta.multicast_metadata.ipv6_multicast_enabled == 1w1) {
             switch (ipv6_multicast_route.apply().action_run) {
@@ -4830,7 +4817,6 @@ control process_ipv6_multicast(inout headers hdr, inout metadata meta, inout sta
                     ipv6_multicast_route_star_g.apply();
                 }
             }
-
         }
     }
 }
@@ -4949,7 +4935,6 @@ control process_ipv4_urpf(inout headers hdr, inout metadata meta, inout standard
                     ipv4_urpf_lpm.apply();
                 }
             }
-
         }
     }
 }
@@ -4997,7 +4982,6 @@ control process_ipv4_fib(inout headers hdr, inout metadata meta, inout standard_
                 ipv4_fib_lpm.apply();
             }
         }
-
     }
 }
 
@@ -5094,7 +5078,6 @@ control process_ipv6_urpf(inout headers hdr, inout metadata meta, inout standard
                     ipv6_urpf_lpm.apply();
                 }
             }
-
         }
     }
 }
@@ -5142,7 +5125,6 @@ control process_ipv6_fib(inout headers hdr, inout metadata meta, inout standard_
                 ipv6_fib_lpm.apply();
             }
         }
-
     }
 }
 
@@ -5802,7 +5784,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                         }
                     }
                 }
-
             }
         }
         process_meter_index_0.apply(hdr, meta, standard_metadata);

--- a/testdata/p4_14_samples_outputs/ternary_match1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-frontend.p4
@@ -30,7 +30,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/ternary_match1-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match1-midend.p4
@@ -30,7 +30,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/ternary_match2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-frontend.p4
@@ -29,7 +29,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/ternary_match2-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match2-midend.p4
@@ -29,7 +29,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/ternary_match3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-frontend.p4
@@ -29,7 +29,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/ternary_match3-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match3-midend.p4
@@ -29,7 +29,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/ternary_match4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-frontend.p4
@@ -29,7 +29,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/ternary_match4-midend.p4
+++ b/testdata/p4_14_samples_outputs/ternary_match4-midend.p4
@@ -29,7 +29,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-frontend.p4
@@ -108,8 +108,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".no_action") action no_action() {
     }
-    @name(".ing_meter_set") action ing_meter_set(bit<16> meter_) {
-        meta.ingress_metadata.ing_meter = meter_;
+    @name(".ing_meter_set") action ing_meter_set(@name("meter_") bit<16> meter_1) {
+        meta.ingress_metadata.ing_meter = meter_1;
     }
     @name(".storm_control") table storm_control_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/test_7_storm_control-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_7_storm_control-midend.p4
@@ -178,8 +178,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".no_action") action no_action() {
     }
-    @name(".ing_meter_set") action ing_meter_set(bit<16> meter_) {
-        meta._ingress_metadata_ing_meter8 = meter_;
+    @name(".ing_meter_set") action ing_meter_set(@name("meter_") bit<16> meter_1) {
+        meta._ingress_metadata_ing_meter8 = meter_1;
     }
     @name(".storm_control") table storm_control_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-frontend.p4
@@ -46,7 +46,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".action_0") action action_0() {
         hdr.pkt.field_a_32 = ~((bit<32>)hdr.pkt.field_b_32 | hdr.pkt.field_c_32);
     }
-    @name(".action_1") action action_1(int<32> param0) {
+    @name(".action_1") action action_1(@name("param0") int<32> param0) {
         hdr.pkt.field_b_32 = ~param0 | (int<32>)hdr.pkt.field_c_32;
     }
     @name(".do_nothing") action do_nothing() {

--- a/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_175_match_table_with_no_key-midend.p4
@@ -46,7 +46,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".action_0") action action_0() {
         hdr.pkt.field_a_32 = ~((bit<32>)hdr.pkt.field_b_32 | hdr.pkt.field_c_32);
     }
-    @name(".action_1") action action_1(int<32> param0) {
+    @name(".action_1") action action_1(@name("param0") int<32> param0) {
         hdr.pkt.field_b_32 = ~param0 | (int<32>)hdr.pkt.field_c_32;
     }
     @name(".do_nothing") action do_nothing() {

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-frontend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-frontend.p4
@@ -67,11 +67,11 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".action_0") action action_0(bit<8> my_param0, bit<8> my_param1) {
+    @name(".action_0") action action_0(@name("my_param0") bit<8> my_param0, @name("my_param1") bit<8> my_param1) {
         hdr.ipv4.protocol[7:3] = my_param0[7:3];
         hdr.ipv4.ttl = my_param1;
     }
-    @name(".action_1") action action_1(bit<8> my_param2) {
+    @name(".action_1") action action_1(@name("my_param2") bit<8> my_param2) {
         hdr.ipv4.totalLen = hdr.ipv4.totalLen;
     }
     @name(".table_0") table table_1 {

--- a/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-midend.p4
+++ b/testdata/p4_14_samples_outputs/test_config_23_same_container_modified-midend.p4
@@ -67,11 +67,11 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".action_0") action action_0(bit<8> my_param0, bit<8> my_param1) {
+    @name(".action_0") action action_0(@name("my_param0") bit<8> my_param0, @name("my_param1") bit<8> my_param1) {
         hdr.ipv4.protocol[7:3] = my_param0[7:3];
         hdr.ipv4.ttl = my_param1;
     }
-    @name(".action_1") action action_1(bit<8> my_param2) {
+    @name(".action_1") action action_1(@name("my_param2") bit<8> my_param2) {
     }
     @name(".table_0") table table_1 {
         actions = {

--- a/testdata/p4_14_samples_outputs/testgw-frontend.p4
+++ b/testdata/p4_14_samples_outputs/testgw-frontend.p4
@@ -52,9 +52,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name(".route_eth") action route_eth(bit<9> egress_spec, bit<48> src_addr) {
-        standard_metadata.egress_spec = egress_spec;
-        hdr.ethernet.src_addr = src_addr;
+    @name(".route_eth") action route_eth(@name("egress_spec") bit<9> egress_spec_1, @name("src_addr") bit<48> src_addr_1) {
+        standard_metadata.egress_spec = egress_spec_1;
+        hdr.ethernet.src_addr = src_addr_1;
     }
     @name(".noop") action noop() {
     }
@@ -62,11 +62,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_4() {
     }
-    @name(".setf2") action setf2(bit<32> val) {
+    @name(".setf2") action setf2(@name("val") bit<32> val) {
         hdr.data.f2 = val;
     }
-    @name(".setf1") action setf1(bit<32> val) {
-        hdr.data.f1 = val;
+    @name(".setf1") action setf1(@name("val") bit<32> val_2) {
+        hdr.data.f1 = val_2;
     }
     @name(".routing") table routing_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/testgw-midend.p4
+++ b/testdata/p4_14_samples_outputs/testgw-midend.p4
@@ -52,9 +52,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name(".route_eth") action route_eth(bit<9> egress_spec, bit<48> src_addr) {
-        standard_metadata.egress_spec = egress_spec;
-        hdr.ethernet.src_addr = src_addr;
+    @name(".route_eth") action route_eth(@name("egress_spec") bit<9> egress_spec_1, @name("src_addr") bit<48> src_addr_1) {
+        standard_metadata.egress_spec = egress_spec_1;
+        hdr.ethernet.src_addr = src_addr_1;
     }
     @name(".noop") action noop() {
     }
@@ -62,11 +62,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_4() {
     }
-    @name(".setf2") action setf2(bit<32> val) {
+    @name(".setf2") action setf2(@name("val") bit<32> val) {
         hdr.data.f2 = val;
     }
-    @name(".setf1") action setf1(bit<32> val) {
-        hdr.data.f1 = val;
+    @name(".setf1") action setf1(@name("val") bit<32> val_2) {
+        hdr.data.f1 = val_2;
     }
     @name(".routing") table routing_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/tmvalid-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid-frontend.p4
@@ -30,7 +30,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/tmvalid-midend.p4
+++ b/testdata/p4_14_samples_outputs/tmvalid-midend.p4
@@ -30,7 +30,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setb1") action setb1(bit<8> val, bit<9> port) {
+    @name(".setb1") action setb1(@name("val") bit<8> val, @name("port") bit<9> port) {
         hdr.data.b1 = val;
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_14_samples_outputs/tp2a-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-frontend.p4
@@ -37,7 +37,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_7() {
     }
-    @name(".setb1") action setb1(bit<32> val) {
+    @name(".setb1") action setb1(@name("val") bit<32> val) {
         hdr.data.b1 = val;
     }
     @name(".noop") action noop() {
@@ -48,14 +48,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_6() {
     }
-    @name(".setb3") action setb3(bit<32> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<32> val_4) {
+        hdr.data.b3 = val_4;
     }
-    @name(".setb2") action setb2(bit<32> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<32> val_5) {
+        hdr.data.b2 = val_5;
     }
-    @name(".setb4") action setb4(bit<32> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<32> val_6) {
+        hdr.data.b4 = val_6;
     }
     @name(".A1") table A1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/tp2a-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2a-midend.p4
@@ -37,7 +37,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_7() {
     }
-    @name(".setb1") action setb1(bit<32> val) {
+    @name(".setb1") action setb1(@name("val") bit<32> val) {
         hdr.data.b1 = val;
     }
     @name(".noop") action noop() {
@@ -48,14 +48,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_6() {
     }
-    @name(".setb3") action setb3(bit<32> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<32> val_4) {
+        hdr.data.b3 = val_4;
     }
-    @name(".setb2") action setb2(bit<32> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<32> val_5) {
+        hdr.data.b2 = val_5;
     }
-    @name(".setb4") action setb4(bit<32> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<32> val_6) {
+        hdr.data.b4 = val_6;
     }
     @name(".A1") table A1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/tp2b-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-frontend.p4
@@ -35,7 +35,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @noWarn("unused") @name(".NoAction") action NoAction_9() {
     }
-    @name(".setf1") action setf1(bit<32> val) {
+    @name(".setf1") action setf1(@name("val") bit<32> val) {
         hdr.data.f1 = val;
     }
     @name(".noop") action noop() {
@@ -44,11 +44,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".noop") action noop_8() {
     }
-    @name(".setb1") action setb1(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1(@name("val") bit<32> val_7) {
+        hdr.data.b1 = val_7;
     }
-    @name(".setb2") action setb2(bit<32> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<32> val_8) {
+        hdr.data.b2 = val_8;
     }
     @name(".E1") table E1_0 {
         actions = {
@@ -102,8 +102,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_13() {
     }
-    @name(".setb1") action setb1_2(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1_2(@name("val") bit<32> val_9) {
+        hdr.data.b1 = val_9;
     }
     @name(".noop") action noop_9() {
     }
@@ -113,14 +113,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_12() {
     }
-    @name(".setb3") action setb3(bit<32> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<32> val_10) {
+        hdr.data.b3 = val_10;
     }
-    @name(".setb2") action setb2_2(bit<32> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2_2(@name("val") bit<32> val_11) {
+        hdr.data.b2 = val_11;
     }
-    @name(".setb4") action setb4(bit<32> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<32> val_12) {
+        hdr.data.b4 = val_12;
     }
     @name(".A1") table A1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/tp2b-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2b-midend.p4
@@ -35,7 +35,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @noWarn("unused") @name(".NoAction") action NoAction_9() {
     }
-    @name(".setf1") action setf1(bit<32> val) {
+    @name(".setf1") action setf1(@name("val") bit<32> val) {
         hdr.data.f1 = val;
     }
     @name(".noop") action noop() {
@@ -44,11 +44,11 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".noop") action noop_8() {
     }
-    @name(".setb1") action setb1(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1(@name("val") bit<32> val_7) {
+        hdr.data.b1 = val_7;
     }
-    @name(".setb2") action setb2(bit<32> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<32> val_8) {
+        hdr.data.b2 = val_8;
     }
     @name(".E1") table E1_0 {
         actions = {
@@ -102,8 +102,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_13() {
     }
-    @name(".setb1") action setb1_2(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1_2(@name("val") bit<32> val_9) {
+        hdr.data.b1 = val_9;
     }
     @name(".noop") action noop_9() {
     }
@@ -113,14 +113,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_12() {
     }
-    @name(".setb3") action setb3(bit<32> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<32> val_10) {
+        hdr.data.b3 = val_10;
     }
-    @name(".setb2") action setb2_2(bit<32> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2_2(@name("val") bit<32> val_11) {
+        hdr.data.b2 = val_11;
     }
-    @name(".setb4") action setb4(bit<32> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<32> val_12) {
+        hdr.data.b4 = val_12;
     }
     @name(".A1") table A1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/tp2c-first.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-first.p4
@@ -125,7 +125,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                     default: {
                     }
                 }
-
             }
         }
         B1.apply();

--- a/testdata/p4_14_samples_outputs/tp2c-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-frontend.p4
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name(".setb1") action setb1(bit<32> val) {
+    @name(".setb1") action setb1(@name("val") bit<32> val) {
         hdr.data.b1 = val;
     }
     @name(".noop") action noop() {
@@ -52,8 +52,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_6() {
     }
-    @name(".setb3") action setb3(bit<32> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<32> val_4) {
+        hdr.data.b3 = val_4;
     }
     @name(".on_hit") action on_hit() {
     }
@@ -63,11 +63,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action on_miss_2() {
     }
-    @name(".setb2") action setb2(bit<32> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<32> val_5) {
+        hdr.data.b2 = val_5;
     }
-    @name(".setb4") action setb4(bit<32> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<32> val_6) {
+        hdr.data.b4 = val_6;
     }
     @name(".A1") table A1_0 {
         actions = {
@@ -147,7 +147,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                     default: {
                     }
                 }
-
             }
         }
         B1_0.apply();

--- a/testdata/p4_14_samples_outputs/tp2c-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp2c-midend.p4
@@ -41,7 +41,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name(".setb1") action setb1(bit<32> val) {
+    @name(".setb1") action setb1(@name("val") bit<32> val) {
         hdr.data.b1 = val;
     }
     @name(".noop") action noop() {
@@ -52,8 +52,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_6() {
     }
-    @name(".setb3") action setb3(bit<32> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<32> val_4) {
+        hdr.data.b3 = val_4;
     }
     @name(".on_hit") action on_hit() {
     }
@@ -63,11 +63,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".on_miss") action on_miss_2() {
     }
-    @name(".setb2") action setb2(bit<32> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<32> val_5) {
+        hdr.data.b2 = val_5;
     }
-    @name(".setb4") action setb4(bit<32> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<32> val_6) {
+        hdr.data.b4 = val_6;
     }
     @name(".A1") table A1_0 {
         actions = {
@@ -147,7 +147,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                     default: {
                     }
                 }
-
             }
         }
         B1_0.apply();

--- a/testdata/p4_14_samples_outputs/tp2c.p4
+++ b/testdata/p4_14_samples_outputs/tp2c.p4
@@ -111,7 +111,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                         A4.apply();
                     }
                 }
-
             }
         }
         B1.apply();

--- a/testdata/p4_14_samples_outputs/tp3a-frontend.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-frontend.p4
@@ -37,7 +37,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @noWarn("unused") @name(".NoAction") action NoAction_12() {
     }
-    @name(".setf1") action setf1(bit<32> val) {
+    @name(".setf1") action setf1(@name("val") bit<32> val) {
         hdr.data.f1 = val;
     }
     @name(".noop") action noop() {
@@ -48,14 +48,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".noop") action noop_11() {
     }
-    @name(".setb4") action setb4(bit<32> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<32> val_7) {
+        hdr.data.b4 = val_7;
     }
-    @name(".setb1") action setb1(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1(@name("val") bit<32> val_8) {
+        hdr.data.b1 = val_8;
     }
-    @name(".setb1") action setb1_2(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1_2(@name("val") bit<32> val_9) {
+        hdr.data.b1 = val_9;
     }
     @name(".E1") table E1_0 {
         actions = {
@@ -123,11 +123,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_17() {
     }
-    @name(".setb1") action setb1_5(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1_5(@name("val") bit<32> val_10) {
+        hdr.data.b1 = val_10;
     }
-    @name(".setb1") action setb1_6(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1_6(@name("val") bit<32> val_11) {
+        hdr.data.b1 = val_11;
     }
     @name(".noop") action noop_12() {
     }
@@ -139,14 +139,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_16() {
     }
-    @name(".setb3") action setb3(bit<32> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<32> val_12) {
+        hdr.data.b3 = val_12;
     }
-    @name(".setb2") action setb2(bit<32> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<32> val_13) {
+        hdr.data.b2 = val_13;
     }
-    @name(".setb4") action setb4_2(bit<32> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4_2(@name("val") bit<32> val_14) {
+        hdr.data.b4 = val_14;
     }
     @name(".A1") table A1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/tp3a-midend.p4
+++ b/testdata/p4_14_samples_outputs/tp3a-midend.p4
@@ -37,7 +37,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @noWarn("unused") @name(".NoAction") action NoAction_12() {
     }
-    @name(".setf1") action setf1(bit<32> val) {
+    @name(".setf1") action setf1(@name("val") bit<32> val) {
         hdr.data.f1 = val;
     }
     @name(".noop") action noop() {
@@ -48,14 +48,14 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name(".noop") action noop_11() {
     }
-    @name(".setb4") action setb4(bit<32> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4(@name("val") bit<32> val_7) {
+        hdr.data.b4 = val_7;
     }
-    @name(".setb1") action setb1(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1(@name("val") bit<32> val_8) {
+        hdr.data.b1 = val_8;
     }
-    @name(".setb1") action setb1_2(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1_2(@name("val") bit<32> val_9) {
+        hdr.data.b1 = val_9;
     }
     @name(".E1") table E1_0 {
         actions = {
@@ -123,11 +123,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_17() {
     }
-    @name(".setb1") action setb1_5(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1_5(@name("val") bit<32> val_10) {
+        hdr.data.b1 = val_10;
     }
-    @name(".setb1") action setb1_6(bit<32> val) {
-        hdr.data.b1 = val;
+    @name(".setb1") action setb1_6(@name("val") bit<32> val_11) {
+        hdr.data.b1 = val_11;
     }
     @name(".noop") action noop_12() {
     }
@@ -139,14 +139,14 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".noop") action noop_16() {
     }
-    @name(".setb3") action setb3(bit<32> val) {
-        hdr.data.b3 = val;
+    @name(".setb3") action setb3(@name("val") bit<32> val_12) {
+        hdr.data.b3 = val_12;
     }
-    @name(".setb2") action setb2(bit<32> val) {
-        hdr.data.b2 = val;
+    @name(".setb2") action setb2(@name("val") bit<32> val_13) {
+        hdr.data.b2 = val_13;
     }
-    @name(".setb4") action setb4_2(bit<32> val) {
-        hdr.data.b4 = val;
+    @name(".setb4") action setb4_2(@name("val") bit<32> val_14) {
+        hdr.data.b4 = val_14;
     }
     @name(".A1") table A1_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/triv_eth-frontend.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-frontend.p4
@@ -26,9 +26,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".route_eth") action route_eth(bit<9> egress_spec, bit<48> src_addr) {
-        standard_metadata.egress_spec = egress_spec;
-        hdr.ethernet.src_addr = src_addr;
+    @name(".route_eth") action route_eth(@name("egress_spec") bit<9> egress_spec_1, @name("src_addr") bit<48> src_addr_1) {
+        standard_metadata.egress_spec = egress_spec_1;
+        hdr.ethernet.src_addr = src_addr_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/triv_eth-midend.p4
+++ b/testdata/p4_14_samples_outputs/triv_eth-midend.p4
@@ -26,9 +26,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".route_eth") action route_eth(bit<9> egress_spec, bit<48> src_addr) {
-        standard_metadata.egress_spec = egress_spec;
-        hdr.ethernet.src_addr = src_addr;
+    @name(".route_eth") action route_eth(@name("egress_spec") bit<9> egress_spec_1, @name("src_addr") bit<48> src_addr_1) {
+        standard_metadata.egress_spec = egress_spec_1;
+        hdr.ethernet.src_addr = src_addr_1;
     }
     @name(".noop") action noop() {
     }

--- a/testdata/p4_14_samples_outputs/triv_ipv4-frontend.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-frontend.p4
@@ -59,9 +59,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".do_drop") action do_drop() {
     }
-    @name(".route_ipv4") action route_ipv4(bit<9> egress_spec) {
+    @name(".route_ipv4") action route_ipv4(@name("egress_spec") bit<9> egress_spec_1) {
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
-        standard_metadata.egress_spec = egress_spec;
+        standard_metadata.egress_spec = egress_spec_1;
     }
     @name(".routing") table routing_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/triv_ipv4-midend.p4
+++ b/testdata/p4_14_samples_outputs/triv_ipv4-midend.p4
@@ -64,9 +64,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name(".do_drop") action do_drop() {
     }
-    @name(".route_ipv4") action route_ipv4(bit<9> egress_spec) {
+    @name(".route_ipv4") action route_ipv4(@name("egress_spec") bit<9> egress_spec_1) {
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
-        standard_metadata.egress_spec = egress_spec;
+        standard_metadata.egress_spec = egress_spec_1;
     }
     @name(".routing") table routing_0 {
         actions = {

--- a/testdata/p4_14_samples_outputs/truncate-frontend.p4
+++ b/testdata/p4_14_samples_outputs/truncate-frontend.p4
@@ -32,7 +32,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop() {
     }
-    @name("._truncate") action _truncate(bit<32> new_length, bit<9> port) {
+    @name("._truncate") action _truncate(@name("new_length") bit<32> new_length, @name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
         truncate(new_length);
     }

--- a/testdata/p4_14_samples_outputs/truncate-midend.p4
+++ b/testdata/p4_14_samples_outputs/truncate-midend.p4
@@ -32,7 +32,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("._nop") action _nop() {
     }
-    @name("._truncate") action _truncate(bit<32> new_length, bit<9> port) {
+    @name("._truncate") action _truncate(@name("new_length") bit<32> new_length, @name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
         truncate(new_length);
     }

--- a/testdata/p4_14_samples_outputs/wide_action1-frontend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-frontend.p4
@@ -51,7 +51,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setmeta") action setmeta(bit<32> v0, bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<16> v5, bit<16> v6) {
+    @name(".setmeta") action setmeta(@name("v0") bit<32> v0, @name("v1") bit<32> v1, @name("v2") bit<32> v2, @name("v3") bit<32> v3, @name("v4") bit<32> v4, @name("v5") bit<16> v5, @name("v6") bit<16> v6) {
         meta.m.m0 = v0;
         meta.m.m1 = v1;
         meta.m.m2 = v2;

--- a/testdata/p4_14_samples_outputs/wide_action1-midend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action1-midend.p4
@@ -64,7 +64,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setmeta") action setmeta(bit<32> v0, bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<16> v5, bit<16> v6) {
+    @name(".setmeta") action setmeta(@name("v0") bit<32> v0, @name("v1") bit<32> v1, @name("v2") bit<32> v2, @name("v3") bit<32> v3, @name("v4") bit<32> v4, @name("v5") bit<16> v5, @name("v6") bit<16> v6) {
         meta._m_m00 = v0;
         meta._m_m11 = v1;
         meta._m_m22 = v2;

--- a/testdata/p4_14_samples_outputs/wide_action3-frontend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-frontend.p4
@@ -51,7 +51,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setmeta") action setmeta(bit<8> v0, bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<16> v5, bit<16> v6) {
+    @name(".setmeta") action setmeta(@name("v0") bit<8> v0, @name("v1") bit<32> v1, @name("v2") bit<32> v2, @name("v3") bit<32> v3, @name("v4") bit<32> v4, @name("v5") bit<16> v5, @name("v6") bit<16> v6) {
         meta.m.m10 = v0;
         meta.m.m1 = v1;
         meta.m.m2 = v2;

--- a/testdata/p4_14_samples_outputs/wide_action3-midend.p4
+++ b/testdata/p4_14_samples_outputs/wide_action3-midend.p4
@@ -64,7 +64,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".setmeta") action setmeta(bit<8> v0, bit<32> v1, bit<32> v2, bit<32> v3, bit<32> v4, bit<16> v5, bit<16> v6) {
+    @name(".setmeta") action setmeta(@name("v0") bit<8> v0, @name("v1") bit<32> v1, @name("v2") bit<32> v2, @name("v3") bit<32> v3, @name("v4") bit<32> v4, @name("v5") bit<16> v5, @name("v6") bit<16> v6) {
         meta._m_m1010 = v0;
         meta._m_m11 = v1;
         meta._m_m22 = v2;

--- a/testdata/p4_16_errors_outputs/duplicate-label.p4
+++ b/testdata/p4_16_errors_outputs/duplicate-label.p4
@@ -16,7 +16,6 @@ control c(out bit<1> arun) {
                 arun = 1;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_errors_outputs/incorrect-label.p4
+++ b/testdata/p4_16_errors_outputs/incorrect-label.p4
@@ -56,7 +56,6 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
                 stdmeta.egress_port = 2;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_errors_outputs/issue1542.p4
+++ b/testdata/p4_16_errors_outputs/issue1542.p4
@@ -21,7 +21,6 @@ control c() {
         const entries = {
                         (true, 1, true) : multicast(2);
         }
-
     }
     apply {
         forward.apply();

--- a/testdata/p4_16_errors_outputs/issue1580.p4
+++ b/testdata/p4_16_errors_outputs/issue1580.p4
@@ -50,7 +50,6 @@ control ingress(inout headers_t hdr, inout user_metadata_t meta, inout standard_
         const entries = {
                         3 : a3();
         }
-
         default_action = a1;
     }
     apply {

--- a/testdata/p4_16_errors_outputs/issue2525.p4
+++ b/testdata/p4_16_errors_outputs/issue2525.p4
@@ -49,7 +49,6 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
                 stdmeta.egress_port = 3;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_errors_outputs/issue2544_shadowing1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2544_shadowing1.p4-stderr
@@ -4,4 +4,3 @@ issue2544_shadowing1.p4(25): [--Werror=shadow] error: declaration of 'h' shadows
 issue2544_shadowing1.p4(23)
 control ingress(inout Headers h) {
                               ^
-

--- a/testdata/p4_16_errors_outputs/issue532-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue532-frontend.p4
@@ -30,8 +30,8 @@ extern s1_t choose_entry(in choices_t choices);
 control ingress(inout parsed_packet_t hdr, inout my_meta_t my_meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("ingress.select_entry") action select_entry(choices_t choices) {
-        my_meta.entry = choose_entry(choices);
+    @name("ingress.select_entry") action select_entry(@name("choices") choices_t choices_1) {
+        my_meta.entry = choose_entry(choices_1);
     }
     @name("ingress.t") table t_0 {
         actions = {

--- a/testdata/p4_16_errors_outputs/not_bound-frontend.p4
+++ b/testdata/p4_16_errors_outputs/not_bound-frontend.p4
@@ -20,7 +20,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("ingress.set_nhop") action set_nhop(bit<9> port) {
+    @name("ingress.set_nhop") action set_nhop(@name("port") bit<9> port) {
         standard_metadata.egress_spec = port;
     }
     apply {

--- a/testdata/p4_16_errors_outputs/not_bound-midend.p4
+++ b/testdata/p4_16_errors_outputs/not_bound-midend.p4
@@ -20,7 +20,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    bit<9> port;
+    @name("port") bit<9> port;
     @name("ingress.set_nhop") action set_nhop() {
         standard_metadata.egress_spec = port;
     }

--- a/testdata/p4_16_errors_outputs/table-entries-decl-order.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-decl-order.p4
@@ -58,7 +58,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x1181 : a_with_control_params(2);
                         0x1181 &&& 0xf00f : a_with_control_params(3);
         }
-
         key = {
             h.h.t: ternary;
         }

--- a/testdata/p4_16_errors_outputs/table-entries-exact-ternary.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-exact-ternary.p4
@@ -70,7 +70,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x1111 &&& 0xf : a();
                         0x1 : a();
         }
-
     }
     apply {
         t_exact_ternary.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-exact.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-exact.p4
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         default : a_with_control_params(3);
                         (0x1111 &&& 0xf, 0x1) : a();
         }
-
     }
     apply {
         t_exact.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2-first.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2-first.p4
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x11 &&& 8w0x81 : a_with_control_params(9w14);
                         8w0x0 : a_with_control_params(9w15);
         }
-
     }
     apply {
         t_lpm.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2-frontend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2-frontend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_lpm") table t_lpm_0 {
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x11 &&& 8w0x81 : a_with_control_params(9w14);
                         8w0x0 : a_with_control_params(9w15);
         }
-
     }
     apply {
         t_lpm_0.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2-midend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2-midend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_lpm") table t_lpm_0 {
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x11 &&& 8w0x81 : a_with_control_params(9w14);
                         8w0x0 : a_with_control_params(9w15);
         }
-
     }
     apply {
         t_lpm_0.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x11 &&& 0x181 : a_with_control_params(14);
                         0x100 : a_with_control_params(15);
         }
-
     }
     apply {
         t_lpm.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-lpm.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm.p4
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x11 &&& 0xf : a_with_control_params(14);
                         (0x1, 0x11 &&& 0xf0) : a();
         }
-
     }
     apply {
         t_lpm.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-non-const.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-non-const.p4
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x1181 : a_with_control_params(2);
                         0x1181 &&& 0xf00f : a_with_control_params(3);
         }
-
     }
     apply {
         t_ternary.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-first.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-first.p4
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (8w0x0, default) : a_with_control_params(9w2);
                         (default, 16w0x0) : a_with_control_params(9w3);
         }
-
     }
     apply {
         t_optional.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-frontend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-frontend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_optional") table t_optional_0 {
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (8w0x0, default) : a_with_control_params(9w2);
                         (default, 16w0x0) : a_with_control_params(9w3);
         }
-
     }
     apply {
         t_optional_0.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-midend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2-midend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_optional") table t_optional_0 {
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (8w0x0, default) : a_with_control_params(9w2);
                         (default, 16w0x0) : a_with_control_params(9w3);
         }
-
     }
     apply {
         t_optional_0.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (0x100, default) : a_with_control_params(2);
                         (default, 0x10000) : a_with_control_params(3);
         }
-
     }
     apply {
         t_optional.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-range.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-range.p4
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         default : a_with_control_params(23);
                         (0x18, 0xf) : a_with_control_params(24);
         }
-
     }
     apply {
         t_range.apply();

--- a/testdata/p4_16_errors_outputs/table-entries-ternary.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-ternary.p4
@@ -71,7 +71,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x1111 : missing_a();
                         0x1111 : a_with_control_params(32w10);
         }
-
     }
     apply {
         t_ternary.apply();

--- a/testdata/p4_16_samples/issue2710.p4
+++ b/testdata/p4_16_samples/issue2710.p4
@@ -1,0 +1,26 @@
+#include <core.p4>
+
+control Wrapped(inout bit<8> valueSet) {
+    @name("set") action set(bit<8> value) {
+        valueSet = value;
+    }
+    @name("doSet") table doSet {
+        actions = {
+            set();
+        }
+        default_action = set(8w0);
+    }
+   apply {
+        doSet.apply();
+   }
+}
+
+control Wrapper(inout bit<8> value) {
+   Wrapped() wrapped;
+   apply { wrapped.apply(value); }
+}
+
+control c(inout bit<8> v);
+package top(c _c);
+
+top(Wrapper()) main;

--- a/testdata/p4_16_samples_outputs/action-bind-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action-bind-frontend.p4
@@ -1,5 +1,5 @@
 control c(inout bit<32> x) {
-    @name("c.a") action a(inout bit<32> b, bit<32> d) {
+    @name("c.a") action a(@name("b") inout bit<32> b, @name("d") bit<32> d) {
         b = d;
     }
     @name("c.t") table t_0 {

--- a/testdata/p4_16_samples_outputs/action-bind-midend.p4
+++ b/testdata/p4_16_samples_outputs/action-bind-midend.p4
@@ -1,5 +1,5 @@
 control c(inout bit<32> x) {
-    @name("c.a") action a(bit<32> d) {
+    @name("c.a") action a(@name("d") bit<32> d) {
         x = d;
     }
     @name("c.t") table t_0 {

--- a/testdata/p4_16_samples_outputs/action-two-params-first.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-first.p4
@@ -57,7 +57,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         const entries = {
                         32w0x20020420 : actTbl(24w42, 32w0x20024200);
         }
-
     }
     apply {
         if (hdr.ipv4.isValid()) {

--- a/testdata/p4_16_samples_outputs/action-two-params-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-frontend.p4
@@ -43,7 +43,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name("MyIngress.drop") action drop() {
         mark_to_drop(standard_metadata);
     }
-    @name("MyIngress.actTbl") action actTbl(bit<24> id, bit<32> ip) {
+    @name("MyIngress.actTbl") action actTbl(@name("id") bit<24> id, @name("ip") bit<32> ip) {
     }
     @name("MyIngress.ingress_tbl") table ingress_tbl_0 {
         key = {
@@ -57,7 +57,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         const entries = {
                         32w0x20020420 : actTbl(24w42, 32w0x20024200);
         }
-
     }
     apply {
         if (hdr.ipv4.isValid()) {

--- a/testdata/p4_16_samples_outputs/action-two-params-midend.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params-midend.p4
@@ -43,7 +43,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name("MyIngress.drop") action drop() {
         mark_to_drop(standard_metadata);
     }
-    @name("MyIngress.actTbl") action actTbl(bit<24> id, bit<32> ip) {
+    @name("MyIngress.actTbl") action actTbl(@name("id") bit<24> id, @name("ip") bit<32> ip) {
     }
     @name("MyIngress.ingress_tbl") table ingress_tbl_0 {
         key = {
@@ -57,7 +57,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         const entries = {
                         32w0x20020420 : actTbl(24w42, 32w0x20024200);
         }
-
     }
     apply {
         if (hdr.ipv4.isValid()) {

--- a/testdata/p4_16_samples_outputs/action-two-params.p4
+++ b/testdata/p4_16_samples_outputs/action-two-params.p4
@@ -57,7 +57,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         const entries = {
                         8w0x20 ++ 8w0x2 ++ 8w0x4 ++ 8w0x20 : actTbl(24w42, 8w0x20 ++ 8w0x2 ++ 8w0x42 ++ 8w0x0);
         }
-
     }
     apply {
         if (hdr.ipv4.isValid()) {

--- a/testdata/p4_16_samples_outputs/action_call_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_call_ebpf-frontend.p4
@@ -12,7 +12,7 @@ parser prs(packet_in p, out Headers_t headers) {
 
 control pipe(inout Headers_t headers, out bool pass) {
     @name("pipe.x") bool x_0;
-    @name("pipe.Reject") action Reject(bool rej) {
+    @name("pipe.Reject") action Reject(@name("rej") bool rej) {
         pass = rej;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/action_call_table_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_call_table_ebpf-frontend.p4
@@ -11,7 +11,7 @@ parser prs(packet_in p, out Headers_t headers) {
 }
 
 control pipe(inout Headers_t headers, out bool pass) {
-    @name("pipe.Reject") action Reject(bit<8> rej, bit<8> bar) {
+    @name("pipe.Reject") action Reject(@name("rej") bit<8> rej, @name("bar") bit<8> bar) {
         if (rej == 8w0) {
             pass = true;
         } else {

--- a/testdata/p4_16_samples_outputs/action_call_table_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_call_table_ebpf-midend.p4
@@ -11,7 +11,7 @@ parser prs(packet_in p, out Headers_t headers) {
 }
 
 control pipe(inout Headers_t headers, out bool pass) {
-    @name("pipe.Reject") action Reject(bit<8> rej, bit<8> bar) {
+    @name("pipe.Reject") action Reject(@name("rej") bit<8> rej, @name("bar") bit<8> bar) {
         pass = rej == 8w0;
         pass = (bar == 8w0 ? false : rej == 8w0);
     }

--- a/testdata/p4_16_samples_outputs/action_call_ubpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_call_ubpf-frontend.p4
@@ -14,7 +14,7 @@ parser prs(packet_in p, out Headers_t headers, inout metadata meta, inout standa
 }
 
 control pipe(inout Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
-    @name("pipe.RejectConditional") action RejectConditional(bit<1> condition) {
+    @name("pipe.RejectConditional") action RejectConditional(@name("condition") bit<1> condition) {
     }
     @name("pipe.act_return") action act_return() {
         @name("pipe.hasReturned") bool hasReturned = false;

--- a/testdata/p4_16_samples_outputs/action_call_ubpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_call_ubpf-midend.p4
@@ -15,7 +15,7 @@ parser prs(packet_in p, out Headers_t headers, inout metadata meta, inout standa
 
 control pipe(inout Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
     bool hasExited;
-    @name("pipe.RejectConditional") action RejectConditional(bit<1> condition) {
+    @name("pipe.RejectConditional") action RejectConditional(@name("condition") bit<1> condition) {
     }
     @name("pipe.act_return") action act_return() {
         mark_to_pass();

--- a/testdata/p4_16_samples_outputs/action_param-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_param-frontend.p4
@@ -1,5 +1,5 @@
 control c(inout bit<32> x) {
-    @name("c.a") action a(in bit<32> arg_1) {
+    @name("c.a") action a(@name("arg") in bit<32> arg_1) {
         x = arg_1;
     }
     @name("c.t") table t_0 {

--- a/testdata/p4_16_samples_outputs/action_param1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/action_param1-frontend.p4
@@ -1,5 +1,5 @@
 control c(inout bit<32> x) {
-    @name("c.a") action a(in bit<32> arg_1) {
+    @name("c.a") action a(@name("arg") in bit<32> arg_1) {
         x = arg_1;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/apply-cf-first.p4
+++ b/testdata/p4_16_samples_outputs/apply-cf-first.p4
@@ -17,7 +17,6 @@ control x() {
             default: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/apply-cf.p4
+++ b/testdata/p4_16_samples_outputs/apply-cf.p4
@@ -16,7 +16,6 @@ control x() {
             default: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2-first.p4
@@ -166,7 +166,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
             nexthop.apply();
         }
     }

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2-frontend.p4
@@ -57,7 +57,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name("egress.on_miss") action on_miss() {
     }
-    @name("egress.rewrite_src_dst_mac") action rewrite_src_dst_mac(bit<48> smac, bit<48> dmac) {
+    @name("egress.rewrite_src_dst_mac") action rewrite_src_dst_mac(@name("smac") bit<48> smac, @name("dmac") bit<48> dmac) {
         hdr.ethernet.srcAddr = smac;
         hdr.ethernet.dstAddr = dmac;
     }
@@ -89,8 +89,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name("ingress.set_vrf") action set_vrf(bit<12> vrf) {
-        meta.ingress_metadata.vrf = vrf;
+    @name("ingress.set_vrf") action set_vrf(@name("vrf") bit<12> vrf_1) {
+        meta.ingress_metadata.vrf = vrf_1;
     }
     @name("ingress.on_miss") action on_miss_2() {
     }
@@ -98,19 +98,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.on_miss") action on_miss_6() {
     }
-    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop(bit<16> nexthop_index) {
-        meta.ingress_metadata.nexthop_index = nexthop_index;
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop(@name("nexthop_index") bit<16> nexthop_index_1) {
+        meta.ingress_metadata.nexthop_index = nexthop_index_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_2(bit<16> nexthop_index) {
-        meta.ingress_metadata.nexthop_index = nexthop_index;
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_2) {
+        meta.ingress_metadata.nexthop_index = nexthop_index_2;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name("ingress.set_egress_details") action set_egress_details(bit<9> egress_spec) {
-        standard_metadata.egress_spec = egress_spec;
+    @name("ingress.set_egress_details") action set_egress_details(@name("egress_spec") bit<9> egress_spec_1) {
+        standard_metadata.egress_spec = egress_spec_1;
     }
-    @name("ingress.set_bd") action set_bd(bit<16> bd) {
-        meta.ingress_metadata.bd = bd;
+    @name("ingress.set_bd") action set_bd(@name("bd") bit<16> bd_2) {
+        meta.ingress_metadata.bd = bd_2;
     }
     @name("ingress.bd") table bd_0 {
         actions = {
@@ -183,7 +183,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
             nexthop_0.apply();
         }
     }

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2-midend.p4
@@ -59,7 +59,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name("egress.on_miss") action on_miss() {
     }
-    @name("egress.rewrite_src_dst_mac") action rewrite_src_dst_mac(bit<48> smac, bit<48> dmac) {
+    @name("egress.rewrite_src_dst_mac") action rewrite_src_dst_mac(@name("smac") bit<48> smac, @name("dmac") bit<48> dmac) {
         hdr.ethernet.srcAddr = smac;
         hdr.ethernet.dstAddr = dmac;
     }
@@ -91,8 +91,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name("ingress.set_vrf") action set_vrf(bit<12> vrf) {
-        meta._ingress_metadata_vrf0 = vrf;
+    @name("ingress.set_vrf") action set_vrf(@name("vrf") bit<12> vrf_1) {
+        meta._ingress_metadata_vrf0 = vrf_1;
     }
     @name("ingress.on_miss") action on_miss_2() {
     }
@@ -100,19 +100,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.on_miss") action on_miss_6() {
     }
-    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop(bit<16> nexthop_index) {
-        meta._ingress_metadata_nexthop_index2 = nexthop_index;
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop(@name("nexthop_index") bit<16> nexthop_index_1) {
+        meta._ingress_metadata_nexthop_index2 = nexthop_index_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_2(bit<16> nexthop_index) {
-        meta._ingress_metadata_nexthop_index2 = nexthop_index;
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_2) {
+        meta._ingress_metadata_nexthop_index2 = nexthop_index_2;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name("ingress.set_egress_details") action set_egress_details(bit<9> egress_spec) {
-        standard_metadata.egress_spec = egress_spec;
+    @name("ingress.set_egress_details") action set_egress_details(@name("egress_spec") bit<9> egress_spec_1) {
+        standard_metadata.egress_spec = egress_spec_1;
     }
-    @name("ingress.set_bd") action set_bd(bit<16> bd) {
-        meta._ingress_metadata_bd1 = bd;
+    @name("ingress.set_bd") action set_bd(@name("bd") bit<16> bd_2) {
+        meta._ingress_metadata_bd1 = bd_2;
     }
     @name("ingress.bd") table bd_0 {
         actions = {
@@ -185,7 +185,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
             nexthop_0.apply();
         }
     }

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2.p4
@@ -152,7 +152,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                     ipv4_fib_lpm.apply();
                 }
             }
-
             nexthop.apply();
         }
     }

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-first.p4
@@ -69,7 +69,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x1 : a_with_control_params(9w1);
                         8w0x2 : a_with_control_params(9w2);
         }
-
     }
     apply {
         t_exact.apply();

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-frontend.p4
@@ -53,7 +53,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_exact") table t_exact_0 {
@@ -69,7 +69,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x1 : a_with_control_params(9w1);
                         8w0x2 : a_with_control_params(9w2);
         }
-
     }
     apply {
         t_exact_0.apply();

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2-midend.p4
@@ -57,7 +57,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_exact") table t_exact_0 {
@@ -73,7 +73,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x1 : a_with_control_params(9w1);
                         8w0x2 : a_with_control_params(9w2);
         }
-
     }
     apply {
         t_exact_0.apply();

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4
@@ -69,7 +69,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x1 : a_with_control_params(1);
                         0x2 : a_with_control_params(2);
         }
-
     }
     apply {
         t_exact.apply();

--- a/testdata/p4_16_samples_outputs/calc-ebpf-first.p4
+++ b/testdata/p4_16_samples_outputs/calc-ebpf-first.p4
@@ -97,7 +97,6 @@ control Ingress(inout headers hdr, out bool xout) {
                         8w0x7c : operation_or();
                         8w0x5e : operation_xor();
         }
-
         implementation = hash_table(32w8);
     }
     apply {

--- a/testdata/p4_16_samples_outputs/calc-ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/calc-ebpf-frontend.p4
@@ -112,7 +112,6 @@ control Ingress(inout headers hdr, out bool xout) {
                         8w0x7c : operation_or();
                         8w0x5e : operation_xor();
         }
-
         implementation = hash_table(32w8);
     }
     apply {

--- a/testdata/p4_16_samples_outputs/calc-ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/calc-ebpf-midend.p4
@@ -133,7 +133,6 @@ control Ingress(inout headers hdr, out bool xout) {
                         8w0x7c : operation_or();
                         8w0x5e : operation_xor();
         }
-
         implementation = hash_table(32w8);
     }
     @hidden action calcebpf152() {

--- a/testdata/p4_16_samples_outputs/calc-ebpf.p4
+++ b/testdata/p4_16_samples_outputs/calc-ebpf.p4
@@ -97,7 +97,6 @@ control Ingress(inout headers hdr, out bool xout) {
                         P4CALC_OR : operation_or();
                         P4CALC_CARET : operation_xor();
         }
-
         implementation = hash_table(8);
     }
     apply {

--- a/testdata/p4_16_samples_outputs/cases-first.p4
+++ b/testdata/p4_16_samples_outputs/cases-first.p4
@@ -22,7 +22,6 @@ control ctrl() {
             default: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/cases.p4
+++ b/testdata/p4_16_samples_outputs/cases.p4
@@ -21,7 +21,6 @@ control ctrl() {
             }
             c: 
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/checksum-l4-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/checksum-l4-bmv2-first.p4
@@ -139,7 +139,6 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
         const entries = {
                         16w80 : foot();
         }
-
     }
     table huh {
         key = {
@@ -153,7 +152,6 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
         const entries = {
                         16w80 : foou();
         }
-
     }
     apply {
         if (hdr.tcp.isValid()) {

--- a/testdata/p4_16_samples_outputs/checksum-l4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/checksum-l4-bmv2-frontend.p4
@@ -161,7 +161,6 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
         const entries = {
                         16w80 : foot();
         }
-
     }
     @name("cIngress.huh") table huh_0 {
         key = {
@@ -175,7 +174,6 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
         const entries = {
                         16w80 : foou();
         }
-
     }
     apply {
         if (hdr.tcp.isValid()) {

--- a/testdata/p4_16_samples_outputs/checksum-l4-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/checksum-l4-bmv2-midend.p4
@@ -158,7 +158,6 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
         const entries = {
                         16w80 : foot();
         }
-
     }
     @name("cIngress.huh") table huh_0 {
         key = {
@@ -172,7 +171,6 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
         const entries = {
                         16w80 : foou();
         }
-
     }
     apply {
         if (hdr.tcp.isValid()) {

--- a/testdata/p4_16_samples_outputs/checksum-l4-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/checksum-l4-bmv2.p4
@@ -139,7 +139,6 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
         const entries = {
                         16w80 : foot();
         }
-
     }
     table huh {
         key = {
@@ -153,7 +152,6 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
         const entries = {
                         16w80 : foou();
         }
-
     }
     apply {
         if (hdr.tcp.isValid()) {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-first.p4
@@ -118,7 +118,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
                         8w0x5e : operation_xor();
                         8w0x3e : operation_crc();
         }
-
     }
     apply {
         if (hdr.p4calc.isValid()) {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-frontend.p4
@@ -143,7 +143,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
                         8w0x5e : operation_xor();
                         8w0x3e : operation_crc();
         }
-
     }
     apply {
         if (hdr.p4calc.isValid()) {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2-midend.p4
@@ -162,7 +162,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
                         8w0x5e : operation_xor();
                         8w0x3e : operation_crc();
         }
-
     }
     @hidden table tbl_operation_drop {
         actions = {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2.p4
@@ -118,7 +118,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
                         P4CALC_CARET : operation_xor();
                         P4CALC_CRC : operation_crc();
         }
-
     }
     apply {
         if (hdr.p4calc.isValid()) {

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields-frontend.p4
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields-frontend.p4
@@ -98,7 +98,7 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
     @name("ingressImpl.my_drop") action my_drop() {
         mark_to_drop(stdmeta);
     }
-    @name("ingressImpl.set_addr") action set_addr(IPv4Addr_t new_dstAddr) {
+    @name("ingressImpl.set_addr") action set_addr(@name("new_dstAddr") IPv4Addr_t new_dstAddr) {
         hdr.ipv4.dstAddr = new_dstAddr;
         stdmeta.egress_spec = stdmeta.ingress_port;
     }

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields-midend.p4
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields-midend.p4
@@ -98,7 +98,7 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
     @name("ingressImpl.my_drop") action my_drop() {
         mark_to_drop(stdmeta);
     }
-    @name("ingressImpl.set_addr") action set_addr(IPv4Addr_t new_dstAddr) {
+    @name("ingressImpl.set_addr") action set_addr(@name("new_dstAddr") IPv4Addr_t new_dstAddr) {
         hdr.ipv4.dstAddr = new_dstAddr;
         stdmeta.egress_spec = stdmeta.ingress_port;
     }

--- a/testdata/p4_16_samples_outputs/decl2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/decl2-frontend.p4
@@ -3,7 +3,7 @@ control p() {
     @name("p.x_0") bit<1> x_2;
     @name("p.x_1") bit<1> x_3;
     @name("p.y_0") bit<1> y_1;
-    @name("p.b") action b(in bit<1> x, out bit<1> y) {
+    @name("p.b") action b(@name("x") in bit<1> x, @name("y") out bit<1> y) {
         x_2 = x;
         z_0 = x & x_2;
         y = z_0;

--- a/testdata/p4_16_samples_outputs/default-switch-first.p4
+++ b/testdata/p4_16_samples_outputs/default-switch-first.p4
@@ -17,7 +17,6 @@ control ctrl() {
                 return;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/default-switch.p4
+++ b/testdata/p4_16_samples_outputs/default-switch.p4
@@ -17,7 +17,6 @@ control ctrl() {
                 return;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-frontend.p4
@@ -43,8 +43,8 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.c.add") action c_add_0(bit<32> data) {
-        h.h.b = h.h.a + data;
+    @name("ingress.c.add") action c_add_0(@name("data") bit<32> data_1) {
+        h.h.b = h.h.a + data_1;
     }
     @name("ingress.c.t") table c_t {
         actions = {

--- a/testdata/p4_16_samples_outputs/default_action-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2-midend.p4
@@ -43,8 +43,8 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.c.add") action c_add_0(bit<32> data) {
-        h.h.b = h.h.a + data;
+    @name("ingress.c.add") action c_add_0(@name("data") bit<32> data_1) {
+        h.h.b = h.h.a + data_1;
     }
     @name("ingress.c.t") table c_t {
         actions = {

--- a/testdata/p4_16_samples_outputs/default_action_ubpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/default_action_ubpf-frontend.p4
@@ -21,7 +21,7 @@ parser prs(packet_in p, out Headers_t headers, inout metadata meta, inout standa
 }
 
 control pipe(inout Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
-    @name("pipe.add") action add(bit<32> data) {
+    @name("pipe.add") action add(@name("data") bit<32> data) {
         headers.h.b = headers.h.a + data;
     }
     @name("pipe.tbl_a") table tbl_a_0 {

--- a/testdata/p4_16_samples_outputs/default_action_ubpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/default_action_ubpf-midend.p4
@@ -21,7 +21,7 @@ parser prs(packet_in p, out Headers_t headers, inout metadata meta, inout standa
 }
 
 control pipe(inout Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
-    @name("pipe.add") action add(bit<32> data) {
+    @name("pipe.add") action add(@name("data") bit<32> data) {
         headers.h.b = headers.h.a + data;
     }
     @name("pipe.tbl_a") table tbl_a_0 {

--- a/testdata/p4_16_samples_outputs/direct-action-frontend.p4
+++ b/testdata/p4_16_samples_outputs/direct-action-frontend.p4
@@ -1,6 +1,6 @@
 control c(inout bit<16> y) {
     @name("c.x") bit<32> x_0;
-    @name("c.a") action a(in bit<32> arg) {
+    @name("c.a") action a(@name("arg") in bit<32> arg) {
         y = (bit<16>)arg;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/direct-action1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/direct-action1-frontend.p4
@@ -1,6 +1,6 @@
 control c(inout bit<16> y) {
     @name("c.x") bit<32> x_0;
-    @name("c.a") action a(bit<32> arg) {
+    @name("c.a") action a(@name("arg") bit<32> arg) {
         y = (bit<16>)arg;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-frontend.p4
@@ -15,7 +15,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
-    @name(".drop") action drop(inout standard_metadata_t smeta_1) {
+    @name(".drop") action drop(@name("smeta") inout standard_metadata_t smeta_1) {
         mark_to_drop(smeta_1);
     }
     @name("IngressI.forward") table forward_0 {

--- a/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/drop-bmv2-midend.p4
@@ -15,7 +15,7 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 }
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
-    standard_metadata_t smeta_1;
+    @name("smeta") standard_metadata_t smeta_1;
     @name(".drop") action drop() {
         smeta_1.ingress_port = smeta.ingress_port;
         smeta_1.egress_spec = smeta.egress_spec;

--- a/testdata/p4_16_samples_outputs/exit5-first.p4
+++ b/testdata/p4_16_samples_outputs/exit5-first.p4
@@ -30,7 +30,6 @@ control ctrl() {
                 c = 32w4;
             }
         }
-
         c = 32w5;
     }
 }

--- a/testdata/p4_16_samples_outputs/exit5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/exit5-frontend.p4
@@ -20,7 +20,6 @@ control ctrl() {
                 t_0.apply();
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/exit5-midend.p4
+++ b/testdata/p4_16_samples_outputs/exit5-midend.p4
@@ -35,7 +35,6 @@ control ctrl() {
                 }
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/exit5.p4
+++ b/testdata/p4_16_samples_outputs/exit5.p4
@@ -30,7 +30,6 @@ control ctrl() {
                 c = 4;
             }
         }
-
         c = 5;
     }
 }

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-frontend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-frontend.p4
@@ -361,10 +361,10 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         hdr.gtpu_udp.setInvalid();
         hdr.gtpu.setInvalid();
     }
-    @name("FabricIngress.spgw_ingress.set_dl_sess_info") action spgw_ingress_set_dl_sess_info_0(bit<32> teid, bit<32> s1u_enb_addr, bit<32> s1u_sgw_addr) {
-        fabric_metadata.spgw.teid = teid;
-        fabric_metadata.spgw.s1u_enb_addr = s1u_enb_addr;
-        fabric_metadata.spgw.s1u_sgw_addr = s1u_sgw_addr;
+    @name("FabricIngress.spgw_ingress.set_dl_sess_info") action spgw_ingress_set_dl_sess_info_0(@name("teid") bit<32> teid_1, @name("s1u_enb_addr") bit<32> s1u_enb_addr_1, @name("s1u_sgw_addr") bit<32> s1u_sgw_addr_1) {
+        fabric_metadata.spgw.teid = teid_1;
+        fabric_metadata.spgw.s1u_enb_addr = s1u_enb_addr_1;
+        fabric_metadata.spgw.s1u_sgw_addr = s1u_sgw_addr_1;
         spgw_ingress_ue_counter.count();
     }
     @name("FabricIngress.spgw_ingress.dl_sess_lookup") table spgw_ingress_dl_sess_lookup {
@@ -396,8 +396,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     @name("FabricIngress.filtering.permit") action filtering_permit_0() {
         filtering_ingress_port_vlan_counter.count();
     }
-    @name("FabricIngress.filtering.permit_with_internal_vlan") action filtering_permit_with_internal_vlan_0(vlan_id_t vlan_id) {
-        fabric_metadata.vlan_id = vlan_id;
+    @name("FabricIngress.filtering.permit_with_internal_vlan") action filtering_permit_with_internal_vlan_0(@name("vlan_id") vlan_id_t vlan_id_2) {
+        fabric_metadata.vlan_id = vlan_id_2;
         filtering_ingress_port_vlan_counter.count();
     }
     @name("FabricIngress.filtering.ingress_port_vlan") table filtering_ingress_port_vlan {
@@ -416,8 +416,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.filtering.fwd_classifier_counter") direct_counter(CounterType.packets_and_bytes) filtering_fwd_classifier_counter;
-    @name("FabricIngress.filtering.set_forwarding_type") action filtering_set_forwarding_type_0(fwd_type_t fwd_type) {
-        fabric_metadata.fwd_type = fwd_type;
+    @name("FabricIngress.filtering.set_forwarding_type") action filtering_set_forwarding_type_0(@name("fwd_type") fwd_type_t fwd_type_1) {
+        fabric_metadata.fwd_type = fwd_type_1;
         filtering_fwd_classifier_counter.count();
     }
     @name("FabricIngress.filtering.fwd_classifier") table filtering_fwd_classifier {
@@ -434,9 +434,9 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.forwarding.bridging_counter") direct_counter(CounterType.packets_and_bytes) forwarding_bridging_counter;
-    @name("FabricIngress.forwarding.set_next_id_bridging") action forwarding_set_next_id_bridging_0(next_id_t next_id) {
+    @name("FabricIngress.forwarding.set_next_id_bridging") action forwarding_set_next_id_bridging_0(@name("next_id") next_id_t next_id_0) {
         @hidden {
-            fabric_metadata.next_id = next_id;
+            fabric_metadata.next_id = next_id_0;
         }
         forwarding_bridging_counter.count();
     }
@@ -454,10 +454,10 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.forwarding.mpls_counter") direct_counter(CounterType.packets_and_bytes) forwarding_mpls_counter;
-    @name("FabricIngress.forwarding.pop_mpls_and_next") action forwarding_pop_mpls_and_next_0(next_id_t next_id) {
+    @name("FabricIngress.forwarding.pop_mpls_and_next") action forwarding_pop_mpls_and_next_0(@name("next_id") next_id_t next_id_6) {
         fabric_metadata.mpls_label = 20w0;
         @hidden {
-            fabric_metadata.next_id = next_id;
+            fabric_metadata.next_id = next_id_6;
         }
         forwarding_mpls_counter.count();
     }
@@ -474,9 +474,9 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.forwarding.routing_v4_counter") direct_counter(CounterType.packets_and_bytes) forwarding_routing_v4_counter;
-    @name("FabricIngress.forwarding.set_next_id_routing_v4") action forwarding_set_next_id_routing_v4_0(next_id_t next_id) {
+    @name("FabricIngress.forwarding.set_next_id_routing_v4") action forwarding_set_next_id_routing_v4_0(@name("next_id") next_id_t next_id_7) {
         @hidden {
-            fabric_metadata.next_id = next_id;
+            fabric_metadata.next_id = next_id_7;
         }
         forwarding_routing_v4_counter.count();
     }
@@ -497,8 +497,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.acl.acl_counter") direct_counter(CounterType.packets_and_bytes) acl_acl_counter;
-    @name("FabricIngress.acl.set_next_id_acl") action acl_set_next_id_acl_0(next_id_t next_id) {
-        fabric_metadata.next_id = next_id;
+    @name("FabricIngress.acl.set_next_id_acl") action acl_set_next_id_acl_0(@name("next_id") next_id_t next_id_8) {
+        fabric_metadata.next_id = next_id_8;
         acl_acl_counter.count();
     }
     @name("FabricIngress.acl.punt_to_cpu") action acl_punt_to_cpu_0() {
@@ -545,8 +545,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         counters = acl_acl_counter;
     }
     @name("FabricIngress.next.next_vlan_counter") direct_counter(CounterType.packets_and_bytes) next_next_vlan_counter;
-    @name("FabricIngress.next.set_vlan") action next_set_vlan_0(vlan_id_t vlan_id) {
-        fabric_metadata.vlan_id = vlan_id;
+    @name("FabricIngress.next.set_vlan") action next_set_vlan_0(@name("vlan_id") vlan_id_t vlan_id_3) {
+        fabric_metadata.vlan_id = vlan_id_3;
         next_next_vlan_counter.count();
     }
     @name("FabricIngress.next.next_vlan") table next_next_vlan {
@@ -562,14 +562,14 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.next.xconnect_counter") direct_counter(CounterType.packets_and_bytes) next_xconnect_counter;
-    @name("FabricIngress.next.output_xconnect") action next_output_xconnect_0(port_num_t port_num) {
+    @name("FabricIngress.next.output_xconnect") action next_output_xconnect_0(@name("port_num") port_num_t port_num) {
         @hidden {
             standard_metadata.egress_spec = port_num;
         }
         next_xconnect_counter.count();
     }
-    @name("FabricIngress.next.set_next_id_xconnect") action next_set_next_id_xconnect_0(next_id_t next_id) {
-        fabric_metadata.next_id = next_id;
+    @name("FabricIngress.next.set_next_id_xconnect") action next_set_next_id_xconnect_0(@name("next_id") next_id_t next_id_9) {
+        fabric_metadata.next_id = next_id_9;
         next_xconnect_counter.count();
     }
     @name("FabricIngress.next.xconnect") table next_xconnect {
@@ -588,13 +588,13 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     }
     @max_group_size(16) @name("FabricIngress.next.hashed_selector") action_selector(HashAlgorithm.crc16, 32w1024, 32w16) next_hashed_selector;
     @name("FabricIngress.next.hashed_counter") direct_counter(CounterType.packets_and_bytes) next_hashed_counter;
-    @name("FabricIngress.next.output_hashed") action next_output_hashed_0(port_num_t port_num) {
+    @name("FabricIngress.next.output_hashed") action next_output_hashed_0(@name("port_num") port_num_t port_num_0) {
         @hidden {
-            standard_metadata.egress_spec = port_num;
+            standard_metadata.egress_spec = port_num_0;
         }
         next_hashed_counter.count();
     }
-    @name("FabricIngress.next.routing_hashed") action next_routing_hashed_0(port_num_t port_num, mac_addr_t smac, mac_addr_t dmac) {
+    @name("FabricIngress.next.routing_hashed") action next_routing_hashed_0(@name("port_num") port_num_t port_num_1, @name("smac") mac_addr_t smac, @name("dmac") mac_addr_t dmac) {
         @hidden {
             @hidden {
                 hdr.ethernet.src_addr = smac;
@@ -603,25 +603,25 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
                 hdr.ethernet.dst_addr = dmac;
             }
             @hidden {
-                standard_metadata.egress_spec = port_num;
+                standard_metadata.egress_spec = port_num_1;
             }
         }
         next_hashed_counter.count();
     }
-    @name("FabricIngress.next.mpls_routing_hashed") action next_mpls_routing_hashed_0(port_num_t port_num, mac_addr_t smac, mac_addr_t dmac, mpls_label_t label) {
+    @name("FabricIngress.next.mpls_routing_hashed") action next_mpls_routing_hashed_0(@name("port_num") port_num_t port_num_2, @name("smac") mac_addr_t smac_0, @name("dmac") mac_addr_t dmac_0, @name("label") mpls_label_t label_0) {
         @hidden {
             @hidden {
-                fabric_metadata.mpls_label = label;
+                fabric_metadata.mpls_label = label_0;
             }
             @hidden {
                 @hidden {
-                    hdr.ethernet.src_addr = smac;
+                    hdr.ethernet.src_addr = smac_0;
                 }
                 @hidden {
-                    hdr.ethernet.dst_addr = dmac;
+                    hdr.ethernet.dst_addr = dmac_0;
                 }
                 @hidden {
-                    standard_metadata.egress_spec = port_num;
+                    standard_metadata.egress_spec = port_num_2;
                 }
             }
         }
@@ -648,7 +648,7 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.next.multicast_counter") direct_counter(CounterType.packets_and_bytes) next_multicast_counter;
-    @name("FabricIngress.next.set_mcast_group_id") action next_set_mcast_group_id_0(mcast_group_id_t group_id) {
+    @name("FabricIngress.next.set_mcast_group_id") action next_set_mcast_group_id_0(@name("group_id") mcast_group_id_t group_id) {
         standard_metadata.mcast_grp = group_id;
         fabric_metadata.is_multicast = true;
         next_multicast_counter.count();

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
@@ -378,10 +378,10 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         hdr.gtpu_udp.setInvalid();
         hdr.gtpu.setInvalid();
     }
-    @name("FabricIngress.spgw_ingress.set_dl_sess_info") action spgw_ingress_set_dl_sess_info_0(bit<32> teid, bit<32> s1u_enb_addr, bit<32> s1u_sgw_addr) {
-        fabric_metadata._spgw_teid19 = teid;
-        fabric_metadata._spgw_s1u_enb_addr20 = s1u_enb_addr;
-        fabric_metadata._spgw_s1u_sgw_addr21 = s1u_sgw_addr;
+    @name("FabricIngress.spgw_ingress.set_dl_sess_info") action spgw_ingress_set_dl_sess_info_0(@name("teid") bit<32> teid_1, @name("s1u_enb_addr") bit<32> s1u_enb_addr_1, @name("s1u_sgw_addr") bit<32> s1u_sgw_addr_1) {
+        fabric_metadata._spgw_teid19 = teid_1;
+        fabric_metadata._spgw_s1u_enb_addr20 = s1u_enb_addr_1;
+        fabric_metadata._spgw_s1u_sgw_addr21 = s1u_sgw_addr_1;
         spgw_ingress_ue_counter.count();
     }
     @name("FabricIngress.spgw_ingress.dl_sess_lookup") table spgw_ingress_dl_sess_lookup {
@@ -413,8 +413,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     @name("FabricIngress.filtering.permit") action filtering_permit_0() {
         filtering_ingress_port_vlan_counter.count();
     }
-    @name("FabricIngress.filtering.permit_with_internal_vlan") action filtering_permit_with_internal_vlan_0(vlan_id_t vlan_id) {
-        fabric_metadata._vlan_id2 = vlan_id;
+    @name("FabricIngress.filtering.permit_with_internal_vlan") action filtering_permit_with_internal_vlan_0(@name("vlan_id") vlan_id_t vlan_id_2) {
+        fabric_metadata._vlan_id2 = vlan_id_2;
         filtering_ingress_port_vlan_counter.count();
     }
     @name("FabricIngress.filtering.ingress_port_vlan") table filtering_ingress_port_vlan {
@@ -433,8 +433,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.filtering.fwd_classifier_counter") direct_counter(CounterType.packets_and_bytes) filtering_fwd_classifier_counter;
-    @name("FabricIngress.filtering.set_forwarding_type") action filtering_set_forwarding_type_0(fwd_type_t fwd_type) {
-        fabric_metadata._fwd_type9 = fwd_type;
+    @name("FabricIngress.filtering.set_forwarding_type") action filtering_set_forwarding_type_0(@name("fwd_type") fwd_type_t fwd_type_1) {
+        fabric_metadata._fwd_type9 = fwd_type_1;
         filtering_fwd_classifier_counter.count();
     }
     @name("FabricIngress.filtering.fwd_classifier") table filtering_fwd_classifier {
@@ -451,8 +451,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.forwarding.bridging_counter") direct_counter(CounterType.packets_and_bytes) forwarding_bridging_counter;
-    @name("FabricIngress.forwarding.set_next_id_bridging") action forwarding_set_next_id_bridging_0(next_id_t next_id) {
-        fabric_metadata._next_id10 = next_id;
+    @name("FabricIngress.forwarding.set_next_id_bridging") action forwarding_set_next_id_bridging_0(@name("next_id") next_id_t next_id_0) {
+        fabric_metadata._next_id10 = next_id_0;
         forwarding_bridging_counter.count();
     }
     @name("FabricIngress.forwarding.bridging") table forwarding_bridging {
@@ -469,9 +469,9 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.forwarding.mpls_counter") direct_counter(CounterType.packets_and_bytes) forwarding_mpls_counter;
-    @name("FabricIngress.forwarding.pop_mpls_and_next") action forwarding_pop_mpls_and_next_0(next_id_t next_id) {
+    @name("FabricIngress.forwarding.pop_mpls_and_next") action forwarding_pop_mpls_and_next_0(@name("next_id") next_id_t next_id_6) {
         fabric_metadata._mpls_label5 = 20w0;
-        fabric_metadata._next_id10 = next_id;
+        fabric_metadata._next_id10 = next_id_6;
         forwarding_mpls_counter.count();
     }
     @name("FabricIngress.forwarding.mpls") table forwarding_mpls {
@@ -487,8 +487,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.forwarding.routing_v4_counter") direct_counter(CounterType.packets_and_bytes) forwarding_routing_v4_counter;
-    @name("FabricIngress.forwarding.set_next_id_routing_v4") action forwarding_set_next_id_routing_v4_0(next_id_t next_id) {
-        fabric_metadata._next_id10 = next_id;
+    @name("FabricIngress.forwarding.set_next_id_routing_v4") action forwarding_set_next_id_routing_v4_0(@name("next_id") next_id_t next_id_7) {
+        fabric_metadata._next_id10 = next_id_7;
         forwarding_routing_v4_counter.count();
     }
     @name("FabricIngress.forwarding.nop_routing_v4") action forwarding_nop_routing_v4_0() {
@@ -508,8 +508,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.acl.acl_counter") direct_counter(CounterType.packets_and_bytes) acl_acl_counter;
-    @name("FabricIngress.acl.set_next_id_acl") action acl_set_next_id_acl_0(next_id_t next_id) {
-        fabric_metadata._next_id10 = next_id;
+    @name("FabricIngress.acl.set_next_id_acl") action acl_set_next_id_acl_0(@name("next_id") next_id_t next_id_8) {
+        fabric_metadata._next_id10 = next_id_8;
         acl_acl_counter.count();
     }
     @name("FabricIngress.acl.punt_to_cpu") action acl_punt_to_cpu_0() {
@@ -556,8 +556,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         counters = acl_acl_counter;
     }
     @name("FabricIngress.next.next_vlan_counter") direct_counter(CounterType.packets_and_bytes) next_next_vlan_counter;
-    @name("FabricIngress.next.set_vlan") action next_set_vlan_0(vlan_id_t vlan_id) {
-        fabric_metadata._vlan_id2 = vlan_id;
+    @name("FabricIngress.next.set_vlan") action next_set_vlan_0(@name("vlan_id") vlan_id_t vlan_id_3) {
+        fabric_metadata._vlan_id2 = vlan_id_3;
         next_next_vlan_counter.count();
     }
     @name("FabricIngress.next.next_vlan") table next_next_vlan {
@@ -573,12 +573,12 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.next.xconnect_counter") direct_counter(CounterType.packets_and_bytes) next_xconnect_counter;
-    @name("FabricIngress.next.output_xconnect") action next_output_xconnect_0(port_num_t port_num) {
+    @name("FabricIngress.next.output_xconnect") action next_output_xconnect_0(@name("port_num") port_num_t port_num) {
         standard_metadata.egress_spec = port_num;
         next_xconnect_counter.count();
     }
-    @name("FabricIngress.next.set_next_id_xconnect") action next_set_next_id_xconnect_0(next_id_t next_id) {
-        fabric_metadata._next_id10 = next_id;
+    @name("FabricIngress.next.set_next_id_xconnect") action next_set_next_id_xconnect_0(@name("next_id") next_id_t next_id_9) {
+        fabric_metadata._next_id10 = next_id_9;
         next_xconnect_counter.count();
     }
     @name("FabricIngress.next.xconnect") table next_xconnect {
@@ -597,21 +597,21 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     }
     @max_group_size(16) @name("FabricIngress.next.hashed_selector") action_selector(HashAlgorithm.crc16, 32w1024, 32w16) next_hashed_selector;
     @name("FabricIngress.next.hashed_counter") direct_counter(CounterType.packets_and_bytes) next_hashed_counter;
-    @name("FabricIngress.next.output_hashed") action next_output_hashed_0(port_num_t port_num) {
-        standard_metadata.egress_spec = port_num;
+    @name("FabricIngress.next.output_hashed") action next_output_hashed_0(@name("port_num") port_num_t port_num_0) {
+        standard_metadata.egress_spec = port_num_0;
         next_hashed_counter.count();
     }
-    @name("FabricIngress.next.routing_hashed") action next_routing_hashed_0(port_num_t port_num, mac_addr_t smac, mac_addr_t dmac) {
+    @name("FabricIngress.next.routing_hashed") action next_routing_hashed_0(@name("port_num") port_num_t port_num_1, @name("smac") mac_addr_t smac, @name("dmac") mac_addr_t dmac) {
         hdr.ethernet.src_addr = smac;
         hdr.ethernet.dst_addr = dmac;
-        standard_metadata.egress_spec = port_num;
+        standard_metadata.egress_spec = port_num_1;
         next_hashed_counter.count();
     }
-    @name("FabricIngress.next.mpls_routing_hashed") action next_mpls_routing_hashed_0(port_num_t port_num, mac_addr_t smac, mac_addr_t dmac, mpls_label_t label) {
-        fabric_metadata._mpls_label5 = label;
-        hdr.ethernet.src_addr = smac;
-        hdr.ethernet.dst_addr = dmac;
-        standard_metadata.egress_spec = port_num;
+    @name("FabricIngress.next.mpls_routing_hashed") action next_mpls_routing_hashed_0(@name("port_num") port_num_t port_num_2, @name("smac") mac_addr_t smac_0, @name("dmac") mac_addr_t dmac_0, @name("label") mpls_label_t label_0) {
+        fabric_metadata._mpls_label5 = label_0;
+        hdr.ethernet.src_addr = smac_0;
+        hdr.ethernet.dst_addr = dmac_0;
+        standard_metadata.egress_spec = port_num_2;
         next_hashed_counter.count();
     }
     @name("FabricIngress.next.hashed") table next_hashed {
@@ -635,7 +635,7 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         size = 1024;
     }
     @name("FabricIngress.next.multicast_counter") direct_counter(CounterType.packets_and_bytes) next_multicast_counter;
-    @name("FabricIngress.next.set_mcast_group_id") action next_set_mcast_group_id_0(mcast_group_id_t group_id) {
+    @name("FabricIngress.next.set_mcast_group_id") action next_set_mcast_group_id_0(@name("group_id") mcast_group_id_t group_id) {
         standard_metadata.mcast_grp = group_id;
         fabric_metadata._is_multicast11 = true;
         next_multicast_counter.count();

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-frontend.p4
@@ -63,7 +63,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress.drop") action drop_2() {
         mark_to_drop(standard_metadata);
     }
-    @name("ingress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
+    @name("ingress.ipv4_forward") action ipv4_forward(@name("dstAddr") macAddr_t dstAddr_1, @name("port") egressSpec_t port) {
         meta.test_bool = true;
     }
     @name("ingress.ipv4_lpm") table ipv4_lpm_0 {

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2-midend.p4
@@ -63,7 +63,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress.drop") action drop_2() {
         mark_to_drop(standard_metadata);
     }
-    @name("ingress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
+    @name("ingress.ipv4_forward") action ipv4_forward(@name("dstAddr") macAddr_t dstAddr_1, @name("port") egressSpec_t port) {
         meta.test_bool = true;
     }
     @name("ingress.ipv4_lpm") table ipv4_lpm_0 {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-frontend.p4
@@ -87,7 +87,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name("egress.rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress._drop") action _drop() {
@@ -132,11 +132,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress._drop") action _drop_6() {
         mark_to_drop(standard_metadata);
     }
-    @name("ingress.set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
+    @name("ingress.set_ecmp_select") action set_ecmp_select(@name("ecmp_base") bit<8> ecmp_base, @name("ecmp_count") bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple<bit<32>, bit<32>, bit<8>, bit<16>, bit<16>, bit<16>>, bit<20>>(meta.ingress_metadata.ecmp_offset, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta.ingress_metadata.flowlet_id }, (bit<20>)ecmp_count);
     }
-    @name("ingress.set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta.ingress_metadata.nhop_ipv4 = nhop_ipv4;
+    @name("ingress.set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta.ingress_metadata.nhop_ipv4 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
@@ -148,7 +148,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta.ingress_metadata.flow_ipg = meta.ingress_metadata.flow_ipg - meta.ingress_metadata.flowlet_lasttime;
         flowlet_lasttime_0.write((bit<32>)meta.ingress_metadata.flowlet_map_index, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
-    @name("ingress.set_dmac") action set_dmac(bit<48> dmac) {
+    @name("ingress.set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("ingress.update_flowlet_id") action update_flowlet_id() {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2-midend.p4
@@ -91,7 +91,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name("egress.rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress._drop") action _drop() {
@@ -153,11 +153,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("ingress._drop") action _drop_6() {
         mark_to_drop(standard_metadata);
     }
-    @name("ingress.set_ecmp_select") action set_ecmp_select(bit<8> ecmp_base, bit<8> ecmp_count) {
+    @name("ingress.set_ecmp_select") action set_ecmp_select(@name("ecmp_base") bit<8> ecmp_base, @name("ecmp_count") bit<8> ecmp_count) {
         hash<bit<14>, bit<10>, tuple_0, bit<20>>(meta._ingress_metadata_ecmp_offset4, HashAlgorithm.crc16, (bit<10>)ecmp_base, { hdr.ipv4.srcAddr, hdr.ipv4.dstAddr, hdr.ipv4.protocol, hdr.tcp.srcPort, hdr.tcp.dstPort, meta._ingress_metadata_flowlet_id2 }, (bit<20>)ecmp_count);
     }
-    @name("ingress.set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta._ingress_metadata_nhop_ipv45 = nhop_ipv4;
+    @name("ingress.set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta._ingress_metadata_nhop_ipv45 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
@@ -169,7 +169,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         meta._ingress_metadata_flow_ipg0 = (bit<32>)standard_metadata.ingress_global_timestamp - meta._ingress_metadata_flowlet_lasttime3;
         flowlet_lasttime_0.write((bit<32>)meta._ingress_metadata_flowlet_map_index1, (bit<32>)standard_metadata.ingress_global_timestamp);
     }
-    @name("ingress.set_dmac") action set_dmac(bit<48> dmac) {
+    @name("ingress.set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("ingress.update_flowlet_id") action update_flowlet_id() {

--- a/testdata/p4_16_samples_outputs/gauntlet_action_return-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_action_return-bmv2-frontend.p4
@@ -24,7 +24,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.tmp_key") bit<128> tmp_key_0;
-    @name("ingress.do_action") action do_action(inout bit<8> val) {
+    @name("ingress.do_action") action do_action(@name("val") inout bit<8> val) {
         @name("ingress.hasReturned") bool hasReturned = false;
         if (val > 8w10) {
             val = 8w2;

--- a/testdata/p4_16_samples_outputs/gauntlet_copy_out-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_copy_out-bmv2-frontend.p4
@@ -23,10 +23,10 @@ struct Meta {
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.c") bit<8> c_0;
-    @name("ingress.do_thing") action do_thing(inout bit<8> inout_c) {
+    @name("ingress.do_thing") action do_thing(@name("inout_c") inout bit<8> inout_c) {
         h.h.a = inout_c;
     }
-    @name("ingress.do_thing") action do_thing_2(inout bit<8> inout_c_1) {
+    @name("ingress.do_thing") action do_thing_2(@name("inout_c") inout bit<8> inout_c_1) {
         h.h.a = inout_c_1;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/gauntlet_ctrl_plane_hdr-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_ctrl_plane_hdr-frontend.p4
@@ -20,7 +20,7 @@ parser p(packet_in pkt, out Headers hdr) {
 control ingress(inout Headers h) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("ingress.do_action") action do_action(ethernet_t ctrl_hdr) {
+    @name("ingress.do_action") action do_action(@name("ctrl_hdr") ethernet_t ctrl_hdr) {
         h.eth_hdr.dst_addr = ctrl_hdr.dst_addr;
     }
     @name("ingress.simple_table") table simple_table_0 {

--- a/testdata/p4_16_samples_outputs/gauntlet_ctrl_plane_hdr-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_ctrl_plane_hdr-midend.p4
@@ -20,7 +20,7 @@ parser p(packet_in pkt, out Headers hdr) {
 control ingress(inout Headers h) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("ingress.do_action") action do_action(ethernet_t ctrl_hdr) {
+    @name("ingress.do_action") action do_action(@name("ctrl_hdr") ethernet_t ctrl_hdr) {
         h.eth_hdr.dst_addr = ctrl_hdr.dst_addr;
     }
     @name("ingress.simple_table") table simple_table_0 {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_18-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_18-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.simple_action") action simple_action(inout bit<48> dummy) {
+    @name("ingress.simple_action") action simple_action(@name("dummy") inout bit<48> dummy) {
         exit;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_3-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_3-bmv2-frontend.p4
@@ -25,11 +25,11 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("ingress.do_action") action do_action(inout bit<48> val) {
+    @name("ingress.do_action") action do_action(@name("val") inout bit<48> val) {
         val = 48w2;
         exit;
     }
-    @name("ingress.do_action") action do_action_2(inout bit<48> val_1) {
+    @name("ingress.do_action") action do_action_2(@name("val") inout bit<48> val_1) {
         val_1 = 48w2;
         exit;
     }

--- a/testdata/p4_16_samples_outputs/gauntlet_function_return-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_function_return-bmv2-frontend.p4
@@ -15,7 +15,7 @@ struct Meta {
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") bit<8> tmp;
-    @name("ingress.action_thing") action action_thing(inout bit<32> c) {
+    @name("ingress.action_thing") action action_thing(@name("c") inout bit<32> c) {
         {
             @name("ingress.d_0") bit<32> d_0;
             @name("ingress.hasReturned") bool hasReturned = false;

--- a/testdata/p4_16_samples_outputs/gauntlet_hdr_out_in_action-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_hdr_out_in_action-bmv2-frontend.p4
@@ -29,7 +29,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.do_action") action do_action(out ethernet_t val) {
+    @name("ingress.do_action") action do_action(@name("val") out ethernet_t val) {
     }
     apply {
         do_action(h.eth_hdr);

--- a/testdata/p4_16_samples_outputs/gauntlet_hdr_out_in_action-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_hdr_out_in_action-bmv2-midend.p4
@@ -29,7 +29,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    ethernet_t val;
+    @name("val") ethernet_t val;
     @name("ingress.do_action") action do_action() {
         h.eth_hdr = val;
     }

--- a/testdata/p4_16_samples_outputs/gauntlet_index_4-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_index_4-bmv2-frontend.p4
@@ -31,7 +31,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") bit<32> tmp;
-    @name("ingress.do_something") action do_something(inout bit<32> val) {
+    @name("ingress.do_something") action do_something(@name("val") inout bit<32> val) {
         if (h.eth_hdr.eth_type == 16w1) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/gauntlet_index_5-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_index_5-bmv2-frontend.p4
@@ -31,7 +31,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") bit<48> tmp;
-    @name("ingress.simple_action") action simple_action(inout bit<32> dummy) {
+    @name("ingress.simple_action") action simple_action(@name("dummy") inout bit<32> dummy) {
     }
     apply {
         tmp = h.eth_hdr.dst_addr;

--- a/testdata/p4_16_samples_outputs/gauntlet_index_6-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_index_6-bmv2-frontend.p4
@@ -31,7 +31,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.simple_action") action simple_action(inout bit<8> val) {
+    @name("ingress.simple_action") action simple_action(@name("val") inout bit<8> val) {
     }
     apply {
         simple_action(h.h[1w0].a);

--- a/testdata/p4_16_samples_outputs/gauntlet_indirect_hdr_assign_1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_indirect_hdr_assign_1-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.do_action") action do_action(inout Headers val) {
+    @name("ingress.do_action") action do_action(@name("val") inout Headers val) {
     }
     apply {
         do_action(h);

--- a/testdata/p4_16_samples_outputs/gauntlet_indirect_hdr_assign_2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_indirect_hdr_assign_2-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.simple_action") action simple_action(in ethernet_t val) {
+    @name("ingress.simple_action") action simple_action(@name("val") in ethernet_t val) {
         h.eth_hdr.src_addr = val.src_addr;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/gauntlet_indirect_hdr_assign_2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_indirect_hdr_assign_2-bmv2-midend.p4
@@ -23,7 +23,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    ethernet_t val;
+    @name("val") ethernet_t val;
     @name("ingress.simple_action") action simple_action() {
         val = h.eth_hdr;
         h.eth_hdr.src_addr = val.src_addr;

--- a/testdata/p4_16_samples_outputs/gauntlet_list_as_in_argument-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_list_as_in_argument-bmv2-frontend.p4
@@ -24,7 +24,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") ethernet_t tmp;
-    @name("ingress.do_action") action do_action(in ethernet_t val) {
+    @name("ingress.do_action") action do_action(@name("val") in ethernet_t val) {
         h.eth_hdr.eth_type = val.eth_type;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/gauntlet_list_as_in_argument-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_list_as_in_argument-bmv2-midend.p4
@@ -24,7 +24,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") ethernet_t tmp;
-    ethernet_t val;
+    @name("val") ethernet_t val;
     @name("ingress.do_action") action do_action() {
         val = tmp;
         h.eth_hdr.eth_type = val.eth_type;

--- a/testdata/p4_16_samples_outputs/gauntlet_nested_switch-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_nested_switch-bmv2-frontend.p4
@@ -26,7 +26,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.simple_val") bit<16> simple_val_0;
-    @name("ingress.call_action") action call_action(inout bit<48> val) {
+    @name("ingress.call_action") action call_action(@name("val") inout bit<48> val) {
     }
     @name("ingress.simple_table") table simple_table_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/gauntlet_return_truncate-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_return_truncate-bmv2-frontend.p4
@@ -25,7 +25,7 @@ struct Meta {
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.y") bit<64> y_0;
     @name("ingress.tmp") bit<16> tmp;
-    @name("ingress.iuJze") action iuJze(in bit<8> hyhe) {
+    @name("ingress.iuJze") action iuJze(@name("hyhe") in bit<8> hyhe) {
         {
             @name("ingress.hasReturned") bool hasReturned = false;
             @name("ingress.retval") bit<16> retval;

--- a/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_1-bmv2-frontend.p4
@@ -31,10 +31,10 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") bit<16> tmp;
     @name("ingress.tmp_0") bit<16> tmp_0;
-    @name("ingress.do_action_2") action do_action(out bit<16> val_0) {
+    @name("ingress.do_action_2") action do_action(@name("val") out bit<16> val_0) {
         {
-            @name("ingress.val") bit<16> val;
-            @name("ingress.val_1") bit<16> val_1;
+            @name("ingress.val_1") bit<16> val;
+            @name("ingress.val_2") bit<16> val_1;
             val = val_1;
             tmp = val;
             tmp_0 = val_1;

--- a/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_1-bmv2-midend.p4
@@ -29,7 +29,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.val_1") bit<16> val_1;
+    @name("ingress.val_2") bit<16> val_1;
     @name("ingress.do_action_2") action do_action() {
         h.h.a = val_1;
     }

--- a/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_2-bmv2-frontend.p4
@@ -31,7 +31,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") bit<8> tmp_0;
     @name("ingress.tmp_1") bit<8> tmp_1;
-    @name("ingress.do_thing") action do_thing(out bit<8> tmp, in bit<8> val_0) {
+    @name("ingress.do_thing") action do_thing(@name("tmp") out bit<8> tmp, @name("val_1") in bit<8> val_0) {
         h.h.a = val_0;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_2-bmv2-midend.p4
@@ -30,7 +30,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp_1") bit<8> tmp_1;
-    bit<8> tmp;
+    @name("tmp") bit<8> tmp;
     @name("ingress.do_thing") action do_thing() {
         h.h.a = tmp_1;
     }

--- a/testdata/p4_16_samples_outputs/gauntlet_switch_nested_table_apply-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_switch_nested_table_apply-bmv2-frontend.p4
@@ -27,7 +27,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name("ingress.set_valid_action") action set_valid_action(out Headers tmp) {
+    @name("ingress.set_valid_action") action set_valid_action(@name("tmp") out Headers tmp) {
         tmp.eth_hdr.setValid();
         tmp.eth_hdr.dst_addr = 48w1;
         tmp.eth_hdr.src_addr = 48w1;

--- a/testdata/p4_16_samples_outputs/gauntlet_uninitialized_bool_struct-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_uninitialized_bool_struct-bmv2-frontend.p4
@@ -30,7 +30,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.tmp") bool_struct tmp_0;
-    @name("ingress.dummy_action") action dummy_action(out bit<16> dummy_bit, out bool_struct dummy_struct) {
+    @name("ingress.dummy_action") action dummy_action(@name("dummy_bit") out bit<16> dummy_bit, @name("dummy_struct") out bool_struct dummy_struct) {
     }
     @name("ingress.simple_table") table simple_table_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/gauntlet_uninitialized_bool_struct-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_uninitialized_bool_struct-bmv2-midend.p4
@@ -29,8 +29,8 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     bool hasExited;
     @name("ingress.tmp") bool_struct tmp_0;
-    bit<16> dummy_bit;
-    bool_struct dummy_struct;
+    @name("dummy_bit") bit<16> dummy_bit;
+    @name("dummy_struct") bool_struct dummy_struct;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.dummy_action") action dummy_action() {

--- a/testdata/p4_16_samples_outputs/global_action_after_exit-frontend.p4
+++ b/testdata/p4_16_samples_outputs/global_action_after_exit-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name(".do_action") action do_action(inout ethernet_t val) {
+    @name(".do_action") action do_action(@name("val") inout ethernet_t val) {
         val.eth_type = 16w0xdead;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/global_action_after_exit-midend.p4
+++ b/testdata/p4_16_samples_outputs/global_action_after_exit-midend.p4
@@ -23,7 +23,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    ethernet_t val;
+    @name("val") ethernet_t val;
     @name(".do_action") action do_action() {
         val = h.eth_hdr;
         val.eth_type = 16w0xdead;

--- a/testdata/p4_16_samples_outputs/hit_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hit_ebpf-frontend.p4
@@ -46,9 +46,9 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4.srcAddr = add;
+        headers.ipv4.srcAddr = add_1;
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/hit_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/hit_ebpf-midend.p4
@@ -47,9 +47,9 @@ control pipe(inout Headers_t headers, out bool pass) {
     @name("pipe.hasReturned") bool hasReturned;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4.srcAddr = add;
+        headers.ipv4.srcAddr = add_1;
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/init_ebpf-first.p4
+++ b/testdata/p4_16_samples_outputs/init_ebpf-first.p4
@@ -34,7 +34,6 @@ control pipe(inout Headers_t headers, out bool pass) {
                         16w0x800 : match(true);
                         16w0xd000 : match(false);
         }
-
         implementation = hash_table(32w64);
         default_action = NoAction();
     }

--- a/testdata/p4_16_samples_outputs/init_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/init_ebpf-frontend.p4
@@ -21,7 +21,7 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.match") action match(bool act) {
+    @name("pipe.match") action match(@name("act") bool act) {
         pass = act;
     }
     @name("pipe.tbl") table tbl_0 {
@@ -36,7 +36,6 @@ control pipe(inout Headers_t headers, out bool pass) {
                         16w0x800 : match(true);
                         16w0xd000 : match(false);
         }
-
         implementation = hash_table(32w64);
         default_action = NoAction_0();
     }

--- a/testdata/p4_16_samples_outputs/init_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/init_ebpf-midend.p4
@@ -21,7 +21,7 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.match") action match(bool act) {
+    @name("pipe.match") action match(@name("act") bool act) {
         pass = act;
     }
     @name("pipe.tbl") table tbl_0 {
@@ -36,7 +36,6 @@ control pipe(inout Headers_t headers, out bool pass) {
                         16w0x800 : match(true);
                         16w0xd000 : match(false);
         }
-
         implementation = hash_table(32w64);
         default_action = NoAction_0();
     }

--- a/testdata/p4_16_samples_outputs/init_ebpf.p4
+++ b/testdata/p4_16_samples_outputs/init_ebpf.p4
@@ -34,7 +34,6 @@ control pipe(inout Headers_t headers, out bool pass) {
                         0x800 : match(true);
                         0xd000 : match(false);
         }
-
         implementation = hash_table(64);
     }
     apply {

--- a/testdata/p4_16_samples_outputs/inline-action-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-action-frontend.p4
@@ -6,7 +6,7 @@ control p(inout bit<1> bt) {
             bt = y0;
         }
         {
-            @name("p.y0_1") bit<1> y0_1 = bt;
+            @name("p.y0") bit<1> y0_1 = bt;
             y0_1 = y0_1 | 1w1;
             bt = y0_1;
         }

--- a/testdata/p4_16_samples_outputs/inline-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-frontend.p4
@@ -2,7 +2,7 @@ control p(out bit<1> y) {
     @name("p.x") bit<1> x_0;
     @name("p.z") bit<1> z_0;
     @name("p.x") bit<1> x_1;
-    @name("p.b") action b(in bit<1> x, out bit<1> y_1) {
+    @name("p.b") action b(@name("x") in bit<1> x, @name("y") out bit<1> y_1) {
         {
             @name("p.x0") bit<1> x0 = x;
             @name("p.y0") bit<1> y0;
@@ -11,8 +11,8 @@ control p(out bit<1> y) {
             z_0 = y0;
         }
         {
-            @name("p.x0_1") bit<1> x0_1 = z_0;
-            @name("p.y0_1") bit<1> y0_1;
+            @name("p.x0") bit<1> x0_1 = z_0;
+            @name("p.y0") bit<1> y0_1;
             x_0 = x0_1;
             y0_1 = x0_1 & x_0;
             y_1 = y0_1;

--- a/testdata/p4_16_samples_outputs/inline-switch-first.p4
+++ b/testdata/p4_16_samples_outputs/inline-switch-first.p4
@@ -22,7 +22,6 @@ control c(out bit<32> x) {
                 return;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/inline-switch-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-switch-frontend.p4
@@ -22,7 +22,6 @@ control d(out bit<32> x) {
                     cinst_hasReturned = true;
                 }
             }
-
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/inline-switch-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-switch-midend.p4
@@ -18,7 +18,6 @@ control d(out bit<32> x) {
             default: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/inline-switch.p4
+++ b/testdata/p4_16_samples_outputs/inline-switch.p4
@@ -22,7 +22,6 @@ control c(out bit<32> x) {
                 return;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/ipv4-actions_ubpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/ipv4-actions_ubpf-frontend.p4
@@ -52,55 +52,55 @@ control pipe(inout Headers_t headers, inout metadata meta, inout standard_metada
     @name("pipe.Reject") action Reject() {
         mark_to_drop();
     }
-    @name("pipe.set_ipv4_version") action set_ipv4_version(bit<4> version) {
-        headers.ipv4.version = version;
+    @name("pipe.set_ipv4_version") action set_ipv4_version(@name("version") bit<4> version_1) {
+        headers.ipv4.version = version_1;
     }
-    @name("pipe.set_ihl") action set_ihl(bit<4> ihl) {
-        headers.ipv4.ihl = ihl;
+    @name("pipe.set_ihl") action set_ihl(@name("ihl") bit<4> ihl_2) {
+        headers.ipv4.ihl = ihl_2;
     }
-    @name("pipe.set_diffserv") action set_diffserv(bit<8> diffserv) {
-        headers.ipv4.diffserv = diffserv;
+    @name("pipe.set_diffserv") action set_diffserv(@name("diffserv") bit<8> diffserv_2) {
+        headers.ipv4.diffserv = diffserv_2;
     }
-    @name("pipe.set_identification") action set_identification(bit<16> identification) {
-        headers.ipv4.identification = identification;
+    @name("pipe.set_identification") action set_identification(@name("identification") bit<16> identification_1) {
+        headers.ipv4.identification = identification_1;
     }
-    @name("pipe.set_flags") action set_flags(bit<3> flags) {
-        headers.ipv4.flags = flags;
+    @name("pipe.set_flags") action set_flags(@name("flags") bit<3> flags_3) {
+        headers.ipv4.flags = flags_3;
     }
-    @name("pipe.set_fragOffset") action set_fragOffset(bit<13> fragOffset) {
-        headers.ipv4.fragOffset = fragOffset;
+    @name("pipe.set_fragOffset") action set_fragOffset(@name("fragOffset") bit<13> fragOffset_3) {
+        headers.ipv4.fragOffset = fragOffset_3;
     }
-    @name("pipe.set_ttl") action set_ttl(bit<8> ttl) {
-        headers.ipv4.ttl = ttl;
+    @name("pipe.set_ttl") action set_ttl(@name("ttl") bit<8> ttl_2) {
+        headers.ipv4.ttl = ttl_2;
     }
-    @name("pipe.set_protocol") action set_protocol(bit<8> protocol) {
-        headers.ipv4.protocol = protocol;
+    @name("pipe.set_protocol") action set_protocol(@name("protocol") bit<8> protocol_1) {
+        headers.ipv4.protocol = protocol_1;
     }
-    @name("pipe.set_srcAddr") action set_srcAddr(bit<32> srcAddr) {
-        headers.ipv4.srcAddr = srcAddr;
+    @name("pipe.set_srcAddr") action set_srcAddr(@name("srcAddr") bit<32> srcAddr_3) {
+        headers.ipv4.srcAddr = srcAddr_3;
     }
-    @name("pipe.set_dstAddr") action set_dstAddr(bit<32> dstAddr) {
-        headers.ipv4.dstAddr = dstAddr;
+    @name("pipe.set_dstAddr") action set_dstAddr(@name("dstAddr") bit<32> dstAddr_2) {
+        headers.ipv4.dstAddr = dstAddr_2;
     }
-    @name("pipe.set_srcAddr_dstAddr") action set_srcAddr_dstAddr(bit<32> srcAddr, bit<32> dstAddr) {
-        headers.ipv4.srcAddr = srcAddr;
-        headers.ipv4.dstAddr = dstAddr;
+    @name("pipe.set_srcAddr_dstAddr") action set_srcAddr_dstAddr(@name("srcAddr") bit<32> srcAddr_4, @name("dstAddr") bit<32> dstAddr_3) {
+        headers.ipv4.srcAddr = srcAddr_4;
+        headers.ipv4.dstAddr = dstAddr_3;
     }
-    @name("pipe.set_ihl_diffserv") action set_ihl_diffserv(bit<4> ihl, bit<8> diffserv) {
-        headers.ipv4.ihl = ihl;
-        headers.ipv4.diffserv = diffserv;
+    @name("pipe.set_ihl_diffserv") action set_ihl_diffserv(@name("ihl") bit<4> ihl_3, @name("diffserv") bit<8> diffserv_3) {
+        headers.ipv4.ihl = ihl_3;
+        headers.ipv4.diffserv = diffserv_3;
     }
-    @name("pipe.set_fragOffset_flags") action set_fragOffset_flags(bit<13> fragOffset, bit<3> flags) {
-        headers.ipv4.flags = flags;
-        headers.ipv4.fragOffset = fragOffset;
+    @name("pipe.set_fragOffset_flags") action set_fragOffset_flags(@name("fragOffset") bit<13> fragOffset_4, @name("flags") bit<3> flags_4) {
+        headers.ipv4.flags = flags_4;
+        headers.ipv4.fragOffset = fragOffset_4;
     }
-    @name("pipe.set_flags_ttl") action set_flags_ttl(bit<3> flags, bit<8> ttl) {
-        headers.ipv4.flags = flags;
-        headers.ipv4.ttl = ttl;
+    @name("pipe.set_flags_ttl") action set_flags_ttl(@name("flags") bit<3> flags_5, @name("ttl") bit<8> ttl_3) {
+        headers.ipv4.flags = flags_5;
+        headers.ipv4.ttl = ttl_3;
     }
-    @name("pipe.set_fragOffset_srcAddr") action set_fragOffset_srcAddr(bit<13> fragOffset, bit<32> srcAddr) {
-        headers.ipv4.fragOffset = fragOffset;
-        headers.ipv4.srcAddr = srcAddr;
+    @name("pipe.set_fragOffset_srcAddr") action set_fragOffset_srcAddr(@name("fragOffset") bit<13> fragOffset_5, @name("srcAddr") bit<32> srcAddr_5) {
+        headers.ipv4.fragOffset = fragOffset_5;
+        headers.ipv4.srcAddr = srcAddr_5;
     }
     @name("pipe.filter_tbl") table filter_tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/ipv4-actions_ubpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/ipv4-actions_ubpf-midend.p4
@@ -52,55 +52,55 @@ control pipe(inout Headers_t headers, inout metadata meta, inout standard_metada
     @name("pipe.Reject") action Reject() {
         mark_to_drop();
     }
-    @name("pipe.set_ipv4_version") action set_ipv4_version(bit<4> version) {
-        headers.ipv4.version = version;
+    @name("pipe.set_ipv4_version") action set_ipv4_version(@name("version") bit<4> version_1) {
+        headers.ipv4.version = version_1;
     }
-    @name("pipe.set_ihl") action set_ihl(bit<4> ihl) {
-        headers.ipv4.ihl = ihl;
+    @name("pipe.set_ihl") action set_ihl(@name("ihl") bit<4> ihl_2) {
+        headers.ipv4.ihl = ihl_2;
     }
-    @name("pipe.set_diffserv") action set_diffserv(bit<8> diffserv) {
-        headers.ipv4.diffserv = diffserv;
+    @name("pipe.set_diffserv") action set_diffserv(@name("diffserv") bit<8> diffserv_2) {
+        headers.ipv4.diffserv = diffserv_2;
     }
-    @name("pipe.set_identification") action set_identification(bit<16> identification) {
-        headers.ipv4.identification = identification;
+    @name("pipe.set_identification") action set_identification(@name("identification") bit<16> identification_1) {
+        headers.ipv4.identification = identification_1;
     }
-    @name("pipe.set_flags") action set_flags(bit<3> flags) {
-        headers.ipv4.flags = flags;
+    @name("pipe.set_flags") action set_flags(@name("flags") bit<3> flags_3) {
+        headers.ipv4.flags = flags_3;
     }
-    @name("pipe.set_fragOffset") action set_fragOffset(bit<13> fragOffset) {
-        headers.ipv4.fragOffset = fragOffset;
+    @name("pipe.set_fragOffset") action set_fragOffset(@name("fragOffset") bit<13> fragOffset_3) {
+        headers.ipv4.fragOffset = fragOffset_3;
     }
-    @name("pipe.set_ttl") action set_ttl(bit<8> ttl) {
-        headers.ipv4.ttl = ttl;
+    @name("pipe.set_ttl") action set_ttl(@name("ttl") bit<8> ttl_2) {
+        headers.ipv4.ttl = ttl_2;
     }
-    @name("pipe.set_protocol") action set_protocol(bit<8> protocol) {
-        headers.ipv4.protocol = protocol;
+    @name("pipe.set_protocol") action set_protocol(@name("protocol") bit<8> protocol_1) {
+        headers.ipv4.protocol = protocol_1;
     }
-    @name("pipe.set_srcAddr") action set_srcAddr(bit<32> srcAddr) {
-        headers.ipv4.srcAddr = srcAddr;
+    @name("pipe.set_srcAddr") action set_srcAddr(@name("srcAddr") bit<32> srcAddr_3) {
+        headers.ipv4.srcAddr = srcAddr_3;
     }
-    @name("pipe.set_dstAddr") action set_dstAddr(bit<32> dstAddr) {
-        headers.ipv4.dstAddr = dstAddr;
+    @name("pipe.set_dstAddr") action set_dstAddr(@name("dstAddr") bit<32> dstAddr_2) {
+        headers.ipv4.dstAddr = dstAddr_2;
     }
-    @name("pipe.set_srcAddr_dstAddr") action set_srcAddr_dstAddr(bit<32> srcAddr, bit<32> dstAddr) {
-        headers.ipv4.srcAddr = srcAddr;
-        headers.ipv4.dstAddr = dstAddr;
+    @name("pipe.set_srcAddr_dstAddr") action set_srcAddr_dstAddr(@name("srcAddr") bit<32> srcAddr_4, @name("dstAddr") bit<32> dstAddr_3) {
+        headers.ipv4.srcAddr = srcAddr_4;
+        headers.ipv4.dstAddr = dstAddr_3;
     }
-    @name("pipe.set_ihl_diffserv") action set_ihl_diffserv(bit<4> ihl, bit<8> diffserv) {
-        headers.ipv4.ihl = ihl;
-        headers.ipv4.diffserv = diffserv;
+    @name("pipe.set_ihl_diffserv") action set_ihl_diffserv(@name("ihl") bit<4> ihl_3, @name("diffserv") bit<8> diffserv_3) {
+        headers.ipv4.ihl = ihl_3;
+        headers.ipv4.diffserv = diffserv_3;
     }
-    @name("pipe.set_fragOffset_flags") action set_fragOffset_flags(bit<13> fragOffset, bit<3> flags) {
-        headers.ipv4.flags = flags;
-        headers.ipv4.fragOffset = fragOffset;
+    @name("pipe.set_fragOffset_flags") action set_fragOffset_flags(@name("fragOffset") bit<13> fragOffset_4, @name("flags") bit<3> flags_4) {
+        headers.ipv4.flags = flags_4;
+        headers.ipv4.fragOffset = fragOffset_4;
     }
-    @name("pipe.set_flags_ttl") action set_flags_ttl(bit<3> flags, bit<8> ttl) {
-        headers.ipv4.flags = flags;
-        headers.ipv4.ttl = ttl;
+    @name("pipe.set_flags_ttl") action set_flags_ttl(@name("flags") bit<3> flags_5, @name("ttl") bit<8> ttl_3) {
+        headers.ipv4.flags = flags_5;
+        headers.ipv4.ttl = ttl_3;
     }
-    @name("pipe.set_fragOffset_srcAddr") action set_fragOffset_srcAddr(bit<13> fragOffset, bit<32> srcAddr) {
-        headers.ipv4.fragOffset = fragOffset;
-        headers.ipv4.srcAddr = srcAddr;
+    @name("pipe.set_fragOffset_srcAddr") action set_fragOffset_srcAddr(@name("fragOffset") bit<13> fragOffset_5, @name("srcAddr") bit<32> srcAddr_5) {
+        headers.ipv4.fragOffset = fragOffset_5;
+        headers.ipv4.srcAddr = srcAddr_5;
     }
     @name("pipe.filter_tbl") table filter_tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/ipv6-actions_ubpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/ipv6-actions_ubpf-frontend.p4
@@ -83,29 +83,29 @@ control pipe(inout Headers_t headers, inout metadata meta, inout standard_metada
     @name("pipe.Reject") action Reject() {
         mark_to_drop();
     }
-    @name("pipe.ipv6_modify_dstAddr") action ipv6_modify_dstAddr(bit<128> dstAddr) {
-        headers.ipv6.dstAddr = dstAddr;
+    @name("pipe.ipv6_modify_dstAddr") action ipv6_modify_dstAddr(@name("dstAddr") bit<128> dstAddr_1) {
+        headers.ipv6.dstAddr = dstAddr_1;
     }
     @name("pipe.ipv6_swap_addr") action ipv6_swap_addr() {
         tmp_0 = headers.ipv6.dstAddr;
         headers.ipv6.dstAddr = headers.ipv6.srcAddr;
         headers.ipv6.srcAddr = tmp_0;
     }
-    @name("pipe.set_flowlabel") action set_flowlabel(bit<20> label) {
-        headers.ipv6.flowLabel = label;
+    @name("pipe.set_flowlabel") action set_flowlabel(@name("label") bit<20> label_2) {
+        headers.ipv6.flowLabel = label_2;
     }
-    @name("pipe.set_traffic_class_flow_label") action set_traffic_class_flow_label(bit<8> trafficClass, bit<20> label) {
-        headers.ipv6.trafficClass = trafficClass;
-        headers.ipv6.flowLabel = label;
+    @name("pipe.set_traffic_class_flow_label") action set_traffic_class_flow_label(@name("trafficClass") bit<8> trafficClass_1, @name("label") bit<20> label_3) {
+        headers.ipv6.trafficClass = trafficClass_1;
+        headers.ipv6.flowLabel = label_3;
     }
-    @name("pipe.set_ipv6_version") action set_ipv6_version(bit<4> version) {
-        headers.ipv6.version = version;
+    @name("pipe.set_ipv6_version") action set_ipv6_version(@name("version") bit<4> version_1) {
+        headers.ipv6.version = version_1;
     }
-    @name("pipe.set_next_hdr") action set_next_hdr(bit<8> nextHdr) {
-        headers.ipv6.nextHdr = nextHdr;
+    @name("pipe.set_next_hdr") action set_next_hdr(@name("nextHdr") bit<8> nextHdr_1) {
+        headers.ipv6.nextHdr = nextHdr_1;
     }
-    @name("pipe.set_hop_limit") action set_hop_limit(bit<8> hopLimit) {
-        headers.ipv6.hopLimit = hopLimit;
+    @name("pipe.set_hop_limit") action set_hop_limit(@name("hopLimit") bit<8> hopLimit_1) {
+        headers.ipv6.hopLimit = hopLimit_1;
     }
     @name("pipe.filter_tbl") table filter_tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/ipv6-actions_ubpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/ipv6-actions_ubpf-midend.p4
@@ -83,29 +83,29 @@ control pipe(inout Headers_t headers, inout metadata meta, inout standard_metada
     @name("pipe.Reject") action Reject() {
         mark_to_drop();
     }
-    @name("pipe.ipv6_modify_dstAddr") action ipv6_modify_dstAddr(bit<128> dstAddr) {
-        headers.ipv6.dstAddr = dstAddr;
+    @name("pipe.ipv6_modify_dstAddr") action ipv6_modify_dstAddr(@name("dstAddr") bit<128> dstAddr_1) {
+        headers.ipv6.dstAddr = dstAddr_1;
     }
     @name("pipe.ipv6_swap_addr") action ipv6_swap_addr() {
         tmp_0 = headers.ipv6.dstAddr;
         headers.ipv6.dstAddr = headers.ipv6.srcAddr;
         headers.ipv6.srcAddr = tmp_0;
     }
-    @name("pipe.set_flowlabel") action set_flowlabel(bit<20> label) {
-        headers.ipv6.flowLabel = label;
+    @name("pipe.set_flowlabel") action set_flowlabel(@name("label") bit<20> label_2) {
+        headers.ipv6.flowLabel = label_2;
     }
-    @name("pipe.set_traffic_class_flow_label") action set_traffic_class_flow_label(bit<8> trafficClass, bit<20> label) {
-        headers.ipv6.trafficClass = trafficClass;
-        headers.ipv6.flowLabel = label;
+    @name("pipe.set_traffic_class_flow_label") action set_traffic_class_flow_label(@name("trafficClass") bit<8> trafficClass_1, @name("label") bit<20> label_3) {
+        headers.ipv6.trafficClass = trafficClass_1;
+        headers.ipv6.flowLabel = label_3;
     }
-    @name("pipe.set_ipv6_version") action set_ipv6_version(bit<4> version) {
-        headers.ipv6.version = version;
+    @name("pipe.set_ipv6_version") action set_ipv6_version(@name("version") bit<4> version_1) {
+        headers.ipv6.version = version_1;
     }
-    @name("pipe.set_next_hdr") action set_next_hdr(bit<8> nextHdr) {
-        headers.ipv6.nextHdr = nextHdr;
+    @name("pipe.set_next_hdr") action set_next_hdr(@name("nextHdr") bit<8> nextHdr_1) {
+        headers.ipv6.nextHdr = nextHdr_1;
     }
-    @name("pipe.set_hop_limit") action set_hop_limit(bit<8> hopLimit) {
-        headers.ipv6.hopLimit = hopLimit;
+    @name("pipe.set_hop_limit") action set_hop_limit(@name("hopLimit") bit<8> hopLimit_1) {
+        headers.ipv6.hopLimit = hopLimit_1;
     }
     @name("pipe.filter_tbl") table filter_tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-frontend.p4
@@ -198,8 +198,8 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata_t meta, inout 
 control ingress(inout headers hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("ingress.set_mcast_grp") action set_mcast_grp(bit<16> mcast_grp, bit<9> port) {
-        standard_metadata.mcast_grp = mcast_grp;
+    @name("ingress.set_mcast_grp") action set_mcast_grp(@name("mcast_grp") bit<16> mcast_grp_1, @name("port") bit<9> port) {
+        standard_metadata.mcast_grp = mcast_grp_1;
         meta.egress_port = port;
     }
     @name("ingress.ipv6_tbl") table ipv6_tbl_0 {
@@ -222,7 +222,7 @@ control ingress(inout headers hdr, inout metadata_t meta, inout standard_metadat
 control egress(inout headers hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name("egress.set_out_bd") action set_out_bd(bit<24> bd) {
+    @name("egress.set_out_bd") action set_out_bd(@name("bd") bit<24> bd) {
         meta.fwd.out_bd = bd;
     }
     @name("egress.get_multicast_copy_out_bd") table get_multicast_copy_out_bd_0 {
@@ -239,7 +239,7 @@ control egress(inout headers hdr, inout metadata_t meta, inout standard_metadata
     @name("egress.drop") action drop() {
         mark_to_drop(standard_metadata);
     }
-    @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name("egress.rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2-midend.p4
@@ -259,8 +259,8 @@ control ingress(inout headers hdr, inout metadata_t meta, inout standard_metadat
     bool key_0;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("ingress.set_mcast_grp") action set_mcast_grp(bit<16> mcast_grp, bit<9> port) {
-        standard_metadata.mcast_grp = mcast_grp;
+    @name("ingress.set_mcast_grp") action set_mcast_grp(@name("mcast_grp") bit<16> mcast_grp_1, @name("port") bit<9> port) {
+        standard_metadata.mcast_grp = mcast_grp_1;
         meta._egress_port1 = port;
     }
     @name("ingress.ipv6_tbl") table ipv6_tbl_0 {
@@ -293,7 +293,7 @@ control ingress(inout headers hdr, inout metadata_t meta, inout standard_metadat
 control egress(inout headers hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name("egress.set_out_bd") action set_out_bd(bit<24> bd) {
+    @name("egress.set_out_bd") action set_out_bd(@name("bd") bit<24> bd) {
         meta._fwd_out_bd69 = bd;
     }
     @name("egress.get_multicast_copy_out_bd") table get_multicast_copy_out_bd_0 {
@@ -310,7 +310,7 @@ control egress(inout headers hdr, inout metadata_t meta, inout standard_metadata
     @name("egress.drop") action drop() {
         mark_to_drop(standard_metadata);
     }
-    @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name("egress.rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/issue-2123-first.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-first.p4
@@ -184,7 +184,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
             nexthop.apply();
         }
     }

--- a/testdata/p4_16_samples_outputs/issue-2123-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-frontend.p4
@@ -72,7 +72,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name("egress.on_miss") action on_miss() {
     }
-    @name("egress.rewrite_src_dst_mac") action rewrite_src_dst_mac(bit<48> smac, bit<48> dmac) {
+    @name("egress.rewrite_src_dst_mac") action rewrite_src_dst_mac(@name("smac") bit<48> smac, @name("dmac") bit<48> dmac) {
         hdr.ethernet.srcAddr = smac;
         hdr.ethernet.dstAddr = dmac;
     }
@@ -104,8 +104,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name("ingress.set_vrf") action set_vrf(bit<12> vrf) {
-        meta.ingress_metadata.vrf = vrf;
+    @name("ingress.set_vrf") action set_vrf(@name("vrf") bit<12> vrf_1) {
+        meta.ingress_metadata.vrf = vrf_1;
     }
     @name("ingress.on_miss") action on_miss_2() {
     }
@@ -113,19 +113,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.on_miss") action on_miss_6() {
     }
-    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop(bit<16> nexthop_index) {
-        meta.ingress_metadata.nexthop_index = nexthop_index;
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop(@name("nexthop_index") bit<16> nexthop_index_1) {
+        meta.ingress_metadata.nexthop_index = nexthop_index_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_2(bit<16> nexthop_index) {
-        meta.ingress_metadata.nexthop_index = nexthop_index;
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_2) {
+        meta.ingress_metadata.nexthop_index = nexthop_index_2;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name("ingress.set_egress_details") action set_egress_details(bit<9> egress_spec) {
-        standard_metadata.egress_spec = egress_spec;
+    @name("ingress.set_egress_details") action set_egress_details(@name("egress_spec") bit<9> egress_spec_1) {
+        standard_metadata.egress_spec = egress_spec_1;
     }
-    @name("ingress.set_bd") action set_bd(bit<16> bd) {
-        meta.ingress_metadata.bd = bd;
+    @name("ingress.set_bd") action set_bd(@name("bd") bit<16> bd_2) {
+        meta.ingress_metadata.bd = bd_2;
     }
     @name("ingress.bd") table bd_0 {
         actions = {
@@ -198,7 +198,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
             nexthop_0.apply();
         }
     }

--- a/testdata/p4_16_samples_outputs/issue-2123-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123-midend.p4
@@ -91,7 +91,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     }
     @name("egress.on_miss") action on_miss() {
     }
-    @name("egress.rewrite_src_dst_mac") action rewrite_src_dst_mac(bit<48> smac, bit<48> dmac) {
+    @name("egress.rewrite_src_dst_mac") action rewrite_src_dst_mac(@name("smac") bit<48> smac, @name("dmac") bit<48> dmac) {
         hdr.ethernet.srcAddr = smac;
         hdr.ethernet.dstAddr = dmac;
     }
@@ -123,8 +123,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_11() {
     }
-    @name("ingress.set_vrf") action set_vrf(bit<12> vrf) {
-        meta._ingress_metadata_vrf0 = vrf;
+    @name("ingress.set_vrf") action set_vrf(@name("vrf") bit<12> vrf_1) {
+        meta._ingress_metadata_vrf0 = vrf_1;
     }
     @name("ingress.on_miss") action on_miss_2() {
     }
@@ -132,19 +132,19 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     }
     @name("ingress.on_miss") action on_miss_6() {
     }
-    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop(bit<16> nexthop_index) {
-        meta._ingress_metadata_nexthop_index2 = nexthop_index;
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop(@name("nexthop_index") bit<16> nexthop_index_1) {
+        meta._ingress_metadata_nexthop_index2 = nexthop_index_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_2(bit<16> nexthop_index) {
-        meta._ingress_metadata_nexthop_index2 = nexthop_index;
+    @name("ingress.fib_hit_nexthop") action fib_hit_nexthop_2(@name("nexthop_index") bit<16> nexthop_index_2) {
+        meta._ingress_metadata_nexthop_index2 = nexthop_index_2;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @name("ingress.set_egress_details") action set_egress_details(bit<9> egress_spec) {
-        standard_metadata.egress_spec = egress_spec;
+    @name("ingress.set_egress_details") action set_egress_details(@name("egress_spec") bit<9> egress_spec_1) {
+        standard_metadata.egress_spec = egress_spec_1;
     }
-    @name("ingress.set_bd") action set_bd(bit<16> bd) {
-        meta._ingress_metadata_bd1 = bd;
+    @name("ingress.set_bd") action set_bd(@name("bd") bit<16> bd_2) {
+        meta._ingress_metadata_bd1 = bd_2;
     }
     @name("ingress.bd") table bd_0 {
         actions = {
@@ -217,7 +217,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                 default: {
                 }
             }
-
             nexthop_0.apply();
         }
     }

--- a/testdata/p4_16_samples_outputs/issue-2123.p4
+++ b/testdata/p4_16_samples_outputs/issue-2123.p4
@@ -170,7 +170,6 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
                     ipv4_fib_lpm.apply();
                 }
             }
-
             nexthop.apply();
         }
     }

--- a/testdata/p4_16_samples_outputs/issue1025-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1025-bmv2-midend.p4
@@ -124,3 +124,4 @@ control DeparserI(packet_out packet, in headers hdr) {
 }
 
 V1Switch<headers, metadata>(parserI(), verifyChecksum(), cIngress(), cEgress(), updateChecksum(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1062-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-1-bmv2-frontend.p4
@@ -47,7 +47,7 @@ control deparser(packet_out b, in Header_t h) {
 }
 
 control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
-    @name("ingress.set_error_idx") action set_error_idx(bit<8> idx) {
+    @name("ingress.set_error_idx") action set_error_idx(@name("idx") bit<8> idx) {
         h.h.e = idx;
     }
     @name("ingress.t_exact") table t_exact_0 {

--- a/testdata/p4_16_samples_outputs/issue1062-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-1-bmv2-midend.p4
@@ -47,7 +47,7 @@ control deparser(packet_out b, in Header_t h) {
 }
 
 control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
-    @name("ingress.set_error_idx") action set_error_idx(bit<8> idx) {
+    @name("ingress.set_error_idx") action set_error_idx(@name("idx") bit<8> idx) {
         h.h.e = idx;
     }
     @name("ingress.t_exact") table t_exact_0 {

--- a/testdata/p4_16_samples_outputs/issue1062-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-bmv2-first.p4
@@ -62,7 +62,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         const entries = {
                         error.NoError : set_error_idx(8w1);
         }
-
     }
     apply {
         t_exact.apply();

--- a/testdata/p4_16_samples_outputs/issue1062-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-bmv2-frontend.p4
@@ -47,7 +47,7 @@ control deparser(packet_out b, in Header_t h) {
 }
 
 control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
-    @name("ingress.set_error_idx") action set_error_idx(bit<8> idx) {
+    @name("ingress.set_error_idx") action set_error_idx(@name("idx") bit<8> idx) {
         h.h.e = idx;
     }
     @name("ingress.t_exact") table t_exact_0 {
@@ -61,7 +61,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         const entries = {
                         error.NoError : set_error_idx(8w1);
         }
-
     }
     apply {
         t_exact_0.apply();

--- a/testdata/p4_16_samples_outputs/issue1062-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-bmv2-midend.p4
@@ -47,7 +47,7 @@ control deparser(packet_out b, in Header_t h) {
 }
 
 control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t standard_meta) {
-    @name("ingress.set_error_idx") action set_error_idx(bit<8> idx) {
+    @name("ingress.set_error_idx") action set_error_idx(@name("idx") bit<8> idx) {
         h.h.e = idx;
     }
     @name("ingress.t_exact") table t_exact_0 {
@@ -61,7 +61,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         const entries = {
                         error.NoError : set_error_idx(8w1);
         }
-
     }
     apply {
         t_exact_0.apply();

--- a/testdata/p4_16_samples_outputs/issue1062-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1062-bmv2.p4
@@ -62,7 +62,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
         const entries = {
                         error.NoError : set_error_idx(1);
         }
-
     }
     apply {
         t_exact.apply();

--- a/testdata/p4_16_samples_outputs/issue1107-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1107-frontend.p4
@@ -19,8 +19,8 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("IngressI.myc.set_eg") action myc_set_eg_0(bit<9> eg) {
-        smeta.egress_spec = eg;
+    @name("IngressI.myc.set_eg") action myc_set_eg_0(@name("eg") bit<9> eg_1) {
+        smeta.egress_spec = eg_1;
     }
     @name("IngressI.myc.myt") table myc_myt {
         key = {

--- a/testdata/p4_16_samples_outputs/issue1107-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1107-midend.p4
@@ -19,8 +19,8 @@ parser ParserI(packet_in pk, out H hdr, inout M meta, inout standard_metadata_t 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("IngressI.myc.set_eg") action myc_set_eg_0(bit<9> eg) {
-        smeta.egress_spec = eg;
+    @name("IngressI.myc.set_eg") action myc_set_eg_0(@name("eg") bit<9> eg_1) {
+        smeta.egress_spec = eg_1;
     }
     @name("IngressI.myc.myt") table myc_myt {
         key = {

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-frontend.p4
@@ -72,8 +72,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name("MyIngress.drop") action drop_2() {
         mark_to_drop(standard_metadata);
     }
-    @name("MyIngress.set_dmac") action set_dmac(macAddr_t dstAddr) {
-        hdr.ethernet.dstAddr = dstAddr;
+    @name("MyIngress.set_dmac") action set_dmac(@name("dstAddr") macAddr_t dstAddr_2) {
+        hdr.ethernet.dstAddr = dstAddr_2;
     }
     @name("MyIngress.forward") table forward_0 {
         key = {
@@ -87,8 +87,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         size = 1024;
         default_action = NoAction_0();
     }
-    @name("MyIngress.set_nhop") action set_nhop(ip4Addr_t dstAddr, egressSpec_t port) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("MyIngress.set_nhop") action set_nhop(@name("dstAddr") ip4Addr_t dstAddr_3, @name("port") egressSpec_t port) {
+        hdr.ipv4.dstAddr = dstAddr_3;
         standard_metadata.egress_spec = port;
     }
     @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
@@ -117,8 +117,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
 control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("MyEgress.rewrite_mac") action rewrite_mac(macAddr_t srcAddr) {
-        hdr.ethernet.srcAddr = srcAddr;
+    @name("MyEgress.rewrite_mac") action rewrite_mac(@name("srcAddr") macAddr_t srcAddr_1) {
+        hdr.ethernet.srcAddr = srcAddr_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
     @name("MyEgress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2-midend.p4
@@ -72,8 +72,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name("MyIngress.drop") action drop_2() {
         mark_to_drop(standard_metadata);
     }
-    @name("MyIngress.set_dmac") action set_dmac(macAddr_t dstAddr) {
-        hdr.ethernet.dstAddr = dstAddr;
+    @name("MyIngress.set_dmac") action set_dmac(@name("dstAddr") macAddr_t dstAddr_2) {
+        hdr.ethernet.dstAddr = dstAddr_2;
     }
     @name("MyIngress.forward") table forward_0 {
         key = {
@@ -87,8 +87,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         size = 1024;
         default_action = NoAction_0();
     }
-    @name("MyIngress.set_nhop") action set_nhop(ip4Addr_t dstAddr, egressSpec_t port) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("MyIngress.set_nhop") action set_nhop(@name("dstAddr") ip4Addr_t dstAddr_3, @name("port") egressSpec_t port) {
+        hdr.ipv4.dstAddr = dstAddr_3;
         standard_metadata.egress_spec = port;
     }
     @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
@@ -123,8 +123,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
 control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("MyEgress.rewrite_mac") action rewrite_mac(macAddr_t srcAddr) {
-        hdr.ethernet.srcAddr = srcAddr;
+    @name("MyEgress.rewrite_mac") action rewrite_mac(@name("srcAddr") macAddr_t srcAddr_1) {
+        hdr.ethernet.srcAddr = srcAddr_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
     @name("MyEgress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/issue1452-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1452-1-frontend.p4
@@ -1,6 +1,6 @@
 control c() {
     @name("c.x") bit<32> x_0;
-    @name("c.b") action b(out bit<32> arg) {
+    @name("c.b") action b(@name("arg") out bit<32> arg) {
         arg = 32w2;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/issue1452-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1452-frontend.p4
@@ -1,6 +1,6 @@
 control c() {
     @name("c.x") bit<32> x_0;
-    @name("c.a") action a(inout bit<32> arg) {
+    @name("c.a") action a(@name("arg") inout bit<32> arg) {
         @name("c.hasReturned") bool hasReturned = false;
         arg = 32w1;
         hasReturned = true;

--- a/testdata/p4_16_samples_outputs/issue1538-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-frontend.p4
@@ -45,10 +45,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+    @name(".my_drop") action my_drop(@name("smeta") inout standard_metadata_t smeta) {
         mark_to_drop(smeta);
     }
-    @name("ingress.set_port") action set_port(bit<9> output_port) {
+    @name("ingress.set_port") action set_port(@name("output_port") bit<9> output_port) {
         standard_metadata.egress_spec = output_port;
     }
     @name("ingress.mac_da") table mac_da_0 {

--- a/testdata/p4_16_samples_outputs/issue1538-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-midend.p4
@@ -26,7 +26,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    standard_metadata_t smeta;
+    @name("smeta") standard_metadata_t smeta;
     @name(".my_drop") action my_drop() {
         smeta.ingress_port = standard_metadata.ingress_port;
         smeta.egress_spec = standard_metadata.egress_spec;
@@ -62,7 +62,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.parser_error = smeta.parser_error;
         standard_metadata.priority = smeta.priority;
     }
-    @name("ingress.set_port") action set_port(bit<9> output_port) {
+    @name("ingress.set_port") action set_port(@name("output_port") bit<9> output_port) {
         standard_metadata.egress_spec = output_port;
     }
     @name("ingress.mac_da") table mac_da_0 {

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-frontend.p4
@@ -23,10 +23,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+    @name(".my_drop") action my_drop(@name("smeta") inout standard_metadata_t smeta) {
         mark_to_drop(smeta);
     }
-    @name("ingress.set_port") action set_port(bit<9> output_port) {
+    @name("ingress.set_port") action set_port(@name("output_port") bit<9> output_port) {
         standard_metadata.egress_spec = output_port;
     }
     @name("ingress.mac_da") table mac_da_0 {

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2-midend.p4
@@ -24,7 +24,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("ingress.tmp") bit<16> tmp_0;
-    standard_metadata_t smeta;
+    @name("smeta") standard_metadata_t smeta;
     @name(".my_drop") action my_drop() {
         smeta.ingress_port = standard_metadata.ingress_port;
         smeta.egress_spec = standard_metadata.egress_spec;
@@ -60,7 +60,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.parser_error = smeta.parser_error;
         standard_metadata.priority = smeta.priority;
     }
-    @name("ingress.set_port") action set_port(bit<9> output_port) {
+    @name("ingress.set_port") action set_port(@name("output_port") bit<9> output_port) {
         standard_metadata.egress_spec = output_port;
     }
     @name("ingress.mac_da") table mac_da_0 {

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-frontend.p4
@@ -23,10 +23,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+    @name(".my_drop") action my_drop(@name("smeta") inout standard_metadata_t smeta) {
         mark_to_drop(smeta);
     }
-    @name("ingress.set_port") action set_port(bit<9> output_port) {
+    @name("ingress.set_port") action set_port(@name("output_port") bit<9> output_port) {
         standard_metadata.egress_spec = output_port;
     }
     @name("ingress.mac_da") table mac_da_0 {

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2-midend.p4
@@ -24,7 +24,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("ingress.tmp") bit<16> tmp_0;
-    standard_metadata_t smeta;
+    @name("smeta") standard_metadata_t smeta;
     @name(".my_drop") action my_drop() {
         smeta.ingress_port = standard_metadata.ingress_port;
         smeta.egress_spec = standard_metadata.egress_spec;
@@ -60,7 +60,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.parser_error = smeta.parser_error;
         standard_metadata.priority = smeta.priority;
     }
-    @name("ingress.set_port") action set_port(bit<9> output_port) {
+    @name("ingress.set_port") action set_port(@name("output_port") bit<9> output_port) {
         standard_metadata.egress_spec = output_port;
     }
     @name("ingress.mac_da") table mac_da_0 {

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-frontend.p4
@@ -23,10 +23,10 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+    @name(".my_drop") action my_drop(@name("smeta") inout standard_metadata_t smeta) {
         mark_to_drop(smeta);
     }
-    @name("ingress.set_port") action set_port(bit<9> output_port) {
+    @name("ingress.set_port") action set_port(@name("output_port") bit<9> output_port) {
         standard_metadata.egress_spec = output_port;
     }
     @name("ingress.mac_da") table mac_da_0 {

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2-midend.p4
@@ -24,7 +24,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("ingress.retval") bit<16> retval;
-    standard_metadata_t smeta;
+    @name("smeta") standard_metadata_t smeta;
     @name(".my_drop") action my_drop() {
         smeta.ingress_port = standard_metadata.ingress_port;
         smeta.egress_spec = standard_metadata.egress_spec;
@@ -60,7 +60,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.parser_error = smeta.parser_error;
         standard_metadata.priority = smeta.priority;
     }
-    @name("ingress.set_port") action set_port(bit<9> output_port) {
+    @name("ingress.set_port") action set_port(@name("output_port") bit<9> output_port) {
         standard_metadata.egress_spec = output_port;
     }
     @name("ingress.mac_da") table mac_da_0 {

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2-frontend.p4
@@ -105,23 +105,23 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("cIngress.foo1") action foo1(IPv4Address dstAddr) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("cIngress.foo1") action foo1(@name("dstAddr") IPv4Address dstAddr_1) {
+        hdr.ipv4.dstAddr = dstAddr_1;
     }
-    @name("cIngress.foo1") action foo1_3(IPv4Address dstAddr) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("cIngress.foo1") action foo1_3(@name("dstAddr") IPv4Address dstAddr_2) {
+        hdr.ipv4.dstAddr = dstAddr_2;
     }
-    @name("cIngress.foo1") action foo1_4(IPv4Address dstAddr) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("cIngress.foo1") action foo1_4(@name("dstAddr") IPv4Address dstAddr_3) {
+        hdr.ipv4.dstAddr = dstAddr_3;
     }
-    @name("cIngress.foo2") action foo2(IPv4Address srcAddr) {
-        hdr.ipv4.srcAddr = srcAddr;
+    @name("cIngress.foo2") action foo2(@name("srcAddr") IPv4Address srcAddr_1) {
+        hdr.ipv4.srcAddr = srcAddr_1;
     }
-    @name("cIngress.foo2") action foo2_3(IPv4Address srcAddr) {
-        hdr.ipv4.srcAddr = srcAddr;
+    @name("cIngress.foo2") action foo2_3(@name("srcAddr") IPv4Address srcAddr_2) {
+        hdr.ipv4.srcAddr = srcAddr_2;
     }
-    @name("cIngress.foo2") action foo2_4(IPv4Address srcAddr) {
-        hdr.ipv4.srcAddr = srcAddr;
+    @name("cIngress.foo2") action foo2_4(@name("srcAddr") IPv4Address srcAddr_3) {
+        hdr.ipv4.srcAddr = srcAddr_3;
     }
     @name("cIngress.t0") table t0_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2-midend.p4
@@ -102,23 +102,23 @@ control cIngress(inout headers hdr, inout metadata meta, inout standard_metadata
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("cIngress.foo1") action foo1(IPv4Address dstAddr) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("cIngress.foo1") action foo1(@name("dstAddr") IPv4Address dstAddr_1) {
+        hdr.ipv4.dstAddr = dstAddr_1;
     }
-    @name("cIngress.foo1") action foo1_3(IPv4Address dstAddr) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("cIngress.foo1") action foo1_3(@name("dstAddr") IPv4Address dstAddr_2) {
+        hdr.ipv4.dstAddr = dstAddr_2;
     }
-    @name("cIngress.foo1") action foo1_4(IPv4Address dstAddr) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("cIngress.foo1") action foo1_4(@name("dstAddr") IPv4Address dstAddr_3) {
+        hdr.ipv4.dstAddr = dstAddr_3;
     }
-    @name("cIngress.foo2") action foo2(IPv4Address srcAddr) {
-        hdr.ipv4.srcAddr = srcAddr;
+    @name("cIngress.foo2") action foo2(@name("srcAddr") IPv4Address srcAddr_1) {
+        hdr.ipv4.srcAddr = srcAddr_1;
     }
-    @name("cIngress.foo2") action foo2_3(IPv4Address srcAddr) {
-        hdr.ipv4.srcAddr = srcAddr;
+    @name("cIngress.foo2") action foo2_3(@name("srcAddr") IPv4Address srcAddr_2) {
+        hdr.ipv4.srcAddr = srcAddr_2;
     }
-    @name("cIngress.foo2") action foo2_4(IPv4Address srcAddr) {
-        hdr.ipv4.srcAddr = srcAddr;
+    @name("cIngress.foo2") action foo2_4(@name("srcAddr") IPv4Address srcAddr_3) {
+        hdr.ipv4.srcAddr = srcAddr_3;
     }
     @name("cIngress.t0") table t0_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue1595-1-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-1-first.p4
@@ -14,7 +14,6 @@ control c(inout bit<32> b) {
                 b[6:3] = 4w1;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1595-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-1-frontend.p4
@@ -14,7 +14,6 @@ control c(inout bit<32> b) {
                 b[6:3] = 4w1;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1595-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-1-midend.p4
@@ -23,7 +23,6 @@ control c(inout bit<32> b) {
                 tbl_issue15951l12.apply();
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1595-1.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-1.p4
@@ -14,7 +14,6 @@ control c(inout bit<32> b) {
                 b[6:3] = 1;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1595-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-first.p4
@@ -74,7 +74,6 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
                 hdr.ethernet.srcAddr[39:32] = 8w5;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1595-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-frontend.p4
@@ -76,7 +76,6 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
                 hdr.ethernet.srcAddr[39:32] = 8w5;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1595-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1595-midend.p4
@@ -112,7 +112,6 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
                 tbl_issue1595l79.apply();
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1595.p4
+++ b/testdata/p4_16_samples_outputs/issue1595.p4
@@ -74,7 +74,6 @@ control cIngress(inout Parsed_packet hdr, inout metadata_t meta, inout standard_
                 hdr.ethernet.srcAddr[39:32] = 5;
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-frontend.p4
@@ -60,9 +60,9 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name("MyIngress.drop") action drop() {
         mark_to_drop(standard_metadata);
     }
-    @name("MyIngress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
+    @name("MyIngress.ipv4_forward") action ipv4_forward(@name("dstAddr") macAddr_t dstAddr_1, @name("port") egressSpec_t port) {
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
-        hdr.ethernet.dstAddr = dstAddr;
+        hdr.ethernet.dstAddr = dstAddr_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
         hdr.ipv4.hdrChecksum = 16w1;

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2-midend.p4
@@ -74,9 +74,9 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name("MyIngress.drop") action drop() {
         mark_to_drop(standard_metadata);
     }
-    @name("MyIngress.ipv4_forward") action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
+    @name("MyIngress.ipv4_forward") action ipv4_forward(@name("dstAddr") macAddr_t dstAddr_1, @name("port") egressSpec_t port) {
         hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
-        hdr.ethernet.dstAddr = dstAddr;
+        hdr.ethernet.dstAddr = dstAddr_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
         hdr.ipv4.hdrChecksum = 16w1;

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-frontend.p4
@@ -51,15 +51,15 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+    @name(".my_drop") action my_drop(@name("smeta") inout standard_metadata_t smeta) {
         mark_to_drop(smeta);
     }
-    @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
+    @name(".my_drop") action my_drop_0(@name("smeta") inout standard_metadata_t smeta_1) {
         mark_to_drop(smeta_1);
     }
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("ingress.set_output") action set_output(bit<9> out_port) {
+    @name("ingress.set_output") action set_output(@name("out_port") bit<9> out_port) {
         standard_metadata.egress_spec = out_port;
     }
     @name("ingress.ipv4_da_lpm") table ipv4_da_lpm_0 {

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2-midend.p4
@@ -51,8 +51,8 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
-    standard_metadata_t smeta;
-    standard_metadata_t smeta_1;
+    @name("smeta") standard_metadata_t smeta;
+    @name("smeta") standard_metadata_t smeta_1;
     @name(".my_drop") action my_drop() {
         smeta.ingress_port = standard_metadata.ingress_port;
         smeta.egress_spec = standard_metadata.egress_spec;
@@ -125,7 +125,7 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
     }
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("ingress.set_output") action set_output(bit<9> out_port) {
+    @name("ingress.set_output") action set_output(@name("out_port") bit<9> out_port) {
         standard_metadata.egress_spec = out_port;
     }
     @name("ingress.ipv4_da_lpm") table ipv4_da_lpm_0 {

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2-frontend.p4
@@ -185,11 +185,11 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @name("MyIngress.mac_tmp") mac_addr_t mac_tmp_0;
     @name("MyIngress.addr_tmp") ipv6_addr_t addr_tmp_0;
-    @name("MyIngress.set_egress_port") action set_egress_port(port_t out_port) {
+    @name("MyIngress.set_egress_port") action set_egress_port(@name("out_port") port_t out_port) {
         standard_metadata.egress_spec = out_port;
     }
-    @name("MyIngress.set_egress_port") action set_egress_port_2(port_t out_port) {
-        standard_metadata.egress_spec = out_port;
+    @name("MyIngress.set_egress_port") action set_egress_port_2(@name("out_port") port_t out_port_1) {
+        standard_metadata.egress_spec = out_port_1;
     }
     @name("MyIngress.controller_debug") action controller_debug() {
         meta.task = 16w3;
@@ -201,13 +201,13 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         meta.ingress_port = standard_metadata.ingress_port;
         clone3<metadata>(CloneType.I2E, 32w100, meta);
     }
-    @name("MyIngress.controller_reply") action controller_reply(task_t task) {
-        meta.task = task;
+    @name("MyIngress.controller_reply") action controller_reply(@name("task") task_t task_1) {
+        meta.task = task_1;
         meta.ingress_port = standard_metadata.ingress_port;
         clone3<metadata>(CloneType.I2E, 32w100, meta);
     }
-    @name("MyIngress.controller_reply") action controller_reply_2(task_t task) {
-        meta.task = task;
+    @name("MyIngress.controller_reply") action controller_reply_2(@name("task") task_t task_2) {
+        meta.task = task_2;
         meta.ingress_port = standard_metadata.ingress_port;
         clone3<metadata>(CloneType.I2E, 32w100, meta);
     }

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2-midend.p4
@@ -193,11 +193,11 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("MyIngress.set_egress_port") action set_egress_port(port_t out_port) {
+    @name("MyIngress.set_egress_port") action set_egress_port(@name("out_port") port_t out_port) {
         standard_metadata.egress_spec = out_port;
     }
-    @name("MyIngress.set_egress_port") action set_egress_port_2(port_t out_port) {
-        standard_metadata.egress_spec = out_port;
+    @name("MyIngress.set_egress_port") action set_egress_port_2(@name("out_port") port_t out_port_1) {
+        standard_metadata.egress_spec = out_port_1;
     }
     @name("MyIngress.controller_debug") action controller_debug() {
         meta.task = 16w3;
@@ -209,13 +209,13 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         meta.ingress_port = standard_metadata.ingress_port;
         clone3<metadata>(CloneType.I2E, 32w100, meta);
     }
-    @name("MyIngress.controller_reply") action controller_reply(task_t task) {
-        meta.task = task;
+    @name("MyIngress.controller_reply") action controller_reply(@name("task") task_t task_1) {
+        meta.task = task_1;
         meta.ingress_port = standard_metadata.ingress_port;
         clone3<metadata>(CloneType.I2E, 32w100, meta);
     }
-    @name("MyIngress.controller_reply") action controller_reply_2(task_t task) {
-        meta.task = task;
+    @name("MyIngress.controller_reply") action controller_reply_2(@name("task") task_t task_2) {
+        meta.task = task_2;
         meta.ingress_port = standard_metadata.ingress_port;
         clone3<metadata>(CloneType.I2E, 32w100, meta);
     }

--- a/testdata/p4_16_samples_outputs/issue1781-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1781-bmv2-frontend.p4
@@ -16,7 +16,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("IngressImpl.value") bit<32> value_0;
-    @name("IngressImpl.update_value") action update_value(out bit<32> value_2) {
+    @name("IngressImpl.update_value") action update_value(@name("value") out bit<32> value_2) {
         {
             @name("IngressImpl.hasReturned") bool hasReturned = false;
             @name("IngressImpl.retval") bit<32> retval;

--- a/testdata/p4_16_samples_outputs/issue1834-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1834-bmv2-frontend.p4
@@ -19,7 +19,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("IngressImpl.act") action act(test_t a) {
+    @name("IngressImpl.act") action act(@name("a") test_t a) {
     }
     @name("IngressImpl.test_table") table test_table_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue1834-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1834-bmv2-midend.p4
@@ -19,7 +19,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control IngressImpl(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("IngressImpl.act") action act(test_t a) {
+    @name("IngressImpl.act") action act(@name("a") test_t a) {
     }
     @name("IngressImpl.test_table") table test_table_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue1937-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1937-1-bmv2-frontend.p4
@@ -15,10 +15,10 @@ struct metadata_t {
 }
 
 control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name(".foo") action foo(out bit<8> x, in bit<8> y=5) {
+    @name(".foo") action foo(@name("x") out bit<8> x, @name("y") in bit<8> y=5) {
         x = y >> 2;
     }
-    @name(".foo") action foo_0(out bit<8> x_1, in bit<8> y_1=5) {
+    @name(".foo") action foo_0(@name("x") out bit<8> x_1, @name("y") in bit<8> y_1=5) {
         x_1 = y_1 >> 2;
     }
     @name("ingressImpl.tmp") bit<8> tmp;

--- a/testdata/p4_16_samples_outputs/issue1985-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1985-frontend.p4
@@ -32,7 +32,7 @@ control c2(inout headers hdr, inout metadata meta, inout standard_metadata_t std
 control c3(inout headers hdr, inout metadata meta, inout standard_metadata_t std_meta) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("c3.a") action a(in bool b_1) {
+    @name("c3.a") action a(@name("b") in bool b_1) {
         hdr.h.x = 8w0;
     }
     @name("c3.t") table t_0 {

--- a/testdata/p4_16_samples_outputs/issue1997-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1997-first.p4
@@ -39,7 +39,6 @@ control c(in hdr h, inout standard_metadata_t standard_meta) {
                         8w0x1 : a();
                         8w0x2 : b();
         }
-
     }
     apply {
         t.apply();

--- a/testdata/p4_16_samples_outputs/issue1997.p4
+++ b/testdata/p4_16_samples_outputs/issue1997.p4
@@ -39,7 +39,6 @@ control c(in hdr h, inout standard_metadata_t standard_meta) {
                         0x1 : a();
                         0x2 : b();
         }
-
     }
     apply {
         t.apply();

--- a/testdata/p4_16_samples_outputs/issue2147-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2147-1-frontend.p4
@@ -1,6 +1,6 @@
 control ingress(inout bit<8> h) {
     @name("ingress.tmp") bit<8> tmp_0;
-    @name("ingress.a") action a(inout bit<8> b) {
+    @name("ingress.a") action a(@name("b") inout bit<8> b) {
     }
     apply {
         tmp_0 = h;

--- a/testdata/p4_16_samples_outputs/issue2147-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2147-bmv2-frontend.p4
@@ -36,7 +36,7 @@ parser p(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout standa
 
 control ingress(inout Parsed_packet hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
     @name("ingress.tmp") bit<7> tmp_0;
-    @name("ingress.do_action") action do_action(inout bit<7> in_bit) {
+    @name("ingress.do_action") action do_action(@name("in_bit") inout bit<7> in_bit) {
         hdr.h.a[0:0] = 1w0;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/issue2147-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2147-frontend.p4
@@ -1,6 +1,6 @@
 control ingress(inout bit<8> h) {
     @name("ingress.tmp") bit<7> tmp_0;
-    @name("ingress.a") action a(inout bit<7> b) {
+    @name("ingress.a") action a(@name("b") inout bit<7> b) {
         h[0:0] = 1w0;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2-first.p4
@@ -62,7 +62,6 @@ control ingress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
             default: {
             }
         }
-
         if (tmp_condition > 8w0) {
             hdr.h.a = 8w0;
         }

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2-frontend.p4
@@ -62,7 +62,6 @@ control ingress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
             default: {
             }
         }
-
         if (tmp_condition_0 > 8w0) {
             hdr.h.a = 8w0;
         }

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2-midend.p4
@@ -90,7 +90,6 @@ control ingress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
             default: {
             }
         }
-
         if (tmp_condition_0 > 8w0) {
             tbl_issue2153bmv2l79.apply();
         }

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2.p4
@@ -60,7 +60,6 @@ control ingress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
                 tmp_condition = 8w1;
             }
         }
-
         if (tmp_condition > 0) {
             hdr.h.a = 8w0;
         }

--- a/testdata/p4_16_samples_outputs/issue2170-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2170-bmv2-first.p4
@@ -61,7 +61,6 @@ control ingress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
             default: {
             }
         }
-
         hdr.h.a = 8w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue2170-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2170-bmv2-frontend.p4
@@ -60,7 +60,6 @@ control ingress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
             default: {
             }
         }
-
         if (!hasReturned) {
             hdr.h.a = 8w0;
         }

--- a/testdata/p4_16_samples_outputs/issue2170-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2170-bmv2-midend.p4
@@ -89,7 +89,6 @@ control ingress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
             default: {
             }
         }
-
         if (!hasReturned) {
             tbl_issue2170bmv2l77.apply();
         }

--- a/testdata/p4_16_samples_outputs/issue2170-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue2170-bmv2.p4
@@ -59,7 +59,6 @@ control ingress(inout Parsed_packet hdr, inout Metadata meta, inout standard_met
                 return;
             }
         }
-
         hdr.h.a = 8w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue2176-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2176-bmv2-frontend.p4
@@ -39,7 +39,7 @@ control ingress(inout Parsed_packet h, inout Metadata m, inout standard_metadata
     @name("ingress.tmp") bit<8> tmp;
     @name("ingress.tmp_0") bit<8> tmp_0;
     @name("ingress.tmp_1") bit<8> tmp_1;
-    @name("ingress.do_action_2") action do_action_0(inout bit<8> val_0, inout bit<8> val_1, inout bit<8> val_2) {
+    @name("ingress.do_action_2") action do_action_0(@name("val_0") inout bit<8> val_0, @name("val_1") inout bit<8> val_1, @name("val_2") inout bit<8> val_2) {
         val_1 = 8w2;
         val_2 = 8w0;
     }

--- a/testdata/p4_16_samples_outputs/issue2176-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2176-bmv2.p4-stderr
@@ -9,10 +9,10 @@ issue2176-bmv2.p4(43): [--Wwarn=ordering] warning: h.h.b: 'out' argument has fie
                            ^^^^^
 issue2176-bmv2.p4(43)
         do_action_2(h.h.b, h.h.b, h.h.b);
-                                  ^^^^^
+                    ^^^^^
 issue2176-bmv2.p4(43): [--Wwarn=ordering] warning: h.h.b: 'out' argument has fields in common with h.h.b
         do_action_2(h.h.b, h.h.b, h.h.b);
                                   ^^^^^
 issue2176-bmv2.p4(43)
         do_action_2(h.h.b, h.h.b, h.h.b);
-                           ^^^^^
+                    ^^^^^

--- a/testdata/p4_16_samples_outputs/issue2225-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2225-bmv2-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.do_action") action do_action(inout bit<16> val_0) {
+    @name("ingress.do_action") action do_action(@name("val_0") inout bit<16> val_0) {
         val_0 = 16w3;
         exit;
     }

--- a/testdata/p4_16_samples_outputs/issue2289-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2289-frontend.p4
@@ -31,7 +31,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.simple_action") action simple_action(out bit<16> byaA) {
+    @name("ingress.simple_action") action simple_action(@name("byaA") out bit<16> byaA) {
     }
     apply {
         simple_action(h.eth_hdr.eth_type);
@@ -60,3 +60,4 @@ control deparser(packet_out b, in Headers h) {
 }
 
 V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2289-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2289-midend.p4
@@ -31,7 +31,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    bit<16> byaA;
+    @name("byaA") bit<16> byaA;
     @name("ingress.simple_action") action simple_action() {
         h.eth_hdr.eth_type = byaA;
     }

--- a/testdata/p4_16_samples_outputs/issue2291-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2291-bmv2-frontend.p4
@@ -52,3 +52,4 @@ control deparser(packet_out b, in Headers h) {
 }
 
 V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-frontend.p4
@@ -34,7 +34,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
                 @name("ingress.val1") Headers val1 = h;
                 {
                     @name("ingress.dst") bit<48> dst = val1.eth_hdr.dst_addr;
-                    @name("ingress.type_1") bit<16> type_1 = val1.eth_hdr.eth_type;
+                    @name("ingress.type") bit<16> type_1 = val1.eth_hdr.eth_type;
                     @name("ingress.c") bool c_0;
                     @name("ingress.c1") bool c1_0;
                     c_0 = true;

--- a/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-midend.p4
@@ -25,7 +25,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     ethernet_t val1_eth_hdr;
     @name("ingress.dst") bit<48> dst;
-    @name("ingress.type_1") bit<16> type_1;
+    @name("ingress.type") bit<16> type_1;
     @name("ingress.c") bool c_0;
     @name("ingress.c1") bool c1_0;
     @name("ingress.simple_action") action simple_action() {

--- a/testdata/p4_16_samples_outputs/issue2359-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2359-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.do_action") action do_action(inout bit<48> val) {
+    @name("ingress.do_action") action do_action(@name("val") inout bit<48> val) {
         @name("ingress.hasReturned") bool hasReturned = false;
         if (h.eth_hdr.eth_type == 16w1) {
             hasReturned = true;

--- a/testdata/p4_16_samples_outputs/issue2375-1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2375-1-bmv2-frontend.p4
@@ -24,7 +24,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") bool tmp_0;
-    @name("ingress.do_action") action do_action(inout bool val) {
+    @name("ingress.do_action") action do_action(@name("val") inout bool val) {
         {
             @name("ingress.val_1") bool val_1 = tmp_0;
             @name("ingress.hasReturned") bool hasReturned = false;

--- a/testdata/p4_16_samples_outputs/issue2375-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2375-1-bmv2-midend.p4
@@ -24,7 +24,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") bool tmp_0;
-    bool val;
+    @name("val") bool val;
     @name("ingress.do_action") action do_action() {
         val = tmp_0;
         tmp_0 = val;

--- a/testdata/p4_16_samples_outputs/issue2375-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2375-bmv2-frontend.p4
@@ -26,7 +26,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.tmp") bool tmp_0;
-    @name("ingress.do_action") action do_action(inout bool val1, inout bool val2) {
+    @name("ingress.do_action") action do_action(@name("val1") inout bool val1, @name("val2") inout bool val2) {
     }
     @name("ingress.simple_table") table simple_table_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue2375-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2375-bmv2-midend.p4
@@ -24,7 +24,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") bool tmp_0;
-    bool val2;
+    @name("val2") bool val2;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.do_action") action do_action() {

--- a/testdata/p4_16_samples_outputs/issue2498-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2498-bmv2-frontend.p4
@@ -30,7 +30,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") bit<1> tmp;
-    @name("ingress.slice_action") action slice_action(inout bit<1> sliced_val) {
+    @name("ingress.slice_action") action slice_action(@name("sliced_val") inout bit<1> sliced_val) {
         h.h.a = 8w2;
         sliced_val = 1w1;
     }

--- a/testdata/p4_16_samples_outputs/issue2514-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2514-first.p4
@@ -47,7 +47,6 @@ control MyIngress(inout my_headers_t hdr, inout my_meta_t meta) {
                         16w0x101 &&& 16w0x505 : hit(16w5);
                         default : hit(16w0);
         }
-
         default_action = NoAction();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/issue2514-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2514-frontend.p4
@@ -17,7 +17,7 @@ struct my_meta_t {
 control MyIngress(inout my_headers_t hdr, inout my_meta_t meta) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("MyIngress.hit") action hit(bit<16> p) {
+    @name("MyIngress.hit") action hit(@name("p") bit<16> p) {
         hdr.h.f1 = p;
     }
     @name("MyIngress.t") table t_0 {
@@ -33,7 +33,6 @@ control MyIngress(inout my_headers_t hdr, inout my_meta_t meta) {
                         16w0x101 &&& 16w0x505 : hit(16w5);
                         default : hit(16w0);
         }
-
         default_action = NoAction_0();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/issue2514-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2514-midend.p4
@@ -17,7 +17,7 @@ struct my_meta_t {
 control MyIngress(inout my_headers_t hdr, inout my_meta_t meta) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("MyIngress.hit") action hit(bit<16> p) {
+    @name("MyIngress.hit") action hit(@name("p") bit<16> p) {
         hdr.h.f1 = p;
     }
     @name("MyIngress.t") table t_0 {
@@ -33,7 +33,6 @@ control MyIngress(inout my_headers_t hdr, inout my_meta_t meta) {
                         16w0x101 &&& 16w0x505 : hit(16w5);
                         default : hit(16w0);
         }
-
         default_action = NoAction_0();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/issue2514.p4
+++ b/testdata/p4_16_samples_outputs/issue2514.p4
@@ -46,7 +46,6 @@ control MyIngress(inout my_headers_t hdr, inout my_meta_t meta) {
                         16w0x101 &&& 16w0x505 : hit(5);
                         default : hit(0);
         }
-
     }
     apply {
         t.apply();

--- a/testdata/p4_16_samples_outputs/issue2710-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2710-first.p4
@@ -1,0 +1,28 @@
+#include <core.p4>
+
+control Wrapped(inout bit<8> valueSet) {
+    @name("set") action set(bit<8> value) {
+        valueSet = value;
+    }
+    @name("doSet") table doSet {
+        actions = {
+            set();
+        }
+        default_action = set(8w0);
+    }
+    apply {
+        doSet.apply();
+    }
+}
+
+control Wrapper(inout bit<8> value) {
+    Wrapped() wrapped;
+    apply {
+        wrapped.apply(value);
+    }
+}
+
+control c(inout bit<8> v);
+package top(c _c);
+top(Wrapper()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2710-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2710-frontend.p4
@@ -1,0 +1,21 @@
+#include <core.p4>
+
+control Wrapper(inout bit<8> value) {
+    @name("Wrapper.wrapped.set") action wrapped_set_0(@name("value") bit<8> value_1) {
+        value = value_1;
+    }
+    @name("Wrapper.wrapped.doSet") table wrapped_doSet {
+        actions = {
+            wrapped_set_0();
+        }
+        default_action = wrapped_set_0(8w0);
+    }
+    apply {
+        wrapped_doSet.apply();
+    }
+}
+
+control c(inout bit<8> v);
+package top(c _c);
+top(Wrapper()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2710-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2710-midend.p4
@@ -1,0 +1,21 @@
+#include <core.p4>
+
+control Wrapper(inout bit<8> value) {
+    @name("Wrapper.wrapped.set") action wrapped_set_0(@name("value") bit<8> value_1) {
+        value = value_1;
+    }
+    @name("Wrapper.wrapped.doSet") table wrapped_doSet {
+        actions = {
+            wrapped_set_0();
+        }
+        default_action = wrapped_set_0(8w0);
+    }
+    apply {
+        wrapped_doSet.apply();
+    }
+}
+
+control c(inout bit<8> v);
+package top(c _c);
+top(Wrapper()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2710.p4
+++ b/testdata/p4_16_samples_outputs/issue2710.p4
@@ -1,0 +1,28 @@
+#include <core.p4>
+
+control Wrapped(inout bit<8> valueSet) {
+    @name("set") action set(bit<8> value) {
+        valueSet = value;
+    }
+    @name("doSet") table doSet {
+        actions = {
+            set();
+        }
+        default_action = set(8w0);
+    }
+    apply {
+        doSet.apply();
+    }
+}
+
+control Wrapper(inout bit<8> value) {
+    Wrapped() wrapped;
+    apply {
+        wrapped.apply(value);
+    }
+}
+
+control c(inout bit<8> v);
+package top(c _c);
+top(Wrapper()) main;
+

--- a/testdata/p4_16_samples_outputs/issue323-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue323-frontend.p4
@@ -42,10 +42,10 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.my_a") action my_a(bit<32> v) {
+    @name("ingress.my_a") action my_a(@name("v") bit<32> v) {
         h.h.f = v;
     }
-    @name("ingress.my_a") action my_a_2(bit<32> v_1) {
+    @name("ingress.my_a") action my_a_2(@name("v") bit<32> v_1) {
         h.h.f = v_1;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/issue364-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2-frontend.p4
@@ -43,8 +43,8 @@ control deparser(packet_out b, in Headers h) {
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.c") direct_counter(CounterType.packets) c_0;
-    @name("ingress.my_action") action my_action(bit<9> a) {
-        sm.egress_spec = a;
+    @name("ingress.my_action") action my_action(@name("a") bit<9> a_1) {
+        sm.egress_spec = a_1;
     }
     @name("ingress.t") table t_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue364-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2-midend.p4
@@ -43,8 +43,8 @@ control deparser(packet_out b, in Headers h) {
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.c") direct_counter(CounterType.packets) c_0;
-    @name("ingress.my_action") action my_action(bit<9> a) {
-        sm.egress_spec = a;
+    @name("ingress.my_action") action my_action(@name("a") bit<9> a_1) {
+        sm.egress_spec = a_1;
     }
     @name("ingress.t") table t_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue420-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue420-frontend.p4
@@ -34,7 +34,7 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout mystruct1 meta, inout
 control cIngress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_metadata_t stdmeta) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("cIngress.foo") action foo(bit<16> bar) {
+    @name("cIngress.foo") action foo(@name("bar") bit<16> bar) {
         @name("cIngress.hasReturned") bool hasReturned = false;
         if (bar == 16w0xf00d) {
             hdr.ethernet.srcAddr = 48w0xdeadbeeff00d;

--- a/testdata/p4_16_samples_outputs/issue420-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue420-midend.p4
@@ -34,7 +34,7 @@ parser parserI(packet_in pkt, out Parsed_packet hdr, inout mystruct1 meta, inout
 control cIngress(inout Parsed_packet hdr, inout mystruct1 meta, inout standard_metadata_t stdmeta) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("cIngress.foo") action foo(bit<16> bar) {
+    @name("cIngress.foo") action foo(@name("bar") bit<16> bar) {
         hdr.ethernet.srcAddr = (bar == 16w0xf00d ? 48w0xdeadbeeff00d : hdr.ethernet.srcAddr);
         hdr.ethernet.srcAddr = (bar != 16w0xf00d ? 48w0x215241100ff2 : hdr.ethernet.srcAddr);
     }

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-frontend.p4
@@ -52,19 +52,19 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+    @name(".my_drop") action my_drop(@name("smeta") inout standard_metadata_t smeta) {
         mark_to_drop(smeta);
     }
     @name("ingress.ipv4_da_lpm_stats") direct_counter(CounterType.packets) ipv4_da_lpm_stats_0;
-    @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
+    @name("ingress.set_l2ptr") action set_l2ptr(@name("l2ptr") bit<32> l2ptr_1) {
         ipv4_da_lpm_stats_0.count();
-        meta.fwd_metadata.l2ptr = l2ptr;
+        meta.fwd_metadata.l2ptr = l2ptr_1;
     }
     @name("ingress.drop_with_count") action drop_with_count() {
         ipv4_da_lpm_stats_0.count();
         mark_to_drop(standard_metadata);
     }
-    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
+    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(@name("bd") bit<24> bd, @name("dmac") bit<48> dmac, @name("intf") bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;
         hdr.ethernet.dstAddr = dmac;
         standard_metadata.egress_spec = intf;
@@ -98,10 +98,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
+    @name(".my_drop") action my_drop_0(@name("smeta") inout standard_metadata_t smeta_1) {
         mark_to_drop(smeta_1);
     }
-    @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name("egress.rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/issue461-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2-midend.p4
@@ -53,7 +53,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    standard_metadata_t smeta;
+    @name("smeta") standard_metadata_t smeta;
     @name(".my_drop") action my_drop() {
         smeta.ingress_port = standard_metadata.ingress_port;
         smeta.egress_spec = standard_metadata.egress_spec;
@@ -90,15 +90,15 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.priority = smeta.priority;
     }
     @name("ingress.ipv4_da_lpm_stats") direct_counter(CounterType.packets) ipv4_da_lpm_stats_0;
-    @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
+    @name("ingress.set_l2ptr") action set_l2ptr(@name("l2ptr") bit<32> l2ptr_1) {
         ipv4_da_lpm_stats_0.count();
-        meta._fwd_metadata_l2ptr0 = l2ptr;
+        meta._fwd_metadata_l2ptr0 = l2ptr_1;
     }
     @name("ingress.drop_with_count") action drop_with_count() {
         ipv4_da_lpm_stats_0.count();
         mark_to_drop(standard_metadata);
     }
-    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
+    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(@name("bd") bit<24> bd, @name("dmac") bit<48> dmac, @name("intf") bit<9> intf) {
         meta._fwd_metadata_out_bd1 = bd;
         hdr.ethernet.dstAddr = dmac;
         standard_metadata.egress_spec = intf;
@@ -132,7 +132,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    standard_metadata_t smeta_1;
+    @name("smeta") standard_metadata_t smeta_1;
     @name(".my_drop") action my_drop_0() {
         smeta_1.ingress_port = standard_metadata.ingress_port;
         smeta_1.egress_spec = standard_metadata.egress_spec;
@@ -168,7 +168,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         standard_metadata.parser_error = smeta_1.parser_error;
         standard_metadata.priority = smeta_1.priority;
     }
-    @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name("egress.rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
@@ -237,14 +237,14 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+    @name(".my_drop") action my_drop(@name("smeta") inout standard_metadata_t smeta) {
         mark_to_drop(smeta);
     }
-    @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
+    @name(".my_drop") action my_drop_0(@name("smeta") inout standard_metadata_t smeta_1) {
         mark_to_drop(smeta_1);
     }
-    @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
-        meta.fwd_metadata.l2ptr = l2ptr;
+    @name("ingress.set_l2ptr") action set_l2ptr(@name("l2ptr") bit<32> l2ptr_1) {
+        meta.fwd_metadata.l2ptr = l2ptr_1;
     }
     @name("ingress.ipv4_da_lpm") table ipv4_da_lpm_0 {
         key = {
@@ -256,7 +256,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = my_drop(standard_metadata);
     }
-    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
+    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(@name("bd") bit<24> bd, @name("dmac") bit<48> dmac, @name("intf") bit<9> intf) {
         meta.fwd_metadata.out_bd = bd;
         hdr.ethernet.dstAddr = dmac;
         standard_metadata.egress_spec = intf;
@@ -279,10 +279,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop_1(inout standard_metadata_t smeta_2) {
+    @name(".my_drop") action my_drop_1(@name("smeta") inout standard_metadata_t smeta_2) {
         mark_to_drop(smeta_2);
     }
-    @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name("egress.rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
@@ -236,8 +236,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 }
 
 control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    standard_metadata_t smeta;
-    standard_metadata_t smeta_1;
+    @name("smeta") standard_metadata_t smeta;
+    @name("smeta") standard_metadata_t smeta_1;
     @name(".my_drop") action my_drop() {
         smeta.ingress_port = standard_metadata.ingress_port;
         smeta.egress_spec = standard_metadata.egress_spec;
@@ -308,8 +308,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         standard_metadata.parser_error = smeta_1.parser_error;
         standard_metadata.priority = smeta_1.priority;
     }
-    @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
-        meta._fwd_metadata_l2ptr0 = l2ptr;
+    @name("ingress.set_l2ptr") action set_l2ptr(@name("l2ptr") bit<32> l2ptr_1) {
+        meta._fwd_metadata_l2ptr0 = l2ptr_1;
     }
     @name("ingress.ipv4_da_lpm") table ipv4_da_lpm_0 {
         key = {
@@ -321,7 +321,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         default_action = my_drop();
     }
-    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
+    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(@name("bd") bit<24> bd, @name("dmac") bit<48> dmac, @name("intf") bit<9> intf) {
         meta._fwd_metadata_out_bd1 = bd;
         hdr.ethernet.dstAddr = dmac;
         standard_metadata.egress_spec = intf;
@@ -344,7 +344,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
 }
 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    standard_metadata_t smeta_2;
+    @name("smeta") standard_metadata_t smeta_2;
     @name(".my_drop") action my_drop_1() {
         smeta_2.ingress_port = standard_metadata.ingress_port;
         smeta_2.egress_spec = standard_metadata.egress_spec;
@@ -380,7 +380,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         standard_metadata.parser_error = smeta_2.parser_error;
         standard_metadata.priority = smeta_2.priority;
     }
-    @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name("egress.rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("egress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/issue870_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue870_ebpf-frontend.p4
@@ -46,9 +46,9 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4.srcAddr = add[31:16] ++ add[15:0];
+        headers.ipv4.srcAddr = add_1[31:16] ++ add_1[15:0];
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue870_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue870_ebpf-midend.p4
@@ -47,9 +47,9 @@ control pipe(inout Headers_t headers, out bool pass) {
     @name("pipe.hasReturned") bool hasReturned;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4.srcAddr = add[31:16] ++ add[15:0];
+        headers.ipv4.srcAddr = add_1[31:16] ++ add_1[15:0];
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/issue982-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue982-frontend.p4
@@ -362,7 +362,7 @@ parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadat
 control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name("ingress.do_clone") action do_clone(PortId_t port) {
+    @name("ingress.do_clone") action do_clone(@name("port") PortId_t port) {
         ostd.clone = true;
         ostd.clone_port = port;
         user_meta.custom_clone_id = 3w1;

--- a/testdata/p4_16_samples_outputs/issue982-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue982-midend.p4
@@ -358,7 +358,7 @@ parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadat
 control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name("ingress.do_clone") action do_clone(PortId_t port) {
+    @name("ingress.do_clone") action do_clone(@name("port") PortId_t port) {
         ostd.clone = true;
         ostd.clone_port = port;
         user_meta._custom_clone_id1 = 3w1;

--- a/testdata/p4_16_samples_outputs/lj_example-frontend.p4
+++ b/testdata/p4_16_samples_outputs/lj_example-frontend.p4
@@ -38,13 +38,13 @@ parser LJparse(packet_in b, out Parsed_rep p) {
 }
 
 control LjPipe(inout Parsed_rep p, in error parseError, in InControl inCtrl, out OutControl outCtrl) {
-    @name("LjPipe.Drop_action") action Drop_action(out PortId port) {
+    @name("LjPipe.Drop_action") action Drop_action(@name("port") out PortId port) {
         port = 4w0xf;
     }
     @name("LjPipe.Drop_1") action Drop_0() {
         outCtrl.outputPort = 4w0xf;
     }
-    @name("LjPipe.Forward") action Forward(PortId outPort) {
+    @name("LjPipe.Forward") action Forward(@name("outPort") PortId outPort) {
         outCtrl.outputPort = outPort;
     }
     @name("LjPipe.Enet_lkup") table Enet_lkup_0 {

--- a/testdata/p4_16_samples_outputs/lj_example-midend.p4
+++ b/testdata/p4_16_samples_outputs/lj_example-midend.p4
@@ -44,7 +44,7 @@ control LjPipe(inout Parsed_rep p, in error parseError, in InControl inCtrl, out
     @name("LjPipe.Drop_1") action Drop_0() {
         outCtrl.outputPort = 4w0xf;
     }
-    @name("LjPipe.Forward") action Forward(PortId outPort) {
+    @name("LjPipe.Forward") action Forward(@name("outPort") PortId outPort) {
         outCtrl.outputPort = outPort;
     }
     @name("LjPipe.Enet_lkup") table Enet_lkup_0 {

--- a/testdata/p4_16_samples_outputs/logging-frontend.p4
+++ b/testdata/p4_16_samples_outputs/logging-frontend.p4
@@ -5,7 +5,7 @@
 control c(inout bit<32> x, inout bit<32> y) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("c.a") action a(inout bit<32> b, inout bit<32> d) {
+    @name("c.a") action a(@name("b") inout bit<32> b, @name("d") inout bit<32> d) {
         log_msg("Logging message.");
         log_msg<tuple<bit<32>, bit<32>>>("Logging values {} and {}", { b, d });
     }

--- a/testdata/p4_16_samples_outputs/lpm_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/lpm_ebpf-frontend.p4
@@ -46,9 +46,9 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4.srcAddr = add;
+        headers.ipv4.srcAddr = add_1;
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/lpm_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/lpm_ebpf-midend.p4
@@ -47,9 +47,9 @@ control pipe(inout Headers_t headers, out bool pass) {
     @name("pipe.hasReturned") bool hasReturned;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4.srcAddr = add;
+        headers.ipv4.srcAddr = add_1;
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/lpm_ubpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/lpm_ubpf-frontend.p4
@@ -49,7 +49,7 @@ parser prs(packet_in p, out Headers_t headers, inout metadata meta, inout standa
 control pipe(inout Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add) {
         mark_to_drop();
         headers.ipv4.srcAddr = add;
     }

--- a/testdata/p4_16_samples_outputs/lpm_ubpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/lpm_ubpf-midend.p4
@@ -50,7 +50,7 @@ control pipe(inout Headers_t headers, inout metadata meta, inout standard_metada
     @name("pipe.hasReturned") bool hasReturned;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add) {
         mark_to_drop();
         headers.ipv4.srcAddr = add;
     }

--- a/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-frontend.p4
@@ -34,7 +34,7 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
     @name("ingressImpl.my_drop") action my_drop() {
         mark_to_drop(stdmeta);
     }
-    @name("ingressImpl.foo") action foo(bit<9> out_port) {
+    @name("ingressImpl.foo") action foo(@name("out_port") bit<9> out_port) {
         hdr.ethernet.dstAddr[22:18] = hdr.ethernet.srcAddr[5:1];
         stdmeta.egress_spec = out_port;
     }

--- a/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs-bmv2-midend.p4
@@ -36,7 +36,7 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
     @name("ingressImpl.my_drop") action my_drop() {
         mark_to_drop(stdmeta);
     }
-    @name("ingressImpl.foo") action foo(bit<9> out_port) {
+    @name("ingressImpl.foo") action foo(@name("out_port") bit<9> out_port) {
         hdr.ethernet.dstAddr[22:18] = hdr.ethernet.srcAddr[5:1];
         stdmeta.egress_spec = out_port;
     }

--- a/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-frontend.p4
@@ -34,7 +34,7 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
     @name("ingressImpl.my_drop") action my_drop() {
         mark_to_drop(stdmeta);
     }
-    @name("ingressImpl.foo") action foo(bit<9> out_port) {
+    @name("ingressImpl.foo") action foo(@name("out_port") bit<9> out_port) {
         hdr.ethernet.dstAddr[22:18] = hdr.ethernet.srcAddr[5:1];
         stdmeta.egress_spec = out_port;
     }

--- a/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2-midend.p4
@@ -36,7 +36,7 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
     @name("ingressImpl.my_drop") action my_drop() {
         mark_to_drop(stdmeta);
     }
-    @name("ingressImpl.foo") action foo(bit<9> out_port) {
+    @name("ingressImpl.foo") action foo(@name("out_port") bit<9> out_port) {
         hdr.ethernet.dstAddr[22:18] = hdr.ethernet.srcAddr[5:1];
         stdmeta.egress_spec = out_port;
     }

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-frontend.p4
@@ -59,7 +59,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name(".rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
@@ -92,7 +92,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".bcast") action bcast() {
         standard_metadata.mcast_grp = 16w1;
     }
-    @name(".set_dmac") action set_dmac(bit<48> dmac) {
+    @name(".set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
@@ -101,8 +101,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_4() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta.routing_metadata.nhop_ipv4 = nhop_ipv4;
+    @name(".set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta.routing_metadata.nhop_ipv4 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }

--- a/testdata/p4_16_samples_outputs/multicast-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2-midend.p4
@@ -58,7 +58,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
 control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name(".rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
     @name("._drop") action _drop() {
@@ -91,7 +91,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name(".bcast") action bcast() {
         standard_metadata.mcast_grp = 16w1;
     }
-    @name(".set_dmac") action set_dmac(bit<48> dmac) {
+    @name(".set_dmac") action set_dmac(@name("dmac") bit<48> dmac) {
         hdr.ethernet.dstAddr = dmac;
     }
     @name("._drop") action _drop_2() {
@@ -100,8 +100,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @name("._drop") action _drop_4() {
         mark_to_drop(standard_metadata);
     }
-    @name(".set_nhop") action set_nhop(bit<32> nhop_ipv4, bit<9> port) {
-        meta._routing_metadata_nhop_ipv40 = nhop_ipv4;
+    @name(".set_nhop") action set_nhop(@name("nhop_ipv4") bit<32> nhop_ipv4_1, @name("port") bit<9> port) {
+        meta._routing_metadata_nhop_ipv40 = nhop_ipv4_1;
         standard_metadata.egress_spec = port;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }

--- a/testdata/p4_16_samples_outputs/mux-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2-frontend.p4
@@ -23,7 +23,7 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
     @name("Eg._sub") bit<32> _sub_0;
     @name("Eg.res") bit<64> res_0;
     @name("Eg.tmp") bit<32> tmp;
-    @name("Eg.update") action update(in bool p_1, inout bit<64> val) {
+    @name("Eg.update") action update(@name("p") in bool p_1, @name("val") inout bit<64> val) {
         _sub_0 = val[31:0];
         if (p_1) {
             tmp = _sub_0;

--- a/testdata/p4_16_samples_outputs/mux-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2-midend.p4
@@ -21,7 +21,7 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
     @name("Eg.res") bit<64> res_0;
-    bit<64> val;
+    @name("val") bit<64> val;
     @name("Eg.update") action update() {
         val = res_0;
         val[31:0] = res_0[31:0];

--- a/testdata/p4_16_samples_outputs/named-arg1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named-arg1-frontend.p4
@@ -21,10 +21,10 @@ control c(out bool b) {
     @name("c.b_0") bool b_0;
     @name("c.x_2") bit<16> x_2;
     @name("c.b_1") bool b_1;
-    @name("c.a") action a(in bit<16> bi, out bit<16> mb) {
+    @name("c.a") action a(@name("bi") in bit<16> bi, @name("mb") out bit<16> mb) {
         mb = -bi;
     }
-    @name("c.a") action a_2(in bit<16> bi_1, out bit<16> mb_1) {
+    @name("c.a") action a_2(@name("bi") in bit<16> bi_1, @name("mb") out bit<16> mb_1) {
         mb_1 = -bi_1;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-frontend.p4
@@ -61,7 +61,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 16;
         default_action = NoAction_0();
     }
-    @name("ingress.m_action") action m_action_0(bit<9> meter_idx) {
+    @name("ingress.m_action") action m_action_0(@name("meter_idx") bit<9> meter_idx) {
         standard_metadata.egress_spec = meter_idx;
         my_meter.read(meta.meta.meter_tag);
     }

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2-midend.p4
@@ -60,7 +60,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 16;
         default_action = NoAction_0();
     }
-    @name("ingress.m_action") action m_action_0(bit<9> meter_idx) {
+    @name("ingress.m_action") action m_action_0(@name("meter_idx") bit<9> meter_idx) {
         standard_metadata.egress_spec = meter_idx;
         my_meter.read(meta._meta_meter_tag0);
     }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-frontend.p4
@@ -60,7 +60,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 16;
         default_action = NoAction_0();
     }
-    @name("ingress.m_action") action m_action_0(bit<9> meter_idx) {
+    @name("ingress.m_action") action m_action_0(@name("meter_idx") bit<9> meter_idx) {
         standard_metadata.egress_spec = 9w1;
         my_meter_0.read(meta.meta.meter_tag);
     }

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2-midend.p4
@@ -59,7 +59,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         size = 16;
         default_action = NoAction_0();
     }
-    @name("ingress.m_action") action m_action_0(bit<9> meter_idx) {
+    @name("ingress.m_action") action m_action_0(@name("meter_idx") bit<9> meter_idx) {
         standard_metadata.egress_spec = 9w1;
         my_meter_0.read(meta._meta_meter_tag0);
     }

--- a/testdata/p4_16_samples_outputs/nested_if_else-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_else-frontend.p4
@@ -65,7 +65,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name("MyIngress.z") bit<16> z_0;
     @name("MyIngress.ipv4_forward") action ipv4_forward() {
         {
-            @name("MyIngress.value_1") bit<16> value_1;
+            @name("MyIngress.value") bit<16> value_1;
             x_0 = hdr.ipv4.identification;
             y_0 = hdr.ipv4.hdrChecksum;
             z_0 = hdr.ipv4.totalLen;

--- a/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies-frontend.p4
@@ -63,7 +63,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name("MyIngress.z") bit<16> z_0;
     @name("MyIngress.ipv4_forward") action ipv4_forward() {
         {
-            @name("MyIngress.value_1") bit<16> value_1;
+            @name("MyIngress.value") bit<16> value_1;
             x_0 = hdr.ipv4.identification;
             y_0 = hdr.ipv4.hdrChecksum;
             z_0 = hdr.ipv4.totalLen;

--- a/testdata/p4_16_samples_outputs/nested_if_statement-frontend.p4
+++ b/testdata/p4_16_samples_outputs/nested_if_statement-frontend.p4
@@ -66,7 +66,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     @name("MyIngress.z") bit<16> z_0;
     @name("MyIngress.ipv4_forward") action ipv4_forward() {
         {
-            @name("MyIngress.value_1") bit<16> value_1;
+            @name("MyIngress.value") bit<16> value_1;
             y_0 = hdr.ipv4.hdrChecksum;
             z_0 = hdr.ipv4.totalLen;
             c_0 = hdr.ipv4.identification > 16w0;

--- a/testdata/p4_16_samples_outputs/op_bin-frontend.p4
+++ b/testdata/p4_16_samples_outputs/op_bin-frontend.p4
@@ -39,7 +39,7 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool xout) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.set_flowlabel") action set_flowlabel(bit<20> label) {
+    @name("pipe.set_flowlabel") action set_flowlabel(@name("label") bit<20> label) {
         headers.ipv6.ip_version_traffic_class_and_flow_label[31:12] = label;
     }
     @name("pipe.filter_tbl") table filter_tbl_0 {

--- a/testdata/p4_16_samples_outputs/op_bin-midend.p4
+++ b/testdata/p4_16_samples_outputs/op_bin-midend.p4
@@ -39,7 +39,7 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool xout) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.set_flowlabel") action set_flowlabel(bit<20> label) {
+    @name("pipe.set_flowlabel") action set_flowlabel(@name("label") bit<20> label) {
         headers.ipv6.ip_version_traffic_class_and_flow_label[31:12] = label;
     }
     @name("pipe.filter_tbl") table filter_tbl_0 {

--- a/testdata/p4_16_samples_outputs/p416-type-use3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/p416-type-use3-frontend.p4
@@ -66,25 +66,25 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
-    @name("ingress.set_output") action set_output(bit<9> out_port) {
+    @name("ingress.set_output") action set_output(@name("out_port") bit<9> out_port) {
         standard_metadata.egress_spec = out_port;
     }
-    @name("ingress.set_headers") action set_headers(bit<8> e, CustomD_t ed, CustomT_t et, CustomDD_t edd, CustomDT_t edt, CustomTD_t etd, CustomTT_t ett, CustomDDD_t eddd, CustomDDT_t eddt, CustomDTD_t edtd, CustomDTT_t edtt, CustomTDD_t etdd, CustomTDT_t etdt, CustomTTD_t ettd, CustomTTT_t ettt) {
-        hdr.custom.e = e;
-        hdr.custom.ed = ed;
-        hdr.custom.et = et;
-        hdr.custom.edd = edd;
-        hdr.custom.edt = edt;
-        hdr.custom.etd = etd;
-        hdr.custom.ett = ett;
-        hdr.custom.eddd = eddd;
-        hdr.custom.eddt = eddt;
-        hdr.custom.edtd = edtd;
-        hdr.custom.edtt = edtt;
-        hdr.custom.etdd = etdd;
-        hdr.custom.etdt = etdt;
-        hdr.custom.ettd = ettd;
-        hdr.custom.ettt = ettt;
+    @name("ingress.set_headers") action set_headers(@name("e") bit<8> e_1, @name("ed") CustomD_t ed_1, @name("et") CustomT_t et_1, @name("edd") CustomDD_t edd_1, @name("edt") CustomDT_t edt_1, @name("etd") CustomTD_t etd_1, @name("ett") CustomTT_t ett_1, @name("eddd") CustomDDD_t eddd_1, @name("eddt") CustomDDT_t eddt_1, @name("edtd") CustomDTD_t edtd_1, @name("edtt") CustomDTT_t edtt_1, @name("etdd") CustomTDD_t etdd_1, @name("etdt") CustomTDT_t etdt_1, @name("ettd") CustomTTD_t ettd_1, @name("ettt") CustomTTT_t ettt_1) {
+        hdr.custom.e = e_1;
+        hdr.custom.ed = ed_1;
+        hdr.custom.et = et_1;
+        hdr.custom.edd = edd_1;
+        hdr.custom.edt = edt_1;
+        hdr.custom.etd = etd_1;
+        hdr.custom.ett = ett_1;
+        hdr.custom.eddd = eddd_1;
+        hdr.custom.eddt = eddt_1;
+        hdr.custom.edtd = edtd_1;
+        hdr.custom.edtt = edtt_1;
+        hdr.custom.etdd = etdd_1;
+        hdr.custom.etdt = etdt_1;
+        hdr.custom.ettd = ettd_1;
+        hdr.custom.ettt = ettt_1;
     }
     @name("ingress.my_drop") action my_drop() {
     }

--- a/testdata/p4_16_samples_outputs/p416-type-use3-midend.p4
+++ b/testdata/p4_16_samples_outputs/p416-type-use3-midend.p4
@@ -66,25 +66,25 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
-    @name("ingress.set_output") action set_output(bit<9> out_port) {
+    @name("ingress.set_output") action set_output(@name("out_port") bit<9> out_port) {
         standard_metadata.egress_spec = out_port;
     }
-    @name("ingress.set_headers") action set_headers(bit<8> e, CustomD_t ed, CustomT_t et, CustomDD_t edd, CustomDT_t edt, CustomTD_t etd, CustomTT_t ett, CustomDDD_t eddd, CustomDDT_t eddt, CustomDTD_t edtd, CustomDTT_t edtt, CustomTDD_t etdd, CustomTDT_t etdt, CustomTTD_t ettd, CustomTTT_t ettt) {
-        hdr.custom.e = e;
-        hdr.custom.ed = ed;
-        hdr.custom.et = et;
-        hdr.custom.edd = edd;
-        hdr.custom.edt = edt;
-        hdr.custom.etd = etd;
-        hdr.custom.ett = ett;
-        hdr.custom.eddd = eddd;
-        hdr.custom.eddt = eddt;
-        hdr.custom.edtd = edtd;
-        hdr.custom.edtt = edtt;
-        hdr.custom.etdd = etdd;
-        hdr.custom.etdt = etdt;
-        hdr.custom.ettd = ettd;
-        hdr.custom.ettt = ettt;
+    @name("ingress.set_headers") action set_headers(@name("e") bit<8> e_1, @name("ed") CustomD_t ed_1, @name("et") CustomT_t et_1, @name("edd") CustomDD_t edd_1, @name("edt") CustomDT_t edt_1, @name("etd") CustomTD_t etd_1, @name("ett") CustomTT_t ett_1, @name("eddd") CustomDDD_t eddd_1, @name("eddt") CustomDDT_t eddt_1, @name("edtd") CustomDTD_t edtd_1, @name("edtt") CustomDTT_t edtt_1, @name("etdd") CustomTDD_t etdd_1, @name("etdt") CustomTDT_t etdt_1, @name("ettd") CustomTTD_t ettd_1, @name("ettt") CustomTTT_t ettt_1) {
+        hdr.custom.e = e_1;
+        hdr.custom.ed = ed_1;
+        hdr.custom.et = et_1;
+        hdr.custom.edd = edd_1;
+        hdr.custom.edt = edt_1;
+        hdr.custom.etd = etd_1;
+        hdr.custom.ett = ett_1;
+        hdr.custom.eddd = eddd_1;
+        hdr.custom.eddt = eddt_1;
+        hdr.custom.edtd = edtd_1;
+        hdr.custom.edtt = edtt_1;
+        hdr.custom.etdd = etdd_1;
+        hdr.custom.etdt = etdt_1;
+        hdr.custom.ettd = ettd_1;
+        hdr.custom.ettt = ettt_1;
     }
     @name("ingress.my_drop") action my_drop() {
     }

--- a/testdata/p4_16_samples_outputs/parser-pragma.p4
+++ b/testdata/p4_16_samples_outputs/parser-pragma.p4
@@ -8,7 +8,6 @@ header ethernet_t {
     bit<16> eth_type;
 }
 
-
 struct Headers {
     ethernet_t eth_hdr;
 }
@@ -20,7 +19,7 @@ struct S {
     bit<8> c;
 }
 
-parser p( packet_in pkt, out Headers hdr, inout S s, inout standard_metadata_t sm) {
+parser p(packet_in pkt, out Headers hdr, inout S s, inout standard_metadata_t sm) {
     state start {
         pkt.extract(hdr.eth_hdr);
         s.start = 0;
@@ -42,7 +41,6 @@ parser p( packet_in pkt, out Headers hdr, inout S s, inout standard_metadata_t s
 
 control ingress(inout Headers h, inout S s, inout standard_metadata_t sm) {
     apply {
-
     }
 }
 
@@ -68,3 +66,4 @@ control deparser(packet_out pkt, in Headers h) {
 }
 
 V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/pipe-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pipe-frontend.p4
@@ -37,10 +37,10 @@ struct Packet_data {
 control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("Q_pipe.p1.thost.B_action") action p1_thost_B_action_0(out bit<9> barg, BParamType bData) {
+    @name("Q_pipe.p1.thost.B_action") action p1_thost_B_action_0(@name("barg") out bit<9> barg, @name("bData") BParamType bData) {
         barg = bData;
     }
-    @name("Q_pipe.p1.thost.C_action") action p1_thost_C_action_0(bit<9> cData) {
+    @name("Q_pipe.p1.thost.C_action") action p1_thost_C_action_0(@name("cData") bit<9> cData) {
         qArg1.field1 = cData;
     }
     @name("Q_pipe.p1.thost.T") table p1_thost_T {

--- a/testdata/p4_16_samples_outputs/pipe-midend.p4
+++ b/testdata/p4_16_samples_outputs/pipe-midend.p4
@@ -37,10 +37,10 @@ struct Packet_data {
 control Q_pipe(inout TArg1 qArg1, inout TArg2 qArg2) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("Q_pipe.p1.thost.B_action") action p1_thost_B_action_0(BParamType bData) {
+    @name("Q_pipe.p1.thost.B_action") action p1_thost_B_action_0(@name("bData") BParamType bData) {
         qArg1.field1 = bData;
     }
-    @name("Q_pipe.p1.thost.C_action") action p1_thost_C_action_0(bit<9> cData) {
+    @name("Q_pipe.p1.thost.C_action") action p1_thost_C_action_0(@name("cData") bit<9> cData) {
         qArg1.field1 = cData;
     }
     @name("Q_pipe.p1.thost.T") table p1_thost_T {

--- a/testdata/p4_16_samples_outputs/predication_issue-frontend.p4
+++ b/testdata/p4_16_samples_outputs/predication_issue-frontend.p4
@@ -23,7 +23,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name(".assign_addrs") action assign_addrs(inout Headers h_1, bool check_1, bool check_2) {
+    @name(".assign_addrs") action assign_addrs(@name("h") inout Headers h_1, @name("check_1") bool check_1, @name("check_2") bool check_2) {
         h_1.eth_hdr.dst_addr = 48w4;
         if (check_1) {
             h_1.eth_hdr.dst_addr = 48w2;

--- a/testdata/p4_16_samples_outputs/proliferation1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/proliferation1-frontend.p4
@@ -28,69 +28,69 @@ control MyVerifyChecksum(inout headers hdr, inout metadata meta) {
 }
 
 control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("MyIngress.do_n_rounds") action do_n_rounds(inout bit<16> x_0) {
+    @name("MyIngress.do_n_rounds") action do_n_rounds(@name("x") inout bit<16> x_0) {
         {
             @name("MyIngress.x") bit<16> x = x_0;
             x = x + 16w65535 & x;
             x_0 = x;
         }
         {
-            @name("MyIngress.x_2") bit<16> x_2 = x_0;
+            @name("MyIngress.x") bit<16> x_2 = x_0;
             x_2 = x_2 + 16w65535 & x_2;
             x_0 = x_2;
         }
         {
-            @name("MyIngress.x_3") bit<16> x_3 = x_0;
+            @name("MyIngress.x") bit<16> x_3 = x_0;
             x_3 = x_3 + 16w65535 & x_3;
             x_0 = x_3;
         }
         {
-            @name("MyIngress.x_4") bit<16> x_4 = x_0;
+            @name("MyIngress.x") bit<16> x_4 = x_0;
             x_4 = x_4 + 16w65535 & x_4;
             x_0 = x_4;
         }
         {
-            @name("MyIngress.x_5") bit<16> x_5 = x_0;
+            @name("MyIngress.x") bit<16> x_5 = x_0;
             x_5 = x_5 + 16w65535 & x_5;
             x_0 = x_5;
         }
         {
-            @name("MyIngress.x_6") bit<16> x_6 = x_0;
+            @name("MyIngress.x") bit<16> x_6 = x_0;
             x_6 = x_6 + 16w65535 & x_6;
             x_0 = x_6;
         }
         {
-            @name("MyIngress.x_7") bit<16> x_7 = x_0;
+            @name("MyIngress.x") bit<16> x_7 = x_0;
             x_7 = x_7 + 16w65535 & x_7;
             x_0 = x_7;
         }
         {
-            @name("MyIngress.x_8") bit<16> x_8 = x_0;
+            @name("MyIngress.x") bit<16> x_8 = x_0;
             x_8 = x_8 + 16w65535 & x_8;
             x_0 = x_8;
         }
         {
-            @name("MyIngress.x_9") bit<16> x_9 = x_0;
+            @name("MyIngress.x") bit<16> x_9 = x_0;
             x_9 = x_9 + 16w65535 & x_9;
             x_0 = x_9;
         }
         {
-            @name("MyIngress.x_10") bit<16> x_10 = x_0;
+            @name("MyIngress.x") bit<16> x_10 = x_0;
             x_10 = x_10 + 16w65535 & x_10;
             x_0 = x_10;
         }
         {
-            @name("MyIngress.x_11") bit<16> x_11 = x_0;
+            @name("MyIngress.x") bit<16> x_11 = x_0;
             x_11 = x_11 + 16w65535 & x_11;
             x_0 = x_11;
         }
         {
-            @name("MyIngress.x_12") bit<16> x_12 = x_0;
+            @name("MyIngress.x") bit<16> x_12 = x_0;
             x_12 = x_12 + 16w65535 & x_12;
             x_0 = x_12;
         }
         {
-            @name("MyIngress.x_13") bit<16> x_13 = x_0;
+            @name("MyIngress.x") bit<16> x_13 = x_0;
             x_13 = x_13 + 16w65535 & x_13;
             x_0 = x_13;
         }

--- a/testdata/p4_16_samples_outputs/psa-action-profile1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1-frontend.p4
@@ -28,11 +28,11 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-profile1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1-midend.p4
@@ -28,11 +28,11 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-profile2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile2-frontend.p4
@@ -29,11 +29,11 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
     @name("MyIC.ap1") ActionProfile(32w1024) ap1_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-profile2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile2-midend.p4
@@ -29,11 +29,11 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
     @name("MyIC.ap1") ActionProfile(32w1024) ap1_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-profile3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3-frontend.p4
@@ -30,17 +30,17 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a1") action a1_2(bit<48> param) {
-        a.dstAddr = param;
+    @name("MyIC.a1") action a1_2(@name("param") bit<48> param_2) {
+        a.dstAddr = param_2;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_3) {
+        a.etherType = param_3;
     }
-    @name("MyIC.a2") action a2_2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2_2(@name("param") bit<16> param_4) {
+        a.etherType = param_4;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-profile3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3-midend.p4
@@ -30,17 +30,17 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a1") action a1_2(bit<48> param) {
-        a.dstAddr = param;
+    @name("MyIC.a1") action a1_2(@name("param") bit<48> param_2) {
+        a.dstAddr = param_2;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_3) {
+        a.etherType = param_3;
     }
-    @name("MyIC.a2") action a2_2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2_2(@name("param") bit<16> param_4) {
+        a.etherType = param_4;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-profile4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4-frontend.p4
@@ -30,11 +30,11 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-profile4-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4-midend.p4
@@ -30,11 +30,11 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-selector1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1-frontend.p4
@@ -32,11 +32,11 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.as") ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-selector1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1-midend.p4
@@ -32,11 +32,11 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.as") ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-selector2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2-frontend.p4
@@ -33,11 +33,11 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.as") ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-selector2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2-midend.p4
@@ -33,11 +33,11 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.as") ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as_0;
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-selector3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3-frontend.p4
@@ -32,11 +32,11 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-action-selector3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3-midend.p4
@@ -32,11 +32,11 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
+        a.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2-frontend.p4
@@ -26,7 +26,7 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_1, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_1, @name("egress_port") in PortId_t egress_port_1) {
         meta_1.drop = false;
         meta_1.multicast_group = (MulticastGroup_t)32w0;
         meta_1.egress_port = egress_port_1;

--- a/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2-frontend.p4
@@ -26,12 +26,12 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_2, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_2, @name("egress_port") in PortId_t egress_port_1) {
         meta_2.drop = false;
         meta_2.multicast_group = (MulticastGroup_t)32w0;
         meta_2.egress_port = egress_port_1;
     }
-    @noWarnUnused @name(".send_to_port") action send_to_port_0(inout psa_ingress_output_metadata_t meta_3, in PortId_t egress_port_2) {
+    @noWarnUnused @name(".send_to_port") action send_to_port_0(@name("meta") inout psa_ingress_output_metadata_t meta_3, @name("egress_port") in PortId_t egress_port_2) {
         meta_3.drop = false;
         meta_3.multicast_group = (MulticastGroup_t)32w0;
         meta_3.egress_port = egress_port_2;
@@ -53,7 +53,7 @@ parser EgressParserImpl(packet_in buffer, out headers_t hdr, inout metadata_t us
 }
 
 control cEgress(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
-    @noWarnUnused @name(".egress_drop") action egress_drop(inout psa_egress_output_metadata_t meta_4) {
+    @noWarnUnused @name(".egress_drop") action egress_drop(@name("meta") inout psa_egress_output_metadata_t meta_4) {
         meta_4.drop = true;
     }
     @name("cEgress.clone") action clone_1() {

--- a/testdata/p4_16_samples_outputs/psa-example-counters-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-counters-bmv2-frontend.p4
@@ -87,11 +87,11 @@ parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata
 control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
     @name("ingress.port_bytes_in") Counter<ByteCounter_t, PortId_t>(32w512, PSA_CounterType_t.BYTES) port_bytes_in_0;
     @name("ingress.per_prefix_pkt_byte_count") DirectCounter<PacketByteCounter_t>(PSA_CounterType_t.PACKETS_AND_BYTES) per_prefix_pkt_byte_count_0;
-    @name("ingress.next_hop") action next_hop(PortId_t oport) {
+    @name("ingress.next_hop") action next_hop(@name("oport") PortId_t oport) {
         per_prefix_pkt_byte_count_0.count();
         @noWarnUnused {
-            @name("ingress.meta_2") psa_ingress_output_metadata_t meta_2 = ostd;
-            @name("ingress.egress_port_1") PortId_t egress_port_1 = oport;
+            @name("ingress.meta") psa_ingress_output_metadata_t meta_2 = ostd;
+            @name("ingress.egress_port") PortId_t egress_port_1 = oport;
             meta_2.drop = false;
             meta_2.multicast_group = (MulticastGroup_t)32w0;
             meta_2.egress_port = egress_port_1;
@@ -101,7 +101,7 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
     @name("ingress.default_route_drop") action default_route_drop() {
         per_prefix_pkt_byte_count_0.count();
         @noWarnUnused {
-            @name("ingress.meta_3") psa_ingress_output_metadata_t meta_3 = ostd;
+            @name("ingress.meta") psa_ingress_output_metadata_t meta_3 = ostd;
             meta_3.drop = true;
             ostd = meta_3;
         }

--- a/testdata/p4_16_samples_outputs/psa-example-counters-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-counters-bmv2-midend.p4
@@ -80,7 +80,7 @@ parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata
 control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
     @name("ingress.port_bytes_in") Counter<ByteCounter_t, PortId_t>(32w512, PSA_CounterType_t.BYTES) port_bytes_in_0;
     @name("ingress.per_prefix_pkt_byte_count") DirectCounter<PacketByteCounter_t>(PSA_CounterType_t.PACKETS_AND_BYTES) per_prefix_pkt_byte_count_0;
-    @name("ingress.next_hop") action next_hop(PortId_t oport) {
+    @name("ingress.next_hop") action next_hop(@name("oport") PortId_t oport) {
         per_prefix_pkt_byte_count_0.count();
         @noWarnUnused {
             ostd.drop = false;

--- a/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-frontend.p4
@@ -118,23 +118,23 @@ control ingress(inout headers hdr, inout metadata meta, in psa_ingress_input_met
         }
         default_action = unknown_source();
     }
-    @name("ingress.do_L2_forward") action do_L2_forward(PortId_t egress_port) {
+    @name("ingress.do_L2_forward") action do_L2_forward(@name("egress_port") PortId_t egress_port_0) {
         @noWarnUnused {
-            @name("ingress.meta_1") psa_ingress_output_metadata_t meta_1 = ostd;
-            @name("ingress.egress_port_1") PortId_t egress_port_1 = egress_port;
+            @name("ingress.meta") psa_ingress_output_metadata_t meta_1 = ostd;
+            @name("ingress.egress_port") PortId_t egress_port_3 = egress_port_0;
             meta_1.drop = false;
             meta_1.multicast_group = (MulticastGroup_t)32w0;
-            meta_1.egress_port = egress_port_1;
+            meta_1.egress_port = egress_port_3;
             ostd = meta_1;
         }
     }
-    @name("ingress.do_tst") action do_tst(PortId_t egress_port, EthTypes serEnumT) {
+    @name("ingress.do_tst") action do_tst(@name("egress_port") PortId_t egress_port_5, @name("serEnumT") EthTypes serEnumT) {
         @noWarnUnused {
-            @name("ingress.meta_2") psa_ingress_output_metadata_t meta_2 = ostd;
-            @name("ingress.egress_port_2") PortId_t egress_port_2 = egress_port;
+            @name("ingress.meta") psa_ingress_output_metadata_t meta_2 = ostd;
+            @name("ingress.egress_port") PortId_t egress_port_4 = egress_port_5;
             meta_2.drop = false;
             meta_2.multicast_group = (MulticastGroup_t)32w0;
-            meta_2.egress_port = egress_port_2;
+            meta_2.egress_port = egress_port_4;
             ostd = meta_2;
         }
     }

--- a/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-midend.p4
@@ -103,18 +103,18 @@ control ingress(inout headers hdr, inout metadata meta, in psa_ingress_input_met
         }
         default_action = unknown_source();
     }
-    @name("ingress.do_L2_forward") action do_L2_forward(PortId_t egress_port) {
+    @name("ingress.do_L2_forward") action do_L2_forward(@name("egress_port") PortId_t egress_port_0) {
         @noWarnUnused {
             ostd.drop = false;
             ostd.multicast_group = 32w0;
-            ostd.egress_port = egress_port;
+            ostd.egress_port = egress_port_0;
         }
     }
-    @name("ingress.do_tst") action do_tst(PortId_t egress_port, bit<16> serEnumT) {
+    @name("ingress.do_tst") action do_tst(@name("egress_port") PortId_t egress_port_5, @name("serEnumT") bit<16> serEnumT) {
         @noWarnUnused {
             ostd.drop = false;
             ostd.multicast_group = 32w0;
-            ostd.egress_port = egress_port;
+            ostd.egress_port = egress_port_5;
         }
     }
     @name("ingress.l2_tbl") table l2_tbl_0 {

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum-frontend.p4
@@ -92,11 +92,11 @@ parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_
 }
 
 control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".ingress_drop") action ingress_drop(inout psa_ingress_output_metadata_t meta_1) {
+    @noWarnUnused @name(".ingress_drop") action ingress_drop(@name("meta") inout psa_ingress_output_metadata_t meta_1) {
         meta_1.drop = true;
     }
     @name("ingress.parser_error_counts") DirectCounter<PacketCounter_t>(PSA_CounterType_t.PACKETS) parser_error_counts_0;
-    @name("ingress.set_error_idx") action set_error_idx(ErrorIndex_t idx) {
+    @name("ingress.set_error_idx") action set_error_idx(@name("idx") ErrorIndex_t idx) {
         parser_error_counts_0.count();
     }
     @name("ingress.parser_error_count_and_convert") table parser_error_count_and_convert_0 {

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum-midend.p4
@@ -104,7 +104,7 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
         ostd.drop = true;
     }
     @name("ingress.parser_error_counts") DirectCounter<PacketCounter_t>(PSA_CounterType_t.PACKETS) parser_error_counts_0;
-    @name("ingress.set_error_idx") action set_error_idx(ErrorIndex_t idx) {
+    @name("ingress.set_error_idx") action set_error_idx(@name("idx") ErrorIndex_t idx) {
         parser_error_counts_0.count();
     }
     @name("ingress.parser_error_count_and_convert") table parser_error_count_and_convert_0 {

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-frontend.p4
@@ -54,7 +54,7 @@ parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadat
 }
 
 control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @name(".update_pkt_ip_byte_count") action update_pkt_ip_byte_count(inout PacketByteCountState_t s, in bit<16> ip_length_bytes) {
+    @name(".update_pkt_ip_byte_count") action update_pkt_ip_byte_count(@name("s") inout PacketByteCountState_t s, @name("ip_length_bytes") in bit<16> ip_length_bytes) {
         s[79:48] = s[79:48] + 32w1;
         s[47:0] = s[47:0] + (bit<48>)ip_length_bytes;
     }

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-midend.p4
@@ -54,7 +54,7 @@ parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadat
 
 control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
     @name("ingress.tmp") PacketByteCountState_t tmp_0;
-    PacketByteCountState_t s;
+    @name("s") PacketByteCountState_t s;
     @name(".update_pkt_ip_byte_count") action update_pkt_ip_byte_count() {
         s = tmp_0;
         s[79:48] = tmp_0[79:48] + 32w1;

--- a/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2-frontend.p4
@@ -26,10 +26,10 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".ingress_drop") action ingress_drop(inout psa_ingress_output_metadata_t meta_2) {
+    @noWarnUnused @name(".ingress_drop") action ingress_drop(@name("meta") inout psa_ingress_output_metadata_t meta_2) {
         meta_2.drop = true;
     }
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_3, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_3, @name("egress_port") in PortId_t egress_port_1) {
         meta_3.drop = false;
         meta_3.multicast_group = (MulticastGroup_t)32w0;
         meta_3.egress_port = egress_port_1;

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout-frontend.p4
@@ -33,23 +33,23 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a1") action a1_3(bit<48> param) {
-        a.dstAddr = param;
+    @name("MyIC.a1") action a1_3(@name("param") bit<48> param_2) {
+        a.dstAddr = param_2;
     }
-    @name("MyIC.a1") action a1_4(bit<48> param) {
-        a.dstAddr = param;
+    @name("MyIC.a1") action a1_4(@name("param") bit<48> param_3) {
+        a.dstAddr = param_3;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_4) {
+        a.etherType = param_4;
     }
-    @name("MyIC.a2") action a2_3(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2_3(@name("param") bit<16> param_5) {
+        a.etherType = param_5;
     }
-    @name("MyIC.a2") action a2_4(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2_4(@name("param") bit<16> param_6) {
+        a.etherType = param_6;
     }
     @name("MyIC.tbl_idle_timeout") table tbl_idle_timeout_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout-midend.p4
@@ -33,23 +33,23 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("MyIC.a1") action a1(bit<48> param) {
+    @name("MyIC.a1") action a1(@name("param") bit<48> param) {
         a.dstAddr = param;
     }
-    @name("MyIC.a1") action a1_3(bit<48> param) {
-        a.dstAddr = param;
+    @name("MyIC.a1") action a1_3(@name("param") bit<48> param_2) {
+        a.dstAddr = param_2;
     }
-    @name("MyIC.a1") action a1_4(bit<48> param) {
-        a.dstAddr = param;
+    @name("MyIC.a1") action a1_4(@name("param") bit<48> param_3) {
+        a.dstAddr = param_3;
     }
-    @name("MyIC.a2") action a2(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2(@name("param") bit<16> param_4) {
+        a.etherType = param_4;
     }
-    @name("MyIC.a2") action a2_3(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2_3(@name("param") bit<16> param_5) {
+        a.etherType = param_5;
     }
-    @name("MyIC.a2") action a2_4(bit<16> param) {
-        a.etherType = param;
+    @name("MyIC.a2") action a2_4(@name("param") bit<16> param_6) {
+        a.etherType = param_6;
     }
     @name("MyIC.tbl_idle_timeout") table tbl_idle_timeout_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-meter1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter1-frontend.p4
@@ -28,8 +28,8 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0_0;
-    @name("MyIC.execute") action execute_1(bit<12> index, PSA_MeterColor_t color) {
-        meter0_0.execute(index, color);
+    @name("MyIC.execute") action execute_1(@name("index") bit<12> index_1, @name("color") PSA_MeterColor_t color_1) {
+        meter0_0.execute(index_1, color_1);
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-meter1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter1-midend.p4
@@ -28,8 +28,8 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0_0;
-    @name("MyIC.execute") action execute_1(bit<12> index, PSA_MeterColor_t color) {
-        meter0_0.execute(index, color);
+    @name("MyIC.execute") action execute_1(@name("index") bit<12> index_1, @name("color") PSA_MeterColor_t color_1) {
+        meter0_0.execute(index_1, color_1);
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-meter7-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter7-bmv2-frontend.p4
@@ -26,7 +26,7 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_1, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_1, @name("egress_port") in PortId_t egress_port_1) {
         meta_1.drop = false;
         meta_1.multicast_group = (MulticastGroup_t)32w0;
         meta_1.egress_port = egress_port_1;

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2-frontend.p4
@@ -35,7 +35,7 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".multicast") action multicast(inout psa_ingress_output_metadata_t meta_1, in MulticastGroup_t multicast_group_1) {
+    @noWarnUnused @name(".multicast") action multicast(@name("meta") inout psa_ingress_output_metadata_t meta_1, @name("multicast_group") in MulticastGroup_t multicast_group_1) {
         meta_1.drop = false;
         meta_1.multicast_group = multicast_group_1;
     }

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2-frontend.p4
@@ -26,7 +26,7 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".multicast") action multicast(inout psa_ingress_output_metadata_t meta_1, in MulticastGroup_t multicast_group_1) {
+    @noWarnUnused @name(".multicast") action multicast(@name("meta") inout psa_ingress_output_metadata_t meta_1, @name("multicast_group") in MulticastGroup_t multicast_group_1) {
         meta_1.drop = false;
         meta_1.multicast_group = multicast_group_1;
     }

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2-frontend.p4
@@ -26,7 +26,7 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".multicast") action multicast(inout psa_ingress_output_metadata_t meta_1, in MulticastGroup_t multicast_group_1) {
+    @noWarnUnused @name(".multicast") action multicast(@name("meta") inout psa_ingress_output_metadata_t meta_1, @name("multicast_group") in MulticastGroup_t multicast_group_1) {
         meta_1.drop = false;
         meta_1.multicast_group = multicast_group_1;
     }

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2-frontend.p4
@@ -35,12 +35,12 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_1, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_1, @name("egress_port") in PortId_t egress_port_1) {
         meta_1.drop = false;
         meta_1.multicast_group = (MulticastGroup_t)32w0;
         meta_1.egress_port = egress_port_1;
     }
-    @noWarnUnused @name(".send_to_port") action send_to_port_0(inout psa_ingress_output_metadata_t meta_2, in PortId_t egress_port_2) {
+    @noWarnUnused @name(".send_to_port") action send_to_port_0(@name("meta") inout psa_ingress_output_metadata_t meta_2, @name("egress_port") in PortId_t egress_port_2) {
         meta_2.drop = false;
         meta_2.multicast_group = (MulticastGroup_t)32w0;
         meta_2.egress_port = egress_port_2;

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2-frontend.p4
@@ -26,7 +26,7 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_1, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_1, @name("egress_port") in PortId_t egress_port_1) {
         meta_1.drop = false;
         meta_1.multicast_group = (MulticastGroup_t)32w0;
         meta_1.egress_port = egress_port_1;

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2-frontend.p4
@@ -41,7 +41,7 @@ parser MyEP(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa
 }
 
 control MyIC(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_1, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_1, @name("egress_port") in PortId_t egress_port_1) {
         meta_1.drop = false;
         meta_1.multicast_group = (MulticastGroup_t)32w0;
         meta_1.egress_port = egress_port_1;

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2-frontend.p4
@@ -26,12 +26,12 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_2, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_2, @name("egress_port") in PortId_t egress_port_1) {
         meta_2.drop = false;
         meta_2.multicast_group = (MulticastGroup_t)32w0;
         meta_2.egress_port = egress_port_1;
     }
-    @noWarnUnused @name(".ingress_drop") action ingress_drop(inout psa_ingress_output_metadata_t meta_3) {
+    @noWarnUnused @name(".ingress_drop") action ingress_drop(@name("meta") inout psa_ingress_output_metadata_t meta_3) {
         meta_3.drop = true;
     }
     @name("cIngress.regfile") Register<EthernetAddress, bit<32>>(32w128) regfile_0;

--- a/testdata/p4_16_samples_outputs/psa-register1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register1-frontend.p4
@@ -28,7 +28,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w1024) reg_0;
-    @name("MyIC.execute_register") action execute_register(bit<10> idx) {
+    @name("MyIC.execute_register") action execute_register(@name("idx") bit<10> idx) {
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-register1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register1-midend.p4
@@ -28,7 +28,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w1024) reg_0;
-    @name("MyIC.execute_register") action execute_register(bit<10> idx) {
+    @name("MyIC.execute_register") action execute_register(@name("idx") bit<10> idx) {
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-register2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register2-frontend.p4
@@ -32,7 +32,7 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w1024) reg_0;
-    @name("MyIC.execute_register") action execute_register(bit<10> idx) {
+    @name("MyIC.execute_register") action execute_register(@name("idx") bit<10> idx) {
         reg_0.write(idx, b.data);
     }
     @name("MyIC.tbl") table tbl_0 {

--- a/testdata/p4_16_samples_outputs/psa-register2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register2-midend.p4
@@ -32,7 +32,7 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w1024) reg_0;
-    @name("MyIC.execute_register") action execute_register(bit<10> idx) {
+    @name("MyIC.execute_register") action execute_register(@name("idx") bit<10> idx) {
         reg_0.write(idx, b.data);
     }
     @name("MyIC.tbl") table tbl_0 {

--- a/testdata/p4_16_samples_outputs/psa-register3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register3-frontend.p4
@@ -32,7 +32,7 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w512) reg_0;
-    @name("MyIC.execute_register") action execute_register(bit<10> idx) {
+    @name("MyIC.execute_register") action execute_register(@name("idx") bit<10> idx) {
         reg_0.write(idx, b.data);
     }
     @name("MyIC.tbl") table tbl_0 {

--- a/testdata/p4_16_samples_outputs/psa-register3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register3-midend.p4
@@ -32,7 +32,7 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w512) reg_0;
-    @name("MyIC.execute_register") action execute_register(bit<10> idx) {
+    @name("MyIC.execute_register") action execute_register(@name("idx") bit<10> idx) {
         reg_0.write(idx, b.data);
     }
     @name("MyIC.tbl") table tbl_0 {

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2-frontend.p4
@@ -35,7 +35,7 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_1, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_1, @name("egress_port") in PortId_t egress_port_1) {
         meta_1.drop = false;
         meta_1.multicast_group = (MulticastGroup_t)32w0;
         meta_1.egress_port = egress_port_1;

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2-frontend.p4
@@ -35,12 +35,12 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_2, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_2, @name("egress_port") in PortId_t egress_port_1) {
         meta_2.drop = false;
         meta_2.multicast_group = (MulticastGroup_t)32w0;
         meta_2.egress_port = egress_port_1;
     }
-    @noWarnUnused @name(".ingress_drop") action ingress_drop(inout psa_ingress_output_metadata_t meta_3) {
+    @noWarnUnused @name(".ingress_drop") action ingress_drop(@name("meta") inout psa_ingress_output_metadata_t meta_3) {
         meta_3.drop = true;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2-frontend.p4
@@ -26,12 +26,12 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 }
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
-    @noWarnUnused @name(".send_to_port") action send_to_port(inout psa_ingress_output_metadata_t meta_2, in PortId_t egress_port_1) {
+    @noWarnUnused @name(".send_to_port") action send_to_port(@name("meta") inout psa_ingress_output_metadata_t meta_2, @name("egress_port") in PortId_t egress_port_1) {
         meta_2.drop = false;
         meta_2.multicast_group = (MulticastGroup_t)32w0;
         meta_2.egress_port = egress_port_1;
     }
-    @noWarnUnused @name(".ingress_drop") action ingress_drop(inout psa_ingress_output_metadata_t meta_3) {
+    @noWarnUnused @name(".ingress_drop") action ingress_drop(@name("meta") inout psa_ingress_output_metadata_t meta_3) {
         meta_3.drop = true;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-first.p4
@@ -89,7 +89,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x3 : sat_plus();
                         8w0x4 : sat_minus();
         }
-
     }
     apply {
         t.apply();

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-frontend.p4
@@ -87,7 +87,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x3 : sat_plus();
                         8w0x4 : sat_minus();
         }
-
     }
     apply {
         t_0.apply();

--- a/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2-midend.p4
@@ -87,7 +87,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x3 : sat_plus();
                         8w0x4 : sat_minus();
         }
-
     }
     apply {
         t_0.apply();

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4
@@ -89,7 +89,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x3 : sat_plus();
                         0x4 : sat_minus();
         }
-
     }
     apply {
         t.apply();

--- a/testdata/p4_16_samples_outputs/simple-actions_ubpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/simple-actions_ubpf-frontend.p4
@@ -63,28 +63,28 @@ control pipe(inout Headers_t headers, inout metadata meta, inout standard_metada
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("pipe.tmp") bit<32> tmp_0;
-    @name("pipe.ip_modify_saddr") action ip_modify_saddr(bit<32> srcAddr) {
-        headers.ipv4.srcAddr = srcAddr;
+    @name("pipe.ip_modify_saddr") action ip_modify_saddr(@name("srcAddr") bit<32> srcAddr_1) {
+        headers.ipv4.srcAddr = srcAddr_1;
     }
-    @name("pipe.mpls_modify_tc") action mpls_modify_tc(bit<3> tc) {
-        headers.mpls.tc = tc;
+    @name("pipe.mpls_modify_tc") action mpls_modify_tc(@name("tc") bit<3> tc_2) {
+        headers.mpls.tc = tc_2;
     }
-    @name("pipe.mpls_set_label") action mpls_set_label(bit<20> label) {
-        headers.mpls.label = label;
+    @name("pipe.mpls_set_label") action mpls_set_label(@name("label") bit<20> label_3) {
+        headers.mpls.label = label_3;
     }
-    @name("pipe.mpls_set_label_tc") action mpls_set_label_tc(bit<20> label, bit<3> tc) {
-        headers.mpls.label = label;
-        headers.mpls.tc = tc;
+    @name("pipe.mpls_set_label_tc") action mpls_set_label_tc(@name("label") bit<20> label_4, @name("tc") bit<3> tc_3) {
+        headers.mpls.label = label_4;
+        headers.mpls.tc = tc_3;
     }
     @name("pipe.mpls_decrement_ttl") action mpls_decrement_ttl() {
         headers.mpls.ttl = headers.mpls.ttl + 8w255;
     }
-    @name("pipe.mpls_set_label_decrement_ttl") action mpls_set_label_decrement_ttl(bit<20> label) {
-        headers.mpls.label = label;
+    @name("pipe.mpls_set_label_decrement_ttl") action mpls_set_label_decrement_ttl(@name("label") bit<20> label_5) {
+        headers.mpls.label = label_5;
         headers.mpls.ttl = headers.mpls.ttl + 8w255;
     }
-    @name("pipe.mpls_modify_stack") action mpls_modify_stack(bit<1> stack) {
-        headers.mpls.stack = stack;
+    @name("pipe.mpls_modify_stack") action mpls_modify_stack(@name("stack") bit<1> stack_1) {
+        headers.mpls.stack = stack_1;
     }
     @name("pipe.change_ip_ver") action change_ip_ver() {
         headers.ipv4.version = 4w6;

--- a/testdata/p4_16_samples_outputs/simple-actions_ubpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/simple-actions_ubpf-midend.p4
@@ -63,28 +63,28 @@ control pipe(inout Headers_t headers, inout metadata meta, inout standard_metada
     @name("pipe.tmp") bit<32> tmp_0;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.ip_modify_saddr") action ip_modify_saddr(bit<32> srcAddr) {
-        headers.ipv4.srcAddr = srcAddr;
+    @name("pipe.ip_modify_saddr") action ip_modify_saddr(@name("srcAddr") bit<32> srcAddr_1) {
+        headers.ipv4.srcAddr = srcAddr_1;
     }
-    @name("pipe.mpls_modify_tc") action mpls_modify_tc(bit<3> tc) {
-        headers.mpls.tc = tc;
+    @name("pipe.mpls_modify_tc") action mpls_modify_tc(@name("tc") bit<3> tc_2) {
+        headers.mpls.tc = tc_2;
     }
-    @name("pipe.mpls_set_label") action mpls_set_label(bit<20> label) {
-        headers.mpls.label = label;
+    @name("pipe.mpls_set_label") action mpls_set_label(@name("label") bit<20> label_3) {
+        headers.mpls.label = label_3;
     }
-    @name("pipe.mpls_set_label_tc") action mpls_set_label_tc(bit<20> label, bit<3> tc) {
-        headers.mpls.label = label;
-        headers.mpls.tc = tc;
+    @name("pipe.mpls_set_label_tc") action mpls_set_label_tc(@name("label") bit<20> label_4, @name("tc") bit<3> tc_3) {
+        headers.mpls.label = label_4;
+        headers.mpls.tc = tc_3;
     }
     @name("pipe.mpls_decrement_ttl") action mpls_decrement_ttl() {
         headers.mpls.ttl = headers.mpls.ttl + 8w255;
     }
-    @name("pipe.mpls_set_label_decrement_ttl") action mpls_set_label_decrement_ttl(bit<20> label) {
-        headers.mpls.label = label;
+    @name("pipe.mpls_set_label_decrement_ttl") action mpls_set_label_decrement_ttl(@name("label") bit<20> label_5) {
+        headers.mpls.label = label_5;
         headers.mpls.ttl = headers.mpls.ttl + 8w255;
     }
-    @name("pipe.mpls_modify_stack") action mpls_modify_stack(bit<1> stack) {
-        headers.mpls.stack = stack;
+    @name("pipe.mpls_modify_stack") action mpls_modify_stack(@name("stack") bit<1> stack_1) {
+        headers.mpls.stack = stack_1;
     }
     @name("pipe.change_ip_ver") action change_ip_ver() {
         headers.ipv4.version = 4w6;

--- a/testdata/p4_16_samples_outputs/simple-firewall_ubpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/simple-firewall_ubpf-frontend.p4
@@ -76,21 +76,21 @@ parser prs(packet_in p, out Headers_t headers, inout metadata meta, inout standa
 control pipe(inout Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
     @name("pipe.conn_state") Register<bit<32>, bit<32>>(32w65536) conn_state_0;
     @name("pipe.conn_srv_addr") Register<bit<32>, bit<32>>(32w65536) conn_srv_addr_0;
-    @name("pipe.update_conn_state") action update_conn_state(bit<32> s_2) {
+    @name("pipe.update_conn_state") action update_conn_state(@name("s") bit<32> s_2) {
         conn_state_0.write(meta.conn_id, s_2);
     }
-    @name("pipe.update_conn_state") action update_conn_state_2(bit<32> s_3) {
+    @name("pipe.update_conn_state") action update_conn_state_2(@name("s") bit<32> s_3) {
         conn_state_0.write(meta.conn_id, s_3);
     }
-    @name("pipe.update_conn_info") action update_conn_info(bit<32> s_4, bit<32> addr) {
+    @name("pipe.update_conn_info") action update_conn_info(@name("s") bit<32> s_4, @name("addr") bit<32> addr) {
         conn_state_0.write(meta.conn_id, s_4);
         conn_srv_addr_0.write(meta.conn_id, addr);
     }
-    @name("pipe.update_conn_info") action update_conn_info_3(bit<32> s_5, bit<32> addr_1) {
+    @name("pipe.update_conn_info") action update_conn_info_3(@name("s") bit<32> s_5, @name("addr") bit<32> addr_1) {
         conn_state_0.write(meta.conn_id, s_5);
         conn_srv_addr_0.write(meta.conn_id, addr_1);
     }
-    @name("pipe.update_conn_info") action update_conn_info_4(bit<32> s_6, bit<32> addr_2) {
+    @name("pipe.update_conn_info") action update_conn_info_4(@name("s") bit<32> s_6, @name("addr") bit<32> addr_2) {
         conn_state_0.write(meta.conn_id, s_6);
         conn_srv_addr_0.write(meta.conn_id, addr_2);
     }

--- a/testdata/p4_16_samples_outputs/spec-ex25-first.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex25-first.p4
@@ -26,7 +26,6 @@ control c(bit<32> x) {
                         32w0xb000003 : Set_dmac(dmac = 48w0x112233445577);
                         32w0xb000000 &&& 32w0xff000000 : drop();
         }
-
         default_action = Set_dmac(48w0xaabbccddeeff);
         implementation = tbl();
     }

--- a/testdata/p4_16_samples_outputs/spec-ex25.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex25.p4
@@ -26,7 +26,6 @@ control c(bit<32> x) {
                         32w0xb000003 : Set_dmac(dmac = (EthernetAddress)48w0x112233445577);
                         32w0xb000000 &&& 32w0xff000000 : drop();
         }
-
         default_action = Set_dmac((EthernetAddress)48w0xaabbccddeeff);
         implementation = tbl();
     }

--- a/testdata/p4_16_samples_outputs/stack_ebpf-first.p4
+++ b/testdata/p4_16_samples_outputs/stack_ebpf-first.p4
@@ -69,7 +69,6 @@ control pipe(inout Headers_t headers, out bool pass) {
             NoAction: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack_ebpf-frontend.p4
@@ -47,9 +47,9 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4[0].srcAddr = add;
+        headers.ipv4[0].srcAddr = add_1;
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {
@@ -71,7 +71,6 @@ control pipe(inout Headers_t headers, out bool pass) {
             NoAction_0: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack_ebpf-midend.p4
@@ -47,9 +47,9 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4[0].srcAddr = add;
+        headers.ipv4[0].srcAddr = add_1;
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {
@@ -89,7 +89,6 @@ control pipe(inout Headers_t headers, out bool pass) {
             NoAction_0: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack_ebpf.p4
+++ b/testdata/p4_16_samples_outputs/stack_ebpf.p4
@@ -69,7 +69,6 @@ control pipe(inout Headers_t headers, out bool pass) {
             NoAction: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/std_meta_inlining-frontend.p4
+++ b/testdata/p4_16_samples_outputs/std_meta_inlining-frontend.p4
@@ -20,7 +20,7 @@ control DeparserImpl(packet_out packet, in headers_t hdr) {
 }
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
-    @name(".send_to_cpu") action send_to_cpu(inout standard_metadata_t standard_metadata_1) {
+    @name(".send_to_cpu") action send_to_cpu(@name("standard_metadata") inout standard_metadata_t standard_metadata_1) {
         standard_metadata_1.egress_spec = 9w64;
     }
     @noWarn("unused") @name(".NoAction") action NoAction_0() {

--- a/testdata/p4_16_samples_outputs/switch_ebpf-first.p4
+++ b/testdata/p4_16_samples_outputs/switch_ebpf-first.p4
@@ -68,7 +68,6 @@ control pipe(inout Headers_t headers, out bool pass) {
             NoAction: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/switch_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/switch_ebpf-frontend.p4
@@ -46,9 +46,9 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4.srcAddr = add;
+        headers.ipv4.srcAddr = add_1;
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {
@@ -70,7 +70,6 @@ control pipe(inout Headers_t headers, out bool pass) {
             NoAction_0: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/switch_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/switch_ebpf-midend.p4
@@ -46,9 +46,9 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4.srcAddr = add;
+        headers.ipv4.srcAddr = add_1;
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {
@@ -88,7 +88,6 @@ control pipe(inout Headers_t headers, out bool pass) {
             NoAction_0: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/switch_ebpf.p4
+++ b/testdata/p4_16_samples_outputs/switch_ebpf.p4
@@ -68,7 +68,6 @@ control pipe(inout Headers_t headers, out bool pass) {
             NoAction: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-first.p4
@@ -65,7 +65,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x1 : a_with_control_params(9w1);
                         8w0x2 : a_with_control_params(9w2);
         }
-
     }
     apply {
         t_exact.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-frontend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_exact") table t_exact_0 {
@@ -65,7 +65,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x1 : a_with_control_params(9w1);
                         8w0x2 : a_with_control_params(9w2);
         }
-
     }
     apply {
         t_exact_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2-midend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_exact") table t_exact_0 {
@@ -65,7 +65,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x1 : a_with_control_params(9w1);
                         8w0x2 : a_with_control_params(9w2);
         }
-
     }
     apply {
         t_exact_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4
@@ -65,7 +65,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x1 : a_with_control_params(1);
                         0x2 : a_with_control_params(2);
         }
-
     }
     apply {
         t_exact.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-first.p4
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params(9w3);
                         (8w0x4, default) : a_with_control_params(9w4);
         }
-
     }
     apply {
         t_exact_ternary.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-frontend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_exact_ternary") table t_exact_ternary_0 {
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params(9w3);
                         (8w0x4, default) : a_with_control_params(9w4);
         }
-
     }
     apply {
         t_exact_ternary_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2-midend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_exact_ternary") table t_exact_ternary_0 {
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params(9w3);
                         (8w0x4, default) : a_with_control_params(9w4);
         }
-
     }
     apply {
         t_exact_ternary_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (0x3, 0x1111 &&& 0xf000) : a_with_control_params(3);
                         (0x4, default) : a_with_control_params(4);
         }
-
     }
     apply {
         t_exact_ternary.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-first.p4
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x12 : a_with_control_params(9w12);
                         default : a_with_control_params(9w13);
         }
-
     }
     apply {
         t_lpm.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-frontend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_lpm") table t_lpm_0 {
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x12 : a_with_control_params(9w12);
                         default : a_with_control_params(9w13);
         }
-
     }
     apply {
         t_lpm_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2-midend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_lpm") table t_lpm_0 {
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w0x12 : a_with_control_params(9w12);
                         default : a_with_control_params(9w13);
         }
-
     }
     apply {
         t_lpm_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x12 : a_with_control_params(12);
                         default : a_with_control_params(13);
         }
-
     }
     apply {
         t_lpm.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-first.p4
@@ -22,7 +22,6 @@ control MyC(inout bit<2> x) {
                         2w2 : a();
                         2w3 : b();
         }
-
         default_action = NoAction();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-frontend.p4
@@ -24,7 +24,6 @@ control MyC(inout bit<2> x) {
                         2w2 : a();
                         2w3 : b();
         }
-
         default_action = NoAction_0();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-no-arg-actions-midend.p4
@@ -24,7 +24,6 @@ control MyC(inout bit<2> x) {
                         2w2 : a();
                         2w3 : b();
         }
-
         default_action = NoAction_0();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/table-entries-no-arg-actions.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-no-arg-actions.p4
@@ -21,7 +21,6 @@ control MyC(inout bit<2> x) {
                         2 : a();
                         3 : b();
         }
-
     }
     apply {
         t.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-first.p4
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (8w0xaa, default) : a_with_control_params(9w3);
                         (default, default) : a_with_control_params(9w4);
         }
-
     }
     apply {
         t_optional.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-frontend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_optional") table t_optional_0 {
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (8w0xaa, default) : a_with_control_params(9w3);
                         (default, default) : a_with_control_params(9w4);
         }
-
     }
     apply {
         t_optional_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2-midend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_optional") table t_optional_0 {
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (8w0xaa, default) : a_with_control_params(9w3);
                         (default, default) : a_with_control_params(9w4);
         }
-
     }
     apply {
         t_optional_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4
@@ -68,7 +68,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (0xaa, default) : a_with_control_params(3);
                         (default, default) : a_with_control_params(4);
         }
-
     }
     apply {
         t_optional.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-first.p4
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         16w0x1181 : a_with_control_params(9w2);
                         16w0x1181 &&& 16w0xf00f : a_with_control_params(9w3)@priority(1) ;
         }
-
     }
     apply {
         t_ternary.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-frontend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_ternary") table t_ternary_0 {
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         16w0x1181 : a_with_control_params(9w2);
                         16w0x1181 &&& 16w0xf00f : a_with_control_params(9w3)@priority(1) ;
         }
-
     }
     apply {
         t_ternary_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2-midend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_ternary") table t_ternary_0 {
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         16w0x1181 : a_with_control_params(9w2);
                         16w0x1181 &&& 16w0xf00f : a_with_control_params(9w3)@priority(1) ;
         }
-
     }
     apply {
         t_ternary_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x1181 : a_with_control_params(2);
                         0x1181 &&& 0xf00f : a_with_control_params(3)@priority(1) ;
         }
-
     }
     apply {
         t_ternary.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-first.p4
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w15 : a_with_control_params(9w24);
                         default : a_with_control_params(9w23);
         }
-
     }
     apply {
         t_range.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-frontend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_range") table t_range_0 {
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w15 : a_with_control_params(9w24);
                         default : a_with_control_params(9w23);
         }
-
     }
     apply {
         t_range_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2-midend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_range") table t_range_0 {
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         8w15 : a_with_control_params(9w24);
                         default : a_with_control_params(9w23);
         }
-
     }
     apply {
         t_range_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         15 : a_with_control_params(24);
                         default : a_with_control_params(23);
         }
-
     }
     apply {
         t_range.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-first.p4
@@ -74,7 +74,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (MyEnum1B.MBR2, MyEnum2B.MBR2 &&& 16w0xff00) : a_with_control_params(9w2);
                         (MyEnum1B.MBR2, default) : a_with_control_params(9w3);
         }
-
     }
     apply {
         t_ternary.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-frontend.p4
@@ -56,7 +56,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_ternary") table t_ternary_0 {
@@ -74,7 +74,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (MyEnum1B.MBR2, MyEnum2B.MBR2 &&& 16w0xff00) : a_with_control_params(9w2);
                         (MyEnum1B.MBR2, default) : a_with_control_params(9w3);
         }
-
     }
     apply {
         t_ternary_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2-midend.p4
@@ -46,7 +46,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_ternary") table t_ternary_0 {
@@ -64,7 +64,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (8w0xff, 16w0xab00 &&& 16w0xff00) : a_with_control_params(9w2);
                         (8w0xff, default) : a_with_control_params(9w3);
         }
-
     }
     apply {
         t_ternary_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4
@@ -74,7 +74,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (MyEnum1B.MBR2, MyEnum2B.MBR2 &&& 0xff00) : a_with_control_params(2);
                         (MyEnum1B.MBR2, default) : a_with_control_params(3);
         }
-
     }
     apply {
         t_ternary.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-first.p4
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         16w0x1111 &&& 16w0xf000 : a_with_control_params(9w3);
                         default : a_with_control_params(9w4);
         }
-
     }
     apply {
         t_ternary.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-frontend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_ternary") table t_ternary_0 {
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         16w0x1111 &&& 16w0xf000 : a_with_control_params(9w3);
                         default : a_with_control_params(9w4);
         }
-
     }
     apply {
         t_ternary_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2-midend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_ternary") table t_ternary_0 {
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         16w0x1111 &&& 16w0xf000 : a_with_control_params(9w3);
                         default : a_with_control_params(9w4);
         }
-
     }
     apply {
         t_ternary_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4
@@ -67,7 +67,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         0x1111 &&& 0xf000 : a_with_control_params(3);
                         default : a_with_control_params(4);
         }
-
     }
     apply {
         t_ternary.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-first.p4
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (true, 8w0x1) : a_with_control_params(9w1);
                         (false, 8w0x2) : a_with_control_params(9w2);
         }
-
     }
     apply {
         t_valid.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-frontend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_valid") table t_valid_0 {
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (true, 8w0x1) : a_with_control_params(9w1);
                         (false, 8w0x2) : a_with_control_params(9w2);
         }
-
     }
     apply {
         t_valid_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2-midend.p4
@@ -49,7 +49,7 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
     @name("ingress.a") action a() {
         standard_meta.egress_spec = 9w0;
     }
-    @name("ingress.a_with_control_params") action a_with_control_params(bit<9> x) {
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x) {
         standard_meta.egress_spec = x;
     }
     @name("ingress.t_valid") table t_valid_0 {
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (true, 8w0x1) : a_with_control_params(9w1);
                         (false, 8w0x2) : a_with_control_params(9w2);
         }
-
     }
     apply {
         t_valid_0.apply();

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4
@@ -66,7 +66,6 @@ control ingress(inout Header_t h, inout Meta_t m, inout standard_metadata_t stan
                         (true, 0x1) : a_with_control_params(1);
                         (false, 0x2) : a_with_control_params(2);
         }
-
     }
     apply {
         t_valid.apply();

--- a/testdata/p4_16_samples_outputs/table-key-serenum-first.p4
+++ b/testdata/p4_16_samples_outputs/table-key-serenum-first.p4
@@ -50,7 +50,6 @@ control c(inout Headers h, inout standard_metadata_t sm) {
                         EthTypes.IPv4 : do_act(32w0x800);
                         EthTypes.VLAN : do_act(32w0x8100);
         }
-
         default_action = NoAction();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/table-key-serenum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-key-serenum-frontend.p4
@@ -37,8 +37,8 @@ parser prs(packet_in p, out Headers h) {
 control c(inout Headers h, inout standard_metadata_t sm) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("c.do_act") action do_act(bit<32> type) {
-        sm.instance_type = type;
+    @name("c.do_act") action do_act(@name("type") bit<32> type_1) {
+        sm.instance_type = type_1;
     }
     @name("c.tns") table tns_0 {
         key = {
@@ -52,7 +52,6 @@ control c(inout Headers h, inout standard_metadata_t sm) {
                         EthTypes.IPv4 : do_act(32w0x800);
                         EthTypes.VLAN : do_act(32w0x8100);
         }
-
         default_action = NoAction_0();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/table-key-serenum-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-key-serenum-midend.p4
@@ -27,8 +27,8 @@ parser prs(packet_in p, out Headers h) {
 control c(inout Headers h, inout standard_metadata_t sm) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("c.do_act") action do_act(bit<32> type) {
-        sm.instance_type = type;
+    @name("c.do_act") action do_act(@name("type") bit<32> type_1) {
+        sm.instance_type = type_1;
     }
     @name("c.tns") table tns_0 {
         key = {
@@ -42,7 +42,6 @@ control c(inout Headers h, inout standard_metadata_t sm) {
                         16w0x800 : do_act(32w0x800);
                         16w0x8100 : do_act(32w0x8100);
         }
-
         default_action = NoAction_0();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/table-key-serenum.p4
+++ b/testdata/p4_16_samples_outputs/table-key-serenum.p4
@@ -49,7 +49,6 @@ control c(inout Headers h, inout standard_metadata_t sm) {
                         EthTypes.IPv4 : do_act(0x800);
                         EthTypes.VLAN : do_act(0x8100);
         }
-
     }
     apply {
         tns.apply();

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-first.p4
@@ -135,7 +135,6 @@ control ingress(inout packet_t hdrs, inout Meta m, inout standard_metadata_t met
             default: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-frontend.p4
@@ -49,7 +49,7 @@ control update(inout packet_t h, inout Meta m) {
 }
 
 control ingress(inout packet_t hdrs, inout Meta m, inout standard_metadata_t meta) {
-    @name("ingress.setb1") action setb1(bit<9> port, bit<8> val) {
+    @name("ingress.setb1") action setb1(@name("port") bit<9> port, @name("val") bit<8> val) {
         hdrs.data.b1 = val;
         meta.egress_spec = port;
     }
@@ -63,26 +63,26 @@ control ingress(inout packet_t hdrs, inout Meta m, inout standard_metadata_t met
     }
     @name("ingress.noop") action noop_8() {
     }
-    @name("ingress.setbyte") action setbyte(out bit<8> reg, bit<8> val) {
-        reg = val;
+    @name("ingress.setbyte") action setbyte(@name("reg") out bit<8> reg, @name("val") bit<8> val_5) {
+        reg = val_5;
     }
-    @name("ingress.setbyte") action setbyte_4(out bit<8> reg_1, bit<8> val) {
-        reg_1 = val;
+    @name("ingress.setbyte") action setbyte_4(@name("reg") out bit<8> reg_1, @name("val") bit<8> val_6) {
+        reg_1 = val_6;
     }
-    @name("ingress.setbyte") action setbyte_5(out bit<8> reg_2, bit<8> val) {
-        reg_2 = val;
+    @name("ingress.setbyte") action setbyte_5(@name("reg") out bit<8> reg_2, @name("val") bit<8> val_7) {
+        reg_2 = val_7;
     }
-    @name("ingress.setbyte") action setbyte_6(out bit<8> reg_3, bit<8> val) {
-        reg_3 = val;
+    @name("ingress.setbyte") action setbyte_6(@name("reg") out bit<8> reg_3, @name("val") bit<8> val_8) {
+        reg_3 = val_8;
     }
-    @name("ingress.act1") action act1(bit<8> val) {
-        hdrs.extra[0].b1 = val;
+    @name("ingress.act1") action act1(@name("val") bit<8> val_9) {
+        hdrs.extra[0].b1 = val_9;
     }
-    @name("ingress.act2") action act2(bit<8> val) {
-        hdrs.extra[0].b1 = val;
+    @name("ingress.act2") action act2(@name("val") bit<8> val_10) {
+        hdrs.extra[0].b1 = val_10;
     }
-    @name("ingress.act3") action act3(bit<8> val) {
-        hdrs.extra[0].b1 = val;
+    @name("ingress.act3") action act3(@name("val") bit<8> val_11) {
+        hdrs.extra[0].b1 = val_11;
     }
     @name("ingress.test1") table test1_0 {
         key = {
@@ -152,7 +152,6 @@ control ingress(inout packet_t hdrs, inout Meta m, inout standard_metadata_t met
             default: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2-midend.p4
@@ -49,7 +49,7 @@ control update(inout packet_t h, inout Meta m) {
 }
 
 control ingress(inout packet_t hdrs, inout Meta m, inout standard_metadata_t meta) {
-    @name("ingress.setb1") action setb1(bit<9> port, bit<8> val) {
+    @name("ingress.setb1") action setb1(@name("port") bit<9> port, @name("val") bit<8> val) {
         hdrs.data.b1 = val;
         meta.egress_spec = port;
     }
@@ -63,26 +63,26 @@ control ingress(inout packet_t hdrs, inout Meta m, inout standard_metadata_t met
     }
     @name("ingress.noop") action noop_8() {
     }
-    @name("ingress.setbyte") action setbyte(bit<8> val) {
-        hdrs.extra[0].b1 = val;
+    @name("ingress.setbyte") action setbyte(@name("val") bit<8> val_5) {
+        hdrs.extra[0].b1 = val_5;
     }
-    @name("ingress.setbyte") action setbyte_4(bit<8> val) {
-        hdrs.data.b2 = val;
+    @name("ingress.setbyte") action setbyte_4(@name("val") bit<8> val_6) {
+        hdrs.data.b2 = val_6;
     }
-    @name("ingress.setbyte") action setbyte_5(bit<8> val) {
-        hdrs.extra[1].b1 = val;
+    @name("ingress.setbyte") action setbyte_5(@name("val") bit<8> val_7) {
+        hdrs.extra[1].b1 = val_7;
     }
-    @name("ingress.setbyte") action setbyte_6(bit<8> val) {
-        hdrs.extra[2].b2 = val;
+    @name("ingress.setbyte") action setbyte_6(@name("val") bit<8> val_8) {
+        hdrs.extra[2].b2 = val_8;
     }
-    @name("ingress.act1") action act1(bit<8> val) {
-        hdrs.extra[0].b1 = val;
+    @name("ingress.act1") action act1(@name("val") bit<8> val_9) {
+        hdrs.extra[0].b1 = val_9;
     }
-    @name("ingress.act2") action act2(bit<8> val) {
-        hdrs.extra[0].b1 = val;
+    @name("ingress.act2") action act2(@name("val") bit<8> val_10) {
+        hdrs.extra[0].b1 = val_10;
     }
-    @name("ingress.act3") action act3(bit<8> val) {
-        hdrs.extra[0].b1 = val;
+    @name("ingress.act3") action act3(@name("val") bit<8> val_11) {
+        hdrs.extra[0].b1 = val_11;
     }
     @name("ingress.test1") table test1_0 {
         key = {
@@ -152,7 +152,6 @@ control ingress(inout packet_t hdrs, inout Meta m, inout standard_metadata_t met
             default: {
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2.p4
@@ -133,7 +133,6 @@ control ingress(inout packet_t hdrs, inout Meta m, inout standard_metadata_t met
                 tbl3.apply();
             }
         }
-
     }
 }
 

--- a/testdata/p4_16_samples_outputs/test_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/test_ebpf-frontend.p4
@@ -46,9 +46,9 @@ parser prs(packet_in p, out Headers_t headers) {
 control pipe(inout Headers_t headers, out bool pass) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4.srcAddr = add;
+        headers.ipv4.srcAddr = add_1;
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/test_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/test_ebpf-midend.p4
@@ -47,9 +47,9 @@ control pipe(inout Headers_t headers, out bool pass) {
     @name("pipe.hasReturned") bool hasReturned;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name("pipe.Reject") action Reject(IPv4Address add) {
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
         pass = false;
-        headers.ipv4.srcAddr = add;
+        headers.ipv4.srcAddr = add_1;
     }
     @name("pipe.Check_src_ip") table Check_src_ip_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2-frontend.p4
@@ -44,8 +44,8 @@ control deparser(packet_out b, in Headers h) {
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.c") direct_counter(CounterType.packets) c_0;
     @name("ingress.c1") direct_counter(CounterType.packets) c1_0;
-    @name("ingress.my_action") action my_action(bit<9> a) {
-        sm.egress_spec = a;
+    @name("ingress.my_action") action my_action(@name("a") bit<9> a_1) {
+        sm.egress_spec = a_1;
     }
     @name("ingress.t") table t_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2-midend.p4
@@ -44,8 +44,8 @@ control deparser(packet_out b, in Headers h) {
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.c") direct_counter(CounterType.packets) c_0;
     @name("ingress.c1") direct_counter(CounterType.packets) c1_0;
-    @name("ingress.my_action") action my_action(bit<9> a) {
-        sm.egress_spec = a;
+    @name("ingress.my_action") action my_action(@name("a") bit<9> a_1) {
+        sm.egress_spec = a_1;
     }
     @name("ingress.t") table t_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-first.p4
@@ -48,7 +48,6 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
                         48w0xa0000000000 &&& 48w0xff0000000000 : act_hit(48w2);
                         48w0x0 &&& 48w0x0 : act_hit(48w3);
         }
-
         const default_action = act_miss();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-frontend.p4
@@ -32,7 +32,7 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
     @name("ingressImpl.act_miss") action act_miss() {
         hdr.ethernet.srcAddr = 48w0xdeadbeef;
     }
-    @name("ingressImpl.act_hit") action act_hit(bit<48> x) {
+    @name("ingressImpl.act_hit") action act_hit(@name("x") bit<48> x) {
         hdr.ethernet.srcAddr = x;
     }
     @name("ingressImpl.lpm1") table lpm1_0 {
@@ -48,7 +48,6 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
                         48w0xa0000000000 &&& 48w0xff0000000000 : act_hit(48w2);
                         48w0x0 &&& 48w0x0 : act_hit(48w3);
         }
-
         const default_action = act_miss();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2-midend.p4
@@ -32,7 +32,7 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
     @name("ingressImpl.act_miss") action act_miss() {
         hdr.ethernet.srcAddr = 48w0xdeadbeef;
     }
-    @name("ingressImpl.act_hit") action act_hit(bit<48> x) {
+    @name("ingressImpl.act_hit") action act_hit(@name("x") bit<48> x) {
         hdr.ethernet.srcAddr = x;
     }
     @name("ingressImpl.lpm1") table lpm1_0 {
@@ -48,7 +48,6 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
                         48w0xa0000000000 &&& 48w0xff0000000000 : act_hit(48w2);
                         48w0x0 &&& 48w0x0 : act_hit(48w3);
         }
-
         const default_action = act_miss();
     }
     @hidden action v1modelconstentriesbmv2l77() {

--- a/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2.p4
@@ -48,7 +48,6 @@ control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_m
                         0xa0000000000 &&& 0xff0000000000 : act_hit(2);
                         0x0 &&& 0x0 : act_hit(3);
         }
-
         const default_action = act_miss();
     }
     apply {

--- a/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-frontend.p4
@@ -90,8 +90,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name("MyIngress.set_dmac") action set_dmac(macAddr_t dstAddr) {
-        hdr.ethernet.dstAddr = dstAddr;
+    @name("MyIngress.set_dmac") action set_dmac(@name("dstAddr") macAddr_t dstAddr_2) {
+        hdr.ethernet.dstAddr = dstAddr_2;
     }
     @name("MyIngress.drop") action drop() {
     }
@@ -109,8 +109,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         size = 1024;
         default_action = NoAction_0();
     }
-    @name("MyIngress.set_nhop") action set_nhop(ip4Addr_t dstAddr, egressSpec_t port) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("MyIngress.set_nhop") action set_nhop(@name("dstAddr") ip4Addr_t dstAddr_3, @name("port") egressSpec_t port) {
+        hdr.ipv4.dstAddr = dstAddr_3;
         standard_metadata.egress_spec = port;
     }
     @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
@@ -146,8 +146,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
 control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("MyEgress.rewrite_mac") action rewrite_mac(macAddr_t srcAddr) {
-        hdr.ethernet.srcAddr = srcAddr;
+    @name("MyEgress.rewrite_mac") action rewrite_mac(@name("srcAddr") macAddr_t srcAddr_1) {
+        hdr.ethernet.srcAddr = srcAddr_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
     @name("MyEgress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum-midend.p4
@@ -87,8 +87,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name("MyIngress.set_dmac") action set_dmac(macAddr_t dstAddr) {
-        hdr.ethernet.dstAddr = dstAddr;
+    @name("MyIngress.set_dmac") action set_dmac(@name("dstAddr") macAddr_t dstAddr_2) {
+        hdr.ethernet.dstAddr = dstAddr_2;
     }
     @name("MyIngress.drop") action drop() {
     }
@@ -106,8 +106,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         size = 1024;
         default_action = NoAction_0();
     }
-    @name("MyIngress.set_nhop") action set_nhop(ip4Addr_t dstAddr, egressSpec_t port) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("MyIngress.set_nhop") action set_nhop(@name("dstAddr") ip4Addr_t dstAddr_3, @name("port") egressSpec_t port) {
+        hdr.ipv4.dstAddr = dstAddr_3;
         standard_metadata.egress_spec = port;
     }
     @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
@@ -149,8 +149,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
 control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("MyEgress.rewrite_mac") action rewrite_mac(macAddr_t srcAddr) {
-        hdr.ethernet.srcAddr = srcAddr;
+    @name("MyEgress.rewrite_mac") action rewrite_mac(@name("srcAddr") macAddr_t srcAddr_1) {
+        hdr.ethernet.srcAddr = srcAddr_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
     @name("MyEgress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/v1model-digest-custom-type-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-custom-type-frontend.p4
@@ -73,8 +73,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name("MyIngress.set_dmac") action set_dmac(EthernetAddr_t dstAddr) {
-        hdr.ethernet.dstAddr = dstAddr;
+    @name("MyIngress.set_dmac") action set_dmac(@name("dstAddr") EthernetAddr_t dstAddr_2) {
+        hdr.ethernet.dstAddr = dstAddr_2;
     }
     @name("MyIngress.drop") action drop() {
     }
@@ -92,8 +92,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         size = 1024;
         default_action = NoAction_0();
     }
-    @name("MyIngress.set_nhop") action set_nhop(IPv4Addr_t dstAddr, egressSpec_t port) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("MyIngress.set_nhop") action set_nhop(@name("dstAddr") IPv4Addr_t dstAddr_3, @name("port") egressSpec_t port) {
+        hdr.ipv4.dstAddr = dstAddr_3;
         standard_metadata.egress_spec = port;
     }
     @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
@@ -125,8 +125,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
 control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("MyEgress.rewrite_mac") action rewrite_mac(EthernetAddr_t srcAddr) {
-        hdr.ethernet.srcAddr = srcAddr;
+    @name("MyEgress.rewrite_mac") action rewrite_mac(@name("srcAddr") EthernetAddr_t srcAddr_1) {
+        hdr.ethernet.srcAddr = srcAddr_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
     @name("MyEgress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/v1model-digest-custom-type-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-digest-custom-type-midend.p4
@@ -76,8 +76,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
-    @name("MyIngress.set_dmac") action set_dmac(EthernetAddr_t dstAddr) {
-        hdr.ethernet.dstAddr = dstAddr;
+    @name("MyIngress.set_dmac") action set_dmac(@name("dstAddr") EthernetAddr_t dstAddr_2) {
+        hdr.ethernet.dstAddr = dstAddr_2;
     }
     @name("MyIngress.drop") action drop() {
     }
@@ -95,8 +95,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         size = 1024;
         default_action = NoAction_0();
     }
-    @name("MyIngress.set_nhop") action set_nhop(IPv4Addr_t dstAddr, egressSpec_t port) {
-        hdr.ipv4.dstAddr = dstAddr;
+    @name("MyIngress.set_nhop") action set_nhop(@name("dstAddr") IPv4Addr_t dstAddr_3, @name("port") egressSpec_t port) {
+        hdr.ipv4.dstAddr = dstAddr_3;
         standard_metadata.egress_spec = port;
     }
     @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
@@ -134,8 +134,8 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
 control MyEgress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
-    @name("MyEgress.rewrite_mac") action rewrite_mac(EthernetAddr_t srcAddr) {
-        hdr.ethernet.srcAddr = srcAddr;
+    @name("MyEgress.rewrite_mac") action rewrite_mac(@name("srcAddr") EthernetAddr_t srcAddr_1) {
+        hdr.ethernet.srcAddr = srcAddr_1;
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
     @name("MyEgress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-enumint-types1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-enumint-types1-frontend.p4
@@ -156,36 +156,36 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, in
 }
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("ingress.set_output") action set_output(bit<9> out_port) {
+    @name("ingress.set_output") action set_output(@name("out_port") bit<9> out_port) {
         stdmeta.egress_spec = out_port;
     }
-    @name("ingress.set_headers") action set_headers(Eth0_t addr0, Eth1_t addr1, Eth2_t addr2, bit<8> e, Custom0_t e0, Custom1_t e1, Custom2_t e2, Custom00_t e00, Custom01_t e01, Custom02_t e02, Custom10_t e10, Custom11_t e11, Custom12_t e12, Custom20_t e20, Custom21_t e21, Custom22_t e22, Custom001_t e001, Custom002_t e002, Custom101_t e101, Custom102_t e102, Custom201_t e201, Custom202_t e202, Custom220_t e220, Custom0020010_t e0020010, Custom0020020_t e0020020, serenum0_t s0) {
-        hdr.custom.addr0 = addr0;
-        hdr.custom.addr1 = addr1;
-        hdr.custom.addr2 = addr2;
-        hdr.custom.e = e;
-        hdr.custom.e0 = e0;
-        hdr.custom.e1 = e1;
-        hdr.custom.e2 = e2;
-        hdr.custom.e00 = e00;
-        hdr.custom.e01 = e01;
-        hdr.custom.e02 = e02;
-        hdr.custom.e10 = e10;
-        hdr.custom.e11 = e11;
-        hdr.custom.e12 = e12;
-        hdr.custom.e20 = e20;
-        hdr.custom.e21 = e21;
-        hdr.custom.e22 = e22;
-        hdr.custom.e001 = e001;
-        hdr.custom.e002 = e002;
-        hdr.custom.e101 = e101;
-        hdr.custom.e102 = e102;
-        hdr.custom.e201 = e201;
-        hdr.custom.e202 = e202;
-        hdr.custom.e220 = e220;
-        hdr.custom.e0020010 = e0020010;
-        hdr.custom.e0020020 = e0020020;
-        hdr.custom.s0 = s0;
+    @name("ingress.set_headers") action set_headers(@name("addr0") Eth0_t addr0_1, @name("addr1") Eth1_t addr1_1, @name("addr2") Eth2_t addr2_1, @name("e") bit<8> e_1, @name("e0") Custom0_t e0_1, @name("e1") Custom1_t e1_1, @name("e2") Custom2_t e2_1, @name("e00") Custom00_t e00_1, @name("e01") Custom01_t e01_1, @name("e02") Custom02_t e02_1, @name("e10") Custom10_t e10_1, @name("e11") Custom11_t e11_1, @name("e12") Custom12_t e12_1, @name("e20") Custom20_t e20_1, @name("e21") Custom21_t e21_1, @name("e22") Custom22_t e22_1, @name("e001") Custom001_t e001_1, @name("e002") Custom002_t e002_1, @name("e101") Custom101_t e101_1, @name("e102") Custom102_t e102_1, @name("e201") Custom201_t e201_1, @name("e202") Custom202_t e202_1, @name("e220") Custom220_t e220_1, @name("e0020010") Custom0020010_t e0020010_1, @name("e0020020") Custom0020020_t e0020020_1, @name("s0") serenum0_t s0_1) {
+        hdr.custom.addr0 = addr0_1;
+        hdr.custom.addr1 = addr1_1;
+        hdr.custom.addr2 = addr2_1;
+        hdr.custom.e = e_1;
+        hdr.custom.e0 = e0_1;
+        hdr.custom.e1 = e1_1;
+        hdr.custom.e2 = e2_1;
+        hdr.custom.e00 = e00_1;
+        hdr.custom.e01 = e01_1;
+        hdr.custom.e02 = e02_1;
+        hdr.custom.e10 = e10_1;
+        hdr.custom.e11 = e11_1;
+        hdr.custom.e12 = e12_1;
+        hdr.custom.e20 = e20_1;
+        hdr.custom.e21 = e21_1;
+        hdr.custom.e22 = e22_1;
+        hdr.custom.e001 = e001_1;
+        hdr.custom.e002 = e002_1;
+        hdr.custom.e101 = e101_1;
+        hdr.custom.e102 = e102_1;
+        hdr.custom.e201 = e201_1;
+        hdr.custom.e202 = e202_1;
+        hdr.custom.e220 = e220_1;
+        hdr.custom.e0020010 = e0020010_1;
+        hdr.custom.e0020020 = e0020020_1;
+        hdr.custom.s0 = s0_1;
     }
     @name("ingress.my_drop") action my_drop() {
     }

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-enumint-types1-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-enumint-types1-midend.p4
@@ -152,36 +152,36 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, in
 }
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("ingress.set_output") action set_output(bit<9> out_port) {
+    @name("ingress.set_output") action set_output(@name("out_port") bit<9> out_port) {
         stdmeta.egress_spec = out_port;
     }
-    @name("ingress.set_headers") action set_headers(Eth0_t addr0, Eth1_t addr1, Eth2_t addr2, bit<8> e, Custom0_t e0, Custom1_t e1, Custom2_t e2, Custom00_t e00, Custom01_t e01, Custom02_t e02, Custom10_t e10, Custom11_t e11, Custom12_t e12, Custom20_t e20, Custom21_t e21, Custom22_t e22, Custom001_t e001, Custom002_t e002, Custom101_t e101, Custom102_t e102, Custom201_t e201, Custom202_t e202, Custom220_t e220, Custom0020010_t e0020010, Custom0020020_t e0020020, int<8> s0) {
-        hdr.custom._addr00 = addr0;
-        hdr.custom._addr11 = addr1;
-        hdr.custom._addr22 = addr2;
-        hdr.custom._e3 = e;
-        hdr.custom._e04 = e0;
-        hdr.custom._e15 = e1;
-        hdr.custom._e26 = e2;
-        hdr.custom._e007 = e00;
-        hdr.custom._e018 = e01;
-        hdr.custom._e029 = e02;
-        hdr.custom._e1010 = e10;
-        hdr.custom._e1111 = e11;
-        hdr.custom._e1212 = e12;
-        hdr.custom._e2013 = e20;
-        hdr.custom._e2114 = e21;
-        hdr.custom._e2215 = e22;
-        hdr.custom._e00116 = e001;
-        hdr.custom._e00217 = e002;
-        hdr.custom._e10118 = e101;
-        hdr.custom._e10219 = e102;
-        hdr.custom._e20120 = e201;
-        hdr.custom._e20221 = e202;
-        hdr.custom._e22022 = e220;
-        hdr.custom._e002001023 = e0020010;
-        hdr.custom._e002002024 = e0020020;
-        hdr.custom._s028 = s0;
+    @name("ingress.set_headers") action set_headers(@name("addr0") Eth0_t addr0_1, @name("addr1") Eth1_t addr1_1, @name("addr2") Eth2_t addr2_1, @name("e") bit<8> e_1, @name("e0") Custom0_t e0_1, @name("e1") Custom1_t e1_1, @name("e2") Custom2_t e2_1, @name("e00") Custom00_t e00_1, @name("e01") Custom01_t e01_1, @name("e02") Custom02_t e02_1, @name("e10") Custom10_t e10_1, @name("e11") Custom11_t e11_1, @name("e12") Custom12_t e12_1, @name("e20") Custom20_t e20_1, @name("e21") Custom21_t e21_1, @name("e22") Custom22_t e22_1, @name("e001") Custom001_t e001_1, @name("e002") Custom002_t e002_1, @name("e101") Custom101_t e101_1, @name("e102") Custom102_t e102_1, @name("e201") Custom201_t e201_1, @name("e202") Custom202_t e202_1, @name("e220") Custom220_t e220_1, @name("e0020010") Custom0020010_t e0020010_1, @name("e0020020") Custom0020020_t e0020020_1, @name("s0") int<8> s0_1) {
+        hdr.custom._addr00 = addr0_1;
+        hdr.custom._addr11 = addr1_1;
+        hdr.custom._addr22 = addr2_1;
+        hdr.custom._e3 = e_1;
+        hdr.custom._e04 = e0_1;
+        hdr.custom._e15 = e1_1;
+        hdr.custom._e26 = e2_1;
+        hdr.custom._e007 = e00_1;
+        hdr.custom._e018 = e01_1;
+        hdr.custom._e029 = e02_1;
+        hdr.custom._e1010 = e10_1;
+        hdr.custom._e1111 = e11_1;
+        hdr.custom._e1212 = e12_1;
+        hdr.custom._e2013 = e20_1;
+        hdr.custom._e2114 = e21_1;
+        hdr.custom._e2215 = e22_1;
+        hdr.custom._e00116 = e001_1;
+        hdr.custom._e00217 = e002_1;
+        hdr.custom._e10118 = e101_1;
+        hdr.custom._e10219 = e102_1;
+        hdr.custom._e20120 = e201_1;
+        hdr.custom._e20221 = e202_1;
+        hdr.custom._e22022 = e220_1;
+        hdr.custom._e002001023 = e0020010_1;
+        hdr.custom._e002002024 = e0020020_1;
+        hdr.custom._s028 = s0_1;
     }
     @name("ingress.my_drop") action my_drop() {
     }

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1-frontend.p4
@@ -156,36 +156,36 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, in
 }
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("ingress.set_output") action set_output(bit<9> out_port) {
+    @name("ingress.set_output") action set_output(@name("out_port") bit<9> out_port) {
         stdmeta.egress_spec = out_port;
     }
-    @name("ingress.set_headers") action set_headers(Eth0_t addr0, Eth1_t addr1, Eth2_t addr2, bit<8> e, Custom0_t e0, Custom1_t e1, Custom2_t e2, Custom00_t e00, Custom01_t e01, Custom02_t e02, Custom10_t e10, Custom11_t e11, Custom12_t e12, Custom20_t e20, Custom21_t e21, Custom22_t e22, Custom001_t e001, Custom002_t e002, Custom101_t e101, Custom102_t e102, Custom201_t e201, Custom202_t e202, Custom220_t e220, Custom0020010_t e0020010, Custom0020020_t e0020020, serenum0_t s0) {
-        hdr.custom.addr0 = addr0;
-        hdr.custom.addr1 = addr1;
-        hdr.custom.addr2 = addr2;
-        hdr.custom.e = e;
-        hdr.custom.e0 = e0;
-        hdr.custom.e1 = e1;
-        hdr.custom.e2 = e2;
-        hdr.custom.e00 = e00;
-        hdr.custom.e01 = e01;
-        hdr.custom.e02 = e02;
-        hdr.custom.e10 = e10;
-        hdr.custom.e11 = e11;
-        hdr.custom.e12 = e12;
-        hdr.custom.e20 = e20;
-        hdr.custom.e21 = e21;
-        hdr.custom.e22 = e22;
-        hdr.custom.e001 = e001;
-        hdr.custom.e002 = e002;
-        hdr.custom.e101 = e101;
-        hdr.custom.e102 = e102;
-        hdr.custom.e201 = e201;
-        hdr.custom.e202 = e202;
-        hdr.custom.e220 = e220;
-        hdr.custom.e0020010 = e0020010;
-        hdr.custom.e0020020 = e0020020;
-        hdr.custom.s0 = s0;
+    @name("ingress.set_headers") action set_headers(@name("addr0") Eth0_t addr0_1, @name("addr1") Eth1_t addr1_1, @name("addr2") Eth2_t addr2_1, @name("e") bit<8> e_1, @name("e0") Custom0_t e0_1, @name("e1") Custom1_t e1_1, @name("e2") Custom2_t e2_1, @name("e00") Custom00_t e00_1, @name("e01") Custom01_t e01_1, @name("e02") Custom02_t e02_1, @name("e10") Custom10_t e10_1, @name("e11") Custom11_t e11_1, @name("e12") Custom12_t e12_1, @name("e20") Custom20_t e20_1, @name("e21") Custom21_t e21_1, @name("e22") Custom22_t e22_1, @name("e001") Custom001_t e001_1, @name("e002") Custom002_t e002_1, @name("e101") Custom101_t e101_1, @name("e102") Custom102_t e102_1, @name("e201") Custom201_t e201_1, @name("e202") Custom202_t e202_1, @name("e220") Custom220_t e220_1, @name("e0020010") Custom0020010_t e0020010_1, @name("e0020020") Custom0020020_t e0020020_1, @name("s0") serenum0_t s0_1) {
+        hdr.custom.addr0 = addr0_1;
+        hdr.custom.addr1 = addr1_1;
+        hdr.custom.addr2 = addr2_1;
+        hdr.custom.e = e_1;
+        hdr.custom.e0 = e0_1;
+        hdr.custom.e1 = e1_1;
+        hdr.custom.e2 = e2_1;
+        hdr.custom.e00 = e00_1;
+        hdr.custom.e01 = e01_1;
+        hdr.custom.e02 = e02_1;
+        hdr.custom.e10 = e10_1;
+        hdr.custom.e11 = e11_1;
+        hdr.custom.e12 = e12_1;
+        hdr.custom.e20 = e20_1;
+        hdr.custom.e21 = e21_1;
+        hdr.custom.e22 = e22_1;
+        hdr.custom.e001 = e001_1;
+        hdr.custom.e002 = e002_1;
+        hdr.custom.e101 = e101_1;
+        hdr.custom.e102 = e102_1;
+        hdr.custom.e201 = e201_1;
+        hdr.custom.e202 = e202_1;
+        hdr.custom.e220 = e220_1;
+        hdr.custom.e0020010 = e0020010_1;
+        hdr.custom.e0020020 = e0020020_1;
+        hdr.custom.s0 = s0_1;
     }
     @name("ingress.my_drop") action my_drop() {
     }

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1-midend.p4
@@ -152,36 +152,36 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, in
 }
 
 control ingress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
-    @name("ingress.set_output") action set_output(bit<9> out_port) {
+    @name("ingress.set_output") action set_output(@name("out_port") bit<9> out_port) {
         stdmeta.egress_spec = out_port;
     }
-    @name("ingress.set_headers") action set_headers(Eth0_t addr0, Eth1_t addr1, Eth2_t addr2, bit<8> e, Custom0_t e0, Custom1_t e1, Custom2_t e2, Custom00_t e00, Custom01_t e01, Custom02_t e02, Custom10_t e10, Custom11_t e11, Custom12_t e12, Custom20_t e20, Custom21_t e21, Custom22_t e22, Custom001_t e001, Custom002_t e002, Custom101_t e101, Custom102_t e102, Custom201_t e201, Custom202_t e202, Custom220_t e220, Custom0020010_t e0020010, Custom0020020_t e0020020, bit<8> s0) {
-        hdr.custom._addr00 = addr0;
-        hdr.custom._addr11 = addr1;
-        hdr.custom._addr22 = addr2;
-        hdr.custom._e3 = e;
-        hdr.custom._e04 = e0;
-        hdr.custom._e15 = e1;
-        hdr.custom._e26 = e2;
-        hdr.custom._e007 = e00;
-        hdr.custom._e018 = e01;
-        hdr.custom._e029 = e02;
-        hdr.custom._e1010 = e10;
-        hdr.custom._e1111 = e11;
-        hdr.custom._e1212 = e12;
-        hdr.custom._e2013 = e20;
-        hdr.custom._e2114 = e21;
-        hdr.custom._e2215 = e22;
-        hdr.custom._e00116 = e001;
-        hdr.custom._e00217 = e002;
-        hdr.custom._e10118 = e101;
-        hdr.custom._e10219 = e102;
-        hdr.custom._e20120 = e201;
-        hdr.custom._e20221 = e202;
-        hdr.custom._e22022 = e220;
-        hdr.custom._e002001023 = e0020010;
-        hdr.custom._e002002024 = e0020020;
-        hdr.custom._s028 = s0;
+    @name("ingress.set_headers") action set_headers(@name("addr0") Eth0_t addr0_1, @name("addr1") Eth1_t addr1_1, @name("addr2") Eth2_t addr2_1, @name("e") bit<8> e_1, @name("e0") Custom0_t e0_1, @name("e1") Custom1_t e1_1, @name("e2") Custom2_t e2_1, @name("e00") Custom00_t e00_1, @name("e01") Custom01_t e01_1, @name("e02") Custom02_t e02_1, @name("e10") Custom10_t e10_1, @name("e11") Custom11_t e11_1, @name("e12") Custom12_t e12_1, @name("e20") Custom20_t e20_1, @name("e21") Custom21_t e21_1, @name("e22") Custom22_t e22_1, @name("e001") Custom001_t e001_1, @name("e002") Custom002_t e002_1, @name("e101") Custom101_t e101_1, @name("e102") Custom102_t e102_1, @name("e201") Custom201_t e201_1, @name("e202") Custom202_t e202_1, @name("e220") Custom220_t e220_1, @name("e0020010") Custom0020010_t e0020010_1, @name("e0020020") Custom0020020_t e0020020_1, @name("s0") bit<8> s0_1) {
+        hdr.custom._addr00 = addr0_1;
+        hdr.custom._addr11 = addr1_1;
+        hdr.custom._addr22 = addr2_1;
+        hdr.custom._e3 = e_1;
+        hdr.custom._e04 = e0_1;
+        hdr.custom._e15 = e1_1;
+        hdr.custom._e26 = e2_1;
+        hdr.custom._e007 = e00_1;
+        hdr.custom._e018 = e01_1;
+        hdr.custom._e029 = e02_1;
+        hdr.custom._e1010 = e10_1;
+        hdr.custom._e1111 = e11_1;
+        hdr.custom._e1212 = e12_1;
+        hdr.custom._e2013 = e20_1;
+        hdr.custom._e2114 = e21_1;
+        hdr.custom._e2215 = e22_1;
+        hdr.custom._e00116 = e001_1;
+        hdr.custom._e00217 = e002_1;
+        hdr.custom._e10118 = e101_1;
+        hdr.custom._e10219 = e102_1;
+        hdr.custom._e20120 = e201_1;
+        hdr.custom._e20221 = e202_1;
+        hdr.custom._e22022 = e220_1;
+        hdr.custom._e002001023 = e0020010_1;
+        hdr.custom._e002002024 = e0020020_1;
+        hdr.custom._s028 = s0_1;
     }
     @name("ingress.my_drop") action my_drop() {
     }

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-frontend.p4
@@ -58,10 +58,10 @@ parser ParserImpl(packet_in packet, out headers_t hdr, inout meta_t meta, inout 
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
-    @name(".my_drop") action my_drop(inout standard_metadata_t smeta) {
+    @name(".my_drop") action my_drop(@name("smeta") inout standard_metadata_t smeta) {
         mark_to_drop(smeta);
     }
-    @name(".my_drop") action my_drop_0(inout standard_metadata_t smeta_1) {
+    @name(".my_drop") action my_drop_0(@name("smeta") inout standard_metadata_t smeta_1) {
         mark_to_drop(smeta_1);
     }
     @name("ingress.ipv4_address_0") bit<32> ipv4_address_0;
@@ -69,19 +69,19 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
     @name("ingress.byte1_0") bit<8> byte1_0;
     @name("ingress.byte2_0") bit<8> byte2_0;
     @name("ingress.byte3_0") bit<8> byte3_0;
-    @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
-        meta.fwd.l2ptr = l2ptr;
+    @name("ingress.set_l2ptr") action set_l2ptr(@name("l2ptr") bit<32> l2ptr_2) {
+        meta.fwd.l2ptr = l2ptr_2;
     }
-    @name("ingress.set_mcast_grp") action set_mcast_grp(bit<16> mcast_grp) {
-        standard_metadata.mcast_grp = mcast_grp;
+    @name("ingress.set_mcast_grp") action set_mcast_grp(@name("mcast_grp") bit<16> mcast_grp_1) {
+        standard_metadata.mcast_grp = mcast_grp_1;
     }
-    @name("ingress.do_resubmit") action do_resubmit(bit<32> new_ipv4_dstAddr) {
+    @name("ingress.do_resubmit") action do_resubmit(@name("new_ipv4_dstAddr") bit<32> new_ipv4_dstAddr) {
         hdr.ipv4.dstAddr = new_ipv4_dstAddr;
         resubmit<tuple<>>({  });
     }
-    @name("ingress.do_clone_i2e") action do_clone_i2e(bit<32> l2ptr) {
+    @name("ingress.do_clone_i2e") action do_clone_i2e(@name("l2ptr") bit<32> l2ptr_3) {
         clone3<tuple<>>(CloneType.I2E, 32w5, {  });
-        meta.fwd.l2ptr = l2ptr;
+        meta.fwd.l2ptr = l2ptr_3;
     }
     @name("ingress.ipv4_da_lpm") table ipv4_da_lpm_0 {
         key = {
@@ -96,7 +96,7 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         }
         default_action = my_drop(standard_metadata);
     }
-    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
+    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(@name("bd") bit<24> bd, @name("dmac") bit<48> dmac, @name("intf") bit<9> intf) {
         meta.fwd.out_bd = bd;
         hdr.ethernet.dstAddr = dmac;
         standard_metadata.egress_spec = intf;
@@ -141,11 +141,11 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
 control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
-    @name(".my_drop") action my_drop_1(inout standard_metadata_t smeta_2) {
+    @name(".my_drop") action my_drop_1(@name("smeta") inout standard_metadata_t smeta_2) {
         mark_to_drop(smeta_2);
     }
-    @name("egress.set_out_bd") action set_out_bd(bit<24> bd) {
-        meta.fwd.out_bd = bd;
+    @name("egress.set_out_bd") action set_out_bd(@name("bd") bit<24> bd_2) {
+        meta.fwd.out_bd = bd_2;
     }
     @name("egress.get_multicast_copy_out_bd") table get_multicast_copy_out_bd_0 {
         key = {
@@ -158,15 +158,15 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
         }
         default_action = NoAction_0();
     }
-    @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name("egress.rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
-    @name("egress.do_recirculate") action do_recirculate(bit<32> new_ipv4_dstAddr) {
-        hdr.ipv4.dstAddr = new_ipv4_dstAddr;
+    @name("egress.do_recirculate") action do_recirculate(@name("new_ipv4_dstAddr") bit<32> new_ipv4_dstAddr_2) {
+        hdr.ipv4.dstAddr = new_ipv4_dstAddr_2;
         recirculate<tuple<>>({  });
     }
-    @name("egress.do_clone_e2e") action do_clone_e2e(bit<48> smac) {
-        hdr.ethernet.srcAddr = smac;
+    @name("egress.do_clone_e2e") action do_clone_e2e(@name("smac") bit<48> smac_2) {
+        hdr.ethernet.srcAddr = smac_2;
         clone3<tuple<>>(CloneType.E2E, 32w11, {  });
     }
     @name("egress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2-midend.p4
@@ -62,8 +62,8 @@ struct tuple_0 {
 }
 
 control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
-    standard_metadata_t smeta;
-    standard_metadata_t smeta_1;
+    @name("smeta") standard_metadata_t smeta;
+    @name("smeta") standard_metadata_t smeta_1;
     @name(".my_drop") action my_drop() {
         smeta.ingress_port = standard_metadata.ingress_port;
         smeta.egress_spec = standard_metadata.egress_spec;
@@ -134,19 +134,19 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         standard_metadata.parser_error = smeta_1.parser_error;
         standard_metadata.priority = smeta_1.priority;
     }
-    @name("ingress.set_l2ptr") action set_l2ptr(bit<32> l2ptr) {
-        meta._fwd_l2ptr0 = l2ptr;
+    @name("ingress.set_l2ptr") action set_l2ptr(@name("l2ptr") bit<32> l2ptr_2) {
+        meta._fwd_l2ptr0 = l2ptr_2;
     }
-    @name("ingress.set_mcast_grp") action set_mcast_grp(bit<16> mcast_grp) {
-        standard_metadata.mcast_grp = mcast_grp;
+    @name("ingress.set_mcast_grp") action set_mcast_grp(@name("mcast_grp") bit<16> mcast_grp_1) {
+        standard_metadata.mcast_grp = mcast_grp_1;
     }
-    @name("ingress.do_resubmit") action do_resubmit(bit<32> new_ipv4_dstAddr) {
+    @name("ingress.do_resubmit") action do_resubmit(@name("new_ipv4_dstAddr") bit<32> new_ipv4_dstAddr) {
         hdr.ipv4.dstAddr = new_ipv4_dstAddr;
         resubmit<tuple_0>({  });
     }
-    @name("ingress.do_clone_i2e") action do_clone_i2e(bit<32> l2ptr) {
+    @name("ingress.do_clone_i2e") action do_clone_i2e(@name("l2ptr") bit<32> l2ptr_3) {
         clone3<tuple_0>(CloneType.I2E, 32w5, {  });
-        meta._fwd_l2ptr0 = l2ptr;
+        meta._fwd_l2ptr0 = l2ptr_3;
     }
     @name("ingress.ipv4_da_lpm") table ipv4_da_lpm_0 {
         key = {
@@ -161,7 +161,7 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
         }
         default_action = my_drop();
     }
-    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(bit<24> bd, bit<48> dmac, bit<9> intf) {
+    @name("ingress.set_bd_dmac_intf") action set_bd_dmac_intf(@name("bd") bit<24> bd, @name("dmac") bit<48> dmac, @name("intf") bit<9> intf) {
         meta._fwd_out_bd1 = bd;
         hdr.ethernet.dstAddr = dmac;
         standard_metadata.egress_spec = intf;
@@ -212,7 +212,7 @@ control ingress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_
 }
 
 control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t standard_metadata) {
-    standard_metadata_t smeta_2;
+    @name("smeta") standard_metadata_t smeta_2;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name(".my_drop") action my_drop_1() {
@@ -250,8 +250,8 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
         standard_metadata.parser_error = smeta_2.parser_error;
         standard_metadata.priority = smeta_2.priority;
     }
-    @name("egress.set_out_bd") action set_out_bd(bit<24> bd) {
-        meta._fwd_out_bd1 = bd;
+    @name("egress.set_out_bd") action set_out_bd(@name("bd") bit<24> bd_2) {
+        meta._fwd_out_bd1 = bd_2;
     }
     @name("egress.get_multicast_copy_out_bd") table get_multicast_copy_out_bd_0 {
         key = {
@@ -264,15 +264,15 @@ control egress(inout headers_t hdr, inout meta_t meta, inout standard_metadata_t
         }
         default_action = NoAction_0();
     }
-    @name("egress.rewrite_mac") action rewrite_mac(bit<48> smac) {
+    @name("egress.rewrite_mac") action rewrite_mac(@name("smac") bit<48> smac) {
         hdr.ethernet.srcAddr = smac;
     }
-    @name("egress.do_recirculate") action do_recirculate(bit<32> new_ipv4_dstAddr) {
-        hdr.ipv4.dstAddr = new_ipv4_dstAddr;
+    @name("egress.do_recirculate") action do_recirculate(@name("new_ipv4_dstAddr") bit<32> new_ipv4_dstAddr_2) {
+        hdr.ipv4.dstAddr = new_ipv4_dstAddr_2;
         recirculate<tuple_0>({  });
     }
-    @name("egress.do_clone_e2e") action do_clone_e2e(bit<48> smac) {
-        hdr.ethernet.srcAddr = smac;
+    @name("egress.do_clone_e2e") action do_clone_e2e(@name("smac") bit<48> smac_2) {
+        hdr.ethernet.srcAddr = smac_2;
         clone3<tuple_0>(CloneType.E2E, 32w11, {  });
     }
     @name("egress.send_frame") table send_frame_0 {

--- a/testdata/p4_16_samples_outputs/vss-example-frontend.p4
+++ b/testdata/p4_16_samples_outputs/vss-example-frontend.p4
@@ -94,7 +94,7 @@ control TopPipe(inout Parsed_packet headers, in error parseError, in InControl i
     @name("TopPipe.Drop_action") action Drop_action_6() {
         outCtrl.outputPort = 4w0xf;
     }
-    @name("TopPipe.Set_nhop") action Set_nhop(IPv4Address ipv4_dest, PortId port) {
+    @name("TopPipe.Set_nhop") action Set_nhop(@name("ipv4_dest") IPv4Address ipv4_dest, @name("port") PortId port) {
         nextHop_0 = ipv4_dest;
         headers.ip.ttl = headers.ip.ttl + 8w255;
         outCtrl.outputPort = port;
@@ -123,7 +123,7 @@ control TopPipe(inout Parsed_packet headers, in error parseError, in InControl i
         }
         const default_action = NoAction_0();
     }
-    @name("TopPipe.Set_dmac") action Set_dmac(EthernetAddress dmac) {
+    @name("TopPipe.Set_dmac") action Set_dmac(@name("dmac") EthernetAddress dmac) {
         headers.ethernet.dstAddr = dmac;
     }
     @name("TopPipe.dmac") table dmac_0 {
@@ -137,7 +137,7 @@ control TopPipe(inout Parsed_packet headers, in error parseError, in InControl i
         size = 1024;
         default_action = Drop_action_4();
     }
-    @name("TopPipe.Set_smac") action Set_smac(EthernetAddress smac) {
+    @name("TopPipe.Set_smac") action Set_smac(@name("smac") EthernetAddress smac) {
         headers.ethernet.srcAddr = smac;
     }
     @name("TopPipe.smac") table smac_0 {

--- a/testdata/p4_16_samples_outputs/vss-example-midend.p4
+++ b/testdata/p4_16_samples_outputs/vss-example-midend.p4
@@ -96,7 +96,7 @@ control TopPipe(inout Parsed_packet headers, in error parseError, in InControl i
     @name("TopPipe.Drop_action") action Drop_action_6() {
         outCtrl.outputPort = 4w0xf;
     }
-    @name("TopPipe.Set_nhop") action Set_nhop(IPv4Address ipv4_dest, PortId port) {
+    @name("TopPipe.Set_nhop") action Set_nhop(@name("ipv4_dest") IPv4Address ipv4_dest, @name("port") PortId port) {
         nextHop_0 = ipv4_dest;
         headers.ip.ttl = headers.ip.ttl + 8w255;
         outCtrl.outputPort = port;
@@ -125,7 +125,7 @@ control TopPipe(inout Parsed_packet headers, in error parseError, in InControl i
         }
         const default_action = NoAction_0();
     }
-    @name("TopPipe.Set_dmac") action Set_dmac(EthernetAddress dmac) {
+    @name("TopPipe.Set_dmac") action Set_dmac(@name("dmac") EthernetAddress dmac) {
         headers.ethernet.dstAddr = dmac;
     }
     @name("TopPipe.dmac") table dmac_0 {
@@ -139,7 +139,7 @@ control TopPipe(inout Parsed_packet headers, in error parseError, in InControl i
         size = 1024;
         default_action = Drop_action_4();
     }
-    @name("TopPipe.Set_smac") action Set_smac(EthernetAddress smac) {
+    @name("TopPipe.Set_smac") action Set_smac(@name("smac") EthernetAddress smac) {
         headers.ethernet.srcAddr = smac;
     }
     @name("TopPipe.smac") table smac_0 {

--- a/testdata/p4_16_samples_outputs/xor_test-first.p4
+++ b/testdata/p4_16_samples_outputs/xor_test-first.p4
@@ -108,7 +108,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
                         9w1 : forward_and_do_something(9w2);
                         9w2 : forward_and_do_something(9w1);
         }
-
         default_action = NoAction();
     }
     table debug {

--- a/testdata/p4_16_samples_outputs/xor_test-frontend.p4
+++ b/testdata/p4_16_samples_outputs/xor_test-frontend.p4
@@ -65,7 +65,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name("MyIngress.forward_and_do_something") action forward_and_do_something(egressSpec_t port) {
+    @name("MyIngress.forward_and_do_something") action forward_and_do_something(@name("port") egressSpec_t port) {
         standard_metadata.egress_spec = port;
         if (hdr.ipv4.isValid()) {
             meta.before1 = hdr.ipv4.srcAddr;
@@ -99,7 +99,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
                         9w1 : forward_and_do_something(9w2);
                         9w2 : forward_and_do_something(9w1);
         }
-
         default_action = NoAction_0();
     }
     @name("MyIngress.debug") table debug_0 {

--- a/testdata/p4_16_samples_outputs/xor_test-midend.p4
+++ b/testdata/p4_16_samples_outputs/xor_test-midend.p4
@@ -71,7 +71,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
-    @name("MyIngress.forward_and_do_something") action forward_and_do_something(egressSpec_t port) {
+    @name("MyIngress.forward_and_do_something") action forward_and_do_something(@name("port") egressSpec_t port) {
         standard_metadata.egress_spec = port;
         meta.before1 = (hdr.ipv4.isValid() ? hdr.ipv4.srcAddr : meta.before1);
         hdr.ipv4.srcAddr = (hdr.ipv4.isValid() ? hdr.ipv4.srcAddr ^ 32w0x12345678 : hdr.ipv4.srcAddr);
@@ -100,7 +100,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
                         9w1 : forward_and_do_something(9w2);
                         9w2 : forward_and_do_something(9w1);
         }
-
         default_action = NoAction_0();
     }
     @name("MyIngress.debug") table debug_0 {

--- a/testdata/p4_16_samples_outputs/xor_test.p4
+++ b/testdata/p4_16_samples_outputs/xor_test.p4
@@ -108,7 +108,6 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
                         1 : forward_and_do_something(2);
                         2 : forward_and_do_something(1);
         }
-
         default_action = NoAction();
     }
     table debug {


### PR DESCRIPTION
Fixes #2710
The code changes are small, but most reference outputs are changed.
I have also modified the test script to make sure that when new reference outputs are changed the p4info files do not change.