### PR TITLE
Fix dpdk regression failure: declaration not found

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -21,17 +21,6 @@ p4c_add_xfail_reason("dpdk"
   )
 
 p4c_add_xfail_reason("dpdk"
-  "declaration not found"
-  testdata/p4_16_samples/psa-action-selector1.p4
-  testdata/p4_16_samples/psa-action-selector2.p4
-  testdata/p4_16_samples/psa-action-selector3.p4
-  testdata/p4_16_samples/psa-hash.p4
-  testdata/p4_16_samples/psa-random.p4
-  testdata/p4_16_samples/psa-register2.p4
-  testdata/p4_16_samples/psa-register3.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
   "Unsupported parser loop"
   testdata/p4_16_samples/psa-example-digest-bmv2.p4
   testdata/p4_16_samples/psa-example-counters-bmv2.p4
@@ -61,6 +50,16 @@ p4c_add_xfail_reason("dpdk"
   )
 
 p4c_add_xfail_reason("dpdk"
+  "Not implemented"
+  testdata/p4_16_samples/psa-random.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
   "Error compiling"
   testdata/p4_16_samples/psa-recirculate-no-meta-bmv2.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  "get_hash's arg is not a ListExpression"
+  testdata/p4_16_samples/psa-hash.p4
   )

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -286,7 +286,26 @@ bool CollectMetadataHeaderInfo::preorder(const IR::Type_Struct *s) {
     return true;
 }
 
+const IR::Node *ReplaceMetadataHeaderName::preorder(IR::PathExpression *pe) {
+    auto declaration = refMap->getDeclaration(pe->path);
+    if (auto decl = declaration->to<IR::Parameter>()) {
+        if (auto type = decl->type->to<IR::Type_Name>()) {
+            if (type->path->name == info->header_type){
+                    return new IR::PathExpression(IR::ID("h"));
+                } else if (type->path->name == info->local_metadata_type){
+                    return new IR::PathExpression(IR::ID("m"));
+                }
+            }
+        }
+    return pe;
+}
+
 const IR::Node *ReplaceMetadataHeaderName::preorder(IR::Member *m) {
+    /* PathExpressions are handled in a separate preorder function
+      Hence do not process them here */
+    if (!(m->expr->is<IR::Member>()))
+        prune();
+
     if (auto p = m->expr->to<IR::PathExpression>()) {
         auto declaration = refMap->getDeclaration(p->path);
         if (auto decl = declaration->to<IR::Parameter>()) {

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -132,6 +132,7 @@ class ReplaceMetadataHeaderName : public Transform {
         : refMap(refMap), info(info) {}
     const IR::Node *preorder(IR::Member *m) override;
     const IR::Node *preorder(IR::Parameter *p) override;
+    const IR::Node *preorder(IR::PathExpression *pe) override;
 };
 
 // Previously, we have collected the information about how the single metadata

--- a/testdata/p4_16_samples_outputs/psa-action-selector1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1.p4.spec
@@ -1,0 +1,82 @@
+
+
+struct user_meta_t {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+}
+metadata instanceof user_meta_t
+
+struct a1_arg_t {
+	bit<48> param
+}
+
+struct a2_arg_t {
+	bit<16> param
+}
+
+action NoAction args none {
+	return
+}
+
+action a1 args instanceof a1_arg_t {
+	mov h.dstAddr t.param
+	return
+}
+
+action a2 args instanceof a2_arg_t {
+	mov h.etherType t.param
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+		m.local_metadata_data selector
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	action_selector as_0
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4.spec
@@ -1,0 +1,84 @@
+
+
+struct user_meta_t {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data1
+	bit<16> local_metadata_data2
+}
+metadata instanceof user_meta_t
+
+struct a1_arg_t {
+	bit<48> param
+}
+
+struct a2_arg_t {
+	bit<16> param
+}
+
+action NoAction args none {
+	return
+}
+
+action a1 args instanceof a1_arg_t {
+	mov h.dstAddr t.param
+	return
+}
+
+action a2 args instanceof a2_arg_t {
+	mov h.etherType t.param
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+		m.local_metadata_data1 selector
+		m.local_metadata_data2 selector
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	action_selector as_0
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4.spec
@@ -1,0 +1,82 @@
+
+struct user_meta_t {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data1
+	bit<16> local_metadata_data2
+}
+metadata instanceof user_meta_t
+
+struct a1_arg_t {
+	bit<48> param
+}
+
+struct a2_arg_t {
+	bit<16> param
+}
+
+action NoAction args none {
+	return
+}
+
+action a1 args instanceof a1_arg_t {
+	mov h.dstAddr t.param
+	return
+}
+
+action a2 args instanceof a2_arg_t {
+	mov h.etherType t.param
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+		m.local_metadata_data1 selector
+		m.local_metadata_data2 selector
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.spec
@@ -1,0 +1,69 @@
+
+
+struct user_meta_t {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+}
+metadata instanceof user_meta_t
+
+struct execute_register_arg_t {
+	bit<10> idx
+}
+
+action NoAction args none {
+	return
+}
+
+action execute_register args instanceof execute_register_arg_t {
+	register_write reg_0 t.idx m.local_metadata_data
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute_register
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.spec
@@ -1,0 +1,69 @@
+
+
+struct user_meta_t {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+}
+metadata instanceof user_meta_t
+
+struct execute_register_arg_t {
+	bit<10> idx
+}
+
+action NoAction args none {
+	return
+}
+
+action execute_register args instanceof execute_register_arg_t {
+	register_write reg_0 t.idx m.local_metadata_data
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute_register
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+


### PR DESCRIPTION
This commit fixes the "declaration not found" error with p4c-dpdk. 
- Added a new preorder function which works on the Pathexpressions for replacing the header and metadata variable references.
- With this change, some of the tests in XFAIL list of dpdk backend are compiling fine. Updated the XFAIL list for the same.