### PR TITLE
Features no longer marked as experimental

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -670,18 +670,15 @@ instantiation
       | typeRef "(" argumentList ")" name ";"
                      { $$ = new IR::Declaration_Instance(@5, *$5, $1, $3);
                        driver.structure->declareObject(*$5, $1->toString()); }
-      /* experimental */
       | annotations typeRef "(" argumentList ")" name "=" objInitializer ";"
                      { $$ = new IR::Declaration_Instance(@6, *$6, new IR::Annotations(*$1),
                                                          $2, $4, $8);
                        driver.structure->declareObject(*$6, $2->toString()); }
-      /* experimental */
       | typeRef "(" argumentList ")" name "=" objInitializer ";"
                      { $$ = new IR::Declaration_Instance(@5, *$5, $1, $3, $7);
                        driver.structure->declareObject(*$5, $1->toString()); }
     ;
 
-/* experimental; includes the following 3 productions */
 objInitializer
     : "{" { driver.structure->pushNamespace(@1, false); } objDeclarations "}"
                                { driver.structure->pop();
@@ -765,7 +762,7 @@ parserStatement
     | variableDeclaration             { $$ = $1; }
     | constantDeclaration             { $$ = $1; }
     | parserBlockStatement            { $$ = $1; }
-    | conditionalStatement            { $$ = $1; }  // experimental
+    | conditionalStatement            { $$ = $1; }
     ;
 
 parserBlockStatement
@@ -926,7 +923,7 @@ methodPrototype
     | optAnnotations ABSTRACT functionPrototype ";" {
             driver.structure->pop();
             $$ = $3; $$->setAbstract();
-            $3->annotations = $1; }  // experimental
+            $3->annotations = $1; }
     | optAnnotations TYPE_IDENTIFIER "(" parameterList ")" ";"  // constructor
                                         { auto par = new IR::ParameterList(@4, *$4);
                                           auto mt = new IR::Type_Method(@2, par, $2);
@@ -1058,7 +1055,6 @@ derivedTypeDeclaration
 
 headerTypeDeclaration
     : optAnnotations HEADER name { driver.structure->pushContainerType(*$3, true); } optTypeParameters {
-        // type parameters are experimental
         driver.structure->markAsTemplate(*$3);
         driver.structure->declareTypes(&$5->parameters); }
       "{" structFieldList "}" { $$ = new IR::Type_Header(@3, *$3, $1, $5, *$8);
@@ -1067,7 +1063,6 @@ headerTypeDeclaration
 
 structTypeDeclaration
     : optAnnotations STRUCT name  { driver.structure->pushContainerType(*$3, true); } optTypeParameters {
-        // type parameters are experimental
         driver.structure->markAsTemplate(*$3);
         driver.structure->declareTypes(&$5->parameters); }
       "{" structFieldList "}" { $$ = new IR::Type_Struct(@3, *$3, $1, $5, *$8);
@@ -1076,7 +1071,6 @@ structTypeDeclaration
 
 headerUnionDeclaration
     : optAnnotations HEADER_UNION name { driver.structure->pushContainerType(*$3, true); } optTypeParameters {
-        // type parameters are experimental
         driver.structure->markAsTemplate(*$3);
         driver.structure->declareTypes(&$5->parameters); }
       "{" structFieldList "}" { $$ = new IR::Type_HeaderUnion(@3, *$3, $1, $5, *$8);
@@ -1390,7 +1384,7 @@ dot_name:
 
 lvalue
     : prefixedNonTypeName                { $$ = new IR::PathExpression($1); }
-    | THIS                               { $$ = new IR::This(@1); }  // experimental
+    | THIS                               { $$ = new IR::This(@1); }
     | lvalue dot_name %prec DOT          { $$ = new IR::Member(@1 + @2, $1, *$2); }
     | lvalue "[" expression "]"          { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | lvalue "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
@@ -1401,7 +1395,7 @@ expression
     | STRING_LITERAL                     { $$ = new IR::StringLiteral(@1, $1); }
     | TRUE                               { $$ = new IR::BoolLiteral(@1, true); }
     | FALSE                              { $$ = new IR::BoolLiteral(@1, false); }
-    | THIS                               { $$ = new IR::This(@1); }  // experimental
+    | THIS                               { $$ = new IR::This(@1); }
     | nonTypeName                        { $$ = new IR::PathExpression(*$1); }
     | dotPrefix nonTypeName              { $$ = new IR::PathExpression(new IR::Path(*$2, true)); driver.structure->clearPath(); }
     | expression "[" expression "]"      { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
@@ -1458,7 +1452,7 @@ nonBraceExpression
     | STRING_LITERAL                     { $$ = new IR::StringLiteral(@1, $1); }
     | TRUE                               { $$ = new IR::BoolLiteral(@1, true); }
     | FALSE                              { $$ = new IR::BoolLiteral(@1, false); }
-    | THIS                               { $$ = new IR::This(@1); }  // experimental
+    | THIS                               { $$ = new IR::This(@1); }
     | nonTypeName                        { $$ = new IR::PathExpression(*$1); }
     | dotPrefix nonTypeName              { $$ = new IR::PathExpression(new IR::Path(*$2, true)); driver.structure->clearPath(); }
     | nonBraceExpression "[" expression "]"      { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }


### PR DESCRIPTION
Removed "experimental" comments from parser features that are slated for inclusion in P4 version 1.2.2.