### PR TITLE
Update PSA test programs to always put parsed headers inside a struct

### DIFF
--- a/testdata/p4_16_errors/psa-meter2.p4
+++ b/testdata/p4_16_errors/psa-meter2.p4
@@ -15,16 +15,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -43,7 +47,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -54,7 +58,7 @@ control MyIC(
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; execute; }
     }
@@ -77,7 +81,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in user_meta_t e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_errors_outputs/psa-meter2.p4
+++ b/testdata/p4_16_errors_outputs/psa-meter2.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Meter<bit<12>>(1024, PSA_MeterType_t.PACKETS) meter0;
     action execute(bit<12> index) {
         b.data = (bit<16>)meter0.execute(index, PSA_MeterColor_t.GREEN);
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -52,7 +56,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_errors_outputs/psa-meter2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/psa-meter2.p4-stderr
@@ -1,4 +1,4 @@
-psa-meter2.p4(53): [--Werror=type-error] error: cast
+psa-meter2.p4(57): [--Werror=type-error] error: cast
         b.data = (bit<16>)meter0.execute(index, PSA_MeterColor_t.GREEN);
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_samples/psa-action-profile1.p4
+++ b/testdata/p4_16_samples/psa-action-profile1.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,17 +43,17 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
 
     ActionProfile(1024) ap;
-    action a1(bit<48> param) { a.dstAddr = param; }
-    action a2(bit<16> param) { a.etherType = param; }
+    action a1(bit<48> param) { hdr.ethernet.dstAddr = param; }
+    action a2(bit<16> param) { hdr.ethernet.etherType = param; }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; a1; a2; }
         psa_implementation = ap;
@@ -73,11 +77,11 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples/psa-action-profile2.p4
+++ b/testdata/p4_16_samples/psa-action-profile2.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,17 +43,17 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
     ActionProfile(1024) ap;
     ActionProfile(1024) ap1;
-    action a1(bit<48> param) { a.dstAddr = param; }
-    action a2(bit<16> param) { a.etherType = param; }
+    action a1(bit<48> param) { hdr.ethernet.dstAddr = param; }
+    action a2(bit<16> param) { hdr.ethernet.etherType = param; }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; a1; a2; }
         psa_implementation = { ap, ap1 };
@@ -72,11 +76,11 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples/psa-action-profile3.p4
+++ b/testdata/p4_16_samples/psa-action-profile3.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,24 +43,24 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
 
     ActionProfile(1024) ap;
-    action a1(bit<48> param) { a.dstAddr = param; }
-    action a2(bit<16> param) { a.etherType = param; }
+    action a1(bit<48> param) { hdr.ethernet.dstAddr = param; }
+    action a2(bit<16> param) { hdr.ethernet.etherType = param; }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; a1; a2; }
         psa_implementation = ap;
     }
     table tbl2 {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; a1; a2; }
         psa_implementation = ap;
@@ -80,11 +84,11 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples/psa-action-profile4.p4
+++ b/testdata/p4_16_samples/psa-action-profile4.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,24 +43,24 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
 
     ActionProfile(1024) ap;
-    action a1(bit<48> param) { a.dstAddr = param; }
-    action a2(bit<16> param) { a.etherType = param; }
+    action a1(bit<48> param) { hdr.ethernet.dstAddr = param; }
+    action a2(bit<16> param) { hdr.ethernet.etherType = param; }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; a2; }
         psa_implementation = ap;
     }
     table tbl2 {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; a1; }
         psa_implementation = ap;
@@ -80,11 +84,11 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples/psa-action-selector1.p4
+++ b/testdata/p4_16_samples/psa-action-selector1.p4
@@ -15,16 +15,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -43,17 +47,17 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
 
     ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as;
-    action a1(bit<48> param) { a.dstAddr = param; }
-    action a2(bit<16> param) { a.etherType = param; }
+    action a1(bit<48> param) { hdr.ethernet.dstAddr = param; }
+    action a2(bit<16> param) { hdr.ethernet.etherType = param; }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
             b.data : selector;
         }
         actions = { NoAction; a1; a2; }
@@ -78,11 +82,11 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in user_meta_t e,
     in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples/psa-action-selector2.p4
+++ b/testdata/p4_16_samples/psa-action-selector2.p4
@@ -16,16 +16,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -44,17 +48,17 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
 
     ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as;
-    action a1(bit<48> param) { a.dstAddr = param; }
-    action a2(bit<16> param) { a.etherType = param; }
+    action a1(bit<48> param) { hdr.ethernet.dstAddr = param; }
+    action a2(bit<16> param) { hdr.ethernet.etherType = param; }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
             b.data1 : selector;
             b.data2 : selector;
         }
@@ -80,11 +84,11 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in user_meta_t e,
     in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples/psa-action-selector3.p4
+++ b/testdata/p4_16_samples/psa-action-selector3.p4
@@ -16,16 +16,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -44,16 +48,16 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
 
-    action a1(bit<48> param) { a.dstAddr = param; }
-    action a2(bit<16> param) { a.etherType = param; }
+    action a1(bit<48> param) { hdr.ethernet.dstAddr = param; }
+    action a2(bit<16> param) { hdr.ethernet.etherType = param; }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
             b.data1 : selector;
             b.data2 : selector;
         }
@@ -78,11 +82,11 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in user_meta_t e,
     in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples/psa-counter1.p4
