### PR TITLE
keep unused method declaration

### DIFF
--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -154,12 +154,15 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::ParserState* state) {
 // Try to guess whether a file is a "system" file
 bool RemoveUnusedDeclarations::isSystemFile(cstring file) {
     if (file.startsWith(p4includePath)) return true;
+    // if the backend is invoked directly with '-I p4include'
+    if (file.startsWith("p4include")) return true;
     return false;
 }
 
 cstring RemoveUnusedDeclarations::ifSystemFile(const IR::Node* node) {
     if (!node->srcInfo.isValid()) return nullptr;
     auto sourceFile = node->srcInfo.getSourceFile();
+    LOG1("source file " << sourceFile << " " << p4includePath);
     if (isSystemFile(sourceFile))
         return sourceFile;
     return nullptr;

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "unusedDeclarations.h"
 #include "sideEffects.h"
+#include "frontends/common/parser_options.h"
 
 namespace P4 {
 
@@ -146,6 +147,35 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::ParserState* state) {
     if (refMap->isUsed(getOriginal<IR::ParserState>()))
         return state;
     LOG3("Removing " << state);
+    prune();
+    return nullptr;
+}
+
+// Try to guess whether a file is a "system" file
+bool RemoveUnusedDeclarations::isSystemFile(cstring file) {
+    if (file.startsWith(p4includePath)) return true;
+    return false;
+}
+
+cstring RemoveUnusedDeclarations::ifSystemFile(const IR::Node* node) {
+    if (!node->srcInfo.isValid()) return nullptr;
+    auto sourceFile = node->srcInfo.getSourceFile();
+    if (isSystemFile(sourceFile))
+        return sourceFile;
+    return nullptr;
+}
+
+// extern functions declared in "system" files should be kept,
+// even if it is not referenced in the user program. Compiler
+// backend may synthesize code to use the extern functions.
+const IR::Node* RemoveUnusedDeclarations::preorder(IR::Method* method)
+{
+    if (ifSystemFile(method->getNode()))
+        return method;
+
+    if (refMap->isUsed(getOriginal<IR::Method>()))
+        return method;
+    LOG3("Removing " << method);
     prune();
     return nullptr;
 }

--- a/frontends/p4/unusedDeclarations.h
+++ b/frontends/p4/unusedDeclarations.h
@@ -32,7 +32,7 @@ namespace P4 {
  *  - IR::Type_Method
  *  - IR::Type_StructLike
  *  - IR::TypeParameters
- *  - IR::Method
+ *  - IR::Method if declared in system headers
  *
  * Additionally, IR::Declaration_Instance nodes for extern instances are not
  * removed but still trigger warnings.
@@ -83,6 +83,7 @@ class RemoveUnusedDeclarations : public Transform {
     const IR::Node* preorder(IR::Type_SerEnum* type)  override;
 
     const IR::Node* preorder(IR::Declaration_Instance* decl) override;
+    const IR::Node* preorder(IR::Method* decl) override;
 
     // The following kinds of nodes are not deleted even if they are unreferenced
     const IR::Node* preorder(IR::Type_Error* type) override
@@ -95,8 +96,6 @@ class RemoveUnusedDeclarations : public Transform {
     { prune(); return type; }
     const IR::Node* preorder(IR::Type_Method* type) override
     { prune(); return type; }
-    const IR::Node* preorder(IR::Method* decl) override
-    { prune(); return decl; }
     const IR::Node* preorder(IR::Parameter* param) override { return param; }  // never dead
     const IR::Node* preorder(IR::NamedExpression* ne) override { return ne; }  // idem
     const IR::Node* preorder(IR::TypeParameters* p) override { prune(); return p; }  // "
@@ -104,6 +103,8 @@ class RemoveUnusedDeclarations : public Transform {
     const IR::Node* preorder(IR::Declaration_Variable* decl)  override;
     const IR::Node* preorder(IR::Declaration* decl) override { return process(decl); }
     const IR::Node* preorder(IR::Type_Declaration* decl) override { return process(decl); }
+    bool isSystemFile(cstring file);
+    cstring ifSystemFile(const IR::Node* node);  // return file containing node if system file
 };
 
 /** @brief Iterates RemoveUnusedDeclarations until convergence.

--- a/frontends/p4/unusedDeclarations.h
+++ b/frontends/p4/unusedDeclarations.h
@@ -32,6 +32,7 @@ namespace P4 {
  *  - IR::Type_Method
  *  - IR::Type_StructLike
  *  - IR::TypeParameters
+ *  - IR::Method
  *
  * Additionally, IR::Declaration_Instance nodes for extern instances are not
  * removed but still trigger warnings.
@@ -94,6 +95,8 @@ class RemoveUnusedDeclarations : public Transform {
     { prune(); return type; }
     const IR::Node* preorder(IR::Type_Method* type) override
     { prune(); return type; }
+    const IR::Node* preorder(IR::Method* decl) override
+    { prune(); return decl; }
     const IR::Node* preorder(IR::Parameter* param) override { return param; }  // never dead
     const IR::Node* preorder(IR::NamedExpression* ne) override { return ne; }  // idem
     const IR::Node* preorder(IR::TypeParameters* p) override { prune(); return p; }  // "

--- a/test/gtest/env.h.in
+++ b/test/gtest/env.h.in
@@ -1,6 +1,7 @@
 #ifndef TEST_GTEST_ENV_H_
 #define TEST_GTEST_ENV_H_
 
-const char* relPath = "${P4C_SOURCE_DIR}/";
+const char* sourcePath = "${P4C_SOURCE_DIR}/";
+const char* buildPath = "${P4C_BINARY_DIR}/";
 
 #endif  // TEST_GTEST_PARSER_UNROLL_H_

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -231,12 +231,12 @@ std::pair<const IR::P4Parser*, const IR::P4Parser*> rewriteParser(const IR::P4Pr
 
 /// Loads example from a file
 const IR::P4Program* load_model(const char* curFile, CompilerOptions& options) {
-    std::string includeDir = std::string(relPath) + std::string("p4include");
+    std::string includeDir = std::string(buildPath) + std::string("p4include");
     auto originalEnv = getenv("P4C_16_INCLUDE_PATH");
     setenv("P4C_16_INCLUDE_PATH", includeDir.c_str(), 1);
     options.loopsUnrolling = true;
     options.compilerVersion = P4TEST_VERSION_STRING;
-    options.file = relPath;
+    options.file = sourcePath;
     options.file += "testdata/p4_16_samples/";
     options.file += curFile;
     auto program = P4::parseP4File(options);

--- a/testdata/p4_16_samples_outputs/default_action_ubpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/default_action_ubpf-frontend.p4
@@ -21,8 +21,8 @@ parser prs(packet_in p, out Headers_t headers, inout metadata meta, inout standa
 }
 
 control pipe(inout Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
-    @name("pipe.add") action add(@name("data") bit<32> data) {
-        headers.h.b = headers.h.a + data;
+    @name("pipe.add") action add(@name("data") bit<32> data_1) {
+        headers.h.b = headers.h.a + data_1;
     }
     @name("pipe.tbl_a") table tbl_a_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/default_action_ubpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/default_action_ubpf-midend.p4
@@ -21,8 +21,8 @@ parser prs(packet_in p, out Headers_t headers, inout metadata meta, inout standa
 }
 
 control pipe(inout Headers_t headers, inout metadata meta, inout standard_metadata std_meta) {
-    @name("pipe.add") action add(@name("data") bit<32> data) {
-        headers.h.b = headers.h.a + data;
+    @name("pipe.add") action add(@name("data") bit<32> data_1) {
+        headers.h.b = headers.h.a + data_1;
     }
     @name("pipe.tbl_a") table tbl_a_0 {
         actions = {

--- a/testdata/p4_16_samples_outputs/psa-action-profile1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1.p4.spec
@@ -45,6 +45,26 @@ struct a2_arg_t {
 	bit<16> param
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-action-profile3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3.p4.spec
@@ -45,6 +45,26 @@ struct a2_arg_t {
 	bit<16> param
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-action-profile4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4.p4.spec
@@ -45,6 +45,26 @@ struct a2_arg_t {
 	bit<16> param
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-action-selector1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1.p4.spec
@@ -46,6 +46,26 @@ struct a2_arg_t {
 	bit<16> param
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4.spec
@@ -47,6 +47,26 @@ struct a2_arg_t {
 	bit<16> param
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4.spec
@@ -46,6 +46,26 @@ struct a2_arg_t {
 	bit<16> param
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
@@ -37,6 +37,26 @@ metadata instanceof metadata_t
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action execute args none {
 	counter_count counter_0 0x100
 	return

--- a/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.spec
@@ -39,6 +39,26 @@ metadata instanceof user_meta_t
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4.spec
@@ -37,6 +37,26 @@ metadata instanceof EMPTY
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4.spec
@@ -38,6 +38,26 @@ metadata instanceof EMPTY
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4.spec
@@ -38,6 +38,26 @@ metadata instanceof EMPTY
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4.spec
@@ -37,6 +37,26 @@ metadata instanceof EMPTY
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.spec
@@ -37,6 +37,26 @@ metadata instanceof EMPTY
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4.spec
@@ -52,6 +52,26 @@ metadata instanceof metadata_t
 header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4.spec
@@ -52,6 +52,26 @@ metadata instanceof metadata_t
 header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-drop.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-drop.p4.spec
@@ -28,6 +28,26 @@ struct EMPTY_M {
 }
 metadata instanceof EMPTY_M
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }
@@ -46,7 +66,7 @@ table tbl {
 		drop
 	}
 	default_action NoAction args none 
-	size 0
+	size 0x10000
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
@@ -36,6 +36,26 @@ metadata instanceof metadata_t
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
@@ -79,6 +79,26 @@ struct forward_arg_t {
 	bit<32> srcAddr
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.spec
@@ -31,6 +31,26 @@ struct metadata {
 }
 metadata instanceof metadata
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-fwd-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-fwd-bmv2.p4.spec
@@ -36,6 +36,26 @@ metadata instanceof metadata
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
@@ -46,6 +46,26 @@ header vlan_tag_0 instanceof vlan_tag_h
 header vlan_tag_1 instanceof vlan_tag_h
 
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
@@ -36,6 +36,26 @@ metadata instanceof metadata_t
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.spec
@@ -46,6 +46,26 @@ struct a2_arg_t {
 	bit<16> param
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-isvalid.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-isvalid.p4.spec
@@ -36,6 +36,26 @@ metadata instanceof EMPTY_M
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-meter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter1.p4.spec
@@ -42,6 +42,26 @@ struct execute_arg_t {
 	bit<32> color
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4.spec
@@ -37,6 +37,26 @@ metadata instanceof EMPTY
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4.spec
@@ -37,6 +37,26 @@ metadata instanceof EMPTY
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
@@ -36,6 +36,26 @@ metadata instanceof metadata_t
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
@@ -36,6 +36,26 @@ metadata instanceof metadata_t
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
@@ -42,6 +42,26 @@ metadata instanceof metadata_t
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 regarray regfile_0 size 0x80 initval 0
 
 apply {

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
@@ -37,6 +37,26 @@ metadata instanceof metadata_t
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 regarray regfile_0 size 0x80 initval 0
 
 apply {

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.spec
@@ -41,6 +41,26 @@ struct execute_register_arg_t {
 	bit<10> idx
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 regarray reg_0 size 0x400 initval 0
 
 action NoAction args none {

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.spec
@@ -42,6 +42,26 @@ struct execute_register_arg_t {
 	bit<10> idx
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 regarray reg_0 size 0x400 initval 0
 
 action NoAction args none {

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.spec
@@ -42,6 +42,26 @@ struct execute_register_arg_t {
 	bit<10> idx
 }
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 regarray reg_0 size 0x200 initval 0
 
 action NoAction args none {

--- a/testdata/p4_16_samples_outputs/psa-remove-action-param.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-remove-action-param.p4.spec
@@ -28,6 +28,26 @@ struct EMPTY_M {
 }
 metadata instanceof EMPTY_M
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-remove-header.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-remove-header.p4.spec
@@ -36,6 +36,26 @@ metadata instanceof EMPTY_M
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
@@ -44,6 +44,26 @@ metadata instanceof metadata_t
 header ethernet instanceof ethernet_t
 header output_data instanceof output_data_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.spec
@@ -36,6 +36,26 @@ metadata instanceof EMPTY_M
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-top-level-assignments-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-top-level-assignments-bmv2.p4.spec
@@ -36,6 +36,26 @@ metadata instanceof metadata_t
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
@@ -36,6 +36,26 @@ metadata instanceof metadata_t
 
 header ethernet instanceof ethernet_t
 
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0


### PR DESCRIPTION
Unused extern function definition is removed by the end of frontend. As a result, if a midend pass generates code that invokes the extern function, we run into an 'declaration not found' error.

The culprit is the the RemoveAllUnusedDeclarations pass which removes unused method declaration including the unused declaration in an architecture definition. 

For instance, 
```
// in arch.p4
extern void funnel_shift_right<T>(inout T dst, in T src1, in T src2, int shift_amount);

// p4 action generated by a midend pass
action foo() {
   funnel_shift_right(dst, src1, src2, 8);  // triggers a 'declaration not found' error
}
```

This declaration is removed at the end of the frontend.

The extern function declaration is parsed as: (note it's IR::Method, not IR::Type_Method).
```
  [1288] Method name=funnel_shift_right declid=205 isAbstract=0
    type: [1287] Type_Method name=funnel_shift_right
      typeParameters: [1270] TypeParameters
        [1268] Type_Var name=T declid=52
      returnType: [1] Type_Void
      parameters: [1285] ParameterList
        [1274] Parameter name=dst declid=201 direction=inout
          annotations: [5] Annotations
          type: [1273] Type_Name
            path: [1272] Path name=T absolute=0
        [1278] Parameter name=src1 declid=202 direction=in
          annotations: [5] Annotations
          type: [1277] Type_Name
            path: [1276] Path name=T absolute=0
        [1281] Parameter name=src2 declid=203 direction=in
          annotations: [5] Annotations
          type: [1280] Type_Name
            path: [1279] Path name=T absolute=0
        [1283] Parameter name=shift_amount declid=204 direction=
          annotations: [5] Annotations
          type: [1282] Type_InfInt declid=108
    annotations: [5] Annotations
```