### PR TITLE
Update StrengthReduction pass relative to signed shift left operation

### DIFF
--- a/frontends/p4/strengthReduction.cpp
+++ b/frontends/p4/strengthReduction.cpp
@@ -379,7 +379,7 @@ const IR::Node* DoStrengthReduction::postorder(IR::Slice* expr) {
     if (shift_of) {
         if (!shift_of->type->is<IR::Type_Bits>())
             return expr;
-        if (shift_of->type->to<IR::Type_Bits>()->isSigned)
+        if (shift_of->type->to<IR::Type_Bits>()->isSigned && expr->e0->is<IR::Shr>())
             return expr;
         int hi = expr->getH();
         int lo = expr->getL();


### PR DESCRIPTION
The current code does not slice a shift left operation if the source
field is signed, e.g.:
   unsigned_val[7:0] = (signed_val << 3)[15:8];
to something like this:
   unsigned_val[7:0] = signed_val[12:5];

This is not in-line with the P4 Spec "8.6. Operations on fixed-width
signed integers" chapter which state "Shifting left produces the exact
same bit pattern as a shift left of an unsigned value. Shift left can
thus overflow, when it leads to a change of the sign bit."

Slicing the operation also help reduce field constraints down the road.