### PR TITLE
Fix typo in def-use analysis

### DIFF
--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -29,11 +29,13 @@ class LocationSet;
 
 /// Abstraction for something that is has a left value (variable, parameter)
 class StorageLocation : public IHasDbPrint {
+    static unsigned crtid;
  public:
     virtual ~StorageLocation() {}
+    unsigned id;
     const IR::Type* type;
     const cstring name;
-    StorageLocation(const IR::Type* type, cstring name) : type(type), name(name)
+    StorageLocation(const IR::Type* type, cstring name) : id(crtid++), type(type), name(name)
     { CHECK_NULL(type); }
     template <class T>
     const T* to() const {
@@ -46,7 +48,7 @@ class StorageLocation : public IHasDbPrint {
         return result != nullptr;
     }
     virtual void dbprint(std::ostream& out) const {
-        out << name;
+        out << id << " " << name;
     }
     cstring toString() const { return name; }
 
@@ -220,7 +222,7 @@ class LocationSet : public IHasDbPrint {
 };
 
 /// Maps a declaration to its associated storage.
-class StorageMap {
+class StorageMap : public IHasDbPrint {
     /// Storage location for each declaration.
     ordered_map<const IR::IDeclaration*, StorageLocation*> storage;
     StorageFactory factory;
@@ -235,7 +237,7 @@ class StorageMap {
     StorageLocation* add(const IR::IDeclaration* decl) {
         CHECK_NULL(decl);
         auto type = typeMap->getType(decl->getNode(), true);
-        auto loc = factory.create(type, decl->externalName());
+        auto loc = factory.create(type, decl->getName() + "/" + decl->externalName());
         if (loc != nullptr)
             storage.emplace(decl, loc);
         return loc;
@@ -447,7 +449,7 @@ class AllDefinitions : public IHasDbPrint {
  *
  */
 
-class ComputeWriteSet : public Inspector {
+class ComputeWriteSet : public Inspector, public IHasDbPrint {
  protected:
     AllDefinitions*     allDefinitions;  /// Result computed by this pass.
     Definitions*        currentDefinitions;  /// Before statement currently processed.
@@ -487,6 +489,12 @@ class ComputeWriteSet : public Inspector {
     void expressionWrites(const IR::Expression* expression, const LocationSet* loc) {
         CHECK_NULL(expression); CHECK_NULL(loc);
         writes.emplace(expression, loc);
+    }
+    virtual void dbprint(std::ostream& out) const {
+        if (writes.empty())
+            out << "No writes";
+        for (auto &it : writes)
+            out << it.first << " writes " << it.second << IndentCtl::endl;
     }
 
  public:

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -30,6 +30,7 @@ class LocationSet;
 /// Abstraction for something that is has a left value (variable, parameter)
 class StorageLocation : public IHasDbPrint {
     static unsigned crtid;
+
  public:
     virtual ~StorageLocation() {}
     unsigned id;

--- a/testdata/p4_16_samples/issue2393.p4
+++ b/testdata/p4_16_samples/issue2393.p4
@@ -1,0 +1,40 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> src_addr;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+action do_global_action(in bool make_zero, out bool val_undefined) {
+    bit<16> tmp;
+    tmp = tmp *  (make_zero ? 16w0: 16w1);
+}
+
+control ingress(inout Headers h) {
+    bool filler_bool = true;
+    bool tmp_bool = false;
+    action do_action() {
+        do_global_action(tmp_bool, tmp_bool);
+    }
+
+    table simple_table {
+        key = {
+            h.eth_hdr.src_addr : exact;
+        }
+        actions = {
+            do_action();
+            do_global_action(true, filler_bool);
+        }
+    }
+    apply {
+        simple_table.apply();
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> _c);
+
+top(ingress()) main;

--- a/testdata/p4_16_samples_outputs/issue2393-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2393-first.p4
@@ -1,0 +1,40 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> src_addr;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+action do_global_action(in bool make_zero, out bool val_undefined) {
+    bit<16> tmp;
+    tmp = tmp * (make_zero ? 16w0 : 16w1);
+}
+control ingress(inout Headers h) {
+    bool filler_bool = true;
+    bool tmp_bool = false;
+    action do_action() {
+        do_global_action(tmp_bool, tmp_bool);
+    }
+    table simple_table {
+        key = {
+            h.eth_hdr.src_addr: exact @name("h.eth_hdr.src_addr") ;
+        }
+        actions = {
+            do_action();
+            do_global_action(true, filler_bool);
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        simple_table.apply();
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> _c);
+top<Headers>(ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2393-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2393-frontend.p4
@@ -1,0 +1,51 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> src_addr;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    @name(".do_global_action") action do_global_action(@name("make_zero") in bool make_zero_1, @name("val_undefined") out bool val_undefined_1) {
+        @name("ingress.tmp") bit<16> tmp;
+        tmp = tmp * (make_zero_1 ? 16w0 : 16w1);
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("ingress.filler_bool") bool filler_bool_0;
+    @name("ingress.tmp_bool") bool tmp_bool_0;
+    @name("ingress.tmp") bool tmp_0;
+    @name("ingress.do_action") action do_action() {
+        tmp_0 = tmp_bool_0;
+        {
+            @name("ingress.make_zero") bool make_zero = tmp_0;
+            @name("ingress.val_undefined") bool val_undefined;
+            @name("ingress.tmp") bit<16> tmp_3;
+            tmp_3 = tmp_3 * (make_zero ? 16w0 : 16w1);
+            tmp_bool_0 = val_undefined;
+        }
+    }
+    @name("ingress.simple_table") table simple_table_0 {
+        key = {
+            h.eth_hdr.src_addr: exact @name("h.eth_hdr.src_addr") ;
+        }
+        actions = {
+            do_action();
+            do_global_action(true, filler_bool_0);
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        tmp_bool_0 = false;
+        simple_table_0.apply();
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> _c);
+top<Headers>(ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2393-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2393-midend.p4
@@ -1,0 +1,55 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> src_addr;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    @name("ingress.tmp") bit<16> tmp;
+    @name("ingress.tmp_bool") bool tmp_bool_0;
+    @name("ingress.val_undefined") bool val_undefined;
+    @name("ingress.tmp") bit<16> tmp_3;
+    @name("val_undefined") bool val_undefined_1;
+    @name(".do_global_action") action do_global_action() {
+        tmp = 16w0;
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("ingress.do_action") action do_action() {
+        tmp_3 = tmp_3 * (tmp_bool_0 ? 16w0 : 16w1);
+        tmp_bool_0 = val_undefined;
+    }
+    @name("ingress.simple_table") table simple_table_0 {
+        key = {
+            h.eth_hdr.src_addr: exact @name("h.eth_hdr.src_addr") ;
+        }
+        actions = {
+            do_action();
+            do_global_action();
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    @hidden action issue2393l18() {
+        tmp_bool_0 = false;
+    }
+    @hidden table tbl_issue2393l18 {
+        actions = {
+            issue2393l18();
+        }
+        const default_action = issue2393l18();
+    }
+    apply {
+        tbl_issue2393l18.apply();
+        simple_table_0.apply();
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> _c);
+top<Headers>(ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2393.p4
+++ b/testdata/p4_16_samples_outputs/issue2393.p4
@@ -1,0 +1,38 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> src_addr;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+action do_global_action(in bool make_zero, out bool val_undefined) {
+    bit<16> tmp;
+    tmp = tmp * (make_zero ? 16w0 : 16w1);
+}
+control ingress(inout Headers h) {
+    bool filler_bool = true;
+    bool tmp_bool = false;
+    action do_action() {
+        do_global_action(tmp_bool, tmp_bool);
+    }
+    table simple_table {
+        key = {
+            h.eth_hdr.src_addr: exact;
+        }
+        actions = {
+            do_action();
+            do_global_action(true, filler_bool);
+        }
+    }
+    apply {
+        simple_table.apply();
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> _c);
+top(ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2393.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2393.p4-stderr
@@ -1,0 +1,9 @@
+issue2393.p4(13): [--Wwarn=uninitialized_use] warning: tmp may be uninitialized
+    tmp = tmp * (make_zero ? 16w0: 16w1);
+          ^^^
+issue2393.p4(11): [--Wwarn=uninitialized_out_param] warning: out parameter 'val_undefined' may be uninitialized when 'do_global_action' terminates
+action do_global_action(in bool make_zero, out bool val_undefined) {
+                                                    ^^^^^^^^^^^^^
+issue2393.p4(11)
+action do_global_action(in bool make_zero, out bool val_undefined) {
+       ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #2393 
Most of the changes are just improved debugging output.
There were two typos in def_use.cpp, as one can notice by comparing with similar code nearby.