### PR TITLE
Eliminate redundant validation code.

### DIFF
--- a/ir/ir.def
+++ b/ir/ir.def
@@ -444,7 +444,6 @@ class IfStatement : Statement {
         clone.visit(ifFalse, "ifFalse");
         v.flow_merge(clone);
     }
-    validate{ CHECK_NULL(ifTrue); }
 }
 
 class BlockStatement : Statement, ISimpleNamespace, IAnnotated {


### PR DESCRIPTION
The `ifTrue` branch doesn't have a `NullOK` annotation, so the IR
generator already adds the same check:
```
void IR::IfStatement::validate() const {
        CHECK_NULL(condition);
        CHECK_NULL(ifTrue);
{ CHECK_NULL(ifTrue); } }
```