### PR TITLE
Test `main` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ make adding new backends easy.
 
 The code contains five sample backends:
 * p4c-bm2-ss: can be used to target the P4 `simple_switch` written using
-  the BMv2 behavioral model https://github.com/p4lang/behavioral-model
-* p4c-ebpf: can be used to generate C code which can be compiled to EBPF
+  the BMv2 behavioral model https://github.com/p4lang/behavioral-model,
+* p4c-dpdk: can be used to target the DPDK software switch (SXS) pipeline 
+  https://doc.dpdk.org/guides/rel_notes/release_20_11.html,
+* p4c-ebpf: can be used to generate C code which can be compiled to eBPF
   https://en.wikipedia.org/wiki/Berkeley_Packet_Filter and then loaded
-  in the Linux kernel for packet filtering
+  in the Linux kernel for packet filtering,
 * p4test: a source-to-source P4 translator which can be used for
-  testing, learning compiler internals and debugging.
+  testing, learning compiler internals and debugging,
 * p4c-graphs: can be used to generate visual representations of a P4 program;
-  for now it only supports generating graphs of top-level control flows.
-* p4c-ubfp: can be used to generate ebpf code that runs in user-space
+  for now it only supports generating graphs of top-level control flows, and
+* p4c-ubfp: can be used to generate eBPF code that runs in user-space.
 
 Sample command lines:
 

--- a/bazel/p4c_deps.bzl
+++ b/bazel/p4c_deps.bzl
@@ -24,8 +24,8 @@ filegroup(
     if not native.existing_rule("com_github_nelhage_rules_boost"):
         git_repository(
             name = "com_github_nelhage_rules_boost",
-            # Newest commit on main branch as of Jan 22, 2021.
-            commit = "77dbe5a5262c71a2fe2c033677f50aaa0e31090d",
+            # Newest commit on main branch as of May 3, 2021.
+            commit = "2598b37ce68226fab465c0f0e10988af872b6dc9",
             remote = "https://github.com/nelhage/rules_boost",
             shallow_since = "1611019749 -0800",
         )


### PR DESCRIPTION
The primary purpose of this commit is to check Travis CI scripts on the recently renamed `main` branch for p4c.

It also updates the list of backends for the open-source compiler.