### PR TITLE
Add width_bits to varbits

### DIFF
--- a/ir/type.def
+++ b/ir/type.def
@@ -110,6 +110,7 @@ class Type_Varbits : Type_Base {
     NullOK optional Expression  expression = nullptr;  // only used temporarily
     static Type_Varbits get(Util::SourceInfo si, int size = 0);
     static Type_Varbits get();
+    int width_bits() const override { return size; }
     toString{ return cstring("varbit<") + Util::toString(size) + ">"; }
     dbprint { out << "varbit<" << size << ">"; }
 }


### PR DESCRIPTION
`Type_Varbits` is missing an implementation for `width_bits()`. If you call it you will always receive zero, even if size is set. This requests adds the function call to `Type_Varbits`. 