### PR TITLE
Refactor error logging

### DIFF
--- a/frontends/p4/typeChecking/typeConstraints.h
+++ b/frontends/p4/typeChecking/typeConstraints.h
@@ -86,25 +86,25 @@ class TypeConstraint : public IHasDbPrint {
         boost::format fmt = boost::format(errFormat);
         switch (errArguments.size()) {
             case 0:
-                message = ::error_helper(fmt, "", "", "", "");
+               message = boost::str(fmt);
                 break;
             case 1:
                 explanation += explain(0, explainer);
-                message = ::error_helper(fmt, "", "", "", "", errArguments.at(0));
+                message = ::error_helper(fmt, errArguments.at(0)).toString();
                 break;
             case 2:
                 explanation += explain(0, explainer);
                 explanation += explain(1, explainer);
                 message = ::error_helper(
-                    fmt, "", "", "", "", errArguments.at(0), errArguments.at(1));
+                    fmt, errArguments.at(0), errArguments.at(1)).toString();
                 break;
             case 3:
                 explanation += explain(0, explainer);
                 explanation += explain(1, explainer);
                 explanation += explain(2, explainer);
                 message = ::error_helper(
-                    fmt, "", "", "", "",
-                    errArguments.at(0), errArguments.at(1), errArguments.at(2));
+                    fmt, errArguments.at(0), errArguments.at(1),
+                    errArguments.at(2)).toString();
                 break;
             case 4:
                 explanation += explain(0, explainer);
@@ -112,8 +112,8 @@ class TypeConstraint : public IHasDbPrint {
                 explanation += explain(2, explainer);
                 explanation += explain(3, explainer);
                 message = ::error_helper(
-                    fmt, "", "", "", "", errArguments.at(0), errArguments.at(1),
-                    errArguments.at(2), errArguments.at(3));
+                    fmt, errArguments.at(0), errArguments.at(1),
+                    errArguments.at(2), errArguments.at(3)).toString();
                 break;
             default:
                 BUG("Unexpected argument count for error message");
