### PR TITLE
Call setInvalid on all uninitialized headers.

### DIFF
--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -666,12 +666,10 @@ bool ComputeWriteSet::preorder(const IR::MethodCallExpression* expression) {
     if (auto bim = mi->to<BuiltInMethod>()) {
         auto base = getWrites(bim->appliedTo);
         cstring name = bim->name.name;
-        if (name == IR::Type_Header::setInvalid) {
-            // modifies all fields of the header!
-            expressionWrites(expression, base);
-            return false;
-        } else if (name == IR::Type_Header::setValid) {
-            // modifies only the valid field
+        if (name == IR::Type_Header::setInvalid || name == IR::Type_Header::setValid) {
+            // modifies only the valid field.
+            // setInvalid may in fact write all fields, but
+            // it will not really "define" them.
             auto v = base->getField(StorageFactory::validFieldName);
             expressionWrites(expression, v);
             return false;

--- a/frontends/p4/resetHeaders.cpp
+++ b/frontends/p4/resetHeaders.cpp
@@ -52,17 +52,17 @@ void DoResetHeaders::generateResets(
 }
 
 const IR::Node* DoResetHeaders::postorder(IR::Declaration_Variable* decl) {
-    if (findContext<IR::ParserState>() == nullptr)
-        return decl;
     if (decl->initializer != nullptr)
         return decl;
     auto resets = new IR::Vector<IR::StatOrDecl>();
     resets->push_back(decl);
+#if 0
     BUG_CHECK(getContext()->node->is<IR::Vector<IR::StatOrDecl>>() ||
               getContext()->node->is<IR::ParserState>() ||
               getContext()->node->is<IR::BlockStatement>(),
               "%1%: parent is not Vector<StatOrDecl>, but %2%",
               decl, getContext()->node);
+#endif
     auto type = typeMap->getType(getOriginal(), true);
     auto path = new IR::PathExpression(decl->getName());
     generateResets(typeMap, type, path, resets);

--- a/frontends/p4/resetHeaders.cpp
+++ b/frontends/p4/resetHeaders.cpp
@@ -35,6 +35,7 @@ void DoResetHeaders::generateResets(
         auto args = new IR::Vector<IR::Argument>();
         auto mc = new IR::MethodCallExpression(expr->srcInfo, method, args);
         auto stat = new IR::MethodCallStatement(mc->srcInfo, mc);
+        LOG3("Reset header " << expr);
         resets->push_back(stat);
     } else if (type->is<IR::Type_Stack>()) {
         auto tstack = type->to<IR::Type_Stack>();

--- a/frontends/p4/resetHeaders.h
+++ b/frontends/p4/resetHeaders.h
@@ -25,8 +25,8 @@ namespace P4 {
 
 /** @brief Explicitly invalidate uninitialized header variables.
  *
- * A local uninitialized variable in a parser state that represents a header
- * must be invalid every time the parser state is entered.  Hence,
+ * A local uninitialized variable that represents a header
+ * must be initialized to invalid.  For example:
  *
 ```
 state X {
@@ -50,11 +50,12 @@ state X {
  *
  * @pre An up-to-date TypeMap.
  *
- * @post All parser states with uninitialized header variables have explicit
+ * @post Uninitialized header variables have explicit
  * statements that invalidate those headers.
  */
 class DoResetHeaders : public Transform {
     const TypeMap* typeMap;
+    IR::IndexedVector<IR::StatOrDecl> insert;
 
  public:
     static void generateResets(
@@ -63,6 +64,8 @@ class DoResetHeaders : public Transform {
     explicit DoResetHeaders(const TypeMap* typeMap) : typeMap(typeMap) {
         CHECK_NULL(typeMap); setName("DoResetHeaders"); }
     const IR::Node* postorder(IR::Declaration_Variable* decl) override;
+    const IR::Node* postorder(IR::P4Control* control) override;
+    const IR::Node* postorder(IR::ParserState* state) override;
 };
 
 /// Invokes TypeChecking followed by DoResetHeaders.

--- a/frontends/p4/resetHeaders.h
+++ b/frontends/p4/resetHeaders.h
@@ -23,8 +23,7 @@ limitations under the License.
 
 namespace P4 {
 
-/** @brief Explicitly invalidate uninitialized header variables declared in
- * parser states.
+/** @brief Explicitly invalidate uninitialized header variables.
  *
  * A local uninitialized variable in a parser state that represents a header
  * must be invalid every time the parser state is entered.  Hence,

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-frontend.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-frontend.p4
@@ -86,6 +86,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".start") state start {
+        tmp_hdr_0.setInvalid();
         transition parse_ethernet;
     }
 }

--- a/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
+++ b/testdata/p4_14_samples_outputs/09-IPv4OptionsUnparsed-midend.p4
@@ -102,6 +102,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @name(".start") state start {
+        tmp_hdr_0.setInvalid();
         transition parse_ethernet;
     }
 }

--- a/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
@@ -131,6 +131,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @header_ordering("ethernet", "ipv4_base", "ipv4_option_security", "ipv4_option_NOP", "ipv4_option_timestamp", "ipv4_option_EOL") @name(".start") state start {
+        tmp_hdr_0.setInvalid();
         transition parse_ethernet;
     }
 }

--- a/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
@@ -131,6 +131,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     @header_ordering("ethernet", "ipv4_base", "ipv4_option_security", "ipv4_option_NOP", "ipv4_option_timestamp", "ipv4_option_EOL") @name(".start") state start {
+        tmp_hdr_0.setInvalid();
         transition parse_ethernet;
     }
     state noMatch {

--- a/testdata/p4_14_samples_outputs/issue576-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue576-frontend.p4
@@ -62,6 +62,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     @name("ParserImpl.tmp_hdr") ipv4_t_1 tmp_hdr_1;
     @name("ParserImpl.tmp_hdr_0") ipv4_t_1 tmp_hdr_2;
     @name(".start") state start {
+        tmp_hdr_1.setInvalid();
+        tmp_hdr_2.setInvalid();
         packet.extract<simpleipv4_t>(hdr.sh.next);
         packet.extract<simpleipv4_t>(hdr.sh.next);
         tmp_hdr_1 = packet.lookahead<ipv4_t_1>();

--- a/testdata/p4_14_samples_outputs/issue576-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue576-midend.p4
@@ -64,6 +64,8 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     bit<160> tmp;
     bit<160> tmp_0;
     @name(".start") state start {
+        tmp_hdr_1.setInvalid();
+        tmp_hdr_2.setInvalid();
         packet.extract<simpleipv4_t>(hdr.sh.next);
         packet.extract<simpleipv4_t>(hdr.sh.next);
         tmp = packet.lookahead<bit<160>>();

--- a/testdata/p4_14_samples_outputs/issue781-frontend.p4
+++ b/testdata/p4_14_samples_outputs/issue781-frontend.p4
@@ -44,6 +44,7 @@ struct headers {
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("ParserImpl.tmp_hdr") ipv4_t_1 tmp_hdr_0;
     @name(".start") state start {
+        tmp_hdr_0.setInvalid();
         tmp_hdr_0 = packet.lookahead<ipv4_t_1>();
         packet.extract<ipv4_t>(hdr.h, ((bit<32>)tmp_hdr_0.ihl << 5) + 32w4294967136);
         transition accept;

--- a/testdata/p4_14_samples_outputs/issue781-midend.p4
+++ b/testdata/p4_14_samples_outputs/issue781-midend.p4
@@ -45,6 +45,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     @name("ParserImpl.tmp_hdr") ipv4_t_1 tmp_hdr_0;
     bit<160> tmp;
     @name(".start") state start {
+        tmp_hdr_0.setInvalid();
         tmp = packet.lookahead<bit<160>>();
         tmp_hdr_0.setValid();
         tmp_hdr_0.version = tmp[159:156];

--- a/testdata/p4_16_samples/issue2344.p4
+++ b/testdata/p4_16_samples/issue2344.p4
@@ -1,0 +1,54 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header H {
+    bit<32> a;
+    bit<32> b;
+}
+
+
+struct Headers {
+    H h;
+}
+
+struct Meta {
+}
+
+bit<32> simple_function() {
+    H tmp1;
+    if (tmp1.a != 10) {
+        tmp1.a = tmp1.a + 10;
+    }
+    return tmp1.a;
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        h.h.a = (bit<32>)(simple_function());
+    }
+    table simple_table {
+        key = {
+            h.h.b        : exact @name("key") ;
+        }
+        actions = {
+            simple_action();
+        }
+    }
+    apply {
+        simple_table.apply();
+        simple_table.apply();
+    }
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+state start {transition accept;}}
+
+control vrfy(inout Headers h, inout Meta m) { apply {} }
+
+control update(inout Headers h, inout Meta m) { apply {} }
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out b, in Headers h) { apply {} }
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/annotation-bug-frontend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-frontend.p4
@@ -22,6 +22,7 @@ control cc() {
     @name("cc.hdr") headers hdr_0;
     @name("cc.tmp") headers tmp;
     apply {
+        hdr_0.ipv4_option_timestamp.setInvalid();
         tmp = (headers){ipv4_option_timestamp = hdr_0.ipv4_option_timestamp};
         get<headers>(tmp);
     }

--- a/testdata/p4_16_samples_outputs/annotation-bug-midend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-bug-midend.p4
@@ -20,17 +20,18 @@ struct tuple_0 {
 extern bit<16> get<T>(in T data);
 control cc() {
     ipv4_option_timestamp_t hdr_0_ipv4_option_timestamp;
-    @hidden action annotationbug24() {
+    @hidden action annotationbug22() {
+        hdr_0_ipv4_option_timestamp.setInvalid();
         get<headers>({ hdr_0_ipv4_option_timestamp });
     }
-    @hidden table tbl_annotationbug24 {
+    @hidden table tbl_annotationbug22 {
         actions = {
-            annotationbug24();
+            annotationbug22();
         }
-        const default_action = annotationbug24();
+        const default_action = annotationbug22();
     }
     apply {
-        tbl_annotationbug24.apply();
+        tbl_annotationbug22.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/complex2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/complex2-frontend.p4
@@ -8,6 +8,8 @@ control c(inout bit<32> r) {
     @name("c.tmp") bit<32> tmp;
     @name("c.tmp_0") bit<32> tmp_0;
     apply {
+        h_0[0].setInvalid();
+        h_0[1].setInvalid();
         tmp = f(32w2);
         tmp_0 = tmp;
         h_0[tmp_0].setValid();

--- a/testdata/p4_16_samples_outputs/complex2-midend.p4
+++ b/testdata/p4_16_samples_outputs/complex2-midend.p4
@@ -6,18 +6,20 @@ header H {
 control c(inout bit<32> r) {
     @name("c.h") H[2] h_0;
     @name("c.tmp") bit<32> tmp;
-    @hidden action complex2l25() {
+    @hidden action complex2l24() {
+        h_0[0].setInvalid();
+        h_0[1].setInvalid();
         tmp = f(32w2);
         h_0[tmp].setValid();
     }
-    @hidden table tbl_complex2l25 {
+    @hidden table tbl_complex2l24 {
         actions = {
-            complex2l25();
+            complex2l24();
         }
-        const default_action = complex2l25();
+        const default_action = complex2l24();
     }
     apply {
-        tbl_complex2l25.apply();
+        tbl_complex2l24.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/equality-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/equality-bmv2-frontend.p4
@@ -44,6 +44,8 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         if (hdr.h == hdr.a[0]) {
             hdr.same.same = hdr.same.same | 8w4;
         }
+        tmp_0[0].setInvalid();
+        tmp_0[1].setInvalid();
         tmp_0[0] = hdr.h;
         tmp_0[1] = hdr.a[0];
         if (tmp_0 == hdr.a) {

--- a/testdata/p4_16_samples_outputs/equality-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/equality-bmv2-midend.p4
@@ -48,7 +48,9 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     @hidden action equalitybmv2l55() {
         hdr.same.same = hdr.same.same | 8w8;
     }
-    @hidden action equalitybmv2l52() {
+    @hidden action equalitybmv2l51() {
+        tmp_0[0].setInvalid();
+        tmp_0[1].setInvalid();
         tmp_0[0] = hdr.h;
         tmp_0[1] = hdr.a[0];
     }
@@ -76,11 +78,11 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         const default_action = equalitybmv2l48();
     }
-    @hidden table tbl_equalitybmv2l52 {
+    @hidden table tbl_equalitybmv2l51 {
         actions = {
-            equalitybmv2l52();
+            equalitybmv2l51();
         }
-        const default_action = equalitybmv2l52();
+        const default_action = equalitybmv2l51();
     }
     @hidden table tbl_equalitybmv2l55 {
         actions = {
@@ -99,7 +101,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         if (!hdr.h.isValid() && !hdr.a[0].isValid() || hdr.h.isValid() && hdr.a[0].isValid() && hdr.h.s == hdr.a[0].s && hdr.h.v == hdr.a[0].v) {
             tbl_equalitybmv2l48.apply();
         }
-        tbl_equalitybmv2l52.apply();
+        tbl_equalitybmv2l51.apply();
         if ((!tmp_0[0].isValid() && !hdr.a[0].isValid() || tmp_0[0].isValid() && hdr.a[0].isValid() && tmp_0[0].s == hdr.a[0].s && tmp_0[0].v == hdr.a[0].v) && (!tmp_0[1].isValid() && !hdr.a[1].isValid() || tmp_0[1].isValid() && hdr.a[1].isValid() && tmp_0[1].s == hdr.a[1].s && tmp_0[1].v == hdr.a[1].v)) {
             tbl_equalitybmv2l55.apply();
         }

--- a/testdata/p4_16_samples_outputs/equality-frontend.p4
+++ b/testdata/p4_16_samples_outputs/equality-frontend.p4
@@ -18,6 +18,14 @@ control c(out bit<1> x) {
     @name("c.a1") H[2] a1_0;
     @name("c.a2") H[2] a2_0;
     apply {
+        h1_0.setInvalid();
+        h2_0.setInvalid();
+        s1_0.h.setInvalid();
+        s2_0.h.setInvalid();
+        a1_0[0].setInvalid();
+        a1_0[1].setInvalid();
+        a2_0[0].setInvalid();
+        a2_0[1].setInvalid();
         if (a_0 == b_0) {
             x = 1w1;
         } else if (h1_0 == h2_0) {

--- a/testdata/p4_16_samples_outputs/equality-midend.p4
+++ b/testdata/p4_16_samples_outputs/equality-midend.p4
@@ -34,6 +34,22 @@ control c(out bit<1> x) {
     @hidden action equality31() {
         x = 1w0;
     }
+    @hidden action equality14() {
+        h1_0.setInvalid();
+        h2_0.setInvalid();
+        s1_0_h.setInvalid();
+        s2_0_h.setInvalid();
+        a1_0[0].setInvalid();
+        a1_0[1].setInvalid();
+        a2_0[0].setInvalid();
+        a2_0[1].setInvalid();
+    }
+    @hidden table tbl_equality14 {
+        actions = {
+            equality14();
+        }
+        const default_action = equality14();
+    }
     @hidden table tbl_equality23 {
         actions = {
             equality23();
@@ -65,6 +81,7 @@ control c(out bit<1> x) {
         const default_action = equality31();
     }
     apply {
+        tbl_equality14.apply();
         if (a_0 == b_0) {
             tbl_equality23.apply();
         } else if (!h1_0.isValid() && !h2_0.isValid() || h1_0.isValid() && h2_0.isValid() && h1_0.a == h2_0.a && h1_0.b == h2_0.b) {

--- a/testdata/p4_16_samples_outputs/gauntlet_hdr_assign_1-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_hdr_assign_1-bmv2-frontend.p4
@@ -32,6 +32,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.x") H x_0;
     apply {
+        x_0.setInvalid();
         x_0.a = 16w2;
         h.eth_hdr.eth_type = x_0.a;
     }

--- a/testdata/p4_16_samples_outputs/gauntlet_hdr_assign_1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_hdr_assign_1-bmv2-midend.p4
@@ -30,17 +30,20 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action gauntlet_hdr_assign_1bmv2l39() {
+    @name("ingress.x") H x_0;
+    @hidden action gauntlet_hdr_assign_1bmv2l34() {
+        x_0.setInvalid();
+        x_0.a = 16w2;
         h.eth_hdr.eth_type = 16w2;
     }
-    @hidden table tbl_gauntlet_hdr_assign_1bmv2l39 {
+    @hidden table tbl_gauntlet_hdr_assign_1bmv2l34 {
         actions = {
-            gauntlet_hdr_assign_1bmv2l39();
+            gauntlet_hdr_assign_1bmv2l34();
         }
-        const default_action = gauntlet_hdr_assign_1bmv2l39();
+        const default_action = gauntlet_hdr_assign_1bmv2l34();
     }
     apply {
-        tbl_gauntlet_hdr_assign_1bmv2l39.apply();
+        tbl_gauntlet_hdr_assign_1bmv2l34.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/gauntlet_hdr_assign_2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_hdr_assign_2-bmv2-frontend.p4
@@ -31,6 +31,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
+        h.h.a = 8w1;
         h.h.setInvalid();
         if (sm.egress_port == 9w2) {
             h.h.setValid();

--- a/testdata/p4_16_samples_outputs/gauntlet_hdr_assign_2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_hdr_assign_2-bmv2-midend.p4
@@ -36,17 +36,18 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @hidden action gauntlet_hdr_assign_2bmv2l43() {
         h.h.setValid();
     }
-    @hidden action gauntlet_hdr_assign_2bmv2l38() {
+    @hidden action gauntlet_hdr_assign_2bmv2l37() {
+        h.h.a = 8w1;
         h.h.setInvalid();
     }
     @hidden action gauntlet_hdr_assign_2bmv2l45() {
         h.h.b = 8w2;
     }
-    @hidden table tbl_gauntlet_hdr_assign_2bmv2l38 {
+    @hidden table tbl_gauntlet_hdr_assign_2bmv2l37 {
         actions = {
-            gauntlet_hdr_assign_2bmv2l38();
+            gauntlet_hdr_assign_2bmv2l37();
         }
-        const default_action = gauntlet_hdr_assign_2bmv2l38();
+        const default_action = gauntlet_hdr_assign_2bmv2l37();
     }
     @hidden table tbl_gauntlet_hdr_assign_2bmv2l41 {
         actions = {
@@ -67,7 +68,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         const default_action = gauntlet_hdr_assign_2bmv2l45();
     }
     apply {
-        tbl_gauntlet_hdr_assign_2bmv2l38.apply();
+        tbl_gauntlet_hdr_assign_2bmv2l37.apply();
         if (sm.egress_port == 9w2) {
             tbl_gauntlet_hdr_assign_2bmv2l41.apply();
         } else {

--- a/testdata/p4_16_samples_outputs/gauntlet_hdr_init-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_hdr_init-bmv2-frontend.p4
@@ -28,6 +28,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp1") ethernet_t tmp1_0;
     @name("ingress.tmp2") ethernet_t tmp2_0;
     apply {
+        tmp1_0.setInvalid();
+        tmp2_0.setInvalid();
         tmp1_0.setValid();
         tmp1_0 = (ethernet_t){dst_addr = 48w1,src_addr = 48w1,eth_type = 16w1};
         h.eth_hdr1 = tmp1_0;

--- a/testdata/p4_16_samples_outputs/gauntlet_hdr_init-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_hdr_init-bmv2-midend.p4
@@ -27,7 +27,9 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp1") ethernet_t tmp1_0;
     @name("ingress.tmp2") ethernet_t tmp2_0;
-    @hidden action gauntlet_hdr_initbmv2l34() {
+    @hidden action gauntlet_hdr_initbmv2l30() {
+        tmp1_0.setInvalid();
+        tmp2_0.setInvalid();
         tmp1_0.setValid();
         tmp1_0.dst_addr = 48w1;
         tmp1_0.src_addr = 48w1;
@@ -39,14 +41,14 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         tmp2_0.eth_type = 16w1;
         h.eth_hdr2 = tmp2_0;
     }
-    @hidden table tbl_gauntlet_hdr_initbmv2l34 {
+    @hidden table tbl_gauntlet_hdr_initbmv2l30 {
         actions = {
-            gauntlet_hdr_initbmv2l34();
+            gauntlet_hdr_initbmv2l30();
         }
-        const default_action = gauntlet_hdr_initbmv2l34();
+        const default_action = gauntlet_hdr_initbmv2l30();
     }
     apply {
-        tbl_gauntlet_hdr_initbmv2l34.apply();
+        tbl_gauntlet_hdr_initbmv2l30.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/gauntlet_mux_eval-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_mux_eval-bmv2-frontend.p4
@@ -25,6 +25,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") ethernet_t tmp_0;
     apply {
+        tmp_0.setInvalid();
         tmp_0.setValid();
         h.eth_hdr.src_addr = tmp_0.src_addr;
     }

--- a/testdata/p4_16_samples_outputs/gauntlet_mux_eval-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_mux_eval-bmv2-midend.p4
@@ -24,18 +24,19 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp") ethernet_t tmp_0;
-    @hidden action gauntlet_mux_evalbmv2l30() {
+    @hidden action gauntlet_mux_evalbmv2l27() {
+        tmp_0.setInvalid();
         tmp_0.setValid();
         h.eth_hdr.src_addr = tmp_0.src_addr;
     }
-    @hidden table tbl_gauntlet_mux_evalbmv2l30 {
+    @hidden table tbl_gauntlet_mux_evalbmv2l27 {
         actions = {
-            gauntlet_mux_evalbmv2l30();
+            gauntlet_mux_evalbmv2l27();
         }
-        const default_action = gauntlet_mux_evalbmv2l30();
+        const default_action = gauntlet_mux_evalbmv2l27();
     }
     apply {
-        tbl_gauntlet_mux_evalbmv2l30.apply();
+        tbl_gauntlet_mux_evalbmv2l27.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/gauntlet_mux_hdr-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_mux_hdr-bmv2-frontend.p4
@@ -29,6 +29,10 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             @name("ingress.retval") bit<32> retval;
             @name("ingress.tmp1") H[2] tmp1_0;
             @name("ingress.tmp2") H[2] tmp2_0;
+            tmp1_0[0].setInvalid();
+            tmp1_0[1].setInvalid();
+            tmp2_0[0].setInvalid();
+            tmp2_0[1].setInvalid();
             if (tmp2_0[0].a <= 32w3) {
                 tmp1_0[0] = tmp2_0[1];
             }

--- a/testdata/p4_16_samples_outputs/gauntlet_mux_hdr-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_mux_hdr-bmv2-midend.p4
@@ -26,6 +26,10 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.simple_action") action simple_action() {
+        tmp1_0[0].setInvalid();
+        tmp1_0[1].setInvalid();
+        tmp2_0[0].setInvalid();
+        tmp2_0[1].setInvalid();
         tmp1_0[0] = (tmp2_0[0].a <= 32w3 ? tmp2_0[1] : tmp1_0[0]);
         h.h.a = tmp1_0[0].a;
     }

--- a/testdata/p4_16_samples_outputs/gauntlet_set_invalid-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_set_invalid-bmv2-frontend.p4
@@ -31,6 +31,7 @@ parser p(packet_in pkt, out Headers h, inout Meta meta, inout standard_metadata_
 
 control ingress(inout Headers h, inout Meta meta, inout standard_metadata_t stdmeta) {
     apply {
+        h.h.a = 8w1;
         h.h.setInvalid();
         h.h.setValid();
         h.h.b = 8w2;

--- a/testdata/p4_16_samples_outputs/gauntlet_set_invalid-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_set_invalid-bmv2-midend.p4
@@ -30,19 +30,20 @@ parser p(packet_in pkt, out Headers h, inout Meta meta, inout standard_metadata_
 }
 
 control ingress(inout Headers h, inout Meta meta, inout standard_metadata_t stdmeta) {
-    @hidden action gauntlet_set_invalidbmv2l36() {
+    @hidden action gauntlet_set_invalidbmv2l35() {
+        h.h.a = 8w1;
         h.h.setInvalid();
         h.h.setValid();
         h.h.b = 8w2;
     }
-    @hidden table tbl_gauntlet_set_invalidbmv2l36 {
+    @hidden table tbl_gauntlet_set_invalidbmv2l35 {
         actions = {
-            gauntlet_set_invalidbmv2l36();
+            gauntlet_set_invalidbmv2l35();
         }
-        const default_action = gauntlet_set_invalidbmv2l36();
+        const default_action = gauntlet_set_invalidbmv2l35();
     }
     apply {
-        tbl_gauntlet_set_invalidbmv2l36.apply();
+        tbl_gauntlet_set_invalidbmv2l35.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/generic-struct-frontend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-frontend.p4
@@ -34,6 +34,7 @@ header GH_1 {
     S data;
 }
 
+typedef GH_1[3] Stack;
 struct H4_0 {
     H2_0 x;
 }
@@ -52,7 +53,16 @@ header_union HU_0 {
 }
 
 control c(out bit<1> x) {
+    @name("c.gh") GH_1 gh_0;
+    @name("c.s") Stack s_0;
+    @name("c.z") HU_0 z_0;
     apply {
+        gh_0.setInvalid();
+        s_0[0].setInvalid();
+        s_0[1].setInvalid();
+        s_0[2].setInvalid();
+        z_0.xu.setInvalid();
+        z_0.h3u.setInvalid();
         x = 1w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/generic-struct-midend.p4
+++ b/testdata/p4_16_samples_outputs/generic-struct-midend.p4
@@ -34,6 +34,7 @@ header GH_1 {
     bit<32> _data_b0;
 }
 
+typedef GH_1[3] Stack;
 struct H4_0 {
     H2_0 x;
 }
@@ -57,17 +58,26 @@ header_union HU_0 {
 }
 
 control c(out bit<1> x) {
-    @hidden action genericstruct99() {
+    @name("c.gh") GH_1 gh_0;
+    @name("c.s") Stack s_0;
+    @name("c.z") HU_0 z_0;
+    @hidden action genericstruct90() {
+        gh_0.setInvalid();
+        s_0[0].setInvalid();
+        s_0[1].setInvalid();
+        s_0[2].setInvalid();
+        z_0.xu.setInvalid();
+        z_0.h3u.setInvalid();
         x = 1w0;
     }
-    @hidden table tbl_genericstruct99 {
+    @hidden table tbl_genericstruct90 {
         actions = {
-            genericstruct99();
+            genericstruct90();
         }
-        const default_action = genericstruct99();
+        const default_action = genericstruct90();
     }
     apply {
-        tbl_genericstruct99.apply();
+        tbl_genericstruct90.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/header-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2-frontend.p4
@@ -44,6 +44,7 @@ control deparser(packet_out b, in Headers h) {
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.c.tmp") hdr c_tmp;
     apply {
+        c_tmp.setInvalid();
         c_tmp.f = h.h.f + 32w1;
         h.h.f = c_tmp.f;
         sm.egress_spec = 9w0;

--- a/testdata/p4_16_samples_outputs/header-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/header-bmv2-midend.p4
@@ -42,18 +42,21 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action headerbmv2l28() {
+    @name("ingress.c.tmp") hdr c_tmp;
+    @hidden action headerbmv2l26() {
+        c_tmp.setInvalid();
+        c_tmp.f = h.h.f + 32w1;
         h.h.f = h.h.f + 32w1;
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_headerbmv2l28 {
+    @hidden table tbl_headerbmv2l26 {
         actions = {
-            headerbmv2l28();
+            headerbmv2l26();
         }
-        const default_action = headerbmv2l28();
+        const default_action = headerbmv2l26();
     }
     apply {
-        tbl_headerbmv2l28.apply();
+        tbl_headerbmv2l26.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/index-frontend.p4
+++ b/testdata/p4_16_samples_outputs/index-frontend.p4
@@ -9,6 +9,7 @@ parser P(packet_in p, out H[2] h) {
     @name("P.tmp") H tmp;
     @name("P.tmp") bit<32> tmp_0;
     state start {
+        tmp.setInvalid();
         p.extract<H>(tmp);
         transition select(tmp.field) {
             32w0: n1;

--- a/testdata/p4_16_samples_outputs/index-midend.p4
+++ b/testdata/p4_16_samples_outputs/index-midend.p4
@@ -8,6 +8,7 @@ parser P(packet_in p, out H[2] h) {
     @name("P.x") bit<32> x_0;
     @name("P.tmp") H tmp;
     state start {
+        tmp.setInvalid();
         p.extract<H>(tmp);
         transition select(tmp.field) {
             32w0: n1;

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2-frontend.p4
@@ -23,7 +23,9 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 }
 
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    @name("ingress.bh") bitvec_hdr bh_0;
     apply {
+        bh_0.setInvalid();
         clone3<parsed_packet_t>(CloneType.I2E, 32w0, h);
     }
 }

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2-midend.p4
@@ -23,17 +23,19 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 }
 
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
-    @hidden action issue1653bmv2l49() {
+    @name("ingress.bh") bitvec_hdr bh_0;
+    @hidden action issue1653bmv2l43() {
+        bh_0.setInvalid();
         clone3<parsed_packet_t>(CloneType.I2E, 32w0, h);
     }
-    @hidden table tbl_issue1653bmv2l49 {
+    @hidden table tbl_issue1653bmv2l43 {
         actions = {
-            issue1653bmv2l49();
+            issue1653bmv2l43();
         }
-        const default_action = issue1653bmv2l49();
+        const default_action = issue1653bmv2l43();
     }
     apply {
-        tbl_issue1653bmv2l49.apply();
+        tbl_issue1653bmv2l43.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-frontend.p4
@@ -70,6 +70,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         default_action = NoAction_0();
     }
     apply {
+        bh_0.setInvalid();
         tns_0.apply();
         bh_0.row.alt1.type = EthTypes.IPv4;
         h.bvh0.row.alt1.type = bh_0.row.alt1.type;

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-midend.p4
@@ -74,6 +74,7 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 }
 
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    @name("ingress.bh") bitvec_hdr bh_0;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.do_act") action do_act() {
@@ -91,20 +92,31 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         }
         default_action = NoAction_0();
     }
-    @hidden action issue1653complexbmv2l95() {
+    @hidden action issue1653complexbmv2l71() {
+        bh_0.setInvalid();
+    }
+    @hidden action issue1653complexbmv2l94() {
+        bh_0._row_alt1_type10 = 16w0x800;
         h.bvh0._row_alt1_type10 = 16w0x800;
         local_metadata._row0_alt0_useHash3 = true;
         clone3<row_t>(CloneType.I2E, 32w0, (row_t){alt0 = (alt_t){valid = local_metadata._row0_alt0_valid0,port = local_metadata._row0_alt0_port1,hashRes = local_metadata._row0_alt0_hashRes2,useHash = true,type = local_metadata._row0_alt0_type4,pad = local_metadata._row0_alt0_pad5},alt1 = (alt_t){valid = local_metadata._row0_alt1_valid6,port = local_metadata._row0_alt1_port7,hashRes = local_metadata._row0_alt1_hashRes8,useHash = local_metadata._row0_alt1_useHash9,type = local_metadata._row0_alt1_type10,pad = local_metadata._row0_alt1_pad11}});
     }
-    @hidden table tbl_issue1653complexbmv2l95 {
+    @hidden table tbl_issue1653complexbmv2l71 {
         actions = {
-            issue1653complexbmv2l95();
+            issue1653complexbmv2l71();
         }
-        const default_action = issue1653complexbmv2l95();
+        const default_action = issue1653complexbmv2l71();
+    }
+    @hidden table tbl_issue1653complexbmv2l94 {
+        actions = {
+            issue1653complexbmv2l94();
+        }
+        const default_action = issue1653complexbmv2l94();
     }
     apply {
+        tbl_issue1653complexbmv2l71.apply();
         tns_0.apply();
-        tbl_issue1653complexbmv2l95.apply();
+        tbl_issue1653complexbmv2l94.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2148-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2148-frontend.p4
@@ -22,6 +22,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
             @name("ingress.retval") bit<16> retval;
             @name("ingress.not_initialized") H not_initialized_0;
             @name("ingress.new_val") bit<32> new_val_0;
+            not_initialized_0.setInvalid();
             new_val_0 = 32w1;
             if (not_initialized_0.a < 16w6) {
                 ;

--- a/testdata/p4_16_samples_outputs/issue2148-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2148-midend.p4
@@ -21,17 +21,18 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @hidden action issue2148l21() {
         new_val_0 = 32w232;
     }
-    @hidden action issue2148l18() {
+    @hidden action issue2148l17() {
+        not_initialized_0.setInvalid();
         new_val_0 = 32w1;
     }
     @hidden action issue2148l30() {
         h.h.a = (bit<16>)new_val_0;
     }
-    @hidden table tbl_issue2148l18 {
+    @hidden table tbl_issue2148l17 {
         actions = {
-            issue2148l18();
+            issue2148l17();
         }
-        const default_action = issue2148l18();
+        const default_action = issue2148l17();
     }
     @hidden table tbl_issue2148l21 {
         actions = {
@@ -52,7 +53,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         const default_action = do_thing_action();
     }
     apply {
-        tbl_issue2148l18.apply();
+        tbl_issue2148l17.apply();
         if (not_initialized_0.a < 16w6) {
             ;
         } else {

--- a/testdata/p4_16_samples_outputs/issue2344-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2344-first.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header H {
+    bit<32> a;
+    bit<32> b;
+}
+
+struct Headers {
+    H h;
+}
+
+struct Meta {
+}
+
+bit<32> simple_function() {
+    H tmp1;
+    if (tmp1.a != 32w10) {
+        tmp1.a = tmp1.a + 32w10;
+    }
+    return tmp1.a;
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        h.h.a = simple_function();
+    }
+    table simple_table {
+        key = {
+            h.h.b: exact @name("key") ;
+        }
+        actions = {
+            simple_action();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        simple_table.apply();
+        simple_table.apply();
+    }
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2344-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2344-frontend.p4
@@ -1,0 +1,77 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header H {
+    bit<32> a;
+    bit<32> b;
+}
+
+struct Headers {
+    H h;
+}
+
+struct Meta {
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("ingress.simple_action") action simple_action() {
+        {
+            @name("ingress.hasReturned") bool hasReturned = false;
+            @name("ingress.retval") bit<32> retval;
+            @name("ingress.tmp1") H tmp1_0;
+            tmp1_0.setInvalid();
+            if (tmp1_0.a != 32w10) {
+                tmp1_0.a = tmp1_0.a + 32w10;
+            }
+            hasReturned = true;
+            retval = tmp1_0.a;
+            h.h.a = retval;
+        }
+    }
+    @name("ingress.simple_table") table simple_table_0 {
+        key = {
+            h.h.b: exact @name("key") ;
+        }
+        actions = {
+            simple_action();
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        simple_table_0.apply();
+        simple_table_0.apply();
+    }
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2344-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2344-midend.p4
@@ -1,0 +1,69 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header H {
+    bit<32> a;
+    bit<32> b;
+}
+
+struct Headers {
+    H h;
+}
+
+struct Meta {
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @name("ingress.tmp1") H tmp1_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("ingress.simple_action") action simple_action() {
+        tmp1_0.setInvalid();
+        tmp1_0.a = (tmp1_0.a != 32w10 ? tmp1_0.a + 32w10 : tmp1_0.a);
+        h.h.a = tmp1_0.a;
+    }
+    @name("ingress.simple_table") table simple_table_0 {
+        key = {
+            h.h.b: exact @name("key") ;
+        }
+        actions = {
+            simple_action();
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        simple_table_0.apply();
+        simple_table_0.apply();
+    }
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2344.p4
+++ b/testdata/p4_16_samples_outputs/issue2344.p4
@@ -1,0 +1,69 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header H {
+    bit<32> a;
+    bit<32> b;
+}
+
+struct Headers {
+    H h;
+}
+
+struct Meta {
+}
+
+bit<32> simple_function() {
+    H tmp1;
+    if (tmp1.a != 10) {
+        tmp1.a = tmp1.a + 10;
+    }
+    return tmp1.a;
+}
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    action simple_action() {
+        h.h.a = (bit<32>)simple_function();
+    }
+    table simple_table {
+        key = {
+            h.h.b: exact @name("key") ;
+        }
+        actions = {
+            simple_action();
+        }
+    }
+    apply {
+        simple_table.apply();
+        simple_table.apply();
+    }
+}
+
+parser p(packet_in b, out Headers h, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, in Headers h) {
+    apply {
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2344.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2344.p4-stderr
@@ -1,0 +1,9 @@
+issue2344.p4(19): [--Wwarn=uninitialized_use] warning: tmp1.a may be uninitialized
+    if (tmp1.a != 10) {
+        ^^^^^^
+issue2344.p4(20): [--Wwarn=uninitialized_use] warning: tmp1.a may be uninitialized
+        tmp1.a = tmp1.a + 10;
+                 ^^^^^^
+issue2344.p4(22): [--Wwarn=uninitialized_use] warning: tmp1.a may be uninitialized
+    return tmp1.a;
+           ^^^^^^

--- a/testdata/p4_16_samples_outputs/issue2344.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue2344.p4.p4info.txt
@@ -1,0 +1,42 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 39789425
+    name: "ingress.simple_table"
+    alias: "simple_table"
+  }
+  match_fields {
+    id: 1
+    name: "key"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  action_refs {
+    id: 25524983
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 25524983
+    name: "ingress.simple_action"
+    alias: "simple_action"
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/issue2391-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2391-frontend.p4
@@ -27,6 +27,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             EthTypes.IPv4: accept;

--- a/testdata/p4_16_samples_outputs/issue2391-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2391-midend.p4
@@ -17,6 +17,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             16w0x800: accept;

--- a/testdata/p4_16_samples_outputs/issue313_1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue313_1-frontend.p4
@@ -15,6 +15,8 @@ control ctrl(inout struct_t input, out header_h output) {
         tmp1_0 = tmp0_0;
     }
     apply {
+        tmp0_0.setInvalid();
+        tmp1_0.setInvalid();
         act();
         output = tmp1_0;
     }

--- a/testdata/p4_16_samples_outputs/issue313_1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue313_1-midend.p4
@@ -14,8 +14,18 @@ control ctrl(inout struct_t input, out header_h output) {
         input.stack.pop_front(1);
         tmp1_0 = tmp0_0;
     }
+    @hidden action issue313_1l26() {
+        tmp0_0.setInvalid();
+        tmp1_0.setInvalid();
+    }
     @hidden action issue313_1l35() {
         output = tmp1_0;
+    }
+    @hidden table tbl_issue313_1l26 {
+        actions = {
+            issue313_1l26();
+        }
+        const default_action = issue313_1l26();
     }
     @hidden table tbl_act {
         actions = {
@@ -30,6 +40,7 @@ control ctrl(inout struct_t input, out header_h output) {
         const default_action = issue313_1l35();
     }
     apply {
+        tbl_issue313_1l26.apply();
         tbl_act.apply();
         tbl_issue313_1l35.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue313_3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue313_3-frontend.p4
@@ -20,6 +20,8 @@ control ctrl(inout struct_t input, out bit<8> out1, out header_h out2) {
         tmp3_0 = tmp2_0;
     }
     apply {
+        tmp2_0.setInvalid();
+        tmp3_0.setInvalid();
         act();
         out1 = tmp1_0;
         out2 = tmp3_0;

--- a/testdata/p4_16_samples_outputs/issue313_3-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue313_3-midend.p4
@@ -19,9 +19,19 @@ control ctrl(inout struct_t input, out bit<8> out1, out header_h out2) {
         input.hdr.setInvalid();
         tmp3_0 = tmp2_0;
     }
+    @hidden action issue313_3l28() {
+        tmp2_0.setInvalid();
+        tmp3_0.setInvalid();
+    }
     @hidden action issue313_3l41() {
         out1 = tmp1_0;
         out2 = tmp3_0;
+    }
+    @hidden table tbl_issue313_3l28 {
+        actions = {
+            issue313_3l28();
+        }
+        const default_action = issue313_3l28();
     }
     @hidden table tbl_act {
         actions = {
@@ -36,6 +46,7 @@ control ctrl(inout struct_t input, out bit<8> out1, out header_h out2) {
         const default_action = issue313_3l41();
     }
     apply {
+        tbl_issue313_3l28.apply();
         tbl_act.apply();
         tbl_issue313_3l41.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-frontend.p4
@@ -53,6 +53,8 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
+    @name("ingress.s") tst_t s_0;
+    @name("ingress.bh") bitvec_hdr bh_0;
     @name("ingress.do_act") action do_act() {
         h.bvh1.row.alt1.valid = 1w0;
     }
@@ -68,6 +70,10 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         default_action = NoAction_0();
     }
     apply {
+        s_0.col.bvh.setInvalid();
+        s_0.bvh0.setInvalid();
+        s_0.bvh1.setInvalid();
+        bh_0.setInvalid();
         tns_0.apply();
         local_metadata.col.bvh.row.alt0.valid = 1w0;
         local_metadata.row0.alt0 = local_metadata.row1.alt1;

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
@@ -60,6 +60,10 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 }
 
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
+    bitvec_hdr s_0_col_bvh;
+    bitvec_hdr s_0_bvh0;
+    bitvec_hdr s_0_bvh1;
+    @name("ingress.bh") bitvec_hdr bh_0;
     @noWarn("unused") @name(".NoAction") action NoAction_0() {
     }
     @name("ingress.do_act") action do_act() {
@@ -76,6 +80,12 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         }
         default_action = NoAction_0();
     }
+    @hidden action issue383bmv2l74() {
+        s_0_col_bvh.setInvalid();
+        s_0_bvh0.setInvalid();
+        s_0_bvh1.setInvalid();
+        bh_0.setInvalid();
+    }
     @hidden action issue383bmv2l104() {
         local_metadata._col_bvh8._row_alt0_valid0 = 1w0;
         local_metadata._row0_alt0_valid0 = local_metadata._row1_alt1_valid6;
@@ -84,6 +94,12 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         local_metadata._row1_alt1_port7 = local_metadata._row0_alt1_port3 + 7w1;
         clone3<row_t>(CloneType.I2E, 32w0, (row_t){alt0 = (alt_t){valid = local_metadata._row1_alt1_valid6,port = local_metadata._row0_alt0_port1},alt1 = (alt_t){valid = local_metadata._row0_alt1_valid2,port = local_metadata._row0_alt1_port3}});
     }
+    @hidden table tbl_issue383bmv2l74 {
+        actions = {
+            issue383bmv2l74();
+        }
+        const default_action = issue383bmv2l74();
+    }
     @hidden table tbl_issue383bmv2l104 {
         actions = {
             issue383bmv2l104();
@@ -91,6 +107,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         const default_action = issue383bmv2l104();
     }
     apply {
+        tbl_issue383bmv2l74.apply();
         tns_0.apply();
         tbl_issue383bmv2l104.apply();
     }

--- a/testdata/p4_16_samples_outputs/issue396-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-frontend.p4
@@ -11,12 +11,18 @@ package top(c _c);
 control d(out bool b) {
     @name("d.h") H h_0;
     @name("d.h3") H[2] h3_0;
+    @name("d.s") S s_0;
     @name("d.s1") S s1_0;
     @name("d.eout") bool eout_0;
     @name("d.tmp") H tmp;
     apply {
+        h_0.setInvalid();
+        h3_0[0].setInvalid();
+        h3_0[1].setInvalid();
         h_0.setValid();
         h_0 = (H){x = 32w0};
+        s_0.h.setInvalid();
+        s1_0.h.setInvalid();
         s1_0.h.setValid();
         s1_0.h = (H){x = 32w0};
         h3_0[1].setValid();

--- a/testdata/p4_16_samples_outputs/issue396-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue396-midend.p4
@@ -11,11 +11,17 @@ package top(c _c);
 control d(out bool b) {
     @name("d.h") H h_0;
     @name("d.h3") H[2] h3_0;
+    H s_0_h;
     H s1_0_h;
     @name("d.tmp") H tmp;
-    @hidden action issue396l39() {
+    @hidden action issue396l36() {
+        h_0.setInvalid();
+        h3_0[0].setInvalid();
+        h3_0[1].setInvalid();
         h_0.setValid();
         h_0.x = 32w0;
+        s_0_h.setInvalid();
+        s1_0_h.setInvalid();
         s1_0_h.setValid();
         s1_0_h.x = 32w0;
         h3_0[1].setValid();
@@ -24,14 +30,14 @@ control d(out bool b) {
         tmp.x = 32w0;
         b = h_0.isValid() && tmp.isValid() && h3_0[1].isValid() && s1_0_h.isValid();
     }
-    @hidden table tbl_issue396l39 {
+    @hidden table tbl_issue396l36 {
         actions = {
-            issue396l39();
+            issue396l36();
         }
-        const default_action = issue396l39();
+        const default_action = issue396l36();
     }
     apply {
-        tbl_issue396l39.apply();
+        tbl_issue396l36.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue561-2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-2-bmv2-frontend.p4
@@ -66,8 +66,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     apply {
         debug_hdr_0.apply();
         if (hdr.u.short.isValid()) {
+            hdr.u.short.data = 16w0xffff;
             hdr.u.short.setInvalid();
         } else if (hdr.u.byte.isValid()) {
+            hdr.u.byte.data = 8w0xff;
             hdr.u.byte.setInvalid();
         }
     }

--- a/testdata/p4_16_samples_outputs/issue561-2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-2-bmv2-midend.p4
@@ -63,30 +63,32 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         const default_action = NoAction_0();
     }
-    @hidden action issue5612bmv2l70() {
+    @hidden action issue5612bmv2l69() {
+        hdr.u.short.data = 16w0xffff;
         hdr.u.short.setInvalid();
     }
-    @hidden action issue5612bmv2l74() {
+    @hidden action issue5612bmv2l73() {
+        hdr.u.byte.data = 8w0xff;
         hdr.u.byte.setInvalid();
     }
-    @hidden table tbl_issue5612bmv2l70 {
+    @hidden table tbl_issue5612bmv2l69 {
         actions = {
-            issue5612bmv2l70();
+            issue5612bmv2l69();
         }
-        const default_action = issue5612bmv2l70();
+        const default_action = issue5612bmv2l69();
     }
-    @hidden table tbl_issue5612bmv2l74 {
+    @hidden table tbl_issue5612bmv2l73 {
         actions = {
-            issue5612bmv2l74();
+            issue5612bmv2l73();
         }
-        const default_action = issue5612bmv2l74();
+        const default_action = issue5612bmv2l73();
     }
     apply {
         debug_hdr_0.apply();
         if (hdr.u.short.isValid()) {
-            tbl_issue5612bmv2l70.apply();
+            tbl_issue5612bmv2l69.apply();
         } else if (hdr.u.byte.isValid()) {
-            tbl_issue5612bmv2l74.apply();
+            tbl_issue5612bmv2l73.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-7-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-7-bmv2-frontend.p4
@@ -63,8 +63,10 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
     apply {
         debug_hdr_0.apply();
         if (hdr.u[0].short.isValid()) {
+            hdr.u[0].short.data = 16w0xffff;
             hdr.u[0].short.setInvalid();
         } else if (hdr.u[0].byte.isValid()) {
+            hdr.u[0].byte.data = 8w0xff;
             hdr.u[0].byte.setInvalid();
         }
     }

--- a/testdata/p4_16_samples_outputs/issue561-7-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-7-bmv2-midend.p4
@@ -60,30 +60,32 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         }
         const default_action = NoAction_0();
     }
-    @hidden action issue5617bmv2l66() {
+    @hidden action issue5617bmv2l65() {
+        hdr.u[0].short.data = 16w0xffff;
         hdr.u[0].short.setInvalid();
     }
-    @hidden action issue5617bmv2l70() {
+    @hidden action issue5617bmv2l69() {
+        hdr.u[0].byte.data = 8w0xff;
         hdr.u[0].byte.setInvalid();
     }
-    @hidden table tbl_issue5617bmv2l66 {
+    @hidden table tbl_issue5617bmv2l65 {
         actions = {
-            issue5617bmv2l66();
+            issue5617bmv2l65();
         }
-        const default_action = issue5617bmv2l66();
+        const default_action = issue5617bmv2l65();
     }
-    @hidden table tbl_issue5617bmv2l70 {
+    @hidden table tbl_issue5617bmv2l69 {
         actions = {
-            issue5617bmv2l70();
+            issue5617bmv2l69();
         }
-        const default_action = issue5617bmv2l70();
+        const default_action = issue5617bmv2l69();
     }
     apply {
         debug_hdr_0.apply();
         if (hdr.u[0].short.isValid()) {
-            tbl_issue5617bmv2l66.apply();
+            tbl_issue5617bmv2l65.apply();
         } else if (hdr.u[0].byte.isValid()) {
-            tbl_issue5617bmv2l70.apply();
+            tbl_issue5617bmv2l69.apply();
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/issue561-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-frontend.p4
@@ -17,6 +17,12 @@ control c(out bit<32> x) {
     @name("c.u") U u_0;
     @name("c.u2") U[2] u2_0;
     apply {
+        u_0.h1.setInvalid();
+        u_0.h2.setInvalid();
+        u2_0[0].h1.setInvalid();
+        u2_0[0].h2.setInvalid();
+        u2_0[1].h1.setInvalid();
+        u2_0[1].h2.setInvalid();
         x = u_0.h1.f + u_0.h2.g;
         u_0.h1.setValid();
         u_0.h1.f = 32w0;

--- a/testdata/p4_16_samples_outputs/issue561-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-midend.p4
@@ -16,7 +16,13 @@ package top(ct _ct);
 control c(out bit<32> x) {
     @name("c.u") U u_0;
     @name("c.u2") U[2] u2_0;
-    @hidden action issue561l35() {
+    @hidden action issue561l29() {
+        u_0.h1.setInvalid();
+        u_0.h2.setInvalid();
+        u2_0[0].h1.setInvalid();
+        u2_0[0].h2.setInvalid();
+        u2_0[1].h1.setInvalid();
+        u2_0[1].h2.setInvalid();
         x = u_0.h1.f + u_0.h2.g;
         u_0.h1.setValid();
         u_0.h1.f = 32w0;
@@ -27,14 +33,14 @@ control c(out bit<32> x) {
         u2_0[0].h1.f = 32w2;
         x = x + u2_0[1].h2.g + 32w2;
     }
-    @hidden table tbl_issue561l35 {
+    @hidden table tbl_issue561l29 {
         actions = {
-            issue561l35();
+            issue561l29();
         }
-        const default_action = issue561l35();
+        const default_action = issue561l29();
     }
     apply {
-        tbl_issue561l35.apply();
+        tbl_issue561l29.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue982-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue982-frontend.p4
@@ -385,6 +385,8 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
 control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd, out psa_ingress_deparser_output_metadata_t ostd) {
     @name("IngressDeparserImpl.clone_md") clone_metadata_t clone_md_0;
     apply {
+        clone_md_0.data.h0.setInvalid();
+        clone_md_0.data.h1.setInvalid();
         clone_md_0.data.h1.setValid();
         clone_md_0.data.h1 = (clone_1_t){data = 32w0};
         clone_md_0.type = 3w0;

--- a/testdata/p4_16_samples_outputs/issue982-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue982-midend.p4
@@ -385,7 +385,9 @@ control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata me
         ostd.clone_metadata.data.h0 = clone_md_0_data.h0;
         ostd.clone_metadata.data.h1 = clone_md_0_data.h1;
     }
-    @hidden action issue982l417() {
+    @hidden action issue982l416() {
+        clone_md_0_data.h0.setInvalid();
+        clone_md_0_data.h1.setInvalid();
         clone_md_0_data.h1.setValid();
         clone_md_0_data.h1.data = 32w0;
     }
@@ -393,11 +395,11 @@ control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata me
         packet.emit<ethernet_t>(hdr.ethernet);
         packet.emit<ipv4_t>(hdr.ipv4);
     }
-    @hidden table tbl_issue982l417 {
+    @hidden table tbl_issue982l416 {
         actions = {
-            issue982l417();
+            issue982l416();
         }
-        const default_action = issue982l417();
+        const default_action = issue982l416();
     }
     @hidden table tbl_issue982l420 {
         actions = {
@@ -412,7 +414,7 @@ control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata me
         const default_action = issue982l422();
     }
     apply {
-        tbl_issue982l417.apply();
+        tbl_issue982l416.apply();
         if (meta._custom_clone_id1 == 3w1) {
             tbl_issue982l420.apply();
         }

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum-first.p4
@@ -1,0 +1,150 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+    bit<32> old_srcAddr;
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition select(parsed_hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action drop() {
+        ingress_drop(ostd);
+    }
+    action forward(PortId_t port, bit<32> srcAddr) {
+        user_meta.fwd_metadata.old_srcAddr = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = srcAddr;
+        send_to_port(ostd, port);
+    }
+    table route {
+        key = {
+            hdr.ipv4.dstAddr: lpm @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            forward();
+            drop();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            route.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    InternetChecksum() ck;
+    apply {
+        ck.clear();
+        ck.add<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = ck.get();
+        ck.clear();
+        ck.subtract<tuple<bit<16>>>({ hdr.tcp.checksum });
+        ck.subtract<tuple<bit<32>>>({ user_meta.fwd_metadata.old_srcAddr });
+        ck.add<tuple<bit<32>>>({ hdr.ipv4.srcAddr });
+        hdr.tcp.checksum = ck.get();
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum-frontend.p4
@@ -1,0 +1,163 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+    bit<32> old_srcAddr;
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition select(parsed_hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("ingress.drop") action drop_1() {
+        @noWarnUnused {
+            @name("ingress.meta") psa_ingress_output_metadata_t meta_2 = ostd;
+            meta_2.drop = true;
+            ostd = meta_2;
+        }
+    }
+    @name("ingress.forward") action forward(@name("port") PortId_t port, @name("srcAddr") bit<32> srcAddr_1) {
+        user_meta.fwd_metadata.old_srcAddr = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = srcAddr_1;
+        @noWarnUnused {
+            @name("ingress.meta") psa_ingress_output_metadata_t meta_3 = ostd;
+            @name("ingress.egress_port") PortId_t egress_port_1 = port;
+            meta_3.drop = false;
+            meta_3.multicast_group = (MulticastGroup_t)32w0;
+            meta_3.egress_port = egress_port_1;
+            ostd = meta_3;
+        }
+    }
+    @name("ingress.route") table route_0 {
+        key = {
+            hdr.ipv4.dstAddr: lpm @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            forward();
+            drop_1();
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            route_0.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @name("EgressDeparserImpl.ck") InternetChecksum() ck_0;
+    apply {
+        ck_0.clear();
+        ck_0.add<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = ck_0.get();
+        ck_0.clear();
+        ck_0.subtract<tuple<bit<16>>>({ hdr.tcp.checksum });
+        ck_0.subtract<tuple<bit<32>>>({ user_meta.fwd_metadata.old_srcAddr });
+        ck_0.add<tuple<bit<32>>>({ hdr.ipv4.srcAddr });
+        hdr.tcp.checksum = ck_0.get();
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum-midend.p4
@@ -1,0 +1,198 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+    bit<32> old_srcAddr;
+}
+
+struct metadata {
+    bit<32> _fwd_metadata_old_srcAddr0;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition select(parsed_hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("ingress.drop") action drop_1() {
+        @noWarnUnused {
+            ostd.drop = true;
+        }
+    }
+    @name("ingress.forward") action forward(@name("port") PortId_t port, @name("srcAddr") bit<32> srcAddr_1) {
+        user_meta._fwd_metadata_old_srcAddr0 = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = srcAddr_1;
+        @noWarnUnused {
+            ostd.drop = false;
+            ostd.multicast_group = 32w0;
+            ostd.egress_port = port;
+        }
+    }
+    @name("ingress.route") table route_0 {
+        key = {
+            hdr.ipv4.dstAddr: lpm @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            forward();
+            drop_1();
+            @defaultonly NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            route_0.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psaexampleincrementalchecksum170() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psaexampleincrementalchecksum170 {
+        actions = {
+            psaexampleincrementalchecksum170();
+        }
+        const default_action = psaexampleincrementalchecksum170();
+    }
+    apply {
+        tbl_psaexampleincrementalchecksum170.apply();
+    }
+}
+
+struct tuple_0 {
+    bit<4>  f0;
+    bit<4>  f1;
+    bit<8>  f2;
+    bit<16> f3;
+    bit<16> f4;
+    bit<3>  f5;
+    bit<13> f6;
+    bit<8>  f7;
+    bit<8>  f8;
+    bit<32> f9;
+    bit<32> f10;
+}
+
+struct tuple_1 {
+    bit<16> f0;
+}
+
+struct tuple_2 {
+    bit<32> f0;
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @name("EgressDeparserImpl.ck") InternetChecksum() ck_0;
+    @hidden action psaexampleincrementalchecksum191() {
+        ck_0.clear();
+        ck_0.add<tuple_0>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = ck_0.get();
+        ck_0.clear();
+        ck_0.subtract<tuple_1>({ hdr.tcp.checksum });
+        ck_0.subtract<tuple_2>({ user_meta._fwd_metadata_old_srcAddr0 });
+        ck_0.add<tuple_2>({ hdr.ipv4.srcAddr });
+        hdr.tcp.checksum = ck_0.get();
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psaexampleincrementalchecksum191 {
+        actions = {
+            psaexampleincrementalchecksum191();
+        }
+        const default_action = psaexampleincrementalchecksum191();
+    }
+    apply {
+        tbl_psaexampleincrementalchecksum191.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4
@@ -1,0 +1,148 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+    bit<32> old_srcAddr;
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        transition select(parsed_hdr.ipv4.protocol) {
+            6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action drop() {
+        ingress_drop(ostd);
+    }
+    action forward(PortId_t port, bit<32> srcAddr) {
+        user_meta.fwd_metadata.old_srcAddr = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = srcAddr;
+        send_to_port(ostd, port);
+    }
+    table route {
+        key = {
+            hdr.ipv4.dstAddr: lpm;
+        }
+        actions = {
+            forward;
+            drop;
+        }
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            route.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    InternetChecksum() ck;
+    apply {
+        ck.clear();
+        ck.add({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = ck.get();
+        ck.clear();
+        ck.subtract({ hdr.tcp.checksum });
+        ck.subtract({ user_meta.fwd_metadata.old_srcAddr });
+        ck.add({ hdr.ipv4.srcAddr });
+        hdr.tcp.checksum = ck.get();
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.p4info.txt
@@ -1,0 +1,74 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 40550280
+    name: "ingress.route"
+    alias: "route"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ipv4.dstAddr"
+    bitwidth: 32
+    match_type: LPM
+  }
+  action_refs {
+    id: 26512162
+  }
+  action_refs {
+    id: 33281717
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 33281717
+    name: "ingress.drop"
+    alias: "drop"
+  }
+}
+actions {
+  preamble {
+    id: 26512162
+    name: "ingress.forward"
+    alias: "forward"
+  }
+  params {
+    id: 1
+    name: "port"
+    bitwidth: 32
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  params {
+    id: 2
+    name: "srcAddr"
+    bitwidth: 32
+  }
+}
+type_info {
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations-first.p4
@@ -1,0 +1,89 @@
+#include <core.p4>
+#include <psa.p4>
+
+header EMPTY_H {
+}
+
+struct EMPTY_RESUB {
+}
+
+struct EMPTY_CLONE {
+}
+
+struct EMPTY_BRIDGE {
+}
+
+struct EMPTY_RECIRC {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct metadata {
+    bit<48> meta;
+    bit<48> meta2;
+    bit<48> meta3;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t h, inout metadata b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+    state start {
+        buffer.extract<ethernet_t>(h);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY_H a, inout metadata b, in psa_egress_parser_input_metadata_t c, in EMPTY_BRIDGE d, in EMPTY_CLONE e, in EMPTY_CLONE f) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    action forward() {
+        b.meta = a.srcAddr | a.dstAddr;
+        b.meta2 = a.srcAddr & a.dstAddr;
+        b.meta3 = a.srcAddr ^ a.dstAddr;
+    }
+    table tbl {
+        key = {
+            a.srcAddr: exact @name("a.srcAddr") ;
+        }
+        actions = {
+            forward();
+            NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+        a.dstAddr = b.meta;
+        a.srcAddr = b.meta2;
+        a.etherType = b.meta3[15:0];
+    }
+}
+
+control MyEC(inout EMPTY_H a, inout metadata b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in metadata e, in psa_ingress_output_metadata_t f) {
+    apply {
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMPTY_H c, in metadata d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<ethernet_t, metadata, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline<EMPTY_H, metadata, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch<ethernet_t, metadata, EMPTY_H, metadata, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations-frontend.p4
@@ -1,0 +1,91 @@
+#include <core.p4>
+#include <psa.p4>
+
+header EMPTY_H {
+}
+
+struct EMPTY_RESUB {
+}
+
+struct EMPTY_CLONE {
+}
+
+struct EMPTY_BRIDGE {
+}
+
+struct EMPTY_RECIRC {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct metadata {
+    bit<48> meta;
+    bit<48> meta2;
+    bit<48> meta3;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t h, inout metadata b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+    state start {
+        buffer.extract<ethernet_t>(h);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY_H a, inout metadata b, in psa_egress_parser_input_metadata_t c, in EMPTY_BRIDGE d, in EMPTY_CLONE e, in EMPTY_CLONE f) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("MyIC.forward") action forward() {
+        b.meta = a.srcAddr | a.dstAddr;
+        b.meta2 = a.srcAddr & a.dstAddr;
+        b.meta3 = a.srcAddr ^ a.dstAddr;
+    }
+    @name("MyIC.tbl") table tbl_0 {
+        key = {
+            a.srcAddr: exact @name("a.srcAddr") ;
+        }
+        actions = {
+            forward();
+            NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    apply {
+        tbl_0.apply();
+        a.dstAddr = b.meta;
+        a.srcAddr = b.meta2;
+        a.etherType = b.meta3[15:0];
+    }
+}
+
+control MyEC(inout EMPTY_H a, inout metadata b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in metadata e, in psa_ingress_output_metadata_t f) {
+    apply {
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMPTY_H c, in metadata d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<ethernet_t, metadata, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline<EMPTY_H, metadata, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch<ethernet_t, metadata, EMPTY_H, metadata, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations-midend.p4
@@ -1,0 +1,100 @@
+#include <core.p4>
+#include <psa.p4>
+
+header EMPTY_H {
+}
+
+struct EMPTY_RESUB {
+}
+
+struct EMPTY_CLONE {
+}
+
+struct EMPTY_BRIDGE {
+}
+
+struct EMPTY_RECIRC {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct metadata {
+    bit<48> meta;
+    bit<48> meta2;
+    bit<48> meta3;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t h, inout metadata b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+    state start {
+        buffer.extract<ethernet_t>(h);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY_H a, inout metadata b, in psa_egress_parser_input_metadata_t c, in EMPTY_BRIDGE d, in EMPTY_CLONE e, in EMPTY_CLONE f) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    @noWarn("unused") @name(".NoAction") action NoAction_0() {
+    }
+    @name("MyIC.forward") action forward() {
+        b.meta = a.srcAddr | a.dstAddr;
+        b.meta2 = a.srcAddr & a.dstAddr;
+        b.meta3 = a.srcAddr ^ a.dstAddr;
+    }
+    @name("MyIC.tbl") table tbl_0 {
+        key = {
+            a.srcAddr: exact @name("a.srcAddr") ;
+        }
+        actions = {
+            forward();
+            NoAction_0();
+        }
+        default_action = NoAction_0();
+    }
+    @hidden action psaexamplelogicaloperations75() {
+        a.dstAddr = b.meta;
+        a.srcAddr = b.meta2;
+        a.etherType = b.meta3[15:0];
+    }
+    @hidden table tbl_psaexamplelogicaloperations75 {
+        actions = {
+            psaexamplelogicaloperations75();
+        }
+        const default_action = psaexamplelogicaloperations75();
+    }
+    apply {
+        tbl_0.apply();
+        tbl_psaexamplelogicaloperations75.apply();
+    }
+}
+
+control MyEC(inout EMPTY_H a, inout metadata b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in metadata e, in psa_ingress_output_metadata_t f) {
+    apply {
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMPTY_H c, in metadata d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<ethernet_t, metadata, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline<EMPTY_H, metadata, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch<ethernet_t, metadata, EMPTY_H, metadata, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4
@@ -1,0 +1,88 @@
+#include <core.p4>
+#include <psa.p4>
+
+header EMPTY_H {
+}
+
+struct EMPTY_RESUB {
+}
+
+struct EMPTY_CLONE {
+}
+
+struct EMPTY_BRIDGE {
+}
+
+struct EMPTY_RECIRC {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct metadata {
+    bit<48> meta;
+    bit<48> meta2;
+    bit<48> meta3;
+}
+
+parser MyIP(packet_in buffer, out ethernet_t h, inout metadata b, in psa_ingress_parser_input_metadata_t c, in EMPTY_RESUB d, in EMPTY_RECIRC e) {
+    state start {
+        buffer.extract(h);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in buffer, out EMPTY_H a, inout metadata b, in psa_egress_parser_input_metadata_t c, in EMPTY_BRIDGE d, in EMPTY_CLONE e, in EMPTY_CLONE f) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
+    action forward() {
+        b.meta = a.srcAddr | a.dstAddr;
+        b.meta2 = a.srcAddr & a.dstAddr;
+        b.meta3 = a.srcAddr ^ a.dstAddr;
+    }
+    table tbl {
+        key = {
+            a.srcAddr: exact;
+        }
+        actions = {
+            forward;
+            NoAction;
+        }
+    }
+    apply {
+        tbl.apply();
+        a.dstAddr = b.meta;
+        a.srcAddr = b.meta2;
+        a.etherType = b.meta3[15:0];
+    }
+}
+
+control MyEC(inout EMPTY_H a, inout metadata b, in psa_egress_input_metadata_t c, inout psa_egress_output_metadata_t d) {
+    apply {
+    }
+}
+
+control MyID(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RESUB b, out EMPTY_BRIDGE c, inout ethernet_t d, in metadata e, in psa_ingress_output_metadata_t f) {
+    apply {
+    }
+}
+
+control MyED(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMPTY_H c, in metadata d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline(MyIP(), MyIC(), MyID()) ip;
+
+EgressPipeline(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.p4info.txt
@@ -1,0 +1,40 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 39967501
+    name: "MyIC.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "a.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 25756908
+  }
+  action_refs {
+    id: 21257015
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 25756908
+    name: "MyIC.forward"
+    alias: "forward"
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/pvs-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-frontend.p4
@@ -8,6 +8,7 @@ parser p(packet_in pk) {
     @name("p.h") H h_0;
     @name("p.vs") value_set<tuple<bit<32>, bit<2>>>(4) vs_0;
     state start {
+        h_0.setInvalid();
         pk.extract<H>(h_0);
         transition select(h_0.f, 2w2) {
             vs_0: next;

--- a/testdata/p4_16_samples_outputs/pvs-midend.p4
+++ b/testdata/p4_16_samples_outputs/pvs-midend.p4
@@ -8,6 +8,7 @@ parser p(packet_in pk) {
     @name("p.h") H h_0;
     @name("p.vs") value_set<tuple<bit<32>, bit<2>>>(4) vs_0;
     state start {
+        h_0.setInvalid();
         pk.extract<H>(h_0);
         transition select(h_0.f, 2w2) {
             vs_0: next;

--- a/testdata/p4_16_samples_outputs/register-serenum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/register-serenum-frontend.p4
@@ -25,6 +25,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             EthTypes.IPv4: accept;

--- a/testdata/p4_16_samples_outputs/register-serenum-midend.p4
+++ b/testdata/p4_16_samples_outputs/register-serenum-midend.p4
@@ -15,6 +15,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             16w0x800: accept;

--- a/testdata/p4_16_samples_outputs/serenum-expr-frontend.p4
+++ b/testdata/p4_16_samples_outputs/serenum-expr-frontend.p4
@@ -23,6 +23,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             EthTypes.IPv4: accept;

--- a/testdata/p4_16_samples_outputs/serenum-expr-midend.p4
+++ b/testdata/p4_16_samples_outputs/serenum-expr-midend.p4
@@ -13,6 +13,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             16w0x800: accept;

--- a/testdata/p4_16_samples_outputs/serenum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/serenum-frontend.p4
@@ -23,6 +23,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             EthTypes.IPv4: accept;

--- a/testdata/p4_16_samples_outputs/serenum-int-frontend.p4
+++ b/testdata/p4_16_samples_outputs/serenum-int-frontend.p4
@@ -23,6 +23,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             EthTypes.IPv4: accept;

--- a/testdata/p4_16_samples_outputs/serenum-int-midend.p4
+++ b/testdata/p4_16_samples_outputs/serenum-int-midend.p4
@@ -13,6 +13,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             24s0x800: accept;

--- a/testdata/p4_16_samples_outputs/serenum-midend.p4
+++ b/testdata/p4_16_samples_outputs/serenum-midend.p4
@@ -13,6 +13,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             16w0x800: accept;

--- a/testdata/p4_16_samples_outputs/stack-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2-frontend.p4
@@ -44,6 +44,7 @@ control deparser(packet_out b, in Headers h) {
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.c.tmp") hdr[1] c_tmp;
     apply {
+        c_tmp[0].setInvalid();
         c_tmp[0].f = h.h.f + 32w1;
         h.h.f = c_tmp[0].f;
         sm.egress_spec = 9w0;

--- a/testdata/p4_16_samples_outputs/stack-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bmv2-midend.p4
@@ -42,18 +42,21 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action stackbmv2l28() {
+    @name("ingress.c.tmp") hdr[1] c_tmp;
+    @hidden action stackbmv2l26() {
+        c_tmp[0].setInvalid();
+        c_tmp[0].f = h.h.f + 32w1;
         h.h.f = h.h.f + 32w1;
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_stackbmv2l28 {
+    @hidden table tbl_stackbmv2l26 {
         actions = {
-            stackbmv2l28();
+            stackbmv2l26();
         }
-        const default_action = stackbmv2l28();
+        const default_action = stackbmv2l26();
     }
     apply {
-        tbl_stackbmv2l28.apply();
+        tbl_stackbmv2l26.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack-bvec-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bvec-bmv2-frontend.p4
@@ -55,6 +55,7 @@ control deparser(packet_out b, in Headers h) {
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.c.tmp") hdr[1] c_tmp;
     apply {
+        c_tmp[0].setInvalid();
         c_tmp[0].row.alt1.valid = 1w1;
         c_tmp[0].f = h.h.f + 32w1;
         h.h.f = c_tmp[0].f;

--- a/testdata/p4_16_samples_outputs/stack-bvec-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-bvec-bmv2-midend.p4
@@ -56,19 +56,23 @@ control deparser(packet_out b, in Headers h) {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @hidden action stackbvecbmv2l40() {
+    @name("ingress.c.tmp") hdr[1] c_tmp;
+    @hidden action stackbvecbmv2l37() {
+        c_tmp[0].setInvalid();
+        c_tmp[0]._row_alt1_valid3 = 1w1;
+        c_tmp[0]._f0 = h.h._f0 + 32w1;
         h.h._f0 = h.h._f0 + 32w1;
         h.h._row_alt1_valid3 = 1w1;
         sm.egress_spec = 9w0;
     }
-    @hidden table tbl_stackbvecbmv2l40 {
+    @hidden table tbl_stackbvecbmv2l37 {
         actions = {
-            stackbvecbmv2l40();
+            stackbvecbmv2l37();
         }
-        const default_action = stackbvecbmv2l40();
+        const default_action = stackbvecbmv2l37();
     }
     apply {
-        tbl_stackbvecbmv2l40.apply();
+        tbl_stackbvecbmv2l37.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/stack-frontend.p4
+++ b/testdata/p4_16_samples_outputs/stack-frontend.p4
@@ -19,6 +19,10 @@ control c() {
     @name("c.stack") h[4] stack_1;
     @name("c.b") h b_0;
     apply {
+        stack_1[0].setInvalid();
+        stack_1[1].setInvalid();
+        stack_1[2].setInvalid();
+        stack_1[3].setInvalid();
         stack_1[3].setValid();
         b_0 = stack_1[3];
         stack_1[2] = b_0;

--- a/testdata/p4_16_samples_outputs/stack-midend.p4
+++ b/testdata/p4_16_samples_outputs/stack-midend.p4
@@ -17,20 +17,24 @@ parser p() {
 
 control c() {
     @name("c.stack") h[4] stack_1;
-    @hidden action stack39() {
+    @hidden action stack38() {
+        stack_1[0].setInvalid();
+        stack_1[1].setInvalid();
+        stack_1[2].setInvalid();
+        stack_1[3].setInvalid();
         stack_1[3].setValid();
         stack_1[2] = stack_1[3];
         stack_1.push_front(2);
         stack_1.pop_front(2);
     }
-    @hidden table tbl_stack39 {
+    @hidden table tbl_stack38 {
         actions = {
-            stack39();
+            stack38();
         }
-        const default_action = stack39();
+        const default_action = stack38();
     }
     apply {
-        tbl_stack39.apply();
+        tbl_stack38.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/table-key-serenum-frontend.p4
+++ b/testdata/p4_16_samples_outputs/table-key-serenum-frontend.p4
@@ -25,6 +25,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             EthTypes.IPv4: accept;

--- a/testdata/p4_16_samples_outputs/table-key-serenum-midend.p4
+++ b/testdata/p4_16_samples_outputs/table-key-serenum-midend.p4
@@ -15,6 +15,7 @@ struct Headers {
 parser prs(packet_in p, out Headers h) {
     @name("prs.e") Ethernet e_0;
     state start {
+        e_0.setInvalid();
         p.extract<Ethernet>(e_0);
         transition select(e_0.type) {
             16w0x800: accept;

--- a/testdata/p4_16_samples_outputs/uninit-frontend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-frontend.p4
@@ -9,10 +9,13 @@ header Header {
 extern void func(in Header h);
 extern bit<32> g(inout bit<32> v, in bit<32> w);
 parser p1(packet_in p, out Header h) {
+    @name("p1.stack") Header[2] stack_0;
     @name("p1.tmp") bit<32> tmp;
     @name("p1.tmp_0") bit<32> tmp_0;
     @name("p1.tmp_1") bit<32> tmp_1;
     state start {
+        stack_0[0].setInvalid();
+        stack_0[1].setInvalid();
         h.data1 = 32w0;
         func(h);
         tmp = h.data2;

--- a/testdata/p4_16_samples_outputs/uninit-midend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-midend.p4
@@ -9,10 +9,13 @@ header Header {
 extern void func(in Header h);
 extern bit<32> g(inout bit<32> v, in bit<32> w);
 parser p1(packet_in p, out Header h) {
+    @name("p1.stack") Header[2] stack_0;
     @name("p1.tmp") bit<32> tmp;
     @name("p1.tmp_0") bit<32> tmp_0;
     @name("p1.tmp_1") bit<32> tmp_1;
     state start {
+        stack_0[0].setInvalid();
+        stack_0[1].setInvalid();
         h.data1 = 32w0;
         func(h);
         tmp = h.data2;


### PR DESCRIPTION
Fixes #2344 
Also changes how def-use analysis treats setInvalid. It does not really define the fields of a header, although it may clobber them.