### PR TITLE
Changing relative paths for parsers Unroll gtests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -91,6 +91,8 @@ set (GTESTP4C_SOURCES ${GTEST_SOURCES} ${GTEST_BASE_SOURCES})
 # can add GTests to `GTEST_SOURCES` to include them in the test executable. They
 # can also link in additional libraries, if needed, by adding them to
 # `GTEST_LDADD`.
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/test)
+configure_file(gtest/env.h.in ${CMAKE_CURRENT_BINARY_DIR}/test/env.h)
 add_executable (gtestp4c ${GTESTP4C_SOURCES})
 target_link_libraries (gtestp4c ${GTEST_LDADD} ${P4C_LIBRARIES} gtest ${P4C_LIB_DEPS})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,8 +94,6 @@ set (GTESTP4C_SOURCES ${GTEST_SOURCES} ${GTEST_BASE_SOURCES})
 add_executable (gtestp4c ${GTESTP4C_SOURCES})
 target_link_libraries (gtestp4c ${GTEST_LDADD} ${P4C_LIBRARIES} gtest ${P4C_LIB_DEPS})
 
-set(ENV{<P4C_SOURCE_DIR>} ${P4C_SOURCE_DIR})
-
 # Tests
 add_test (NAME gtestp4c COMMAND gtestp4c WORKING_DIRECTORY ${P4C_BINARY_DIR})
 set_tests_properties (gtestp4c PROPERTIES LABELS "gtest")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,6 +94,8 @@ set (GTESTP4C_SOURCES ${GTEST_SOURCES} ${GTEST_BASE_SOURCES})
 add_executable (gtestp4c ${GTESTP4C_SOURCES})
 target_link_libraries (gtestp4c ${GTEST_LDADD} ${P4C_LIBRARIES} gtest ${P4C_LIB_DEPS})
 
+set(ENV{<P4C_SOURCE_DIR>} ${P4C_SOURCE_DIR})
+
 # Tests
 add_test (NAME gtestp4c COMMAND gtestp4c WORKING_DIRECTORY ${P4C_BINARY_DIR})
 set_tests_properties (gtestp4c PROPERTIES LABELS "gtest")

--- a/test/gtest/env.h.in
+++ b/test/gtest/env.h.in
@@ -1,0 +1,6 @@
+#ifndef TEST_GTEST_ENV_H_
+#define TEST_GTEST_ENV_H_
+
+const char* relPath = "${P4C_SOURCE_DIR}/";
+
+#endif  // TEST_GTEST_PARSER_UNROLL_H_

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -2,6 +2,8 @@
 
 #include <fstream>
 
+#include "env.h"
+
 #include "gtest/gtest.h"
 #include "ir/ir.h"
 #include "helpers.h"
@@ -232,11 +234,7 @@ std::pair<const IR::P4Parser*, const IR::P4Parser*> rewriteParser(const IR::P4Pr
 
 /// Loads example from a file
 const IR::P4Program* load_model(const char* curFile, CompilerOptions& options) {
-    const char* sourceDir = getenv("P4C_SOURCE_DIR");
-    BUG_CHECK(sourceDir, "Can't find environment variale 'P4C_SOURCE_DIR'"); 
-    std::string relPath = sourceDir;
-    relPath.append("/");
-    std::string includeDir = relPath + std::string("p4include");
+    std::string includeDir = std::string(relPath) + std::string("p4include");
     setenv("P4C_16_INCLUDE_PATH", includeDir.c_str(), 1);
     options.loopsUnrolling = true;
     options.compilerVersion = P4TEST_VERSION_STRING;

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -241,7 +241,7 @@ const IR::P4Program* load_model(const char* curFile, CompilerOptions& options) {
     options.loopsUnrolling = true;
     options.compilerVersion = P4TEST_VERSION_STRING;
     options.file = relPath;
-    options.file += "testdata/p4_16_sample/";
+    options.file += "testdata/p4_16_samples/";
     options.file += curFile;
     return P4::parseP4File(options);
 }

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -241,6 +241,7 @@ const IR::P4Program* load_model(const char* curFile, CompilerOptions& options) {
     options.loopsUnrolling = true;
     options.compilerVersion = P4TEST_VERSION_STRING;
     options.file = relPath;
+    options.file += "testdata/p4_16_sample/";
     options.file += curFile;
     return P4::parseP4File(options);
 }

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -232,7 +232,9 @@ std::pair<const IR::P4Parser*, const IR::P4Parser*> rewriteParser(const IR::P4Pr
 
 /// Loads example from a file
 const IR::P4Program* load_model(const char* curFile, CompilerOptions& options) {
-    std::string relPath = getenv("P4C_SOURCE_DIR");
+    const char* sourceDir = getenv("P4C_SOURCE_DIR");
+    BUG_CHECK(sourceDir, "Can't find environment variale 'P4C_SOURCE_DIR'"); 
+    std::string relPath = sourceDir;
     relPath.append("/");
     std::string includeDir = relPath + std::string("p4include");
     setenv("P4C_16_INCLUDE_PATH", includeDir.c_str(), 1);

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -186,9 +186,6 @@ class MidEnd : public PassManager {
         return toplevel; }
 };
 
-/// Relative path to the examples
-const char *relPath = "../testdata/p4_16_samples/";
-
 // #define PARSER_UNROLL_TIME_CHECKING
 
 #ifdef PARSER_UNROLL_TIME_CHECKING
@@ -235,7 +232,10 @@ std::pair<const IR::P4Parser*, const IR::P4Parser*> rewriteParser(const IR::P4Pr
 
 /// Loads example from a file
 const IR::P4Program* load_model(const char* curFile, CompilerOptions& options) {
-    setenv("P4C_16_INCLUDE_PATH", "../p4include", 1);
+    std::string relPath = getenv("P4C_SOURCE_DIR");
+    relPath.append("/");
+    std::string includeDir = relPath + std::string("p4include");
+    setenv("P4C_16_INCLUDE_PATH", includeDir.c_str(), 1);
     options.loopsUnrolling = true;
     options.compilerVersion = P4TEST_VERSION_STRING;
     options.file = relPath;


### PR DESCRIPTION
These changes allow running gtestp4c from different folders. 