### PR TITLE
Fix dpdk regression failure: Duplicates declaration

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -1,26 +1,4 @@
 p4c_add_xfail_reason("dpdk"
-  "Duplicates declaration"
-  testdata/p4_16_samples/psa-action-profile1.p4
-  testdata/p4_16_samples/psa-action-profile2.p4
-  testdata/p4_16_samples/psa-action-profile3.p4
-  testdata/p4_16_samples/psa-action-profile4.p4
-  testdata/p4_16_samples/psa-counter1.p4
-  testdata/p4_16_samples/psa-counter2.p4
-  testdata/p4_16_samples/psa-counter3.p4
-  testdata/p4_16_samples/psa-counter4.p4
-  testdata/p4_16_samples/psa-counter6.p4
-  testdata/p4_16_samples/psa-custom-type-counter-index.p4
-  testdata/p4_16_samples/psa-idle-timeout.p4
-  testdata/p4_16_samples/psa-meter1.p4
-  testdata/p4_16_samples/psa-meter3.p4
-  testdata/p4_16_samples/psa-meter4.p4
-  testdata/p4_16_samples/psa-meter5.p4
-  testdata/p4_16_samples/psa-meter6.p4
-  testdata/p4_16_samples/psa-test.p4
-  testdata/p4_16_samples/psa-register1.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
   "Unsupported parser loop"
   testdata/p4_16_samples/psa-example-digest-bmv2.p4
   testdata/p4_16_samples/psa-example-counters-bmv2.p4
@@ -28,11 +6,14 @@ p4c_add_xfail_reason("dpdk"
 
 p4c_add_xfail_reason("dpdk"
   "not implemented"
+  testdata/p4_16_samples/psa-action-profile2.p4
   testdata/p4_16_samples/psa-example-register2-bmv2.p4
   )
 
 p4c_add_xfail_reason("dpdk"
   "Unhandled type for"
+  testdata/p4_16_samples/psa-meter3.p4
+  testdata/p4_16_samples/psa-meter1.p4
   testdata/p4_16_samples/psa-meter7-bmv2.p4
   )
 
@@ -62,4 +43,15 @@ p4c_add_xfail_reason("dpdk"
 p4c_add_xfail_reason("dpdk"
   "get_hash's arg is not a ListExpression"
   testdata/p4_16_samples/psa-hash.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  "Unknown extern function"
+  testdata/p4_16_samples/psa-counter6.p4
+  testdata/p4_16_samples/psa-meter6.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  "unhandled declaration type"
+  testdata/p4_16_samples/psa-test.p4
   )

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -356,17 +356,18 @@ const IR::Node *ReplaceMetadataHeaderName::preorder(IR::Type_Control *c) {
         auto header = c->applyParams->parameters.at(1);
         auto local_metadata = c->applyParams->parameters.at(2);
         header = new IR::Parameter(IR::ID("h"), header->direction, header->type);
-        local_metadata = new IR::Parameter(IR::ID("m"), local_metadata->direction, local_metadata->type);
+        local_metadata = new IR::Parameter(IR::ID("m"),
+                                           local_metadata->direction, local_metadata->type);
         applyParams->push_back(c->getApplyParameters()->getParameter(0));
         applyParams->push_back(header);
         applyParams->push_back(local_metadata);
-    }
-    else {
+    } else {
         /* For Ingress and Egress blocks, there are only two parameters: header and metadata */
         auto header = c->applyParams->parameters.at(0);
         auto local_metadata = c->applyParams->parameters.at(1);
         header = new IR::Parameter(IR::ID("h"), header->direction, header->type);
-        local_metadata = new IR::Parameter(IR::ID("m"), local_metadata->direction, local_metadata->type);
+        local_metadata = new IR::Parameter(IR::ID("m"),
+                                           local_metadata->direction, local_metadata->type);
         applyParams->push_back(header);
         applyParams->push_back(local_metadata);
     }
@@ -387,11 +388,12 @@ const IR::Node *ReplaceMetadataHeaderName::preorder(IR::Type_Parser *p) {
     auto header = p->applyParams->parameters.at(1);
     auto local_metadata = p->applyParams->parameters.at(2);
     header = new IR::Parameter(IR::ID("h"), header->direction, header->type);
-    local_metadata = new IR::Parameter(IR::ID("m"), local_metadata->direction, local_metadata->type);
+    local_metadata = new IR::Parameter(IR::ID("m"),
+                                       local_metadata->direction, local_metadata->type);
     applyParams->push_back(p->getApplyParameters()->getParameter(0));
     applyParams->push_back(header);
     applyParams->push_back(local_metadata);
- 
+
     return new IR::Type_Parser(p->name, p->annotations, p->typeParameters,
                                applyParams);
 }

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -339,8 +339,8 @@ const IR::Node *ReplaceMetadataHeaderName::preorder(IR::Member *m) {
  * blocks with "h" and "m" respectively.
  * It assumes that ConvertToDpdkArch pass has converted the control blocks to
  * the following form for DPDK Architecture:
- *         control ingressDeparser(packet_out bufffer, header hdr, metadata md);
- *         control egressDeparser(packet_out bufffer, header hdr, metadata md);
+ *         control ingressDeparser(packet_out buffer, header hdr, metadata md);
+ *         control egressDeparser(packet_out buffer, header hdr, metadata md);
  *         control ingress(header hdr, metadata md);
  *         control egress(header hdr, metadata md);
 */
@@ -348,57 +348,55 @@ const IR::Node *ReplaceMetadataHeaderName::preorder(IR::Type_Control *c) {
     auto applyParams = new IR::ParameterList();
     auto paramSize = c->applyParams->size();
 
-    if (paramSize == 2 || paramSize == 3) {
-        int header_index = 0;
+    if (!(paramSize == 2 || paramSize == 3))
+        BUG("Unexpected number of arguments for %1%", c->name);
 
-        /* For IngressDeparser and EgressDeparser, Header and metadata parameters are
-           at index 1 and 2 respectively. */
-        if (paramSize == 3) {
-            header_index = 1;
-            applyParams->push_back(c->getApplyParameters()->getParameter(0));
-        }
+    int header_index = 0;
 
-        auto header = c->applyParams->parameters.at(header_index);
-        auto local_metadata = c->applyParams->parameters.at(header_index + 1);
-        header = new IR::Parameter(IR::ID("h"), header->direction, header->type);
-        local_metadata = new IR::Parameter(IR::ID("m"), local_metadata->direction,
-                                           local_metadata->type);
-        applyParams->push_back(header);
-        applyParams->push_back(local_metadata);
-
-        return new IR::Type_Control(c->name, c->annotations, c->typeParameters,
-                                    applyParams);
+    /* For IngressDeparser and EgressDeparser, Header and metadata parameters are
+       at index 1 and 2 respectively. */
+    if (paramSize == 3) {
+        header_index = 1;
+        applyParams->push_back(c->getApplyParameters()->getParameter(0));
     }
 
-    return c;
+    auto header = c->applyParams->parameters.at(header_index);
+    auto local_metadata = c->applyParams->parameters.at(header_index + 1);
+    header = new IR::Parameter(IR::ID("h"), header->direction, header->type);
+    local_metadata = new IR::Parameter(IR::ID("m"), local_metadata->direction,
+                                       local_metadata->type);
+    applyParams->push_back(header);
+    applyParams->push_back(local_metadata);
+
+    return new IR::Type_Control(c->name, c->annotations, c->typeParameters,
+                                applyParams);
 }
 
 /* This function replaces the header and metadata parameter names in parser
  * blocks with "h" and "m" respectively.
  * It assumes that ConvertToDpdkArch pass has converted Ingress/Egress
  * parser blocks to the following form for DPDK Architecture:
- *         parser ingressParser(packet_in bufffer, header hdr, metadata md);
- *         parser egressParser(packet_in bufffer, header hdr, metadata md);
+ *         parser ingressParser(packet_in buffer, header hdr, metadata md);
+ *         parser egressParser(packet_in buffer, header hdr, metadata md);
 */
 const IR::Node *ReplaceMetadataHeaderName::preorder(IR::Type_Parser *p) {
     auto applyParams = new IR::ParameterList();
     auto paramSize = p->applyParams->size();
 
-    if (paramSize == 3) {
-        auto header = p->applyParams->parameters.at(1);
-        auto local_metadata = p->applyParams->parameters.at(2);
-        header = new IR::Parameter(IR::ID("h"), header->direction, header->type);
-        local_metadata = new IR::Parameter(IR::ID("m"), local_metadata->direction,
-                                           local_metadata->type);
-        applyParams->push_back(p->getApplyParameters()->getParameter(0));
-        applyParams->push_back(header);
-        applyParams->push_back(local_metadata);
+    if (paramSize != 3)
+        BUG("Unexpected number of arguments for %1%", p->name);
 
-        return new IR::Type_Parser(p->name, p->annotations, p->typeParameters,
-                                   applyParams);
-    }
+    auto header = p->applyParams->parameters.at(1);
+    auto local_metadata = p->applyParams->parameters.at(2);
+    header = new IR::Parameter(IR::ID("h"), header->direction, header->type);
+    local_metadata = new IR::Parameter(IR::ID("m"), local_metadata->direction,
+                                       local_metadata->type);
+    applyParams->push_back(p->getApplyParameters()->getParameter(0));
+    applyParams->push_back(header);
+    applyParams->push_back(local_metadata);
 
-    return p;
+    return new IR::Type_Parser(p->name, p->annotations, p->typeParameters,
+                               applyParams);
 }
 
 const IR::Node *InjectJumboStruct::preorder(IR::Type_Struct *s) {

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -349,7 +349,9 @@ const IR::Node *ReplaceMetadataHeaderName::preorder(IR::Type_Control *c) {
     auto paramSize = c->applyParams->size();
 
     if (!(paramSize == 2 || paramSize == 3))
-        BUG("Unexpected number of arguments for %1%", c->name);
+        ::error(ErrorType::ERR_MODEL,
+                ("Unexpected number of arguments for %1%. Are you using an up-to-date 'psa.p4'?"),
+                 c->name);
 
     int header_index = 0;
 
@@ -384,7 +386,9 @@ const IR::Node *ReplaceMetadataHeaderName::preorder(IR::Type_Parser *p) {
     auto paramSize = p->applyParams->size();
 
     if (paramSize != 3)
-        BUG("Unexpected number of arguments for %1%", p->name);
+        ::error(ErrorType::ERR_MODEL,
+                ("Unexpected number of arguments for %1%. Are you using an up-to-date 'psa.p4'?"),
+                 p->name);
 
     auto header = p->applyParams->parameters.at(1);
     auto local_metadata = p->applyParams->parameters.at(2);

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -122,6 +122,8 @@ class CollectMetadataHeaderInfo : public Inspector {
 // This pass modifies all metadata references and header reference. For
 // metadata, struct_name.field_name -> m.struct_name_field_name. For header
 // headers.header_name.field_name -> h.header_name.field_name
+// The parameter named for header and metadata are also updated to "h" and
+// "m" respectively.
 class ReplaceMetadataHeaderName : public Transform {
     P4::ReferenceMap *refMap;
     CollectMetadataHeaderInfo *info;
@@ -130,8 +132,9 @@ class ReplaceMetadataHeaderName : public Transform {
     ReplaceMetadataHeaderName(P4::ReferenceMap *refMap,
                               CollectMetadataHeaderInfo *info)
         : refMap(refMap), info(info) {}
+    const IR::Node *preorder(IR::Type_Parser *p) override;
+    const IR::Node *preorder(IR::Type_Control *c) override;
     const IR::Node *preorder(IR::Member *m) override;
-    const IR::Node *preorder(IR::Parameter *p) override;
     const IR::Node *preorder(IR::PathExpression *pe) override;
 };
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -29,6 +35,8 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 struct a1_arg_t {
 	bit<48> param
 }
@@ -42,18 +50,18 @@ action NoAction args none {
 }
 
 action a1 args instanceof a1_arg_t {
-	mov h.dstAddr t.param
+	mov h.ethernet.dstAddr t.param
 	return
 }
 
 action a2 args instanceof a2_arg_t {
-	mov h.etherType t.param
+	mov h.ethernet.etherType t.param
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -69,10 +77,10 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
-	emit h
+	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP : drop
 }

--- a/testdata/p4_16_samples_outputs/psa-action-profile1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1.p4.spec
@@ -1,0 +1,80 @@
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+struct a1_arg_t {
+	bit<48> param
+}
+
+struct a2_arg_t {
+	bit<16> param
+}
+
+action NoAction args none {
+	return
+}
+
+action a1 args instanceof a1_arg_t {
+	mov h.dstAddr t.param
+	return
+}
+
+action a2 args instanceof a2_arg_t {
+	mov h.etherType t.param
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	action_selector ap_0
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-action-profile3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -29,6 +35,8 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 struct a1_arg_t {
 	bit<48> param
 }
@@ -42,18 +50,18 @@ action NoAction args none {
 }
 
 action a1 args instanceof a1_arg_t {
-	mov h.dstAddr t.param
+	mov h.ethernet.dstAddr t.param
 	return
 }
 
 action a2 args instanceof a2_arg_t {
-	mov h.etherType t.param
+	mov h.ethernet.etherType t.param
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -68,7 +76,7 @@ table tbl {
 
 table tbl2 {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -84,11 +92,11 @@ table tbl2 {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	table tbl2
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
-	emit h
+	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP : drop
 }

--- a/testdata/p4_16_samples_outputs/psa-action-profile3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3.p4.spec
@@ -1,0 +1,96 @@
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+struct a1_arg_t {
+	bit<48> param
+}
+
+struct a2_arg_t {
+	bit<16> param
+}
+
+action NoAction args none {
+	return
+}
+
+action a1 args instanceof a1_arg_t {
+	mov h.dstAddr t.param
+	return
+}
+
+action a2 args instanceof a2_arg_t {
+	mov h.etherType t.param
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	action_selector ap_0
+	size 0
+}
+
+
+table tbl2 {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	action_selector ap_0
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	table tbl2
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-action-profile4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -29,6 +35,8 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 struct a1_arg_t {
 	bit<48> param
 }
@@ -42,18 +50,18 @@ action NoAction args none {
 }
 
 action a1 args instanceof a1_arg_t {
-	mov h.dstAddr t.param
+	mov h.ethernet.dstAddr t.param
 	return
 }
 
 action a2 args instanceof a2_arg_t {
-	mov h.etherType t.param
+	mov h.ethernet.etherType t.param
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -67,7 +75,7 @@ table tbl {
 
 table tbl2 {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -82,11 +90,11 @@ table tbl2 {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	table tbl2
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
-	emit h
+	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP : drop
 }

--- a/testdata/p4_16_samples_outputs/psa-action-profile4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4.p4.spec
@@ -1,0 +1,94 @@
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+struct a1_arg_t {
+	bit<48> param
+}
+
+struct a2_arg_t {
+	bit<16> param
+}
+
+action NoAction args none {
+	return
+}
+
+action a1 args instanceof a1_arg_t {
+	mov h.dstAddr t.param
+	return
+}
+
+action a2 args instanceof a2_arg_t {
+	mov h.etherType t.param
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		a2
+	}
+	default_action NoAction args none 
+	action_selector ap_0
+	size 0
+}
+
+
+table tbl2 {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		a1
+	}
+	default_action NoAction args none 
+	action_selector ap_0
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	table tbl2
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4.spec
@@ -1,0 +1,64 @@
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	counter_count counter_0 0x400
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -29,6 +35,8 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 action NoAction args none {
 	return
 }
@@ -40,7 +48,7 @@ action execute args none {
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -54,7 +62,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4.spec
@@ -1,6 +1,12 @@
 
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -30,6 +36,8 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 action NoAction args none {
 	return
 }
@@ -42,7 +50,7 @@ action execute args none {
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -56,7 +64,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4.spec
@@ -1,0 +1,66 @@
+
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	counter_count counter0_0 0x400
+	counter_count counter1_0 0x400
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4.spec
@@ -1,6 +1,12 @@
 
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -30,10 +36,12 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	counter_count counter0_0 0x400
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4.spec
@@ -1,0 +1,43 @@
+
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	counter_count counter0_0 0x400
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -29,13 +35,15 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 action NoAction args none {
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -48,7 +56,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4.spec
@@ -1,0 +1,58 @@
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+action NoAction args none {
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.spec
@@ -1,0 +1,64 @@
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	counter_count counter_0 0x400
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -29,6 +35,8 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 action NoAction args none {
 	return
 }
@@ -40,7 +48,7 @@ action execute args none {
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -54,7 +62,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
@@ -67,13 +67,15 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	jmpeq MYIP_PARSE_VLAN_TAG h.ethernet.etherType 0x8100
-	jmp MYIP_PARSE_VLAN_TAG2
+	jmp MYIP_ACCEPT
 	MYIP_PARSE_VLAN_TAG :	extract h.vlan_tag_0
 	jmpeq MYIP_PARSE_VLAN_TAG1 h.vlan_tag_0.ether_type 0x8100
-	jmp MYIP_PARSE_VLAN_TAG2
+	jmp MYIP_ACCEPT
 	MYIP_PARSE_VLAN_TAG1 :	extract h.vlan_tag_1
+	jmpeq MYIP_PARSE_VLAN_TAG2 h.vlan_tag_1.ether_type 0x8100
+	jmp MYIP_ACCEPT
 	MYIP_PARSE_VLAN_TAG2 :	verify 0 error.StackOutOfBounds
-	jmpv LABEL_0END h.ethernet
+	MYIP_ACCEPT :	jmpv LABEL_0END h.ethernet
 	table tbl
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
@@ -67,15 +67,13 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	jmpeq MYIP_PARSE_VLAN_TAG h.ethernet.etherType 0x8100
-	jmp MYIP_ACCEPT
+	jmp MYIP_PARSE_VLAN_TAG2
 	MYIP_PARSE_VLAN_TAG :	extract h.vlan_tag_0
 	jmpeq MYIP_PARSE_VLAN_TAG1 h.vlan_tag_0.ether_type 0x8100
-	jmp MYIP_ACCEPT
+	jmp MYIP_PARSE_VLAN_TAG2
 	MYIP_PARSE_VLAN_TAG1 :	extract h.vlan_tag_1
-	jmpeq MYIP_PARSE_VLAN_TAG2 h.vlan_tag_1.ether_type 0x8100
-	jmp MYIP_ACCEPT
 	MYIP_PARSE_VLAN_TAG2 :	verify 0 error.StackOutOfBounds
-	MYIP_ACCEPT :	jmpv LABEL_0END h.ethernet
+	jmpv LABEL_0END h.ethernet
 	table tbl
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.spec
@@ -1,0 +1,108 @@
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+struct a1_arg_t {
+	bit<48> param
+}
+
+struct a2_arg_t {
+	bit<16> param
+}
+
+action NoAction args none {
+	return
+}
+
+action a1 args instanceof a1_arg_t {
+	mov h.dstAddr t.param
+	return
+}
+
+action a2 args instanceof a2_arg_t {
+	mov h.etherType t.param
+	return
+}
+
+table tbl_idle_timeout {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+table tbl_no_idle_timeout {
+	key {
+		h.srcAddr2 exact
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+table tbl_no_idle_timeout_prop {
+	key {
+		h.srcAddr2 exact
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl_idle_timeout
+	table tbl_no_idle_timeout
+	table tbl_no_idle_timeout_prop
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-meter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter1.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -29,6 +35,8 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 struct execute_arg_t {
 	bit<12> index
 	bit<32> color
@@ -45,7 +53,7 @@ action execute args instanceof execute_arg_t {
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -59,7 +67,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -29,13 +35,15 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 action NoAction args none {
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -48,7 +56,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4.spec
@@ -1,0 +1,58 @@
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+action NoAction args none {
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -29,13 +35,15 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 action NoAction args none {
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -48,7 +56,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4.spec
@@ -1,0 +1,58 @@
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+action NoAction args none {
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.spec
@@ -1,0 +1,67 @@
+
+
+struct EMPTY {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+}
+metadata instanceof EMPTY
+
+struct execute_register_arg_t {
+	bit<10> idx
+}
+
+action NoAction args none {
+	return
+}
+
+action execute_register args instanceof execute_register_arg_t {
+	return
+}
+
+table tbl {
+	key {
+		h.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute_register
+	}
+	default_action NoAction args none 
+	size 0
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -29,6 +35,8 @@ struct EMPTY {
 }
 metadata instanceof EMPTY
 
+header ethernet instanceof ethernet_t
+
 struct execute_register_arg_t {
 	bit<10> idx
 }
@@ -43,7 +51,7 @@ action execute_register args instanceof execute_register_arg_t {
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -57,7 +65,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port


### PR DESCRIPTION
This commit fixes the "Duplicates declaration" error with p4c-dpdk.

Added new preorder functions for Type_Control and Type_Parser. These functions updates the names of header and metadata parameters to "h" and "m" respectively.

With this change, some of the tests in XFAIL list of dpdk backend are compiling fine. Updated the XFAIL list and sample outputs for the same.