+++ b/testdata/p4_16_samples/psa-counter1.p4
@@ -13,16 +13,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY_H d,
     in EMPTY_H e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -41,7 +45,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -54,7 +58,7 @@ control MyIC(
 
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = {
             NoAction;
@@ -80,7 +84,7 @@ control MyID(
     out EMPTY_H a,
     out EMPTY_H b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-counter2.p4
+++ b/testdata/p4_16_samples/psa-counter2.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -52,7 +56,7 @@ control MyIC(
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; execute(); }
     }
@@ -74,7 +78,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-counter3.p4
+++ b/testdata/p4_16_samples/psa-counter3.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -65,7 +69,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-counter4.p4
+++ b/testdata/p4_16_samples/psa-counter4.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -47,7 +51,7 @@ control MyIC(
     DirectCounter<bit<12>>(PSA_CounterType_t.PACKETS) counter0;
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; }
         psa_direct_counter = counter0;
@@ -71,7 +75,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-counter6.p4
+++ b/testdata/p4_16_samples/psa-counter6.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -50,14 +54,14 @@ control MyIC(
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; execute; }
         psa_direct_counter = counter0;
     }
     table tbl2 {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; execute; }
         psa_direct_counter = counter0;
@@ -82,7 +86,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-custom-type-counter-index.p4
+++ b/testdata/p4_16_samples/psa-custom-type-counter-index.p4
@@ -13,16 +13,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY_H d,
     in EMPTY_H e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -43,7 +47,7 @@ parser MyEP(
 type bit<12> CounterIndex_t;
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -56,7 +60,7 @@ control MyIC(
 
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = {
             NoAction;
@@ -82,7 +86,7 @@ control MyID(
     out EMPTY_H a,
     out EMPTY_H b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-hash.p4
+++ b/testdata/p4_16_samples/psa-hash.p4
@@ -15,16 +15,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -43,17 +47,17 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
     Hash<bit<16>>(PSA_HashAlgorithm_t.CRC16) h;
     action a1() {
-        b.data = h.get_hash(a);
+        b.data = h.get_hash(hdr.ethernet);
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; a1; }
     }
@@ -76,7 +80,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in user_meta_t e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-isvalid.p4
+++ b/testdata/p4_16_samples/psa-isvalid.p4
@@ -16,16 +16,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t h,
+    out headers_t hdr,
     inout EMPTY_M b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY_RESUB d,
     in EMPTY_RECIRC e) {
 
     state start {
-        buffer.extract(h);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -44,7 +48,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY_M b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -55,7 +59,7 @@ control MyIC(
 
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = {
             NoAction;
@@ -63,7 +67,7 @@ control MyIC(
     }
 
     apply {
-        if (!a.isValid()) {
+        if (!hdr.ethernet.isValid()) {
             tbl.apply();
         }
     }
@@ -82,7 +86,7 @@ control MyID(
     out EMPTY_CLONE a,
     out EMPTY_RESUB b,
     out EMPTY_BRIDGE c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY_M e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-meter1.p4
+++ b/testdata/p4_16_samples/psa-meter1.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -50,7 +54,7 @@ control MyIC(
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; execute; }
     }
@@ -73,7 +77,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-meter3.p4
+++ b/testdata/p4_16_samples/psa-meter3.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -47,7 +51,7 @@ control MyIC(
     Meter<bit<12>>(1024, PSA_MeterType_t.PACKETS) meter0;
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; }
     }
@@ -71,7 +75,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-meter4.p4
+++ b/testdata/p4_16_samples/psa-meter4.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -48,7 +52,7 @@ control MyIC(
 
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; }
         psa_direct_meter = meter0;
@@ -72,7 +76,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-meter5.p4
+++ b/testdata/p4_16_samples/psa-meter5.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -50,7 +54,7 @@ control MyIC(
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; }
         psa_direct_meter = meter0;
@@ -74,7 +78,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-meter6.p4
+++ b/testdata/p4_16_samples/psa-meter6.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -50,14 +54,14 @@ control MyIC(
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; }
         psa_direct_meter = meter0;
     }
     table tbl2 {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; execute_meter; }
     }
@@ -81,7 +85,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-random.p4
+++ b/testdata/p4_16_samples/psa-random.p4
@@ -15,16 +15,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -43,7 +47,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -53,7 +57,7 @@ control MyIC(
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; execute_random; }
     }
@@ -75,7 +79,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in user_meta_t e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-register1.p4
+++ b/testdata/p4_16_samples/psa-register1.p4
@@ -11,16 +11,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -50,7 +54,7 @@ control MyIC(
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; execute_register; }
     }
@@ -72,7 +76,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-register2.p4
+++ b/testdata/p4_16_samples/psa-register2.p4
@@ -15,16 +15,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -43,7 +47,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -53,7 +57,7 @@ control MyIC(
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; execute_register; }
     }
@@ -75,7 +79,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in user_meta_t e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-register3.p4
+++ b/testdata/p4_16_samples/psa-register3.p4
@@ -15,16 +15,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t eth,
+    out headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
     in EMPTY e) {
 
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -43,7 +47,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout user_meta_t b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -53,7 +57,7 @@ control MyIC(
     }
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = { NoAction; execute_register; }
     }
@@ -75,7 +79,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in user_meta_t e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-remove-header.p4
+++ b/testdata/p4_16_samples/psa-remove-header.p4
@@ -16,16 +16,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t h,
+    out headers_t hdr,
     inout EMPTY_M b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY_RESUB d,
     in EMPTY_RECIRC e) {
 
     state start {
-        buffer.extract(h);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -44,18 +48,18 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY_M b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
 
     action remove_header() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
 
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = {
             NoAction;
@@ -81,7 +85,7 @@ control MyID(
     out EMPTY_CLONE a,
     out EMPTY_RESUB b,
     out EMPTY_BRIDGE c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY_M e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-table-hit-miss.p4
+++ b/testdata/p4_16_samples/psa-table-hit-miss.p4
@@ -16,16 +16,20 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
+struct headers_t {
+    ethernet_t       ethernet;
+}
+
 parser MyIP(
     packet_in buffer,
-    out ethernet_t h,
+    out headers_t hdr,
     inout EMPTY_M b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY_RESUB d,
     in EMPTY_RECIRC e) {
 
     state start {
-        buffer.extract(h);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -44,18 +48,18 @@ parser MyEP(
 }
 
 control MyIC(
-    inout ethernet_t a,
+    inout headers_t hdr,
     inout EMPTY_M b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
 
     action remove_header() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
 
     table tbl {
         key = {
-            a.srcAddr : exact;
+            hdr.ethernet.srcAddr : exact;
         }
         actions = {
             NoAction;
@@ -64,11 +68,11 @@ control MyIC(
     }
 
     action ifHit() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
 
     action ifMiss() {
-        a.setValid();
+        hdr.ethernet.setValid();
     }
 
     apply {
@@ -100,7 +104,7 @@ control MyID(
     out EMPTY_CLONE a,
     out EMPTY_RESUB b,
     out EMPTY_BRIDGE c,
-    inout ethernet_t d,
+    inout headers_t hdr,
     in EMPTY_M e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples/psa-test.p4
+++ b/testdata/p4_16_samples/psa-test.p4
@@ -7,9 +7,13 @@ header hdr_t {
     bit<16> field;
 }
 
+struct headers_t {
+    hdr_t       h1;
+}
+
 parser MyIP(
     packet_in buffer,
-    out hdr_t a,
+    out headers_t hdr,
     inout EMPTY b,
     in psa_ingress_parser_input_metadata_t c,
     in EMPTY d,
@@ -17,8 +21,8 @@ parser MyIP(
 
     value_set<bit<16>>(4) pvs;
     state start {
-        buffer.extract(a);
-        transition select(a.field) {
+        buffer.extract(hdr.h1);
+        transition select(hdr.h1.field) {
             pvs : accept;
             default : accept;
         }
@@ -39,7 +43,7 @@ parser MyEP(
 }
 
 control MyIC(
-    inout hdr_t a,
+    inout headers_t hdr,
     inout EMPTY b,
     in psa_ingress_input_metadata_t c,
     inout psa_ingress_output_metadata_t d) {
@@ -59,7 +63,7 @@ control MyID(
     out EMPTY a,
     out EMPTY b,
     out EMPTY c,
-    inout hdr_t d,
+    inout headers_t hdr,
     in EMPTY e,
     in psa_ingress_output_metadata_t f) {
     apply { }

--- a/testdata/p4_16_samples_outputs/psa-action-profile1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,17 +28,17 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionProfile(32w1024) ap;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -54,9 +58,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,19 +28,19 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -56,9 +60,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -67,9 +71,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,19 +28,19 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -56,18 +60,18 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
-    @hidden action psaactionprofile1l80() {
-        buffer.emit<ethernet_t>(d);
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    @hidden action psaactionprofile1l84() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_psaactionprofile1l80 {
+    @hidden table tbl_psaactionprofile1l84 {
         actions = {
-            psaactionprofile1l80();
+            psaactionprofile1l84();
         }
-        const default_action = psaactionprofile1l80();
+        const default_action = psaactionprofile1l84();
     }
     apply {
-        tbl_psaactionprofile1l80.apply();
+        tbl_psaactionprofile1l84.apply();
     }
 }
 
@@ -76,9 +80,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile1.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,17 +28,17 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionProfile(1024) ap;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -53,9 +57,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-action-profile2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile2-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,18 +28,18 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionProfile(32w1024) ap;
     ActionProfile(32w1024) ap1;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -55,9 +59,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -66,9 +70,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile2-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,20 +28,20 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
     @name("MyIC.ap1") ActionProfile(32w1024) ap1_0;
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -57,9 +61,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -68,9 +72,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile2-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,20 +28,20 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
     @name("MyIC.ap1") ActionProfile(32w1024) ap1_0;
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -57,18 +61,18 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
-    @hidden action psaactionprofile2l79() {
-        buffer.emit<ethernet_t>(d);
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    @hidden action psaactionprofile2l83() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_psaactionprofile2l79 {
+    @hidden table tbl_psaactionprofile2l83 {
         actions = {
-            psaactionprofile2l79();
+            psaactionprofile2l83();
         }
-        const default_action = psaactionprofile2l79();
+        const default_action = psaactionprofile2l83();
     }
     apply {
-        tbl_psaactionprofile2l79.apply();
+        tbl_psaactionprofile2l83.apply();
     }
 }
 
@@ -77,9 +81,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile2.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile2.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,18 +28,18 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionProfile(1024) ap;
     ActionProfile(1024) ap1;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -54,9 +58,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile2.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-action-profile3-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,17 +28,17 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionProfile(32w1024) ap;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -46,7 +50,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl2 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -67,9 +71,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -78,9 +82,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,27 +28,27 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a1") action a1_2(@name("param") bit<48> param_2) {
-        a.dstAddr = param_2;
+        hdr.ethernet.dstAddr = param_2;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_3) {
-        a.etherType = param_3;
+        hdr.ethernet.etherType = param_3;
     }
     @name("MyIC.a2") action a2_2(@name("param") bit<16> param_4) {
-        a.etherType = param_4;
+        hdr.ethernet.etherType = param_4;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -56,7 +60,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl2") table tbl2_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_3();
@@ -77,9 +81,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -88,9 +92,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile3.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,17 +28,17 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionProfile(1024) ap;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -45,7 +49,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl2 {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -65,9 +69,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }
@@ -32,7 +32,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-action-profile4-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,17 +28,17 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionProfile(32w1024) ap;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -45,7 +49,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl2 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -65,9 +69,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -76,9 +80,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,21 +28,21 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -49,7 +53,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl2") table tbl2_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_3();
@@ -69,9 +73,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -80,9 +84,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile4-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,21 +28,21 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
     }
     @name("MyIC.ap") ActionProfile(32w1024) ap_0;
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -49,7 +53,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl2") table tbl2_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_3();
@@ -69,18 +73,18 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
-    @hidden action psaactionprofile4l87() {
-        buffer.emit<ethernet_t>(d);
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    @hidden action psaactionprofile4l91() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_psaactionprofile4l87 {
+    @hidden table tbl_psaactionprofile4l91 {
         actions = {
-            psaactionprofile4l87();
+            psaactionprofile4l91();
         }
-        const default_action = psaactionprofile4l87();
+        const default_action = psaactionprofile4l91();
     }
     apply {
-        tbl_psaactionprofile4l87.apply();
+        tbl_psaactionprofile4l91.apply();
     }
 }
 
@@ -89,9 +93,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile4.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,17 +28,17 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionProfile(1024) ap;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -44,7 +48,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl2 {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -63,9 +67,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }
@@ -29,7 +29,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-action-selector1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1-first.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,18 +32,18 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
-            b.data   : selector @name("b.data") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            b.data              : selector @name("b.data") ;
         }
         actions = {
             NoAction();
@@ -59,9 +63,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -70,9 +74,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1-frontend.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,20 +32,20 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.as") ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as_0;
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
-            b.data   : selector @name("b.data") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            b.data              : selector @name("b.data") ;
         }
         actions = {
             NoAction_0();
@@ -61,9 +65,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -72,9 +76,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector1.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,18 +32,18 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
-            b.data   : selector;
+            hdr.ethernet.srcAddr: exact;
+            b.data              : selector;
         }
         actions = {
             NoAction;
@@ -58,9 +62,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-action-selector2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2-first.p4
@@ -16,9 +16,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -29,19 +33,19 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
-            b.data1  : selector @name("b.data1") ;
-            b.data2  : selector @name("b.data2") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            b.data1             : selector @name("b.data1") ;
+            b.data2             : selector @name("b.data2") ;
         }
         actions = {
             NoAction();
@@ -61,9 +65,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -72,9 +76,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2-frontend.p4
@@ -16,9 +16,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -29,21 +33,21 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.as") ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as_0;
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
-            b.data1  : selector @name("b.data1") ;
-            b.data2  : selector @name("b.data2") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            b.data1             : selector @name("b.data1") ;
+            b.data2             : selector @name("b.data2") ;
         }
         actions = {
             NoAction_0();
@@ -63,9 +67,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -74,9 +78,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2-midend.p4
@@ -16,9 +16,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -29,21 +33,21 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.as") ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as_0;
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
-            b.data1  : selector @name("b.data1") ;
-            b.data2  : selector @name("b.data2") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            b.data1             : selector @name("b.data1") ;
+            b.data2             : selector @name("b.data2") ;
         }
         actions = {
             NoAction_0();
@@ -63,18 +67,18 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
-    @hidden action psaactionselector2l87() {
-        buffer.emit<ethernet_t>(d);
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+    @hidden action psaactionselector2l91() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_psaactionselector2l87 {
+    @hidden table tbl_psaactionselector2l91 {
         actions = {
-            psaactionselector2l87();
+            psaactionselector2l91();
         }
-        const default_action = psaactionselector2l87();
+        const default_action = psaactionselector2l91();
     }
     apply {
-        tbl_psaactionselector2l87.apply();
+        tbl_psaactionselector2l91.apply();
     }
 }
 
@@ -83,9 +87,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4
@@ -16,9 +16,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -29,19 +33,19 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as;
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
-            b.data1  : selector;
-            b.data2  : selector;
+            hdr.ethernet.srcAddr: exact;
+            b.data1             : selector;
+            b.data2             : selector;
         }
         actions = {
             NoAction;
@@ -60,9 +64,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct user_meta_t {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -31,6 +37,8 @@ struct user_meta_t {
 }
 metadata instanceof user_meta_t
 
+header ethernet instanceof ethernet_t
+
 struct a1_arg_t {
 	bit<48> param
 }
@@ -44,18 +52,18 @@ action NoAction args none {
 }
 
 action a1 args instanceof a1_arg_t {
-	mov h.dstAddr t.param
+	mov h.ethernet.dstAddr t.param
 	return
 }
 
 action a2 args instanceof a2_arg_t {
-	mov h.etherType t.param
+	mov h.ethernet.etherType t.param
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 		m.local_metadata_data1 selector
 		m.local_metadata_data2 selector
 	}
@@ -73,10 +81,10 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
-	emit h
+	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP : drop
 }

--- a/testdata/p4_16_samples_outputs/psa-action-selector3-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3-first.p4
@@ -16,9 +16,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -29,18 +33,18 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
-            b.data1  : selector @name("b.data1") ;
-            b.data2  : selector @name("b.data2") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            b.data1             : selector @name("b.data1") ;
+            b.data2             : selector @name("b.data2") ;
         }
         actions = {
             NoAction();
@@ -59,9 +63,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -70,9 +74,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3-frontend.p4
@@ -16,9 +16,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -29,20 +33,20 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
-            b.data1  : selector @name("b.data1") ;
-            b.data2  : selector @name("b.data2") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            b.data1             : selector @name("b.data1") ;
+            b.data2             : selector @name("b.data2") ;
         }
         actions = {
             NoAction_0();
@@ -61,9 +65,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -72,9 +76,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3-midend.p4
@@ -16,9 +16,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -29,20 +33,20 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_2) {
-        a.etherType = param_2;
+        hdr.ethernet.etherType = param_2;
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
-            b.data1  : selector @name("b.data1") ;
-            b.data2  : selector @name("b.data2") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            b.data1             : selector @name("b.data1") ;
+            b.data2             : selector @name("b.data2") ;
         }
         actions = {
             NoAction_0();
@@ -61,18 +65,18 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
-    @hidden action psaactionselector3l85() {
-        buffer.emit<ethernet_t>(d);
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+    @hidden action psaactionselector3l89() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_psaactionselector3l85 {
+    @hidden table tbl_psaactionselector3l89 {
         actions = {
-            psaactionselector3l85();
+            psaactionselector3l89();
         }
-        const default_action = psaactionselector3l85();
+        const default_action = psaactionselector3l89();
     }
     apply {
-        tbl_psaactionselector3l85.apply();
+        tbl_psaactionselector3l89.apply();
     }
 }
 
@@ -81,9 +85,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4
@@ -16,9 +16,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -29,18 +33,18 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
-            b.data1  : selector;
-            b.data2  : selector;
+            hdr.ethernet.srcAddr: exact;
+            b.data1             : selector;
+            b.data2             : selector;
         }
         actions = {
             NoAction;
@@ -58,9 +62,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4.spec
@@ -1,4 +1,10 @@
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct user_meta_t {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -30,6 +36,8 @@ struct user_meta_t {
 }
 metadata instanceof user_meta_t
 
+header ethernet instanceof ethernet_t
+
 struct a1_arg_t {
 	bit<48> param
 }
@@ -43,18 +51,18 @@ action NoAction args none {
 }
 
 action a1 args instanceof a1_arg_t {
-	mov h.dstAddr t.param
+	mov h.ethernet.dstAddr t.param
 	return
 }
 
 action a2 args instanceof a2_arg_t {
-	mov h.etherType t.param
+	mov h.ethernet.etherType t.param
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 		m.local_metadata_data1 selector
 		m.local_metadata_data2 selector
 	}
@@ -71,10 +79,10 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
-	emit h
+	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP : drop
 }

--- a/testdata/p4_16_samples_outputs/psa-counter1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter1-first.p4
@@ -14,9 +14,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -27,14 +31,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter;
     action execute() {
         counter.count(12w1024);
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -52,7 +56,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -62,9 +66,9 @@ control MyED(packet_out buffer, out EMPTY_H a, out EMPTY_H b, inout EMPTY c, in 
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter1-frontend.p4
@@ -14,9 +14,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -27,7 +31,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.counter") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter_0;
@@ -36,7 +40,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -54,7 +58,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -64,9 +68,9 @@ control MyED(packet_out buffer, out EMPTY_H a, out EMPTY_H b, inout EMPTY c, in 
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter1-midend.p4
@@ -14,9 +14,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -27,7 +31,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.counter") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter_0;
@@ -36,7 +40,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -54,7 +58,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -64,9 +68,9 @@ control MyED(packet_out buffer, out EMPTY_H a, out EMPTY_H b, inout EMPTY c, in 
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4
@@ -14,9 +14,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -27,14 +31,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter;
     action execute() {
         counter.count(1024);
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -51,7 +55,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-counter2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter2-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter0;
     Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
     action execute() {
@@ -33,7 +37,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -51,7 +55,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -61,9 +65,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter2-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter0_0;
@@ -35,7 +39,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -53,7 +57,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -63,9 +67,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter2-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter0_0;
@@ -35,7 +39,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -53,7 +57,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -63,9 +67,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter0;
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
     action execute() {
@@ -33,7 +37,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -50,7 +54,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-counter3-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter3-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter0;
     Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
     apply {
@@ -37,7 +41,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -47,9 +51,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter3-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @name("MyIC.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter0_0;
     @name("MyIC.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
     apply {
@@ -37,7 +41,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -47,9 +51,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter3-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,20 +28,20 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @name("MyIC.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter0_0;
     @name("MyIC.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
-    @hidden action psacounter3l51() {
+    @hidden action psacounter3l55() {
         counter0_0.count(12w1024);
     }
-    @hidden table tbl_psacounter3l51 {
+    @hidden table tbl_psacounter3l55 {
         actions = {
-            psacounter3l51();
+            psacounter3l55();
         }
-        const default_action = psacounter3l51();
+        const default_action = psacounter3l55();
     }
     apply {
-        tbl_psacounter3l51.apply();
+        tbl_psacounter3l55.apply();
     }
 }
 
@@ -46,7 +50,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -56,9 +60,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter0;
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
     apply {
@@ -37,7 +41,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4-stderr
@@ -1,3 +1,3 @@
-psa-counter3.p4(48): [--Wwarn=unused] warning: counter1: unused instance
+psa-counter3.p4(52): [--Wwarn=unused] warning: counter1: unused instance
     Counter<bit<10>,bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
                                                               ^^^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-counter4-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter4-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,11 +28,11 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     DirectCounter<bit<12>>(PSA_CounterType_t.PACKETS) counter0;
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -46,7 +50,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -56,9 +60,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter4-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,13 +28,13 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.counter0") DirectCounter<bit<12>>(PSA_CounterType_t.PACKETS) counter0_0;
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -48,7 +52,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -58,9 +62,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter4-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter4-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,13 +28,13 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.counter0") DirectCounter<bit<12>>(PSA_CounterType_t.PACKETS) counter0_0;
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -48,7 +52,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -58,9 +62,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,11 +28,11 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     DirectCounter<bit<12>>(PSA_CounterType_t.PACKETS) counter0;
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -45,7 +49,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-counter6.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-counter6.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }
@@ -31,7 +31,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-first.p4
@@ -14,9 +14,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 }
 
 type bit<12> CounterIndex_t;
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Counter<bit<10>, CounterIndex_t>(32w1024, PSA_CounterType_t.PACKETS) counter;
     action execute() {
         counter.count((CounterIndex_t)12w1024);
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -53,7 +57,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -63,9 +67,9 @@ control MyED(packet_out buffer, out EMPTY_H a, out EMPTY_H b, inout EMPTY c, in 
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-frontend.p4
@@ -14,9 +14,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,7 +32,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 }
 
 type bit<12> CounterIndex_t;
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.counter") Counter<bit<10>, CounterIndex_t>(32w1024, PSA_CounterType_t.PACKETS) counter_0;
@@ -37,7 +41,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -55,7 +59,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY_H a, out EMPTY_H b, inout EMPTY c, in 
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index-midend.p4
@@ -14,9 +14,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,7 +32,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 }
 
 typedef bit<12> CounterIndex_t;
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.counter") Counter<bit<10>, CounterIndex_t>(32w1024, PSA_CounterType_t.PACKETS) counter_0;
@@ -37,7 +41,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -55,7 +59,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY_H a, out EMPTY_H b, inout EMPTY c, in 
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY_H, EMPTY_H, EMPTY_H, EMPTY_H>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4
@@ -14,9 +14,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY_H d, in EMPTY_H e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 }
 
 type bit<12> CounterIndex_t;
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Counter<bit<10>, CounterIndex_t>(1024, PSA_CounterType_t.PACKETS) counter;
     action execute() {
         counter.count((CounterIndex_t)1024);
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -52,7 +56,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_H a, out EMPTY_H b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-hash-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-hash-first.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Hash<bit<16>>(PSA_HashAlgorithm_t.CRC16) h;
     action a1() {
-        b.data = h.get_hash<ethernet_t>(a);
+        b.data = h.get_hash<ethernet_t>(hdr.ethernet);
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -53,7 +57,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -63,9 +67,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-hash-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-hash-frontend.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,16 +32,16 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.h") Hash<bit<16>>(PSA_HashAlgorithm_t.CRC16) h_0;
     @name("MyIC.a1") action a1() {
-        b.data = h_0.get_hash<ethernet_t>(a);
+        b.data = h_0.get_hash<ethernet_t>(hdr.ethernet);
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -55,7 +59,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-hash-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-hash-midend.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,16 +32,16 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.h") Hash<bit<16>>(PSA_HashAlgorithm_t.CRC16) h_0;
     @name("MyIC.a1") action a1() {
-        b.data = h_0.get_hash<ethernet_t>(a);
+        b.data = h_0.get_hash<ethernet_t>(hdr.ethernet);
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -55,7 +59,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-hash.p4
+++ b/testdata/p4_16_samples_outputs/psa-hash.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Hash<bit<16>>(PSA_HashAlgorithm_t.CRC16) h;
     action a1() {
-        b.data = h.get_hash(a);
+        b.data = h.get_hash(hdr.ethernet);
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -52,7 +56,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-hash.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-hash.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout-first.p4
@@ -13,9 +13,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -26,16 +30,16 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl_idle_timeout {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -47,7 +51,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl_no_idle_timeout {
         key = {
-            a.srcAddr2: exact @name("a.srcAddr2") ;
+            hdr.ethernet.srcAddr2: exact @name("hdr.ethernet.srcAddr2") ;
         }
         actions = {
             NoAction();
@@ -59,7 +63,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl_no_idle_timeout_prop {
         key = {
-            a.srcAddr2: exact @name("a.srcAddr2") ;
+            hdr.ethernet.srcAddr2: exact @name("hdr.ethernet.srcAddr2") ;
         }
         actions = {
             NoAction();
@@ -80,9 +84,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -91,9 +95,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout-frontend.p4
@@ -13,9 +13,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -26,7 +30,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @noWarn("unused") @name(".NoAction") action NoAction_4() {
@@ -34,26 +38,26 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a1") action a1_3(@name("param") bit<48> param_2) {
-        a.dstAddr = param_2;
+        hdr.ethernet.dstAddr = param_2;
     }
     @name("MyIC.a1") action a1_4(@name("param") bit<48> param_3) {
-        a.dstAddr = param_3;
+        hdr.ethernet.dstAddr = param_3;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_4) {
-        a.etherType = param_4;
+        hdr.ethernet.etherType = param_4;
     }
     @name("MyIC.a2") action a2_3(@name("param") bit<16> param_5) {
-        a.etherType = param_5;
+        hdr.ethernet.etherType = param_5;
     }
     @name("MyIC.a2") action a2_4(@name("param") bit<16> param_6) {
-        a.etherType = param_6;
+        hdr.ethernet.etherType = param_6;
     }
     @name("MyIC.tbl_idle_timeout") table tbl_idle_timeout_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -65,7 +69,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl_no_idle_timeout") table tbl_no_idle_timeout_0 {
         key = {
-            a.srcAddr2: exact @name("a.srcAddr2") ;
+            hdr.ethernet.srcAddr2: exact @name("hdr.ethernet.srcAddr2") ;
         }
         actions = {
             NoAction_4();
@@ -77,7 +81,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl_no_idle_timeout_prop") table tbl_no_idle_timeout_prop_0 {
         key = {
-            a.srcAddr2: exact @name("a.srcAddr2") ;
+            hdr.ethernet.srcAddr2: exact @name("hdr.ethernet.srcAddr2") ;
         }
         actions = {
             NoAction_5();
@@ -98,9 +102,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit<ethernet_t>(d);
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
 }
 
@@ -109,9 +113,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout-midend.p4
@@ -13,9 +13,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -26,7 +30,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @noWarn("unused") @name(".NoAction") action NoAction_4() {
@@ -34,26 +38,26 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @noWarn("unused") @name(".NoAction") action NoAction_5() {
     }
     @name("MyIC.a1") action a1(@name("param") bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     @name("MyIC.a1") action a1_3(@name("param") bit<48> param_2) {
-        a.dstAddr = param_2;
+        hdr.ethernet.dstAddr = param_2;
     }
     @name("MyIC.a1") action a1_4(@name("param") bit<48> param_3) {
-        a.dstAddr = param_3;
+        hdr.ethernet.dstAddr = param_3;
     }
     @name("MyIC.a2") action a2(@name("param") bit<16> param_4) {
-        a.etherType = param_4;
+        hdr.ethernet.etherType = param_4;
     }
     @name("MyIC.a2") action a2_3(@name("param") bit<16> param_5) {
-        a.etherType = param_5;
+        hdr.ethernet.etherType = param_5;
     }
     @name("MyIC.a2") action a2_4(@name("param") bit<16> param_6) {
-        a.etherType = param_6;
+        hdr.ethernet.etherType = param_6;
     }
     @name("MyIC.tbl_idle_timeout") table tbl_idle_timeout_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -65,7 +69,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl_no_idle_timeout") table tbl_no_idle_timeout_0 {
         key = {
-            a.srcAddr2: exact @name("a.srcAddr2") ;
+            hdr.ethernet.srcAddr2: exact @name("hdr.ethernet.srcAddr2") ;
         }
         actions = {
             NoAction_4();
@@ -77,7 +81,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl_no_idle_timeout_prop") table tbl_no_idle_timeout_prop_0 {
         key = {
-            a.srcAddr2: exact @name("a.srcAddr2") ;
+            hdr.ethernet.srcAddr2: exact @name("hdr.ethernet.srcAddr2") ;
         }
         actions = {
             NoAction_5();
@@ -98,18 +102,18 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
-    @hidden action psaidletimeout98() {
-        buffer.emit<ethernet_t>(d);
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    @hidden action psaidletimeout102() {
+        buffer.emit<ethernet_t>(hdr.ethernet);
     }
-    @hidden table tbl_psaidletimeout98 {
+    @hidden table tbl_psaidletimeout102 {
         actions = {
-            psaidletimeout98();
+            psaidletimeout102();
         }
-        const default_action = psaidletimeout98();
+        const default_action = psaidletimeout102();
     }
     apply {
-        tbl_psaidletimeout98.apply();
+        tbl_psaidletimeout102.apply();
     }
 }
 
@@ -118,9 +122,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout.p4
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout.p4
@@ -13,9 +13,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -26,16 +30,16 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     action a1(bit<48> param) {
-        a.dstAddr = param;
+        hdr.ethernet.dstAddr = param;
     }
     action a2(bit<16> param) {
-        a.etherType = param;
+        hdr.ethernet.etherType = param;
     }
     table tbl_idle_timeout {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -46,7 +50,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl_no_idle_timeout {
         key = {
-            a.srcAddr2: exact;
+            hdr.ethernet.srcAddr2: exact;
         }
         actions = {
             NoAction;
@@ -57,7 +61,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl_no_idle_timeout_prop {
         key = {
-            a.srcAddr2: exact;
+            hdr.ethernet.srcAddr2: exact;
         }
         actions = {
             NoAction;
@@ -77,9 +81,9 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
-        buffer.emit(d);
+        buffer.emit(hdr.ethernet);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }
@@ -33,7 +33,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr2"
+    name: "hdr.ethernet.srcAddr2"
     bitwidth: 48
     match_type: EXACT
   }
@@ -56,7 +56,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr2"
+    name: "hdr.ethernet.srcAddr2"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-isvalid-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-isvalid-first.p4
@@ -26,9 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t h, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
     state start {
-        buffer.extract<ethernet_t>(h);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,13 +43,13 @@ parser MyEP(packet_in buffer, out EMPTY_H a, inout EMPTY_M b, in psa_egress_pars
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     action forward() {
         d.egress_port = (PortId_t)32w1;
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -53,7 +57,7 @@ control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_
         default_action = NoAction();
     }
     apply {
-        if (!a.isValid()) {
+        if (!hdr.ethernet.isValid()) {
             tbl.apply();
         }
     }
@@ -64,7 +68,7 @@ control MyEC(inout EMPTY_H a, inout EMPTY_M b, in psa_egress_input_metadata_t c,
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout headers_t hdr, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -74,9 +78,9 @@ control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMP
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-isvalid-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-isvalid-frontend.p4
@@ -26,9 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t h, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
     state start {
-        buffer.extract<ethernet_t>(h);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,12 +43,12 @@ parser MyEP(packet_in buffer, out EMPTY_H a, inout EMPTY_M b, in psa_egress_pars
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -52,7 +56,7 @@ control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_
         default_action = NoAction_0();
     }
     apply {
-        if (!a.isValid()) {
+        if (!hdr.ethernet.isValid()) {
             tbl_0.apply();
         }
     }
@@ -63,7 +67,7 @@ control MyEC(inout EMPTY_H a, inout EMPTY_M b, in psa_egress_input_metadata_t c,
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout headers_t hdr, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -73,9 +77,9 @@ control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMP
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-isvalid-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-isvalid-midend.p4
@@ -26,9 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t h, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
     state start {
-        buffer.extract<ethernet_t>(h);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,12 +43,12 @@ parser MyEP(packet_in buffer, out EMPTY_H a, inout EMPTY_M b, in psa_egress_pars
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -52,7 +56,7 @@ control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_
         default_action = NoAction_0();
     }
     apply {
-        if (!a.isValid()) {
+        if (!hdr.ethernet.isValid()) {
             tbl_0.apply();
         }
     }
@@ -63,7 +67,7 @@ control MyEC(inout EMPTY_H a, inout EMPTY_M b, in psa_egress_input_metadata_t c,
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout headers_t hdr, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -73,9 +77,9 @@ control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMP
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-isvalid.p4
+++ b/testdata/p4_16_samples_outputs/psa-isvalid.p4
@@ -26,9 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t h, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
     state start {
-        buffer.extract(h);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,20 +43,20 @@ parser MyEP(packet_in buffer, out EMPTY_H a, inout EMPTY_M b, in psa_egress_pars
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     action forward() {
         d.egress_port = (PortId_t)1;
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
         }
     }
     apply {
-        if (!a.isValid()) {
+        if (!hdr.ethernet.isValid()) {
             tbl.apply();
         }
     }
@@ -63,7 +67,7 @@ control MyEC(inout EMPTY_H a, inout EMPTY_M b, in psa_egress_input_metadata_t c,
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout headers_t hdr, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-isvalid.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-isvalid.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-isvalid.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-isvalid.p4.spec
@@ -1,4 +1,10 @@
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY_M {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -28,13 +34,15 @@ struct EMPTY_M {
 }
 metadata instanceof EMPTY_M
 
+header ethernet instanceof ethernet_t
+
 action NoAction args none {
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -47,8 +55,8 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
-	jmpv LABEL_0END h
+	extract h.ethernet
+	jmpv LABEL_0END h.ethernet
 	table tbl
 	LABEL_0END :	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP : drop

--- a/testdata/p4_16_samples_outputs/psa-meter1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter1-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,14 +28,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0;
     action execute(bit<12> index, PSA_MeterColor_t color) {
         meter0.execute(index, color);
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -49,7 +53,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -59,9 +63,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter1-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0_0;
@@ -33,7 +37,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -51,7 +55,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -61,9 +65,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter1-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0_0;
@@ -33,7 +37,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -51,7 +55,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -61,9 +65,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter1.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter1.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,14 +28,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Meter<bit<12>>(1024, PSA_MeterType_t.PACKETS) meter0;
     action execute(bit<12> index, PSA_MeterColor_t color) {
         meter0.execute(index, color);
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -48,7 +52,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-meter3-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter3-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,11 +28,11 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0;
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -47,7 +51,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -57,9 +61,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter3-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.tmp") PSA_MeterColor_t tmp;
@@ -32,7 +36,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     @name("MyIC.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0_0;
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -53,7 +57,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -63,9 +67,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter3-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,14 +28,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @name("MyIC.tmp") PSA_MeterColor_t tmp;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0_0;
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -60,7 +64,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -70,9 +74,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter3.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter3.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,11 +28,11 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Meter<bit<12>>(1024, PSA_MeterType_t.PACKETS) meter0;
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -46,7 +50,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-meter3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter3.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-meter4-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter4-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,11 +28,11 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     DirectMeter(PSA_MeterType_t.PACKETS) meter0;
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -46,7 +50,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -56,9 +60,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter4-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,13 +28,13 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.meter0") DirectMeter(PSA_MeterType_t.PACKETS) meter0_0;
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -48,7 +52,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -58,9 +62,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter4-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter4-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,13 +28,13 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.meter0") DirectMeter(PSA_MeterType_t.PACKETS) meter0_0;
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -48,7 +52,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -58,9 +62,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,11 +28,11 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     DirectMeter(PSA_MeterType_t.PACKETS) meter0;
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -45,7 +49,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-meter5-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter5-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,14 +28,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     DirectMeter(PSA_MeterType_t.PACKETS) meter0;
     action execute_meter() {
         meter0.execute();
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -49,7 +53,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -59,9 +63,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter5-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,13 +28,13 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.meter0") DirectMeter(PSA_MeterType_t.PACKETS) meter0_0;
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -48,7 +52,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -58,9 +62,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter5-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter5-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,13 +28,13 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.meter0") DirectMeter(PSA_MeterType_t.PACKETS) meter0_0;
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -48,7 +52,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -58,9 +62,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,14 +28,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     DirectMeter(PSA_MeterType_t.PACKETS) meter0;
     action execute_meter() {
         meter0.execute();
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -48,7 +52,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-meter6-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter6-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,14 +28,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     DirectMeter(PSA_MeterType_t.PACKETS) meter0;
     action execute_meter() {
         meter0.execute();
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -41,7 +45,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl2 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -60,7 +64,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -70,9 +74,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter6-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
@@ -35,7 +39,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -45,7 +49,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl2") table tbl2_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_3();
@@ -64,7 +68,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -74,9 +78,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter6-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter6-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @noWarn("unused") @name(".NoAction") action NoAction_3() {
@@ -35,7 +39,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -45,7 +49,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl2") table tbl2_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_3();
@@ -64,7 +68,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -74,9 +78,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-meter6.p4
+++ b/testdata/p4_16_samples_outputs/psa-meter6.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,14 +28,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     DirectMeter(PSA_MeterType_t.PACKETS) meter0;
     action execute_meter() {
         meter0.execute();
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -40,7 +44,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     table tbl2 {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -58,7 +62,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-meter6.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-meter6.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }
@@ -27,7 +27,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-random-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-random-first.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Random<bit<16>>(16w200, 16w400) rand;
     action execute_random() {
         b.data = rand.read();
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -53,7 +57,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -63,9 +67,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-random-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-random-frontend.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,7 +32,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.rand") Random<bit<16>>(16w200, 16w400) rand_0;
@@ -37,7 +41,7 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -55,7 +59,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-random-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-random-midend.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,7 +32,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.rand") Random<bit<16>>(16w200, 16w400) rand_0;
@@ -37,7 +41,7 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -55,7 +59,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-random.p4
+++ b/testdata/p4_16_samples_outputs/psa-random.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Random<bit<16>>(200, 400) rand;
     action execute_random() {
         b.data = rand.read();
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -52,7 +56,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-random.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-random.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-register1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-register1-first.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,14 +28,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Register<bit<16>, bit<10>>(32w1024) reg;
     action execute_register(bit<10> idx) {
         bit<16> data = reg.read(idx);
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -49,7 +53,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -59,9 +63,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-register1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register1-frontend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w1024) reg_0;
@@ -32,7 +36,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -50,7 +54,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -60,9 +64,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-register1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register1-midend.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,7 +28,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w1024) reg_0;
@@ -32,7 +36,7 @@ control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t 
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -50,7 +54,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -60,9 +64,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-register1.p4
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4
@@ -11,9 +11,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -24,14 +28,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Register<bit<16>, bit<10>>(1024) reg;
     action execute_register(bit<10> idx) {
         bit<16> data = reg.read(idx);
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -48,7 +52,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-register2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-register2-first.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Register<bit<16>, bit<10>>(32w1024) reg;
     action execute_register(bit<10> idx) {
         reg.write(idx, b.data);
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -53,7 +57,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -63,9 +67,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-register2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register2-frontend.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,7 +32,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w1024) reg_0;
@@ -37,7 +41,7 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -55,7 +59,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-register2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register2-midend.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,7 +32,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w1024) reg_0;
@@ -37,7 +41,7 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -55,7 +59,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-register2.p4
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Register<bit<16>, bit<10>>(1024) reg;
     action execute_register(bit<10> idx) {
         reg.write(idx, b.data);
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -52,7 +56,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct user_meta_t {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -30,6 +36,8 @@ struct user_meta_t {
 }
 metadata instanceof user_meta_t
 
+header ethernet instanceof ethernet_t
+
 struct execute_register_arg_t {
 	bit<10> idx
 }
@@ -45,7 +53,7 @@ action execute_register args instanceof execute_register_arg_t {
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -59,7 +67,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-register3-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-register3-first.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Register<bit<16>, bit<10>>(32w512) reg;
     action execute_register(bit<10> idx) {
         reg.write(idx, b.data);
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -53,7 +57,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -63,9 +67,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-register3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register3-frontend.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,7 +32,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w512) reg_0;
@@ -37,7 +41,7 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -55,7 +59,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-register3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register3-midend.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract<ethernet_t>(eth);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,7 +32,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.reg") Register<bit<16>, bit<10>>(32w512) reg_0;
@@ -37,7 +41,7 @@ control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metad
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -55,7 +59,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -65,9 +69,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, user_meta_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-register3.p4
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4
@@ -15,9 +15,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t eth, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout user_meta_t b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     state start {
-        buffer.extract(eth);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -28,14 +32,14 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout ethernet_t a, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     Register<bit<16>, bit<10>>(512) reg;
     action execute_register(bit<10> idx) {
         reg.write(idx, b.data);
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -52,7 +56,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout ethernet_t d, in user_meta_t e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in user_meta_t e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.spec
@@ -1,5 +1,11 @@
 
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct user_meta_t {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -30,6 +36,8 @@ struct user_meta_t {
 }
 metadata instanceof user_meta_t
 
+header ethernet instanceof ethernet_t
+
 struct execute_register_arg_t {
 	bit<10> idx
 }
@@ -45,7 +53,7 @@ action execute_register args instanceof execute_register_arg_t {
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -59,7 +67,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-remove-header-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-remove-header-first.p4
@@ -26,9 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t h, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
     state start {
-        buffer.extract<ethernet_t>(h);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,13 +43,13 @@ parser MyEP(packet_in buffer, out EMPTY_H a, inout EMPTY_M b, in psa_egress_pars
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     action remove_header() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -63,7 +67,7 @@ control MyEC(inout EMPTY_H a, inout EMPTY_M b, in psa_egress_input_metadata_t c,
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout headers_t hdr, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -73,9 +77,9 @@ control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMP
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-remove-header.p4
+++ b/testdata/p4_16_samples_outputs/psa-remove-header.p4
@@ -26,9 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t h, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
     state start {
-        buffer.extract(h);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,13 +43,13 @@ parser MyEP(packet_in buffer, out EMPTY_H a, inout EMPTY_M b, in psa_egress_pars
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     action remove_header() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -62,7 +66,7 @@ control MyEC(inout EMPTY_H a, inout EMPTY_M b, in psa_egress_input_metadata_t c,
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout headers_t hdr, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-remove-header.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-remove-header.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-remove-header.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-remove-header.p4.spec
@@ -1,4 +1,10 @@
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY_M {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -28,18 +34,20 @@ struct EMPTY_M {
 }
 metadata instanceof EMPTY_M
 
+header ethernet instanceof ethernet_t
+
 action NoAction args none {
 	return
 }
 
 action remove_header args none {
-	invalidate h
+	invalidate h.ethernet
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -53,7 +61,7 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss-first.p4
@@ -26,9 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t h, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
     state start {
-        buffer.extract<ethernet_t>(h);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,13 +43,13 @@ parser MyEP(packet_in buffer, out EMPTY_H a, inout EMPTY_M b, in psa_egress_pars
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     action remove_header() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     table tbl {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction();
@@ -54,10 +58,10 @@ control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_
         default_action = NoAction();
     }
     action ifHit() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     action ifMiss() {
-        a.setValid();
+        hdr.ethernet.setValid();
     }
     apply {
         if (tbl.apply().hit) {
@@ -80,7 +84,7 @@ control MyEC(inout EMPTY_H a, inout EMPTY_M b, in psa_egress_input_metadata_t c,
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout headers_t hdr, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -90,9 +94,9 @@ control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMP
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss-frontend.p4
@@ -26,9 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t h, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
     state start {
-        buffer.extract<ethernet_t>(h);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,15 +43,15 @@ parser MyEP(packet_in buffer, out EMPTY_H a, inout EMPTY_M b, in psa_egress_pars
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.remove_header") action remove_header() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -56,16 +60,16 @@ control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_
         default_action = NoAction_0();
     }
     @name("MyIC.ifHit") action ifHit() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     @name("MyIC.ifHit") action ifHit_2() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     @name("MyIC.ifMiss") action ifMiss() {
-        a.setValid();
+        hdr.ethernet.setValid();
     }
     @name("MyIC.ifMiss") action ifMiss_2() {
-        a.setValid();
+        hdr.ethernet.setValid();
     }
     apply {
         if (tbl_0.apply().hit) {
@@ -88,7 +92,7 @@ control MyEC(inout EMPTY_H a, inout EMPTY_M b, in psa_egress_input_metadata_t c,
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout headers_t hdr, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -98,9 +102,9 @@ control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMP
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss-midend.p4
@@ -26,9 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t h, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
     state start {
-        buffer.extract<ethernet_t>(h);
+        buffer.extract<ethernet_t>(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,15 +43,15 @@ parser MyEP(packet_in buffer, out EMPTY_H a, inout EMPTY_M b, in psa_egress_pars
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("MyIC.remove_header") action remove_header() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {
-            a.srcAddr: exact @name("a.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
         }
         actions = {
             NoAction_0();
@@ -56,16 +60,16 @@ control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_
         default_action = NoAction_0();
     }
     @name("MyIC.ifHit") action ifHit() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     @name("MyIC.ifHit") action ifHit_2() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     @name("MyIC.ifMiss") action ifMiss() {
-        a.setValid();
+        hdr.ethernet.setValid();
     }
     @name("MyIC.ifMiss") action ifMiss_2() {
-        a.setValid();
+        hdr.ethernet.setValid();
     }
     @hidden table tbl_ifHit {
         actions = {
@@ -112,7 +116,7 @@ control MyEC(inout EMPTY_H a, inout EMPTY_M b, in psa_egress_input_metadata_t c,
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout headers_t hdr, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -122,9 +126,9 @@ control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMP
     }
 }
 
-IngressPipeline<ethernet_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<ethernet_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY_M, EMPTY_H, EMPTY_M, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4
@@ -26,9 +26,13 @@ header ethernet_t {
     bit<16>         etherType;
 }
 
-parser MyIP(packet_in buffer, out ethernet_t h, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY_M b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
     state start {
-        buffer.extract(h);
+        buffer.extract(hdr.ethernet);
         transition accept;
     }
 }
@@ -39,13 +43,13 @@ parser MyEP(packet_in buffer, out EMPTY_H a, inout EMPTY_M b, in psa_egress_pars
     }
 }
 
-control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY_M b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     action remove_header() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     table tbl {
         key = {
-            a.srcAddr: exact;
+            hdr.ethernet.srcAddr: exact;
         }
         actions = {
             NoAction;
@@ -53,10 +57,10 @@ control MyIC(inout ethernet_t a, inout EMPTY_M b, in psa_ingress_input_metadata_
         }
     }
     action ifHit() {
-        a.setInvalid();
+        hdr.ethernet.setInvalid();
     }
     action ifMiss() {
-        a.setValid();
+        hdr.ethernet.setValid();
     }
     apply {
         if (tbl.apply().hit) {
@@ -79,7 +83,7 @@ control MyEC(inout EMPTY_H a, inout EMPTY_M b, in psa_egress_input_metadata_t c,
     }
 }
 
-control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout headers_t hdr, in EMPTY_M e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.p4info.txt
@@ -9,7 +9,7 @@ tables {
   }
   match_fields {
     id: 1
-    name: "a.srcAddr"
+    name: "hdr.ethernet.srcAddr"
     bitwidth: 48
     match_type: EXACT
   }

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.spec
@@ -1,4 +1,10 @@
 
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
 struct EMPTY_M {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
 	bit<32> psa_ingress_parser_input_metadata_packet_path
@@ -28,18 +34,20 @@ struct EMPTY_M {
 }
 metadata instanceof EMPTY_M
 
+header ethernet instanceof ethernet_t
+
 action NoAction args none {
 	return
 }
 
 action remove_header args none {
-	invalidate h
+	invalidate h.ethernet
 	return
 }
 
 table tbl {
 	key {
-		h.srcAddr exact
+		h.ethernet.srcAddr exact
 	}
 	actions {
 		NoAction
@@ -53,19 +61,19 @@ table tbl {
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	extract h
+	extract h.ethernet
 	table tbl
 	jmpnh LABEL_0END
-	invalidate h
+	invalidate h.ethernet
 	LABEL_0END :	table tbl
 	jmph LABEL_1END
-	validate h
+	validate h.ethernet
 	LABEL_1END :	table tbl
 	jmph LABEL_2END
-	validate h
+	validate h.ethernet
 	LABEL_2END :	table tbl
 	jmpnh LABEL_3END
-	invalidate h
+	invalidate h.ethernet
 	LABEL_3END :	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP : drop
 }

--- a/testdata/p4_16_samples_outputs/psa-test-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-test-first.p4
@@ -8,11 +8,15 @@ header hdr_t {
     bit<16> field;
 }
 
-parser MyIP(packet_in buffer, out hdr_t a, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    hdr_t h1;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     value_set<bit<16>>(4) pvs;
     state start {
-        buffer.extract<hdr_t>(a);
-        transition select(a.field) {
+        buffer.extract<hdr_t>(hdr.h1);
+        transition select(hdr.h1.field) {
             pvs: accept;
             default: accept;
         }
@@ -25,7 +29,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout hdr_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     apply {
     }
 }
@@ -35,7 +39,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout hdr_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -45,9 +49,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<hdr_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<hdr_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-test-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-test-frontend.p4
@@ -8,11 +8,15 @@ header hdr_t {
     bit<16> field;
 }
 
-parser MyIP(packet_in buffer, out hdr_t a, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    hdr_t h1;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     @name("MyIP.pvs") value_set<bit<16>>(4) pvs_0;
     state start {
-        buffer.extract<hdr_t>(a);
-        transition select(a.field) {
+        buffer.extract<hdr_t>(hdr.h1);
+        transition select(hdr.h1.field) {
             pvs_0: accept;
             default: accept;
         }
@@ -25,7 +29,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout hdr_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     apply {
     }
 }
@@ -35,7 +39,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout hdr_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -45,9 +49,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<hdr_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<hdr_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-test-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-test-midend.p4
@@ -8,11 +8,15 @@ header hdr_t {
     bit<16> field;
 }
 
-parser MyIP(packet_in buffer, out hdr_t a, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    hdr_t h1;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     @name("MyIP.pvs") value_set<bit<16>>(4) pvs_0;
     state start {
-        buffer.extract<hdr_t>(a);
-        transition select(a.field) {
+        buffer.extract<hdr_t>(hdr.h1);
+        transition select(hdr.h1.field) {
             pvs_0: accept;
             default: accept;
         }
@@ -25,7 +29,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout hdr_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     apply {
     }
 }
@@ -35,7 +39,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout hdr_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }
@@ -45,9 +49,9 @@ control MyED(packet_out buffer, out EMPTY a, out EMPTY b, inout EMPTY c, in EMPT
     }
 }
 
-IngressPipeline<hdr_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+IngressPipeline<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
 
 EgressPipeline<EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
 
-PSA_Switch<hdr_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+PSA_Switch<headers_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
 

--- a/testdata/p4_16_samples_outputs/psa-test.p4
+++ b/testdata/p4_16_samples_outputs/psa-test.p4
@@ -8,11 +8,15 @@ header hdr_t {
     bit<16> field;
 }
 
-parser MyIP(packet_in buffer, out hdr_t a, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
+struct headers_t {
+    hdr_t h1;
+}
+
+parser MyIP(packet_in buffer, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
     value_set<bit<16>>(4) pvs;
     state start {
-        buffer.extract(a);
-        transition select(a.field) {
+        buffer.extract(hdr.h1);
+        transition select(hdr.h1.field) {
             pvs: accept;
             default: accept;
         }
@@ -25,7 +29,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
     }
 }
 
-control MyIC(inout hdr_t a, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     apply {
     }
 }
@@ -35,7 +39,7 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
-control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout hdr_t d, in EMPTY e, in psa_ingress_output_metadata_t f) {
+control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     apply {
     }
 }


### PR DESCRIPTION
Many of these test programs were written so that a single Ethernet
header type was being passed as the parameter to top level parsers and
controls in the PSA architecture, rather than the more typical struct
of multiple headers.  This was not necessarily an error, but at least
the v1model architecture explicitly documents the user-defined headers
type H must be a struct containing header/stack/union types, but not
itself a header.  It would be best to avoid any special-case code in
the PSA back end to handle this unlikely use case.  I call it unlikely
because almost no one ever writes a program that only parses a single
header.