@@ -136,7 +136,7 @@ class TypeConstraint : public IHasDbPrint {
         /// the analysis started.
         boost::format fmt(format);
         cstring message = cstring("  ---- Actual error:\n") +
-                ::error_helper(fmt, "", "", "", "", args...);
+                ::error_helper(fmt, args...).toString();
         auto o = origin;
         auto constraint = this;
         Explain explainer(subst);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -19,6 +19,7 @@ set (LIBP4CTOOLKIT_SRCS
 	crash.cpp
 	cstring.cpp
         error_catalog.cpp
+		error_message.cpp
         exename.cpp
 	gc.cpp
 	gmputil.cpp
@@ -47,6 +48,7 @@ set (LIBP4CTOOLKIT_HDRS
 	enumerator.h
 	error.h
         error_catalog.h
+		error_message.h
         error_helper.h
 	error_reporter.h
 	exceptions.h

--- a/lib/compile_context.h
+++ b/lib/compile_context.h
@@ -93,7 +93,7 @@ class BaseCompileContext : public ICompileContext {
     static BaseCompileContext& get();
 
     /// @return the error reporter for this compilation context.
-    ErrorReporter& errorReporter();
+    virtual ErrorReporter& errorReporter();
 
     /// @return the default diagnostic action for calls to `::warning()`.
     virtual DiagnosticAction getDefaultWarningDiagnosticAction();

--- a/lib/error_helper.h
+++ b/lib/error_helper.h
@@ -151,7 +151,6 @@ auto error_helper(boost::format& f, ErrorMessage out, const T *t, Args... args) 
 template<typename T, class... Args>
 auto error_helper(boost::format& f, ErrorMessage out, const T &t, Args... args) ->
     typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type {
-
     auto info = t.getSourceInfo();
     if (info.isValid()) out.locations.push_back(info);
     return error_helper(f % t.toString(), out, std::forward<Args>(args)...);

--- a/lib/error_helper.h
+++ b/lib/error_helper.h
@@ -28,169 +28,247 @@ limitations under the License.
 #include "lib/source_file.h"
 #include "lib/stringify.h"
 
+struct ErrorMessage {
+    enum class Type : std::size_t { None, Error, Warning };
+
+    Type type = Type::None;
+    std::string prefix = "";  // Typically error/warning type from catalog
+    std::string message = "";  // Actual formatted message
+    std::vector<Util::SourceInfo> locations; // Relevant source locations for this error
+    Util::SourceInfo position;  // Position in P4 source
+    std::string tail = "";  // Extra P4 source positions
+    std::string suffix = "";  // Used by errorWithSuffix
+
+    ErrorMessage() {}
+    // Invoked from backwards compatible error_helper
+    ErrorMessage(const std::string &prefix, const Util::SourceInfo &info, std::string &suffix)
+        : prefix(prefix), position(info), suffix(suffix) {}
+    // Invoked from error_reporter
+    ErrorMessage(Type type, const std::string &prefix, const std::string &suffix)
+        : type(type), prefix(prefix), suffix(suffix) {}
+
+    std::string getPrefix() const {
+        std::string p = prefix;
+        if (type == Type::Error) {
+            if (p.empty()) p = "error: ";
+            else p = "[--Werror=" + p + "] error: ";
+        } else if (type == Type::Warning) {
+            if (p.empty()) p = "warning: ";
+            else p = "[--Wwarn=" + p + "] warning: ";
+        }
+        return p;
+    }
+
+    std::string toString() const {
+        std::string result = position.toPositionString().c_str();
+        if (!result.empty()) result += ": ";
+        result += getPrefix() + message + "\n" + tail + suffix;
+        return result;
+    }
+
+    std::string toString2() const {
+        std::string result = "";
+        if (!locations.empty()) {
+            result += locations.front().toPositionString() + ": ";
+        }
+
+        result += getPrefix() + message;
+
+        for (unsigned i = 1; i < locations.size(); i++) {
+            result += "\n" + locations[i].toPositionString() + "\n" + locations[i].toSourceFragment();
+        }
+
+        return result;
+    }
+};
+
+struct ParserErrorMessage {
+    Util::SourceInfo location;
+    cstring message;
+
+    ParserErrorMessage(const Util::SourceInfo &loc, const cstring &msg) : location(loc), message(msg) {}
+
+    std::string toString() const {
+        return std::string(location.toPositionString().c_str()) + ":" + message + "\n" + location.toSourceFragment().c_str();
+    }
+};
+
+namespace priv {
+
 // All these methods return std::string because this is the native format of boost::format
 // Position is printed at the beginning.
-static inline std::string error_helper(boost::format& f, std::string message,
-                                       std::string position, std::string tail, std::string suffix) {
-    std::string text = boost::str(f);
-    std::string result = position;
-    if (!position.empty())
-        result += ": ";
-    result += message + text + "\n" + tail + suffix;
-    return result;
+static inline ErrorMessage error_helper(boost::format& f, ErrorMessage out) {
+    out.message = boost::str(f);
+    return out;
 }
 
 template<class... Args>
-std::string error_helper(boost::format& f, std::string message, std::string position,
-                         std::string tail, std::string suffix, const char* t, Args... args);
+ErrorMessage error_helper(boost::format& f, ErrorMessage out,
+                         const char* t, Args... args);
 
 template<class... Args>
-std::string error_helper(boost::format& f, std::string message, std::string position,
-                         std::string tail, std::string suffix, const cstring& t, Args... args);
+ErrorMessage error_helper(boost::format& f, ErrorMessage out,
+                         const cstring& t, Args... args);
 
+// use: ir/mau.cpp:805
 template<class... Args>
-std::string error_helper(boost::format& f, std::string message,
-                         std::string position, std::string tail, std::string suffix,
+ErrorMessage error_helper(boost::format& f, ErrorMessage out,
                          const Util::SourceInfo &info, Args... args);
 
 template<typename T, class... Args>
-auto error_helper(boost::format& f, std::string message, std::string position,
-                  std::string tail, std::string suffix, const T &t, Args... args) ->
+auto error_helper(boost::format& f, ErrorMessage out,
+                  const T &t, Args... args) ->
     typename std::enable_if<Util::HasToString<T>::value &&
-                            !std::is_base_of<Util::IHasSourceInfo, T>::value, std::string>::type;
+                            !std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type;
 
 template<typename T, class... Args>
-auto error_helper(boost::format& f, std::string message, std::string position,
-                  std::string tail, std::string suffix, const T *t, Args... args) ->
+auto error_helper(boost::format& f, ErrorMessage out,
+                  const T *t, Args... args) ->
     typename std::enable_if<Util::HasToString<T>::value &&
-                            !std::is_base_of<Util::IHasSourceInfo, T>::value, std::string>::type;
+                            !std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type;
 
 template<typename T, class... Args>
-auto error_helper(boost::format& f, std::string message, std::string position,
-                  std::string tail, std::string suffix, const T &t, Args... args) ->
-    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, std::string>::type;
+auto error_helper(boost::format& f, ErrorMessage out,
+                  const T &t, Args... args) ->
+    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type;
 
 template<typename T, class... Args>
-auto error_helper(boost::format& f, std::string message, std::string position,
-                  std::string tail, std::string suffix, const T *t, Args... args) ->
-    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, std::string>::type;
+auto error_helper(boost::format& f, ErrorMessage out,
+                  const T *t, Args... args) ->
+    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type;
 
 template<class... Args>
-std::string error_helper(boost::format& f, std::string message, std::string position,
-                         std::string tail, std::string suffix, const big_int *t, Args... args);
+ErrorMessage error_helper(boost::format& f, ErrorMessage out,
+                         const big_int *t, Args... args);
 
 template<class... Args>
-std::string error_helper(boost::format& f, std::string message, std::string position,
-                         std::string tail, std::string suffix, const big_int &t, Args... args);
+ErrorMessage error_helper(boost::format& f, ErrorMessage out,
+                         const big_int &t, Args... args);
 
 template<typename T, class... Args>
-auto
-error_helper(boost::format& f, std::string message,
-             std::string position, std::string tail, std::string suffix,
+auto error_helper(boost::format& f, ErrorMessage out,
              const T& t, Args... args) ->
-    typename std::enable_if<std::is_arithmetic<T>::value, std::string>::type;
+    typename std::enable_if<std::is_arithmetic<T>::value, ErrorMessage>::type;
 
 // actual implementations
 
 template<class... Args>
-std::string error_helper(boost::format& f, std::string message, std::string position,
-                         std::string tail, std::string suffix, const char* t, Args... args) {
-    return error_helper(f % t, message, position, tail, suffix, std::forward<Args>(args)...);
+ErrorMessage error_helper(boost::format& f, ErrorMessage out,
+                         const char* t, Args... args) {
+    return error_helper(f % t, out, std::forward<Args>(args)...);
 }
 
 template<class... Args>
-std::string error_helper(boost::format& f, std::string message, std::string position,
-                         std::string tail, std::string suffix, const cstring& t, Args... args) {
-    return error_helper(f % t.c_str(), message, position, tail,
-                        suffix, std::forward<Args>(args)...);
+ErrorMessage error_helper(boost::format& f, ErrorMessage out,
+                         const cstring& t, Args... args) {
+    return error_helper(f % t.c_str(), out, std::forward<Args>(args)...);
 }
 
 template<typename T, class... Args>
-auto error_helper(boost::format& f, std::string message, std::string position,
-                  std::string tail, std::string suffix, const T &t, Args... args) ->
+auto error_helper(boost::format& f, ErrorMessage out,
+                  const T &t, Args... args) ->
     typename std::enable_if<Util::HasToString<T>::value &&
-                            !std::is_base_of<Util::IHasSourceInfo, T>::value, std::string>::type {
-    return error_helper(f % t.toString(), message, position, tail,
-                        suffix, std::forward<Args>(args)...);
+                            !std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type {
+    return error_helper(f % t.toString(), out, std::forward<Args>(args)...);
 }
 
 template<typename T, class... Args>
-auto error_helper(boost::format& f, std::string message, std::string position,
-                  std::string tail, std::string suffix, const T *t, Args... args) ->
+auto error_helper(boost::format& f, ErrorMessage out,
+                  const T *t, Args... args) ->
     typename std::enable_if<Util::HasToString<T>::value &&
-                            !std::is_base_of<Util::IHasSourceInfo, T>::value, std::string>::type {
-    return error_helper(f % t->toString(), message, position, tail,
-                        suffix, std::forward<Args>(args)...);
+                            !std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type {
+    return error_helper(f % t->toString(), out, std::forward<Args>(args)...);
 }
 
 template<class... Args>
-std::string error_helper(boost::format& f, std::string message, std::string position,
-                         std::string tail, std::string suffix, const big_int *t, Args... args) {
-    return error_helper(f % t, message, position, tail, suffix, std::forward<Args>(args)...);
+ErrorMessage error_helper(boost::format& f, ErrorMessage out,
+                         const big_int *t, Args... args) {
+    return error_helper(f % t, out, std::forward<Args>(args)...);
 }
 
 template<class... Args>
-std::string error_helper(boost::format& f, std::string message, std::string position,
-                         std::string tail, std::string suffix, const big_int &t, Args... args) {
-    return error_helper(f % t, message, position, tail, suffix, std::forward<Args>(args)...);
+ErrorMessage error_helper(boost::format& f, ErrorMessage out, const big_int &t, Args... args) {
+    return error_helper(f % t, out, std::forward<Args>(args)...);
 }
 
 template<typename T, class... Args>
-auto
-error_helper(boost::format& f, std::string message, std::string position,
-             std::string tail, std::string suffix, const T& t, Args... args) ->
-    typename std::enable_if<std::is_arithmetic<T>::value, std::string>::type {
-    return error_helper(f % t, message, position, tail, suffix, std::forward<Args>(args)...);
+auto error_helper(boost::format& f, ErrorMessage out, const T& t, Args... args) ->
+    typename std::enable_if<std::is_arithmetic<T>::value, ErrorMessage>::type {
+    return error_helper(f % t, out, std::forward<Args>(args)...);
 }
 
 template<class... Args>
-std::string error_helper(boost::format& f, std::string message, std::string position,
-                         std::string tail, std::string suffix, const Util::SourceInfo &info,
+ErrorMessage error_helper(boost::format& f, ErrorMessage out, const Util::SourceInfo &info,
                          Args... args) {
     cstring posString = info.toPositionString();
-    if (position.empty()) {
-        position = posString;
+    out.locations.push_back(info);
+    if (!out.position.isValid()) { // if there is not already something stored in out.position
+        out.position = info;
         posString = "";
     } else {
         if (!posString.isNullOrEmpty())
             posString += "\n";
     }
-    return error_helper(f % "", message, position, tail + posString + info.toSourceFragment(),
-                        suffix, std::forward<Args>(args)...);
+    out.tail += posString + info.toSourceFragment();
+
+    return error_helper(f % "", out, std::forward<Args>(args)...);
 }
 
 template<typename T, class... Args>
-auto error_helper(boost::format& f, std::string message, std::string position,
-                  std::string tail, std::string suffix, const T *t, Args... args) ->
-    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, std::string>::type {
+auto error_helper(boost::format& f, ErrorMessage out, const T *t, Args... args) ->
+    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type {
     cstring posString = t->getSourceInfo().toPositionString();
-    if (position.empty()) {
-        position = posString;
+    out.locations.push_back(t->getSourceInfo());
+    if (!out.position.isValid()) {
+        out.position = t->getSourceInfo();
         posString = "";
     } else {
         if (!posString.isNullOrEmpty())
             posString += "\n";
     }
-    return error_helper(f % t->toString(), message, position,
-                        tail + posString + t->getSourceInfo().toSourceFragment(), suffix,
-                        std::forward<Args>(args)...);
+    out.tail += posString + t->getSourceInfo().toSourceFragment();
+
+    return error_helper(f % t->toString(), out, std::forward<Args>(args)...);
 }
 
 template<typename T, class... Args>
-auto error_helper(boost::format& f, std::string message, std::string position,
-                  std::string tail, std::string suffix, const T &t, Args... args) ->
-    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, std::string>::type {
+auto error_helper(boost::format& f, ErrorMessage out, const T &t, Args... args) ->
+    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type {
     cstring posString = t.getSourceInfo().toPositionString();
-    if (position.empty()) {
-        position = posString;
+    out.locations.push_back(t.getSourceInfo());
+    if (!out.position.isValid()) {
+        out.position = t.getSourceInfo();
         posString = "";
     } else {
         if (!posString.isNullOrEmpty())
             posString += "\n";
     }
-    return error_helper(f % t.toString(), message, position,
-                        tail + posString + t.getSourceInfo().toSourceFragment(), suffix,
-                        std::forward<Args>(args)...);
+    out.tail += posString + t.getSourceInfo().toSourceFragment();
+
+    return error_helper(f % t.toString(), out, std::forward<Args>(args)...);
+}
+
+}  // namespace priv
+
+// Most direct invocations of error_helper usually only reduce arguments
+template<class... Args>
+ErrorMessage error_helper(boost::format& f, Args... args) {
+    ErrorMessage msg;
+    return ::priv::error_helper(f, msg, std::forward<Args>(args)...);
+}
+
+// Invoked from ErrorReporter
+template<class... Args>
+ErrorMessage error_helper(boost::format& f, ErrorMessage &msg, Args... args) {
+    return ::priv::error_helper(f, msg, std::forward<Args>(args)...);
+}
+
+// This overload exists for backwards compatibility
+template<class... Args>
+ErrorMessage error_helper(boost::format& f, std::string prefix,
+                          Util::SourceInfo info, std::string suffix, Args... args) {
+    ErrorMessage msg(prefix, info, suffix);
+    return ::priv::error_helper(f, msg, std::forward<Args>(args)...);
 }
 
 /***********************************************************************************/
@@ -301,8 +379,9 @@ std::string bug_helper(boost::format& f, std::string message, std::string positi
         position = posString;
         posString = "";
     } else {
-        if (!posString.isNullOrEmpty())
+        if (!posString.isNullOrEmpty()) {
             posString += "\n";
+        }
     }
     return bug_helper(f % "", message, position, tail + posString + info.toSourceFragment(),
                         std::forward<Args>(args)...);
@@ -322,8 +401,9 @@ auto bug_helper(boost::format& f, std::string message, std::string position,
         position = posString;
         posString = "";
     } else {
-        if (!posString.isNullOrEmpty())
+        if (!posString.isNullOrEmpty()) {
             posString += "\n";
+        }
     }
     std::stringstream str;
     str << t;
@@ -341,8 +421,9 @@ auto bug_helper(boost::format& f, std::string message, std::string position,
         position = posString;
         posString = "";
     } else {
-        if (!posString.isNullOrEmpty())
+        if (!posString.isNullOrEmpty()) {
             posString += "\n";
+        }
     }
     std::stringstream str;
     str << t;

--- a/lib/error_helper.h
+++ b/lib/error_helper.h
@@ -27,80 +27,7 @@ limitations under the License.
 #include "lib/cstring.h"
 #include "lib/source_file.h"
 #include "lib/stringify.h"
-
-struct ErrorMessage {
-    enum class Type : std::size_t { None, Error, Warning };
-
-    Type type = Type::None;
-    std::string prefix = "";  // Typically error/warning type from catalog
-    std::string message = "";  // Actual formatted message
-    std::vector<Util::SourceInfo> locations = {}; // Relevant source locations for this error
-    std::string suffix = "";  // Used by errorWithSuffix
-
-/*
-    Util::SourceInfo position;  // Position in P4 source
-    std::string tail = "";  // Extra P4 source positions
-*/
-
-    ErrorMessage() {}
-    // Invoked from backwards compatible error_helper
-    ErrorMessage(const std::string &prefix, const Util::SourceInfo &info, std::string &suffix)
-        : prefix(prefix), locations({info}), suffix(suffix) {}
-    // Invoked from error_reporter
-    ErrorMessage(Type type, const std::string &prefix, const std::string &suffix)
-        : type(type), prefix(prefix), suffix(suffix) {}
-
-    std::string getPrefix() const {
-        std::string p = prefix;
-        if (type == Type::Error) {
-            if (p.empty()) p = "error: ";
-            else p = "[--Werror=" + p + "] error: ";
-        } else if (type == Type::Warning) {
-            if (p.empty()) p = "warning: ";
-            else p = "[--Wwarn=" + p + "] warning: ";
-        }
-        return p;
-    }
-
-    // original implementation, TODO: delete this
-    /*std::string _toString() const {
-        std::string result = position.toPositionString().c_str();
-        if (!result.empty()) result += ": ";
-        result += getPrefix() + message + "\n" + tail + suffix;
-        return result;
-    }*/
-
-    std::string toString() const {
-        std::string result = "";
-        std::string mainFragment = "";
-        if (!locations.empty() && locations.front().isValid()) {
-            result += locations.front().toPositionString() + ": ";
-            mainFragment = locations.front().toSourceFragment();
-        }
-
-        result += getPrefix() + message + "\n" + mainFragment;
-
-        for (unsigned i = 1; i < locations.size(); i++) {
-            if (locations[i].isValid())
-                result += locations[i].toPositionString() + "\n" + locations[i].toSourceFragment();
-        }
-
-        result += suffix;
-
-        return result;
-    }
-};
-
-struct ParserErrorMessage {
-    Util::SourceInfo location;
-    cstring message;
-
-    ParserErrorMessage(const Util::SourceInfo &loc, const cstring &msg) : location(loc), message(msg) {}
-
-    std::string toString() const {
-        return std::string(location.toPositionString().c_str()) + ":" + message + "\n" + location.toSourceFragment().c_str();
-    }
-};
+#include "lib/error_message.h"
 
 namespace priv {
 
@@ -209,16 +136,6 @@ auto error_helper(boost::format& f, ErrorMessage out, const T& t, Args... args) 
 template<class... Args>
 ErrorMessage error_helper(boost::format& f, ErrorMessage out, const Util::SourceInfo &info,
                          Args... args) {
-    /*cstring posString = info.toPositionString();
-    if (!out.position.isValid()) { // if there is not already something stored in out.position
-        out.position = info;
-        posString = "";
-    } else {
-        if (!posString.isNullOrEmpty())
-            posString += "\n";
-    }
-    out.tail += posString + info.toSourceFragment();*/
-
     if (info.isValid()) out.locations.push_back(info);
     return error_helper(f % "", out, std::forward<Args>(args)...);
 }
@@ -226,16 +143,6 @@ ErrorMessage error_helper(boost::format& f, ErrorMessage out, const Util::Source
 template<typename T, class... Args>
 auto error_helper(boost::format& f, ErrorMessage out, const T *t, Args... args) ->
     typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type {
-    /*cstring posString = t->getSourceInfo().toPositionString();
-    if (!out.position.isValid()) {
-        out.position = t->getSourceInfo();
-        posString = "";
-    } else {
-        if (!posString.isNullOrEmpty())
-            posString += "\n";
-    }
-    out.tail += posString + t->getSourceInfo().toSourceFragment();*/
-
     auto info = t->getSourceInfo();
     if (info.isValid()) out.locations.push_back(info);
     return error_helper(f % t->toString(), out, std::forward<Args>(args)...);
@@ -244,15 +151,6 @@ auto error_helper(boost::format& f, ErrorMessage out, const T *t, Args... args) 
 template<typename T, class... Args>
 auto error_helper(boost::format& f, ErrorMessage out, const T &t, Args... args) ->
     typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type {
-    /*cstring posString = t.getSourceInfo().toPositionString();
-    if (!out.position.isValid()) {
-        out.position = t.getSourceInfo();
-        posString = "";
-    } else {
-        if (!posString.isNullOrEmpty())
-            posString += "\n";
-    }
-    out.tail += posString + t.getSourceInfo().toSourceFragment();*/
 
     auto info = t.getSourceInfo();
     if (info.isValid()) out.locations.push_back(info);

--- a/lib/error_helper.h
+++ b/lib/error_helper.h
@@ -59,24 +59,29 @@ struct ErrorMessage {
         return p;
     }
 
-    std::string toString() const {
+    // original implementation, TODO: delete this
+    std::string _toString() const {
         std::string result = position.toPositionString().c_str();
         if (!result.empty()) result += ": ";
         result += getPrefix() + message + "\n" + tail + suffix;
         return result;
     }
 
-    std::string toString2() const {
+    std::string toString() const {
         std::string result = "";
-        if (!locations.empty()) {
+        std::string mainFragment = "";
+        if (!locations.empty() && locations.front().isValid()) {
             result += locations.front().toPositionString() + ": ";
+            mainFragment = locations.front().toSourceFragment();
         }
 
-        result += getPrefix() + message;
+        result += getPrefix() + message + "\n" + mainFragment;
 
         for (unsigned i = 1; i < locations.size(); i++) {
-            result += "\n" + locations[i].toPositionString() + "\n" + locations[i].toSourceFragment();
+            result += locations[i].toPositionString() + "\n" + locations[i].toSourceFragment();
         }
+
+        result += suffix;
 
         return result;
     }

--- a/lib/error_message.cpp
+++ b/lib/error_message.cpp
@@ -2,12 +2,16 @@
 
 std::string ErrorMessage::getPrefix() const {
     std::string p = prefix;
-    if (type == Type::Error) {
-        if (p.empty()) p = "error: ";
-        else p = "[--Werror=" + p + "] error: ";
-    } else if (type == Type::Warning) {
-        if (p.empty()) p = "warning: ";
-        else p = "[--Wwarn=" + p + "] warning: ";
+    if (type == MessageType::Error) {
+        if (p.empty())
+            p = "error: ";
+        else
+            p = "[--Werror=" + p + "] error: ";
+    } else if (type == MessageType::Warning) {
+        if (p.empty())
+            p = "warning: ";
+        else
+            p = "[--Wwarn=" + p + "] warning: ";
     }
     return p;
 }
@@ -33,5 +37,6 @@ std::string ErrorMessage::toString() const {
 }
 
 std::string ParserErrorMessage::toString() const {
-    return std::string(location.toPositionString().c_str()) + ":" + message + "\n" + location.toSourceFragment().c_str();
+    return std::string(location.toPositionString().c_str()) + ":" + message + "\n" +
+           location.toSourceFragment().c_str();
 }

--- a/lib/error_message.cpp
+++ b/lib/error_message.cpp
@@ -1,0 +1,37 @@
+#include "error_message.h"
+
+std::string ErrorMessage::getPrefix() const {
+    std::string p = prefix;
+    if (type == Type::Error) {
+        if (p.empty()) p = "error: ";
+        else p = "[--Werror=" + p + "] error: ";
+    } else if (type == Type::Warning) {
+        if (p.empty()) p = "warning: ";
+        else p = "[--Wwarn=" + p + "] warning: ";
+    }
+    return p;
+}
+
+std::string ErrorMessage::toString() const {
+    std::string result = "";
+    std::string mainFragment = "";
+    if (!locations.empty() && locations.front().isValid()) {
+        result += locations.front().toPositionString() + ": ";
+        mainFragment = locations.front().toSourceFragment();
+    }
+
+    result += getPrefix() + message + "\n" + mainFragment;
+
+    for (unsigned i = 1; i < locations.size(); i++) {
+        if (locations[i].isValid())
+            result += locations[i].toPositionString() + "\n" + locations[i].toSourceFragment();
+    }
+
+    result += suffix;
+
+    return result;
+}
+
+std::string ParserErrorMessage::toString() const {
+    return std::string(location.toPositionString().c_str()) + ":" + message + "\n" + location.toSourceFragment().c_str();
+}

--- a/lib/error_message.h
+++ b/lib/error_message.h
@@ -1,0 +1,70 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef _LIB_ERROR_MESSAGE_H_
+#define _LIB_ERROR_MESSAGE_H_
+
+#include <vector>
+#include <cstring>
+
+#include "lib/source_file.h"
+
+/**
+ *  Structure populated via error_helper functions
+ *
+ *  Typically, calls to ::error/::warning have many parameters, some of them
+ *  might have SourceInfo attribute. ::error_helper parse those parameters, format
+ *  parameters to output message and extracts SourceInfo wherever possible.
+ *
+ *  Populated structure can be serialized to canonical error message with toString() method.
+ *
+ *  This structure is mainly used inside ErrorReporter, but some uses invoke ::error_helper
+ *  directly and those uses need to call toString() on returned object.
+ */
+struct ErrorMessage {
+    enum class Type : std::size_t { None, Error, Warning };
+
+    Type type = Type::None;
+    std::string prefix = "";  /// Typically error/warning type from catalog
+    std::string message = "";  /// Particular formatted message
+    std::vector<Util::SourceInfo> locations = {}; /// Relevant source locations for this error
+    std::string suffix = "";  /// Used by errorWithSuffix
+
+    ErrorMessage() {}
+    // Invoked from backwards compatible error_helper
+    ErrorMessage(const std::string &prefix, const Util::SourceInfo &info, std::string &suffix)
+        : prefix(prefix), locations({info}), suffix(suffix) {}
+    // Invoked from error_reporter
+    ErrorMessage(Type type, const std::string &prefix, const std::string &suffix)
+        : type(type), prefix(prefix), suffix(suffix) {}
+
+    std::string getPrefix() const;
+    std::string toString() const;
+};
+
+/**
+ *  Variation on ErrorMessage, this one is used for errors coming from parser.
+ *  This is exclusively used in ErrorReporter
+ */
+struct ParserErrorMessage {
+    Util::SourceInfo location;
+    cstring message;
+
+    ParserErrorMessage(const Util::SourceInfo &loc, const cstring &msg) : location(loc), message(msg) {}
+
+    std::string toString() const;
+};
+
+#endif  /* _LIB_ERROR_MESSAGE_H_ */

--- a/lib/error_message.h
+++ b/lib/error_message.h
@@ -34,22 +34,22 @@ limitations under the License.
  *  directly and those uses need to call toString() on returned object.
  */
 struct ErrorMessage {
-    enum class Type : std::size_t { None, Error, Warning };
+    enum class MessageType : std::size_t { None, Error, Warning };
 
-    Type type = Type::None;
+    MessageType type = MessageType::None;
     std::string prefix = "";  /// Typically error/warning type from catalog
     std::string message = "";  /// Particular formatted message
-    std::vector<Util::SourceInfo> locations = {}; /// Relevant source locations for this error
+    std::vector<Util::SourceInfo> locations = {};  /// Relevant source locations for this error
     std::string suffix = "";  /// Used by errorWithSuffix
 
     ErrorMessage() {}
     // Invoked from backwards compatible error_helper
-    ErrorMessage(const std::string &prefix, const Util::SourceInfo &info, std::string &suffix)
+    ErrorMessage(const std::string &prefix, const Util::SourceInfo &info, const std::string &suffix)
         : prefix(prefix), locations({info}), suffix(suffix) {}
     // Invoked from error_reporter
-    ErrorMessage(Type type, const std::string &prefix, const std::string &suffix)
+    ErrorMessage(MessageType type, const std::string &prefix, const std::string &suffix)
         : type(type), prefix(prefix), suffix(suffix) {}
-    ErrorMessage(Type type, const std::string &prefix, const std::string &message,
+    ErrorMessage(MessageType type, const std::string &prefix, const std::string &message,
                  const std::vector<Util::SourceInfo> &locations, const std::string &suffix)
         : type(type), prefix(prefix), message(message), locations(locations), suffix(suffix) {}
 
@@ -65,7 +65,8 @@ struct ParserErrorMessage {
     Util::SourceInfo location;
     cstring message;
 
-    ParserErrorMessage(const Util::SourceInfo &loc, const cstring &msg) : location(loc), message(msg) {}
+    ParserErrorMessage(const Util::SourceInfo &loc, const cstring &msg)
+        : location(loc), message(msg) {}
 
     std::string toString() const;
 };

--- a/lib/error_message.h
+++ b/lib/error_message.h
@@ -49,6 +49,9 @@ struct ErrorMessage {
     // Invoked from error_reporter
     ErrorMessage(Type type, const std::string &prefix, const std::string &suffix)
         : type(type), prefix(prefix), suffix(suffix) {}
+    ErrorMessage(Type type, const std::string &prefix, const std::string &message,
+                 const std::vector<Util::SourceInfo> &locations, const std::string &suffix)
+        : type(type), prefix(prefix), message(message), locations(locations), suffix(suffix) {}
 
     std::string getPrefix() const;
     std::string toString() const;

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -132,17 +132,17 @@ class ErrorReporter {
                   const char* format, const char* suffix, T... args) {
         if (action == DiagnosticAction::Ignore) return;
 
-        ErrorMessage::Type msgType = ErrorMessage::Type::None;
+        ErrorMessage::MessageType msgType = ErrorMessage::MessageType::None;
         if (action == DiagnosticAction::Warn) {
             // Avoid burying errors in a pile of warnings: don't emit any more warnings if we've
             // emitted errors.
             if (errorCount > 0) return;
 
             warningCount++;
-            msgType = ErrorMessage::Type::Warning;
+            msgType = ErrorMessage::MessageType::Warning;
         } else if (action == DiagnosticAction::Error) {
             errorCount++;
-            msgType = ErrorMessage::Type::Error;
+            msgType = ErrorMessage::MessageType::Error;
         }
 
         boost::format fmt(format);

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -34,16 +34,22 @@ enum class DiagnosticAction {
 // that use boost::format format strings, i.e.,
 // %1%, %2%, etc (starting at 1, not at 0).
 // Some compatibility for printf-style arguments is also supported.
-class ErrorReporter final {
- private:
+class ErrorReporter {
+ protected:
     std::ostream* outputstream;
 
     /// Track errors or warnings that have already been issued for a particular source location
     std::set<std::pair<int, const Util::SourceInfo>> errorTracker;
 
     /// Output the message and flush the stream
-    void emit_message(cstring message) {
-        *outputstream << message;
+    virtual void emit_message(const ErrorMessage &msg) {
+        std::cerr << "Emmiting: " << outputstream << std::endl;
+        *outputstream << msg.toString();
+        outputstream->flush();
+    }
+
+    virtual void emit_message(const ParserErrorMessage &msg) {
+        *outputstream << msg.toString();
         outputstream->flush();
     }
 
@@ -80,7 +86,7 @@ class ErrorReporter final {
     template <typename... T>
     std::string format_message(const char* format, T... args) {
         boost::format fmt(format);
-        std::string message = ::error_helper(fmt, "", "", "", "", args...);
+        std::string message = ::error_helper(fmt, args...).toString();
         return message;
     }
 
@@ -127,34 +133,24 @@ class ErrorReporter final {
                   const char* format, const char* suffix, T... args) {
         if (action == DiagnosticAction::Ignore) return;
 
-        std::string prefix;
+        ErrorMessage::Type msgType = ErrorMessage::Type::None;
         if (action == DiagnosticAction::Warn) {
             // Avoid burying errors in a pile of warnings: don't emit any more warnings if we've
             // emitted errors.
             if (errorCount > 0) return;
 
             warningCount++;
-            if (diagnosticName != nullptr) {
-                prefix.append("[--Wwarn=");
-                prefix.append(diagnosticName);
-                prefix.append("] warning: ");
-            } else {
-                prefix.append("warning: ");
-            }
+            msgType = ErrorMessage::Type::Warning;
         } else if (action == DiagnosticAction::Error) {
             errorCount++;
-            if (diagnosticName != nullptr) {
-                prefix.append("[--Werror=");
-                prefix.append(diagnosticName);
-                prefix.append("] error: ");
-            } else {
-                prefix.append("error: ");
-            }
+            msgType = ErrorMessage::Type::Error;
         }
 
         boost::format fmt(format);
-        std::string message = ::error_helper(fmt, prefix, "", "", suffix, args...);
-        emit_message(message);
+        ErrorMessage msg(msgType, diagnosticName ? diagnosticName : "", suffix);
+        msg = ::error_helper(fmt, msg, args...);
+        emit_message(msg);
+
         if (errorCount >= maxErrorCount)
             FATAL_ERROR("Number of errors exceeded set maximum of %1%", maxErrorCount);
     }
@@ -185,8 +181,11 @@ class ErrorReporter final {
     template <typename T>
     void parser_error(const Util::SourceInfo& location, const T& message) {
         errorCount++;
-        *outputstream << location.toPositionString() << ":" << message << std::endl;
-        emit_message(location.toSourceFragment());  // This flushes the stream.
+        std::stringstream ss;
+        ss << message;
+
+        ParserErrorMessage msg(location, ss.str());
+        emit_message(msg);
     }
 
     /**
@@ -203,12 +202,11 @@ class ErrorReporter final {
 
         Util::SourcePosition position = sources->getCurrentPosition();
         position--;
-        Util::SourceFileLine fileError =
-                sources->getSourceLine(position.getLineNumber());
-        cstring msg = Util::vprintf_format(fmt, args);
-        *outputstream << fileError.toString() << ":" << msg << std::endl;
-        cstring sourceFragment = sources->getSourceFragment(position);
-        emit_message(sourceFragment);
+        cstring message = Util::vprintf_format(fmt, args);
+
+        Util::SourceInfo info(sources, position);
+        ParserErrorMessage msg(info, message);
+        emit_message(msg);
 
         va_end(args);
     }

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -43,7 +43,6 @@ class ErrorReporter {
 
     /// Output the message and flush the stream
     virtual void emit_message(const ErrorMessage &msg) {
-        std::cerr << "Emmiting: " << outputstream << std::endl;
         *outputstream << msg.toString();
         outputstream->flush();
     }


### PR DESCRIPTION
Motivation behind this PR is to be able to use custom sinks for logging errors and to have maximum flexibility when formatting these messages.

Originally, all error/warning messages were send to `error_helper` functions which used template metaprogramming to serialize arguments into `boost::format` object and to add diagnostic information to the message. It used four string values to hold intermediate results and returned one formatted string at the end.

This PR uses dedicated struct for holding those intermediate values, most notably storing vector of `SourceInfo`s instead of serializing it into strings. This struct (`ErrorMessage`) contains `toString`` method which yields the same formatted strings as before, but `ErrorReporter::emit_message` function has been modified to accept this `ErrorMessage` object rather than preformatted string and this method has been marked `virtual` so any user can overload it and their own log sink.

Also, `CompileContext::errorReporter` accessor has been declared virtual so users can instantiate their own `ErrorReporter`s with custom sinks withing their custom `CompileContext  and due to nature of implementation of `CompileContext` stack, their `ErrorReporter` will be automatically used once the appropriate `CompileContext` is pushed to the shared stack.

> This change is **NOT** backwards compatible, but migration is very easy, as demonstrated in `typeConstraints.h`. A version of `error_helper` method with backwards compatible list of arguments has been preserved, also one simplified version has been added and since these methods now return `ErrorMessage` instead of `std::string`, users have to call `toString` on the returned object.