### PR TITLE
dpdk: implement checksum clear method

### DIFF
--- a/backends/dpdk/dpdk.def
+++ b/backends/dpdk/dpdk.def
@@ -389,6 +389,13 @@ class DpdkChecksumSubStatement : DpdkAsmStatement, IDPDKNode {
 #nodbprint
 }
 
+class DpdkChecksumClearStatement : DpdkAsmStatement, IDPDKNode {
+    cstring csum;
+    cstring intermediate_value;
+    std::ostream& toSpec(std::ostream& out) const override;
+#nodbprint
+}
+
 class DpdkGetHashStatement : DpdkAsmStatement, IDPDKNode {
     cstring hash;
     Expression fields;

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -357,8 +357,8 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                             a->object->getName(), intermediate, field));
                     }
                 } else {
-                    ::error(
-                        "The argument of InternetCheckSum.add is not a list.");
+                    add_instr(new IR::DpdkChecksumAddStatement(
+                                a->object->getName(), intermediate, arg->expression));
                 }
             } else if (a->method->getName().name == "subtract") {
                 auto args = a->expr->arguments;
@@ -369,9 +369,12 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                             a->object->getName(), intermediate, field));
                     }
                 } else {
-                    ::error(
-                        "The argument of InternetCheckSum.subtract is not a list.");
+                    add_instr(new IR::DpdkChecksumSubStatement(
+                                a->object->getName(), intermediate, arg->expression));
                 }
+            } else if (a->method->getName().name == "clear") {
+                add_instr(new IR::DpdkChecksumClearStatement(
+                            a->object->getName(), intermediate));
             }
         } else if (a->originalExternType->getName().name == "packet_out") {
             if (a->method->getName().name == "emit") {

--- a/backends/dpdk/spec.cpp
+++ b/backends/dpdk/spec.cpp
@@ -383,6 +383,12 @@ std::ostream &IR::DpdkChecksumSubStatement::toSpec(std::ostream &out) const {
     return out;
 }
 
+std::ostream &IR::DpdkChecksumClearStatement::toSpec(std::ostream &out) const {
+    out << "mov "
+        << "h.cksum_state." << intermediate_value << " " << "0x0";
+    return out;
+}
+
 std::ostream &IR::DpdkGetHashStatement::toSpec(std::ostream &out) const {
     out << "hash_get " << DPDK::toStr(dst) << " " << hash << " (";
     if (auto l = fields->to<IR::ListExpression>()) {

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
@@ -127,6 +127,7 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
+	mov h.cksum_state.state_0 0x0
 	ckadd h.cksum_state.state_0 h.ipv4.version
 	ckadd h.cksum_state.state_0 h.ipv4.ihl
 	ckadd h.cksum_state.state_0 h.ipv4.diffserv
@@ -139,6 +140,7 @@ apply {
 	ckadd h.cksum_state.state_0 h.ipv4.srcAddr
 	ckadd h.cksum_state.state_0 h.ipv4.dstAddr
 	mov h.ipv4.hdrChecksum h.cksum_state.state_0
+	mov h.cksum_state.state_0 0x0
 	cksub h.cksum_state.state_0 h.tcp.checksum
 	cksub h.cksum_state.state_0 m.local_metadata__fwd_metadata_old_srcAddr0
 	ckadd h.cksum_state.state_0 h.ipv4.srcAddr


### PR DESCRIPTION
checksum clear() method is implemented by initializing the internal state to 0.