### PR TITLE
Add some more required dependencies for the validation tests.

### DIFF
--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -82,29 +82,37 @@ rm -rf /tmp/pip
 # ! ------  BEGIN VALIDATION -----------------------------------------------
 
 function build_gauntlet() {
-  # for add-apt-repository
+  # For add-apt-repository.
   apt-get install -y software-properties-common
-  # Also pull Gauntlet for translation validation
+  # Also pull Gauntlet for translation validation.
   git clone -b stable https://github.com/p4gauntlet/gauntlet /gauntlet
   cd /gauntlet
   git submodule update --init --recursive
   cd -
-  # Symlink the parent p4c repository with Gauntlet
+  # Symlink the parent p4c repository with Gauntlet.
+  # TODO: Only use the extension module and its tests.
   rm -rf /gauntlet/modules/p4c
   ln -s /p4c /gauntlet/modules/p4c
-
-  # Symlink the toz3 extension for the p4 compiler
+  # Symlink the toz3 extension for the p4 compiler.
   mkdir -p /p4c/extensions
   ln -sf /gauntlet/modules/toz3 /p4c/extensions/toz3
 
-  # Install Gauntlet Python dependencies locally
-  # Unfortunately we need Python 3.6, which Xenial does not have
+  # Install Gauntlet Python dependencies locally.
+  # Unfortunately we need Python 3.6, which Xenial (Ubuntu 16.04) does not have.
   add-apt-repository ppa:deadsnakes/ppa
+  # The interpreter requires a more modern version of GCC.
+  # We install gcc-8 and set it as default. This is also because of Xenial.
+  add-apt-repository ppa:ubuntu-toolchain-r/test
   apt update
   apt install -y python3.6
-  # pytest-xdist to parallelize tests
-  # dataclasses for Python3.6 compatibility
-  python3.6 -m pip install z3-solver pytest pytest-xdist==1.34.0 dataclasses
+  apt install -y g++-8
+  apt install -y gcc-8
+  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 10
+  update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 10
+  # The interpreter requires boost filesystem for file management.
+  apt install -y libboost-filesystem-dev
+  # Install pytest and pytest-xdist to parallelize tests.
+  python3.6 -m pip install pytest pytest-xdist==1.34.0
 }
 
 # These steps are necessary to validate the correct compilation of the P4C test


### PR DESCRIPTION
I recently switched to a C++-based interpreter for validation. The functionality should stay the same, but it is easier to maintain and much faster. However, there are some additional dependencies required when building with Ubuntu 16.04. I hope I can sort them out over time. For now they have to  be added to get the tests to run again. 