### PR TITLE
Cleanups to help with resolving methodcalls without a typeMap

### DIFF
--- a/frontends/p4/cloner.h
+++ b/frontends/p4/cloner.h
@@ -28,7 +28,8 @@ class ClonePathExpressions : public Transform {
     ClonePathExpressions()
     { visitDagOnce = false; setName("ClonePathExpressions"); }
     const IR::Node* postorder(IR::PathExpression* path) override
-    { return new IR::PathExpression(path->path->clone()); }
+    { path->path = path->path->clone();
+      return path; }
 
     template<typename T>
     const T* clone(const IR::Node* node)

--- a/frontends/p4/methodInstance.cpp
+++ b/frontends/p4/methodInstance.cpp
@@ -25,14 +25,14 @@ MethodInstance*
 MethodInstance::resolve(const IR::MethodCallExpression* mce, DeclarationLookup* refMap,
                         TypeMap* typeMap, bool useExpressionType, const Visitor::Context *ctxt,
                         bool incomplete) {
-    auto mt = typeMap->getType(mce->method);
+    auto mt = typeMap ? typeMap->getType(mce->method) : nullptr;
     if (mt == nullptr && useExpressionType)
         mt = mce->method->type;
     CHECK_NULL(mt);
     BUG_CHECK(mt->is<IR::Type_MethodBase>(), "%1%: expected a MethodBase type", mt);
     auto originalType = mt->to<IR::Type_MethodBase>();
     auto actualType = originalType;
-    if (!mce->typeArguments->empty()) {
+    if (typeMap && !mce->typeArguments->empty()) {
         auto t = TypeInference::specialize(originalType, mce->typeArguments);
         CHECK_NULL(t);
         actualType = t->to<IR::Type_MethodBase>();
@@ -44,7 +44,7 @@ MethodInstance::resolve(const IR::MethodCallExpression* mce, DeclarationLookup* 
     // mt can be Type_Method or Type_Action
     if (mce->method->is<IR::Member>()) {
         auto mem = mce->method->to<IR::Member>();
-        auto basetype = typeMap->getType(mem->expr);
+        auto basetype = typeMap ? typeMap->getType(mem->expr) : mem->expr->type;
         if (basetype == nullptr) {
             if (useExpressionType)
                 basetype = mem->expr->type;
@@ -73,7 +73,7 @@ MethodInstance::resolve(const IR::MethodCallExpression* mce, DeclarationLookup* 
                 decl = refMap->getDeclaration(th, true);
             } else if (auto pe = mem->expr->to<IR::PathExpression>()) {
                 decl = refMap->getDeclaration(pe->path, true);
-                type = typeMap->getType(decl->getNode());
+                type = typeMap ? typeMap->getType(decl->getNode()) : pe->type;
             } else if (auto mc = mem->expr->to<IR::MethodCallExpression>()) {
                 auto mi = resolve(mc, refMap, typeMap, useExpressionType);
                 decl = mi->object;
@@ -81,7 +81,7 @@ MethodInstance::resolve(const IR::MethodCallExpression* mce, DeclarationLookup* 
             } else if (auto cce = mem->expr->to<IR::ConstructorCallExpression>()) {
                 auto cc = ConstructorCall::resolve(cce, refMap, typeMap);
                 decl = cc->to<ExternConstructorCall>()->type;
-                type = typeMap->getTypeType(cce->constructedType, true);
+                type = typeMap ? typeMap->getTypeType(cce->constructedType, true) : cce->type;
             } else {
                 BUG("unexpected expression %1% resolving method instance", mem->expr); }
             if (type->is<IR::Type_SpecializedCanonical>())
@@ -127,7 +127,7 @@ MethodInstance::resolve(const IR::MethodCallExpression* mce, DeclarationLookup* 
 ConstructorCall*
 ConstructorCall::resolve(const IR::ConstructorCallExpression* cce,
                          DeclarationLookup* refMap, TypeMap* typeMap) {
-    auto ct = typeMap->getTypeType(cce->constructedType, true);
+    auto ct = typeMap ? typeMap->getTypeType(cce->constructedType, true) : cce->type;
     ConstructorCall* result;
     const IR::Vector<IR::Type>* typeArguments;
     const IR::Type_Name* type;
@@ -144,7 +144,7 @@ ConstructorCall::resolve(const IR::ConstructorCallExpression* cce,
     }
 
     if (auto tsc = ct->to<IR::Type_SpecializedCanonical>())
-        ct = typeMap->getTypeType(tsc->baseType, true);
+        ct = typeMap ? typeMap->getTypeType(tsc->baseType, true) : tsc;
 
     if (ct->is<IR::Type_Extern>()) {
         auto decl = refMap->getDeclaration(type->path, true);
@@ -172,7 +172,7 @@ ConstructorCall::resolve(const IR::ConstructorCallExpression* cce,
 Instantiation* Instantiation::resolve(const IR::Declaration_Instance* instance,
                                       DeclarationLookup* ,
                                       TypeMap* typeMap) {
-    auto type = typeMap->getTypeType(instance->type, true);
+    auto type = typeMap ? typeMap->getTypeType(instance->type, true) : instance->type;
     auto simpleType = type;
     const IR::Vector<IR::Type>* typeArguments;
 

--- a/frontends/p4/methodInstance.h
+++ b/frontends/p4/methodInstance.h
@@ -104,6 +104,14 @@ class MethodInstance : public InstanceBase {
                                    DeclarationLookup* refMap, TypeMap* typeMap,
                                    const Visitor::Context *ctxt = nullptr)
     { return resolve(mcs->methodCall, refMap, typeMap, false, ctxt, false); }
+    static MethodInstance* resolve(const IR::MethodCallExpression* mce,
+                                   DeclarationLookup* refMap,
+                                   const Visitor::Context *ctxt = nullptr)
+    { return resolve(mce, refMap, nullptr, true, ctxt, false); }
+    static MethodInstance* resolve(const IR::MethodCallStatement* mcs,
+                                   DeclarationLookup* refMap,
+                                   const Visitor::Context *ctxt = nullptr)
+    { return resolve(mcs->methodCall, refMap, nullptr, true, ctxt, false); }
     const IR::ParameterList* getOriginalParameters() const
     { return originalMethodType->parameters; }
     const IR::ParameterList* getActualParameters() const

--- a/frontends/p4/uniqueNames.cpp
+++ b/frontends/p4/uniqueNames.cpp
@@ -139,8 +139,8 @@ const IR::Node* RenameSymbols::postorder(IR::PathExpression* expression) {
     auto newName = renameMap->getName(decl);
     auto name = IR::ID(expression->path->name.srcInfo, newName,
                        expression->path->name.originalName);
-    auto result = new IR::PathExpression(name);
-    return result;
+    expression->path = new IR::Path(name);
+    return expression;
 }
 
 const IR::Node* RenameSymbols::postorder(IR::Declaration_Instance* decl) {

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -191,6 +191,10 @@ class Visitor {
     template <class T> inline const T *findOrigCtxt() const {
         const Context *c = ctxt;
         return findOrigCtxt<T>(c); }
+    inline bool isInContext(const IR::Node *n) const {
+        for (auto *c = ctxt; c; c = c->parent) {
+            if (c->node == n || c->original == n) return true; }
+        return false; }
 
     /// @return the current node - i.e., the node that was passed to preorder()
     /// or postorder(). For Modifiers and Transforms, this is a clone of the
@@ -322,11 +326,11 @@ class Transform : public virtual Visitor {
 };
 
 class ControlFlowVisitor : public virtual Visitor {
-    std::map<const IR::Node *, std::pair<ControlFlowVisitor *, int>> *flow_join_points = 0;
     std::map<cstring, ControlFlowVisitor &>     &globals;
 
  protected:
     ControlFlowVisitor* clone() const override = 0;
+    std::map<const IR::Node *, std::pair<ControlFlowVisitor *, int>> *flow_join_points = 0;
     void init_join_flows(const IR::Node *root) override;
     bool join_flows(const IR::Node *n) override;
 


### PR DESCRIPTION
Once type inferencing is finished, the typemap is no longer needed to resolve method calls, so this allows not providing one.  This change allows calling MethodInstance::resolve with a nullptr for the typeMap, so it can be used when a type map is not available.

Also clean up some redundant clones that were making things harder to debug (and just wasting space/time), and better allow ControlFlowVisitor to be extended to allow more general stuff.