### PR TITLE
Cancel active workflows on new push

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,6 +25,11 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Cancel previous runs
+      uses: styfle/cancel-workflow-action@0.9.0
+      with:
+        access_token: ${{ github.token }}
+
     - name: Build (Linux)
       run: |
         tools/start_ccache


### PR DESCRIPTION
I don't really understand github actions, but I copied some code I found on the net.
When we have multiple push requests to the same PR or branch we run needless workflows.
I hope that this cancels all runs of the same branch.